### PR TITLE
Add Location support to tab-completes

### DIFF
--- a/Spigot-API-Patches/0015-Add-Location-support-to-tab-completers-vanilla-featu.patch
+++ b/Spigot-API-Patches/0015-Add-Location-support-to-tab-completers-vanilla-featu.patch
@@ -1,0 +1,173 @@
+From fe0db51a7d21aa243baeaca88edb3b1e8b7ac981 Mon Sep 17 00:00:00 2001
+From: DemonWav <demonwav@gmail.com>
+Date: Sat, 30 Jan 2016 18:58:09 -0600
+Subject: [PATCH] Add Location support to tab completers (vanilla feature
+ missing in CraftBukkit)
+
+
+diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
+index 548d570..c126a1e 100644
+--- a/src/main/java/org/bukkit/command/Command.java
++++ b/src/main/java/org/bukkit/command/Command.java
+@@ -8,6 +8,7 @@ import java.util.Set;
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.Bukkit;
+ import org.bukkit.ChatColor;
++import org.bukkit.Location;
+ import org.bukkit.Server;
+ import org.bukkit.entity.Player;
+ import org.bukkit.entity.minecart.CommandMinecart;
+@@ -109,6 +110,30 @@ public abstract class Command {
+         return matchedPlayers;
+     }
+ 
++    // PaperSpigot start - location tab-completes
++    /**
++     * Executed on tab completion for this command, returning a list of options the player can tab through. This method
++     * returns the {@link Location} of the block the player is looking at at the time of the tab complete.
++     * <p>
++     * Commands that want to use the Location information in their tab-complete implementations need to override this
++     * method. The Location provided by this method is the block that the player is currently looking at when the player
++     * attempts the tab complete. For this to be valid, the block must be highlighted by the player (i.e. the player is
++     * close enough to interact with the block).
++     *
++     * @param sender Source object which is executing this command
++     * @param alias the alias being used
++     * @param args All arguments passed to the command, split via ' '
++     * @param location the location of the block the player is looking at
++     * @return a list of tab-completions for the specified arguments. This
++     *     will never be null. List may be immutable.
++     * @throws IllegalArgumentException if sender, alias, or args is null
++     */
++    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
++        // Simply default to the standard tab-complete, subclasses can override this if needed
++        return tabComplete(sender, alias, args);
++    }
++    // PaperSpigot end
++
+     /**
+      * Returns the name of this command
+      *
+diff --git a/src/main/java/org/bukkit/command/PluginCommand.java b/src/main/java/org/bukkit/command/PluginCommand.java
+index 3bfa31f..e3f8295 100644
+--- a/src/main/java/org/bukkit/command/PluginCommand.java
++++ b/src/main/java/org/bukkit/command/PluginCommand.java
+@@ -3,6 +3,7 @@ package org.bukkit.command;
+ import java.util.List;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.Location;
+ import org.bukkit.plugin.Plugin;
+ 
+ /**
+@@ -122,6 +123,15 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+      */
+     @Override
+     public java.util.List<String> tabComplete(CommandSender sender, String alias, String[] args) throws CommandException, IllegalArgumentException {
++        return tabComplete(sender, alias, args, null); // PaperSpigot - The code from this method has been (slightly modified) moved to the Location method.
++    }
++
++    // PaperSpigot start - location tab-completes
++    /*
++        this code was copied, except for the noted changes, from tabComplete(CommandSender sender, String alias, String[] args)
++     */
++    @Override
++    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws CommandException, IllegalArgumentException {
+         Validate.notNull(sender, "Sender cannot be null");
+         Validate.notNull(args, "Arguments cannot be null");
+         Validate.notNull(alias, "Alias cannot be null");
+@@ -129,10 +139,10 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+         List<String> completions = null;
+         try {
+             if (completer != null) {
+-                completions = completer.onTabComplete(sender, this, alias, args);
++                completions = completer.onTabComplete(sender, this, alias, args, location); // PaperSpigot - add location argument
+             }
+             if (completions == null && executor instanceof TabCompleter) {
+-                completions = ((TabCompleter) executor).onTabComplete(sender, this, alias, args);
++                completions = ((TabCompleter) executor).onTabComplete(sender, this, alias, args, location); // PaperSpigot - add location argument
+             }
+         } catch (Throwable ex) {
+             StringBuilder message = new StringBuilder();
+@@ -145,10 +155,11 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
+         }
+ 
+         if (completions == null) {
+-            return super.tabComplete(sender, alias, args);
++            return super.tabComplete(sender, alias, args, location); // PaperSpigot - add location argument
+         }
+         return completions;
+     }
++    // PaperSpigot end
+ 
+     @Override
+     public String toString() {
+diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+index a300ae7..12d9232 100644
+--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
++++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+@@ -12,6 +12,7 @@ import java.util.Map;
+ import java.util.regex.Pattern;
+ 
+ import org.apache.commons.lang.Validate;
++import org.bukkit.Location;
+ import org.bukkit.Server;
+ import org.bukkit.command.defaults.*;
+ import org.bukkit.entity.Player;
+@@ -167,6 +168,14 @@ public class SimpleCommandMap implements CommandMap {
+     }
+ 
+     public List<String> tabComplete(CommandSender sender, String cmdLine) {
++        return tabComplete(sender, cmdLine, null); // PaperSpigot - location tab-completes, code moved below
++    }
++
++    // PaperSpigot start - location tab-completes
++    /*
++        this code was copied, except for the noted change, from tabComplete(CommandSender sender, String cmdLine)
++     */
++    public List<String> tabComplete(CommandSender sender, String cmdLine, Location location) {
+         Validate.notNull(sender, "Sender cannot be null");
+         Validate.notNull(cmdLine, "Command line cannot null");
+ 
+@@ -211,13 +220,14 @@ public class SimpleCommandMap implements CommandMap {
+         String[] args = PATTERN_ON_SPACE.split(argLine, -1);
+ 
+         try {
+-            return target.tabComplete(sender, commandName, args);
++            return target.tabComplete(sender, commandName, args, location); // PaperSpigot - add location argument
+         } catch (CommandException ex) {
+             throw ex;
+         } catch (Throwable ex) {
+             throw new CommandException("Unhandled exception executing tab-completer for '" + cmdLine + "' in " + target, ex);
+         }
+     }
++    // PaperSpigot end
+ 
+     public Collection<Command> getCommands() {
+         return Collections.unmodifiableCollection(knownCommands.values());
+diff --git a/src/main/java/org/bukkit/command/TabCompleter.java b/src/main/java/org/bukkit/command/TabCompleter.java
+index 6d61e3a..2cb971c 100644
+--- a/src/main/java/org/bukkit/command/TabCompleter.java
++++ b/src/main/java/org/bukkit/command/TabCompleter.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.command;
+ 
++import org.bukkit.Location;
++
+ import java.util.List;
+ 
+ /**
+@@ -19,4 +21,10 @@ public interface TabCompleter {
+      *     to default to the command executor
+      */
+     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args);
++
++    // PaperSpigot start - location tab-completes
++    default List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args, Location location) {
++        return onTabComplete(sender, command, alias, args);
++    }
++    // PaperSpigot end
+ }
+-- 
+1.9.1
+

