### PR TITLE
Fix infinite loop when saving chunks

### DIFF
--- a/Spigot-Server-Patches/0163-Fix-infinite-loop-when-saving-chunks.patch
+++ b/Spigot-Server-Patches/0163-Fix-infinite-loop-when-saving-chunks.patch
@@ -1,0 +1,23 @@
+From d2f4f7f5f8868078bedfad4f64e84e54782fd694 Mon Sep 17 00:00:00 2001
+From: Jadon Fowler <jadonflower@gmail.com>
+Date: Fri, 17 Jun 2016 02:26:58 -0700
+Subject: [PATCH] Fix infinite loop when saving chunks
+
+Running `/save-all flush` would start an infinite loop that prints:
+    ThreadedAnvilChunkStorage (world): All chunks are saved
+
+diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+index facc97b..2081c29 100644
+--- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
++++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+@@ -219,6 +219,7 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
+                 if (this.c()) {
+                     continue;
+                 }
++                break; // Paper - fix infinite loop when saving chunks
+             }
+         } finally {
+             this.f = false;
+-- 
+2.7.4
+


### PR DESCRIPTION
Running `/save-all flush` would start an infinite loop that prints:

```
ThreadedAnvilChunkStorage (world): All chunks are saved
```
