### PR TITLE
Allow Reloading of Custom Permissions

### DIFF
--- a/Spigot-API-Patches/0026-Add-command-to-reload-permissions.yml.patch
+++ b/Spigot-API-Patches/0026-Add-command-to-reload-permissions.yml.patch
@@ -1,0 +1,83 @@
+From e78f2b0a6014d98fb0dd2992da41e321176d94ea Mon Sep 17 00:00:00 2001
+From: William <admin@domnian.com>
+Date: Fri, 18 Mar 2016 03:28:07 -0400
+Subject: [PATCH] Add command to reload permissions.yml
+
+https://github.com/PaperMC/Paper/issues/49
+
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 91bde81..6b1f2a4 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1018,4 +1018,6 @@ public interface Server extends PluginMessageRecipient {
+     }
+ 
+     Spigot spigot();
++
++    void reloadPermissions(); // Paper
+ }
+diff --git a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+index c70d512..7f32a7c 100644
+--- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+@@ -11,15 +11,28 @@ public class ReloadCommand extends BukkitCommand {
+     public ReloadCommand(String name) {
+         super(name);
+         this.description = "Reloads the server configuration and plugins";
+-        this.usageMessage = "/reload";
++        this.usageMessage = "/reload [permissions]"; // Paper
+         this.setPermission("bukkit.command.reload");
+         this.setAliases(Arrays.asList("rl"));
+     }
+ 
+     @Override
+     public boolean execute(CommandSender sender, String currentAlias, String[] args) {
++
+         if (!testPermission(sender)) return true;
+ 
++        // Paper start - Reload permissions.yml (PAPER-49)
++        if (args.length == 1) {
++            if (args[0].equalsIgnoreCase("permissions")) {
++                Bukkit.getServer().reloadPermissions();
++                Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Permissions successfully reloaded.");
++                return true;
++            } else {
++                return false;
++            }
++        }
++        // Paper end
++
+         Command.broadcastCommandMessage(sender, ChatColor.RED + "Please note that this command is not supported and may cause issues when using some plugins.");
+         Command.broadcastCommandMessage(sender, ChatColor.RED + "If you encounter any issues please use the /stop command to restart your server.");
+         Bukkit.reload();
+@@ -32,7 +45,8 @@ public class ReloadCommand extends BukkitCommand {
+     @Override
+     public java.util.List<String> tabComplete(CommandSender sender, String alias, String[] args) throws IllegalArgumentException
+     {
+-        return java.util.Collections.emptyList();
++        return java.util.Collections.singletonList("permissions"); // Paper
+     }
+     // Spigot End
++
+ }
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 49f5872..e988a7c 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -750,4 +750,13 @@ public final class SimplePluginManager implements PluginManager {
+     public void useTimings(boolean use) {
+         co.aikar.timings.Timings.setTimingsEnabled(use); // Spigot
+     }
++
++    // Paper start
++    public void clearPermissions() {
++        permissions.clear();
++        defaultPerms.get(true).clear();
++        defaultPerms.get(false).clear();
++    }
++    // Paper end
++
+ }
+-- 
+2.5.0
+

--- a/Spigot-Server-Patches/0085-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0085-Allow-Reloading-of-Custom-Permissions.patch
@@ -1,0 +1,27 @@
+From 8b0fab818c1a07dab47347144e4b53e395cf4e99 Mon Sep 17 00:00:00 2001
+From: William <admin@domnian.com>
+Date: Fri, 18 Mar 2016 03:30:17 -0400
+Subject: [PATCH] Allow Reloading of Custom Permissions
+
+https://github.com/PaperMC/Paper/issues/49
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index cb9906a..3977bff 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1833,4 +1833,12 @@ public final class CraftServer implements Server {
+     {
+         return spigot;
+     }
++
++    // Paper start
++    @Override
++    public void reloadPermissions() {
++        ((SimplePluginManager) pluginManager).clearPermissions();
++        loadCustomPermissions();
++    }
++    // Paper end
+ }
+-- 
+2.5.0
+


### PR DESCRIPTION
Add the ability to reload the custom permissions file by doing "/reload permissions"
Implements Feature Request: https://github.com/PaperMC/Paper/issues/49

Sorry about reposting/recreating this, but I was unable to re-open the original PR.
