### PR TITLE
Fix block break desync

### DIFF
--- a/Spigot-Server-Patches/0205-Fix-block-break-desync.patch
+++ b/Spigot-Server-Patches/0205-Fix-block-break-desync.patch
@@ -1,0 +1,21 @@
+From c59f5e3136aef85ce9ee1926f495469682065d9d Mon Sep 17 00:00:00 2001
+From: Michael Himing <mhiming@gmail.com>
+Date: Sun, 8 Jan 2017 18:50:35 +1100
+Subject: [PATCH] Fix block break desync
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index e5caad8..a63bf40 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -821,6 +821,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+             double d3 = d0 * d0 + d1 * d1 + d2 * d2;
+ 
+             if (d3 > 36.0D) {
++                this.sendPacket(new PacketPlayOutBlockChange(worldserver, blockposition)); // Paper - Fix block break desync
+                 return;
+             } else if (blockposition.getY() >= this.minecraftServer.getMaxBuildHeight()) {
+                 return;
+-- 
+2.9.2.windows.1
+


### PR DESCRIPTION
The server "cancels" block break packets that are more than six units away, without actually notifying the player. This can happen when mining fast or being teleported (with a little latency).