### PR TITLE
Fix hopper lag by making entities look for hoppers.

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -1,4 +1,4 @@
-From 6eedc7262e0065a783f81e33daeffaf2afad0440 Mon Sep 17 00:00:00 2001
+From 73d2ddd776712fc5317714a83c7150f1f95a8246 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:55:47 -0400
 Subject: [PATCH] MC Utils
@@ -6,21 +6,26 @@ Subject: [PATCH] MC Utils
 Collection of utils to help reduce NMS diff
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 00fb20d..ceef4f4 100644
+index 00fb20d..030e4af 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -676,7 +676,7 @@ public class Chunk {
+@@ -675,6 +675,13 @@ public class Chunk {
+         return !block.isTileEntity() ? null : ((ITileEntity) block).a(this.world, iblockdata.getBlock().toLegacyData(iblockdata));
      }
  
++    // Paper start - OBFHELPER
++    @Nullable
++    public final TileEntity getTileEntityImmediately(BlockPosition pos) {
++        return a(pos, EnumTileEntityState.IMMEDIATE);
++    }
++    // Paper end
++
      @Nullable
--    public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
-+    public final TileEntity getTileEntity(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } @Nullable public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) { // Paper - OBFHELPER
+     public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
          // CraftBukkit start
-         TileEntity tileentity = null;
-         if (world.captureBlockStates) {
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 new file mode 100644
-index 0000000..bb1fa40
+index 0000000..2724678
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -0,0 +1,197 @@
@@ -213,7 +218,7 @@ index 0000000..bb1fa40
 +    public static TileEntityHopper getHopper(World world, BlockPosition pos) {
 +        Chunk chunk = world.getChunkIfLoaded(pos.getX() >> 4, pos.getZ() >> 4);
 +        if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
-+            TileEntity tileEntity = chunk.getTileEntity(pos);
++            TileEntity tileEntity = chunk.getTileEntityImmediately(pos);
 +            if (tileEntity instanceof TileEntityHopper) {
 +                return (TileEntityHopper) tileEntity;
 +            }

--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -1,16 +1,29 @@
-From 9e9204318a93e93baf42cab944f182a7d8c38d78 Mon Sep 17 00:00:00 2001
+From 6eedc7262e0065a783f81e33daeffaf2afad0440 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:55:47 -0400
 Subject: [PATCH] MC Utils
 
 Collection of utils to help reduce NMS diff
 
+diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
+index 00fb20d..ceef4f4 100644
+--- a/src/main/java/net/minecraft/server/Chunk.java
++++ b/src/main/java/net/minecraft/server/Chunk.java
+@@ -676,7 +676,7 @@ public class Chunk {
+     }
+ 
+     @Nullable
+-    public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
++    public final TileEntity getTileEntity(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } @Nullable public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) { // Paper - OBFHELPER
+         // CraftBukkit start
+         TileEntity tileentity = null;
+         if (world.captureBlockStates) {
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 new file mode 100644
-index 0000000..f059bc2
+index 0000000..bb1fa40
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,197 @@
 +package net.minecraft.server;
 +
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
@@ -195,6 +208,18 @@ index 0000000..f059bc2
 +    public static void scheduleAsyncTask(Runnable run) {
 +        asyncExecutor.execute(run);
 +    }
++
++    @Nullable
++    public static TileEntityHopper getHopper(World world, BlockPosition pos) {
++        Chunk chunk = world.getChunkIfLoaded(pos.getX() >> 4, pos.getZ() >> 4);
++        if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
++            TileEntity tileEntity = chunk.getTileEntity(pos);
++            if (tileEntity instanceof TileEntityHopper) {
++                return (TileEntityHopper) tileEntity;
++            }
++        }
++        return null;
++    }
 +}
 diff --git a/src/main/java/net/minecraft/server/NBTTagCompound.java b/src/main/java/net/minecraft/server/NBTTagCompound.java
 index c01cecb..7fa49dd 100644
@@ -237,5 +262,5 @@ index 256614d..e86ca6c 100644
  
      public NBTTagList() {}
 -- 
-2.7.4 (Apple Git-66)
+2.8.3
 

--- a/Spigot-Server-Patches/0021-Remove-invalid-mob-spawner-tile-entities.patch
+++ b/Spigot-Server-Patches/0021-Remove-invalid-mob-spawner-tile-entities.patch
@@ -1,14 +1,14 @@
-From f739616fdab39b3ef5bdd9e64fdaf319f262026c Mon Sep 17 00:00:00 2001
+From 4f42f838608bebcdeff9ad07b917eec2837cd1ab Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Tue, 1 Mar 2016 15:08:03 -0600
 Subject: [PATCH] Remove invalid mob spawner tile entities
 
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 00fb20d..5690e81 100644
+index 030e4af..ab56040 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -721,6 +721,10 @@ public class Chunk {
+@@ -728,6 +728,10 @@ public class Chunk {
              tileentity.z();
              this.tileEntities.put(blockposition, tileentity);
              // CraftBukkit start
@@ -20,5 +20,5 @@ index 00fb20d..5690e81 100644
              System.out.println("Attempted to place a tile entity (" + tileentity + ") at " + tileentity.position.getX() + "," + tileentity.position.getY() + "," + tileentity.position.getZ()
                  + " (" + org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(getBlockData(blockposition).getBlock()) + ") where there was no entity tile!");
 -- 
-2.8.2
+2.8.3
 

--- a/Spigot-Server-Patches/0061-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/Spigot-Server-Patches/0061-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -1,4 +1,4 @@
-From 1bba159601a998917f3ebe31c6b6642951a02ef7 Mon Sep 17 00:00:00 2001
+From ac85cea2d386822bf5759cbea98e36e212b50baf Mon Sep 17 00:00:00 2001
 From: CullanP <cullanpage@gmail.com>
 Date: Thu, 3 Mar 2016 02:13:38 -0600
 Subject: [PATCH] Avoid hopper searches if there are no items
@@ -14,7 +14,7 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 3806def..acce7cb 100644
+index 31992a6..67c9fef 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -47,6 +47,13 @@ public class Chunk {
@@ -59,7 +59,7 @@ index 3806def..acce7cb 100644
          // Spigot start - decrement creature type count
          // Keep this synced up with World.a(Class)
          if (entity instanceof EntityInsentient) {
-@@ -848,6 +869,15 @@ public class Chunk {
+@@ -855,6 +876,15 @@ public class Chunk {
              if (!this.entitySlices[k].isEmpty()) {
                  Iterator iterator = this.entitySlices[k].iterator();
  
@@ -75,7 +75,7 @@ index 3806def..acce7cb 100644
                  while (iterator.hasNext()) {
                      Entity entity1 = (Entity) iterator.next();
  
-@@ -880,7 +910,18 @@ public class Chunk {
+@@ -887,7 +917,18 @@ public class Chunk {
          i = MathHelper.clamp(i, 0, this.entitySlices.length - 1);
          j = MathHelper.clamp(j, 0, this.entitySlices.length - 1);
  
@@ -95,5 +95,5 @@ index 3806def..acce7cb 100644
  
              while (iterator.hasNext()) {
 -- 
-2.8.2
+2.8.3
 

--- a/Spigot-Server-Patches/0062-Expose-server-CommandMap.patch
+++ b/Spigot-Server-Patches/0062-Expose-server-CommandMap.patch
@@ -1,4 +1,4 @@
-From ef4ff54759bcfc8a1002c2bec92d661542798468 Mon Sep 17 00:00:00 2001
+From 83e8c9c450f8b47849440dad6ea2b7c7a98cdd1b Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Thu, 3 Mar 2016 02:15:57 -0600
 Subject: [PATCH] Expose server CommandMap
@@ -17,5 +17,5 @@ index bc48cf6..47851c1 100644
          return commandMap;
      }
 -- 
-2.8.2
+2.8.3
 

--- a/Spigot-Server-Patches/0063-Be-a-bit-more-informative-in-maxHealth-exception.patch
+++ b/Spigot-Server-Patches/0063-Be-a-bit-more-informative-in-maxHealth-exception.patch
@@ -1,4 +1,4 @@
-From d161119c1c5608813fb96a56afc6ab967c087faf Mon Sep 17 00:00:00 2001
+From 979cee973c90861e4e336dd2b80033f7c1acc24a Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Thu, 3 Mar 2016 02:18:39 -0600
 Subject: [PATCH] Be a bit more informative in maxHealth exception
@@ -21,5 +21,5 @@ index e662e4a..f13ca63 100644
  
          if (entity instanceof EntityPlayer && health == 0) {
 -- 
-2.8.2
+2.8.3
 

--- a/Spigot-Server-Patches/0071-Add-exception-reporting-event.patch
+++ b/Spigot-Server-Patches/0071-Add-exception-reporting-event.patch
@@ -1,4 +1,4 @@
-From 46b6f1db57959a42d8f67fbbbb8c7e2f2a8de68f Mon Sep 17 00:00:00 2001
+From cb04f99e741cd68a4522fbdcd052250ee8991aec Mon Sep 17 00:00:00 2001
 From: Joseph Hirschfeld <joe@ibj.io>
 Date: Thu, 3 Mar 2016 03:15:41 -0600
 Subject: [PATCH] Add exception reporting event
@@ -50,7 +50,7 @@ index 0000000..9339718
 +}
 \ No newline at end of file
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index acce7cb..b39960a 100644
+index 67c9fef..b6408bd 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -1,5 +1,6 @@
@@ -68,7 +68,7 @@ index acce7cb..b39960a 100644
  
  public class Chunk {
  
-@@ -763,10 +765,15 @@ public class Chunk {
+@@ -770,10 +772,15 @@ public class Chunk {
              this.tileEntities.remove(blockposition);
              // Paper end
          } else {
@@ -292,7 +292,7 @@ index 26d7d12..fcd2ddf 100644
              }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 26352d2..ccbfda0 100644
+index 0258f4b..e092ba5 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1,5 +1,7 @@
@@ -372,5 +372,5 @@ index 2a22697..d82dddf 100644
                  // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
              }
 -- 
-2.8.2.windows.1
+2.8.3
 

--- a/Spigot-Server-Patches/0108-Configurable-Chunk-Inhabited-Timer.patch
+++ b/Spigot-Server-Patches/0108-Configurable-Chunk-Inhabited-Timer.patch
@@ -1,4 +1,4 @@
-From 072fc0b7c6a6bc4d38bbd078405d29255b5f4a9a Mon Sep 17 00:00:00 2001
+From 9628fd1e52e46907ccfa12546115afc7ca5b3af8 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:46:14 -0400
 Subject: [PATCH] Configurable Chunk Inhabited Timer
@@ -23,10 +23,10 @@ index a97eee7..8966b4a 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 98d9e99..7144227 100644
+index 465638c..bcd0fcd 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -1371,7 +1371,7 @@ public class Chunk {
+@@ -1378,7 +1378,7 @@ public class Chunk {
      }
  
      public long x() {

--- a/Spigot-Server-Patches/0110-Prevent-Waterflow-BlockFromToEvent-from-loading-chun.patch
+++ b/Spigot-Server-Patches/0110-Prevent-Waterflow-BlockFromToEvent-from-loading-chun.patch
@@ -1,4 +1,4 @@
-From 17e02093634440f31ef3ddc7ee91b3b3a5b21dea Mon Sep 17 00:00:00 2001
+From 48e9c2fb6601c2d0f244c15f9a658ee13f5196fb Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 22:03:09 -0400
 Subject: [PATCH] Prevent Waterflow BlockFromToEvent from loading chunks
@@ -48,5 +48,5 @@ index 2eb8622..4ff7635 100644
                  if (this.material == Material.LAVA) {
                      this.fizz(world, blockposition);
 -- 
-2.8.2
+2.8.3
 

--- a/Spigot-Server-Patches/0151-Do-not-mark-chunks-as-active-for-neighbor-updates.patch
+++ b/Spigot-Server-Patches/0151-Do-not-mark-chunks-as-active-for-neighbor-updates.patch
@@ -1,4 +1,4 @@
-From a7138126f853f5b09a48a0e348dbaf7dd93c39a8 Mon Sep 17 00:00:00 2001
+From 16b5efc6d5910d4e79e28914acd29aeb9d6cb410 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 12 May 2016 01:55:17 -0400
 Subject: [PATCH] Do not mark chunks as active for neighbor updates
@@ -6,10 +6,10 @@ Subject: [PATCH] Do not mark chunks as active for neighbor updates
 Fixes chunk unload issues
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 904141a..d7b9581 100644
+index 3ef781e..1f596eb 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -991,25 +991,25 @@ public class Chunk {
+@@ -998,25 +998,25 @@ public class Chunk {
  
      public void loadNearby(IChunkProvider ichunkprovider, ChunkGenerator chunkgenerator) {
          world.timings.syncChunkLoadPostTimer.startTiming(); // Spigot
@@ -109,5 +109,5 @@ index 7b61b14..7752b50 100644
                      neighbor.setNeighborLoaded(-x, -z);
                      chunk.setNeighborLoaded(x, z);
 -- 
-2.7.4 (Apple Git-66)
+2.8.3
 

--- a/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
@@ -1,4 +1,4 @@
-From 4e348d99589417c4a6784fede0491c29cdd28c68 Mon Sep 17 00:00:00 2001
+From 9e115c48246a2acbf2458f3588aed38a1a9fc3ff Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Fri, 24 Jul 2015 16:20:18 -0700
 Subject: [PATCH] Fix hopper lag by making entities look for hoppers.
@@ -12,62 +12,17 @@ Pushing out of hoppers causes a bouding box lookup, which this patch replaces wi
 
 This patch may causes a decrease in the performance of dropped items, which is why it can be disabled in the configuration.
 
-diff --git a/src/main/java/com/destroystokyo/paper/HopperHelper.java b/src/main/java/com/destroystokyo/paper/HopperHelper.java
-new file mode 100644
-index 0000000..db0f414
---- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/HopperHelper.java
-@@ -0,0 +1,38 @@
-+package com.destroystokyo.paper;
-+
-+import net.minecraft.server.Block;
-+import net.minecraft.server.BlockChest;
-+import net.minecraft.server.BlockPosition;
-+import net.minecraft.server.Blocks;
-+import net.minecraft.server.Chunk;
-+import net.minecraft.server.IInventory;
-+import net.minecraft.server.TileEntity;
-+import net.minecraft.server.TileEntityHopper;
-+import net.minecraft.server.World;
-+
-+public class HopperHelper {
-+
-+    public static TileEntityHopper getHopper(World world, BlockPosition pos) {
-+        Chunk chunk = world.getChunkIfLoaded(pos);
-+        if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
-+            TileEntity tileEntity = chunk.a(pos, Chunk.EnumTileEntityState.IMMEDIATE);
-+            if (tileEntity instanceof TileEntityHopper) {
-+                return (TileEntityHopper) tileEntity;
-+            }
-+        }
-+        return null;
-+    }
-+
-+    public static IInventory getInventory(World world, BlockPosition position) {
-+        Block block = world.getType(position).getBlock();
-+        if (block instanceof BlockChest) {
-+            return ((BlockChest) block).c(world, position);
-+        }
-+        if (block.isTileEntity()) {
-+            TileEntity tile = world.getTileEntity(position);
-+            if (tile instanceof IInventory) return (IInventory) tile;
-+        }
-+        return null;
-+    }
-+
-+}
 diff --git a/src/main/java/com/destroystokyo/paper/HopperPusher.java b/src/main/java/com/destroystokyo/paper/HopperPusher.java
 new file mode 100644
-index 0000000..7f38adb
+index 0000000..a03e94d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/HopperPusher.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,57 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.AxisAlignedBB;
 +import net.minecraft.server.BlockPosition;
-+import net.minecraft.server.Entity;
-+import net.minecraft.server.IHopper;
++import net.minecraft.server.MCUtil;
 +import net.minecraft.server.TileEntityHopper;
 +import net.minecraft.server.World;
 +
@@ -85,7 +40,7 @@ index 0000000..7f38adb
 +            for (int y = startY; y <= endY; y++) {
 +                for (int z = startZ; z <= endZ; z++) {
 +                    BlockPosition adjacentPos = new BlockPosition(x, y, z);
-+                    TileEntityHopper hopper = HopperHelper.getHopper(getWorld(), adjacentPos);
++                    TileEntityHopper hopper = MCUtil.getHopper(getWorld(), adjacentPos);
 +                    if (hopper == null) continue; // Avoid playing with the bounding boxes, if at all possible
 +                    AxisAlignedBB hopperBoundingBox = hopper.getHopperLookupBoundingBox();
 +                    /*
@@ -114,20 +69,11 @@ index 0000000..7f38adb
 +
 +    World getWorld();
 +
-+    // Default implementations for entities
++    double getX();
 +
-+    default double getX() {
-+        return ((Entity) this).locX;
-+    }
++    double getY();
 +
-+    default double getY() {
-+        return ((Entity) this).locY;
-+    }
-+
-+    default double getZ() {
-+        return ((Entity) this).locZ;
-+    }
-+
++    double getZ();
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index 40ede20..0d2af96 100644
@@ -143,6 +89,34 @@ index 40ede20..0d2af96 100644
 +        isHopperPushBased = getBoolean("hopper.push-based", true);
 +    }
  }
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index d54a30b..2b81881 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -74,9 +74,23 @@ public abstract class Entity implements ICommandListener {
+     public double lastX;
+     public double lastY;
+     public double lastZ;
++    // Paper start - getters to implement HopperPusher
+     public double locX;
+     public double locY;
+     public double locZ;
++
++    public double getX() {
++        return locX;
++    }
++
++    public double getY() {
++        return locY;
++    }
++
++    public double getZ() {
++        return locZ;
++    }
++    // Paper end
+     public double motX;
+     public double motY;
+     public double motZ;
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
 index 0b11fd7..c806012 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
@@ -219,19 +193,28 @@ index 7216fa5..054a877 100644
  
      private ItemStack[] items = new ItemStack[27]; // CraftBukkit - 36 -> 27
      private boolean b = true;
+diff --git a/src/main/java/net/minecraft/server/IHopper.java b/src/main/java/net/minecraft/server/IHopper.java
+index 804215a..e830d83 100644
+--- a/src/main/java/net/minecraft/server/IHopper.java
++++ b/src/main/java/net/minecraft/server/IHopper.java
+@@ -4,9 +4,9 @@ public interface IHopper extends IInventory {
+ 
+     World getWorld();
+ 
+-    double E();
++    double E(); default double getX() { return E(); } // Paper - OBFHELPER
+ 
+-    double F();
++    double F(); default double getY() { return F(); } // Paper - OBFHELPER
+ 
+-    double G();
++    double G(); default double getZ() { return G(); } // Paper - OBFHELPER
+ }
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index a695207..3529be0 100644
+index a695207..64f783c 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
-@@ -12,6 +12,7 @@ import org.bukkit.event.inventory.InventoryMoveItemEvent;
- import org.bukkit.event.inventory.InventoryPickupItemEvent;
- import org.bukkit.inventory.Inventory;
- // CraftBukkit end
-+import com.destroystokyo.paper.HopperHelper; // Paper
- 
- public class TileEntityHopper extends TileEntityLootable implements IHopper, ITickable {
- 
-@@ -155,6 +156,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+@@ -155,6 +155,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
      }
  
      public void c() {
@@ -239,7 +222,7 @@ index a695207..3529be0 100644
          if (this.world != null && !this.world.isClientSide) {
              --this.g;
              if (!this.o()) {
-@@ -175,6 +177,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+@@ -175,6 +176,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
                  }
  
                  if (!this.r()) {
@@ -247,7 +230,7 @@ index a695207..3529be0 100644
                      flag = a((IHopper) this) || flag;
                  }
  
-@@ -197,6 +200,14 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+@@ -197,6 +199,14 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
          }
      }
  
@@ -262,29 +245,15 @@ index a695207..3529be0 100644
      private boolean q() {
          ItemStack[] aitemstack = this.items;
          int i = aitemstack.length;
-@@ -228,7 +239,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
-     }
- 
-     private boolean H() {
--        IInventory iinventory = this.I();
-+        IInventory iinventory = HopperHelper.getInventory(getWorld(), getPosition().shift(BlockHopper.e(this.u()))); // Paper - avoid bounding box search
- 
-         if (iinventory == null) {
-             return false;
-@@ -333,8 +344,20 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+@@ -333,8 +343,15 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
          return true;
      }
  
 +    // Paper start - split methods, and only do entity lookup if in pull mode
      public static boolean a(IHopper ihopper) {
 -        IInventory iinventory = b(ihopper);
-+        IInventory iinventory;
-+        if (ihopper.getWorld().paperConfig.isHopperPushBased && ihopper instanceof TileEntityHopper) {
-+            BlockPosition pos = ((TileEntityHopper) ihopper).getPosition().up(); // Only pull from above, as everything else is pushed into the hopper
-+            iinventory = HopperHelper.getInventory(ihopper.getWorld(), pos);
-+        } else {
-+            iinventory = b(ihopper);
-+        }
++        IInventory iinventory = getInventory(ihopper, !(ihopper instanceof TileEntityHopper) || !ihopper.getWorld().paperConfig.isHopperPushBased);
++
 +        return acceptItem(ihopper, iinventory);
 +    }
 +
@@ -293,34 +262,75 @@ index a695207..3529be0 100644
  
          if (iinventory != null) {
              EnumDirection enumdirection = EnumDirection.DOWN;
-@@ -361,7 +384,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+@@ -361,8 +378,8 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
                      }
                  }
              }
 -        } else {
+-            Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator();
 +        } else if (!ihopper.getWorld().paperConfig.isHopperPushBased || !(ihopper instanceof TileEntityHopper)) { // Paper - only search for entities in 'pull mode'
-             Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator();
++            Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator(); // Change getHopperLookupBoundingBox() if this ever changes
  
              while (iterator.hasNext()) {
-@@ -537,6 +560,18 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
-         return world.a(EntityItem.class, new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D), IEntitySelector.a);
+                 EntityItem entityitem = (EntityItem) iterator.next();
+@@ -526,18 +543,44 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+     private IInventory I() {
+         EnumDirection enumdirection = BlockHopper.e(this.u());
+ 
+-        return b(this.getWorld(), this.E() + (double) enumdirection.getAdjacentX(), this.F() + (double) enumdirection.getAdjacentY(), this.G() + (double) enumdirection.getAdjacentZ());
++        // Paper start - don't search for entities in push mode
++        World world = getWorld();
++        return getInventory(world, this.E() + (double) enumdirection.getAdjacentX(), this.F() + (double) enumdirection.getAdjacentY(), this.G() + (double) enumdirection.getAdjacentZ(), !world.paperConfig.isHopperPushBased);
++        // Paper endtcon
      }
  
-+    // Paper start
-+    public AxisAlignedBB getHopperLookupBoundingBox() {
-+        // Change this if b(IHopper) ever changes
-+        return getHopperLookupBoundingBox(this.E(), this.F(), this.G());
+-    public static IInventory b(IHopper ihopper) {
+-        return b(ihopper.getWorld(), ihopper.E(), ihopper.F() + 1.0D, ihopper.G());
++    // Paper start - add option to search for entities
++    public static IInventory b(IHopper hopper) {
++        return getInventory(hopper, true);
 +    }
 +
++    public static IInventory getInventory(IHopper ihopper, boolean searchForEntities) {
++        return getInventory(ihopper.getWorld(), ihopper.E(), ihopper.F() + 1.0D, ihopper.G(), searchForEntities);
++        // Paper end
+     }
+ 
+     public static List<EntityItem> a(World world, double d0, double d1, double d2) {
+-        return world.a(EntityItem.class, new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D), IEntitySelector.a);
++        return world.a(EntityItem.class, new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D), IEntitySelector.a); // Change getHopperLookupBoundingBox(double, double, double) if the bounding box calculation is ever changed
++    }
++
++    // Paper start
++    public AxisAlignedBB getHopperLookupBoundingBox() {
++        return getHopperLookupBoundingBox(this.getX(), this.getY(), this.getZ());
+     }
+ 
 +    private static AxisAlignedBB getHopperLookupBoundingBox(double d0, double d1, double d2) {
 +        // Change this if a(World, double, double, double) above ever changes
 +        return new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D);
 +    }
 +    // Paper end
 +
++    // Paper start - add option to searchForEntities
      public static IInventory b(World world, double d0, double d1, double d2) {
++        return getInventory(world, d0, d1, d2, true);
++    }
++
++    public static IInventory getInventory(World world, double d0, double d1, double d2, boolean searchForEntities) {
++        // Paper end
          Object object = null;
          int i = MathHelper.floor(d0);
+         int j = MathHelper.floor(d1);
+@@ -557,7 +600,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+             }
+         }
+ 
+-        if (object == null) {
++        if (object == null && searchForEntities) { // Paper - only if searchForEntities
+             List list = world.getEntities((Entity) null, new AxisAlignedBB(d0 - 0.5D, d1 - 0.5D, d2 - 0.5D, d0 + 0.5D, d1 + 0.5D, d2 + 0.5D), IEntitySelector.c);
+ 
+             if (!list.isEmpty()) {
 -- 
 2.8.3
 

--- a/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
@@ -1,0 +1,326 @@
+From 4e348d99589417c4a6784fede0491c29cdd28c68 Mon Sep 17 00:00:00 2001
+From: Techcable <Techcable@outlook.com>
+Date: Fri, 24 Jul 2015 16:20:18 -0700
+Subject: [PATCH] Fix hopper lag by making entities look for hoppers.
+
+Every tick hoppers try and find an block-inventory to extract from.
+If no tile entity is above the hopper (which there often isn't) it will do a bounding box search for minecart chests and minecart hoppers.
+If it can't find an inventory, it will then look for a dropped item, which is another bounding box search.
+This patch eliminates that expensive check by having dropped items and minecart hoppers/chests look for hoppers instead.
+Hoppers are tile entities meaning you can do a simple tile entity lookup to find the nearest hopper in range.
+Pushing out of hoppers causes a bouding box lookup, which this patch replaces with a tile entity lookup.
+
+This patch may causes a decrease in the performance of dropped items, which is why it can be disabled in the configuration.
+
+diff --git a/src/main/java/com/destroystokyo/paper/HopperHelper.java b/src/main/java/com/destroystokyo/paper/HopperHelper.java
+new file mode 100644
+index 0000000..db0f414
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/HopperHelper.java
+@@ -0,0 +1,38 @@
++package com.destroystokyo.paper;
++
++import net.minecraft.server.Block;
++import net.minecraft.server.BlockChest;
++import net.minecraft.server.BlockPosition;
++import net.minecraft.server.Blocks;
++import net.minecraft.server.Chunk;
++import net.minecraft.server.IInventory;
++import net.minecraft.server.TileEntity;
++import net.minecraft.server.TileEntityHopper;
++import net.minecraft.server.World;
++
++public class HopperHelper {
++
++    public static TileEntityHopper getHopper(World world, BlockPosition pos) {
++        Chunk chunk = world.getChunkIfLoaded(pos);
++        if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
++            TileEntity tileEntity = chunk.a(pos, Chunk.EnumTileEntityState.IMMEDIATE);
++            if (tileEntity instanceof TileEntityHopper) {
++                return (TileEntityHopper) tileEntity;
++            }
++        }
++        return null;
++    }
++
++    public static IInventory getInventory(World world, BlockPosition position) {
++        Block block = world.getType(position).getBlock();
++        if (block instanceof BlockChest) {
++            return ((BlockChest) block).c(world, position);
++        }
++        if (block.isTileEntity()) {
++            TileEntity tile = world.getTileEntity(position);
++            if (tile instanceof IInventory) return (IInventory) tile;
++        }
++        return null;
++    }
++
++}
+diff --git a/src/main/java/com/destroystokyo/paper/HopperPusher.java b/src/main/java/com/destroystokyo/paper/HopperPusher.java
+new file mode 100644
+index 0000000..7f38adb
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/HopperPusher.java
+@@ -0,0 +1,67 @@
++package com.destroystokyo.paper;
++
++import net.minecraft.server.AxisAlignedBB;
++import net.minecraft.server.BlockPosition;
++import net.minecraft.server.Entity;
++import net.minecraft.server.IHopper;
++import net.minecraft.server.TileEntityHopper;
++import net.minecraft.server.World;
++
++public interface HopperPusher {
++
++    default TileEntityHopper findHopper() {
++        BlockPosition pos = new BlockPosition(getX(), getY(), getZ());
++        int startX = pos.getX() - 1;
++        int endX = pos.getX() + 1;
++        int startY = Math.max(0, pos.getY() - 1);
++        int endY = Math.min(255, pos.getY() + 1);
++        int startZ = pos.getZ() - 1;
++        int endZ = pos.getZ() + 1;
++        for (int x = startX; x <= endX; x++) {
++            for (int y = startY; y <= endY; y++) {
++                for (int z = startZ; z <= endZ; z++) {
++                    BlockPosition adjacentPos = new BlockPosition(x, y, z);
++                    TileEntityHopper hopper = HopperHelper.getHopper(getWorld(), adjacentPos);
++                    if (hopper == null) continue; // Avoid playing with the bounding boxes, if at all possible
++                    AxisAlignedBB hopperBoundingBox = hopper.getHopperLookupBoundingBox();
++                    /*
++                     * Check if the entity's bounding box intersects with the hopper's lookup box.
++                     * This operation doesn't work both ways!
++                     * Make sure you check if the entity's box intersects the hopper's box, not vice versa!
++                     */
++                    if (this.getBoundingBox().b(hopperBoundingBox)) {
++                        return hopper;
++                    }
++                }
++            }
++        }
++        return null;
++    }
++
++    boolean acceptItem(TileEntityHopper hopper);
++
++    default boolean tryPutInHopper() {
++        if (!getWorld().paperConfig.isHopperPushBased) return false;
++        TileEntityHopper hopper = findHopper();
++        return hopper != null && hopper.canAcceptItems() && acceptItem(hopper);
++    }
++
++    AxisAlignedBB getBoundingBox();
++
++    World getWorld();
++
++    // Default implementations for entities
++
++    default double getX() {
++        return ((Entity) this).locX;
++    }
++
++    default double getY() {
++        return ((Entity) this).locY;
++    }
++
++    default double getZ() {
++        return ((Entity) this).locZ;
++    }
++
++}
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 40ede20..0d2af96 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -363,4 +363,9 @@ public class PaperWorldConfig {
+             log("Old Cannon Behaviors: This feature may not be working entirely properly at the moment");
+         }
+     }
++
++    public boolean isHopperPushBased;
++    private void isHopperPushBased() {
++        isHopperPushBased = getBoolean("hopper.push-based", true);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index 0b11fd7..c806012 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -6,8 +6,15 @@ import javax.annotation.Nullable;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ import org.bukkit.event.player.PlayerPickupItemEvent; // CraftBukkit
++import com.destroystokyo.paper.HopperPusher; // Paper
+ 
+-public class EntityItem extends Entity {
++// Paper start - implement HopperPusher
++public class EntityItem extends Entity implements HopperPusher {
++    @Override
++    public boolean acceptItem(TileEntityHopper hopper) {
++        return TileEntityHopper.a(hopper, this);
++    }
++// Paper end
+ 
+     private static final Logger b = LogManager.getLogger();
+     private static final DataWatcherObject<Optional<ItemStack>> c = DataWatcher.a(EntityItem.class, DataWatcherRegistry.f);
+@@ -63,6 +70,7 @@ public class EntityItem extends Entity {
+             this.die();
+         } else {
+             super.m();
++            if (tryPutInHopper()) return; // Paper
+             // CraftBukkit start - Use wall time for pickup and despawn timers
+             int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
+             if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
+@@ -127,6 +135,7 @@ public class EntityItem extends Entity {
+     // Spigot start - copied from above
+     @Override
+     public void inactiveTick() {
++        if (tryPutInHopper()) return; // Paper
+         // CraftBukkit start - Use wall time for pickup and despawn timers
+         int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
+         if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
+diff --git a/src/main/java/net/minecraft/server/EntityMinecartContainer.java b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
+index 7216fa5..054a877 100644
+--- a/src/main/java/net/minecraft/server/EntityMinecartContainer.java
++++ b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
+@@ -6,6 +6,7 @@ import javax.annotation.Nullable;
+ import java.util.List;
+ import org.bukkit.Location;
+ 
++import com.destroystokyo.paper.HopperPusher; // Paper
+ import com.destroystokyo.paper.loottable.CraftLootableInventoryData; // Paper
+ import com.destroystokyo.paper.loottable.CraftLootableInventory; // Paper
+ import com.destroystokyo.paper.loottable.LootableInventory; // Paper
+@@ -14,7 +15,25 @@ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.inventory.InventoryHolder;
+ // CraftBukkit end
+ 
+-public abstract class EntityMinecartContainer extends EntityMinecartAbstract implements ITileInventory, ILootable, CraftLootableInventory { // Paper
++// Paper start - push into hoppers
++public abstract class EntityMinecartContainer extends EntityMinecartAbstract implements ITileInventory, ILootable, CraftLootableInventory, HopperPusher { // Paper - CraftLootableInventory
++    @Override
++    public boolean acceptItem(TileEntityHopper hopper) {
++        return TileEntityHopper.acceptItem(hopper, this);
++    }
++
++    @Override
++    public void m() {
++        super.m();
++        tryPutInHopper();
++    }
++
++    @Override
++    public void inactiveTick() {
++        super.inactiveTick();
++        tryPutInHopper();
++    }
++    // Paper end
+ 
+     private ItemStack[] items = new ItemStack[27]; // CraftBukkit - 36 -> 27
+     private boolean b = true;
+diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
+index a695207..3529be0 100644
+--- a/src/main/java/net/minecraft/server/TileEntityHopper.java
++++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
+@@ -12,6 +12,7 @@ import org.bukkit.event.inventory.InventoryMoveItemEvent;
+ import org.bukkit.event.inventory.InventoryPickupItemEvent;
+ import org.bukkit.inventory.Inventory;
+ // CraftBukkit end
++import com.destroystokyo.paper.HopperHelper; // Paper
+ 
+ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITickable {
+ 
+@@ -155,6 +156,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+     }
+ 
+     public void c() {
++        mayAcceptItems = false; // Paper - at the beginning of a tick, assume we can't accept items
+         if (this.world != null && !this.world.isClientSide) {
+             --this.g;
+             if (!this.o()) {
+@@ -175,6 +177,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+                 }
+ 
+                 if (!this.r()) {
++                    mayAcceptItems = true; // Paper - flag this hopper to be able to accept items
+                     flag = a((IHopper) this) || flag;
+                 }
+ 
+@@ -197,6 +200,14 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         }
+     }
+ 
++    // Paper start
++    private boolean mayAcceptItems = true;
++
++    public boolean canAcceptItems() {
++        return mayAcceptItems;
++    }
++    // Paper end
++
+     private boolean q() {
+         ItemStack[] aitemstack = this.items;
+         int i = aitemstack.length;
+@@ -228,7 +239,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+     }
+ 
+     private boolean H() {
+-        IInventory iinventory = this.I();
++        IInventory iinventory = HopperHelper.getInventory(getWorld(), getPosition().shift(BlockHopper.e(this.u()))); // Paper - avoid bounding box search
+ 
+         if (iinventory == null) {
+             return false;
+@@ -333,8 +344,20 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return true;
+     }
+ 
++    // Paper start - split methods, and only do entity lookup if in pull mode
+     public static boolean a(IHopper ihopper) {
+-        IInventory iinventory = b(ihopper);
++        IInventory iinventory;
++        if (ihopper.getWorld().paperConfig.isHopperPushBased && ihopper instanceof TileEntityHopper) {
++            BlockPosition pos = ((TileEntityHopper) ihopper).getPosition().up(); // Only pull from above, as everything else is pushed into the hopper
++            iinventory = HopperHelper.getInventory(ihopper.getWorld(), pos);
++        } else {
++            iinventory = b(ihopper);
++        }
++        return acceptItem(ihopper, iinventory);
++    }
++
++    public static boolean acceptItem(IHopper ihopper, IInventory iinventory) {
++        // Paper end
+ 
+         if (iinventory != null) {
+             EnumDirection enumdirection = EnumDirection.DOWN;
+@@ -361,7 +384,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+                     }
+                 }
+             }
+-        } else {
++        } else if (!ihopper.getWorld().paperConfig.isHopperPushBased || !(ihopper instanceof TileEntityHopper)) { // Paper - only search for entities in 'pull mode'
+             Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator();
+ 
+             while (iterator.hasNext()) {
+@@ -537,6 +560,18 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return world.a(EntityItem.class, new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D), IEntitySelector.a);
+     }
+ 
++    // Paper start
++    public AxisAlignedBB getHopperLookupBoundingBox() {
++        // Change this if b(IHopper) ever changes
++        return getHopperLookupBoundingBox(this.E(), this.F(), this.G());
++    }
++
++    private static AxisAlignedBB getHopperLookupBoundingBox(double d0, double d1, double d2) {
++        // Change this if a(World, double, double, double) above ever changes
++        return new AxisAlignedBB(d0 - 0.5D, d1, d2 - 0.5D, d0 + 0.5D, d1 + 1.5D, d2 + 0.5D);
++    }
++    // Paper end
++
+     public static IInventory b(World world, double d0, double d1, double d2) {
+         Object object = null;
+         int i = MathHelper.floor(d0);
+-- 
+2.8.3
+

--- a/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
@@ -1,4 +1,4 @@
-From 9e115c48246a2acbf2458f3588aed38a1a9fc3ff Mon Sep 17 00:00:00 2001
+From 17f62a2d5120e7a8f964027b42043f8464c7efe1 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Fri, 24 Jul 2015 16:20:18 -0700
 Subject: [PATCH] Fix hopper lag by making entities look for hoppers.
@@ -14,10 +14,10 @@ This patch may causes a decrease in the performance of dropped items, which is w
 
 diff --git a/src/main/java/com/destroystokyo/paper/HopperPusher.java b/src/main/java/com/destroystokyo/paper/HopperPusher.java
 new file mode 100644
-index 0000000..a03e94d
+index 0000000..5ff43e2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/HopperPusher.java
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,59 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.AxisAlignedBB;
@@ -36,10 +36,11 @@ index 0000000..a03e94d
 +        int endY = Math.min(255, pos.getY() + 1);
 +        int startZ = pos.getZ() - 1;
 +        int endZ = pos.getZ() + 1;
++        BlockPosition.PooledBlockPosition adjacentPos = BlockPosition.PooledBlockPosition.aquire();
 +        for (int x = startX; x <= endX; x++) {
 +            for (int y = startY; y <= endY; y++) {
 +                for (int z = startZ; z <= endZ; z++) {
-+                    BlockPosition adjacentPos = new BlockPosition(x, y, z);
++                    adjacentPos.setValues(x, y, z);
 +                    TileEntityHopper hopper = MCUtil.getHopper(getWorld(), adjacentPos);
 +                    if (hopper == null) continue; // Avoid playing with the bounding boxes, if at all possible
 +                    AxisAlignedBB hopperBoundingBox = hopper.getHopperLookupBoundingBox();
@@ -54,6 +55,7 @@ index 0000000..a03e94d
 +                }
 +            }
 +        }
++        adjacentPos.free();
 +        return null;
 +    }
 +
@@ -89,19 +91,58 @@ index 40ede20..0d2af96 100644
 +        isHopperPushBased = getBoolean("hopper.push-based", true);
 +    }
  }
+diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
+index 2c60d6e..8730cf5 100644
+--- a/src/main/java/net/minecraft/server/BlockPosition.java
++++ b/src/main/java/net/minecraft/server/BlockPosition.java
+@@ -265,6 +265,7 @@ public class BlockPosition extends BaseBlockPosition {
+             super(i, j, k);
+         }
+ 
++        public static BlockPosition.PooledBlockPosition aquire() { return s(); } // Paper - OBFHELPER
+         public static BlockPosition.PooledBlockPosition s() {
+             return e(0, 0, 0);
+         }
+@@ -291,6 +292,7 @@ public class BlockPosition extends BaseBlockPosition {
+             return new BlockPosition.PooledBlockPosition(i, j, k);
+         }
+ 
++        public void free() { t(); } // Paper - OBFHELPER
+         public void t() {
+             List list = BlockPosition.PooledBlockPosition.g;
+ 
+@@ -388,6 +390,7 @@ public class BlockPosition extends BaseBlockPosition {
+             return this.d;
+         }
+ 
++        public void setValues(int x, int y, int z) { c(x, y, z); } // Paper - OBFHELPER
+         public BlockPosition.MutableBlockPosition c(int i, int j, int k) {
+             this.b = i;
+             this.c = j;
+diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
+index 3f411df..32c56c2 100644
+--- a/src/main/java/net/minecraft/server/Chunk.java
++++ b/src/main/java/net/minecraft/server/Chunk.java
+@@ -742,7 +742,9 @@ public class Chunk {
+     }
+ 
+     @Nullable
+-    public final TileEntity getTileEntity(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } @Nullable public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) { // Paper - OBFHELPER
++    public final TileEntity getTileEntityImmediately(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } // Paper - OBFHELPER
++    @Nullable
++    public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
+         // CraftBukkit start
+         TileEntity tileentity = null;
+         if (world.captureBlockStates) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d54a30b..2b81881 100644
+index d54a30b..70e6c8c 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -74,9 +74,23 @@ public abstract class Entity implements ICommandListener {
-     public double lastX;
-     public double lastY;
-     public double lastZ;
-+    // Paper start - getters to implement HopperPusher
+@@ -77,6 +77,19 @@ public abstract class Entity implements ICommandListener {
      public double locX;
      public double locY;
      public double locZ;
-+
++    // Paper start - getters to implement HopperPusher
 +    public double getX() {
 +        return locX;
 +    }
@@ -210,6 +251,19 @@ index 804215a..e830d83 100644
 -    double G();
 +    double G(); default double getZ() { return G(); } // Paper - OBFHELPER
  }
+diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
+index bb1fa40..2724678 100644
+--- a/src/main/java/net/minecraft/server/MCUtil.java
++++ b/src/main/java/net/minecraft/server/MCUtil.java
+@@ -187,7 +187,7 @@ public final class MCUtil {
+     public static TileEntityHopper getHopper(World world, BlockPosition pos) {
+         Chunk chunk = world.getChunkIfLoaded(pos.getX() >> 4, pos.getZ() >> 4);
+         if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
+-            TileEntity tileEntity = chunk.getTileEntity(pos);
++            TileEntity tileEntity = chunk.getTileEntityImmediately(pos);
+             if (tileEntity instanceof TileEntityHopper) {
+                 return (TileEntityHopper) tileEntity;
+             }
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
 index a695207..64f783c 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java

--- a/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0165-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
@@ -1,4 +1,4 @@
-From 17f62a2d5120e7a8f964027b42043f8464c7efe1 Mon Sep 17 00:00:00 2001
+From bcdf1c54c0ce2350c3f11c6add67f87f70472615 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Fri, 24 Jul 2015 16:20:18 -0700
 Subject: [PATCH] Fix hopper lag by making entities look for hoppers.
@@ -119,21 +119,6 @@ index 2c60d6e..8730cf5 100644
          public BlockPosition.MutableBlockPosition c(int i, int j, int k) {
              this.b = i;
              this.c = j;
-diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 3f411df..32c56c2 100644
---- a/src/main/java/net/minecraft/server/Chunk.java
-+++ b/src/main/java/net/minecraft/server/Chunk.java
-@@ -742,7 +742,9 @@ public class Chunk {
-     }
- 
-     @Nullable
--    public final TileEntity getTileEntity(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } @Nullable public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) { // Paper - OBFHELPER
-+    public final TileEntity getTileEntityImmediately(BlockPosition pos) { return a(pos, EnumTileEntityState.IMMEDIATE); } // Paper - OBFHELPER
-+    @Nullable
-+    public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
-         // CraftBukkit start
-         TileEntity tileentity = null;
-         if (world.captureBlockStates) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
 index d54a30b..70e6c8c 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
@@ -251,19 +236,6 @@ index 804215a..e830d83 100644
 -    double G();
 +    double G(); default double getZ() { return G(); } // Paper - OBFHELPER
  }
-diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index bb1fa40..2724678 100644
---- a/src/main/java/net/minecraft/server/MCUtil.java
-+++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -187,7 +187,7 @@ public final class MCUtil {
-     public static TileEntityHopper getHopper(World world, BlockPosition pos) {
-         Chunk chunk = world.getChunkIfLoaded(pos.getX() >> 4, pos.getZ() >> 4);
-         if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
--            TileEntity tileEntity = chunk.getTileEntity(pos);
-+            TileEntity tileEntity = chunk.getTileEntityImmediately(pos);
-             if (tileEntity instanceof TileEntityHopper) {
-                 return (TileEntityHopper) tileEntity;
-             }
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
 index a695207..64f783c 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -57,6 +57,7 @@ import EULA
 import EntitySquid
 import EntityWaterAnimal
 import FileIOThread
+import IHopper
 import ItemBlock
 import NavigationAbstract
 import NBTTagCompound


### PR DESCRIPTION
Every tick hoppers try and find an block-inventory to extract from.
If no tile entity is above the hopper (which there often isn't) it will do a bounding box search for minecart chests and minecart hoppers.
If it can't find an inventory, it will then look for a dropped item, which is another bounding box search.
This patch eliminates that expensive check by having dropped items and minecart hoppers/chests look for hoppers instead.
Hoppers are tile entities meaning you can do a simple tile entity lookup to find the nearest hopper in range.
This usually results in a net performance gain, since tile entity lookups are around a order of magnitude faster then bounding box lookups.
Pushing out of hoppers also causes a unessicary bouding box lookup, which this patch replaces with a tile entity lookup.

This patch may causes a decrease in the performance of dropped items, which is why it can be disabled in the configuration.
# 

This patch has gone through signifigant improvements since you [first saw it a year ago](https://hub.spigotmc.org/stash/projects/PAPER/repos/paperspigot/pull-requests/9/overview).
- It is now fully compatible with `useHopperCheck` and preserves vanilla lookup behavior for items and minecarts.
- It has survived a major mincraft update with no major changes, and multple minor updates.
  - The only issue was that it conflicted with @Aikar 's hopper cooldown reset, but that was later fixed in TacoSpigot#TacoSpigot@577f2ec93a57c7767acbf2605ba33ffd2928ecf9
- Should emulate vanilla behavior perfectly
- Used in production on [over 50 servers serving over 100 players](http://mcstats.org/plugin/TacoSpigot)
  - This includes @L4BORG, @PhanaticD and @CullanP 's servers
- It has been refactored to use java 8's default interface methods per @0x277F 's suggestion
- Many of its unnecessary diffs were removed (like that one with the Chunk.tileEntityMap using trove)
