### PR TITLE
EntityPickupItemEvent

### DIFF
--- a/Spigot-API-Patches/0051-EntityPickupItemEvent.patch
+++ b/Spigot-API-Patches/0051-EntityPickupItemEvent.patch
@@ -39,10 +39,12 @@ index 00000000..f485f313
 +        return item;
 +    }
 +
++    @Override
 +    public boolean isCancelled() {
 +        return cancel;
 +    }
 +
++    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancel = cancel;
 +    }

--- a/Spigot-API-Patches/0051-EntityPickupItemEvent.patch
+++ b/Spigot-API-Patches/0051-EntityPickupItemEvent.patch
@@ -1,0 +1,61 @@
+From a22f01307daf61a282adc1665cffc08e47871490 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 5 May 2017 01:16:10 -0500
+Subject: [PATCH] EntityPickupItemEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+new file mode 100644
+index 00000000..f485f313
+--- /dev/null
++++ b/src/main/java/org/bukkit/event/entity/EntityPickupItemEvent.java
+@@ -0,0 +1,46 @@
++package org.bukkit.event.entity;
++
++import org.bukkit.entity.Item;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++
++/**
++ * Thrown when an entity picks an item up from the ground
++ */
++public class EntityPickupItemEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final Item item;
++    private boolean cancel = false;
++
++    public EntityPickupItemEvent(final LivingEntity entity, final Item item) {
++        super(entity);
++        this.item = item;
++    }
++
++    /**
++     * Gets the Item picked up by the entity.
++     *
++     * @return Item
++     */
++    public Item getItem() {
++        return item;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0211-EntityPickupItemEvent.patch
+++ b/Spigot-Server-Patches/0211-EntityPickupItemEvent.patch
@@ -1,0 +1,44 @@
+From 8dc26cb4650fa9a4825cc14552845ed6f010ecb3 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 5 May 2017 01:16:22 -0500
+Subject: [PATCH] EntityPickupItemEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index 1d26555d..8cc55734 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -10,8 +10,11 @@ import java.util.UUID;
+ import javax.annotation.Nullable;
+ 
+ // CraftBukkit start
++import org.bukkit.craftbukkit.entity.CraftItem;
+ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.entity.CraftLivingEntity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.entity.EntityPickupItemEvent;
+ import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
+ import org.bukkit.event.entity.EntityTargetEvent;
+ import org.bukkit.event.entity.EntityUnleashEvent;
+@@ -558,6 +561,18 @@ public abstract class EntityInsentient extends EntityLiving {
+         }
+ 
+         if (flag && this.c(itemstack)) {
++
++            // Paper Start
++            EntityPickupItemEvent event = new EntityPickupItemEvent(
++                    (LivingEntity) this.getBukkitEntity(),
++                    new CraftItem(this.world.getServer(), entityitem));
++            this.world.getServer().getPluginManager().callEvent(event);
++
++            if (event.isCancelled()) {
++                return;
++            }
++            // Paper end
++
+             double d0;
+ 
+             switch (enumitemslot.a()) {
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0211-EntityPickupItemEvent.patch
+++ b/Spigot-Server-Patches/0211-EntityPickupItemEvent.patch
@@ -26,9 +26,7 @@ index 1d26555d..8cc55734 100644
          if (flag && this.c(itemstack)) {
 +
 +            // Paper Start
-+            EntityPickupItemEvent event = new EntityPickupItemEvent(
-+                    (LivingEntity) this.getBukkitEntity(),
-+                    new CraftItem(this.world.getServer(), entityitem));
++            EntityPickupItemEvent event = new EntityPickupItemEvent((LivingEntity) this.getBukkitEntity(), new CraftItem(this.world.getServer(), entityitem));
 +            this.world.getServer().getPluginManager().callEvent(event);
 +
 +            if (event.isCancelled()) {


### PR DESCRIPTION
I finally found a need to cancel zombie/skeleton from picking up items. Upon searching for a way to do it, I found many requests to both Spigot and Bukkit dating as far back as 2012 (maybe older) for this event. Since it's now mid-way through 2017, I figure its time we have this.

Tested with sample plugin:

`

    @EventHandler
    public void onEntityPickupItem(EntityPickupItemEvent event) {
        ItemStack stack = event.getItem().getItemStack();

        System.out.println(event.getEntity().getType()
                + " tried to picked up "
                + stack.getAmount()
                + "x "
                + stack.getType()
                + " but event was cancelled");

        event.setCancelled(true);
    }


`