### PR TITLE
Only set the location of the newly spawned entity

### DIFF
--- a/Spigot-Server-Patches/0213-Fix-a-duplicate-alive-entity-on-second-world.patch
+++ b/Spigot-Server-Patches/0213-Fix-a-duplicate-alive-entity-on-second-world.patch
@@ -1,11 +1,11 @@
-From cfd888d784201ae7ec2a67352ca5747e9bae5a91 Mon Sep 17 00:00:00 2001
+From 791a5b0f6feb0c241429bd044f2255ee251c3bc4 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Fri, 17 Mar 2017 01:45:15 +0000
 Subject: [PATCH] Fix a duplicate alive entity on second world
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 0e1d9817b..92ba4fcb5 100644
+index 0e1d9817b..385329774 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2325,7 +2325,7 @@ public abstract class Entity implements ICommandListener {
@@ -17,30 +17,28 @@ index 0e1d9817b..92ba4fcb5 100644
              this.world.methodProfiler.a("reposition");
              /* CraftBukkit start - Handled in calculateTarget
              BlockPosition blockposition;
-diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index a9d59bbf5..4ba4d527e 100644
---- a/src/main/java/net/minecraft/server/PlayerList.java
-+++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -969,7 +969,7 @@ public abstract class PlayerList {
-             d0 = (double) MathHelper.clamp((int) d0, -29999872, 29999872);
-             d1 = (double) MathHelper.clamp((int) d1, -29999872, 29999872);
-             */
--            if (entity.isAlive()) {
-+            //if (entity.isAlive()) { // Paper - Moved down
-                 // entity.setPositionRotation(d0, entity.locY, d1, entity.yaw, entity.pitch);
-                 // worldserver1.getTravelAgent().a(entity, f);
-                 if (portal) {
-@@ -981,8 +981,8 @@ public abstract class PlayerList {
-                     }
+@@ -2376,7 +2376,20 @@ public abstract class Entity implements ICommandListener {
+                     entity.setPositionRotation(blockposition, entity.yaw, entity.pitch);
                  }
-                 // worldserver1.addEntity(entity);
--                worldserver1.entityJoinedWorld(entity, false);
--            }
-+                if (entity.isAlive()) worldserver1.entityJoinedWorld(entity, false); // Paper - Moved down from above
-+            //} // Paper
+                 // CraftBukkit end */
+-
++                // Paper Start - relocate code to modify the entities exit in a portal
++                if (portal) {
++                    org.bukkit.util.Vector velocity = entity.getBukkitEntity().getVelocity();
++                    worldserver1.getTravelAgent().adjustExit(entity, exit, velocity);
++                    entity.setPositionRotation(exit.getX(), exit.getY(), exit.getZ(), exit.getYaw(), exit.getPitch());
++                    if (entity.motX != velocity.getX() || entity.motY != velocity.getY() || entity.motZ != velocity.getZ()) {
++                        //entity.getBukkitEntity().setVelocity(velocity); // We don't have a CraftEntity yet, set these manually...
++                        entity.motX = velocity.getX();
++                        entity.motY = velocity.getY();
++                        entity.motZ = velocity.getZ();
++                        entity.velocityChanged = true;
++                    }
++                }
++                // Paper end
+                 boolean flag = entity.attachedToPlayer;
  
-             worldserver.methodProfiler.b();
-         }
+                 entity.attachedToPlayer = true;
 -- 
-2.12.0.windows.1
+2.12.0
 


### PR DESCRIPTION
#PushToMasterMasterRace

The following patch refines the entity transfer between worlds to only actually relocate the new entity, after testing this multiple times I achieved much more successful teleporting of entities over the world without them suffocating (in fact, I was not able to suffocate a single entity on teleporting, which seems like an improvement over the last commit where I think it was more chance based...)

I can also (still) no longer replicate the dupe bug, However, I've been unable to replicate this on all commits that I've actually tested this in since my original PR.

#633 
https://keybase.pub/electronicboy/paperclip.jar