### PR TITLE
Add methods for working with arrows stuck in living entities

### DIFF
--- a/Spigot-API-Patches/0021-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/Spigot-API-Patches/0021-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -1,0 +1,34 @@
+From 1cb67a39c970d8d631acce5e5b4c0a1ddb295c13 Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Sun, 25 Nov 2012 13:47:27 -0600
+Subject: [PATCH] Add methods for working with arrows stuck in living entities
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 46347b9..56c837b 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -366,4 +366,20 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+      * @return whether the operation was successful
+      */
+     public boolean setLeashHolder(Entity holder);
++
++    // Paper start
++    /**
++     * Get the number of arrows stuck in this entity
++     *
++     * @return Number of arrows stuck
++     */
++    int getArrowsStuck();
++
++    /**
++     * Set the number of arrows stuck in this entity
++     *
++     * @param arrows Number of arrows to stick in this entity
++     */
++    void setArrowsStuck(int arrows);
++    // Paper end
+ }
+-- 
+2.7.2
+

--- a/Spigot-Server-Patches/0080-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/Spigot-Server-Patches/0080-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -1,0 +1,47 @@
+From 080f6f76edc93265017af03097d1a11e744630f1 Mon Sep 17 00:00:00 2001
+From: mrapple <tony@oc.tc>
+Date: Sun, 25 Nov 2012 13:43:39 -0600
+Subject: [PATCH] Add methods for working with arrows stuck in living entities
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index b10475f..37d877e 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1264,10 +1264,12 @@ public abstract class EntityLiving extends Entity {
+         return (float) this.getAttributeInstance(GenericAttributes.maxHealth).getValue();
+     }
+ 
++    public final int getStuckArrows() { return this.bX(); } // Paper - deobfuscation helper
+     public final int bX() {
+         return ((Integer) this.datawatcher.get(EntityLiving.h)).intValue();
+     }
+ 
++    public final void setStuckArrows(int arrows) { this.k(arrows); } // Paper - deobfuscation helper
+     public final void k(int i) {
+         this.datawatcher.set(EntityLiving.h, Integer.valueOf(i));
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index ebf378b..c9564bd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -503,4 +503,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public AttributeInstance getAttribute(Attribute attribute) {
+         return getHandle().craftAttributes.getAttribute(attribute);
+     }
++
++    // Paper start
++    @Override
++    public int getArrowsStuck() {
++        return this.getHandle().getStuckArrows();
++    }
++
++    @Override
++    public void setArrowsStuck(int arrows) {
++        this.getHandle().setStuckArrows(arrows);
++    }
++    // Paper end
+ }
+-- 
+2.7.2
+


### PR DESCRIPTION
This brings in https://github.com/OvercastNetwork/SportBukkit/blob/rebase19/Bukkit/0003-Add-methods-for-working-with-arrows-stuck-in-living-.patch and https://github.com/OvercastNetwork/SportBukkit/blob/rebase19/CraftBukkit/0007-Add-methods-for-working-with-arrows-stuck-in-living-.patch from SportBukkit.
