### PR TITLE
Make main task queue size() a constant-time operation

### DIFF
--- a/Spigot-API-Patches/0042-Misc-Utils.patch
+++ b/Spigot-API-Patches/0042-Misc-Utils.patch
@@ -1,0 +1,46 @@
+From 37bc40ae29d91e8f1f7ffc1ad83b6f3987c16515 Mon Sep 17 00:00:00 2001
+From: vemacs <d@nkmem.es>
+Date: Wed, 23 Nov 2016 12:53:43 -0500
+Subject: [PATCH] Misc Utils
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/utils/CachedSizeConcurrentLinkedQueue.java b/src/main/java/com/destroystokyo/paper/utils/CachedSizeConcurrentLinkedQueue.java
+new file mode 100644
+index 0000000..d60ecbb
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/utils/CachedSizeConcurrentLinkedQueue.java
+@@ -0,0 +1,31 @@
++package com.destroystokyo.paper.utils;
++
++import java.util.concurrent.ConcurrentLinkedQueue;
++import java.util.concurrent.atomic.LongAdder;
++
++public class CachedSizeConcurrentLinkedQueue<E> extends ConcurrentLinkedQueue<E> {
++    private final LongAdder cachedSize = new LongAdder();
++
++    @Override
++    public boolean add(E e) {
++        boolean result = super.add(e);
++        if (result) {
++            cachedSize.increment();
++        }
++        return result;
++    }
++
++    @Override
++    public E poll() {
++        E result = super.poll();
++        if (result != null) {
++            cachedSize.decrement();
++        }
++        return result;
++    }
++
++    @Override
++    public int size() {
++        return cachedSize.intValue();
++    }
++}
+-- 
+2.8.3.windows.1
+

--- a/Spigot-Server-Patches/0181-Optimize-Network-Queue.patch
+++ b/Spigot-Server-Patches/0181-Optimize-Network-Queue.patch
@@ -1,0 +1,22 @@
+From 43efcd35598c5cfcfec9845b843c7a3ce1380b20 Mon Sep 17 00:00:00 2001
+From: vemacs <d@nkmem.es>
+Date: Wed, 23 Nov 2016 12:54:56 -0500
+Subject: [PATCH] Optimize Network Queue
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 683ace3..b4adf7e 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -102,7 +102,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
+     private final GameProfileRepository X;
+     private final UserCache Y;
+     private long Z;
+-    protected final Queue<FutureTask<?>> j = new java.util.concurrent.ConcurrentLinkedQueue<FutureTask<?>>(); // Spigot, PAIL: Rename
++    protected final Queue<FutureTask<?>> j = new com.destroystokyo.paper.utils.CachedSizeConcurrentLinkedQueue<>(); // Spigot, PAIL: Rename // Paper - Make size() constant-time
+     private Thread serverThread;
+     private long ab = aw();
+ 
+-- 
+2.8.3.windows.1
+


### PR DESCRIPTION
I don't think contention is an issue as I am using LongAdder. This solves many scalability issues with main thread tasks in general (especially network ones at high player counts).