### PR TITLE
Add API and Implementation for a Name to UUID Cache.

### DIFF
--- a/Spigot-API-Patches/0017-API-for-Name-to-UUID-caching.patch
+++ b/Spigot-API-Patches/0017-API-for-Name-to-UUID-caching.patch
@@ -1,134 +1,65 @@
-From 74f3eba7481f1a142c94d03dab601a0756c80da0 Mon Sep 17 00:00:00 2001
+From 91cec68f3e2a2bed046554b9549f2cd20de94321 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fabian=20Fa=C3=9Fbender?=
  <fabian.fassbender42@googlemail.com>
 Date: Wed, 3 Feb 2016 19:32:10 +0100
 Subject: [PATCH] API for Name to UUID caching
 
 
-diff --git a/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java
-new file mode 100644
-index 0000000..7b130c6
---- /dev/null
-+++ b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java
-@@ -0,0 +1,59 @@
-+package org.github.paperspigot.event.cache;
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index ae75bd4..a83f3de 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -42,6 +42,7 @@ import org.bukkit.generator.ChunkGenerator;
+ 
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
++import org.github.paperspigot.cache.ProfileCacheAdapter;
+ 
+ /**
+  * Represents a server implementation.
+@@ -978,6 +979,13 @@ public interface Server extends PluginMessageRecipient {
+             throw new UnsupportedOperationException( "Not supported yet." );
+         }
+         // PaperSpigot end
 +
-+import org.bukkit.event.Event;
-+import org.bukkit.event.HandlerList;
++        // PaperSpigot start - Add setProfileCacheAdapter method
++        public void setProfileCacheAdapter( ProfileCacheAdapter adapter )
++        {
++            throw new UnsupportedOperationException( "Not supported yet." );
++        }
++        // PaperSpigot end
+     }
+ 
+     Spigot spigot();
+diff --git a/src/main/java/org/github/paperspigot/cache/ProfileCacheAdapter.java b/src/main/java/org/github/paperspigot/cache/ProfileCacheAdapter.java
+new file mode 100644
+index 0000000..31ce477
+--- /dev/null
++++ b/src/main/java/org/github/paperspigot/cache/ProfileCacheAdapter.java
+@@ -0,0 +1,24 @@
++package org.github.paperspigot.cache;
 +
 +import java.util.UUID;
 +
 +/**
-+ * Gets called when the UserCache wants to resolve a UUID from a Name
++ * Used to bind an external Cache implementation like Redis into the UserCache of MC
 + */
