### PR TITLE
Add server-name as server parameter

### DIFF
--- a/Spigot-Server-Patches/0161-Add-server-name-parameter.patch
+++ b/Spigot-Server-Patches/0161-Add-server-name-parameter.patch
@@ -1,0 +1,28 @@
+From 2f122ad5d0c01346958f8df83947936b53b75236 Mon Sep 17 00:00:00 2001
+From: Martin Panzer <postremus1996@googlemail.com>
+Date: Sat, 28 May 2016 16:54:03 +0200
+Subject: [PATCH] Add server-name parameter
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 979adad..2aad1e8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -130,6 +130,14 @@ public class Main {
+                         .defaultsTo(new File("paper.yml"))
+                         .describedAs("Yml file");
+                 // Paper end
++
++                // Paper start
++                acceptsAll(asList("server-name"), "Name of the server")
++                        .withRequiredArg()
++                        .ofType(String.class)
++                        .defaultsTo("Unknown Server")
++                        .describedAs("Name");
++                // Paper end
+             }
+         };
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
Some plugins (e.g. Chat related once) tend to use this option, and changing it in the server.properties is not always possible without duplicating this file, or some other effort. 
