### PR TITLE
Call stopRiding() on a Players death

### DIFF
--- a/Spigot-Server-Patches/0215-call-stopRiding-on-players-death.patch
+++ b/Spigot-Server-Patches/0215-call-stopRiding-on-players-death.patch
@@ -1,0 +1,22 @@
+From fb9a4072a4c5fd2d0e109e626e49e348463d0ef7 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Tue, 18 Apr 2017 15:01:43 +0100
+Subject: [PATCH] call stopRiding on players death.
+
+When a death occurs, any entity that the player is riding has the potential to be duplicated, as well as affecting the position of the entities position after respawning
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index a5c5bd4be..ad3218108 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -495,6 +495,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+             entityliving.b(this, this.bb);
+         }
+ 
++        this.stopRiding(); // Paper - stop riding entities on death, preventing the entity from adjusting our location or duping the ridden entity
+         this.b(StatisticList.A);
+         this.a(StatisticList.h);
+         this.extinguish();
+-- 
+2.12.2
+


### PR DESCRIPTION
Currently, when a player dies they are not automatically ejected from the entity they are riding, which allows for the ridden entity to affect the players location on respawn (we're still riding it for the current tick, and potentially the next), as well as allows a dupe to occur with the ridden entity teleporting to the new world with the player.

as per, #657 and in the grand scheme of trivial patches for fixing issues, This commit has been tested by me on a plain server, and doesn't really perform any behavioral changes that should cause any issues (especially as existing plugins will see the same state as before in regards to player riding entities on the death event). Would be nice for some confirmation on this, however this seems to solve the issue with no bad effects