-+public class NameToUUIDResolveEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    private String name;
-+    private UUID uuid;
-+
-+    public NameToUUIDResolveEvent( String name, UUID uuid ) {
-+        this.name = name;
-+        this.uuid = uuid;
-+    }
-+
++public interface ProfileCacheAdapter {
 +    /**
-+     * Name of the User
++     * Resolve a name to its uuid
 +     *
-+     * @return unchanged name of the user
++     * @param name of the player in any case (like given into {@link org.bukkit.inventory.meta.SkullMeta#setOwner(String)})
++     * @return the resolved uuid or null if the cache does not recognize this name
 +     */
-+    public String getName() {
-+        return name;
-+    }
++    UUID resolve( String name );
 +
 +    /**
-+     * Should be null on the first listener but everybody else it can
-+     * be the resolved UUID. When this is not null the return value is
-+     * used to complete the GameProfile
++     * Announce a new profile which has been resolved from the mojang API
 +     *
-+     * @return null or the resolved UUID
-+     */
-+    public UUID getUuid() {
-+        return uuid;
-+    }
-+
-+    /**
-+     * Used by the caching implementation to set the UUID from it instead of asking Mojang to provide some
-+     *
-+     * @param uuid which has been resolved from the cache
-+     */
-+    public void setUuid( UUID uuid ) {
-+        this.uuid = uuid;
-+    }
-+
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
-+}
-diff --git a/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java
-new file mode 100644
-index 0000000..ed43b51
---- /dev/null
-+++ b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java
-@@ -0,0 +1,54 @@
-+package org.github.paperspigot.event.cache;
-+
-+import org.bukkit.event.Event;
-+import org.bukkit.event.HandlerList;
-+
-+import java.util.UUID;
-+
-+/**
-+ * Called when the UserCache has resolved a User with the help of the mojang API
-+ */
-+public class NameToUUIDResolvedEvent extends Event {
-+    private static final HandlerList handlers = new HandlerList();
-+
-+    private String name;
-+    private UUID uuid;
-+
-+    /**
-+     * Construct a new Event after it got resolved from the mojang API
-+     *
-+     * @param name of the player
++     * @param name of the profile (in correct case)
 +     * @param uuid of the profile
 +     */
-+    public NameToUUIDResolvedEvent( String name, UUID uuid ) {
-+        this.name = name;
-+        this.uuid = uuid;
-+    }
-+
-+    /**
-+     * Get the correct name of the player
-+     *
-+     * @return name in correct case
-+     */
-+    public String getName() {
-+        return name;
-+    }
-+
-+    /**
-+     * UUID of the profile which has been resolved from mojang
-+     *
-+     * @return profile UUID
-+     */
-+    public UUID getUuid() {
-+        return uuid;
-+    }
-+
-+    @Override
-+    public HandlerList getHandlers() {
-+        return handlers;
-+    }
-+
-+    public static HandlerList getHandlerList() {
-+        return handlers;
-+    }
++    void newProfile( String name, UUID uuid );
 +}
 -- 
 2.6.0.windows.1

