### PR TITLE
PlayerPickupItemEvent#setFlyAtPlayer

### DIFF
--- a/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -22,8 +22,7 @@ index dfba8163..fd97ea21 100644
  
 +    // Paper Start
 +    /**
-+     * Set if the item will fly at the player
-+     * <p>
++     * <p>Set if the item will fly at the player</p>
 +     * Cancelling the event will set this value to false.
 +     *
 +     * @param flyAtPlayer True for item to fly at player

--- a/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -22,8 +22,8 @@ index dfba8163..fd97ea21 100644
  
 +    // Paper Start
 +    /**
-+     * <p>Set if the item will fly at the player</p>
-+     * Cancelling the event will set this value to false.
++     * Set if the item will fly at the player
++     * <p>Cancelling the event will set this value to false.</p>
 +     *
 +     * @param flyAtPlayer True for item to fly at player
 +     */

--- a/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-API-Patches/0051-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -1,0 +1,57 @@
+From 1c5d13ab2ee4ed3b4014df257470cf39889789e5 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 7 May 2017 06:26:01 -0500
+Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+index dfba8163..fd97ea21 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
+@@ -11,6 +11,7 @@ import org.bukkit.event.HandlerList;
+ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final Item item;
++    private boolean flyAtPlayer = true; // Paper
+     private boolean cancel = false;
+     private final int remaining;
+ 
+@@ -38,12 +39,35 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+         return remaining;
+     }
+ 
++    // Paper Start
++    /**
++     * Set if the item will fly at the player
++     * <p>
++     * Cancelling the event will set this value to false.
++     *
++     * @param flyAtPlayer True for item to fly at player
++     */
++    public void setFlyAtPlayer(boolean flyAtPlayer) {
++        this.flyAtPlayer = flyAtPlayer;
++    }
++
++    /**
++     * Gets if the item will fly at the player
++     *
++     * @return True if the item will fly at the player
++     */
++    public boolean getFlyAtPlayer() {
++        return flyAtPlayer;
++    }
++    // Paper End
++
+     public boolean isCancelled() {
+         return cancel;
+     }
+ 
+     public void setCancelled(boolean cancel) {
+         this.cancel = cancel;
++        this.flyAtPlayer = !cancel; // Paper
+     }
+ 
+     @Override
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0211-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-Server-Patches/0211-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -1,0 +1,49 @@
+From b8cff2eed487001ad1dfca2d176a6840ef524edc Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 7 May 2017 06:26:09 -0500
+Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index 95ca1b8e..2dd27d1c 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -328,6 +328,7 @@ public class EntityItem extends Entity implements HopperPusher {
+             // CraftBukkit start - fire PlayerPickupItemEvent
+             int canHold = entityhuman.inventory.canHold(itemstack);
+             int remaining = i - canHold;
++            boolean flyAtPlayer = false; // Paper
+ 
+             if (this.pickupDelay <= 0 && canHold > 0) {
+                 itemstack.setCount(canHold);
+@@ -335,8 +336,14 @@ public class EntityItem extends Entity implements HopperPusher {
+                 // event.setCancelled(!entityhuman.canPickUpLoot); TODO
+                 this.world.getServer().getPluginManager().callEvent(event);
+                 itemstack.setCount(canHold + remaining);
++                flyAtPlayer = event.getFlyAtPlayer(); // Paper
+ 
+                 if (event.isCancelled()) {
++                    // Paper Start
++                    if (flyAtPlayer) {
++                        entityhuman.receive(this, i);
++                    }
++                    // Paper End
+                     return;
+                 }
+ 
+@@ -374,7 +381,11 @@ public class EntityItem extends Entity implements HopperPusher {
+                     }
+                 }
+ 
+-                entityhuman.receive(this, i);
++                // Paper Start
++                if (flyAtPlayer) {
++                    entityhuman.receive(this, i);
++                }
++                // Paper End
+                 if (itemstack.isEmpty()) {
+                     this.die();
+                     itemstack.setCount(i);
+-- 
+2.11.0
+


### PR DESCRIPTION
Not sure how practical this is at all for a PR. But, I'm bored, and I could use this in one of my plugins.

My exact use case is a money drop plugin. Killing mobs drops gold nuggets with some metadata worth a certain amount of vault money. Player picks up the item and I cancel the pickup, remove the item, and pay the player the value from metadata. The problem is, the item just disappears on the player's screen. I have to reach into NSM just to call EntityHuman.receive(EntityItem, 1) to make the item fly at the player like a normal picked up drop. An alternative to NMS would be ProtocolLib, but then I'd have to run my own tracker, because the player picking up the item isn't the only one getting sent the PacketPlayOutCollect packet.

Might have other use-cases, so I kept that in mind when designing this API. Not only can you do what I mentioned, but you could also stop the item from flying at the player if you want. Etc.