### PR TITLE
Add EntityZapEvent, replace PigZapEvent, include villagers

### DIFF
--- a/Spigot-API-Patches/0040-Add-EntityZapEvent-replace-PigZapEvent-include-villa.patch
+++ b/Spigot-API-Patches/0040-Add-EntityZapEvent-replace-PigZapEvent-include-villa.patch
@@ -1,0 +1,86 @@
+From ba2f5fab215c209e83c7f3813f986d52012b96fe Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Sun, 16 Oct 2016 23:19:34 -0700
+Subject: [PATCH] Add EntityZapEvent, replace PigZapEvent, include villagers
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java
+new file mode 100644
+index 0000000..ce3e329
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityZapEvent.java
+@@ -0,0 +1,56 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.LightningStrike;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++/**
++ *  Fired when lightning strikes an entity
++ */
++public class EntityZapEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++    private final LightningStrike bolt;
++    private final Entity replacementEntity;
++
++    public EntityZapEvent(final Entity entity, final LightningStrike bolt, final Entity replacementEntity) {
++        super(entity);
++        this.bolt = bolt;
++        this.replacementEntity = replacementEntity;
++    }
++
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    /**
++     * Gets the lightning bolt that is striking the entity.
++     * @return The lightning bolt responsible for this event
++     */
++    public LightningStrike getBolt() {
++        return bolt;
++    }
++
++    /**
++     * Gets the entity that will replace the struck entity.
++     * @return The entity that will replace the struck entity
++     */
++    public Entity getReplacementEntity() {
++        return replacementEntity;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/org/bukkit/event/entity/PigZapEvent.java b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+index aa80ebf..3470d9d 100644
+--- a/src/main/java/org/bukkit/event/entity/PigZapEvent.java
++++ b/src/main/java/org/bukkit/event/entity/PigZapEvent.java
+@@ -15,6 +15,10 @@ public class PigZapEvent extends EntityEvent implements Cancellable {
+     private final PigZombie pigzombie;
+     private final LightningStrike bolt;
+ 
++    /**
++     * @deprecated deprecated, see {@link com.destroystokyo.paper.event.entity.EntityZapEvent}
++     */
++    @Deprecated
+     public PigZapEvent(final Pig pig, final LightningStrike bolt, final PigZombie pigzombie) {
+         super(pig);
+         this.bolt = bolt;
+-- 
+2.10.0.windows.1
+

--- a/Spigot-Server-Patches/0180-Add-EntityZapEvent-replace-PigZapEvent-include-villa.patch
+++ b/Spigot-Server-Patches/0180-Add-EntityZapEvent-replace-PigZapEvent-include-villa.patch
@@ -1,0 +1,73 @@
+From ebfa9f8ac461512f7a829b120b14ebeceda6bf68 Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Sun, 16 Oct 2016 23:19:30 -0700
+Subject: [PATCH] Add EntityZapEvent, replace PigZapEvent, include villagers
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPig.java b/src/main/java/net/minecraft/server/EntityPig.java
+index 7cee3de..816918e 100644
+--- a/src/main/java/net/minecraft/server/EntityPig.java
++++ b/src/main/java/net/minecraft/server/EntityPig.java
+@@ -139,7 +139,13 @@ public class EntityPig extends EntityAnimal {
+         if (!this.world.isClientSide && !this.dead) {
+             EntityPigZombie entitypigzombie = new EntityPigZombie(this.world);
+ 
+-            // CraftBukkit start
++            // Paper start
++            if (CraftEventFactory.callEntityZapEvent(this, entitylightning, entitypigzombie).isCancelled()) {
++                return;
++            }
++            // Paper end
++
++            // CraftBukkit start - Paper - left in for compatibility
+             if (CraftEventFactory.callPigZapEvent(this, entitylightning, entitypigzombie).isCancelled()) {
+                 return;
+             }
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index 029b916..c3ec21a 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -566,6 +566,12 @@ public class EntityVillager extends EntityAgeable implements IMerchant, NPC {
+         if (!this.world.isClientSide && !this.dead) {
+             EntityWitch entitywitch = new EntityWitch(this.world);
+ 
++            // Paper start
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityZapEvent(this, entitylightning, entitywitch).isCancelled()) {
++                return;
++            }
++            // Paper end
++
+             entitywitch.setPositionRotation(this.locX, this.locY, this.locZ, this.yaw, this.pitch);
+             entitywitch.prepare(this.world.D(new BlockPosition(entitywitch)), (GroupDataEntity) null);
+             entitywitch.setAI(this.hasAI());
+@@ -574,7 +580,7 @@ public class EntityVillager extends EntityAgeable implements IMerchant, NPC {
+                 entitywitch.setCustomNameVisible(this.getCustomNameVisible());
+             }
+ 
+-            this.world.addEntity(entitywitch);
++            this.world.addEntity(entitywitch, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING); // Paper - Added lightning spawn reason for this entity
+             this.die();
+         }
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 949db83..a01f109 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -668,6 +668,14 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
++    // Paper start
++    public static com.destroystokyo.paper.event.entity.EntityZapEvent callEntityZapEvent (Entity entity, Entity lightning, Entity changedEntity) {
++        com.destroystokyo.paper.event.entity.EntityZapEvent event = new com.destroystokyo.paper.event.entity.EntityZapEvent((org.bukkit.entity.Entity) entity.getBukkitEntity(), (LightningStrike) lightning.getBukkitEntity(), (org.bukkit.entity.Entity) changedEntity.getBukkitEntity());
++        entity.getBukkitEntity().getServer().getPluginManager().callEvent(event);
++        return event;
++    }
++    // Paper end
++
+     public static HorseJumpEvent callHorseJumpEvent(Entity horse, float power) {
+         HorseJumpEvent event = new HorseJumpEvent((Horse) horse.getBukkitEntity(), power);
+         horse.getBukkitEntity().getServer().getPluginManager().callEvent(event);
+-- 
+2.10.0.windows.1
+


### PR DESCRIPTION
This PR does 2 things. First of all, it adds a missing event for villagers getting zapped by lightning. Secondly, it creates a generalized event, EntityZapEvent, which also replaces the current PigZapEvent which has been deprecated.
