### PR TITLE
Fix fallingblocks getting stuck on fences

### DIFF
--- a/Spigot-Server-Patches/0164-Fix-FallingBlocks-being-stuck-on-fences.patch
+++ b/Spigot-Server-Patches/0164-Fix-FallingBlocks-being-stuck-on-fences.patch
@@ -1,0 +1,89 @@
+From a96203f8a887b86b0717f8c24bbb4d5ee3821c21 Mon Sep 17 00:00:00 2001
+From: Martin Panzer <postremus1996@googlemail.com>
+Date: Fri, 3 Jun 2016 23:13:39 +0200
+Subject: [PATCH] Fix FallingBlocks being stuck on fences
+
+Fallingblocks would previously only check if directly beneath them a block exists. They also
+hover on top of the 1.5 block tall hitbox of fences during these check. This
+resulted in them always thinking they would be on air.
+
+We now first check, if if we are already on the ground.
+if not, we check if the falling block is inside of the hitbox of the block at y - 1.
+
+diff --git a/src/main/java/net/minecraft/server/BlockFalling.java b/src/main/java/net/minecraft/server/BlockFalling.java
+index e770063..1824587 100644
+--- a/src/main/java/net/minecraft/server/BlockFalling.java
++++ b/src/main/java/net/minecraft/server/BlockFalling.java
+@@ -71,5 +71,11 @@ public class BlockFalling extends Block {
+         return block == Blocks.FIRE || material == Material.AIR || material == Material.WATER || material == Material.LAVA;
+     }
+ 
++    // Paper start - OBFHELPER
++    public static boolean canMoveThrough(IBlockData blockdata) {
++        return BlockFalling.i(blockdata);
++    }
++    // Paper end
++
+     public void a_(World world, BlockPosition blockposition) {}
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+index a5d8f02..c0f0b07 100644
+--- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
++++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+@@ -2,7 +2,9 @@ package net.minecraft.server;
+ 
+ import com.google.common.collect.Lists;
+ import java.util.ArrayList;
++import java.util.Arrays;
+ import java.util.Iterator;
++import java.util.List;
+ import javax.annotation.Nullable;
+ 
+ import org.bukkit.craftbukkit.event.CraftEventFactory; // CraftBukkit
+@@ -95,10 +97,9 @@ public class EntityFallingBlock extends Entity {
+                 blockposition = new BlockPosition(this);
+                 if (this.onGround) {
+                     IBlockData iblockdata = this.world.getType(blockposition);
+-
+-                    if (BlockFalling.i(this.world.getType(new BlockPosition(this.locX, this.locY - 0.009999999776482582D, this.locZ)))) {
++                    if (!isOnGround()) {
+                         this.onGround = false;
+-                        // return; // CraftBukkit
++                        return; // Paper
+                     }
+ 
+                     this.motX *= 0.699999988079071D;
+@@ -155,6 +156,30 @@ public class EntityFallingBlock extends Entity {
+         }
+     }
+ 
++    // Paper start
++    private boolean isOnGround() {
++        BlockPosition where = new BlockPosition(this.locX, this.locY - 0.009999999776482582D, this.locZ);
++
++        if (!BlockFalling.canMoveThrough(this.world.getType(where))) {
++            return true;
++        }
++
++        IBlockData blockData = this.world.getType(where.down());
++        if (BlockFalling.canMoveThrough(blockData)) {
++            return false;
++        }
++
++        List<AxisAlignedBB> list = new ArrayList<>();
++        addCollisions(blockData, getWorld(), where, this.getBoundingBox(), list, this);
++        return list.size() > 0;
++    }
++
++    // OBFHELPER
++    private void addCollisions(IBlockData blockData, World world, BlockPosition where, AxisAlignedBB collider, List<AxisAlignedBB> list, Entity entity) {
++        blockData.a(world, where, collider, list, entity);
++    }
++    // Paper end
++
+     public void e(float f, float f1) {
+         Block block = this.block.getBlock();
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
Fallingblocks would previously only check, if directly beneath them a block exists. They also
hover on top of the 1.5 block tall hitbox of fences during these check. This
resulted in them always thinking they would be on air.

We now first check, if if we are already on the ground.
if not, we check if the falling block is inside of the hitbox of the block at y - 1.

This Patch basicly reverts https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/616a9687a101689f8ad577446cf9caf80ee8ecd4, which introduced https://hub.spigotmc.org/jira/browse/SPIGOT-2046.

Provides a (real) fix for https://hub.spigotmc.org/jira/browse/SPIGOT-1975. 
For more information, see https://bugs.mojang.com/browse/MC-90523
