### PR TITLE
Fix build error

### DIFF
--- a/applyPatches.sh
+++ b/applyPatches.sh
@@ -43,7 +43,7 @@ basedir=$basedir/Spigot
 applyPatch ../Bukkit Spigot-API HEAD && applyPatch ../CraftBukkit Spigot-Server patched
 # Move out of Spigot
 popd
-basedir=$(dirname $basedir)
+basedir=$(dirname "$basedir")
 
 # Apply paper
 applyPatch Spigot/Spigot-API Paper-API HEAD && applyPatch Spigot/Spigot-Server Paper-Server HEAD


### PR DESCRIPTION
If the path to the Paper repository contained a space, it would fail to execute
`dirname $PATH_WITH_SPACE`

Fix for #130 
