### PR TITLE
Fix backwards compatibility with spigot title api

### DIFF
--- a/Spigot-Server-Patches/0069-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-Server-Patches/0069-Player-Tab-List-and-Title-APIs.patch
@@ -1,11 +1,11 @@
-From 17182b51ae5cd672659b0a43455af918e8bb60c9 Mon Sep 17 00:00:00 2001
+From 6bc0cb76575e073281e081ed2e932a1c7ddede7f Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Thu, 3 Mar 2016 02:32:10 -0600
 Subject: [PATCH] Player Tab List and Title APIs
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 10bf160..0c2d2c6 100644
+index 10bf160..70f3fcc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -99,31 +99,29 @@ index 10bf160..0c2d2c6 100644
      // Paper end
  
      @Override
-@@ -1341,21 +1419,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
- 
+@@ -1342,19 +1420,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void sendTitle(String title, String subtitle) {
--        if (title != null) {
+         if (title != null) {
 -            PacketPlayOutTitle packetTitle = new PacketPlayOutTitle(EnumTitleAction.TITLE, CraftChatMessage.fromString(title)[0]);
--            getHandle().playerConnection.sendPacket(packetTitle);
--        }
--
--        if (subtitle != null) {
++            PacketPlayOutTitle packetTitle = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.TITLE, CraftChatMessage.fromString(title)[0]);
+             getHandle().playerConnection.sendPacket(packetTitle);
+         }
+ 
+         if (subtitle != null) {
 -            PacketPlayOutTitle packetSubtitle = new PacketPlayOutTitle(EnumTitleAction.SUBTITLE, CraftChatMessage.fromString(subtitle)[0]);
--            getHandle().playerConnection.sendPacket(packetSubtitle);
--        }
-+        Preconditions.checkNotNull(title, "Null title");
-+        this.sendTitle(new Title(title, subtitle));
++            PacketPlayOutTitle packetSubtitle = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.SUBTITLE, CraftChatMessage.fromString(subtitle)[0]);
+             getHandle().playerConnection.sendPacket(packetSubtitle);
+         }
      }
  
      @Override
      public void resetTitle() {
 -        PacketPlayOutTitle packetReset = new PacketPlayOutTitle(EnumTitleAction.RESET, null);
--        getHandle().playerConnection.sendPacket(packetReset);
-+        getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.RESET, (BaseComponent[]) null, 0, 0, 0));
++        PacketPlayOutTitle packetReset = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.RESET, null);
+         getHandle().playerConnection.sendPacket(packetReset);
      }
  
-     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/PacketPlayOutPlayerListHeaderFooter.java b/src/main/java/org/bukkit/craftbukkit/entity/PacketPlayOutPlayerListHeaderFooter.java
 index 842db1d..2d1bc58 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/PacketPlayOutPlayerListHeaderFooter.java

--- a/Spigot-Server-Patches/0080-Complete-resource-pack-API.patch
+++ b/Spigot-Server-Patches/0080-Complete-resource-pack-API.patch
@@ -1,4 +1,4 @@
-From f73bf84af55020b362b2dca1b51f1f706c0e4205 Mon Sep 17 00:00:00 2001
+From 8deb8c6b91025b9a8d39fdb3f5245c3f06066ff6 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sat, 4 Apr 2015 23:17:52 -0400
 Subject: [PATCH] Complete resource pack API
@@ -37,7 +37,7 @@ index 27f78ab..1b16b54 100644
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4be2653..b2b2bf4 100644
+index ca48442..46533fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -72,6 +72,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -51,7 +51,7 @@ index 4be2653..b2b2bf4 100644
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
          super(server, entity);
-@@ -1514,6 +1518,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1522,6 +1526,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          ((WorldServer) getHandle().world).getPlayerChunkMap().updateViewDistance(getHandle(), viewDistance);
      }
@@ -86,5 +86,5 @@ index 4be2653..b2b2bf4 100644
  
      // Spigot start
 -- 
-2.7.3
+2.7.2
 


### PR DESCRIPTION
I shouldn't have assumed their api was anything other but a thin (and incomplete) wrapper over the packets.

Fixes #94
