### PR TITLE
Added source to PlayerExpChangeEvent

### DIFF
--- a/Spigot-API-Patches/0039-Added-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-API-Patches/0039-Added-source-to-PlayerExpChangeEvent.patch
@@ -1,0 +1,57 @@
+From f2bbcf1d0933150f52637d689c14b4b2a9d6f0af Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Thu, 8 Sep 2016 08:47:08 -0700
+Subject: [PATCH] Added source to PlayerExpChangeEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
+index f37491d..3315547 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.event.player;
+ 
++import org.bukkit.entity.Entity; // Paper
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.HandlerList;
+ 
+@@ -8,14 +9,36 @@ import org.bukkit.event.HandlerList;
+  */
+ public class PlayerExpChangeEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();
++    // Paper start
++    private final Entity source;
+     private int exp;
+ 
+     public PlayerExpChangeEvent(final Player player, final int expAmount) {
++          this(player, null, expAmount);
++    }
++
++    public PlayerExpChangeEvent(final Player player, final Entity sourceEntity, final int expAmount) {
+          super(player);
++         source = sourceEntity;
+          exp = expAmount;
+     }
+ 
+     /**
++     * Get the source that provided the experience.
++     *
++     * Be aware that this may be null depending on
++     * how the event was constructed, so it is
++     * advised to check if this is null before
++     * doing anything with it.
++     *
++     * @return The source of the experience
++     */
++    public Entity getSource() {
++        return source;
++    }
++    // Paper end
++
++    /**
+      * Get the amount of experience the player will receive
+      *
+      * @return The amount of experience
+-- 
+2.9.3.windows.2
+

--- a/Spigot-Server-Patches/0171-Hook-up-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-Server-Patches/0171-Hook-up-source-to-PlayerExpChangeEvent.patch
@@ -1,0 +1,70 @@
+From 157978a4e7f41c7540c9775c0402c625cf1e04d2 Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Thu, 8 Sep 2016 08:48:33 -0700
+Subject: [PATCH] Hook up source to PlayerExpChangeEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
+index e8162b2..6e43257 100644
+--- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
++++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
+@@ -173,7 +173,7 @@ public class EntityExperienceOrb extends Entity {
+                 }
+ 
+                 if (this.value > 0) {
+-                    entityhuman.giveExp(CraftEventFactory.callPlayerExpChangeEvent(entityhuman, this.value).getAmount()); // CraftBukkit - this.value -> event.getAmount()
++                    entityhuman.giveExp(CraftEventFactory.callPlayerExpChangeEvent(entityhuman, this).getAmount()); // CraftBukkit - this.value -> event.getAmount() Paper - supply experience orb object
+                 }
+ 
+                 this.die();
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index e39de2b..c752d4a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -35,6 +35,7 @@ import org.bukkit.entity.AreaEffectCloud;
+ import org.bukkit.entity.Arrow;
+ import org.bukkit.entity.Creeper;
+ import org.bukkit.entity.EntityType;
++import org.bukkit.entity.ExperienceOrb; // Paper
+ import org.bukkit.entity.Firework;
+ import org.bukkit.entity.Horse;
+ import org.bukkit.entity.LightningStrike;
+@@ -197,7 +198,7 @@ public class CraftEventFactory {
+     public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, EnumHand hand) {
+         return callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
+     }
+-    
++
+     public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, boolean cancelledBlock, EnumHand hand) {
+         Player player = (who == null) ? null : (Player) who.getBukkitEntity();
+         CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
+@@ -640,6 +641,17 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
++    // Paper start
++    public static PlayerExpChangeEvent callPlayerExpChangeEvent(EntityHuman entity, EntityExperienceOrb entityOrb) {
++        Player player = (Player) entity.getBukkitEntity();
++        ExperienceOrb source = (ExperienceOrb) entityOrb.getBukkitEntity();
++        int expAmount = source.getExperience();
++        PlayerExpChangeEvent event = new PlayerExpChangeEvent(player, source, expAmount);
++        Bukkit.getPluginManager().callEvent(event);
++        return event;
++    }
++    // Paper end
++
+     public static boolean handleBlockGrowEvent(World world, int x, int y, int z, net.minecraft.server.Block type, int data) {
+         Block block = world.getWorld().getBlockAt(x, y, z);
+         CraftBlockState state = (CraftBlockState) block.getState();
+@@ -652,7 +664,7 @@ public class CraftEventFactory {
+         if (!event.isCancelled()) {
+             state.update(true);
+         }
+-        
++
+         return !event.isCancelled();
+     }
+ 
+-- 
+2.9.3.windows.2
+


### PR DESCRIPTION
Added source entity to the PlayerExpChangeEvent event to allow extra calculations based on the source of the event.

A use-case of this case might be spawning in custom experience orbs and associating custom data to them by their UUID. It would be nice if the original experience orb could be retrieved and its UUID checked to make use of this custom data.
