### PR TITLE
[Untested] Fix iteration speed in NavigationListener

### DIFF
--- a/Spigot-Server-Patches/0003-mc-dev-imports.patch
+++ b/Spigot-Server-Patches/0003-mc-dev-imports.patch
@@ -1,4 +1,4 @@
-From 541eaa4579cd06028863b58078500cdcb86fab6d Mon Sep 17 00:00:00 2001
+From 2ed32dcde7b7d6a64d067738d321a57ee0e47e36 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 21:09:10 -0600
 Subject: [PATCH] mc-dev imports
@@ -3123,6 +3123,81 @@ index 0000000..2f4265a
 +        return this.b.getType(blockposition.down()).b();
 +    }
 +}
+diff --git a/src/main/java/net/minecraft/server/NavigationListener.java b/src/main/java/net/minecraft/server/NavigationListener.java
+new file mode 100644
+index 0000000..f82ea80
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/NavigationListener.java
+@@ -0,0 +1,69 @@
++package net.minecraft.server;
++
++import java.util.WeakHashMap;
++
++public class NavigationListener implements IWorldAccess {
++
++    private static final Object a = new Object();
++    private final WeakHashMap<NavigationAbstract, Object> b = new WeakHashMap();
++
++    public NavigationListener() {}
++
++    public void a(NavigationAbstract navigationabstract) {
++        this.b.put(navigationabstract, NavigationListener.a);
++    }
++
++    public void a(World world, BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1, int i) {
++        if (this.a(world, blockposition, iblockdata, iblockdata1)) {
++            NavigationAbstract[] anavigationabstract = (NavigationAbstract[]) this.b.keySet().toArray(new NavigationAbstract[0]);
++            NavigationAbstract[] anavigationabstract1 = anavigationabstract;
++            int j = anavigationabstract.length;
++
++            for (int k = 0; k < j; ++k) {
++                NavigationAbstract navigationabstract = anavigationabstract1[k];
++
++                if (navigationabstract != null && !navigationabstract.i()) {
++                    PathEntity pathentity = navigationabstract.k();
++
++                    if (pathentity != null && !pathentity.b() && pathentity.d() != 0) {
++                        PathPoint pathpoint = navigationabstract.c.c();
++                        double d0 = blockposition.distanceSquared(((double) pathpoint.a + navigationabstract.a.locX) / 2.0D, ((double) pathpoint.b + navigationabstract.a.locY) / 2.0D, ((double) pathpoint.c + navigationabstract.a.locZ) / 2.0D);
++                        int l = (pathentity.d() - pathentity.e()) * (pathentity.d() - pathentity.e());
++
++                        if (d0 < (double) l) {
++                            navigationabstract.j();
++                        }
++                    }
++                }
++            }
++
++        }
++    }
++
++    protected boolean a(World world, BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1) {
++        AxisAlignedBB axisalignedbb = iblockdata.d(world, blockposition);
++        AxisAlignedBB axisalignedbb1 = iblockdata1.d(world, blockposition);
++
++        return axisalignedbb != axisalignedbb1 && (axisalignedbb == null || !axisalignedbb.equals(axisalignedbb1));
++    }
++
++    public void a(BlockPosition blockposition) {}
++
++    public void a(int i, int j, int k, int l, int i1, int j1) {}
++
++    public void a(EntityHuman entityhuman, SoundEffect soundeffect, SoundCategory soundcategory, double d0, double d1, double d2, float f, float f1) {}
++
++    public void a(int i, boolean flag, double d0, double d1, double d2, double d3, double d4, double d5, int... aint) {}
++
++    public void a(Entity entity) {}
++
++    public void b(Entity entity) {}
++
++    public void a(SoundEffect soundeffect, BlockPosition blockposition) {}
++
++    public void a(int i, BlockPosition blockposition, int j) {}
++
++    public void a(EntityHuman entityhuman, int i, BlockPosition blockposition, int j) {}
++
++    public void b(int i, BlockPosition blockposition, int j) {}
++}
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalFloat.java b/src/main/java/net/minecraft/server/PathfinderGoalFloat.java
 new file mode 100644
 index 0000000..1a20dbf
@@ -3391,5 +3466,5 @@ index 0000000..2286c9e
 +    }
 +}
 -- 
-2.7.2
+2.7.1
 

--- a/Spigot-Server-Patches/0036-Stop-updating-flowing-block-if-material-has-changed.patch
+++ b/Spigot-Server-Patches/0036-Stop-updating-flowing-block-if-material-has-changed.patch
@@ -1,4 +1,4 @@
-From f78ee3cdf59990c2d828a298c6bf4c06bcd82dc0 Mon Sep 17 00:00:00 2001
+From 09d4d444cad72200010dfe7ee07085bee41af771 Mon Sep 17 00:00:00 2001
 From: Iceee <andrew@opticgaming.tv>
 Date: Wed, 2 Mar 2016 12:03:23 -0600
 Subject: [PATCH] Stop updating flowing block if material has changed
