### PR TITLE
Disable ticking of snow blocks

### DIFF
--- a/Spigot-Server-Patches/0168-Disable-ticking-of-snow-blocks.patch
+++ b/Spigot-Server-Patches/0168-Disable-ticking-of-snow-blocks.patch
@@ -1,0 +1,38 @@
+From a7532ff3e8feb8093c83ac7e6604b5e6cba8546c Mon Sep 17 00:00:00 2001
+From: killme <killme-git@ibts.me>
+Date: Tue, 30 Aug 2016 16:39:48 +0200
+Subject: [PATCH] Disable ticking of snow blocks
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockSnowBlock.java b/src/main/java/net/minecraft/server/BlockSnowBlock.java
+index 1c43a37..a3b1998 100644
+--- a/src/main/java/net/minecraft/server/BlockSnowBlock.java
++++ b/src/main/java/net/minecraft/server/BlockSnowBlock.java
+@@ -7,7 +7,7 @@ public class BlockSnowBlock extends Block {
+ 
+     protected BlockSnowBlock() {
+         super(Material.SNOW_BLOCK);
+-        this.a(true);
++        // this.a(true); // Paper - snow blocks don't need to tick
+         this.a(CreativeModeTab.b);
+     }
+ 
+@@ -20,6 +20,8 @@ public class BlockSnowBlock extends Block {
+         return 4;
+     }
+ 
++    // Paper start - snow blocks don't need to tick
++    /*
+     public void b(World world, BlockPosition blockposition, IBlockData iblockdata, Random random) {
+         if (world.b(EnumSkyBlock.BLOCK, blockposition) > 11) {
+             this.b(world, blockposition, world.getType(blockposition), 0);
+@@ -27,4 +29,6 @@ public class BlockSnowBlock extends Block {
+         }
+ 
+     }
++    */
++    //Paper end
+ }
+-- 
+2.7.4
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -44,6 +44,7 @@ import BlockFalling
 import BlockFluids
 import BlockFurnace
 import BlockIceFrost
+import BlockSnowBlock
 import BlockPosition
 import BlockStateEnum
 import ChunkCache


### PR DESCRIPTION
Minecraft bug: https://bugs.mojang.com/browse/MC-88097

Snow blocks do not melt under normal circumstances and do not need to be ticked.
This commit removes the block type specific tick function and removes the line marking the block as "needs to be ticked".

This patch significantly increased the TPS in a very snowy world.
