### PR TITLE
Add proper equals and hashCode specifications and implementations to…

### DIFF
--- a/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
+++ b/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
@@ -1,4 +1,4 @@
-From a90e554b815af1065b680847eddb1227a5b177fe Mon Sep 17 00:00:00 2001
+From b56507323afd7a004be1b872141a7eef0f48909a Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Searchndstroy@users.noreply.github.com>
 Date: Sun, 24 Apr 2016 01:23:11 -0700
 Subject: [PATCH] Add proper Entity/Player/OfflinePlayer equals and hashCode
@@ -8,7 +8,7 @@ Entity hashCode specifies that the implementation should implement the hash
 code only including the entity id (see Javadoc for the specifics).
 
 Entity equals specifies that the implementation should implemnet the equality
-algorithm by checking the interface, entity id and uuid (see Javadoc).
+algorithm by checking 'instanceof Entity' and entity id (see Javadoc).
 
 The Player interface uses the hashCode specification from OfflinePlayer to
 retain compatibility. To ensure that the Object.equals specification is not
@@ -70,10 +70,10 @@ index e98706a..f17c684 100644
 +
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index ef6d467..5e6c3bf 100644
+index ef6d467..bc2732f 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -374,6 +374,55 @@ public interface Entity extends Metadatable, CommandSender {
+@@ -374,6 +374,50 @@ public interface Entity extends Metadatable, CommandSender {
       */
      public boolean isInvulnerable();
  
@@ -91,10 +91,6 @@ index ef6d467..5e6c3bf 100644
 +     *             The entity ids are equal, returned by
 +     *             {@link Entity#getEntityId()}.
 +     *         </li>
-+     *         <li>
-+     *             The entity's persistent ids are equal, returned by
-+     *             {@link Entity#getUniqueId()}.
-+     *         </li>
 +     *     </ul>
 +     * </p>
 +     * Sub-interfaces are allowed to change these specifications, but they must
@@ -103,7 +99,6 @@ index ef6d467..5e6c3bf 100644
 +     * @return {@code true} if this {@code Entity} is equal to the specified
 +     *     object, {@code false} otherwise.
 +     *
-+     * @see Entity#getEntityId()
 +     * @see Entity#getEntityId()
 +     */
 +    @Override

--- a/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
+++ b/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
@@ -1,4 +1,4 @@
-From b56507323afd7a004be1b872141a7eef0f48909a Mon Sep 17 00:00:00 2001
+From 178a45771ec9aadf2aaecf3bfa53513a35b8180b Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Searchndstroy@users.noreply.github.com>
 Date: Sun, 24 Apr 2016 01:23:11 -0700
 Subject: [PATCH] Add proper Entity/Player/OfflinePlayer equals and hashCode
@@ -19,15 +19,14 @@ The OfflinePlayer interface equals and hashCode specification align with the
 (un-changed) direct OfflinePlayer implementation.
 
 diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
-index e98706a..f17c684 100644
+index e98706a..15bfd03 100644
 --- a/src/main/java/org/bukkit/OfflinePlayer.java
 +++ b/src/main/java/org/bukkit/OfflinePlayer.java
-@@ -115,4 +115,46 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+@@ -115,4 +115,44 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
       */
      public Location getBedSpawnLocation();
  
 +    // Paper start - define equals and hashCode for special case with Entity
-+
 +    /**
 +     * Checks if this {@code OfflinePlayer} is equal to the other {@code Object}.
 +     * <p>
@@ -65,20 +64,18 @@ index e98706a..f17c684 100644
 +     */
 +    @Override
 +    int hashCode();
-+
 +    // Paper end
 +
  }
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index ef6d467..bc2732f 100644
+index ef6d467..03af980 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
-@@ -374,6 +374,50 @@ public interface Entity extends Metadatable, CommandSender {
+@@ -374,6 +374,48 @@ public interface Entity extends Metadatable, CommandSender {
       */
      public boolean isInvulnerable();
  
 +    // Paper start - Add equals and hashCode specifications
-+
 +    /**
 +     * Checks if this {@code Entity} is equal to the other {@code Object}.
 +     * <p>
@@ -118,17 +115,16 @@ index ef6d467..bc2732f 100644
 +     */
 +    @Override
 +    int hashCode();
-+
 +    // Paper end
 +
      // Spigot Start
      public class Spigot
      {
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d636c63..e366e23 100644
+index d636c63..738c118 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1488,6 +1488,57 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+@@ -1488,6 +1488,55 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
      boolean hasResourcePack();
      // Paper end
  
@@ -136,7 +132,6 @@ index d636c63..e366e23 100644
 +    /*
 +     * For backwards compatibility with old CraftPlayer.equals
 +     */
-+
 +    /**
 +     * Checks if this {@code Player} is equal to the specified object.
 +     * <p>
@@ -180,7 +175,6 @@ index d636c63..e366e23 100644
 +     */
 +    @Override
 +    boolean equals(final Object other);
-+
 +    // Paper end
 +
      // Spigot start

--- a/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
+++ b/Spigot-API-Patches/0038-Add-proper-Entity-Player-OfflinePlayer-equals-and-ha.patch
@@ -1,0 +1,196 @@
+From a90e554b815af1065b680847eddb1227a5b177fe Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Searchndstroy@users.noreply.github.com>
+Date: Sun, 24 Apr 2016 01:23:11 -0700
+Subject: [PATCH] Add proper Entity/Player/OfflinePlayer equals and hashCode
+ specifications to Paper API
+
+Entity hashCode specifies that the implementation should implement the hash
+code only including the entity id (see Javadoc for the specifics).
+
+Entity equals specifies that the implementation should implemnet the equality
+algorithm by checking the interface, entity id and uuid (see Javadoc).
+
+The Player interface uses the hashCode specification from OfflinePlayer to
+retain compatibility. To ensure that the Object.equals specification is not
+broken as well as possible backwards compatibility, the Player.equals specification
+aligns with the previous implementation of Player.equals.
+
+The OfflinePlayer interface equals and hashCode specification align with the
+(un-changed) direct OfflinePlayer implementation.
+
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index e98706a..f17c684 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -115,4 +115,46 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+      */
+     public Location getBedSpawnLocation();
+ 
++    // Paper start - define equals and hashCode for special case with Entity
++
++    /**
++     * Checks if this {@code OfflinePlayer} is equal to the other {@code Object}.
++     * <p>
++     *     This {@code OfflinePlayer} will be equal to the specified object if:
++     *     <ul>
++     *         <li>
++     *             The specified object is an instance of {@code OfflinePlayer}
++     *             and the uuids returned by {@link OfflinePlayer#getUniqueId()}
++     *             are equal.
++     *         </li>
++     *     </ul>
++     * </p>
++     *
++     * Sub-interfaces are allowed to change these specifications,
++     * but they must document the difference.
++     *
++     * @param other The specified object.
++     * @return {@code true} if this {@code OfflinePlayer} is equal to the specified
++     *     object, {@code false} otherwise.
++     *
++     * @see OfflinePlayer#getUniqueId()
++     */
++    @Override
++    boolean equals(final Object other);
++
++    /**
++     * The hash code for this class is defined as:
++     * <p>
++     *     {@code final int hash = (97 * 5) +
++     *     (getUniqueId() != null ? getUniqueId().hashCode() : 0);}
++     * </p>
++     * Sub-interfaces are allowed to change these specifications,
++     * but they must document the difference.
++     * @return The hash code for this object.
++     */
++    @Override
++    int hashCode();
++
++    // Paper end
++
+ }
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index ef6d467..5e6c3bf 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -374,6 +374,55 @@ public interface Entity extends Metadatable, CommandSender {
+      */
+     public boolean isInvulnerable();
+ 
++    // Paper start - Add equals and hashCode specifications
++
++    /**
++     * Checks if this {@code Entity} is equal to the other {@code Object}.
++     * <p>
++     *     This {@code Entity} will be equal to the specified object if:
++     *     <ul>
++     *         <li>
++     *             The specified object is an instance of {@code Entity}.
++     *         </li>
++     *         <li>
++     *             The entity ids are equal, returned by
++     *             {@link Entity#getEntityId()}.
++     *         </li>
++     *         <li>
++     *             The entity's persistent ids are equal, returned by
++     *             {@link Entity#getUniqueId()}.
++     *         </li>
++     *     </ul>
++     * </p>
++     * Sub-interfaces are allowed to change these specifications, but they must
++     * document the difference.
++     * @param other The specified object.
++     * @return {@code true} if this {@code Entity} is equal to the specified
++     *     object, {@code false} otherwise.
++     *
++     * @see Entity#getEntityId()
++     * @see Entity#getEntityId()
++     */
++    @Override
++    boolean equals(final Object other);
++
++    /**
++     * Returns the hash code for this {@code Entity}.
++     * The entity's hash code is defined to be as:
++     * <pre>
++     *     <code>    int hash = 7;
++     *         hash = (hash * 29) + getEntityId();
++     *     </code>
++     * </pre>
++     * Sub-interfaces are allowed to change these specifications,
++     * but they must document the difference.
++     * @return The hash code for this entity.
++     */
++    @Override
++    int hashCode();
++
++    // Paper end
++
+     // Spigot Start
+     public class Spigot
+     {
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index d636c63..e366e23 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1488,6 +1488,57 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+     boolean hasResourcePack();
+     // Paper end
+ 
++    // Paper start
++    /*
++     * For backwards compatibility with old CraftPlayer.equals
++     */
++
++    /**
++     * Checks if this {@code Player} is equal to the specified object.
++     * <p>
++     *     This method will check for equality based upon the instance of the
++     *     specified object:
++     *     <ol>
++     *         <li>
++     *             If the instance is an instance of {@code Player}:
++     *             <ul>
++     *                 <li>
++     *                     If the entity ids and entity uuids are equal.
++     *                 </li>
++     *             </ul>
++     *         </li>
++     *         <li>
++     *             If the instance is an instance of {@code OfflinePlayer}
++     *             and not an instance of {@code Player}:
++     *             <ul>
++     *                 <li>
++     *                     If the uuids are equal, returned by
++     *                     {@link OfflinePlayer#getUniqueId()}.
++     *                 </li>
++     *             </ul>
++     *         </li>
++     *         <li>
++     *             Any other case will return {@code false}.
++     *         </li>
++     *     </ol>
++     * </p>
++     *
++     * Sub-interfaces are allowed to change these specifications,
++     * but they must document the difference.
++     *
++     * @param other The specified object.
++     * @return {@code true} if this {@code Player} is equal to the specified
++     *     object, {@code false} otherwise.
++     *
++     * @see Entity#getEntityId()
++     * @see Entity#getUniqueId()
++     * @see OfflinePlayer#getUniqueId()
++     */
++    @Override
++    boolean equals(final Object other);
++
++    // Paper end
++
+     // Spigot start
+     public class Spigot extends Entity.Spigot
+     {
+-- 
+2.5.0
+

--- a/Spigot-Server-Patches/0146-Implement-Add-proper-Entity-Player-OfflinePlayer-equ.patch
+++ b/Spigot-Server-Patches/0146-Implement-Add-proper-Entity-Player-OfflinePlayer-equ.patch
@@ -1,4 +1,4 @@
-From 2d1892fb8670508fe15fc346c2cb749ab4feefb4 Mon Sep 17 00:00:00 2001
+From f3a5a6ff4ff81bc84ce94e26f36cd8766240907b Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Searchndstroy@users.noreply.github.com>
 Date: Sun, 24 Apr 2016 01:37:40 -0700
 Subject: [PATCH] Implement Add proper Entity/Player/OfflinePlayer equals and
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement Add proper Entity/Player/OfflinePlayer equals and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 5934be1..d7ad0c9 100644
+index 5934be1..90e2d1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -389,6 +389,8 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -18,15 +18,14 @@ index 5934be1..d7ad0c9 100644
          if (obj == null) {
              return false;
          }
-@@ -397,6 +399,14 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -397,6 +399,13 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
          final CraftEntity other = (CraftEntity) obj;
          return (this.getEntityId() == other.getEntityId());
 +        */
 +        if (obj instanceof org.bukkit.entity.Entity) {
 +            final org.bukkit.entity.Entity entity = (org.bukkit.entity.Entity) obj;
-+            return entity.getEntityId() == getEntityId()
-+                    && entity.getUniqueId().equals(getUniqueId());
++            return entity.getEntityId() == getEntityId();
 +        }
 +        return false;
 +        // Paper end

--- a/Spigot-Server-Patches/0146-Implement-Add-proper-Entity-Player-OfflinePlayer-equ.patch
+++ b/Spigot-Server-Patches/0146-Implement-Add-proper-Entity-Player-OfflinePlayer-equ.patch
@@ -1,0 +1,53 @@
+From 2d1892fb8670508fe15fc346c2cb749ab4feefb4 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Searchndstroy@users.noreply.github.com>
+Date: Sun, 24 Apr 2016 01:37:40 -0700
+Subject: [PATCH] Implement Add proper Entity/Player/OfflinePlayer equals and
+ hashCode specifications to Paper API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 5934be1..d7ad0c9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -389,6 +389,8 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+ 
+     @Override
+     public boolean equals(Object obj) {
++        // Paper start - comply with Entity.equals
++        /*
+         if (obj == null) {
+             return false;
+         }
+@@ -397,6 +399,14 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         }
+         final CraftEntity other = (CraftEntity) obj;
+         return (this.getEntityId() == other.getEntityId());
++        */
++        if (obj instanceof org.bukkit.entity.Entity) {
++            final org.bukkit.entity.Entity entity = (org.bukkit.entity.Entity) obj;
++            return entity.getEntityId() == getEntityId()
++                    && entity.getUniqueId().equals(getUniqueId());
++        }
++        return false;
++        // Paper end
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 003f700..a3f1ccb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -296,8 +296,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         boolean uuidEquals = this.getUniqueId().equals(other.getUniqueId());
+         boolean idEquals = true;
+ 
+-        if (other instanceof CraftPlayer) {
+-            idEquals = this.getEntityId() == ((CraftPlayer) other).getEntityId();
++        if (other instanceof Player) { // Paper - change CraftPlayer to Player
++            idEquals = this.getEntityId() == ((Player) other).getEntityId(); // Paper - change CraftPlayer to Player
+         }
+ 
+         return uuidEquals && idEquals;
+-- 
+2.5.0
+


### PR DESCRIPTION
… Entity/Player/OfflinePlayer

When referring to "the patch", I am actually referring to the API patch and not the implementation patch. "the patches" refer to all patches in this PR.

**What does the patch do?**
The patch adds specifications to the hashCode and equals methods of Entity, Player and OfflinePlayer.

Note that the following specifications can be redefined in sub-interfaces.

_Entity hashCode:_
An Entity's hash code is defined to be the hash of an entity's id. This makes **no** changes to the current implementation.

_Entity equals:_
The specification is defined to check for equality via:
1. Instanceof Entity
2. Entity id equals

Note that 1 makes implementation changes.
1. Changes a class check (thisClass == otherClass) to (other instanceof Entity)

OfflinePlayer simply defines what the implementation was doing, as well as Player.

The only difference for Player is that the implementation now checks instanceof with the interface and not the implementing class.

**Why is this needed?**

Convention. Objects which can be mapped and/or checked for equality should clearly define the specifications for hashCode and equals. The API, in its current state, does not do that for Entity/Player/OfflinePlayer (which are probably going to be mapped commonly to avoid lookups with UUIDs).

**Backwards compatible?**
Unless something in the codebase relied on equality checking for **exact** classes, it will be compatible with the previous codebase.

**Maintenance?**
Only when the equals or hashCode needs to be modified for an Entity interface or implementation.
As the Javadocs state, that is entirely legal, but it **must** be documented.

Your thoughts (also, is this PR format good)?
