### PR TITLE
Fix-Banner Patch: Display correct time in F3

### DIFF
--- a/Spigot-Server-Patches/0092-Waving-banner-workaround.patch
+++ b/Spigot-Server-Patches/0092-Waving-banner-workaround.patch
@@ -1,4 +1,4 @@
-From 6f283d5d1557aaa49bb6a9e1cee6835f59a5e1da Mon Sep 17 00:00:00 2001
+From 505e41c56fd3272ec2ff4e2e938ba521174913e7 Mon Sep 17 00:00:00 2001
 From: Gabscap <sonstige.netzwerke@gabriel-paradzik.de>
 Date: Sat, 19 Mar 2016 22:25:11 +0100
 Subject: [PATCH] Waving banner workaround
@@ -6,32 +6,33 @@ Subject: [PATCH] Waving banner workaround
 This patch is a workaround for MC-63720
 
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
-index c5c3f40..3ed2356 100644
+index c5c3f40..6413f76 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
-@@ -4,7 +4,11 @@ import java.io.IOException;
+@@ -4,7 +4,13 @@ import java.io.IOException;
  
  public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
  
 +    // World Age in ticks
 +    // Not changed by server commands
++    // World Age must not be negative
      private long a;
 +    // Time of Day in ticks
 +    // If negative the sun will stop moving at the Math.abs of the time
++    // Displayed in the debug screen (F3)
      private long b;
  
      public PacketPlayOutUpdateTime() {}
-@@ -19,6 +23,10 @@ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
+@@ -19,6 +25,9 @@ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
              }
          }
  
 +        // Paper start
-+        this.a = this.a % 192000; // World age must not be negative
-+        this.b = this.b % 192000 - (this.b < 0 ? 192000 : 0); // Keep sign
++        this.a = this.a % 192000;
 +        // Paper end
      }
  
      public void a(PacketDataSerializer packetdataserializer) throws IOException {
 -- 
-2.9.0
+2.9.2
 


### PR DESCRIPTION
The client only uses the world age (this.a) to compute banners while displaying the time of day (this.b) in the debug screen (F3). Instead of changing both values before sending it to the client, only the world age gets modified. This should fix banners and display the correct time in F3.
