### PR TITLE
paper tools - fix shell matching

### DIFF
--- a/paper
+++ b/paper
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 # resolve shell-specifics
-case "$(echo "$SHELL" | sed 's|/usr||g')" in
+case "$(echo "$SHELL" | sed -E 's|/usr(/local)?||g')" in
     "/bin/zsh")
         RCPATH="$HOME/.zshrc"
         SOURCE="${BASH_SOURCE[0]:-${(%):-%N}}"


### PR DESCRIPTION
on macOS, it's common for zsh to be installed via homebrew, which by default installs into /usr/local, this PR should fix the matching to account for that, allowing the paper script to run on macOS without any issues in such a (fairly common) setup