@@ -17,5 +17,5 @@ index f35f30c..1f07f82 100644
  
          if (this.h(world, blockposition.down(), iblockdata2)) {
 -- 
-2.7.2
+2.7.1
 

--- a/Spigot-Server-Patches/0037-Fast-draining.patch
+++ b/Spigot-Server-Patches/0037-Fast-draining.patch
@@ -1,4 +1,4 @@
-From 60647fcd622bf436128c3f5d98e953ec0530a013 Mon Sep 17 00:00:00 2001
+From 5f99f22ddcc3e3c54d63ae96003921becdb3acde Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Wed, 2 Mar 2016 12:20:52 -0600
 Subject: [PATCH] Fast draining
@@ -96,5 +96,5 @@ index 1f07f82..517c1e8 100644
 +    }
  }
 -- 
-2.7.2
+2.7.1
 

--- a/Spigot-Server-Patches/0078-Fix-iteration-speed-in-NavigationListener.patch
+++ b/Spigot-Server-Patches/0078-Fix-iteration-speed-in-NavigationListener.patch
@@ -1,0 +1,91 @@
+From bac54e7fdf4fc01e7612add17775850de8ab036a Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@outlook.com>
+Date: Fri, 4 Mar 2016 23:12:22 -0700
+Subject: [PATCH] Fix iteration speed in NavigationListener
+
+Mojang was iterating over a copy of a key set of a map.
+This was very slow, since maps are slow, and copies are pretty slow.
+Mojang was using maps for their weak-key functionality, which we reimplement directly.
+
+diff --git a/src/main/java/net/minecraft/server/NavigationListener.java b/src/main/java/net/minecraft/server/NavigationListener.java
+index f82ea80..a2e4d0c 100644
+--- a/src/main/java/net/minecraft/server/NavigationListener.java
++++ b/src/main/java/net/minecraft/server/NavigationListener.java
+@@ -1,26 +1,56 @@
+ package net.minecraft.server;
+ 
+ import java.util.WeakHashMap;
++// Paper start
++import java.lang.ref.WeakReference;
++import java.lang.ref.Reference;
++import java.lang.ref.ReferenceQueue;
++import java.util.HashSet;
++import java.util.Set;
++import java.util.List;
++import java.util.ArrayList;
++// Paper end
+ 
+ public class NavigationListener implements IWorldAccess {
+-
+-    private static final Object a = new Object();
+-    private final WeakHashMap<NavigationAbstract, Object> b = new WeakHashMap();
++    // Paper start
++    private final List<Reference<NavigationAbstract>> navigations = new ArrayList<>();
++    private static final ReferenceQueue<NavigationAbstract> referenceQueue = new ReferenceQueue<>();
++
++    private void cleanup() {
++        Reference<NavigationAbstract> navigation;
++        Set<Reference<NavigationAbstract>> toRemove = new HashSet<>();
++        while ((navigation = (Reference<NavigationAbstract>) referenceQueue.poll()) != null) {
++            toRemove.add(navigation);
++        }
++        navigations.removeAll(toRemove);
++    }
++    // Paper end
+ 
+     public NavigationListener() {}
+ 
+     public void a(NavigationAbstract navigationabstract) {
+-        this.b.put(navigationabstract, NavigationListener.a);
++        // Paper start
++        if (navigationabstract == null) throw new IllegalArgumentException("Null navigation");
++        cleanup();
++        navigations.add(new WeakReference<>(navigationabstract));
++        // Paper end
+     }
+ 
+     public void a(World world, BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1, int i) {
+         if (this.a(world, blockposition, iblockdata, iblockdata1)) {
+-            NavigationAbstract[] anavigationabstract = (NavigationAbstract[]) this.b.keySet().toArray(new NavigationAbstract[0]);
+-            NavigationAbstract[] anavigationabstract1 = anavigationabstract;
+-            int j = anavigationabstract.length;
+-
++            // Paper start - iterate over our own array instead of a copied array from the set
++            cleanup();
++            Set<Reference<NavigationAbstract>> toRemove = new HashSet<>();
++            int j = navigations.size();
+             for (int k = 0; k < j; ++k) {
+-                NavigationAbstract navigationabstract = anavigationabstract1[k];
++                Reference<NavigationAbstract> ref = navigations.get(k);
++                NavigationAbstract navigationabstract = ref.get();
++                if (navigationabstract == null) {
++                    // Ugg, lets remove this
++                    toRemove.add(ref);
++                    continue;
++                }
++                // Paper end
+ 
+                 if (navigationabstract != null && !navigationabstract.i()) {
+                     PathEntity pathentity = navigationabstract.k();
+@@ -36,7 +66,7 @@ public class NavigationListener implements IWorldAccess {
+                     }
+                 }
+             }
+-
++            navigations.removeAll(toRemove); // Paper
+         }
+     }
+ 
+-- 
+2.7.1
+


### PR DESCRIPTION
Should fix #51 if it works.

Mojang was iterating over a copy of a key set of a map. (quite a mouthful)
This was very slow, since maps are slow, and copies are pretty slow.
Mojang was using maps for their weak-key functionality, which we reimplement directly.

This is untested.
@mibby please test.
