### PR TITLE
Add hit entity to ProjectileHitEvent

### DIFF
--- a/Spigot-API-Patches/0039-Add-hit-entity-to-ProjectileHitEvent.patch
+++ b/Spigot-API-Patches/0039-Add-hit-entity-to-ProjectileHitEvent.patch
@@ -1,0 +1,59 @@
+From 28987a009c4b6cce2fdf4e9890320a035196f0b8 Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Wed, 21 Sep 2016 20:40:21 -0700
+Subject: [PATCH] Add hit entity to ProjectileHitEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+index 25ae832..ddccbf4 100644
+--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.event.entity;
+ 
++import org.bukkit.entity.Entity; // Paper
+ import org.bukkit.entity.Projectile;
+ import org.bukkit.event.HandlerList;
+ 
+@@ -8,16 +9,38 @@ import org.bukkit.event.HandlerList;
+  */
+ public class ProjectileHitEvent extends EntityEvent {
+     private static final HandlerList handlers = new HandlerList();
++    // Paper start
++    private final Entity hitEntity;
+ 
+     public ProjectileHitEvent(final Projectile projectile) {
++        this(projectile, null);
++    }
++
++    public ProjectileHitEvent(final Projectile projectile, final Entity hitEntity) {
+         super(projectile);
++        this.hitEntity = hitEntity;
+     }
++    // Paper end
+ 
+     @Override
+     public Projectile getEntity() {
+         return (Projectile) entity;
+     }
+ 
++    // Paper start
++    /**
++     * Gets the entity that was hit by the projectile.
++     *
++     * This may be null, depending on if the projectile
++     * actually hit an entity.
++     *
++     * @return The entity that was hit, or null otherwise
++     */
++    public Entity getHitEntity() {
++        return hitEntity;
++    }
++    // Paper end
++
+     @Override
+     public HandlerList getHandlers() {
+         return handlers;
+-- 
+2.9.3.windows.2
+

--- a/Spigot-Server-Patches/0173-Add-hit-entity-to-ProjectileHitEvent.patch
+++ b/Spigot-Server-Patches/0173-Add-hit-entity-to-ProjectileHitEvent.patch
@@ -1,0 +1,108 @@
+From e9c1dbbb31f01642641ba1f5da0d390c97235552 Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Wed, 21 Sep 2016 20:40:46 -0700
+Subject: [PATCH] Add hit entity to ProjectileHitEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
+index 37cb17c..2e03161 100644
+--- a/src/main/java/net/minecraft/server/EntityArrow.java
++++ b/src/main/java/net/minecraft/server/EntityArrow.java
+@@ -263,7 +263,7 @@ public abstract class EntityArrow extends Entity implements IProjectile {
+ 
+     protected void a(MovingObjectPosition movingobjectposition) {
+         Entity entity = movingobjectposition.entity;
+-        org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this); // CraftBukkit - Call event
++        org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, entity); // CraftBukkit - Call event Paper - Include entity in movingobjectposition
+         if (entity != null) {
+             float f = MathHelper.sqrt(this.motX * this.motX + this.motY * this.motY + this.motZ * this.motZ);
+             int i = MathHelper.f((double) f * this.damage);
+diff --git a/src/main/java/net/minecraft/server/EntityFireball.java b/src/main/java/net/minecraft/server/EntityFireball.java
+index 393f26e..7cd3054 100644
+--- a/src/main/java/net/minecraft/server/EntityFireball.java
++++ b/src/main/java/net/minecraft/server/EntityFireball.java
+@@ -99,7 +99,7 @@ public abstract class EntityFireball extends Entity {
+ 
+                 // CraftBukkit start - Fire ProjectileHitEvent
+                 if (this.dead) {
+-                    CraftEventFactory.callProjectileHitEvent(this);
++                    CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Paper - include entity in movingobjectposition
+                 }
+                 // CraftBukkit end
+             }
+diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
+index 9b71cdd..7222903 100644
+--- a/src/main/java/net/minecraft/server/EntityFishingHook.java
++++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
+@@ -207,7 +207,7 @@ public class EntityFishingHook extends Entity {
+                 // Paper end
+ 
+                 if (movingobjectposition != null) {
+-                    org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this); // Craftbukkit - Call event
++                    org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Craftbukkit - Call event Paper - Include entity in movingobjectposition
+                     if (movingobjectposition.entity != null) {
+                         this.hooked = movingobjectposition.entity;
+                         this.getDataWatcher().set(EntityFishingHook.c, Integer.valueOf(this.hooked.getId() + 1));
+@@ -459,7 +459,7 @@ public class EntityFishingHook extends Entity {
+                     if (playerFishEvent.getExpToDrop() > 0) {
+                         this.owner.world.addEntity(new EntityExperienceOrb(this.owner.world, this.owner.locX, this.owner.locY + 0.5D, this.owner.locZ + 0.5D, playerFishEvent.getExpToDrop()));
+                     }
+-                    // CraftBukkit end                
++                    // CraftBukkit end
+                 }
+ 
+                 i = 1;
+diff --git a/src/main/java/net/minecraft/server/EntityProjectile.java b/src/main/java/net/minecraft/server/EntityProjectile.java
+index 770f130..e95cc24 100644
+--- a/src/main/java/net/minecraft/server/EntityProjectile.java
++++ b/src/main/java/net/minecraft/server/EntityProjectile.java
+@@ -175,7 +175,7 @@ public abstract class EntityProjectile extends Entity implements IProjectile {
+                 this.a(movingobjectposition);
+                 // CraftBukkit start
+                 if (this.dead) {
+-                    org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this);
++                    org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Paper - include Entity in movingobjectposition
+                 }
+                 // CraftBukkit end
+             }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index e39de2b..c92a80b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -197,7 +197,7 @@ public class CraftEventFactory {
+     public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, EnumHand hand) {
+         return callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
+     }
+-    
++
+     public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, boolean cancelledBlock, EnumHand hand) {
+         Player player = (who == null) ? null : (Player) who.getBukkitEntity();
+         CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
+@@ -652,7 +652,7 @@ public class CraftEventFactory {
+         if (!event.isCancelled()) {
+             state.update(true);
+         }
+-        
++
+         return !event.isCancelled();
+     }
+ 
+@@ -782,6 +782,15 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
++    // Paper start
++    public static ProjectileHitEvent callProjectileHitEvent(Entity entity, Entity hitEntity) {
++        ProjectileHitEvent event = new ProjectileHitEvent((Projectile) entity.getBukkitEntity(), (hitEntity == null ? null : (org.bukkit.entity.Entity) hitEntity.getBukkitEntity()));
++
++        entity.world.getServer().getPluginManager().callEvent(event);
++        return event;
++    }
++    // Paper end
++
+     public static ExpBottleEvent callExpBottleEvent(Entity entity, int exp) {
+         ThrownExpBottle bottle = (ThrownExpBottle) entity.getBukkitEntity();
+         ExpBottleEvent event = new ExpBottleEvent(bottle, exp);
+-- 
+2.9.3.windows.2
+


### PR DESCRIPTION
We know what projectile hit something in ProjectileHitEvent but we don't know what it hit. This adds a hit entity so we can grab what was hit.
