### PR TITLE
Relocate bad call to ProjectileHitEvent

### DIFF
--- a/Spigot-Server-Patches/0179-Move-ProjectileHitEvent-call-to-proper-place.patch
+++ b/Spigot-Server-Patches/0179-Move-ProjectileHitEvent-call-to-proper-place.patch
@@ -1,0 +1,30 @@
+From d53a1a9a43aed5dc7b733fceca073bf954966f27 Mon Sep 17 00:00:00 2001
+From: AlphaBlend <whizkid3000@hotmail.com>
+Date: Mon, 21 Nov 2016 22:21:53 -0800
+Subject: [PATCH] Move ProjectileHitEvent call to proper place
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
+index 395f30b..9f631d1 100644
+--- a/src/main/java/net/minecraft/server/EntityFishingHook.java
++++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
+@@ -234,7 +234,7 @@ public class EntityFishingHook extends Entity {
+         // Paper end
+ 
+         if (movingobjectposition != null) {
+-            org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Craftbukkit - Call event // Paper - Include entity in movingobjectposition
++            //org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Craftbukkit - Call event // Paper - Wrong location, moved down to proper location
+             vec3d1 = new Vec3D(movingobjectposition.pos.x, movingobjectposition.pos.y, movingobjectposition.pos.z);
+         }
+ 
+@@ -267,6 +267,7 @@ public class EntityFishingHook extends Entity {
+ 
+         if (movingobjectposition != null && movingobjectposition.type != MovingObjectPosition.EnumMovingObjectType.MISS) {
+             if (movingobjectposition.type == MovingObjectPosition.EnumMovingObjectType.ENTITY) {
++                org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition.entity); // Craftbukkit - Call event // Paper - Include entity in movingobjectposition
+                 this.hooked = movingobjectposition.entity;
+                 this.s();
+             } else {
+-- 
+2.10.0.windows.1
+


### PR DESCRIPTION
With the Minecraft 1.11 update, the ProjectileHitEvent was called incorrectly when the fishing rod bobber hit an entity. It would call if the bobber hit the ground, but not if it hit an entity. This PR fixes that.