### PR TITLE
Provide a configurable option to disable creeper lingering effect spawns

### DIFF
--- a/Spigot-Server-Patches/0213-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0213-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -1,0 +1,38 @@
+From 41485db87dc97472c2155e45146a5118ae61be07 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Sun, 11 Jun 2017 21:01:18 +0100
+Subject: [PATCH] provide a configurable option to disable creeper lingering
+ effect spawns
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 1ce3aaa8c..54d081fd2 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -422,4 +422,10 @@ public class PaperWorldConfig {
+         parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
+         log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
+     }
++
++    public boolean disableCreeperLingeringEffect;
++    private void setDisableCreeperLingeringEffect() {
++        disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
++        log("Creeper lingering effect: " + disableCreeperLingeringEffect);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 4a5e87b5f..6a653f8b5 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -222,7 +222,7 @@ public class EntityCreeper extends EntityMonster {
+     private void ds() {
+         Collection collection = this.getEffects();
+ 
+-        if (!collection.isEmpty()) {
++        if (!collection.isEmpty() && !world.paperConfig.disableCreeperLingeringEffect) { // Paper
+             EntityAreaEffectCloud entityareaeffectcloud = new EntityAreaEffectCloud(this.world, this.locX, this.locY, this.locZ);
+ 
+             entityareaeffectcloud.setRadius(2.5F);
+-- 
+2.13.1
+


### PR DESCRIPTION
#689 quite simply provides a per-world configurable option to disable the spawning of lingering effects from creepers.

figured it was a 2-minute job, and always nice to get stuff off the issues list