### PR TITLE
Ensure inv drag is in bounds - Fixes #30

### DIFF
--- a/Spigot-Server-Patches/0095-Ensure-inv-drag-is-in-bounds.patch
+++ b/Spigot-Server-Patches/0095-Ensure-inv-drag-is-in-bounds.patch
@@ -1,0 +1,22 @@
+From 66012dd148e4fd8a3645c1388927c4260de23c8c Mon Sep 17 00:00:00 2001
+From: Joseph Hirschfeld <joe@ibj.io>
+Date: Sat, 20 Feb 2016 02:19:31 -0500
+Subject: [PATCH] Ensure inv drag is in bounds
+
+
+diff --git a/src/main/java/net/minecraft/server/Container.java b/src/main/java/net/minecraft/server/Container.java
+index 3cfaa75..3818ceb 100644
+--- a/src/main/java/net/minecraft/server/Container.java
++++ b/src/main/java/net/minecraft/server/Container.java
+@@ -138,7 +138,7 @@ public abstract class Container {
+                     this.d();
+                 }
+             } else if (this.g == 1) {
+-                Slot slot = (Slot) this.c.get(i);
++                Slot slot = i < this.c.size() ? this.c.get(i) : null; //PaperSpigot- ensure drag in bounds
+ 
+                 if (slot != null && a(slot, playerinventory.getCarried(), true) && slot.isAllowed(playerinventory.getCarried()) && playerinventory.getCarried().count > this.h.size() && this.b(slot)) {
+                     this.h.add(slot);
+-- 
+2.5.0
+


### PR DESCRIPTION
#30 looked like a malicious party was dragging with an illegal index. This will simply ignore the input in the future, assuming it is unintended.
