### PR TITLE
Banner waving workaround

### DIFF
--- a/Spigot-Server-Patches/0003-mc-dev-imports.patch
+++ b/Spigot-Server-Patches/0003-mc-dev-imports.patch
@@ -1,4 +1,4 @@
-From c247bf9b0fb7799531e500d1ba852b887aa3e613 Mon Sep 17 00:00:00 2001
+From 175bf165592619de67980426a5dd8cfbc629d194 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 21:09:10 -0600
 Subject: [PATCH] mc-dev imports
@@ -5037,6 +5037,49 @@ index 0000000..30ca225
 +        private EnumResourcePackStatus() {}
 +    }
 +}
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+new file mode 100644
+index 0000000..c5c3f40
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+@@ -0,0 +1,37 @@
++package net.minecraft.server;
++
++import java.io.IOException;
++
++public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
++
++    private long a;
++    private long b;
++
++    public PacketPlayOutUpdateTime() {}
++
++    public PacketPlayOutUpdateTime(long i, long j, boolean flag) {
++        this.a = i;
++        this.b = j;
++        if (!flag) {
++            this.b = -this.b;
++            if (this.b == 0L) {
++                this.b = -1L;
++            }
++        }
++
++    }
++
++    public void a(PacketDataSerializer packetdataserializer) throws IOException {
++        this.a = packetdataserializer.readLong();
++        this.b = packetdataserializer.readLong();
++    }
++
++    public void b(PacketDataSerializer packetdataserializer) throws IOException {
++        packetdataserializer.writeLong(this.a);
++        packetdataserializer.writeLong(this.b);
++    }
++
++    public void a(PacketListenerPlayOut packetlistenerplayout) {
++        packetlistenerplayout.a(this);
++    }
++}
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalFloat.java b/src/main/java/net/minecraft/server/PathfinderGoalFloat.java
 new file mode 100644
 index 0000000..1a20dbf
@@ -5577,5 +5620,5 @@ index 0000000..2286c9e
 +    }
 +}
 -- 
-2.7.4.windows.1
+2.7.4
 

--- a/Spigot-Server-Patches/0024-FallingBlock-and-TNTPrimed-source-location-API.patch
+++ b/Spigot-Server-Patches/0024-FallingBlock-and-TNTPrimed-source-location-API.patch
@@ -1,4 +1,4 @@
-From 6e8b4f64650ff93e2a9ae61032fc47165a7ab07b Mon Sep 17 00:00:00 2001
+From efc500c63a06c023dbb9c79c72ec0affd8d7bc1f Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Tue, 1 Mar 2016 23:45:08 -0600
 Subject: [PATCH] FallingBlock and TNTPrimed source location API
@@ -193,10 +193,10 @@ index 564ea37..1820c7b 100644
  
      public EntityLiving getSource() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a487c2f..33c3428 100644
+index 83e3003..25edfb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -916,7 +916,10 @@ public class CraftWorld implements World {
+@@ -921,7 +921,10 @@ public class CraftWorld implements World {
          double y = location.getBlockY() + 0.5;
          double z = location.getBlockZ() + 0.5;
  
@@ -208,7 +208,7 @@ index a487c2f..33c3428 100644
          entity.ticksLived = 1;
  
          world.addEntity(entity, SpawnReason.CUSTOM);
-@@ -952,7 +955,10 @@ public class CraftWorld implements World {
+@@ -957,7 +960,10 @@ public class CraftWorld implements World {
              int type = CraftMagicNumbers.getId(blockData.getBlock());
              int data = blockData.getBlock().toLegacyData(blockData);
  
@@ -220,7 +220,7 @@ index a487c2f..33c3428 100644
          } else if (Projectile.class.isAssignableFrom(clazz)) {
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new EntitySnowball(world, x, y, z);
-@@ -1157,7 +1163,8 @@ public class CraftWorld implements World {
+@@ -1162,7 +1168,8 @@ public class CraftWorld implements World {
                  throw new IllegalArgumentException("Cannot spawn hanging entity for " + clazz.getName() + " at " + location);
              }
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {

--- a/Spigot-Server-Patches/0101-Waving-banner-workaround.patch
+++ b/Spigot-Server-Patches/0101-Waving-banner-workaround.patch
@@ -1,0 +1,37 @@
+From 2b2d1075dc7870416e90329e352e5fa2aff32998 Mon Sep 17 00:00:00 2001
+From: Gabscap <sonstige.netzwerke@gabriel-paradzik.de>
+Date: Sat, 19 Mar 2016 22:25:11 +0100
+Subject: [PATCH] Waving banner workaround
+
+This patch is a workaround for MC-63720
+
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+index c5c3f40..3ed2356 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+@@ -4,7 +4,11 @@ import java.io.IOException;
+ 
+ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
+ 
++    // World Age in ticks
++    // Not changed by server commands
+     private long a;
++    // Time of Day in ticks
++    // If negative the sun will stop moving at the Math.abs of the time
+     private long b;
+ 
+     public PacketPlayOutUpdateTime() {}
+@@ -19,6 +23,10 @@ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
+             }
+         }
+ 
++        // Paper start
++        this.a = this.a % 192000; // World age must not be negative
++        this.b = this.b % 192000 - (this.b < 0 ? 192000 : 0); // Keep sign
++        // Paper end
+     }
+ 
+     public void a(PacketDataSerializer packetdataserializer) throws IOException {
+-- 
+2.7.4
+


### PR DESCRIPTION
[MC-63720](https://bugs.mojang.com/browse/MC-63720) causes the client not to render moving banners correctly if the full server time exceeds a certain number. This patch should work as a workaround by sending every player the lowest possible time, so that all 8 moon phases are displayed correctly.

I can also add a paper config option if desired.
