### PR TITLE
Load chunks before player teleport - Fixes #147

### DIFF
--- a/Spigot-Server-Patches/0110-Load-chunk-before-player-teleport.patch
+++ b/Spigot-Server-Patches/0110-Load-chunk-before-player-teleport.patch
@@ -1,0 +1,27 @@
+From faf78a71681822c4466de19eeb9f92f2df454e29 Mon Sep 17 00:00:00 2001
+From: Gabscap <sonstige.netzwerke@gabriel-paradzik.de>
+Date: Sat, 26 Mar 2016 18:41:22 +0100
+Subject: [PATCH] Load chunk before player teleport
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 8b1daaf..0e56151 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -553,6 +553,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             getHandle().closeInventory();
+         }
+ 
++        // Paper start - Load chunk before player teleport
++        org.bukkit.Chunk chunk = to.getChunk();
++        if (!chunk.isLoaded()) {
++            chunk.load();
++        }
++        // Paper end
++
+         // Check if the fromWorld and toWorld are the same.
+         if (fromWorld == toWorld) {
+             entity.playerConnection.teleport(to);
+-- 
+2.7.4
+


### PR DESCRIPTION
Load the destination chunk before teleporting the player. Fixes #147 
