### PR TITLE
Allow Changing of Player Sample in ServerListPingEvent

### DIFF
--- a/Spigot-API-Patches/0038-Add-EntityZapEvent.patch
+++ b/Spigot-API-Patches/0038-Add-EntityZapEvent.patch
@@ -1,4 +1,4 @@
-From 2b3054eda2cfa7dd47f019fa1d1eda5537c73266 Mon Sep 17 00:00:00 2001
+From 972c2db2d7b3dc3117be8812c404fbeaf03e7c6c Mon Sep 17 00:00:00 2001
 From: AlphaBlend <whizkid3000@hotmail.com>
 Date: Sun, 16 Oct 2016 23:19:34 -0700
 Subject: [PATCH] Add EntityZapEvent
@@ -119,5 +119,5 @@ index aa80ebf1..73844b8f 100644
 +    // Paper end
  }
 -- 
-2.12.2
+2.11.0
 

--- a/Spigot-API-Patches/0061-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
+++ b/Spigot-API-Patches/0061-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
@@ -1,0 +1,37 @@
+From fd17520035a7195a2314c1648f29ae84c1d9233b Mon Sep 17 00:00:00 2001
+From: willies952002 <admin@domnian.com>
+Date: Thu, 20 Jul 2017 18:05:36 -0400
+Subject: [PATCH] Allow Changing of Player Sample in ServerListPingEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+index 3c38d857..84de3ce4 100644
+--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+@@ -2,6 +2,7 @@ package org.bukkit.event.server;
+ 
+ import java.net.InetAddress;
+ import java.util.Iterator;
++import java.util.List;
+ 
+ import org.apache.commons.lang.Validate;
+ import org.bukkit.entity.Player;
+@@ -145,4 +146,15 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     public Iterator<Player> iterator() throws UnsupportedOperationException {
+         throw new UnsupportedOperationException();
+     }
++
++    // Paper start
++    private java.util.List<String> sample;
++    public void setSampleText(java.util.List<String> sample) {
++        this.sample = sample;
++    }
++    public java.util.List<String> getSampleText() {
++        return sample;
++    }
++    // Paper end
++
+ }
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0223-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
+++ b/Spigot-Server-Patches/0223-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
@@ -1,0 +1,68 @@
+From 516cd29396e0b5ffdd77c417aa21fc683120265a Mon Sep 17 00:00:00 2001
+From: willies952002 <admin@domnian.com>
+Date: Fri, 5 May 2017 18:59:22 -0400
+Subject: [PATCH] Allow Changing of Player Sample in ServerListPingEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PacketStatusListener.java b/src/main/java/net/minecraft/server/PacketStatusListener.java
+index 313bb0007..45d6984f7 100644
+--- a/src/main/java/net/minecraft/server/PacketStatusListener.java
++++ b/src/main/java/net/minecraft/server/PacketStatusListener.java
+@@ -5,6 +5,7 @@ import com.mojang.authlib.GameProfile;
+ import io.netty.channel.ChannelFutureListener;
+ import java.net.InetSocketAddress;
+ import java.util.Iterator;
++import java.util.UUID;
+ 
+ import org.bukkit.craftbukkit.util.CraftIconCache;
+ import org.bukkit.entity.Player;
+@@ -97,23 +98,44 @@ public class PacketStatusListener implements PacketStatusInListener {
+                 }
+             }
+ 
++            // Paper start
++            java.util.List<String> sample = new java.util.ArrayList<>(players.length);
++            for (Object player : players) {
++                if (player != null) sample.add(((EntityPlayer) player).getName());
++            }
++            if (!sample.isEmpty()) {
++                java.util.Collections.shuffle(sample);
++                sample = sample.subList(0, Math.min(sample.size(), org.spigotmc.SpigotConfig.playerSample));
++            }
++            // Paper end
++
+             ServerListPingEvent event = new ServerListPingEvent();
++            event.setSampleText(sample); // Paper
+             this.minecraftServer.server.getPluginManager().callEvent(event);
+-
+             java.util.List<GameProfile> profiles = new java.util.ArrayList<GameProfile>(players.length);
++            // Paper start
++            if (event.getSampleText() != sample) sample = event.getSampleText();
++            sample.forEach(line -> profiles.add(new GameProfile(UUID.randomUUID(), line)));
++            /*
+             for (Object player : players) {
+                 if (player != null) {
+                     profiles.add(((EntityPlayer) player).getProfile());
+                 }
+             }
++            */
++            // Paper end
+ 
+-            ServerPing.ServerPingPlayerSample playerSample = new ServerPing.ServerPingPlayerSample(event.getMaxPlayers(), profiles.size());
++            ServerPing.ServerPingPlayerSample playerSample = new ServerPing.ServerPingPlayerSample(event.getMaxPlayers(), minecraftServer.getPlayerList().getPlayerCount()); // Paper
+             // Spigot Start
++            // Paper start - Move up
++            /*
+             if ( !profiles.isEmpty() )
+             {
+                 java.util.Collections.shuffle( profiles ); // This sucks, its inefficient but we have no simple way of doing it differently
+                 profiles = profiles.subList( 0, Math.min( profiles.size(), org.spigotmc.SpigotConfig.playerSample ) ); // Cap the sample to n (or less) displayed players, ie: Vanilla behaviour
+             }
++            */
++            // Paper end
+             // Spigot End
+             playerSample.a(profiles.toArray(new GameProfile[profiles.size()]));
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
This will allow plugins to change what a player sees when they hover over the player count on the multiplayer server list when the `ServerListPingEvent` is fired.