### PR TITLE
Toggleable Elytra Wall Damage

### DIFF
--- a/Spigot-Server-Patches/0167-Toggleable-Elytra-Wall-Damage.patch
+++ b/Spigot-Server-Patches/0167-Toggleable-Elytra-Wall-Damage.patch
@@ -1,0 +1,45 @@
+From e03e8a975e0e96c5de2e5e63aff85251e1561850 Mon Sep 17 00:00:00 2001
+From: Jadon Fowler <jadonflower@gmail.com>
+Date: Sat, 18 Jun 2016 23:13:59 -0700
+Subject: [PATCH] Toggleable Elytra Wall Damage
+
+Instead of calculating the damage taken from hitting a wall, you can
+disable it in the config.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index bc41b7e..e3fe8f4 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -377,4 +377,9 @@ public class PaperWorldConfig {
+     private void isHopperPushBased() {
+         isHopperPushBased = getBoolean("hopper.push-based", true);
+     }
++
++    public boolean elytraHitWallDamage = true;
++    private void elytraHitWallDamage() {
++        elytraHitWallDamage = getBoolean("elytra-hit-wall-damage", true);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 4e424aa..af0127e 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1615,6 +1615,7 @@ public abstract class EntityLiving extends Entity {
+                     this.motY = 0.30000001192092896D;
+                 }
+             } else if (this.cG()) {
++                if(world.paperConfig.elytraHitWallDamage) { // Paper start - Toggleable Elytra Wall Damage
+                 if (this.motY > -0.5D) {
+                     this.fallDistance = 1.0F;
+                 }
+@@ -1664,6 +1665,7 @@ public abstract class EntityLiving extends Entity {
+                         this.damageEntity(DamageSource.FLY_INTO_WALL, f7);
+                     }
+                 }
++                } // Paper end - Elyta Wall Damage if statement
+ 
+                 if (this.onGround && !this.world.isClientSide) {
+                     if (getFlag(7) && !CraftEventFactory.callToggleGlideEvent(this, false).isCancelled()) // CraftBukkit
+-- 
+2.7.4
+


### PR DESCRIPTION
Instead of calculating the damage taken from hitting a wall, you can disable it in the config.

These calculations took ~40,000ns on my machine, though it reached as high as 120,000ns.
