### PR TITLE
Add a workaround for bugged Minecart drop names

### DIFF
--- a/Spigot-Server-Patches/0113-Minecart-drop-name-workaround.patch
+++ b/Spigot-Server-Patches/0113-Minecart-drop-name-workaround.patch
@@ -1,0 +1,24 @@
+From fad038a0de0981cdc89c2e0d4d8818e4ab6b4d16 Mon Sep 17 00:00:00 2001
+From: Fabse <fabse@uwmc.info>
+Date: Mon, 28 Mar 2016 00:46:46 +0200
+Subject: [PATCH] Minecart drop name workaround
+
+This is a workaround for MC-68446 (or similar).
+In Survival Minecraft this bug only shows in minecart drops, so this is the only thing fixed here.
+
+diff --git a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+index a649ae7..f0d503c 100644
+--- a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+@@ -168,7 +168,7 @@ public abstract class EntityMinecartAbstract extends Entity implements INamableT
+         if (this.world.getGameRules().getBoolean("doEntityDrops")) {
+             ItemStack itemstack = new ItemStack(Items.MINECART, 1);
+ 
+-            if (this.getName() != null) {
++            if (this.hasCustomName()) { // Paper - Only set item name if custom name is set. Workaround for MC-68446
+                 itemstack.c(this.getName());
+             }
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
Currently when destroying a Minecart the drop is named "entity.MinecartRideable.name". This is a workaround by not setting a name for the drop if there is no custom name.

The same behavior happens to other entities/items as well, see [MC-68446](https://bugs.mojang.com/browse/MC-68446).
I only fixed it for Minecart drops, as this is the only behavior that will happen during Survival Minecraft.