--- a/Spigot-Server-Patches/0086-Add-Location-support-to-tab-completers-vanilla-featu.patch
+++ b/Spigot-Server-Patches/0086-Add-Location-support-to-tab-completers-vanilla-featu.patch
@@ -1,0 +1,138 @@
+From 89f0cb0fb82ec84a13ddb088b944ac1d4167bb0f Mon Sep 17 00:00:00 2001
+From: DemonWav <demonwav@gmail.com>
+Date: Sat, 30 Jan 2016 19:17:19 -0600
+Subject: [PATCH] Add Location support to tab completers (vanilla feature
+ missing in CraftBukkit)
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 4a421ba..ff8770b 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1151,7 +1151,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+             return arraylist;
+         }
+         */
+-        return server.tabComplete(icommandlistener, s);
++        return server.tabComplete(icommandlistener, s, blockposition); // PaperSpigot - add Location argument
+         // CraftBukkit end
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index a54b3e8..e130052 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -29,6 +29,7 @@ import org.bukkit.BanList;
+ import org.bukkit.Bukkit;
+ import org.bukkit.ChatColor;
+ import org.bukkit.GameMode;
++import org.bukkit.Location;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.Server;
+ import org.bukkit.UnsafeValues;
+@@ -1597,21 +1598,38 @@ public final class CraftServer implements Server {
+     }
+ 
+     public List<String> tabComplete(net.minecraft.server.ICommandListener sender, String message) {
++        return tabComplete(sender, message, null); // PaperSpigot - location tab-completes. Original code here moved below
++    }
++
++    // PaperSpigot start - add BlockPosition support
++    /*
++        this code is copied, except for the noted change, from the original tabComplete(net.minecraft.server.ICommandListener sender, String message) method
++     */
++    public List<String> tabComplete(net.minecraft.server.ICommandListener sender, String message, BlockPosition blockPosition) {
+         if (!(sender instanceof EntityPlayer)) {
+             return ImmutableList.of();
+         }
+ 
+         Player player = ((EntityPlayer) sender).getBukkitEntity();
+         if (message.startsWith("/")) {
+-            return tabCompleteCommand(player, message);
++            return tabCompleteCommand(player, message, blockPosition);
+         } else {
+             return tabCompleteChat(player, message);
+         }
+     }
++    // PaperSpigot end
+ 
+     public List<String> tabCompleteCommand(Player player, String message) {
++        return tabCompleteCommand(player, message, null); // PaperSpigot - location tab-completes. Original code here moved below
++    }
++
++    // PaperSpigot start - add BlockPosition support
++    /*
++        this code is copied, except for the noted change, from the original tabCompleteCommand(Player player, String message) method
++     */
++    public List<String> tabCompleteCommand(Player player, String message, BlockPosition blockPosition) {
+         // Spigot Start
+-		if ( (org.spigotmc.SpigotConfig.tabComplete < 0 || message.length() <= org.spigotmc.SpigotConfig.tabComplete) && !message.contains( " " ) )
++        if ( (org.spigotmc.SpigotConfig.tabComplete < 0 || message.length() <= org.spigotmc.SpigotConfig.tabComplete) && !message.contains( " " ) )
+         {
+             return ImmutableList.of();
+         }
+@@ -1619,7 +1637,13 @@ public final class CraftServer implements Server {
+ 
+         List<String> completions = null;
+         try {
+-            completions = getCommandMap().tabComplete(player, message.substring(1));
++            // send location info if present
++            // completions = getCommandMap().tabComplete(player, message.substring(1));
++            if (blockPosition == null) {
++                completions = getCommandMap().tabComplete(player, message.substring(1));
++            } else {
++                completions = getCommandMap().tabComplete(player, message.substring(1), new Location(player.getWorld(), blockPosition.getX(), blockPosition.getY(), blockPosition.getZ()));
++            }
+         } catch (CommandException ex) {
+             player.sendMessage(ChatColor.RED + "An internal error occurred while attempting to tab-complete this command");
+             getLogger().log(Level.SEVERE, "Exception when " + player.getName() + " attempted to tab complete " + message, ex);
+@@ -1627,6 +1651,7 @@ public final class CraftServer implements Server {
+ 
+         return completions == null ? ImmutableList.<String>of() : completions;
+     }
++    // PaperSpigot end
+ 
+     public List<String> tabCompleteChat(Player player, String message) {
+         List<String> completions = new ArrayList<String>();
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+index de788d6..db46eb0 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+@@ -7,6 +7,7 @@ import net.minecraft.server.*;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.apache.logging.log4j.Level;
++import org.bukkit.Location;
+ import org.bukkit.command.BlockCommandSender;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.command.ConsoleCommandSender;
+@@ -46,11 +47,25 @@ public final class VanillaCommandWrapper extends VanillaCommand {
+ 
+     @Override
+     public List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException {
++        return tabComplete(sender, alias, args, null); // PaperSpigot - location tab-completes. Original code moved below
++    }
++
++    // PaperSpigot start - location tab-completes
++    /*
++        this code is copied, except for the noted change, from the original tabComplete(CommandSender sender, String alias, String[] args) method
++     */
++    @Override
++    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
+         Validate.notNull(sender, "Sender cannot be null");
+         Validate.notNull(args, "Arguments cannot be null");
+         Validate.notNull(alias, "Alias cannot be null");
+-        return (List<String>) vanillaCommand.tabComplete(getListener(sender), args, new BlockPosition(0, 0, 0));
++        if (location == null) { // PaperSpigot use location information if available
++            return (List<String>) vanillaCommand.tabComplete(getListener(sender), args, new BlockPosition(0, 0, 0));
++        } else {
++            return (List<String>) vanillaCommand.tabComplete(getListener(sender), args, new BlockPosition(location.getBlockX(), location.getBlockY(), location.getBlockZ()));
++        }
+     }
++    // PaperSpigot end
+ 
+     public static CommandSender lastSender = null; // Nasty :(
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
This is a feature in vanilla Minecraft that has somehow been missing from CraftBukkit for years.
I wasn't sure the best way to move code from one method to another, so I decided deleting it and noting the move would be better than huge blocks of commented out code. I can change that if it's better the other way.
