### PR TITLE
Implement a new and improved in-memory UUID cache

### DIFF
--- a/Spigot-API-Patches/0040-Add-Profile-API.patch
+++ b/Spigot-API-Patches/0040-Add-Profile-API.patch
@@ -1,0 +1,1656 @@
+From 12a33e204c1a232e38758aff3543c817616cdc02 Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@outlook.com>
+Date: Thu, 18 Feb 2016 14:37:38 -0700
+Subject: [PATCH] Add Profile API
+
+Plugins can modify lookup behavior through events.
+Adds a skin api
+
+diff --git a/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java b/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java
+new file mode 100644
+index 0000000..b98d733
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java
+@@ -0,0 +1,180 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.UUID;
++
++import com.google.common.base.Objects;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.Bukkit;
++import org.bukkit.OfflinePlayer;
++import org.bukkit.entity.Player;
++
++/**
++ * Represents a player's profile
++ * Contains their uuid and username
++ * <p>
++ * This may or may not have properties
++ */
++public final class AccountProfile {
++    private final UUID id;
++    private final String name;
++    private final ProfileProperties properties;
++
++    public AccountProfile(UUID id, String name, ProfileProperties properties) {
++        Preconditions.checkNotNull(id, "Null id");
++        Preconditions.checkNotNull(name, "Null name");
++        Preconditions.checkArgument(ProfileLookup.isValidName(name), "Invalid name %s", name);
++        this.id = id;
++        this.name = name;
++        this.properties = properties;
++    }
++
++    public AccountProfile(UUID id, String name) {
++        this(id, name, null);
++    }
++
++    /**
++     * Get this player's uuid
++     *
++     * @return this players uuid
++     */
++    public UUID getId() {
++        return id;
++    }
++
++    /**
++     * Get this player's name
++     *
++     * @return this player's name
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * Get a json array with this players propertes
++     *
++     * @return a json array with this player's properties or null if not retreived
++     * @throws IllegalStateException if the player's profiles haven't been looked up
++     */
++    public ProfileProperties getProperties() {
++        Preconditions.checkState(hasProperties(), "Profile %s has no properties", this);
++        return properties;
++    }
++
++    /**
++     * Return if the player has its profiles
++     *
++     * @return if the player has its properties
++     */
++    public boolean hasProperties() {
++        return properties != null;
++    }
++
++    /**
++     * Return the player's textures, or null if none
++     *
++     * @return the player's textures, or null if none
++     * @throws IllegalStateException if the player has no properties
++     */
++    public PlayerTextures getTextures() {
++        Preconditions.checkState(hasProperties(), "Profile %s has no properties", this);
++        return PlayerTextures.parseTextures(this);
++    }
++
++    /**
++     * Return the player if online
++     *
++     * @return the player, or null if none
++     */
++    public Player getPlayer() {
++        return Bukkit.getPlayer(this.getId());
++    }
++
++    /**
++     * Return the offline player
++     * <p>Should never return null, even if the player doesn't exist.2</p>
++     *
++     * @return the offline player
++     */
++    public OfflinePlayer getOfflinePlayer() {
++        return Bukkit.getOfflinePlayer(getId());
++    }
++
++    /**
++     * Return a version of this profile with no properties
++     * <p>
++     * Returns this object if this object has no properties
++     *
++     * @return a version of this profile with no properties
++     */
++    public AccountProfile clearProperties() {
++        return withProperties(null);
++    }
++
++    /**
++     * Lookup the properties if needed
++     * <p>
++     * Unlike {@link #lookupProperties()}, this only does a lookup if needed
++     * Looks up from the default lookup.
++     *
++     * @return the profile, with properties looked up
++     * @throws IllegalArgumentException if there is no player found with this profile
++     * @throws LookupFailedException    if unable to lookup properties
++     */
++    public AccountProfile withProperties() {
++        if (hasProperties()) {
++            return this;
++        } else {
++            return lookupProperties();
++        }
++    }
++
++    /**
++     * Return a copy of this profile with properties looked up from the default lookup
++     * <p>
++     * This is just a utility wrapper for {@link ProfileLookup#lookupProperties(AccountProfile)}
++     *
++     * @return a copy of this profile with updated properties
++     * @throws IllegalArgumentException if there is no player found with this profile
++     * @throws LookupFailedException    if unable to lookup properties
++     */
++    public AccountProfile lookupProperties() {
++        return withProperties(Bukkit.getProfileLookup().lookupProperties(this));
++    }
++
++    /**
++     * Return a copy of this profile with the given properties
++     * <p>
++     * Returns this object if the properties are the same as the current properties
++     *
++     * @param properties the properties to use for the new profile
++     * @return a copy of this profile with the given properties
++     */
++    public AccountProfile withProperties(ProfileProperties properties) {
++        return this.properties == properties ? this : new AccountProfile(getId(), getName(), properties);
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        if (obj == this) return true;
++        if (obj == null) return false;
++        if (obj.getClass() == AccountProfile.class) {
++            AccountProfile other = (AccountProfile) obj;
++            return other.getId().equals(this.getId())
++                    && other.getName().equals(this.getName())
++                    && Objects.equal(this.properties, other.properties);
++        }
++        return false;
++    }
++
++    @Override
++    public int hashCode() {
++        return getId().hashCode();
++    }
++
++    @Override
++    public String toString() {
++        return getName() + ": " + getId();
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/LookupCause.java b/src/main/java/com/destroystokyo/paper/profile/LookupCause.java
+new file mode 100644
+index 0000000..be392e3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/LookupCause.java
+@@ -0,0 +1,7 @@
++package com.destroystokyo.paper.profile;
++
++public enum LookupCause {
++    UUID_LOOKUP,
++    NAME_LOOKUP,
++    PROPERTIES_LOOKUP;
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java b/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java
+new file mode 100644
+index 0000000..11628b7
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java
+@@ -0,0 +1,19 @@
++package com.destroystokyo.paper.profile;
++
++/**
++ * Thrown when the lookup fails, for reason other then a profile not found
++ */
++public class LookupFailedException extends RuntimeException {
++    public LookupFailedException(Throwable cause) {
++        super(cause);
++    }
++
++    public LookupFailedException(String message, Throwable cause) {
++        super(message, cause);
++    }
++
++    public LookupFailedException(String s) {
++        super(s);
++    }
++
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java b/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java
+new file mode 100644
+index 0000000..2a8667c
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java
+@@ -0,0 +1,265 @@
++package com.destroystokyo.paper.profile;
++
++import java.net.MalformedURLException;
++import java.net.URL;
++import java.util.Base64;
++import java.util.Map;
++
++import com.google.common.base.Charsets;
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableMap;
++import com.google.common.collect.Iterables;
++import com.google.gson.JsonElement;
++import com.google.gson.JsonObject;
++import com.google.gson.JsonParseException;
++import com.google.gson.JsonParser;
++
++/**
++ * A player's texture data, including skin and cape.
++ */
++public final class PlayerTextures {
++    private final AccountProfile profile;
++    private final TextureData skinData, capeData;
++
++    public PlayerTextures(AccountProfile profile, TextureData skinData, TextureData capeData) {
++        Preconditions.checkNotNull(profile, "Null profile");
++        Preconditions.checkArgument(profile.hasProperties(), "No properties for %s", profile);
++        Preconditions.checkArgument(getProperty(profile.getProperties()) != null, "No texture data for %s", profile);
++        this.profile = profile;
++        this.skinData = skinData;
++        this.capeData = capeData;
++    }
++
++    /**
++     * Return the player's skin data, or null if the player has no skin
++     *
++     * @return the player's skin data, or null if none
++     */
++    public TextureData getSkinData() {
++        return skinData;
++    }
++
++    /**
++     * Return the player's cape data, or null if the player has no cape
++     *
++     * @return the player's cape data, or null if none
++     */
++    public TextureData getCapeData() {
++        return skinData;
++    }
++
++    /**
++     * Return the url of the player's skin, or null if the player has no skin
++     *
++     * @return the url of the player's skin, or null if none
++     */
++    public URL getSkin() {
++        return getSkinData() == null ? null : getSkinData().getUrl();
++    }
++
++    /**
++     * Return if the player has a skin
++     *
++     * @return the player has a skin
++     */
++    public boolean hasSkin() {
++        return getSkinData() != null;
++    }
++
++    /**
++     * Return if the player has a cape
++     *
++     * @return the player has a cape
++     */
++    public boolean hasCape() {
++        return getCapeData() != null;
++    }
++
++    /**
++     * Return the url of the player's cape, or null if the player has no cape
++     *
++     * @return the url of the player's cape, or null if none
++     */
++    public URL getCape() {
++        return getCapeData() == null ? null : getCapeData().getUrl();
++    }
++
++    /**
++     * Return if the player's skin has slim arms, or false if the player has no skin.
++     * <p>Alex style skins should return true. Steve style skins should return false.
++     * If the player has no skin, returns false.</p>
++     *
++     * @return if the player has slim arms
++     */
++    public boolean isSlimSkin() {
++        String model;
++        return hasSkin() && (model = getSkinData().getMetadata().get("model")) != null && model.equals("slim");
++    }
++
++    /**
++     * Get the profile this texture is associated with
++     *
++     * @return the profile
++     */
++    public AccountProfile getProfile() {
++        return profile;
++    }
++
++    public static PlayerTextures parseTextures(final AccountProfile profile) {
++        Preconditions.checkNotNull(profile, "Null profile");
++        Preconditions.checkArgument(profile.hasProperties(), "No properties for %s", profile);
++        ProfileProperty texture = getProperty(profile.getProperties());
++        if (texture == null) return null;
++        TextureData skinData = null;
++        TextureData capeData = null;
++        try {
++            JsonObject textureData = new JsonParser().parse(new String(Base64.getDecoder().decode(texture.getValue()), Charsets.UTF_8)).getAsJsonObject();
++            Preconditions.checkArgument(UUIDUtils.toMojangString(profile.getId()).equals(textureData.get("id").getAsString()), "Unexpected id: %s", textureData.get("id").getAsString());
++            JsonObject textures = textureData.get("textures").getAsJsonObject();
++            JsonObject skinJson = textures.getAsJsonObject("SKIN");
++            JsonObject capeJson = textures.getAsJsonObject("CAPE");
++            if (skinJson != null) {
++                String url = skinJson.getAsJsonPrimitive("url").getAsString();
++                ImmutableMap<String, String> metadata;
++                JsonObject metadataJson = skinJson.getAsJsonObject("metadata");
++                if (metadataJson != null) {
++                    ImmutableMap.Builder<String, String> metadataBuilder = ImmutableMap.builder();
++                    for (Map.Entry<String, JsonElement> entry : metadataJson.entrySet()) {
++                        metadataBuilder.put(entry.getKey(), entry.getValue().getAsString());
++                    }
++                    metadata = metadataBuilder.build();
++                } else {
++                    metadata = ImmutableMap.of();
++                }
++                skinData = new TextureData(url, metadata);
++            }
++            if (capeJson != null) {
++                String url = capeJson.getAsJsonPrimitive("url").getAsString();
++                ImmutableMap<String, String> metadata;
++                JsonObject metadataJson = capeJson.getAsJsonObject("metadata");
++                if (metadataJson != null) {
++                    ImmutableMap.Builder<String, String> metadataBuilder = ImmutableMap.builder();
++                    for (Map.Entry<String, JsonElement> entry : metadataJson.entrySet()) {
++                        metadataBuilder.put(entry.getKey(), entry.getValue().getAsString());
++                    }
++                    metadata = metadataBuilder.build();
++                } else {
++                    metadata = ImmutableMap.of();
++                }
++                capeData = new TextureData(url, metadata);
++            }
++            return new PlayerTextures(profile, skinData, capeData);
++        } catch (JsonParseException | ClassCastException | IllegalStateException e) { // IllegalStateException or ClassCastException is thrown by 'getAs()' methods
++            throw new IllegalArgumentException("Invalid json in textures", e);
++        }
++    }
++
++    private volatile Boolean signedByMojang;
++
++    /**
++     * Return if the texture has been singed by mojang
++     * <p>Clients will not accept textures that have not been signed by mojang.</p>
++     *
++     * @return if signed by mojang
++     */
++    public boolean isSignedByMojang() {
++        // Cache if we have a signature, to avoid verifying the texture twice
++        if (signedByMojang == null) {
++                synchronized (this) {
++                    if (signedByMojang == null) {
++                        signedByMojang = isSigned() && getProperty().isSignedByMojang();
++                    }
++                }
++        }
++        return signedByMojang;
++    }
++
++    /**
++     * Return if the texture has a signature.
++     *
++     * @return if the texture has a signature
++     */
++    public boolean isSigned() {
++        return getProperty().isSigned();
++    }
++
++    public ProfileProperty getProperty() {
++        return getProperty(profile.getProperties());
++    }
++
++    private static ProfileProperty getProperty(ProfileProperties properties) {
++        // Don't worry, getProperties() is immutable and IterableSet has a defined iteration order
++        return Iterables.getFirst(properties.getProperties("textures"), null);
++    }
++
++    @Override
++    public boolean equals(Object o) {
++        if (this == o) return true;
++        if (o == null || getClass() != o.getClass()) return false;
++
++        PlayerTextures that = (PlayerTextures) o;
++
++        if (!profile.equals(that.profile)) return false;
++        if (skinData != null ? !skinData.equals(that.skinData) : that.skinData != null) return false;
++        return !(capeData != null ? !capeData.equals(that.capeData) : that.capeData != null);
++
++    }
++
++    @Override
++    public int hashCode() {
++        return profile.hashCode();
++    }
++
++    public static final class TextureData {
++        private final URL url;
++        private final ImmutableMap<String, String> metadata;
++
++        public URL getUrl() {
++            return url;
++        }
++
++        public ImmutableMap<String, String> getMetadata() {
++            return metadata;
++        }
++
++        public TextureData(String url, ImmutableMap<String, String> metadata) {
++            Preconditions.checkNotNull(url, "Null url");
++            Preconditions.checkNotNull(metadata, "Null metadata");
++            try {
++                this.url = new URL(url);
++                this.metadata = metadata;
++            } catch (MalformedURLException e) {
++                throw new IllegalArgumentException("Invalid url " + url, e);
++            }
++        }
++
++        public TextureData(URL url, ImmutableMap<String, String> metadata) {
++            Preconditions.checkNotNull(url, "Null url");
++            Preconditions.checkNotNull(metadata, "Null metadata");
++            this.url = url;
++            this.metadata = metadata;
++        }
++
++        @Override
++        public boolean equals(Object o) {
++            if (this == o) return true;
++            if (o == null || getClass() != o.getClass()) return false;
++
++            TextureData data = (TextureData) o;
++
++            if (!url.equals(data.url)) return false;
++            return metadata.equals(data.metadata);
++
++        }
++
++        @Override
++        public int hashCode() {
++            return url.hashCode();
++        }
++
++        @Override
++        public String toString() {
++            return url.toString();
++        }
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java
+new file mode 100644
+index 0000000..359cf03
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java
+@@ -0,0 +1,194 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.Collection;
++import java.util.UUID;
++import java.util.regex.Matcher;
++import java.util.regex.Pattern;
++
++import com.google.common.collect.ImmutableList;
++
++public interface ProfileLookup {
++
++    /**
++     * A regex of valid minecraft usernames
++     * <p>
++     * We have to accept spaces due to this bug: https://www.reddit.com/r/Minecraft/comments/276wcb/psa_usernames_can_contain_spaces_this_effectively/
++     * We also have to accept names less than 3 characters
++     */
++    public static final Pattern NAME_PATTERN = Pattern.compile("[ \\w]{1,16}+");
++
++    /**
++     * Return if the name is valid
++     * <p>
++     * This does not mean there is a player with a name, but that there *could* be a player with that name
++     *
++     * @param s the name to check
++     * @return true if valid
++     */
++    public static boolean isValidName(String s) {
++        Matcher m = NAME_PATTERN.matcher(s);
++        return m.matches();
++    }
++
++    /**
++     * Lookup a profile with the given name
++     * <p>
++     * Returns null if there is no player with the given name.
++     * The returned player profile may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     *
++     * @param name look for a profile with this name
++     * @return a profile with the given name, or null if there is no player
++     * @throws LookupFailedException if unable to lookup
++     * @throws NullPointerException if
++     */
++    public AccountProfile lookup(String name);
++
++    /**
++     * Lookup a profile with the given uuid
++     * <p>
++     * Returns null if there is no player with the given name.
++     * The looked up profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     *
++     * @param id look for a profile with this uuid
++     * @return a profile with the given id
++     * @throws LookupFailedException if unable to lookup
++     */
++    public AccountProfile lookup(UUID id);
++
++    /**
++     * Lookup a profile with the given name
++     * <p>
++     * The looked up profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     *
++     * @param name     look for a profile with this name
++     * @param callback the callback to handle the result of the lookups
++     */
++    public default void lookup(String name, ProfileLookupCallback<String> callback) {
++        try {
++            AccountProfile profile = lookup(name);
++            callback.onLookup(profile, name);
++        } catch (LookupFailedException e) {
++            callback.onLookupFailed(e.getCause(), name);
++        } catch (Throwable t) {
++            callback.onLookupFailed(t, name);
++        }
++    }
++
++
++    /**
++     * Lookup a profile with the given id
++     * <p>
++     * The returned player profile may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     *
++     * @param id       look for a profile with this id
++     * @param callback the callback to handle the result of the lookups
++     */
++    public default void lookup(UUID id, ProfileLookupCallback<UUID> callback) {
++        try {
++            AccountProfile profile = lookup(id);
++            callback.onLookup(profile, id);
++        } catch (LookupFailedException e) {
++            callback.onLookupFailed(e.getCause(), id);
++        } catch (Throwable t) {
++            callback.onLookupFailed(t, id);
++        }
++    }
++
++    /**
++     * Lookup all profiles with the given ids, earring on non-existent players
++     * <p>
++     * The returned profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     * <p>
++     * Use the callback version of the method if you want to handle (or ignore) non-existent players.
++     * The ordering of the returned profiles may or may not coincide with the ordering of the passed collection.
++     * Therefore, if you need the original id that you used for lookup, you should use the callback-version,
++     *
++     * @param ids the ids to lookup
++     * @return the resulting profiles
++     * @throws LookupFailedException    if lookup fails
++     * @throws IllegalArgumentException if one of the ids doesn't exist
++     */
++    public default ImmutableList<AccountProfile> lookupIds(Collection<UUID> ids) {
++        ImmutableList.Builder<AccountProfile> profileBuilder = ImmutableList.builder();
++        lookupIds(ids, ProfileLookupCallback.assumeFound((profile, original) -> profileBuilder.add(profile)));
++        return profileBuilder.build();
++    }
++
++    /**
++     * Lookup all profiles with the given names, ignoring non-existent profiles
++     * <p>
++     * The looked up profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     * <p>
++     * Use the callback version of the method if you want to handle (or ignore) non-existent players.
++     * The ordering of the returned profiles may or may not coincide with the ordering of the passed collection.
++     * Therefore, if you need the original name that you used for lookup, you should use the callback-version,
++     *
++     * @param names the names to lookup
++     * @return the resulting profiles
++     * @throws LookupFailedException    if lookup fails
++     * @throws IllegalArgumentException if one of the names doesn't exist
++     */
++    public default ImmutableList<AccountProfile> lookupNames(Collection<String> names) {
++        ImmutableList.Builder<AccountProfile> profileBuilder = ImmutableList.builder();
++        lookupNames(names, ProfileLookupCallback.assumeFound((profile, original) -> profileBuilder.add(profile)));
++        return profileBuilder.build();
++    }
++
++    /**
++     * Lookup all profiles with the given ids
++     * <p>
++     * The looked up profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     * <p>
++     * Blocks until the lookups complete
++     *
++     * @param ids      the ids to lookup
++     * @param callback the callback to handle the lookups
++     */
++    public default void lookupIds(Collection<UUID> ids, ProfileLookupCallback<UUID> callback) {
++        ids.forEach((id) -> lookup(id, callback));
++    }
++
++    /**
++     * Lookup all profiles with the given names
++     * <p>
++     * The looked up profiles may or may not include properties
++     * If properties are needed, proceed to use a property lookup
++     * <p>
++     * Blocks until the lookups complete
++     *
++     * @param names    the names to lookup
++     * @param callback the callback to handle the lookups
++     */
++    public default void lookupNames(Collection<String> names, ProfileLookupCallback<String> callback) {
++        names.forEach((name) -> lookup(name, callback));
++    }
++
++    /**
++     * Lookup the player's properties
++     * <p>
++     * Should never return null
++     *
++     * @param profile the profile to lookup properties for
++     * @return the player's properties
++     * @throws IllegalArgumentException if there is no player with the given name/uuid
++     * @throws LookupFailedException    if unable to lookup properties
++     */
++    public ProfileProperties lookupProperties(AccountProfile profile);
++
++    /**
++     * Return if the lookups have the same underlying source
++     * <p>
++     * Two lookups are considered equal if they use the same underlying source
++     *
++     * @param other the object to check equality with
++     * @return if equal
++     */
++    public boolean equals(Object other);
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java b/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java
+new file mode 100644
+index 0000000..859aff1
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java
+@@ -0,0 +1,51 @@
++package com.destroystokyo.paper.profile;
++
++import com.google.common.base.Preconditions;
++
++/**
++ * A callback for profile lookup
++ * <p/>
++ * Methods may be called multiple times in a bulk lookup.
++ * <b>Just because a success method is called, doesn't mean the lookup wont fail!</b>
++ * Callbacks should take this into account, and wait till completion to handle
++ *
++ * @param <T> the key that is being looked up
++ */
++@FunctionalInterface
++public interface ProfileLookupCallback<T> {
++
++    /**
++     * Calls when a lookup succeeds
++     * <p>
++     * Profile may not be null if the player doesn't exist
++     *
++     * @param profile  the profile that was found, or null if the player
++     * @param original the key that was being looked up
++     */
++    public void onLookup(AccountProfile profile, T original);
++
++    /**
++     * Called when a lookup fails
++     *
++     * @param t        the exception that was caught, may be null
++     * @param original the key that was being looked up
++     */
++    public default void onLookupFailed(Throwable t, T original) {
++        throw new LookupFailedException("Unable to lookup " + original.toString(), t);
++    }
++
++    public static <T> ProfileLookupCallback<T> assumeFound(ProfileLookupCallback<T> delegate) {
++        return new ProfileLookupCallback<T>() {
++            @Override
++            public void onLookup(AccountProfile profile, T original) {
++                Preconditions.checkArgument(profile != null, "%s doesn't exist", original);
++                delegate.onLookup(profile, original);
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, T original) {
++                delegate.onLookupFailed(t, original);
++            }
++        };
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java b/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java
+new file mode 100644
+index 0000000..8d1ad99
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java
+@@ -0,0 +1,112 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.Collection;
++import java.util.Map;
++import java.util.function.BiConsumer;
++
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableSet;
++import com.google.common.collect.ImmutableSetMultimap;
++import com.google.common.collect.SetMultimap;
++
++public final class ProfileProperties {
++    private final ImmutableSetMultimap<String, ProfileProperty> properties;
++
++    private ProfileProperties(ImmutableSetMultimap<String, ProfileProperty> properties) {
++        this.properties = Preconditions.checkNotNull(properties);;
++    }
++
++    public static final ProfileProperties EMPTY = new ProfileProperties(ImmutableSetMultimap.of());
++
++    public ImmutableSet<ProfileProperty> getProperties(String name) {
++        return properties.get(name);
++    }
++
++    /**
++     * Get a single property with the given name
++     * <p>
++     * Throws an exception if there is more than one, or none at all
++     *
++     * @param name the name of the property to get
++     * @return the only property with the given name
++     * @throws IllegalStateException if there are no properties
++     * @throws IllegalStateException if there are more than one property with the name
++     */
++    public ProfileProperty getOnlyProperty(String name) {
++        ImmutableSet<ProfileProperty> properties = getProperties(name);
++        Preconditions.checkState(!properties.isEmpty(), "No properties named %s", name);
++        Preconditions.checkState(properties.size() == 1, "%s properties named %s", properties.size(), name);
++        return properties.iterator().next();
++    }
++
++    public boolean hasProperty(String name) {
++        return !getProperties(name).isEmpty();
++    }
++
++    public static ProfileProperties copyOf(Collection<ProfileProperty> properties) {
++        Builder builder = new Builder();
++        properties.forEach(builder::put);
++        return builder.build();
++    }
++
++    public static ProfileProperties copyOf(SetMultimap<String, ProfileProperty> originalMultimap) {
++        Preconditions.checkNotNull(originalMultimap, "Null multimap");
++        ImmutableSetMultimap<String, ProfileProperty> multimap = ImmutableSetMultimap.copyOf(originalMultimap);
++        if (multimap.isEmpty()) return EMPTY;
++        for (Map.Entry<String, ProfileProperty> entry : multimap.entries()) {
++            String name = entry.getKey();
++            ProfileProperty property = entry.getValue();
++            Preconditions.checkArgument(property.getName().equals(name), "Property %s with key %s", property, name);
++        }
++        return new ProfileProperties(multimap);
++    }
++
++    public int size() {
++        return properties.size();
++    }
++
++    public boolean isEmpty() {
++        return properties.isEmpty();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return obj instanceof ProfileProperties && ((ProfileProperties) obj).properties.equals(this.properties);
++    }
++
++    public void forEach(BiConsumer<String, ProfileProperty> consumer) {
++        for (Map.Entry<String, ProfileProperty> entry : properties.entries()) {
++            consumer.accept(entry.getKey(), entry.getValue());
++        }
++    }
++
++    public static ProfileProperties.Builder builder() {
++        return new Builder();
++    }
++
++    public final static class Builder {
++        private final ImmutableSetMultimap.Builder<String, ProfileProperty> builder = ImmutableSetMultimap.builder();
++        private int size;
++
++        public void put(ProfileProperty property) {
++            Preconditions.checkNotNull(property, "Null property");
++            put0(property.getName(), property);
++        }
++
++        public void put(String name, ProfileProperty value) {
++            Preconditions.checkNotNull(name, "Null name");
++            Preconditions.checkNotNull(value, "Null property");
++            Preconditions.checkArgument(name.equals(value.getName()), "Name %s doesn't match property %s", name, value);
++            put0(name, value);
++        }
++
++        private void put0(String name, ProfileProperty property) {
++            builder.put(name, property);
++            size++;
++        }
++
++        public ProfileProperties build() {
++            return size == 0 ? EMPTY : new ProfileProperties(builder.build());
++        }
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java b/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java
+new file mode 100644
+index 0000000..16deedf
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java
+@@ -0,0 +1,128 @@
++package com.destroystokyo.paper.profile;
++
++import java.io.BufferedInputStream;
++import java.io.IOException;
++import java.security.InvalidKeyException;
++import java.security.KeyFactory;
++import java.security.NoSuchAlgorithmException;
++import java.security.PublicKey;
++import java.security.Signature;
++import java.security.SignatureException;
++import java.security.spec.InvalidKeySpecException;
++import java.security.spec.X509EncodedKeySpec;
++import java.util.Base64;
++
++import com.google.common.base.Preconditions;
++import com.google.common.io.ByteStreams;
++
++public final class ProfileProperty {
++    private final String name, value, signature;
++
++    public ProfileProperty(String name, String value, String signature) {
++        this.name = Preconditions.checkNotNull(name, "Name of the property can't be null");
++        this.value = Preconditions.checkNotNull(value, "Value of the property can't be null");
++        this.signature = signature;
++    }
++
++    public ProfileProperty(String name, String value) {
++        this(name, value, null);
++    }
++
++    /**
++     * Return the name of this property
++     *
++     * @return the name of this property
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * Return the value of this property
++     *
++     * @return the value of this property
++     */
++    public String getValue() {
++        return value;
++    }
++
++    /**
++     * Return the signature of this property
++     * <p>
++     * This performs no verification of the returned signature.
++     *
++     * @return the signature of this property
++     * @throws IllegalStateException if the property is not singed
++     */
++    public String getSignature() {
++        Preconditions.checkState(signature != null, "Property is not signed");
++        return signature;
++    }
++
++    /**
++     * Return if the property is signed
++     *
++     * @return if the property is signed
++     */
++    public boolean isSigned() {
++        return signature != null;
++    }
++
++    /**
++     * Return if the signature is valid with the specified public key
++     *
++     * @param key the public key
++     * @return if valid
++     * @throws IllegalArgumentException if the key is invalid
++     * @throws IllegalStateException    if the property is not signed
++     * @throws RuntimeException         if unable to verify for some other reason
++     */
++    public boolean isSignatureValid(PublicKey key) {
++        try {
++            Signature signature = Signature.getInstance("SHA1withRSA");
++            signature.initVerify(key);
++            signature.update(this.value.getBytes());
++            return signature.verify(Base64.getDecoder().decode(getSignature()));
++        } catch (InvalidKeyException e) {
++            throw new IllegalArgumentException("Invalid key", e);
++        } catch (SignatureException e) {
++            throw new RuntimeException("Unable to verify", e);
++        } catch (NoSuchAlgorithmException e) {
++            throw new AssertionError("Couldn't find required algorithm", e);
++        }
++    }
++
++    /**
++     * Return if the signature has been signed by mojang
++     *
++     * @return if valid with mojang
++     * @throws IllegalStateException if the property is not signed
++     * @throws RuntimeException      if unable to verify for some other reason
++     */
++    public boolean isSignedByMojang() {
++        try {
++            return isSignatureValid(YGGDRASIL_PUBLIC_KEY);
++        } catch (IllegalArgumentException e) {
++            throw new RuntimeException("Invalid mojang key", e);
++        }
++    }
++
++    public static final PublicKey YGGDRASIL_PUBLIC_KEY;
++
++    static {
++        try (
++                // NOTE: Update this if yggdrasil public key location changes
++                BufferedInputStream in = new BufferedInputStream(ProfileProperty.class.getResourceAsStream("/yggdrasil_session_pubkey.der"))
++        ) {
++            X509EncodedKeySpec spec = new X509EncodedKeySpec(ByteStreams.toByteArray(in));
++            KeyFactory factory = KeyFactory.getInstance("RSA");
++            YGGDRASIL_PUBLIC_KEY = factory.generatePublic(spec);
++        } catch (InvalidKeySpecException e) {
++            throw new AssertionError("Missing/invalid yggdrasil public key!", e);
++        } catch (IOException e) {
++            throw new AssertionError("Couldn't load key", e);
++        } catch (NoSuchAlgorithmException e) {
++            throw new AssertionError("Missing RSA", e);
++        }
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java b/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java
+new file mode 100644
+index 0000000..96c8b5f
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java
+@@ -0,0 +1,56 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.UUID;
++
++import com.destroystokyo.paper.utils.Hex;
++import com.google.common.base.Preconditions;
++import com.google.common.primitives.Longs;
++
++public class UUIDUtils {
++    private UUIDUtils() {}
++
++    public static String toMojangString(UUID id) {
++        Preconditions.checkNotNull(id, "Null id");
++        return Hex.encodeString(toBytes(id));
++    }
++
++    public static UUID fromString(String s) {
++        Preconditions.checkNotNull(s, "Null string");
++        if (s.length() == 36) { // UUID.toString() uuid
++            s = s.replace("-", "");
++        } else if (s.length() != 32) {
++            throw new IllegalArgumentException("Invalid UUID: " + s);
++        }
++        try {
++            return fromBytes(Hex.decode(s));
++        } catch (IllegalArgumentException e) {
++            throw new IllegalArgumentException("Invalid UUID: " + s);
++        }
++    }
++
++    public static byte[] toBytes(UUID id) {
++        Preconditions.checkNotNull(id, "Null id");
++        byte[] result = new byte[16];
++        long lsb = id.getLeastSignificantBits();
++        for (int i = 15; i >= 8; i--) {
++            result[i] = (byte) (lsb & 0xffL);
++            lsb >>= 8;
++        }
++        long msb = id.getMostSignificantBits();
++        for (int i = 7; i >= 0; i--) {
++            result[i] = (byte) (msb & 0xffL);
++            msb >>= 8;
++        }
++        return result;
++    }
++
++    public static UUID fromBytes(byte[] bytes) {
++        Preconditions.checkNotNull(bytes, "Null bytes");
++        Preconditions.checkArgument(bytes.length == 16, "Invalid length: %s", bytes.length);
++        long msb = Longs.fromBytes(bytes[0], bytes[1], bytes[2], bytes[3],
++                bytes[4], bytes[5], bytes[6], bytes[7]);
++        long lsb = Longs.fromBytes(bytes[8], bytes[9], bytes[10], bytes[11],
++                bytes[12], bytes[13], bytes[14], bytes[15]);
++        return new UUID(msb, lsb);
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java
+new file mode 100644
+index 0000000..57776d5
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java
+@@ -0,0 +1,55 @@
++package com.destroystokyo.paper.profile.event;
++
++import com.destroystokyo.paper.profile.LookupCause;
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called before a uuid is requested from mojang.
++ * <p>
++ * <p>The event may be called synchronouslys if the uuid is resolved on the main thread</p>
++ */
++public class AsyncNamePreResolveEvent extends AsyncProfilePreResolveEvent {
++    private final String name;
++
++    public AsyncNamePreResolveEvent(String name) {
++        super(LookupCause.NAME_LOOKUP);
++        Preconditions.checkNotNull(name, "Null name");
++        this.name = name;
++    }
++
++    /**
++     * Return the name that was used to request the profile
++     *
++     * @return the name that was requested
++     */
++    public String getName() {
++        return name;
++    }
++
++    /**
++     * {@inheritDoc}
++     *
++     * @throws IllegalArgumentException if the profile's name doesn't match the looked up names
++     */
++    @Override
++    public void setResult(AccountProfile result) {
++        if (result != null) {
++            Preconditions.checkArgument(result.getName().equalsIgnoreCase(this.getName()), "Name %s doesn't match looked up name: %s", result.getName(), this.getName());
++        }
++        super.setResult(result);
++    }
++
++    private static final HandlerList handlerList = new HandlerList();
++
++    public static HandlerList getHandlerList() {
++        return handlerList;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlerList;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java
+new file mode 100644
+index 0000000..bc81ec3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java
+@@ -0,0 +1,62 @@
++package com.destroystokyo.paper.profile.event;
++
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.Bukkit;
++import org.bukkit.event.Event;
++import com.destroystokyo.paper.profile.LookupCause;
++
++/**
++ * Called before a profile is looked up from mojang.
++ * Plugins can set a profile, which will effectively 'cancel' the lookup from mojang.
++ * <p>May be called from the main thread if the lookup is from the main thread.</p>
++ */
++public abstract class AsyncProfilePreResolveEvent extends Event {
++    private final LookupCause cause;
++    private AccountProfile result;
++
++    public AsyncProfilePreResolveEvent(LookupCause cause) {
++        super(!Bukkit.isPrimaryThread());
++        this.cause = Preconditions.checkNotNull(cause, "Null cause");;
++    }
++
++    /**
++     * Get the reason this profile is being looked up
++     * @return the reason this profile is being looked up
++     */
++    public LookupCause getCause() {
++        return cause;
++    }
++
++    /**
++     * Set the profile that will be returned by the lookup
++     * <p>Overrides any existing profile, and prevents a lookup from mojang.
++     * Setting to null re-allows a mojang lookup.</p>
++     *
++     * @param result the profile that will be returned by the lookup
++     */
++    public void setResult(AccountProfile result) {
++        this.result = result;
++    }
++
++    /**
++     * Get if a plugin has set the profile to be returned, and prevented a lookup to mojang
++     * <p>If not, it must be looked up from mojang</p>
++     *
++     * @return if a plugin has overriden the profile to be returned
++     */
++    public boolean isResolved() {
++        return result != null;
++    }
++
++    /**
++     * Get the profile that will be returned by the lookup, if another plugin has set it
++     * <p>If this returns null, than no plugin has set the profile and it must be looked up from mojang</p>
++     *
++     * @return the profile that has been set, or null if not set
++     */
++    public AccountProfile getResult() {
++        return result;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java
+new file mode 100644
+index 0000000..cbc2572
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java
+@@ -0,0 +1,80 @@
++package com.destroystokyo.paper.profile.event;
++
++import com.google.common.base.Preconditions;
++
++import org.bukkit.Bukkit;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import com.destroystokyo.paper.profile.LookupCause;
++import com.destroystokyo.paper.profile.AccountProfile;
++
++/**
++ * Called once a profile is resolved.
++ * <p>May come from a plugin or from mojang.</p>
++ */
++public class AsyncProfileResolveEvent extends Event {
++    private final LookupCause cause;
++    private AccountProfile result;
++    private boolean mojang;
++
++    public AsyncProfileResolveEvent(LookupCause cause, AccountProfile result, boolean mojang) {
++        super(!Bukkit.isPrimaryThread());
++        this.cause = Preconditions.checkNotNull(cause, "Null cause");;
++        setResult(result);
++        this.mojang = mojang;
++    }
++
++    /**
++     * Return the result of this lookup
++     *
++     * @return the result of the lookup
++     */
++    public AccountProfile getResult() {
++        return result;
++    }
++
++    /**
++     * Set the result of this lookup
++     * <p>Can't be null. If the lookup is a properties lookup, the properties must be set.</p>
++     *
++     * @param result the result of the lookup
++     */
++    public void setResult(AccountProfile result) {
++        Preconditions.checkNotNull(result, "Null result");
++        if (this.getCause() == LookupCause.PROPERTIES_LOOKUP) {
++            Preconditions.checkArgument(result.hasProperties(), "Result doesn't have properties in properties lookup: %s", result);
++        }
++        this.result = result;
++        this.mojang = false;
++    }
++
++    /**
++     * Get what caused this lookup
++     *
++     * @return what caused this lookup
++     */
++    public LookupCause getCause() {
++        return cause;
++    }
++
++    /**
++     * Return if the profile is known to come from mojang
++     * <p>If not, it is probably from a plugin.</p>
++     *
++     * @return if the profile is known to come from mojang
++     */
++    public boolean isFromMojang() {
++        return mojang;
++    }
++
++    private static final HandlerList handlerList = new HandlerList();
++
++    public HandlerList getHandlerList() {
++        return handlerList;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return getHandlerList();
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java
+new file mode 100644
+index 0000000..cf74f7a
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java
+@@ -0,0 +1,68 @@
++package com.destroystokyo.paper.profile.event;
++
++import com.destroystokyo.paper.profile.ProfileProperties;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.event.HandlerList;
++import com.destroystokyo.paper.profile.LookupCause;
++import com.destroystokyo.paper.profile.AccountProfile;
++
++/**
++ * Called before profile properties are requested from mojang.
++ * Plugins can set a profile, which will effectively 'cancel' the lookup from mojang.
++ * <p>The event may be called synchronously if the uuid is resolved on the main thread</p>
++ */
++public class AsyncPropertiesPreResolveEvent extends AsyncProfilePreResolveEvent {
++    private final AccountProfile profile;
++
++    public AsyncPropertiesPreResolveEvent(AccountProfile profile) {
++        super(LookupCause.PROPERTIES_LOOKUP);
++        Preconditions.checkNotNull(profile, "Null profile");
++        this.profile = profile.withProperties(null);
++    }
++
++    /**
++     * Set the profile whose properties are being looked up
++     */
++    public AccountProfile getProfile() {
++        return profile;
++    }
++
++    /**
++     * Set the properties that will be returned by the lookup
++     * <p>Overrides any existing profile, and prevents a lookup from mojang.
++     * Setting to null re-allows a mojang lookup.</p>
++     *
++     * @param properties the properties that will be returned by the lookup
++     */
++    public void setProperties(ProfileProperties properties) {
++        setResult(properties == null ? null : getResult().withProperties(properties));
++    }
++
++    /**
++     * {@inheritDoc}
++     * @throws IllegalArgumentException if the profile's id doesn't match the looked up id
++     * @throws IllegalArgumentException if the profile's id doesn't match the looked up name
++     * @throws IllegalArgumentException if the profile has 'unset' properties
++     */
++    @Override
++    public void setResult(AccountProfile result) {
++        if (result != null) {
++            Preconditions.checkArgument(result.hasProperties(), "Profile has unset properties");
++            Preconditions.checkArgument(result.getId().equals(this.getProfile().getId()), "Profile id %s doesn't match looked up %s", result.getId(), getProfile().getId());
++            Preconditions.checkArgument(result.getName().equals(this.getProfile().getName()), "Profile name %s doesn't match looked up %s", result.getName(), getProfile().getName());
++        }
++        super.setResult(result);
++    }
++
++    private static final HandlerList handlerList = new HandlerList();
++
++    public static HandlerList getHandlerList() {
++        return handlerList;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return getHandlerList();
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java
+new file mode 100644
+index 0000000..1cf537e
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java
+@@ -0,0 +1,55 @@
++package com.destroystokyo.paper.profile.event;
++
++import java.util.UUID;
++
++import com.destroystokyo.paper.profile.LookupCause;
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.event.HandlerList;
++
++/**
++ * Called before a profile is requested from mojang.
++ * Plugins can set a profile, which will effectively 'cancel' the lookup from mojang.
++ * <p>The event may be called synchronously if the uuid is resolved on the main thread</p>
++ */
++public class AsyncUUIDPreResolveEvent extends AsyncProfilePreResolveEvent {
++    private final UUID id;
++
++    public AsyncUUIDPreResolveEvent(UUID id) {
++        super(LookupCause.UUID_LOOKUP);
++        this.id = Preconditions.checkNotNull(id, "Null id");;
++    }
++
++    /**
++     * Return the id whose profile was requested
++     *
++     * @return the id that was requested
++     */
++    public UUID getId() {
++        return id;
++    }
++
++    /**
++     * {@inheritDoc}
++     *
++     * @throws IllegalArgumentException if the profile's id doesn't match the looked up id
++     */
++    @Override
++    public void setResult(AccountProfile result) {
++        if (result != null) {
++            Preconditions.checkArgument(result.getId().equals(this.getId()), "Id %s doesn't match looked up id: %s", result.getId(), this.getId());
++        }
++        super.setResult(result);
++    }
++    private static final HandlerList handlerList = new HandlerList();
++
++    public static HandlerList getHandlerList() {
++        return handlerList;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return getHandlerList();
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/utils/Hex.java b/src/main/java/com/destroystokyo/paper/utils/Hex.java
+new file mode 100644
+index 0000000..a705db0
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/utils/Hex.java
+@@ -0,0 +1,113 @@
++package com.destroystokyo.paper.utils;
++
++import java.util.Arrays;
++import java.util.Objects;
++
++public class Hex {
++
++    public static byte[] decode(CharSequence chars) {
++        byte[] bytes = new byte[chars.length() >> 1];
++        decode(chars, 0, bytes, 0, bytes.length);
++        return bytes;
++    }
++
++    public static void decode(char[] chars, int charOffset, byte[] dest, int offset, int length) {
++        decode(new CharSequence() {
++            @Override
++            public int length() {
++                return chars.length;
++            }
++
++            @Override
++            public char charAt(int index) {
++                return chars[index];
++            }
++
++            @Override
++            public CharSequence subSequence(int start, int end) {
++                return toString().substring(start, end);
++            }
++
++            @Override
++            public String toString() {
++                return new String(chars, charOffset, chars.length);
++            }
++        });
++    }
++
++    public static void decode(CharSequence chars, int charOffset, byte[] dest, int offset, int length) {
++        Objects.requireNonNull(chars, "Null chars");
++        Objects.requireNonNull(chars, "Null destination");
++        final int numChars = chars.length();
++        if ((numChars & 0x01) != 0) {
++            throw new IllegalArgumentException("Odd number of characters: " + numChars);
++        } else if (length < (numChars - charOffset) >> 1) {
++            throw new IllegalArgumentException("Too many bytes to fill with " + numChars + " characters: " + length);
++        } else if (offset < 0 || charOffset < 0 || length < 0 || length * 2 > numChars - charOffset || length > dest.length - offset) {
++            throw new IndexOutOfBoundsException();
++        }
++        for (int i = 0, charIndex = charOffset; i < length; i++) {
++            char first = chars.charAt(charIndex++);
++            char second = chars.charAt(charIndex++);
++            dest[i + offset] = (byte) ((toDigit(first) << 4) | (toDigit(second)));
++        }
++    }
++
++    public static String encodeString(byte[] bytes) {
++        return new String(encode(bytes));
++    }
++
++    public static char[] encode(byte[] bytes) {
++        char[] chars = new char[bytes.length << 1];
++        encode(chars, 0, bytes, 0, bytes.length);
++        return chars;
++    }
++
++    public static void encode(char[] chars, int charOffset, byte[] source, int offset, int length) {
++        Objects.requireNonNull(chars, "Null chars");
++        Objects.requireNonNull(chars, "Null bytes");
++        if (offset < 0 || charOffset < 0 || length < 0 || length * 2 > chars.length - charOffset || length > source.length - offset) {
++            throw new IndexOutOfBoundsException();
++        } else if (length == 0) {
++            return;
++        }
++        for (int i = 0, charIndex = charOffset; i < length; i++) {
++            byte b = source[i + offset];
++            chars[charIndex++] = fromDigit((byte) ((b >> 4) & 0xF));
++            chars[charIndex++] = fromDigit((byte) (b & 0xF));
++        }
++    }
++    private static final char[] ENCODE_TABLE = new char[]{
++            '0', '1', '2', '3', '4', '5', '6', '7',
++            '8', '9', 'a', 'b', 'c', 'd', 'e', 'f'
++    };
++    private static final byte[] DECODE_TABLE = new byte[128];
++
++    static {
++        Arrays.fill(DECODE_TABLE, (byte) -1);
++        for (int value = 0; value < ENCODE_TABLE.length; value++) {
++            char c = ENCODE_TABLE[value];
++            DECODE_TABLE[c] = (byte) value;
++            char upper;
++            if ((upper = Character.toUpperCase(c)) != c) {
++                DECODE_TABLE[upper] = (byte) value;
++            }
++        }
++    }
++
++    private static byte toDigit(char c) {
++        byte value;
++        if (c < DECODE_TABLE.length) {
++            value = DECODE_TABLE[c];
++        } else {
++            value = -1;
++        }
++        if (value < 0) throw new IllegalArgumentException("Invalid character " + c);
++        return value;
++    }
++
++    private static char fromDigit(byte b) {
++        assert (b & 0xF) == b : "Out of range " + b;
++        return ENCODE_TABLE[b];
++    }
++}
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 9d61cc5..6361a71 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -43,6 +43,8 @@ import org.bukkit.generator.ChunkGenerator;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
+ 
++import com.destroystokyo.paper.profile.ProfileLookup; // Paper
++
+ /**
+  * Represents the Bukkit core, for version and Server singleton handling
+  */
+@@ -1205,4 +1207,15 @@ public final class Bukkit {
+     {
+         return server.spigot();
+     }
++
++    // Paper start
++    /**
++     * Get the server's profile lookup
++     *
++     * @return the server's profile lookup
++     */
++    public static ProfileLookup getProfileLookup() {
++        return getServer().getProfileLookup();
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/OfflinePlayer.java b/src/main/java/org/bukkit/OfflinePlayer.java
+index e98706a..8d7feef 100644
+--- a/src/main/java/org/bukkit/OfflinePlayer.java
++++ b/src/main/java/org/bukkit/OfflinePlayer.java
+@@ -7,6 +7,7 @@ import org.bukkit.configuration.serialization.ConfigurationSerializable;
+ import org.bukkit.entity.AnimalTamer;
+ import org.bukkit.entity.Player;
+ import org.bukkit.permissions.ServerOperator;
++import com.destroystokyo.paper.profile.AccountProfile; // Paper
+ 
+ public interface OfflinePlayer extends ServerOperator, AnimalTamer, ConfigurationSerializable {
+ 
+@@ -115,4 +116,12 @@ public interface OfflinePlayer extends ServerOperator, AnimalTamer, Configuratio
+      */
+     public Location getBedSpawnLocation();
+ 
++    // Paper start
++    /**
++     * Return this player's profile
++     *
++     * @return this player's profile
++     */
++    public AccountProfile getAccount();
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 1c8140f..b0f5fb5 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -44,6 +44,8 @@ import org.bukkit.generator.ChunkGenerator;
+ import org.bukkit.inventory.ItemFactory;
+ import org.bukkit.inventory.meta.ItemMeta;
+ 
++import com.destroystokyo.paper.profile.ProfileLookup; // Paper
++
+ /**
+  * Represents a server implementation.
+  */
+@@ -1019,6 +1021,15 @@ public interface Server extends PluginMessageRecipient {
+ 
+     Spigot spigot();
+ 
++    // Paper start - profile api
++    /**
++     * Get the server's profile lookup
++     *
++     * @return the server's profile lookup
++     */
++    public ProfileLookup getProfileLookup();
++    // Paper end
++
+     void reloadPermissions(); // Paper
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index d636c63..52af44a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -21,6 +21,7 @@ import org.bukkit.conversations.Conversable;
+ import org.bukkit.map.MapView;
+ import org.bukkit.plugin.messaging.PluginMessageRecipient;
+ import org.bukkit.scoreboard.Scoreboard;
++import com.destroystokyo.paper.profile.AccountProfile; // Paper
+ 
+ /**
+  * Represents a player, connected or not
+@@ -1607,4 +1608,14 @@ public interface Player extends HumanEntity, Conversable, CommandSender, Offline
+ 
+     Spigot spigot();
+     // Spigot end
++
++    // Paper start
++    /**
++     * Return this player's profile
++     *
++     * @return this player's profile
++     */
++    @Override
++    public AccountProfile getAccount();
++    // Paper end
+ }
+-- 
+2.8.0
+

--- a/Spigot-API-Patches/0041-Add-an-api-to-access-the-uuid-cache.patch
+++ b/Spigot-API-Patches/0041-Add-an-api-to-access-the-uuid-cache.patch
@@ -1,0 +1,616 @@
+From 9628176f5c2df155a4317831a60c1d3c30ab854a Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@techcable.net>
+Date: Thu, 14 Apr 2016 17:41:40 -0700
+Subject: [PATCH] Add an api to access the uuid cache
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java b/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java
+index b98d733..b7dbdc0 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java
++++ b/src/main/java/com/destroystokyo/paper/profile/AccountProfile.java
+@@ -1,14 +1,13 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.util.UUID;
+-
+ import com.google.common.base.Objects;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.Bukkit;
+ import org.bukkit.OfflinePlayer;
+ import org.bukkit.entity.Player;
+ 
++import java.util.UUID;
++
+ /**
+  * Represents a player's profile
+  * Contains their uuid and username
+diff --git a/src/main/java/com/destroystokyo/paper/profile/CachingProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/CachingProfileLookup.java
+new file mode 100644
+index 0000000..36c3872
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/CachingProfileLookup.java
+@@ -0,0 +1,24 @@
++package com.destroystokyo.paper.profile;
++
++import com.google.common.collect.ImmutableCollection;
++
++import java.util.UUID;
++
++public interface CachingProfileLookup extends ProfileLookup {
++
++    ImmutableCollection<AccountProfile> getCachedProfiles();
++
++    AccountProfile getIfCached(UUID id);
++
++    AccountProfile getIfCached(String name);
++
++    void cache(AccountProfile profile);
++
++    void clearProfile(AccountProfile profile);
++
++    AccountProfile refresh(UUID id);
++
++    AccountProfile refresh(String name);
++
++    ProfileProperties refreshProperties(AccountProfile profile);
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/LookupCause.java b/src/main/java/com/destroystokyo/paper/profile/LookupCause.java
+index be392e3..d6fc8ae 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/LookupCause.java
++++ b/src/main/java/com/destroystokyo/paper/profile/LookupCause.java
+@@ -1,7 +1,7 @@
+ package com.destroystokyo.paper.profile;
+ 
+ public enum LookupCause {
+-    UUID_LOOKUP,
+-    NAME_LOOKUP,
+-    PROPERTIES_LOOKUP;
++    UUID,
++    NAME,
++    PROPERTIES;
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java b/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java
+index 11628b7..4ed0d49 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java
++++ b/src/main/java/com/destroystokyo/paper/profile/LookupFailedException.java
+@@ -4,16 +4,13 @@ package com.destroystokyo.paper.profile;
+  * Thrown when the lookup fails, for reason other then a profile not found
+  */
+ public class LookupFailedException extends RuntimeException {
+-    public LookupFailedException(Throwable cause) {
+-        super(cause);
+-    }
+ 
+     public LookupFailedException(String message, Throwable cause) {
+         super(message, cause);
+     }
+ 
+-    public LookupFailedException(String s) {
+-        super(s);
++    public LookupFailedException(String message) {
++        super(message);
+     }
+ 
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java b/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java
+index 2a8667c..bd6379a 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java
++++ b/src/main/java/com/destroystokyo/paper/profile/PlayerTextures.java
+@@ -1,10 +1,5 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.net.MalformedURLException;
+-import java.net.URL;
+-import java.util.Base64;
+-import java.util.Map;
+-
+ import com.google.common.base.Charsets;
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.ImmutableMap;
+@@ -14,6 +9,11 @@ import com.google.gson.JsonObject;
+ import com.google.gson.JsonParseException;
+ import com.google.gson.JsonParser;
+ 
++import java.net.MalformedURLException;
++import java.net.URL;
++import java.util.Base64;
++import java.util.Map;
++
+ /**
+  * A player's texture data, including skin and cape.
+  */
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java
+index 359cf03..a42f443 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileLookup.java
+@@ -1,12 +1,12 @@
+ package com.destroystokyo.paper.profile;
+ 
++import com.google.common.collect.ImmutableList;
++
+ import java.util.Collection;
+ import java.util.UUID;
+ import java.util.regex.Matcher;
+ import java.util.regex.Pattern;
+ 
+-import com.google.common.collect.ImmutableList;
+-
+ public interface ProfileLookup {
+ 
+     /**
+@@ -15,7 +15,7 @@ public interface ProfileLookup {
+      * We have to accept spaces due to this bug: https://www.reddit.com/r/Minecraft/comments/276wcb/psa_usernames_can_contain_spaces_this_effectively/
+      * We also have to accept names less than 3 characters
+      */
+-    public static final Pattern NAME_PATTERN = Pattern.compile("[ \\w]{1,16}+");
++    Pattern NAME_PATTERN = Pattern.compile("[ \\w]{1,16}+");
+ 
+     /**
+      * Return if the name is valid
+@@ -25,7 +25,7 @@ public interface ProfileLookup {
+      * @param s the name to check
+      * @return true if valid
+      */
+-    public static boolean isValidName(String s) {
++    static boolean isValidName(String s) {
+         Matcher m = NAME_PATTERN.matcher(s);
+         return m.matches();
+     }
+@@ -42,7 +42,7 @@ public interface ProfileLookup {
+      * @throws LookupFailedException if unable to lookup
+      * @throws NullPointerException if
+      */
+-    public AccountProfile lookup(String name);
++    AccountProfile lookup(String name);
+ 
+     /**
+      * Lookup a profile with the given uuid
+@@ -55,7 +55,7 @@ public interface ProfileLookup {
+      * @return a profile with the given id
+      * @throws LookupFailedException if unable to lookup
+      */
+-    public AccountProfile lookup(UUID id);
++    AccountProfile lookup(UUID id);
+ 
+     /**
+      * Lookup a profile with the given name
+@@ -66,7 +66,7 @@ public interface ProfileLookup {
+      * @param name     look for a profile with this name
+      * @param callback the callback to handle the result of the lookups
+      */
+-    public default void lookup(String name, ProfileLookupCallback<String> callback) {
++    default void lookup(String name, ProfileLookupCallback<String> callback) {
+         try {
+             AccountProfile profile = lookup(name);
+             callback.onLookup(profile, name);
+@@ -87,7 +87,7 @@ public interface ProfileLookup {
+      * @param id       look for a profile with this id
+      * @param callback the callback to handle the result of the lookups
+      */
+-    public default void lookup(UUID id, ProfileLookupCallback<UUID> callback) {
++    default void lookup(UUID id, ProfileLookupCallback<UUID> callback) {
+         try {
+             AccountProfile profile = lookup(id);
+             callback.onLookup(profile, id);
+@@ -113,7 +113,7 @@ public interface ProfileLookup {
+      * @throws LookupFailedException    if lookup fails
+      * @throws IllegalArgumentException if one of the ids doesn't exist
+      */
+-    public default ImmutableList<AccountProfile> lookupIds(Collection<UUID> ids) {
++    default ImmutableList<AccountProfile> lookupIds(Collection<UUID> ids) {
+         ImmutableList.Builder<AccountProfile> profileBuilder = ImmutableList.builder();
+         lookupIds(ids, ProfileLookupCallback.assumeFound((profile, original) -> profileBuilder.add(profile)));
+         return profileBuilder.build();
+@@ -134,7 +134,7 @@ public interface ProfileLookup {
+      * @throws LookupFailedException    if lookup fails
+      * @throws IllegalArgumentException if one of the names doesn't exist
+      */
+-    public default ImmutableList<AccountProfile> lookupNames(Collection<String> names) {
++    default ImmutableList<AccountProfile> lookupNames(Collection<String> names) {
+         ImmutableList.Builder<AccountProfile> profileBuilder = ImmutableList.builder();
+         lookupNames(names, ProfileLookupCallback.assumeFound((profile, original) -> profileBuilder.add(profile)));
+         return profileBuilder.build();
+@@ -151,7 +151,7 @@ public interface ProfileLookup {
+      * @param ids      the ids to lookup
+      * @param callback the callback to handle the lookups
+      */
+-    public default void lookupIds(Collection<UUID> ids, ProfileLookupCallback<UUID> callback) {
++    default void lookupIds(Collection<UUID> ids, ProfileLookupCallback<UUID> callback) {
+         ids.forEach((id) -> lookup(id, callback));
+     }
+ 
+@@ -166,7 +166,7 @@ public interface ProfileLookup {
+      * @param names    the names to lookup
+      * @param callback the callback to handle the lookups
+      */
+-    public default void lookupNames(Collection<String> names, ProfileLookupCallback<String> callback) {
++    default void lookupNames(Collection<String> names, ProfileLookupCallback<String> callback) {
+         names.forEach((name) -> lookup(name, callback));
+     }
+ 
+@@ -180,7 +180,7 @@ public interface ProfileLookup {
+      * @throws IllegalArgumentException if there is no player with the given name/uuid
+      * @throws LookupFailedException    if unable to lookup properties
+      */
+-    public ProfileProperties lookupProperties(AccountProfile profile);
++    ProfileProperties lookupProperties(AccountProfile profile);
+ 
+     /**
+      * Return if the lookups have the same underlying source
+@@ -190,5 +190,5 @@ public interface ProfileLookup {
+      * @param other the object to check equality with
+      * @return if equal
+      */
+-    public boolean equals(Object other);
++    boolean equals(Object other);
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java b/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java
+index 859aff1..d5f8a4f 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileLookupCallback.java
+@@ -22,7 +22,7 @@ public interface ProfileLookupCallback<T> {
+      * @param profile  the profile that was found, or null if the player
+      * @param original the key that was being looked up
+      */
+-    public void onLookup(AccountProfile profile, T original);
++    void onLookup(AccountProfile profile, T original);
+ 
+     /**
+      * Called when a lookup fails
+@@ -30,11 +30,11 @@ public interface ProfileLookupCallback<T> {
+      * @param t        the exception that was caught, may be null
+      * @param original the key that was being looked up
+      */
+-    public default void onLookupFailed(Throwable t, T original) {
++    default void onLookupFailed(Throwable t, T original) {
+         throw new LookupFailedException("Unable to lookup " + original.toString(), t);
+     }
+ 
+-    public static <T> ProfileLookupCallback<T> assumeFound(ProfileLookupCallback<T> delegate) {
++    static <T> ProfileLookupCallback<T> assumeFound(ProfileLookupCallback<T> delegate) {
+         return new ProfileLookupCallback<T>() {
+             @Override
+             public void onLookup(AccountProfile profile, T original) {
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java b/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java
+index 8d1ad99..c8d9c15 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileProperties.java
+@@ -1,14 +1,14 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.util.Collection;
+-import java.util.Map;
+-import java.util.function.BiConsumer;
+-
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.ImmutableSet;
+ import com.google.common.collect.ImmutableSetMultimap;
+ import com.google.common.collect.SetMultimap;
+ 
++import java.util.Collection;
++import java.util.Map;
++import java.util.function.BiConsumer;
++
+ public final class ProfileProperties {
+     private final ImmutableSetMultimap<String, ProfileProperty> properties;
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java b/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java
+index 16deedf..96d6ad9 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileProperty.java
+@@ -1,5 +1,8 @@
+ package com.destroystokyo.paper.profile;
+ 
++import com.google.common.base.Preconditions;
++import com.google.common.io.ByteStreams;
++
+ import java.io.BufferedInputStream;
+ import java.io.IOException;
+ import java.security.InvalidKeyException;
+@@ -12,11 +15,14 @@ import java.security.spec.InvalidKeySpecException;
+ import java.security.spec.X509EncodedKeySpec;
+ import java.util.Base64;
+ 
+-import com.google.common.base.Preconditions;
+-import com.google.common.io.ByteStreams;
+-
+ public final class ProfileProperty {
+-    private final String name, value, signature;
++    private final String name;
++    private final String value;
++    private final String signature;
++
++    public ProfileProperty(String name, String value) {
++        this(name, value, null);
++    }
+ 
+     public ProfileProperty(String name, String value, String signature) {
+         this.name = Preconditions.checkNotNull(name, "Name of the property can't be null");
+@@ -24,10 +30,6 @@ public final class ProfileProperty {
+         this.signature = signature;
+     }
+ 
+-    public ProfileProperty(String name, String value) {
+-        this(name, value, null);
+-    }
+-
+     /**
+      * Return the name of this property
+      *
+diff --git a/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java b/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java
+index 96c8b5f..cfde6f4 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java
++++ b/src/main/java/com/destroystokyo/paper/profile/UUIDUtils.java
+@@ -1,11 +1,11 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.util.UUID;
+-
+ import com.destroystokyo.paper.utils.Hex;
+ import com.google.common.base.Preconditions;
+ import com.google.common.primitives.Longs;
+ 
++import java.util.UUID;
++
+ public class UUIDUtils {
+     private UUIDUtils() {}
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java
+index 57776d5..c6d4d5a 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncNamePreResolveEvent.java
+@@ -1,23 +1,25 @@
+ package com.destroystokyo.paper.profile.event;
+ 
+-import com.destroystokyo.paper.profile.LookupCause;
+ import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.LookupCause;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.event.HandlerList;
+ 
++import java.util.UUID;
++
+ /**
+- * Called before a uuid is requested from mojang.
++ * Called before a {@link UUID} is requested from Mojang.
+  * <p>
+- * <p>The event may be called synchronouslys if the uuid is resolved on the main thread</p>
++ * <p>The event may be called synchronously if the uuid is resolved on the main thread</p>
+  */
+ public class AsyncNamePreResolveEvent extends AsyncProfilePreResolveEvent {
++
++    private static final HandlerList handlers = new HandlerList();
+     private final String name;
+ 
+     public AsyncNamePreResolveEvent(String name) {
+-        super(LookupCause.NAME_LOOKUP);
+-        Preconditions.checkNotNull(name, "Null name");
+-        this.name = name;
++        super(LookupCause.NAME);
++        this.name = Preconditions.checkNotNull(name, "Null name");
+     }
+ 
+     /**
+@@ -42,14 +44,12 @@ public class AsyncNamePreResolveEvent extends AsyncProfilePreResolveEvent {
+         super.setResult(result);
+     }
+ 
+-    private static final HandlerList handlerList = new HandlerList();
+-
+-    public static HandlerList getHandlerList() {
+-        return handlerList;
+-    }
+-
+     @Override
+     public HandlerList getHandlers() {
+-        return handlerList;
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
+     }
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java
+index bc81ec3..6688293 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfilePreResolveEvent.java
+@@ -1,11 +1,10 @@
+ package com.destroystokyo.paper.profile.event;
+ 
+ import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.LookupCause;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.Bukkit;
+ import org.bukkit.event.Event;
+-import com.destroystokyo.paper.profile.LookupCause;
+ 
+ /**
+  * Called before a profile is looked up from mojang.
+@@ -18,7 +17,7 @@ public abstract class AsyncProfilePreResolveEvent extends Event {
+ 
+     public AsyncProfilePreResolveEvent(LookupCause cause) {
+         super(!Bukkit.isPrimaryThread());
+-        this.cause = Preconditions.checkNotNull(cause, "Null cause");;
++        this.cause = Preconditions.checkNotNull(cause, "Null cause");
+     }
+ 
+     /**
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java
+index cbc2572..e3751a7 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncProfileResolveEvent.java
+@@ -1,25 +1,26 @@
+ package com.destroystokyo.paper.profile.event;
+ 
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.LookupCause;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.Bukkit;
+ import org.bukkit.event.Event;
+ import org.bukkit.event.HandlerList;
+-import com.destroystokyo.paper.profile.LookupCause;
+-import com.destroystokyo.paper.profile.AccountProfile;
+ 
+ /**
+  * Called once a profile is resolved.
+  * <p>May come from a plugin or from mojang.</p>
+  */
+ public class AsyncProfileResolveEvent extends Event {
++
++    private static final HandlerList handlers = new HandlerList();
+     private final LookupCause cause;
+     private AccountProfile result;
+     private boolean mojang;
+ 
+     public AsyncProfileResolveEvent(LookupCause cause, AccountProfile result, boolean mojang) {
+         super(!Bukkit.isPrimaryThread());
+-        this.cause = Preconditions.checkNotNull(cause, "Null cause");;
++        this.cause = Preconditions.checkNotNull(cause, "Null cause");
+         setResult(result);
+         this.mojang = mojang;
+     }
+@@ -41,7 +42,7 @@ public class AsyncProfileResolveEvent extends Event {
+      */
+     public void setResult(AccountProfile result) {
+         Preconditions.checkNotNull(result, "Null result");
+-        if (this.getCause() == LookupCause.PROPERTIES_LOOKUP) {
++        if (this.getCause() == LookupCause.PROPERTIES) {
+             Preconditions.checkArgument(result.hasProperties(), "Result doesn't have properties in properties lookup: %s", result);
+         }
+         this.result = result;
+@@ -67,14 +68,12 @@ public class AsyncProfileResolveEvent extends Event {
+         return mojang;
+     }
+ 
+-    private static final HandlerList handlerList = new HandlerList();
+-
+-    public HandlerList getHandlerList() {
+-        return handlerList;
+-    }
+-
+     @Override
+     public HandlerList getHandlers() {
+-        return getHandlerList();
++        return handlers;
++    }
++
++    public HandlerList getHandlerList() {
++        return handlers;
+     }
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java
+index cf74f7a..26a3b6d 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncPropertiesPreResolveEvent.java
+@@ -1,11 +1,10 @@
+ package com.destroystokyo.paper.profile.event;
+ 
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.LookupCause;
+ import com.destroystokyo.paper.profile.ProfileProperties;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.event.HandlerList;
+-import com.destroystokyo.paper.profile.LookupCause;
+-import com.destroystokyo.paper.profile.AccountProfile;
+ 
+ /**
+  * Called before profile properties are requested from mojang.
+@@ -13,10 +12,12 @@ import com.destroystokyo.paper.profile.AccountProfile;
+  * <p>The event may be called synchronously if the uuid is resolved on the main thread</p>
+  */
+ public class AsyncPropertiesPreResolveEvent extends AsyncProfilePreResolveEvent {
++
++    private static final HandlerList handlers = new HandlerList();
+     private final AccountProfile profile;
+ 
+     public AsyncPropertiesPreResolveEvent(AccountProfile profile) {
+-        super(LookupCause.PROPERTIES_LOOKUP);
++        super(LookupCause.PROPERTIES);
+         Preconditions.checkNotNull(profile, "Null profile");
+         this.profile = profile.withProperties(null);
+     }
+@@ -55,14 +56,12 @@ public class AsyncPropertiesPreResolveEvent extends AsyncProfilePreResolveEvent
+         super.setResult(result);
+     }
+ 
+-    private static final HandlerList handlerList = new HandlerList();
+-
+-    public static HandlerList getHandlerList() {
+-        return handlerList;
+-    }
+-
+     @Override
+     public HandlerList getHandlers() {
+-        return getHandlerList();
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
+     }
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java b/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java
+index 1cf537e..83554aa 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java
++++ b/src/main/java/com/destroystokyo/paper/profile/event/AsyncUUIDPreResolveEvent.java
+@@ -1,24 +1,25 @@
+ package com.destroystokyo.paper.profile.event;
+ 
+-import java.util.UUID;
+-
+-import com.destroystokyo.paper.profile.LookupCause;
+ import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.LookupCause;
+ import com.google.common.base.Preconditions;
+-
+ import org.bukkit.event.HandlerList;
+ 
++import java.util.UUID;
++
+ /**
+  * Called before a profile is requested from mojang.
+  * Plugins can set a profile, which will effectively 'cancel' the lookup from mojang.
+  * <p>The event may be called synchronously if the uuid is resolved on the main thread</p>
+  */
+ public class AsyncUUIDPreResolveEvent extends AsyncProfilePreResolveEvent {
++
++    private static final HandlerList handlers = new HandlerList();
+     private final UUID id;
+ 
+     public AsyncUUIDPreResolveEvent(UUID id) {
+-        super(LookupCause.UUID_LOOKUP);
+-        this.id = Preconditions.checkNotNull(id, "Null id");;
++        super(LookupCause.UUID);
++        this.id = Preconditions.checkNotNull(id, "Null id");
+     }
+ 
+     /**
+@@ -42,14 +43,13 @@ public class AsyncUUIDPreResolveEvent extends AsyncProfilePreResolveEvent {
+         }
+         super.setResult(result);
+     }
+-    private static final HandlerList handlerList = new HandlerList();
+-
+-    public static HandlerList getHandlerList() {
+-        return handlerList;
+-    }
+ 
+     @Override
+     public HandlerList getHandlers() {
+-        return getHandlerList();
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
+     }
+ }
+-- 
+2.7.4
+

--- a/Spigot-Server-Patches/0156-Implement-Profile-api.patch
+++ b/Spigot-Server-Patches/0156-Implement-Profile-api.patch
@@ -1,0 +1,770 @@
+From d99192ff867f5a7ab2d82d2c2ef33b631fcb0c95 Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@outlook.com>
+Date: Sun, 13 Mar 2016 20:42:57 -0700
+Subject: [PATCH] Implement Profile api.
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java
+new file mode 100644
+index 0000000..f2ad29d
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java
+@@ -0,0 +1,141 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.ArrayList;
++import java.util.Collection;
++import java.util.List;
++import java.util.UUID;
++
++import com.destroystokyo.paper.profile.event.AsyncPropertiesPreResolveEvent;
++import com.google.common.base.Preconditions;
++
++import org.bukkit.Bukkit;
++import com.destroystokyo.paper.profile.event.AsyncNamePreResolveEvent;
++import com.destroystokyo.paper.profile.event.AsyncProfileResolveEvent;
++import com.destroystokyo.paper.profile.event.AsyncUUIDPreResolveEvent;
++
++public class EventProfileLookup implements ProfileLookup {
++    private final ProfileLookup delegate;
++
++    public EventProfileLookup(ProfileLookup delegate) {
++        Preconditions.checkNotNull(delegate, "Null delegate");
++        this.delegate = Preconditions.checkNotNull(delegate, "Null delegate");;
++    }
++
++    @Override
++    public AccountProfile lookup(String name) {
++        Preconditions.checkNotNull(name, "Null name");
++        AsyncNamePreResolveEvent preResolveEvent = new AsyncNamePreResolveEvent(name);
++        Bukkit.getPluginManager().callEvent(preResolveEvent);
++        AsyncProfileResolveEvent resolveEvent;
++        if (preResolveEvent.isResolved()) { // Plugin set result
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, preResolveEvent.getResult(), false);
++        } else {
++            // Lookup result from mojang
++            AccountProfile profile = delegate.lookup(name);
++            if (profile == null) return null; // Not found
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, profile, true);
++        }
++        Bukkit.getPluginManager().callEvent(resolveEvent);
++        return resolveEvent.getResult();
++    }
++
++    @Override
++    public AccountProfile lookup(UUID id) {
++        Preconditions.checkNotNull(id, "Null id");
++        AsyncUUIDPreResolveEvent preResolveEvent = new AsyncUUIDPreResolveEvent(id);
++        Bukkit.getPluginManager().callEvent(preResolveEvent);
++        AsyncProfileResolveEvent resolveEvent;
++        if (preResolveEvent.isResolved()) { // Plugin set result
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, preResolveEvent.getResult(), false);
++        } else {
++            // Lookup result from mojang
++            AccountProfile profile = delegate.lookup(id);
++            if (profile == null) return null; // Not found
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, profile, true);
++        }
++        Bukkit.getPluginManager().callEvent(resolveEvent);
++        return resolveEvent.getResult();
++    }
++
++    @Override
++    public void lookupIds(Collection<UUID> ids, ProfileLookupCallback<UUID> callback) {
++        List<UUID> toLookup = new ArrayList<>(ids.size());
++        for (UUID id : ids) {
++            Preconditions.checkNotNull(id, "Null id");
++            AsyncUUIDPreResolveEvent preResolveEvent = new AsyncUUIDPreResolveEvent(id);
++            Bukkit.getPluginManager().callEvent(preResolveEvent);
++            if (preResolveEvent.isResolved()) { // Plugin set result
++                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, preResolveEvent.getResult(), false);
++                Bukkit.getPluginManager().callEvent(resolveEvent);
++                callback.onLookup(resolveEvent.getResult(), id);
++            } else {
++                toLookup.add(id);
++            }
++        }
++        delegate.lookupIds(toLookup, new ProfileLookupCallback<UUID>() {
++            @Override
++            public void onLookup(AccountProfile profile, UUID original) {
++                if (profile != null) {
++                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, profile, true);
++                    Bukkit.getPluginManager().callEvent(resolveEvent);
++                    profile = resolveEvent.getResult();
++                }
++                callback.onLookup(profile, original);
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, UUID original) {
++                callback.onLookupFailed(t, original);
++            }
++        });
++    }
++
++    @Override
++    public void lookupNames(Collection<String> names, ProfileLookupCallback<String> callback) {
++        List<String> toLookup = new ArrayList<>(names.size());
++        for (String name : names) {
++            Preconditions.checkNotNull(name, "Null id");
++            AsyncNamePreResolveEvent preResolveEvent = new AsyncNamePreResolveEvent(name);
++            Bukkit.getPluginManager().callEvent(preResolveEvent);
++            if (preResolveEvent.isResolved()) { // Plugin set result
++                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, preResolveEvent.getResult(), false);
++                Bukkit.getPluginManager().callEvent(resolveEvent);
++                callback.onLookup(resolveEvent.getResult(), name);
++            } else {
++                toLookup.add(name);
++            }
++        }
++        delegate.lookupNames(toLookup, new ProfileLookupCallback<String>() {
++            @Override
++            public void onLookup(AccountProfile profile, String original) {
++                if (profile != null) {
++                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, profile, true);
++                    Bukkit.getPluginManager().callEvent(resolveEvent);
++                    profile = resolveEvent.getResult();
++                }
++                callback.onLookup(profile, original);
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, String original) {
++                callback.onLookupFailed(t, original);
++            }
++        });
++    }
++
++    @Override
++    public ProfileProperties lookupProperties(AccountProfile profile) {
++        AsyncPropertiesPreResolveEvent preResolveEvent = new AsyncPropertiesPreResolveEvent(profile);
++        Bukkit.getPluginManager().callEvent(preResolveEvent);
++        AsyncProfileResolveEvent resolveEvent;
++        if (preResolveEvent.isResolved()) {
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES_LOOKUP, preResolveEvent.getResult(), false);
++        } else {
++            ProfileProperties properties = delegate.lookupProperties(profile);
++            if (properties == null) return null;
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES_LOOKUP, profile.withProperties(properties), true);
++        }
++        Bukkit.getPluginManager().callEvent(resolveEvent);
++        return resolveEvent.getResult().getProperties();
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java b/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java
+new file mode 100644
+index 0000000..f58b36a
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java
+@@ -0,0 +1,45 @@
++package com.destroystokyo.paper.profile;
++
++import java.util.Collection;
++import java.util.UUID;
++
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableList;
++
++public final class MojangLookup implements ProfileLookup {
++
++    @Override
++    public AccountProfile lookup(String name) {
++        AccountProfile[] profileHolder = new AccountProfile[1];
++        lookupNames(ImmutableList.of(name), (profile, original) -> profileHolder[0] = profile);
++        return profileHolder[0];
++    }
++
++    @Override
++    public AccountProfile lookup(UUID id) {
++        return ProfileUtils.requestProfile(id).orElse(null);
++    }
++
++    @Override
++    public void lookupNames(Collection<String> names, final ProfileLookupCallback<String> callback) {
++        Preconditions.checkNotNull(callback, "Null callback");
++
++    }
++
++    @Override
++    public ProfileProperties lookupProperties(AccountProfile profile) {
++        AccountProfile newProfile = lookup(profile.getId());
++        Preconditions.checkArgument(newProfile != null, "%s doesn't exist", profile);
++        return newProfile.getProperties();
++    }
++
++    @Override
++    public boolean equals(Object obj) {
++        return obj instanceof MojangLookup;
++    }
++
++    @Override
++    public int hashCode() {
++        return 0;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java b/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java
+new file mode 100644
+index 0000000..dc50aaf
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java
+@@ -0,0 +1,290 @@
++package com.destroystokyo.paper.profile;
++
++import java.io.BufferedReader;
++import java.io.BufferedWriter;
++import java.io.IOException;
++import java.io.InputStreamReader;
++import java.io.OutputStreamWriter;
++import java.net.HttpURLConnection;
++import java.net.MalformedURLException;
++import java.net.URL;
++import java.util.List;
++import java.util.Map;
++import java.util.Optional;
++import java.util.UUID;
++
++import com.destroystokyo.paper.utils.json.ProfilePropertyTypeAdapter;
++import com.destroystokyo.paper.utils.json.UUIDTypeAdapter;
++import com.google.common.base.Charsets;
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableList;
++import com.google.common.collect.ImmutableSet;
++import com.google.common.collect.UnmodifiableIterator;
++import com.google.common.net.HttpHeaders;
++import com.google.gson.Gson;
++import com.google.gson.GsonBuilder;
++import com.google.gson.JsonIOException;
++import com.google.gson.JsonParseException;
++import com.google.gson.stream.JsonReader;
++import com.google.gson.stream.JsonWriter;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.properties.Property;
++import com.mojang.authlib.properties.PropertyMap;
++
++import static com.destroystokyo.paper.profile.UUIDUtils.fromString;
++import static com.destroystokyo.paper.profile.UUIDUtils.toMojangString;
++
++public class ProfileUtils {
++
++    private static final Gson GSON = new GsonBuilder()
++            .registerTypeAdapter(UUID.class, UUIDTypeAdapter.createMojang())
++            .registerTypeAdapter(ProfileProperty.class, new ProfilePropertyTypeAdapter())
++            .create();
++
++    public static Optional<AccountProfile> requestProfile(UUID id) {
++        Preconditions.checkNotNull(id, "Null id");
++        try {
++            URL url = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + toMojangString(id) + "?unsigned=false");
++            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
++            connection.connect();
++            if (connection.getResponseCode() == HttpURLConnection.HTTP_NO_CONTENT) {
++                return Optional.empty(); // Profile not found
++            }
++            if (connection.getResponseCode() == 429) {
++                throw new LookupFailedException("Mojang rate limited request for: " + id);
++            }
++            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {
++                ProfileResponse response = GSON.fromJson(reader, ProfileResponse.class);
++
++                if (response.errorMessage != null) {
++                    throw new LookupFailedException("Mojang returned error: " + response.errorMessage);
++                } else if (response.id == null || response.name == null || response.profile == null) {
++                    throw new LookupFailedException("Unknown error looking up " + id.toString());
++                }
++
++                return Optional.of(new AccountProfile(response.id, response.name, ProfileProperties.copyOf(response.profile)));
++            }
++        } catch (JsonIOException e) {
++            throw new LookupFailedException("Error contacting mojang", e.getCause());
++        } catch (MalformedURLException e) {
++            // This shouldn't happen as UUID.toString() is a perfectly valid url
++            throw new AssertionError("Unable to parse url " + e);
++        } catch (IOException | JsonParseException e) {
++            throw new LookupFailedException("Error contacting mojang", e);
++        }
++    }
++
++    private static class ProfileResponse {
++        private String errorMessage;
++        private UUID id;
++        private String name;
++        private List<ProfileProperty> profile;
++    }
++
++    public static Optional<AccountProfile> lookup(String name) {
++        Preconditions.checkNotNull(name, "Null name");
++        Preconditions.checkArgument(ProfileLookup.isValidName(name), "Invalid name %s", name);
++        try {
++            URL url = new URL("https://api.mojang.com/users/profiles/minecraft/" + name);
++            HttpURLConnection connection = (HttpURLConnection) url.openConnection();
++            connection.connect();
++            if (connection.getResponseCode() == HttpURLConnection.HTTP_NO_CONTENT) {
++                return Optional.empty(); // Profile not found
++            }
++            if (connection.getResponseCode() == 429) {
++                throw new LookupFailedException("Mojang rate limited request for: " + name);
++            }
++
++            try (JsonReader reader = new JsonReader(new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8)))) {
++                reader.beginObject();
++                UUID id = null;
++                name = null; // Reset to null so we can check for errors
++                while (reader.hasNext()) {
++                    String key;
++                    switch ((key = reader.nextName())) {
++                        case "id":
++                            String s = reader.nextString();
++                            if (s == null) throw new LookupFailedException("Mojang returned null id");
++                            id = fromString(s);
++                            break;
++                        case "name":
++                            name = reader.nextString(); // Now reset to case-corrected name
++                            if (name == null) throw new LookupFailedException("Mojang returned null name");
++                            break;
++                        case "legacy":
++                        case "demo":
++                            break;
++                        default:
++                            throw new LookupFailedException("Invalid json, unexpected object key: " + key);
++                    }
++                }
++
++                if (id == null) {
++                    throw new LookupFailedException("Mojang didn't return id");
++                } else if (name == null) {
++                    throw new LookupFailedException("Mojang didn't return name");
++                }
++                reader.endObject();
++                if (reader.hasNext()) {
++                    throw new LookupFailedException("Didn't read all data mojang sent. Unexpected " + reader.peek());
++                }
++                return Optional.of(new AccountProfile(id, name));
++            }
++        } catch (JsonIOException e) {
++            throw new LookupFailedException("Error contacting mojang", e.getCause());
++        } catch (MalformedURLException e) {
++            // This shouldn't happen as names are perfectly valid urls
++            throw new AssertionError("Unable to parse url " + e);
++        } catch (IOException | JsonParseException e) {
++            throw new LookupFailedException("Error contacting mojang", e);
++        }
++    }
++
++    public static final URL BULK_NAME_LOOKUP_URL;
++
++    static {
++        try {
++            BULK_NAME_LOOKUP_URL = new URL("https://api.mojang.com/profiles/minecraft");
++        } catch (MalformedURLException e) {
++            throw new AssertionError("Couldn't  parse URL", e);
++        }
++    }
++
++    public static ImmutableList<AccountProfile> lookupNames(ImmutableSet<String> names) {
++        Preconditions.checkNotNull(names, "Null names");
++        if (names.isEmpty()) return ImmutableList.of();
++        if (names.size() > 100) {
++            ImmutableList.Builder<AccountProfile> result = ImmutableList.builder();
++            // Split up the request to meet mojang's limit of 100 names per request
++            UnmodifiableIterator<String> iterator = names.iterator();
++            while (iterator.hasNext()) {
++                ImmutableSet.Builder<String> split = ImmutableSet.builder();
++                for (int i = 0; i < 100 && iterator.hasNext(); i++) {
++                    String name = iterator.next();
++                    split.add(name);
++                }
++                result.addAll(lookupNames(split.build()));
++            }
++            return result.build();
++        }
++        try {
++            HttpURLConnection connection = (HttpURLConnection) BULK_NAME_LOOKUP_URL.openConnection();
++            connection.setDoOutput(true);
++            connection.setRequestProperty(HttpHeaders.CONTENT_TYPE, "application/json");
++            connection.connect();
++            if (connection.getResponseCode() == 429) {
++                throw new LookupFailedException("Mojang rate limited request for " + names.size() + " names");
++            }
++            try (JsonWriter writer = new JsonWriter(new BufferedWriter(new OutputStreamWriter(connection.getOutputStream(), Charsets.UTF_8)))) {
++                writer.beginArray();
++                for (String name : names) {
++                    writer.value(name);
++                }
++                writer.endArray();
++            }
++            ImmutableList.Builder<AccountProfile> profiles = ImmutableList.builder();
++            try (JsonReader reader = new JsonReader(new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8)))) {
++                reader.beginArray();
++                while (reader.hasNext()) {
++                    reader.beginObject();
++                    UUID id = null;
++                    String name = null;
++                    while (reader.hasNext()) {
++                        String key;
++                        switch ((key = reader.nextName())) {
++                            case "id":
++                                String s = reader.nextString();
++                                if (s == null) throw new LookupFailedException("Mojang returned null id");
++                                id = fromString(s);
++                                break;
++                            case "name":
++                                name = reader.nextString();
++                                if (name == null) throw new LookupFailedException("Mojang returned null name");
++                                break;
++                            case "legacy":
++                            case "demo":
++                                break;
++                            default:
++                                throw new LookupFailedException("Invalid json. Unexpected object key: " + key);
++                        }
++                    }
++
++                    if (id == null) {
++                        throw new LookupFailedException("Mojang didn't return id");
++                    } else if (name == null) {
++                        throw new LookupFailedException("Mojang didn't return name");
++                    }
++                    profiles.add(new AccountProfile(id, name));
++                    reader.endObject();
++                }
++                reader.endArray();
++                if (reader.hasNext()) {
++                    throw new LookupFailedException("Didn't read response fully. Unexpected: " + reader.peek());
++                }
++                return profiles.build();
++            }
++        } catch (IOException e) {
++            throw new LookupFailedException("Error contacting mojang", e);
++        }
++    }
++
++    //
++    // Converters
++    //
++
++    public static GameProfile toMojang(AccountProfile paper) {
++        if (paper == null) return null;
++        GameProfile mojang = new GameProfile(paper.getId(), paper.getName());
++        if (paper.hasProperties()) {
++            mojang.getProperties().clear();
++            addAllToMojang(paper.getProperties(), mojang.getProperties());
++        }
++        return mojang;
++    }
++
++    public static AccountProfile toPaper(GameProfile mojang) {
++        if (mojang == null) return null;
++        // If the profile's properties aren't empty, we must know them
++        return toPaper0(mojang, !mojang.getProperties().isEmpty());
++    }
++
++    public static AccountProfile toPaperWithProperties(GameProfile mojang) {
++        if (mojang == null) return null;
++        return toPaper0(mojang, true);
++    }
++
++    private static AccountProfile toPaper0(GameProfile mojang, boolean propertiesKnown) {
++        Preconditions.checkArgument(mojang.isComplete(), "Incomplete profile %s", mojang);
++        return new AccountProfile(mojang.getId(), mojang.getName(), propertiesKnown ? toPaper(mojang.getProperties()) : null);
++    }
++
++    public static PropertyMap toMojang(ProfileProperties paper) {
++        if (paper == null) return null;
++        PropertyMap mojang = new PropertyMap();
++        addAllToMojang(paper, mojang);
++        return mojang;
++    }
++
++    private static void addAllToMojang(ProfileProperties paper, PropertyMap mojang) {
++        paper.forEach((name, property) -> mojang.put(name, toMojang(property)));
++    }
++
++    public static ProfileProperties toPaper(PropertyMap mojang) {
++        if (mojang == null) return null;
++        ProfileProperties.Builder builder = ProfileProperties.builder();
++        for (Map.Entry<String, Property> entry : mojang.entries()) {
++            builder.put(entry.getKey(), toPaper(entry.getValue()));
++        }
++        return builder.build();
++    }
++
++    public static Property toMojang(ProfileProperty paper) {
++        if (paper == null) return null;
++        return new Property(paper.getName(), paper.getValue(), paper.isSigned() ? paper.getSignature() : null);
++    }
++
++    public static ProfileProperty toPaper(Property mojang) {
++        if (mojang == null) return null;
++        return new ProfileProperty(mojang.getName(), mojang.getValue(), mojang.getSignature());
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java b/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java
+new file mode 100644
+index 0000000..590a778
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java
+@@ -0,0 +1,31 @@
++package com.destroystokyo.paper.utils.json;
++
++import java.io.IOException;
++
++import com.destroystokyo.paper.profile.ProfileProperty;
++import com.google.gson.TypeAdapter;
++import com.google.gson.stream.JsonReader;
++import com.google.gson.stream.JsonWriter;
++
++public class ProfilePropertyTypeAdapter extends TypeAdapter<ProfileProperty> {
++    @Override
++    public void write(JsonWriter out, ProfileProperty property) throws IOException {
++        if (property != null) {
++            out.beginObject();
++            out.name("name");
++            out.value(property.getName());
++            out.name("value");
++            out.value(property.getName());
++            if (property.isSigned()) {
++                out.name("signature");
++                out.name(property.getSignature());
++            }
++            out.endObject();
++        }
++    }
++
++    @Override
++    public ProfileProperty read(JsonReader in) throws IOException {
++        return null;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java b/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java
+new file mode 100644
+index 0000000..908c7b4
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java
+@@ -0,0 +1,54 @@
++package com.destroystokyo.paper.utils.json;
++
++import java.io.IOException;
++import java.util.UUID;
++
++import com.google.gson.TypeAdapter;
++import com.google.gson.stream.JsonReader;
++import com.google.gson.stream.JsonToken;
++import com.google.gson.stream.JsonWriter;
++
++import com.destroystokyo.paper.profile.UUIDUtils;
++
++public class UUIDTypeAdapter extends TypeAdapter<UUID> {
++    private final boolean mojangStyle;
++    private final boolean lenient;
++
++    private UUIDTypeAdapter(boolean mojangStyle, boolean lenient) {
++        if (mojangStyle && !lenient) throw new AssertionError("Mojang style should imply lenient");
++        this.mojangStyle = mojangStyle;
++        this.lenient = lenient;
++    }
++
++    public static UUIDTypeAdapter create() {
++        return new UUIDTypeAdapter(false, false);
++    }
++
++    public static UUIDTypeAdapter createMojang() {
++        return new UUIDTypeAdapter(true, true);
++    }
++
++    public static UUIDTypeAdapter createLenient() {
++        return new UUIDTypeAdapter(false, true);
++    }
++
++    @Override
++    public void write(JsonWriter out, UUID value) throws IOException {
++        if (value != null) {
++            out.value(mojangStyle ? UUIDUtils.toMojangString(value) : value.toString());
++        } else {
++            out.nullValue();
++        }
++    }
++
++    @Override
++    public UUID read(JsonReader in) throws IOException {
++        if (in.peek() != JsonToken.NULL) {
++            String s = in.nextString();
++            return lenient ? UUIDUtils.fromString(s) : UUID.fromString(s);
++        } else {
++            in.nextNull();
++            return null;
++        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 696f21f..bd77866 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -23,6 +23,10 @@ import org.bukkit.event.player.PlayerDropItemEvent;
+ import org.bukkit.event.player.PlayerVelocityEvent;
+ import org.bukkit.util.Vector;
+ // CraftBukkit end
++// Paper start
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.ProfileUtils;
++// Paper end
+ 
+ public abstract class EntityHuman extends EntityLiving {
+ 
+@@ -1214,6 +1218,14 @@ public abstract class EntityHuman extends EntityLiving {
+         return this.bS;
+     }
+ 
++    // Paper start - bukkit profile method
++    private final AccountProfile bukkitProfile = ProfileUtils.toPaperWithProperties(getProfile());
++
++    public AccountProfile getBukkitProfile() {
++        return bukkitProfile;
++    }
++    // Paper end
++
+     public EntityHuman.EnumBedResult a(BlockPosition blockposition) {
+         if (!this.world.isClientSide) {
+             if (this.isSleeping() || !this.isAlive()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index 4521786..e902cd8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -21,6 +21,10 @@ import org.bukkit.configuration.serialization.SerializableAs;
+ import org.bukkit.entity.Player;
+ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.plugin.Plugin;
++// Paper start
++import com.destroystokyo.paper.profile.ProfileUtils;
++import com.destroystokyo.paper.profile.AccountProfile;
++// Paper end
+ 
+ @SerializableAs("Player")
+ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializable {
+@@ -32,7 +36,20 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+         this.server = server;
+         this.profile = profile;
+         this.storage = (WorldNBTStorage) (server.console.worlds.get(0).getDataManager());
++        // Paper start - store our profile
++        this.paperProfile = ProfileUtils.toPaper(profile);
++    }
++    private final AccountProfile paperProfile;
++
++    protected CraftOfflinePlayer(CraftServer server, AccountProfile profile) {
++        this.server = server;
++        this.profile = ProfileUtils.toMojang(profile);
++        this.storage = (WorldNBTStorage) (server.console.worlds.get(0).getDataManager());
++        this.paperProfile = profile;
++    }
+ 
++    public AccountProfile getAccount() {
++        return paperProfile;
+     }
+ 
+     public GameProfile getProfile() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index e6a76cf..b12dfc2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -122,6 +122,12 @@ import io.netty.buffer.Unpooled;
+ import io.netty.handler.codec.base64.Base64;
+ import jline.console.ConsoleReader;
+ import net.md_5.bungee.api.chat.BaseComponent;
++// Paper start
++import com.destroystokyo.paper.profile.EventProfileLookup;
++import com.destroystokyo.paper.profile.MojangLookup;
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.ProfileLookup;
++// Paper end
+ 
+ public final class CraftServer implements Server {
+     private static final Player[] EMPTY_PLAYER_ARRAY = new Player[0];
+@@ -1344,11 +1350,13 @@ public final class CraftServer implements Server {
+         OfflinePlayer result = getPlayerExact(name);
+         if (result == null) {
+             // Spigot Start
+-            GameProfile profile = null;
++            // Paper start  use our uuid lookup
++            AccountProfile profile = null;
+             // Only fetch an online UUID in online mode
+             if ( MinecraftServer.getServer().getOnlineMode() || org.spigotmc.SpigotConfig.bungee )
+             {
+-                profile = console.getUserCache().getProfile( name );
++                profile = getProfileLookup().lookup(name);
++                // Paper end
+             }
+             // Spigot end
+             if (profile == null) {
+@@ -1356,7 +1364,10 @@ public final class CraftServer implements Server {
+                 result = getOfflinePlayer(new GameProfile(UUID.nameUUIDFromBytes(("OfflinePlayer:" + name).getBytes(Charsets.UTF_8)), name));
+             } else {
+                 // Use the GameProfile even when we get a UUID so we ensure we still have a name
+-                result = getOfflinePlayer(profile);
++                // Paper start
++                result = new CraftOfflinePlayer(this, profile);
++                offlinePlayers.put(result.getUniqueId(), result);
++                // Paper end
+             }
+         } else {
+             offlinePlayers.remove(result.getUniqueId());
+@@ -1373,7 +1384,7 @@ public final class CraftServer implements Server {
+         if (result == null) {
+             result = offlinePlayers.get(id);
+             if (result == null) {
+-                result = new CraftOfflinePlayer(this, new GameProfile(id, null));
++                result = new CraftOfflinePlayer(this, getProfileLookup().lookup(id)); // Paper - do lookup
+                 offlinePlayers.put(id, result);
+             }
+         } else {
+@@ -1415,7 +1426,7 @@ public final class CraftServer implements Server {
+ 
+         for (JsonListEntry entry : playerList.getProfileBans().getValues()) {
+             result.add(getOfflinePlayer((GameProfile) entry.getKey()));
+-        }        
++        }
+ 
+         return result;
+     }
+@@ -1844,6 +1855,14 @@ public final class CraftServer implements Server {
+         return spigot;
+     }
+ 
++    // Paper start - uuid api
++    private final ProfileLookup lookup = new EventProfileLookup(new MojangLookup());
++
++    @Override
++    public ProfileLookup getProfileLookup() {
++        return lookup;
++    }
++    // Paper end
+     // Paper start
+     @Override
+     public void reloadPermissions() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index d23cade..3c57acf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -59,6 +59,7 @@ import org.bukkit.metadata.MetadataValue;
+ import org.bukkit.plugin.Plugin;
+ import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.scoreboard.Scoreboard;
++import com.destroystokyo.paper.profile.AccountProfile; // Paper
+ 
+ @DelegateDeserialization(CraftOfflinePlayer.class)
+ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -83,6 +84,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         firstPlayed = System.currentTimeMillis();
+     }
+ 
++    // Paper start
++    @Override
++    public AccountProfile getAccount() {
++        return getHandle().getBukkitProfile();
++    }
++    // Paper end
++
+     public GameProfile getProfile() {
+         return getHandle().getProfile();
+     }
+-- 
+2.8.3
+

--- a/Spigot-Server-Patches/0157-Cache-uuid-requests-in-memory.patch
+++ b/Spigot-Server-Patches/0157-Cache-uuid-requests-in-memory.patch
@@ -1,0 +1,990 @@
+From 9535266c1d59420db27343bcf119313a783b19a9 Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@techcable.net>
+Date: Thu, 14 Apr 2016 11:21:49 -0700
+Subject: [PATCH] Cache uuid requests in memory
+
+Re-routes requests throught NMS throught the API.
+Avoids lookups for online players.
+Overrides authlib lookups with delegates.
+
+diff --git a/src/main/java/com/destroystokyo/paper/InternalListener.java b/src/main/java/com/destroystokyo/paper/InternalListener.java
+new file mode 100644
+index 0000000..a38da4e
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/InternalListener.java
+@@ -0,0 +1,43 @@
++package com.destroystokyo.paper;
++
++import com.destroystokyo.paper.profile.AccountProfile;
++import net.minecraft.server.EntityPlayer;
++
++import java.util.Set;
++import java.util.concurrent.CopyOnWriteArraySet;
++
++public interface InternalListener {
++
++    Set<InternalListener> LISTENERS = new CopyOnWriteArraySet<>();
++
++    /**
++     * Called before a player logs in
++     * <p>May be called from any thread.</p>
++     *
++     * @param profile the profile that is attempting to login
++     */
++    default void onAsyncPreLogin(AccountProfile profile) {}
++
++    /**
++     * Called if a player's login is attempt is cancelled
++     * <p>May be called from any thread.</p>
++     * <p>Always called after {@link #onAsyncPreLogin(AccountProfile)}.</p>
++     *
++     * @param profile the profile whose login was cancelled
++     */
++    default void onCancelledLogin(AccountProfile profile) {}
++
++    /**
++     * Called if a player quits the game
++     *
++     * @param player the player who quit the game
++     */
++    default void onQuit(EntityPlayer player) {}
++
++    /**
++     * Called if a player is kicked from the game
++     *
++     * @param player the player who was kicked
++     */
++    default void onKick(EntityPlayer player) {}
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/BukkitGameProfileRepository.java b/src/main/java/com/destroystokyo/paper/profile/BukkitGameProfileRepository.java
+new file mode 100644
+index 0000000..7387112
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/BukkitGameProfileRepository.java
+@@ -0,0 +1,39 @@
++package com.destroystokyo.paper.profile;
++
++import com.google.common.base.Preconditions;
++import com.google.common.collect.ImmutableSet;
++import com.mojang.authlib.Agent;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.GameProfileRepository;
++import com.mojang.authlib.ProfileLookupCallback;
++
++public class BukkitGameProfileRepository implements GameProfileRepository {
++    private final ProfileLookup lookup;
++
++    public BukkitGameProfileRepository(ProfileLookup lookup) {
++        this.lookup = lookup;
++    }
++
++    @Override
++    public void findProfilesByNames(String[] nameArray, Agent agent, ProfileLookupCallback nmsCallback) {
++        Preconditions.checkArgument(agent == Agent.MINECRAFT, "Unexpected agent: %s", agent);
++        ImmutableSet<String> names = ImmutableSet.copyOf(nameArray);
++        lookup.lookupNames(names, new com.destroystokyo.paper.profile.ProfileLookupCallback<String>() {
++            @Override
++            public void onLookup(AccountProfile profile, String original) {
++                nmsCallback.onProfileLookupSucceeded(ProfileUtils.toMojang(profile));
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, String original) {
++                Exception e;
++                if (t instanceof Exception) {
++                    e = (Exception) t;
++                } else {
++                    e = new RuntimeException("Throwable (not-exception) caught", t);
++                }
++                nmsCallback.onProfileLookupFailed(new GameProfile(null, original), e);
++            }
++        });
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/BukkitSessionService.java b/src/main/java/com/destroystokyo/paper/profile/BukkitSessionService.java
+new file mode 100644
+index 0000000..ecb55c1
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/BukkitSessionService.java
+@@ -0,0 +1,64 @@
++package com.destroystokyo.paper.profile;
++
++import com.google.common.collect.ImmutableMap;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.exceptions.AuthenticationException;
++import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
++import com.mojang.authlib.minecraft.InsecureTextureException;
++import com.mojang.authlib.minecraft.MinecraftProfileTexture;
++import com.mojang.authlib.minecraft.MinecraftSessionService;
++
++import java.util.Map;
++
++public class BukkitSessionService implements MinecraftSessionService {
++    private final MinecraftSessionService delegate;
++    private final ProfileLookup lookup;
++
++    public BukkitSessionService(MinecraftSessionService delegate, ProfileLookup lookup) {
++        this.delegate = delegate;
++        this.lookup = lookup;
++    }
++
++    @Override
++    public void joinServer(GameProfile gameProfile, String s, String s1) throws AuthenticationException {
++        delegate.joinServer(gameProfile, s, s1);
++    }
++
++    @Override
++    public GameProfile hasJoinedServer(GameProfile gameProfile, String s) throws AuthenticationUnavailableException {
++        return delegate.hasJoinedServer(gameProfile, s);
++    }
++
++    @Override
++    public Map<MinecraftProfileTexture.Type, MinecraftProfileTexture> getTextures(GameProfile mojangProfile, boolean checkSignature) {
++        if (mojangProfile.getProperties().isEmpty()) return ImmutableMap.of();
++        AccountProfile profile = ProfileUtils.toPaperWithProperties(mojangProfile);
++        PlayerTextures texture = profile.getTextures();
++        if (texture == null) return ImmutableMap.of();
++        if (checkSignature) {
++            if (!texture.isSigned()) {
++                throw new InsecureTextureException("Unsigned texture");
++            }
++            if (!texture.isSignedByMojang()) {
++                throw new InsecureTextureException("Textures payload has been tampered with (signature invalid)");
++            }
++        }
++        ImmutableMap.Builder<MinecraftProfileTexture.Type, MinecraftProfileTexture> builder = ImmutableMap.builder();
++        if (texture.hasCape()) {
++            MinecraftProfileTexture cape = new MinecraftProfileTexture(texture.getCape().toString(), texture.getCapeData().getMetadata());
++            builder.put(MinecraftProfileTexture.Type.CAPE, cape);
++        }
++        if (texture.hasSkin()) {
++            MinecraftProfileTexture skin = new MinecraftProfileTexture(texture.getSkin().toString(), texture.getSkinData().getMetadata());
++            builder.put(MinecraftProfileTexture.Type.SKIN, skin);
++        }
++        return builder.build();
++    }
++
++    @Override
++    public GameProfile fillProfileProperties(GameProfile gameProfile, boolean b) {
++        AccountProfile profile = ProfileUtils.toPaper(gameProfile);
++        ProfileProperties properties = lookup.lookupProperties(profile);
++        return ProfileUtils.toMojang(profile.withProperties(properties));
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java
+index f2ad29d..0ede303 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java
++++ b/src/main/java/com/destroystokyo/paper/profile/EventProfileLookup.java
+@@ -1,18 +1,17 @@
+ package com.destroystokyo.paper.profile;
+ 
++import com.destroystokyo.paper.profile.event.AsyncNamePreResolveEvent;
++import com.destroystokyo.paper.profile.event.AsyncProfileResolveEvent;
++import com.destroystokyo.paper.profile.event.AsyncPropertiesPreResolveEvent;
++import com.destroystokyo.paper.profile.event.AsyncUUIDPreResolveEvent;
++import com.google.common.base.Preconditions;
++import org.bukkit.Bukkit;
++
+ import java.util.ArrayList;
+ import java.util.Collection;
+ import java.util.List;
+ import java.util.UUID;
+ 
+-import com.destroystokyo.paper.profile.event.AsyncPropertiesPreResolveEvent;
+-import com.google.common.base.Preconditions;
+-
+-import org.bukkit.Bukkit;
+-import com.destroystokyo.paper.profile.event.AsyncNamePreResolveEvent;
+-import com.destroystokyo.paper.profile.event.AsyncProfileResolveEvent;
+-import com.destroystokyo.paper.profile.event.AsyncUUIDPreResolveEvent;
+-
+ public class EventProfileLookup implements ProfileLookup {
+     private final ProfileLookup delegate;
+ 
+@@ -28,12 +27,12 @@ public class EventProfileLookup implements ProfileLookup {
+         Bukkit.getPluginManager().callEvent(preResolveEvent);
+         AsyncProfileResolveEvent resolveEvent;
+         if (preResolveEvent.isResolved()) { // Plugin set result
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, preResolveEvent.getResult(), false);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME, preResolveEvent.getResult(), false);
+         } else {
+             // Lookup result from mojang
+             AccountProfile profile = delegate.lookup(name);
+             if (profile == null) return null; // Not found
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, profile, true);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME, profile, true);
+         }
+         Bukkit.getPluginManager().callEvent(resolveEvent);
+         return resolveEvent.getResult();
+@@ -46,12 +45,12 @@ public class EventProfileLookup implements ProfileLookup {
+         Bukkit.getPluginManager().callEvent(preResolveEvent);
+         AsyncProfileResolveEvent resolveEvent;
+         if (preResolveEvent.isResolved()) { // Plugin set result
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, preResolveEvent.getResult(), false);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID, preResolveEvent.getResult(), false);
+         } else {
+             // Lookup result from mojang
+             AccountProfile profile = delegate.lookup(id);
+             if (profile == null) return null; // Not found
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, profile, true);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID, profile, true);
+         }
+         Bukkit.getPluginManager().callEvent(resolveEvent);
+         return resolveEvent.getResult();
+@@ -65,7 +64,7 @@ public class EventProfileLookup implements ProfileLookup {
+             AsyncUUIDPreResolveEvent preResolveEvent = new AsyncUUIDPreResolveEvent(id);
+             Bukkit.getPluginManager().callEvent(preResolveEvent);
+             if (preResolveEvent.isResolved()) { // Plugin set result
+-                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, preResolveEvent.getResult(), false);
++                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID, preResolveEvent.getResult(), false);
+                 Bukkit.getPluginManager().callEvent(resolveEvent);
+                 callback.onLookup(resolveEvent.getResult(), id);
+             } else {
+@@ -76,7 +75,7 @@ public class EventProfileLookup implements ProfileLookup {
+             @Override
+             public void onLookup(AccountProfile profile, UUID original) {
+                 if (profile != null) {
+-                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID_LOOKUP, profile, true);
++                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.UUID, profile, true);
+                     Bukkit.getPluginManager().callEvent(resolveEvent);
+                     profile = resolveEvent.getResult();
+                 }
+@@ -98,7 +97,7 @@ public class EventProfileLookup implements ProfileLookup {
+             AsyncNamePreResolveEvent preResolveEvent = new AsyncNamePreResolveEvent(name);
+             Bukkit.getPluginManager().callEvent(preResolveEvent);
+             if (preResolveEvent.isResolved()) { // Plugin set result
+-                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, preResolveEvent.getResult(), false);
++                AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME, preResolveEvent.getResult(), false);
+                 Bukkit.getPluginManager().callEvent(resolveEvent);
+                 callback.onLookup(resolveEvent.getResult(), name);
+             } else {
+@@ -109,7 +108,7 @@ public class EventProfileLookup implements ProfileLookup {
+             @Override
+             public void onLookup(AccountProfile profile, String original) {
+                 if (profile != null) {
+-                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME_LOOKUP, profile, true);
++                    AsyncProfileResolveEvent resolveEvent = new AsyncProfileResolveEvent(LookupCause.NAME, profile, true);
+                     Bukkit.getPluginManager().callEvent(resolveEvent);
+                     profile = resolveEvent.getResult();
+                 }
+@@ -129,11 +128,11 @@ public class EventProfileLookup implements ProfileLookup {
+         Bukkit.getPluginManager().callEvent(preResolveEvent);
+         AsyncProfileResolveEvent resolveEvent;
+         if (preResolveEvent.isResolved()) {
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES_LOOKUP, preResolveEvent.getResult(), false);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES, preResolveEvent.getResult(), false);
+         } else {
+             ProfileProperties properties = delegate.lookupProperties(profile);
+             if (properties == null) return null;
+-            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES_LOOKUP, profile.withProperties(properties), true);
++            resolveEvent = new AsyncProfileResolveEvent(LookupCause.PROPERTIES, profile.withProperties(properties), true);
+         }
+         Bukkit.getPluginManager().callEvent(resolveEvent);
+         return resolveEvent.getResult().getProperties();
+diff --git a/src/main/java/com/destroystokyo/paper/profile/MemoryCachingProfileLookup.java b/src/main/java/com/destroystokyo/paper/profile/MemoryCachingProfileLookup.java
+new file mode 100644
+index 0000000..9e60111
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/profile/MemoryCachingProfileLookup.java
+@@ -0,0 +1,286 @@
++package com.destroystokyo.paper.profile;
++
++import com.destroystokyo.paper.InternalListener;
++import com.google.common.base.Preconditions;
++import com.google.common.cache.CacheBuilder;
++import com.google.common.cache.CacheLoader;
++import com.google.common.cache.LoadingCache;
++import com.google.common.cache.RemovalCause;
++import com.google.common.cache.RemovalNotification;
++import com.google.common.collect.ImmutableCollection;
++import com.google.common.collect.ImmutableList;
++import com.google.common.collect.ImmutableSet;
++import com.google.common.util.concurrent.UncheckedExecutionException;
++import com.mojang.authlib.yggdrasil.ProfileNotFoundException;
++import net.minecraft.server.EntityPlayer;
++import org.spigotmc.SneakyThrow;
++
++import java.util.Collection;
++import java.util.Locale;
++import java.util.UUID;
++import java.util.concurrent.ConcurrentHashMap;
++import java.util.concurrent.ConcurrentMap;
++import java.util.concurrent.ExecutionException;
++import java.util.concurrent.TimeUnit;
++
++public class MemoryCachingProfileLookup implements ProfileLookup, CachingProfileLookup, InternalListener {
++
++    private ProfileLookup backing;
++
++    public void setBacking(ProfileLookup backing) {
++        this.backing = backing;
++    }
++
++    private final LoadingCache<String, AccountProfile> nameCache;
++    private final LoadingCache<UUID, AccountProfile> idCache;
++
++    public MemoryCachingProfileLookup(ProfileLookup backing) {
++        InternalListener.LISTENERS.add(this);
++        this.backing = backing;
++        nameCache = CacheBuilder.<String, AccountProfile>newBuilder()
++                .build(new CacheLoader<String, AccountProfile>() {
++                    @Override
++                    public AccountProfile load(String name) throws Exception {
++                        AccountProfile profile = backing.lookup(name);
++                        if (profile == null) throw new ProfileNotFoundException();
++                        idCache.put(profile.getId(), profile);
++                        return profile;
++                    }
++                });
++        idCache = CacheBuilder.<UUID, AccountProfile>newBuilder()
++                .removalListener((RemovalNotification<UUID, AccountProfile> notification) -> {
++                    if (notification.getCause() == RemovalCause.REPLACED) return;
++                    final AccountProfile profile = notification.getValue();
++                    AccountProfile onlineProfile;
++                    if ((onlineProfile = onlinePlayers.get(notification.getKey())) != null) {
++                        // Eek, don't remove an online player!
++                        cache(onlineProfile);
++                    } else if (profile != null) {
++                        nameCache.invalidate(toLowerCase(profile.getName()));
++                    }
++                })
++                .expireAfterAccess(5, TimeUnit.HOURS)
++                .softValues() // Don't cause an OOME
++                .build(new CacheLoader<UUID, AccountProfile>() {
++                    @Override
++                    public AccountProfile load(UUID id) throws Exception {
++                        AccountProfile profile = backing.lookup(id);
++                        if (profile == null) throw new ProfileNotFoundException();
++                        nameCache.put(profile.getName(), profile);
++                        return profile;
++                    }
++                });
++    }
++
++    private final ConcurrentMap<UUID, AccountProfile> onlinePlayers = new ConcurrentHashMap<>();
++
++    @Override
++    public void onAsyncPreLogin(AccountProfile profile) {
++        onlinePlayers.put(profile.getId(), profile);
++    }
++
++    @Override
++    public void onCancelledLogin(AccountProfile profile) {
++        AccountProfile old = onlinePlayers.remove(profile.getId());
++        assert old != null : "Player not present for cancelled login";
++        assert old.equals(profile);
++    }
++
++    @Override
++    public void onQuit(EntityPlayer player) {
++        AccountProfile old = onlinePlayers.remove(player.getUniqueID());
++        assert old.equals(player.getBukkitProfile());
++    }
++
++    @Override
++    public void onKick(EntityPlayer player) {
++        AccountProfile old = onlinePlayers.remove(player.getUniqueID());
++        assert old.equals(player.getBukkitProfile());
++    }
++
++    @Override
++    public AccountProfile lookup(UUID id) {
++        AccountProfile online;
++        if ((online = onlinePlayers.get(id)) != null) {
++            assert nameCache.getIfPresent(toLowerCase(online.getName())) != null : "Online player not in name cache";
++            return online;
++        }
++        return lookup0(id);
++    }
++
++    private AccountProfile lookup0(UUID id) {
++        try {
++            return idCache.get(id);
++        } catch (ExecutionException | UncheckedExecutionException e) {
++            if (e.getCause() instanceof ProfileNotFoundException) return null;
++            SneakyThrow.sneaky(e.getCause());
++            throw new AssertionError("Couldn't throw", e);
++        }
++    }
++
++    @Override
++    public AccountProfile lookup(String name) {
++        try {
++            return nameCache.get(toLowerCase(name));
++        } catch (ExecutionException | UncheckedExecutionException e) {
++            if (e.getCause() instanceof ProfileNotFoundException) return null;
++            SneakyThrow.sneaky(e);
++            throw new AssertionError("Couldn't throw", e);
++        }
++    }
++
++    private AccountProfile lookup0(String name) {
++        try {
++            return nameCache.get(toLowerCase(name));
++        } catch (ExecutionException | UncheckedExecutionException e) {
++            if (e.getCause() instanceof ProfileNotFoundException) return null;
++            SneakyThrow.sneaky(e);
++            throw new AssertionError("Couldn't throw", e);
++        }
++    }
++
++    @Override
++    public void lookupNames(Collection<String> names, ProfileLookupCallback<String> callback) {
++        ImmutableList.Builder<String> toLookup = ImmutableList.builder();
++        for (String name : names) {
++            AccountProfile cached = getIfCached(name);
++            if (cached == null) {
++                toLookup.add(name);
++            } else {
++                callback.onLookup(cached, name);
++            }
++        }
++        backing.lookupNames(toLookup.build(), new ProfileLookupCallback<String>() {
++            @Override
++            public void onLookup(AccountProfile profile, String original) {
++                cache(profile);
++                callback.onLookup(profile, original);
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, String original) {
++                callback.onLookupFailed(t, original);
++            }
++        });
++    }
++
++    @Override
++    public void lookupIds(Collection<UUID> ids, ProfileLookupCallback<UUID> callback) {
++        ImmutableList.Builder<UUID> toLookup = ImmutableList.builder();
++        for (UUID id : ids) {
++            AccountProfile cached = getIfCached(id);
++            if (cached == null) {
++                toLookup.add(id);
++            } else {
++                callback.onLookup(cached, id);
++            }
++        }
++        backing.lookupIds(toLookup.build(), new ProfileLookupCallback<UUID>() {
++            @Override
++            public void onLookup(AccountProfile profile, UUID original) {
++                cache(profile);
++                callback.onLookup(profile, original);
++            }
++
++            @Override
++            public void onLookupFailed(Throwable t, UUID original) {
++                callback.onLookupFailed(t, original);
++            }
++        });
++    }
++
++    @Override
++    public ProfileProperties lookupProperties(AccountProfile profile) {
++        AccountProfile cached;
++        if ((cached = onlinePlayers.get(profile.getId())) != null) {
++            assert nameCache.getIfPresent(toLowerCase(cached.getName())) != null : "Online player not in name cache";
++            return cached.getProperties();
++        } else if (profile.hasProperties()) {
++            cache(profile);
++            return profile.getProperties();
++        } else if ((cached = getIfCached(profile.getId())).hasProperties()) {
++            return cached.getProperties();
++        } else {
++            return refreshProperties(profile);
++        }
++    }
++
++    @Override
++    public AccountProfile getIfCached(UUID id) {
++        AccountProfile profile;
++        if ((profile = onlinePlayers.get(id)) != null) {
++            assert nameCache.getIfPresent(toLowerCase(profile.getName())) != null : "Online player not in name cache";
++            return profile;
++        }
++        return idCache.getIfPresent(id);
++    }
++
++    @Override
++    public AccountProfile getIfCached(String name) {
++        return nameCache.getIfPresent(toLowerCase(name));
++    }
++
++    @Override
++    public void cache(AccountProfile profile) {
++        Preconditions.checkNotNull(profile, "Null entry");
++        if (onlinePlayers.containsKey(profile.getId())) {
++            assert nameCache.getIfPresent(toLowerCase(profile.getName())) != null : "Online player not in name cache";
++            return;
++        }
++        // Don't override the cache if we don't have profiles, but the existing entry does
++        AccountProfile cached;
++        if (!profile.hasProperties() && (cached = getIfCached(profile.getId())) != null && cached.hasProperties()) {
++            return;
++        }
++        idCache.put(profile.getId(), profile);
++        nameCache.put(toLowerCase(profile.getName()), profile);
++    }
++
++    @Override
++    public void clearProfile(AccountProfile profile) {
++        if (!onlinePlayers.containsKey(profile.getId())) {
++            idCache.invalidate(profile.getId());
++            nameCache.invalidate(toLowerCase(profile.getName()));
++        }
++    }
++
++    @Override
++    public AccountProfile refresh(UUID id) {
++        AccountProfile profile;
++        if ((profile = onlinePlayers.get(id)) != null) return profile;
++        idCache.invalidate(id);
++        return lookup0(id);
++    }
++
++    @Override
++    public AccountProfile refresh(String name) {
++        name = toLowerCase(name);
++        AccountProfile profile;
++        if ((profile = nameCache.getIfPresent(name)) != null) {
++            if (onlinePlayers.containsKey(profile.getId())) {
++                return profile;
++            } else {
++                nameCache.invalidate(name);
++            }
++        }
++        return lookup0(name);
++    }
++
++    @Override
++    public ProfileProperties refreshProperties(AccountProfile profile) {
++        AccountProfile online;
++        if ((online = onlinePlayers.get(profile.getId())) != null) return online.getProperties();
++        ProfileProperties properties = backing.lookupProperties(profile);
++        cache(profile.withProperties(properties));
++        return properties;
++    }
++
++    @Override
++    public ImmutableCollection<AccountProfile> getCachedProfiles() {
++        return ImmutableSet.copyOf(idCache.asMap().values());
++    }
++
++    private static String toLowerCase(final String original) {
++        return original.toLowerCase(Locale.ROOT);
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java b/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java
+index f58b36a..9869429 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java
++++ b/src/main/java/com/destroystokyo/paper/profile/MojangLookup.java
+@@ -1,11 +1,11 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.util.Collection;
+-import java.util.UUID;
+-
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.ImmutableList;
+ 
++import java.util.Collection;
++import java.util.UUID;
++
+ public final class MojangLookup implements ProfileLookup {
+ 
+     @Override
+diff --git a/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java b/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java
+index dc50aaf..57fcfa7 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java
++++ b/src/main/java/com/destroystokyo/paper/profile/ProfileUtils.java
+@@ -1,17 +1,7 @@
+ package com.destroystokyo.paper.profile;
+ 
+-import java.io.BufferedReader;
+-import java.io.BufferedWriter;
+-import java.io.IOException;
+-import java.io.InputStreamReader;
+-import java.io.OutputStreamWriter;
+-import java.net.HttpURLConnection;
+-import java.net.MalformedURLException;
+-import java.net.URL;
+-import java.util.List;
+-import java.util.Map;
+-import java.util.Optional;
+-import java.util.UUID;
++import static com.destroystokyo.paper.profile.UUIDUtils.fromString;
++import static com.destroystokyo.paper.profile.UUIDUtils.toMojangString;
+ 
+ import com.destroystokyo.paper.utils.json.ProfilePropertyTypeAdapter;
+ import com.destroystokyo.paper.utils.json.UUIDTypeAdapter;
+@@ -31,8 +21,18 @@ import com.mojang.authlib.GameProfile;
+ import com.mojang.authlib.properties.Property;
+ import com.mojang.authlib.properties.PropertyMap;
+ 
+-import static com.destroystokyo.paper.profile.UUIDUtils.fromString;
+-import static com.destroystokyo.paper.profile.UUIDUtils.toMojangString;
++import java.io.BufferedReader;
++import java.io.BufferedWriter;
++import java.io.IOException;
++import java.io.InputStreamReader;
++import java.io.OutputStreamWriter;
++import java.net.HttpURLConnection;
++import java.net.MalformedURLException;
++import java.net.URL;
++import java.util.List;
++import java.util.Map;
++import java.util.Optional;
++import java.util.UUID;
+ 
+ public class ProfileUtils {
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java b/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java
+index 590a778..df016f5 100644
+--- a/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java
++++ b/src/main/java/com/destroystokyo/paper/utils/json/ProfilePropertyTypeAdapter.java
+@@ -1,12 +1,12 @@
+ package com.destroystokyo.paper.utils.json;
+ 
+-import java.io.IOException;
+-
+ import com.destroystokyo.paper.profile.ProfileProperty;
+ import com.google.gson.TypeAdapter;
+ import com.google.gson.stream.JsonReader;
+ import com.google.gson.stream.JsonWriter;
+ 
++import java.io.IOException;
++
+ public class ProfilePropertyTypeAdapter extends TypeAdapter<ProfileProperty> {
+     @Override
+     public void write(JsonWriter out, ProfileProperty property) throws IOException {
+diff --git a/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java b/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java
+index 908c7b4..147b9eb 100644
+--- a/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java
++++ b/src/main/java/com/destroystokyo/paper/utils/json/UUIDTypeAdapter.java
+@@ -1,14 +1,13 @@
+ package com.destroystokyo.paper.utils.json;
+ 
+-import java.io.IOException;
+-import java.util.UUID;
+-
++import com.destroystokyo.paper.profile.UUIDUtils;
+ import com.google.gson.TypeAdapter;
+ import com.google.gson.stream.JsonReader;
+ import com.google.gson.stream.JsonToken;
+ import com.google.gson.stream.JsonWriter;
+ 
+-import com.destroystokyo.paper.profile.UUIDUtils;
++import java.io.IOException;
++import java.util.UUID;
+ 
+ public class UUIDTypeAdapter extends TypeAdapter<UUID> {
+     private final boolean mojangStyle;
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index efa785f..0254ad9 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -5,7 +5,6 @@ import com.mojang.authlib.GameProfile;
+ import com.mojang.authlib.exceptions.AuthenticationUnavailableException;
+ import io.netty.channel.ChannelFuture;
+ import io.netty.channel.ChannelFutureListener;
+-import io.netty.util.concurrent.Future;
+ import io.netty.util.concurrent.GenericFutureListener;
+ import java.math.BigInteger;
+ import java.security.PrivateKey;
+@@ -13,7 +12,6 @@ import java.util.Arrays;
+ import java.util.Random;
+ import java.util.UUID;
+ import java.util.concurrent.atomic.AtomicInteger;
+-import java.util.logging.Level;
+ import javax.crypto.SecretKey;
+ import org.apache.commons.lang3.Validate;
+ import org.apache.logging.log4j.LogManager;
+@@ -24,6 +22,11 @@ import org.bukkit.craftbukkit.util.Waitable;
+ import org.bukkit.event.player.AsyncPlayerPreLoginEvent;
+ import org.bukkit.event.player.PlayerPreLoginEvent;
+ // CraftBukkit end
++// Paper start
++import com.destroystokyo.paper.InternalListener;
++import com.destroystokyo.paper.profile.AccountProfile;
++import com.destroystokyo.paper.profile.ProfileUtils;
++// Paper end
+ 
+ public class LoginListener implements PacketLoginInListener, ITickable {
+ 
+@@ -68,7 +71,13 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+ 
+     }
+ 
++    private AccountProfile profile; // Paper - store bukkit profile (if pre-login fired)
+     public void disconnect(String s) {
++        // Paper start - fire internal login cancelled if pre login fired
++        if (profile != null) {
++            InternalListener.LISTENERS.forEach((listener) -> listener.onCancelledLogin(profile));
++        }
++        // Paper end
+         try {
+             LoginListener.c.info("Disconnecting " + this.d() + ": " + s);
+             ChatComponentText chatcomponenttext = new ChatComponentText(s);
+@@ -244,6 +253,11 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+                             java.util.UUID uniqueId = i.getId();
+                             final org.bukkit.craftbukkit.CraftServer server = LoginListener.this.server.server;
+ 
++                            // Paper start - fire pre join for all our internal listeners
++                            LoginListener.this.profile = ProfileUtils.toPaperWithProperties(i); // Mark the pre login event as 'fired', so cancel event will fire if needed
++                            InternalListener.LISTENERS.forEach((listener) -> listener.onAsyncPreLogin(profile));
++                            // Paper end
++
+                             AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId);
+                             server.getPluginManager().callEvent(asyncEvent);
+ 
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 3b04681..eaaab7e 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -53,6 +53,8 @@ import org.bukkit.craftbukkit.CraftServer;
+ import co.aikar.timings.MinecraftTimings; // Paper
+ 
+ // Paper start
++import com.destroystokyo.paper.profile.BukkitGameProfileRepository;
++import com.destroystokyo.paper.profile.BukkitSessionService;
+ import java.util.LinkedList;
+ import java.util.Queue;
+ // Paper end
+@@ -132,8 +134,10 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+         io.netty.util.ResourceLeakDetector.setEnabled( false ); // Spigot - disable
+         this.e = proxy;
+         this.U = yggdrasilauthenticationservice;
+-        this.V = minecraftsessionservice;
+-        this.W = gameprofilerepository;
++        // Paper start - use our special wrappers
++        this.V = new BukkitSessionService(minecraftsessionservice, Bukkit.getProfileLookup());
++        this.W = new BukkitGameProfileRepository(Bukkit.getProfileLookup());
++        // Paper end
+         this.X = usercache;
+         // this.universe = file; // CraftBukkit
+         // this.p = new ServerConnection(this); // Spigot
+@@ -572,7 +576,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+         }
+     }
+     // Paper End
+- 
++
+     public void run() {
+         try {
+             if (this.init()) {
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index cf27086..5eca0e7 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -60,6 +60,10 @@ import org.bukkit.util.NumberConversions;
+ import co.aikar.timings.MinecraftTimings; // Paper
+ // CraftBukkit end
+ 
++// Paper start
++import com.destroystokyo.paper.InternalListener;
++// Paper end
++
+ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+ 
+     private static final Logger LOGGER = LogManager.getLogger();
+@@ -231,6 +235,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+             // Do not kick the player
+             return;
+         }
++        InternalListener.LISTENERS.forEach((listener) -> listener.onKick(player)); // Paper - fire internally
+         // Send the possibly modified leave message
+         s = event.getReason();
+         // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 9d25312..fbb3294 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -39,6 +39,7 @@ import org.bukkit.event.player.PlayerTeleportEvent.TeleportCause;
+ import org.bukkit.util.Vector;
+ import org.spigotmc.event.player.PlayerSpawnLocationEvent;
+ // CraftBukkit end
++import com.destroystokyo.paper.InternalListener; // Paper
+ 
+ public abstract class PlayerList {
+ 
+@@ -400,6 +401,8 @@ public abstract class PlayerList {
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game.");
+         cserver.getPluginManager().callEvent(playerQuitEvent);
+         entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
++        InternalListener.LISTENERS.forEach((listener) -> listener.onQuit(entityplayer)); // Paper - fire internally
++
+         // CraftBukkit end
+         
+         this.savePlayerFile(entityplayer);
+diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
+index 5cc2731..2e97804 100644
+--- a/src/main/java/net/minecraft/server/UserCache.java
++++ b/src/main/java/net/minecraft/server/UserCache.java
+@@ -31,7 +31,6 @@ import java.util.ArrayList;
+ import java.util.Calendar;
+ import java.util.Date;
+ import java.util.Iterator;
+-import java.util.LinkedList;
+ import java.util.List;
+ import java.util.Locale;
+ import java.util.Map;
+@@ -39,6 +38,14 @@ import java.util.UUID;
+ import javax.annotation.Nullable;
+ import org.apache.commons.io.IOUtils;
+ 
++// Paper start
++import org.bukkit.Bukkit;
++
++import com.destroystokyo.paper.profile.CachingProfileLookup;
++import com.destroystokyo.paper.profile.ProfileUtils;
++import com.destroystokyo.paper.profile.AccountProfile;
++// Paper end
++
+ public class UserCache {
+ 
+     public static final SimpleDateFormat a = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z");
+@@ -109,6 +116,11 @@ public class UserCache {
+     }
+ 
+     private void a(GameProfile gameprofile, Date date) {
++        // Paper start - add to our own cache
++        if (Bukkit.getProfileLookup() instanceof CachingProfileLookup) {
++            ((CachingProfileLookup) Bukkit.getProfileLookup()).cache(ProfileUtils.toPaper(gameprofile));
++        }
++        // Paper end
+         UUID uuid = gameprofile.getId();
+ 
+         if (date == null) {
+@@ -137,6 +149,12 @@ public class UserCache {
+ 
+     @Nullable
+     public GameProfile getProfile(String s) {
++        // Paper start - check our cache
++        if (Bukkit.getProfileLookup() instanceof CachingProfileLookup) {
++            AccountProfile cached = ((CachingProfileLookup) Bukkit.getProfileLookup()).getIfCached(s);
++            return ProfileUtils.toMojang(cached);
++        }
++        // Paper end
+         String s1 = s.toLowerCase(Locale.ROOT);
+         UserCache.UserCacheEntry usercache_usercacheentry = (UserCache.UserCacheEntry) this.d.get(s1);
+ 
+@@ -162,17 +180,37 @@ public class UserCache {
+         }
+ 
+         if( !org.spigotmc.SpigotConfig.saveUserCacheOnStopOnly ) this.c(); // Spigot - skip saving if disabled
++        // Paper start - add to our cache
++        if (usercache_usercacheentry != null && Bukkit.getProfileLookup() instanceof CachingProfileLookup) {
++            ((CachingProfileLookup) Bukkit.getProfileLookup()).cache(ProfileUtils.toPaper(usercache_usercacheentry.a()));
++        }
++        // Paper end
+         return usercache_usercacheentry == null ? null : usercache_usercacheentry.a();
+     }
+ 
+     public String[] a() {
+         ArrayList arraylist = Lists.newArrayList(this.d.keySet());
+-
++        // Paper start
++        if (Bukkit.getProfileLookup() instanceof CachingProfileLookup) {
++            for (AccountProfile profile : ((CachingProfileLookup) Bukkit.getProfileLookup()).getCachedProfiles()) {
++                arraylist.add(profile.getName());
++            }
++        }
++        // Paper end
+         return (String[]) arraylist.toArray(new String[arraylist.size()]);
+     }
+ 
+     @Nullable
+     public GameProfile a(UUID uuid) {
++        // Paper start
++        if (Bukkit.getProfileLookup() instanceof CachingProfileLookup) {
++            AccountProfile profile = ((CachingProfileLookup) Bukkit.getProfileLookup()).getIfCached(uuid);
++            // We'd normally return on not found, but its okay since its just checking the NMS cache
++            if (profile != null) {
++                return ProfileUtils.toMojang(profile);
++            }
++        }
++        // Paper end
+         UserCache.UserCacheEntry usercache_usercacheentry = (UserCache.UserCacheEntry) this.e.get(uuid);
+ 
+         return usercache_usercacheentry == null ? null : usercache_usercacheentry.a();
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index b12dfc2..3a014cd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -124,6 +124,7 @@ import jline.console.ConsoleReader;
+ import net.md_5.bungee.api.chat.BaseComponent;
+ // Paper start
+ import com.destroystokyo.paper.profile.EventProfileLookup;
++import com.destroystokyo.paper.profile.MemoryCachingProfileLookup;
+ import com.destroystokyo.paper.profile.MojangLookup;
+ import com.destroystokyo.paper.profile.AccountProfile;
+ import com.destroystokyo.paper.profile.ProfileLookup;
+@@ -1856,7 +1857,7 @@ public final class CraftServer implements Server {
+     }
+ 
+     // Paper start - uuid api
+-    private final ProfileLookup lookup = new EventProfileLookup(new MojangLookup());
++    private final ProfileLookup lookup = new MemoryCachingProfileLookup(new EventProfileLookup(new MojangLookup()));
+ 
+     @Override
+     public ProfileLookup getProfileLookup() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/MojangNameLookup.java b/src/main/java/org/bukkit/craftbukkit/util/MojangNameLookup.java
+index 93a8f0b..b2a1798 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/MojangNameLookup.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/MojangNameLookup.java
+@@ -1,17 +1,15 @@
+ package org.bukkit.craftbukkit.util;
+ 
+-import com.google.common.base.Charsets;
+-import com.google.gson.Gson;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+-import java.io.IOException;
+-import java.io.InputStream;
+-import java.net.MalformedURLException;
+-import java.net.URL;
+-import java.net.URLConnection;
+ import java.util.UUID;
+-import org.apache.commons.io.IOUtils;
++// Paper start
++import org.bukkit.Bukkit;
++
++import com.destroystokyo.paper.profile.LookupFailedException;
++import com.destroystokyo.paper.profile.AccountProfile;
++// Paper end
+ 
+ public class MojangNameLookup {
+     private static final Logger logger = LogManager.getFormatterLogger(MojangNameLookup.class);
+@@ -21,6 +19,20 @@ public class MojangNameLookup {
+             return null;
+         }
+ 
++        // Paper start - delegate to UUID api
++        try {
++            AccountProfile profile = Bukkit.getProfileLookup().lookup(id);
++            if (profile == null) {
++                logger.warn("Couldn't find a player with id: %s", id);
++                return null;
++            } else {
++                return profile.getName();
++            }
++        } catch (LookupFailedException e) {
++            logger.warn("Error getting name: " + id, e);
++            return null;
++        }
++        /*
+         InputStream inputStream = null;
+         try {
+             URL url = new URL("https://sessionserver.mojang.com/session/minecraft/profile/" + id.toString().replace("-", ""));
+@@ -53,6 +65,8 @@ public class MojangNameLookup {
+         }
+ 
+         return null;
++        */
++        // Paper end
+     }
+ 
+     private class Response {
+-- 
+2.8.3
+


### PR DESCRIPTION
With the new UUID API, plugins will be hitting the UserCache very heavily.
The UserCache has a number of disadvantages:
1. Not designed to be thread safe
   - Paper has modified the UserCache to be thread safe for the UUID API
     - Due to the delicate nature of thread-safety, this is likely to break without warning if mojang ever modifies the user cache
   - Even with mojang's changes the UserCache will lock on lookups, so if one thread is doing uuid-intensive work, it is likely to block other lookups
2. It only clears cache entries on exit.
   - If a plugin does a lot of UUID lookups, those entries will persist in memory until shutdown _even if not needed_
   - There is no limit to how large this map can grow, and it may even cause an OOME
3. It evicts entries based on when they were added, not when they were last used  - Commonly used entires may be evicted in favor of less commonly used entries _even though the entries are still valid_
4. The UserCache isn't transparent to calling code, and often isn't used
   - Mojang's internal UUID fetching API completly ignores the UserCache
   - Code must explicitly use the uuid api in order to benifit from the cache
   - Caches are reimplemented all around the codebase (for example in TileEntitySkull)

However this reimplementation:
1. Is designed to be thread safe
   - Will never break across updates, since its a complete reimplementation
   - Uses guava's Cache based on ConcurrentHashMap for fully concurrent reads and highly concurrent writes
2. Automatically clears cache entries
   - If a plugin does a lot of UUID lookups, the cache will intelligently cleanup  - Will automatically clear entries based on last access if low on memory
3. It evicts cache entries based on last access, not based on when they were first added
   - Commonly used entries will remain in the cache, while uncommonly uses entries will be cleared
   - Invalid entries will be removed as in the previous system
4. Transparent to calling code
   - The UserCache now wraps the new cache, so code will automatically use the new system
   - Mojang's internal UUID API now checks the new cache, so code will automatically check the new cache, and so now almost all code benifits from the cache
   - Caches all around the code base are unified into the new implementation
     - For example TileEntitySkull now uses the new cache instead of implementing its own

Requires #33 
