### PR TITLE
Do not relocate fastutil

### DIFF
--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -1,11 +1,11 @@
-From 3960b77a1b0f1bf81f46f96395a983b476460a1d Mon Sep 17 00:00:00 2001
+From a5da8516e3b9ef3ceb08cb5d373593a8775f42c8 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 20:40:33 -0600
 Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index d677e79df..78395669f 100644
+index d677e79df..b2aa10ff7 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,12 +1,12 @@
@@ -106,7 +106,7 @@ index d677e79df..78395669f 100644
                              <Implementation-Vendor>${maven.build.timestamp}</Implementation-Vendor>
                              <Specification-Title>Bukkit</Specification-Title>
                              <Specification-Version>${api.version}</Specification-Version>
-@@ -195,11 +184,13 @@
+@@ -195,19 +184,22 @@
                              <goal>shade</goal>
                          </goals>
                          <configuration>
@@ -124,7 +124,20 @@ index d677e79df..78395669f 100644
                                  <relocation>
                                      <pattern>jline</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.jline</shadedPattern>
-@@ -234,20 +225,6 @@
+                                 </relocation>
+-                                <relocation>
+-                                    <pattern>it.unimi</pattern>
+-                                    <shadedPattern>org.bukkit.craftbukkit.libs.it.unimi</shadedPattern>
+-                                </relocation>
++                                <!-- Paper - Don't relocate fastutil in order to prevent api breakage -->
++                                <!--<relocation>-->
++                                    <!--<pattern>it.unimi</pattern>-->
++                                    <!--<shadedPattern>org.bukkit.craftbukkit.libs.it.unimi</shadedPattern>-->
++                                <!--</relocation>-->
+                                 <relocation>
+                                     <pattern>org.bukkit.craftbukkit</pattern>
+                                     <shadedPattern>org.bukkit.craftbukkit.v${minecraft_version}</shadedPattern>
+@@ -234,20 +226,6 @@
                  <artifactId>maven-compiler-plugin</artifactId>
                  <!-- versions after this appear to be broken -->
                  <version>3.1</version>

--- a/Spigot-Server-Patches/0006-Timings-v2.patch
+++ b/Spigot-Server-Patches/0006-Timings-v2.patch
@@ -1,26 +1,9 @@
-From 1dcc85c66e450b5212e23981c7b8e5a381f66dfc Mon Sep 17 00:00:00 2001
+From e8b95df429fa6c189cc22b2bc26d27c24bfd3c8e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
 
 
-diff --git a/pom.xml b/pom.xml
-index 78395669f..39ca6aede 100644
---- a/pom.xml
-+++ b/pom.xml
-@@ -65,6 +65,12 @@
-             <scope>compile</scope>
-         </dependency>
-         <dependency>
-+            <groupId>co.aikar</groupId>
-+            <artifactId>fastutil-lite</artifactId>
-+            <version>1.0</version>
-+            <scope>compile</scope>
-+        </dependency>
-+        <dependency>
-             <groupId>net.sf.trove4j</groupId>
-             <artifactId>trove4j</artifactId>
-             <version>3.0.3</version>
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
 index 000000000..1b33390de


### PR DESCRIPTION
Revert spigots relocation of fastutil and remove Aikars fastutil-lite from the timings v2 patch