### PR TITLE
Actually exit the JVM after stopping the server when /restart is ran

### DIFF
--- a/Spigot-Server-Patches/0211-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/Spigot-Server-Patches/0211-Properly-handle-async-calls-to-restart-the-server.patch
@@ -1,4 +1,4 @@
-From 554073bf2250350eccddf53021abab00aa749b5d Mon Sep 17 00:00:00 2001
+From dff57ca19996fcfe3b01da38e2f19d2166fdd252 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Fri, 12 May 2017 23:34:11 -0500
 Subject: [PATCH] Properly handle async calls to restart the server
@@ -107,16 +107,14 @@ index 034bdb7cf..34236c622 100644
      // CraftBukkit start
      public void sendMessage(IChatBaseComponent[] iChatBaseComponents) {
 diff --git a/src/main/java/org/spigotmc/RestartCommand.java b/src/main/java/org/spigotmc/RestartCommand.java
-index 49768734d..e1bc3e64e 100644
+index 49768734d..d51636c8e 100644
 --- a/src/main/java/org/spigotmc/RestartCommand.java
 +++ b/src/main/java/org/spigotmc/RestartCommand.java
-@@ -45,88 +45,119 @@ public class RestartCommand extends Command
+@@ -45,88 +45,123 @@ public class RestartCommand extends Command
          AsyncCatcher.enabled = false; // Disable async catcher incase it interferes with us
          try
          {
 -            if ( script.isFile() )
--            {
--                System.out.println( "Attempting to restart with " + SpigotConfig.restartScript );
 +            // Paper - extract method and cleanup
 +            boolean isRestarting = addShutdownHook(script);
 +            if (isRestarting) {
@@ -124,48 +122,17 @@ index 49768734d..e1bc3e64e 100644
 +            } else {
 +                System.out.println( "Startup script '" + SpigotConfig.restartScript + "' does not exist! Stopping server." );
 +            }
- 
--                // Disable Watchdog
--                WatchdogThread.doStop();
++
 +            // Stop the watchdog
 +            WatchdogThread.doStop();
- 
--                // Kick all players
--                for ( EntityPlayer p : (List< EntityPlayer>) MinecraftServer.getServer().getPlayerList().players )
--                {
--                    p.playerConnection.disconnect(SpigotConfig.restartMessage);
--                }
--                // Give the socket a chance to send the packets
--                try
--                {
--                    Thread.sleep( 100 );
--                } catch ( InterruptedException ex )
--                {
--                }
--                // Close the socket so we can rebind with the new process
--                MinecraftServer.getServer().getServerConnection().b();
--
--                // Give time for it to kick in
--                try
--                {
--                    Thread.sleep( 100 );
--                } catch ( InterruptedException ex )
--                {
--                }
++
 +            shutdownServer(isRestarting);
 +        } catch ( Exception ex )
 +        {
 +            ex.printStackTrace();
 +        }
 +    }
- 
--                // Actually shutdown
--                try
--                {
--                    MinecraftServer.getServer().stop();
--                } catch ( Throwable t )
--                {
--                }
++
 +    // Paper start - sync copied from above with minor changes, async added
 +    private static void shutdownServer(boolean isRestarting)
 +    {
@@ -181,8 +148,57 @@ index 49768734d..e1bc3e64e 100644
 +            {
 +                Thread.sleep( 100 );
 +            } catch ( InterruptedException ex )
+             {
+-                System.out.println( "Attempting to restart with " + SpigotConfig.restartScript );
++            }
+ 
+-                // Disable Watchdog
+-                WatchdogThread.doStop();
++            closeSocket();
+ 
+-                // Kick all players
+-                for ( EntityPlayer p : (List< EntityPlayer>) MinecraftServer.getServer().getPlayerList().players )
+-                {
+-                    p.playerConnection.disconnect(SpigotConfig.restartMessage);
+-                }
+-                // Give the socket a chance to send the packets
+-                try
+-                {
+-                    Thread.sleep( 100 );
+-                } catch ( InterruptedException ex )
+-                {
+-                }
+-                // Close the socket so we can rebind with the new process
+-                MinecraftServer.getServer().getServerConnection().b();
++            // Actually shutdown
++            try
++            {
++                MinecraftServer.getServer().stop();
++            } catch ( Throwable t )
 +            {
 +            }
+ 
+-                // Give time for it to kick in
+-                try
+-                {
+-                    Thread.sleep( 100 );
+-                } catch ( InterruptedException ex )
+-                {
+-                }
++            // Actually stop the JVM
++            System.exit(0);
+ 
+-                // Actually shutdown
+-                try
+-                {
+-                    MinecraftServer.getServer().stop();
+-                } catch ( Throwable t )
+-                {
+-                }
++        } else
++        {
++            // Mark the server to shutdown at the end of the tick
++            MinecraftServer.getServer().safeShutdown(isRestarting);
  
 -                // This will be done AFTER the server has completely halted
 -                Thread shutdownHook = new Thread()
@@ -209,24 +225,19 @@ index 49768734d..e1bc3e64e 100644
 -                        }
 -                    }
 -                };
-+            closeSocket();
  
 -                shutdownHook.setDaemon( true );
 -                Runtime.getRuntime().addShutdownHook( shutdownHook );
 -            } else
-+            // Actually shutdown
++            // wait 10 seconds to see if we're actually going to try shutdown
 +            try
++            {
++                Thread.sleep(10000);
++            }
++            catch (InterruptedException ignored)
              {
 -                System.out.println( "Startup script '" + SpigotConfig.restartScript + "' does not exist! Stopping server." );
-+                MinecraftServer.getServer().stop();
-+            } catch ( Throwable t )
-+            {
-+            }
-+        } else
-+        {
-+            // Mark the server to shutdown at the end of the tick
-+            MinecraftServer.getServer().safeShutdown(isRestarting);
- 
+-
 -                // Actually shutdown
 -                try
 -                {
@@ -234,14 +245,6 @@ index 49768734d..e1bc3e64e 100644
 -                } catch ( Throwable t )
 -                {
 -                }
-+
-+            // wait 10 seconds to see if we're actually going to try shutdown
-+            try
-+            {
-+                Thread.sleep(10000);
-+            }
-+            catch (InterruptedException ignored)
-+            {
              }
 +
 +            // Check if we've actually hit a state where the server is going to safely shutdown


### PR DESCRIPTION
Fixes #699, looks like in decluttering the RestartCommand class, a stray System.exit call lost its way.