### PR TITLE
Fix building when parent directory with spaces is used

### DIFF
--- a/paper
+++ b/paper
@@ -24,7 +24,7 @@ done
 SOURCE=$([[ "$SOURCE" = /* ]] && echo "$SOURCE" || echo "$PWD/${SOURCE#./}")
 basedir=$(dirname "$SOURCE")
 
-. $basedir/scripts/functions.sh
+source "$basedir/scripts/functions.sh"
 
 case "$1" in
     "rb" | "rbp" | "rebuild")

--- a/scripts/remap.sh
+++ b/scripts/remap.sh
@@ -5,12 +5,12 @@ set -e
 PS1="$"
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
-minecraftversion=$(cat ${workdir}/BuildData/info.json | grep minecraftVersion | cut -d '"' -f 4)
-minecrafthash=$(cat ${workdir}/BuildData/info.json | grep minecraftHash | cut -d '"' -f 4)
-accesstransforms="$workdir/BuildData/mappings/"$(cat ${workdir}/BuildData/info.json | grep accessTransforms | cut -d '"' -f 4)
-classmappings="$workdir/BuildData/mappings/"$(cat ${workdir}/BuildData/info.json | grep classMappings | cut -d '"' -f 4)
-membermappings="$workdir/BuildData/mappings/"$(cat ${workdir}/BuildData/info.json | grep memberMappings | cut -d '"' -f 4)
-packagemappings="$workdir/BuildData/mappings/"$(cat ${workdir}/BuildData/info.json | grep packageMappings | cut -d '"' -f 4)
+minecraftversion=$(cat "${workdir}/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
+minecrafthash=$(cat "${workdir}/BuildData/info.json" | grep minecraftHash | cut -d '"' -f 4)
+accesstransforms="$workdir/BuildData/mappings/"$(cat "${workdir}/BuildData/info.json" | grep accessTransforms | cut -d '"' -f 4)
+classmappings="$workdir/BuildData/mappings/"$(cat "${workdir}/BuildData/info.json" | grep classMappings | cut -d '"' -f 4)
+membermappings="$workdir/BuildData/mappings/"$(cat "${workdir}/BuildData/info.json" | grep memberMappings | cut -d '"' -f 4)
+packagemappings="$workdir/BuildData/mappings/"$(cat "${workdir}/BuildData/info.json" | grep packageMappings | cut -d '"' -f 4)
 jarpath="$workdir/$minecraftversion/$minecraftversion"
 
 echo "Downloading unmapped vanilla jar..."


### PR DESCRIPTION
If you try to build PaperSpigot on path where parent directory contains spaces, then you'll get "No such file or directory" errors. This change fixes that issue.