### PR TITLE
Fire PlayerPickupItemEvent as cancelled if inventory is full

### DIFF
--- a/Spigot-Server-Patches/0211-Fire-PlayerPickupItemEvent-as-cancelled-if-inventory.patch
+++ b/Spigot-Server-Patches/0211-Fire-PlayerPickupItemEvent-as-cancelled-if-inventory.patch
@@ -1,0 +1,26 @@
+From 2da73e389028808ad70c78dc6963c5c43a8e3995 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 7 May 2017 07:37:05 -0500
+Subject: [PATCH] Fire PlayerPickupItemEvent as cancelled if inventory is full
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index 95ca1b8e..6ddc4e57 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -329,10 +329,10 @@ public class EntityItem extends Entity implements HopperPusher {
+             int canHold = entityhuman.inventory.canHold(itemstack);
+             int remaining = i - canHold;
+ 
+-            if (this.pickupDelay <= 0 && canHold > 0) {
++            if (this.pickupDelay <= 0) { // Paper
+                 itemstack.setCount(canHold);
+                 PlayerPickupItemEvent event = new PlayerPickupItemEvent((org.bukkit.entity.Player) entityhuman.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
+-                // event.setCancelled(!entityhuman.canPickUpLoot); TODO
++                event.setCancelled(canHold <= 0); // Paper
+                 this.world.getServer().getPluginManager().callEvent(event);
+                 itemstack.setCount(canHold + remaining);
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
This seems like something that was partially implemented (canHold still stopped full inventories) by [fieldmaster back in 2012](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/430d352a5a3d1f8d83276f0af43065b49e3b9822#src/main/java/net/minecraft/server/EntityItem.java), but was commented out and negated by [Thinkofname in 2014](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/24557bc2b37deb6a0edf497d547471832457b1dd#nms-patches/EntityItem.patch).

This may break some existing plugins that listen to the event and assume it isn't cancelled. If the event fires as cancelled the item amount is 0.

If this doesn't seem sane I could always just add a new event PlayerAttemptPickupItemEvent.

Use-case for this would be my money drop plugin I keep talking about in my other 3 PRs this weekend. I would like for players to still be able to pick up money even when their inventory is full (since the money item isnt going to their inventory anyways). Currently there is no way to do this other than tracking all money drop locations and player locations and comparing distance in a repeating task (not very sane). Firing this event in a cancelled state (or a new "attempt" event) would allow plugins like mine to function correctly without laggy repeating tasks.