### PR TITLE
1.8.8 port of the "Introduce a setting to handle offline proxies" patch

### DIFF
--- a/Spigot-API-Patches/0022-Fix-ServerListPingEvent-flagging-as-Async.patch
+++ b/Spigot-API-Patches/0022-Fix-ServerListPingEvent-flagging-as-Async.patch
@@ -1,0 +1,54 @@
+From 173bcd9c0bba74cb72b41cd9fa73ac8b612e3314 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Wed, 24 Feb 2016 00:57:22 -0500
+Subject: [PATCH] Fix ServerListPingEvent flagging as Async
+
+This event can sometimes fire Async, set the proper boolean
+
+diff --git a/src/main/java/org/bukkit/event/server/ServerEvent.java b/src/main/java/org/bukkit/event/server/ServerEvent.java
+index eb00d6a..70416c8 100644
+--- a/src/main/java/org/bukkit/event/server/ServerEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerEvent.java
+@@ -1,9 +1,19 @@
+ package org.bukkit.event.server;
+ 
++import org.bukkit.Bukkit;
+ import org.bukkit.event.Event;
+ 
+ /**
+  * Miscellaneous server events
+  */
+ public abstract class ServerEvent extends Event {
++    // Paper start
++    public ServerEvent(boolean isAsync) {
++        super(isAsync);
++    }
++
++    public ServerEvent() {
++        super(!Bukkit.isPrimaryThread());
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+index 343f238..3c38d85 100644
+--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+@@ -21,6 +21,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     private int maxPlayers;
+ 
+     public ServerListPingEvent(final InetAddress address, final String motd, final int numPlayers, final int maxPlayers) {
++        super(); // Paper - Is this event being fired async?
+         Validate.isTrue(numPlayers >= 0, "Cannot have negative number of players online", numPlayers);
+         this.address = address;
+         this.motd = motd;
+@@ -38,6 +39,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+      * @param maxPlayers the max number of players
+      */
+     protected ServerListPingEvent(final InetAddress address, final String motd, final int maxPlayers) {
++        super(); // Paper - Is this event being fired async?
+         this.numPlayers = MAGIC_PLAYER_COUNT;
+         this.address = address;
+         this.motd = motd;
+-- 
+2.5.2.windows.1
+

--- a/Spigot-Server-Patches/0003-mc-dev-imports.patch
+++ b/Spigot-Server-Patches/0003-mc-dev-imports.patch
@@ -1,4 +1,4 @@
-From e9f93a9efde92cdfd70b6d404621281f3761c519 Mon Sep 17 00:00:00 2001
+From b21f0fd18330e7c83eb4df06fb40fee5890e2c38 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 25 May 2015 15:37:00 -0500
 Subject: [PATCH] mc-dev imports
@@ -3557,6 +3557,47 @@ index 0000000..d5eaa24
 +
 +    protected abstract boolean a(Vec3D vec3d, Vec3D vec3d1, int i, int j, int k);
 +}
+diff --git a/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java b/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java
+new file mode 100644
+index 0000000..1d2e855
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java
+@@ -0,0 +1,35 @@
++package net.minecraft.server;
++
++import java.io.IOException;
++import java.security.PrivateKey;
++import javax.crypto.SecretKey;
++
++public class PacketLoginInEncryptionBegin implements Packet<PacketLoginInListener> {
++
++    private byte[] a = new byte[0];
++    private byte[] b = new byte[0];
++
++    public PacketLoginInEncryptionBegin() {}
++
++    public void a(PacketDataSerializer packetdataserializer) throws IOException {
++        this.a = packetdataserializer.a();
++        this.b = packetdataserializer.a();
++    }
++
++    public void b(PacketDataSerializer packetdataserializer) throws IOException {
++        packetdataserializer.a(this.a);
++        packetdataserializer.a(this.b);
++    }
++
++    public void a(PacketLoginInListener packetlogininlistener) {
++        packetlogininlistener.a(this);
++    }
++
++    public SecretKey a(PrivateKey privatekey) {
++        return MinecraftEncryption.a(privatekey, this.a);
++    }
++
++    public byte[] b(PrivateKey privatekey) {
++        return privatekey == null ? this.b : MinecraftEncryption.b(privatekey, this.b);
++    }
++}
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java b/src/main/java/net/minecraft/server/PacketPlayOutPlayerListHeaderFooter.java
 new file mode 100644
 index 0000000..1606d6d
@@ -4074,47 +4115,6 @@ index 0000000..f75e2de
 +
 +    }
 +}
-diff --git a/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java b/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java
-new file mode 100644
-index 0000000..1d2e855
---- /dev/null
-+++ b/src/main/java/net/minecraft/server/PacketLoginInEncryptionBegin.java
-@@ -0,0 +1,35 @@
-+package net.minecraft.server;
-+
-+import java.io.IOException;
-+import java.security.PrivateKey;
-+import javax.crypto.SecretKey;
-+
-+public class PacketLoginInEncryptionBegin implements Packet<PacketLoginInListener> {
-+
-+    private byte[] a = new byte[0];
-+    private byte[] b = new byte[0];
-+
-+    public PacketLoginInEncryptionBegin() {}
-+
-+    public void a(PacketDataSerializer packetdataserializer) throws IOException {
-+        this.a = packetdataserializer.a();
-+        this.b = packetdataserializer.a();
-+    }
-+
-+    public void b(PacketDataSerializer packetdataserializer) throws IOException {
-+        packetdataserializer.a(this.a);
-+        packetdataserializer.a(this.b);
-+    }
-+
-+    public void a(PacketLoginInListener packetlogininlistener) {
-+        packetlogininlistener.a(this);
-+    }
-+
-+    public SecretKey a(PrivateKey privatekey) {
-+        return MinecraftEncryption.a(privatekey, this.a);
-+    }
-+
-+    public byte[] b(PrivateKey privatekey) {
-+        return privatekey == null ? this.b : MinecraftEncryption.b(privatekey, this.b);
-+    }
-+}
 -- 
-2.7.1
+2.5.2.windows.1
 

--- a/Spigot-Server-Patches/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -1,0 +1,53 @@
+From efa121444d697457e82db6cef1db5a0c42f1c667 Mon Sep 17 00:00:00 2001
+From: Gabriele C <sgdc3.mail@gmail.com>
+Date: Fri, 26 Aug 2016 15:30:07 +0200
+Subject: [PATCH] Add setting for proxy online mode status
+
+
+diff --git a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
+index 4029109..eeaacf3 100644
+--- a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
++++ b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
+@@ -66,7 +66,8 @@ public class NameReferencingFileConverter {
+             }
+         }), String.class);
+ 
+-        if (minecraftserver.getOnlineMode() || org.spigotmc.SpigotConfig.bungee) { // Spigot: bungee = online mode, for now.
++        if (minecraftserver.getOnlineMode()
++                || (org.spigotmc.SpigotConfig.bungee && org.github.paperspigot.PaperSpigotConfig.bungeeOnlineMode)) { // Spigot: bungee = online mode, for now.  // Paper - Handle via setting
+             minecraftserver.getGameProfileRepository().findProfilesByNames(astring, Agent.MINECRAFT, profilelookupcallback);
+         } else {
+             String[] astring1 = astring;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 69485fa..bcb3bb1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1338,8 +1338,8 @@ public final class CraftServer implements Server {
+             // Spigot Start
+             GameProfile profile = null;
+             // Only fetch an online UUID in online mode
+-            if ( MinecraftServer.getServer().getOnlineMode() || org.spigotmc.SpigotConfig.bungee )
+-            {
++            if (MinecraftServer.getServer().getOnlineMode()
++                    || (org.spigotmc.SpigotConfig.bungee && org.github.paperspigot.PaperSpigotConfig.bungeeOnlineMode)) { // Spigot: bungee = online mode, for now.  // Paper - Handle via setting
+                 profile = MinecraftServer.getServer().getUserCache().getProfile( name );
+             }
+             // Spigot end
+diff --git a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+index d6d9899..4184f36 100644
+--- a/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
++++ b/src/main/java/org/github/paperspigot/PaperSpigotConfig.java
+@@ -222,4 +222,10 @@ public class PaperSpigotConfig
+     {
+         warnForExcessiveVelocity = getBoolean("warnWhenSettingExcessiveVelocity", true);
+     }
++
++    public static boolean bungeeOnlineMode;
++    private static void bungeeOnlineMode()
++    {
++        bungeeOnlineMode = getBoolean("bungee-online-mode", true);
++    }
+ }
+-- 
+2.5.2.windows.1
+


### PR DESCRIPTION
Servers behind a bungeecord proxy in offline mode
will now properly pull offline mode UUIDs and data
when this setting is set to false. Default is unchanged.
Ported from Paper 1.10.2
