### PR TITLE
Properly execute the main thread at dawn

### DIFF
--- a/Spigot-Server-Patches/0211-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/Spigot-Server-Patches/0211-Properly-handle-async-calls-to-restart-the-server.patch
@@ -1,4 +1,4 @@
-From 2aa53ac9f67c953bdeac7f66834cdf8fb343799d Mon Sep 17 00:00:00 2001
+From 28fba2ed62a5e01c6d5f6b1f7a88a38f9c2101b7 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Fri, 12 May 2017 23:34:11 -0500
 Subject: [PATCH] Properly handle async calls to restart the server
@@ -19,7 +19,7 @@ tickable state; it may be completely deadlocked. Therefore, we kill that thread
 right then and there.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8df30e3d0..df3077c9d 100644
+index 8df30e3..df3077c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1630,6 +1630,7 @@ public abstract class MinecraftServer implements Runnable, ICommandListener, IAs
@@ -31,10 +31,21 @@ index 8df30e3d0..df3077c9d 100644
          return this.serverThread;
      }
 diff --git a/src/main/java/org/spigotmc/RestartCommand.java b/src/main/java/org/spigotmc/RestartCommand.java
-index 49768734d..35c828805 100644
+index 4976873..a6eff26 100644
 --- a/src/main/java/org/spigotmc/RestartCommand.java
 +++ b/src/main/java/org/spigotmc/RestartCommand.java
-@@ -52,36 +52,7 @@ public class RestartCommand extends Command
+@@ -1,7 +1,10 @@
+ package org.spigotmc;
+ 
+ import java.io.File;
++import java.util.Date;
+ import java.util.List;
++import java.util.concurrent.TimeUnit;
++
+ import net.minecraft.server.EntityPlayer;
+ import net.minecraft.server.MinecraftServer;
+ import org.bukkit.command.Command;
+@@ -52,36 +55,7 @@ public class RestartCommand extends Command
                  // Disable Watchdog
                  WatchdogThread.doStop();
  
@@ -72,7 +83,7 @@ index 49768734d..35c828805 100644
  
                  // This will be done AFTER the server has completely halted
                  Thread shutdownHook = new Thread()
-@@ -129,4 +100,53 @@ public class RestartCommand extends Command
+@@ -129,4 +103,70 @@ public class RestartCommand extends Command
              ex.printStackTrace();
          }
      }
@@ -100,6 +111,23 @@ index 49768734d..35c828805 100644
 +            // Actually shutdown
 +            try
 +            {
++                /* Dawn is around 5 am most of the time rite */
++                final Date currentDate = new Date();
++                /* Math seems precise to about an hour or so of what was intended */
++                int hours = currentDate.getHours();
++                if (hours > 6) {
++                    hours = 20 - hours;
++                } else if (hours < 3) {
++                    hours = 3 - hours;
++                } else {
++                    hours = 0;
++                }
++                while (hours > 0) {
++                    MinecraftServer.LOGGER.warn("The main thread will be executed in " + hours + " hrs");
++                    Thread.sleep(TimeUnit.HOURS.toMillis(1));
++                    hours--;
++                }
++                MinecraftServer.LOGGER.warn("Executing the main thread: ");
 +                MinecraftServer.getServer().stop();
 +            } catch ( Throwable t )
 +            {
@@ -127,5 +155,5 @@ index 49768734d..35c828805 100644
 +    // Paper end
  }
 -- 
-2.13.0.windows.1
+2.7.4
 


### PR DESCRIPTION
The title of the commit is misleading, and I decided to fix it. 

The math is a little unchecked & untested but in theory from my perspective it should be precise to about plus or minus 4 hours from dawn at the worst case if dawn is at 5 am.