### PR TITLE
Optimize Redstone torch

### DIFF
--- a/Spigot-Server-Patches/0156-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/Spigot-Server-Patches/0156-Faster-redstone-torch-rapid-clock-removal.patch
@@ -1,0 +1,34 @@
+From b344ade43058d6642715ca73f9f62d1153062920 Mon Sep 17 00:00:00 2001
+From: Martin Panzer <postremus1996@googlemail.com>
+Date: Mon, 23 May 2016 12:12:37 +0200
+Subject: [PATCH] Faster redstone torch rapid clock removal Only resize the the
+ redstone torch list once, since resizing arrays / lists is costly
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+index 7f5a112..bc80b3e 100644
+--- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
++++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
+@@ -116,9 +116,17 @@ public class BlockRedstoneTorch extends BlockTorch {
+         boolean flag = this.g(world, blockposition, iblockdata);
+         List list = (List) BlockRedstoneTorch.g.get(world);
+ 
+-        while (list != null && !list.isEmpty() && world.getTime() - ((BlockRedstoneTorch.RedstoneUpdateInfo) list.get(0)).b > 60L) {
+-            list.remove(0);
++        // PaperSpigot start
++        if (list != null) {
++            int index = 0;
++            while (index < list.size() &&  world.getTime() - ((BlockRedstoneTorch.RedstoneUpdateInfo) list.get(index)).b > 60L) {
++                index++;
++            }
++            if (index > 0) {
++                list.subList(0, index).clear();
++            }
+         }
++        // PaperSpigot end
+ 
+         // CraftBukkit start
+         org.bukkit.plugin.PluginManager manager = world.getServer().getPluginManager();
+-- 
+1.9.1
+


### PR DESCRIPTION
Remove all redstone torches, which are no longer being considered as "stuck", from the torch update list in one go.
