### PR TITLE
Don't Display Success Message on Alias Reload Fail

### DIFF
--- a/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From 9942e2dbb75147e6fe06aec8405f1f221fa802d8 Mon Sep 17 00:00:00 2001
+From 9b40254808daac69e7657b3c20e4316de8cfac6b Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:16:39 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f5af400..2255551 100644
+index f5af400d..1f663fa1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1194,6 +1194,13 @@ public final class Bukkit {
@@ -17,14 +17,14 @@ index f5af400..2255551 100644
 +    /**
 +     * Reload the Command Aliases in commands.yml
 +     */
-+    public static void reloadCommandAliases() {
-+        server.reloadCommandAliases();
++    public static boolean reloadCommandAliases() {
++        return server.reloadCommandAliases();
 +    }
      // Paper end
  
      public static Server.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 2df8324..179e08d 100644
+index 2df83245..4a90d581 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1027,4 +1027,6 @@ public interface Server extends PluginMessageRecipient {
@@ -32,10 +32,10 @@ index 2df8324..179e08d 100644
  
      void reloadPermissions(); // Paper
 +
-+    void reloadCommandAliases(); // Paper
++    boolean reloadCommandAliases(); // Paper
  }
 diff --git a/src/main/java/org/bukkit/command/CommandMap.java b/src/main/java/org/bukkit/command/CommandMap.java
-index 30d6024..d8a7560 100644
+index 30d60247..d8a75607 100644
 --- a/src/main/java/org/bukkit/command/CommandMap.java
 +++ b/src/main/java/org/bukkit/command/CommandMap.java
 @@ -123,4 +123,12 @@ public interface CommandMap {
@@ -52,7 +52,7 @@ index 30d6024..d8a7560 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 08976cd..2e232fd 100644
+index 08976cd4..2e232fd1 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
 @@ -280,4 +280,10 @@ public class SimpleCommandMap implements CommandMap {
@@ -67,7 +67,7 @@ index 08976cd..2e232fd 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
-index 040509c..585bac7 100644
+index 040509c1..0069bcc0 100644
 --- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
 +++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
 @@ -11,7 +11,7 @@ public class ReloadCommand extends BukkitCommand {
@@ -79,17 +79,20 @@ index 040509c..585bac7 100644
          this.setPermission("bukkit.command.reload");
          this.setAliases(Arrays.asList("rl"));
      }
-@@ -28,6 +28,10 @@ public class ReloadCommand extends BukkitCommand {
+@@ -28,6 +28,13 @@ public class ReloadCommand extends BukkitCommand {
                  Bukkit.getServer().reloadPermissions();
                  Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Permissions successfully reloaded.");
                  return true;
 +            } else if ("commands".equalsIgnoreCase(args[0])) {
-+                Bukkit.getServer().reloadCommandAliases();
-+                Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Command aliases successfully reloaded.");
++                if (Bukkit.getServer().reloadCommandAliases()) {
++                    Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Command aliases successfully reloaded.");
++                } else {
++                    Command.broadcastCommandMessage(sender, ChatColor.RED + "An error occurred while trying to reload command aliases.");
++                }
 +                return true;
              } else if ("confirm".equalsIgnoreCase(args[0])) {
                  confirmed = true;
              } else {
 -- 
-2.9.3
+2.11.0
 

--- a/Spigot-Server-Patches/0174-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-Server-Patches/0174-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From fc71852806d0c70c3300d5bb6055c1de552842e4 Mon Sep 17 00:00:00 2001
+From 1a43c3c56d5e7aa343c4ead1342df0dc0546b656 Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:21:52 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -6,22 +6,31 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1bbce7a78..31c9a66b6 100644
+index 1bbce7a78..225e118dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1848,5 +1848,15 @@ public final class CraftServer implements Server {
+@@ -1848,5 +1848,24 @@ public final class CraftServer implements Server {
              });
          }
      }
 +
 +    @Override
-+    public void reloadCommandAliases() {
++    public boolean reloadCommandAliases() {
 +        Set<String> removals = getCommandAliases().keySet().stream()
 +                .map(key -> key.toLowerCase(java.util.Locale.ENGLISH))
 +                .collect(java.util.stream.Collectors.toSet());
 +        getCommandMap().getKnownCommands().keySet().removeIf(removals::contains);
-+        commandsConfiguration = YamlConfiguration.loadConfiguration(getCommandsConfigFile());
++        File file = getCommandsConfigFile();
++        try {
++            commandsConfiguration.load(file);
++        } catch (FileNotFoundException ex) {
++            return false;
++        } catch (IOException | org.bukkit.configuration.InvalidConfigurationException ex) {
++            Bukkit.getLogger().log(Level.SEVERE, "Cannot load " + file, ex);
++            return false;
++        }
 +        commandMap.registerServerAliases();
++        return true;
 +    }
      // Paper end
  }


### PR DESCRIPTION
Make it so that if reloading the command aliases fails, a failure message is displayed instead of always showing the success message. Also add "commands" to Tab Completion

**Note:** This required a signature change to Bukkit#reloadCommandAliases() so that it returns a boolean based on if the command aliases reloaded or not.