### PR TITLE
Fix portal teleportation causing a duplicate alive entity on the seco…

### DIFF
--- a/Spigot-Server-Patches/0213-Set-the-original-entity-involved-in-teleportation-vi.patch
+++ b/Spigot-Server-Patches/0213-Set-the-original-entity-involved-in-teleportation-vi.patch
@@ -1,0 +1,31 @@
+From d91515c1234db0d83cbc0e41a68b878632f0c8bb Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Fri, 17 Mar 2017 01:45:15 +0000
+Subject: [PATCH] Set the original entity involved in teleportation via a
+ portal to be marked as dead at an earlier stage, preventing a duplication bug
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 0e1d9817b..8870228b8 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2359,6 +2359,7 @@ public abstract class Entity implements ICommandListener {
+             // CraftBukkit end */
+             // CraftBukkit start - Ensure chunks are loaded in case TravelAgent is not used which would initially cause chunks to load during find/create
+             // minecraftserver.getPlayerList().changeWorld(this, j, worldserver, worldserver1);
++            this.dead = true; // Paper: Mark entity as dead before we actually move it to the new world
+             worldserver1.getMinecraftServer().getPlayerList().repositionEntity(this, exit, portal);
+             // worldserver.entityJoinedWorld(this, false); // Handled in repositionEntity
+             // CraftBukkit end
+@@ -2393,7 +2394,7 @@ public abstract class Entity implements ICommandListener {
+                 // CraftBukkit end
+             }
+ 
+-            this.dead = true;
++            //this.dead = true; // Paper: Moved this up to ensure that the entity is dead when it's placed on the new world
+             this.world.methodProfiler.b();
+             worldserver.m();
+             worldserver1.m();
+-- 
+2.12.0
+


### PR DESCRIPTION
…nd world, thus preventing a dupe bug #633

Setting the entity to be dead before creating a copy of it for the teleportation event prevents us from calling WorldServer#entityJoinedWorld on the existing entity (which is moved over to the new world), and then the new entity that is placed onto the destination world)

If you wish to test this and report any issues, I had a quick play and couldn't seen any, but here is a paperclip jar with the patch in this PR:
https://keybase.pub/electronicboy/paperclip.jar