--- a/Spigot-API-Patches/0017-API-for-Name-to-UUID-caching.patch
+++ b/Spigot-API-Patches/0017-API-for-Name-to-UUID-caching.patch
@@ -1,0 +1,135 @@
+From 74f3eba7481f1a142c94d03dab601a0756c80da0 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fabian=20Fa=C3=9Fbender?=
+ <fabian.fassbender42@googlemail.com>
+Date: Wed, 3 Feb 2016 19:32:10 +0100
+Subject: [PATCH] API for Name to UUID caching
+
+
+diff --git a/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java
+new file mode 100644
+index 0000000..7b130c6
+--- /dev/null
++++ b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolveEvent.java
+@@ -0,0 +1,59 @@
++package org.github.paperspigot.event.cache;
++
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++
++import java.util.UUID;
++
++/**
++ * Gets called when the UserCache wants to resolve a UUID from a Name
++ */
++public class NameToUUIDResolveEvent extends Event {
++    private static final HandlerList handlers = new HandlerList();
++
++    private String name;
++    private UUID uuid;
++
++    public NameToUUIDResolveEvent( String name, UUID uuid ) {
++        this.name = name;
++        this.uuid = uuid;
++    }
++
++    /**
++     * Name of the User
++     *
++     * @return unchanged name of the user
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * Should be null on the first listener but everybody else it can
++     * be the resolved UUID. When this is not null the return value is
++     * used to complete the GameProfile
++     *
++     * @return null or the resolved UUID
++     */
++    public UUID getUuid() {
++        return uuid;
++    }
++
++    /**
++     * Used by the caching implementation to set the UUID from it instead of asking Mojang to provide some
++     *
++     * @param uuid which has been resolved from the cache
++     */
++    public void setUuid( UUID uuid ) {
++        this.uuid = uuid;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java
+new file mode 100644
+index 0000000..ed43b51
+--- /dev/null
++++ b/src/main/java/org/github/paperspigot/event/cache/NameToUUIDResolvedEvent.java
+@@ -0,0 +1,54 @@
++package org.github.paperspigot.event.cache;
++
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++
++import java.util.UUID;
++
++/**
++ * Called when the UserCache has resolved a User with the help of the mojang API
++ */
++public class NameToUUIDResolvedEvent extends Event {
++    private static final HandlerList handlers = new HandlerList();
++
++    private String name;
++    private UUID uuid;
++
++    /**
++     * Construct a new Event after it got resolved from the mojang API
++     *
++     * @param name of the player
++     * @param uuid of the profile
++     */
++    public NameToUUIDResolvedEvent( String name, UUID uuid ) {
++        this.name = name;
++        this.uuid = uuid;
++    }
++
++    /**
++     * Get the correct name of the player
++     *
++     * @return name in correct case
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * UUID of the profile which has been resolved from mojang
++     *
++     * @return profile UUID
++     */
++    public UUID getUuid() {
++        return uuid;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.6.0.windows.1
+

--- a/Spigot-Server-Patches/0080-Timings-v2.patch
+++ b/Spigot-Server-Patches/0080-Timings-v2.patch
@@ -1,6 +1,6 @@
-From a74e60b0c8d1e751e7e8e29600c6068ece507919 Mon Sep 17 00:00:00 2001
+From b46d7d1913a5ef9e6966f4eab8e74146725a798e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
-Date: Fri, 8 Jan 2016 23:36:39 -0600
+Date: Fri, 8 Jan 2016 00:19:32 -0600
 Subject: [PATCH] Timings v2
 
 
@@ -1142,5 +1142,5 @@ index f6a67d6..93825d9 100644
      {
          int count = getInt( "settings.netty-threads", 4 );
 -- 
-2.7.0
+2.6.0.windows.1
 

--- a/Spigot-Server-Patches/0088-Implementation-of-the-Name-to-UUID-caching.patch
+++ b/Spigot-Server-Patches/0088-Implementation-of-the-Name-to-UUID-caching.patch
@@ -1,4 +1,4 @@
-From e81b8ed1ed3fffcad21158f5d6516b274aa1cece Mon Sep 17 00:00:00 2001
+From 05251121920f4e6bf7d13afad30e9e34274a396e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Fabian=20Fa=C3=9Fbender?=
  <fabian.fassbender42@googlemail.com>
 Date: Wed, 3 Feb 2016 19:32:44 +0100
@@ -6,33 +6,42 @@ Subject: [PATCH] Implementation of the Name to UUID caching
 
 
 diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
-index 0f82e06..d8df0f6 100644
+index 0f82e06..0865327 100644
 --- a/src/main/java/net/minecraft/server/UserCache.java
 +++ b/src/main/java/net/minecraft/server/UserCache.java
-@@ -36,6 +36,10 @@ import java.util.Locale;
+@@ -30,15 +30,17 @@ import java.util.ArrayList;
+ import java.util.Calendar;
+ import java.util.Date;
+ import java.util.Iterator;
+-import java.util.LinkedList;
+ import java.util.List;
+ import java.util.Locale;
  import java.util.Map;
  import java.util.UUID;
  import org.apache.commons.io.IOUtils;
-+import org.bukkit.Bukkit;
-+import org.github.paperspigot.event.cache.NameToUUIDResolveEvent;
-+import org.github.paperspigot.event.cache.NameToUUIDResolvedEvent;
++import org.github.paperspigot.cache.ProfileCacheAdapter;
 +import org.spigotmc.SpigotConfig;
  
  public class UserCache {
  
-@@ -75,6 +79,11 @@ public class UserCache {
++    public static ProfileCacheAdapter profileCacheAdapter = null; // PaperSpigot
+     public static final SimpleDateFormat a = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+     private final Map<String, UserCache.UserCacheEntry> c = Maps.newHashMap();
+     private final Map<UUID, UserCache.UserCacheEntry> d = Maps.newHashMap();
+@@ -75,6 +77,12 @@ public class UserCache {
          ProfileLookupCallback profilelookupcallback = new ProfileLookupCallback() {
              public void onProfileLookupSucceeded(GameProfile gameprofile) {
                  agameprofile[0] = gameprofile;
 +
-+                if (gameprofile != null && gameprofile.getId() != null && (minecraftserver.getOnlineMode() || SpigotConfig.bungee)) {
-+                    NameToUUIDResolvedEvent nameToUUIDResolvedEvent = new NameToUUIDResolvedEvent( s, agameprofile[0].getId() );
-+                    Bukkit.getPluginManager().callEvent( nameToUUIDResolvedEvent );
++                // PaperSpigot - Implement caching of uuids
++                if (profileCacheAdapter != null && gameprofile != null && gameprofile.getId() != null && (minecraftserver.getOnlineMode() || SpigotConfig.bungee)) {
++                    profileCacheAdapter.newProfile( gameprofile.getName(), gameprofile.getId() );
 +                }
++                // PaperSpigot
              }
  
              public void onProfileLookupFailed(GameProfile gameprofile, Exception exception) {
-@@ -82,12 +91,20 @@ public class UserCache {
+@@ -82,12 +90,20 @@ public class UserCache {
              }
          };
  
@@ -40,24 +49,50 @@ index 0f82e06..d8df0f6 100644
 -        if (!minecraftserver.getOnlineMode() && agameprofile[0] == null) {
 -            UUID uuid = EntityHuman.a(new GameProfile((UUID) null, s));
 -            GameProfile gameprofile = new GameProfile(uuid, s);
-+        // First check for Event (Cache)
-+        NameToUUIDResolveEvent nameToUUIDResolveEvent = new NameToUUIDResolveEvent( s, null );
-+        Bukkit.getPluginManager().callEvent(nameToUUIDResolveEvent);
++        // PaperSpigot - Check for cached UUIDs
++        if ( profileCacheAdapter != null ) {
++            UUID cachedUUID = profileCacheAdapter.resolve( s );
++            if ( cachedUUID != null ) {
++                return new GameProfile( cachedUUID, s );
++            }
++        }
++        // PaperSpigot
  
 -            profilelookupcallback.onProfileLookupSucceeded(gameprofile);
-+        if ( nameToUUIDResolveEvent.getUuid() == null ) {
-+            minecraftserver.getGameProfileRepository().findProfilesByNames( new String[]{s}, Agent.MINECRAFT, profilelookupcallback );
-+            if ( !minecraftserver.getOnlineMode() && !SpigotConfig.bungee && agameprofile[0] == null ) {
-+                UUID uuid = EntityHuman.a( new GameProfile( null, s ) );
-+                GameProfile profile = new GameProfile( uuid, s );
-+                profilelookupcallback.onProfileLookupSucceeded( profile );
-+            }
-+        } else {
-+            GameProfile gameProfile = new GameProfile( nameToUUIDResolveEvent.getUuid(), s );
-+            profilelookupcallback.onProfileLookupSucceeded( gameProfile );
++        minecraftserver.getGameProfileRepository().findProfilesByNames( new String[]{s}, Agent.MINECRAFT, profilelookupcallback );
++        if ( !minecraftserver.getOnlineMode() && !SpigotConfig.bungee && agameprofile[0] == null ) {
++            UUID uuid = EntityHuman.a( new GameProfile( null, s ) );
++            GameProfile profile = new GameProfile( uuid, s );
++            profilelookupcallback.onProfileLookupSucceeded( profile );
          }
  
          return agameprofile[0];
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 642880e..5e2599e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -102,6 +102,7 @@ import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.scheduler.BukkitWorker;
+ import org.bukkit.util.StringUtil;
+ import org.bukkit.util.permissions.DefaultPermissions;
++import org.github.paperspigot.cache.ProfileCacheAdapter;
+ import org.yaml.snakeyaml.Yaml;
+ import org.yaml.snakeyaml.constructor.SafeConstructor;
+ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -1764,6 +1765,13 @@ public final class CraftServer implements Server {
+         }
+         // PaperSpigot end
+ 
++        // PaperSpigot start - Add setProfileCacheAdapter (Third party UUID caching)
++        @Override
++        public void setProfileCacheAdapter( ProfileCacheAdapter adapter ) {
++            UserCache.profileCacheAdapter = adapter;
++        }
++        // PaperSpigot end
++
+         @Deprecated
+         @Override
+         public YamlConfiguration getConfig()
 -- 
 2.6.0.windows.1
 

--- a/Spigot-Server-Patches/0088-Implementation-of-the-Name-to-UUID-caching.patch
+++ b/Spigot-Server-Patches/0088-Implementation-of-the-Name-to-UUID-caching.patch
@@ -1,0 +1,63 @@
+From e81b8ed1ed3fffcad21158f5d6516b274aa1cece Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Fabian=20Fa=C3=9Fbender?=
+ <fabian.fassbender42@googlemail.com>
+Date: Wed, 3 Feb 2016 19:32:44 +0100
+Subject: [PATCH] Implementation of the Name to UUID caching
+
+
+diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
+index 0f82e06..d8df0f6 100644
+--- a/src/main/java/net/minecraft/server/UserCache.java
++++ b/src/main/java/net/minecraft/server/UserCache.java
+@@ -36,6 +36,10 @@ import java.util.Locale;
+ import java.util.Map;
+ import java.util.UUID;
+ import org.apache.commons.io.IOUtils;
++import org.bukkit.Bukkit;
++import org.github.paperspigot.event.cache.NameToUUIDResolveEvent;
++import org.github.paperspigot.event.cache.NameToUUIDResolvedEvent;
++import org.spigotmc.SpigotConfig;
+ 
+ public class UserCache {
+ 
+@@ -75,6 +79,11 @@ public class UserCache {
+         ProfileLookupCallback profilelookupcallback = new ProfileLookupCallback() {
+             public void onProfileLookupSucceeded(GameProfile gameprofile) {
+                 agameprofile[0] = gameprofile;
++
++                if (gameprofile != null && gameprofile.getId() != null && (minecraftserver.getOnlineMode() || SpigotConfig.bungee)) {
++                    NameToUUIDResolvedEvent nameToUUIDResolvedEvent = new NameToUUIDResolvedEvent( s, agameprofile[0].getId() );
++                    Bukkit.getPluginManager().callEvent( nameToUUIDResolvedEvent );
++                }
+             }
+ 
+             public void onProfileLookupFailed(GameProfile gameprofile, Exception exception) {
+@@ -82,12 +91,20 @@ public class UserCache {
+             }
+         };
+ 
+-        minecraftserver.getGameProfileRepository().findProfilesByNames(new String[] { s}, Agent.MINECRAFT, profilelookupcallback);
+-        if (!minecraftserver.getOnlineMode() && agameprofile[0] == null) {
+-            UUID uuid = EntityHuman.a(new GameProfile((UUID) null, s));
+-            GameProfile gameprofile = new GameProfile(uuid, s);
++        // First check for Event (Cache)
++        NameToUUIDResolveEvent nameToUUIDResolveEvent = new NameToUUIDResolveEvent( s, null );
++        Bukkit.getPluginManager().callEvent(nameToUUIDResolveEvent);
+ 
+-            profilelookupcallback.onProfileLookupSucceeded(gameprofile);
++        if ( nameToUUIDResolveEvent.getUuid() == null ) {
++            minecraftserver.getGameProfileRepository().findProfilesByNames( new String[]{s}, Agent.MINECRAFT, profilelookupcallback );
++            if ( !minecraftserver.getOnlineMode() && !SpigotConfig.bungee && agameprofile[0] == null ) {
++                UUID uuid = EntityHuman.a( new GameProfile( null, s ) );
++                GameProfile profile = new GameProfile( uuid, s );
++                profilelookupcallback.onProfileLookupSucceeded( profile );
++            }
++        } else {
++            GameProfile gameProfile = new GameProfile( nameToUUIDResolveEvent.getUuid(), s );
++            profilelookupcallback.onProfileLookupSucceeded( gameProfile );
+         }
+ 
+         return agameprofile[0];
+-- 
+2.6.0.windows.1
+


### PR DESCRIPTION
Some bigger Networks have the problem of hitting the Mojang API Limit with multiple instances at once. The solution was to implement some sort of HTTP Proxy which always has been a pain. This implementation can use caching of any sort. 
