### PR TITLE
Item#canEntityPickup

### DIFF
--- a/Spigot-API-Patches/0051-Item-canEntityPickup.patch
+++ b/Spigot-API-Patches/0051-Item-canEntityPickup.patch
@@ -1,0 +1,34 @@
+From e704dc9588b52864b7a812d19cb31db68e34a155 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 5 May 2017 03:57:08 -0500
+Subject: [PATCH] Item#canEntityPickup
+
+
+diff --git a/src/main/java/org/bukkit/entity/Item.java b/src/main/java/org/bukkit/entity/Item.java
+index 90260b7e..7163f8b0 100644
+--- a/src/main/java/org/bukkit/entity/Item.java
++++ b/src/main/java/org/bukkit/entity/Item.java
+@@ -34,4 +34,20 @@ public interface Item extends Entity {
+      * @param delay New delay
+      */
+     public void setPickupDelay(int delay);
++
++    // Paper Start
++    /**
++     * Gets if non-player entities can pick this Item up
++     *
++     * @return True if non-player entities can pickup
++     */
++     public boolean canEntityPickup();
++
++    /**
++     * Sets if non-player entities can pick this Item up
++     *
++     * @param canEntityPickup True to allow non-player entity pickup
++     */
++    public void setCanEntityPickup(boolean canEntityPickup);
++    // Paper end
+ }
+-- 
+2.11.0
+

--- a/Spigot-API-Patches/0051-Item-canEntityPickup.patch
+++ b/Spigot-API-Patches/0051-Item-canEntityPickup.patch
@@ -19,14 +19,14 @@ index 90260b7e..7163f8b0 100644
 +     *
 +     * @return True if non-player entities can pickup
 +     */
-+     public boolean canEntityPickup();
++     public boolean canMobPickup();
 +
 +    /**
 +     * Sets if non-player entities can pick this Item up
 +     *
-+     * @param canEntityPickup True to allow non-player entity pickup
++     * @param canMobPickup True to allow non-player entity pickup
 +     */
-+    public void setCanEntityPickup(boolean canEntityPickup);
++    public void setCanMobPickup(boolean canMobPickup);
 +    // Paper end
  }
 -- 

--- a/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
+++ b/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
@@ -13,7 +13,7 @@ index 1d26555d..3179e627 100644
                  EntityItem entityitem = (EntityItem) iterator.next();
  
 +                // Paper Start
-+                if (!entityitem.canEntityPickup) {
++                if (!entityitem.canMobPickup) {
 +                    continue;
 +                }
 +                // Paper End
@@ -29,7 +29,7 @@ index 95ca1b8e..207b6f0b 100644
      private static final DataWatcherObject<ItemStack> c = DataWatcher.a(EntityItem.class, DataWatcherRegistry.f);
      private int age;
      public int pickupDelay;
-+    public boolean canEntityPickup = true; // Paper
++    public boolean canMobPickup = true; // Paper
      private int f;
      private String g;
      private String h;
@@ -42,12 +42,12 @@ index a17a537d..6bacf204 100644
      }
  
 +    // Paper Start
-+    public boolean canEntityPickup() {
-+        return item.canEntityPickup;
++    public boolean canMobPickup() {
++        return item.canMobPickup;
 +    }
 +
-+    public void setCanEntityPickup(boolean canEntityPickup) {
-+        item.canEntityPickup = canEntityPickup;
++    public void setCanMobPickup(boolean canMobPickup) {
++        item.canMobPickup = canMobPickup;
 +    }
 +    // Paper End
 +

--- a/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
+++ b/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
@@ -1,0 +1,59 @@
+From 57a1a544e630803a6471f7ce122d23edf24c6f43 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 5 May 2017 03:57:17 -0500
+Subject: [PATCH] Item#canEntityPickup
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index 1d26555d..3179e627 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -508,6 +508,12 @@ public abstract class EntityInsentient extends EntityLiving {
+             while (iterator.hasNext()) {
+                 EntityItem entityitem = (EntityItem) iterator.next();
+ 
++                // Paper Start
++                if (!entityitem.canEntityPickup) {
++                    continue;
++                }
++                // Paper End
++
+                 if (!entityitem.dead && !entityitem.getItemStack().isEmpty() && !entityitem.t()) {
+                     this.a(entityitem);
+                 }
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index 95ca1b8e..207b6f0b 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -19,6 +19,7 @@ public class EntityItem extends Entity implements HopperPusher {
+     private static final DataWatcherObject<ItemStack> c = DataWatcher.a(EntityItem.class, DataWatcherRegistry.f);
+     private int age;
+     public int pickupDelay;
++    public boolean canEntityPickup = true; // Paper
+     private int f;
+     private String g;
+     private String h;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
+index a17a537d..6bacf204 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
+@@ -37,6 +37,16 @@ public class CraftItem extends CraftEntity implements Item {
+         item.pickupDelay = Math.min(delay, Short.MAX_VALUE);
+     }
+ 
++    // Paper Start
++    public boolean canEntityPickup() {
++        return item.canEntityPickup;
++    }
++
++    public void setCanEntityPickup(boolean canEntityPickup) {
++        item.canEntityPickup = canEntityPickup;
++    }
++    // Paper End
++
+     @Override
+     public String toString() {
+         return "CraftItem";
+-- 
+2.11.0
+


### PR DESCRIPTION
This is related to #679 due to the fact that cancelling the EntityPickupItemEvent can be somewhat spammy (~15 calls per second). I decided to put the two in different PRs because they both have separate use-cases where they do not rely on each other (event for listening, flag for blocking).

With this PR you can set an Item to not be picked up by a non-player entity, such as a money drop plugin that uses gold nuggets/ingots/blocks as dropped currency, for example. This flag is beneficial over #679 due to the fact is skips a lot of logic and does not call a spammy event which may have a listener with its own heavy logic. The flag can be set at the time the Item was created and then forgotten about.