### PR TITLE
Also Reload Plugin-Defined Permissions

### DIFF
--- a/Spigot-Server-Patches/0083-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0083-Allow-Reloading-of-Custom-Permissions.patch
@@ -1,4 +1,4 @@
-From f16d9f3d2bd240842f3320382d4b11f5d9df0647 Mon Sep 17 00:00:00 2001
+From baab12e28aa5f7507d3c3ca7493ca47354c39117 Mon Sep 17 00:00:00 2001
 From: William <admin@domnian.com>
 Date: Fri, 18 Mar 2016 03:30:17 -0400
 Subject: [PATCH] Allow Reloading of Custom Permissions
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5b91630..ab18e1a 100644
+index 5b91630..20a8ef7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1834,4 +1834,12 @@ public final class CraftServer implements Server {
+@@ -1834,4 +1834,21 @@ public final class CraftServer implements Server {
      {
          return spigot;
      }
@@ -19,9 +19,18 @@ index 5b91630..ab18e1a 100644
 +    public void reloadPermissions() {
 +        ((SimplePluginManager) pluginManager).clearPermissions();
 +        loadCustomPermissions();
++        for (Plugin plugin : pluginManager.getPlugins()) {
++            plugin.getDescription().getPermissions().forEach((perm) -> {
++                try {
++                    pluginManager.addPermission(perm);
++                } catch (IllegalArgumentException ex) {
++                    getLogger().log(Level.WARNING, "Plugin " + plugin.getDescription().getFullName() + " tried to register permission '" + perm.getName() + "' but it's already registered", ex);
++                }
++            });
++        }
 +    }
 +    // Paper end
  }
 -- 
-2.8.0
+2.5.0
 

--- a/Spigot-Server-Patches/0119-Add-getEntity-by-UUID-API.patch
+++ b/Spigot-Server-Patches/0119-Add-getEntity-by-UUID-API.patch
@@ -1,4 +1,4 @@
-From 1225a5c9172f97e3dd4edb31ce1357ab905ea957 Mon Sep 17 00:00:00 2001
+From 93bf1fc5f332c5e23f50737a5ca7197cd92c1522 Mon Sep 17 00:00:00 2001
 From: DemonWav <demonwav@gmail.com>
 Date: Wed, 30 Mar 2016 01:20:11 -0500
 Subject: [PATCH] Add getEntity by UUID API
@@ -30,7 +30,7 @@ index 058735e..06dec17 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 281f4a4..128b597 100644
+index e957ed0..0a5301f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,6 +46,7 @@ import org.bukkit.configuration.serialization.ConfigurationSerialization;
@@ -41,9 +41,9 @@ index 281f4a4..128b597 100644
  import org.bukkit.craftbukkit.entity.CraftPlayer;
  import org.bukkit.craftbukkit.generator.CraftChunkData;
  import org.bukkit.craftbukkit.help.SimpleHelpMap;
-@@ -1849,5 +1850,14 @@ public final class CraftServer implements Server {
-         ((SimplePluginManager) pluginManager).clearPermissions();
-         loadCustomPermissions();
+@@ -1858,5 +1859,14 @@ public final class CraftServer implements Server {
+             });
+         }
      }
 +
 +    @Override
@@ -57,5 +57,5 @@ index 281f4a4..128b597 100644
      // Paper end
  }
 -- 
-2.8.0
+2.5.0
 


### PR DESCRIPTION
Reload plugin-defined permission nodes when running `/reload permissions`
Closes GH-210
