### PR TITLE
Fix silly Javadocs in Bukkit.broadcast(BaseComponent) and Bukkit.broadcast(BaseComponent...)

### DIFF
--- a/Spigot-API-Patches/0017-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/Spigot-API-Patches/0017-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -1,11 +1,12 @@
-From fa2a28d2fc072ee99ab42c2539338c9338ad940a Mon Sep 17 00:00:00 2001
+From bf356f311d416d289300d477d2328d28c039fe76 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 19:54:32 -0600
 Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 
+Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b6a0b40..f93ca2e 100644
+index b6a0b40..5b37396 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -292,6 +292,26 @@ public final class Bukkit {
@@ -14,16 +15,16 @@ index b6a0b40..f93ca2e 100644
  
 +    // Paper start
 +    /**
-+     * Sends the component to the player
++     * Sends the component to all online players.
 +     *
-+     * @param component the components to send
++     * @param component the component to send
 +     */
 +    public static void broadcast(net.md_5.bungee.api.chat.BaseComponent component) {
 +        server.broadcast(component);
 +    }
 +
 +    /**
-+     * Sends an array of components as a single message to the player
++     * Sends an array of components as a single message to all online players.
 +     *
 +     * @param components the components to send
 +     */
@@ -98,5 +99,5 @@ index e13ca66..c19bb76 100644
       * Forces an update of the player's entire inventory.
       *
 -- 
-2.8.0
+2.5.0
 


### PR DESCRIPTION
The Javadocs for Bukkit.broadcast(BaseComponent) and Bukkit.broadcast(BaseComponent...) specified a **single player**. Changed to specify "all online players"
