### PR TITLE
Remove unneeded WINDOWS_COMPAT ConsoleAppender

### DIFF
--- a/Spigot-Server-Patches/0212-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0212-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 3d69c48006f75e45b053b2d626a1829f71d1a7d6 Mon Sep 17 00:00:00 2001
+From 54a6c5e33ce7d79a8bf8110a35cf9b9ec1b26e60 Mon Sep 17 00:00:00 2001
 From: Minecrell <dev@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -173,7 +173,7 @@ index 00000000..dcd31fbc
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 2feeb855..db9ace0c 100644
+index 2feeb855..3266df1f 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -73,7 +73,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -206,15 +206,25 @@ index 2feeb855..db9ace0c 100644
                          if (s != null && s.trim().length() > 0) { // Trim to filter lines which are just spaces
                              issueCommand(s, DedicatedServer.this);
                          }
-@@ -113,8 +122,6 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-             }
+@@ -106,6 +115,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         }
+         global.addHandler(new org.bukkit.craftbukkit.util.ForwardLogHandler());
+ 
++        // Paper start - Not needed with TerminalConsoleAppender
++        final org.apache.logging.log4j.Logger logger = LogManager.getRootLogger();
++        /*
+         final org.apache.logging.log4j.core.Logger logger = ((org.apache.logging.log4j.core.Logger) LogManager.getRootLogger());
+         for (org.apache.logging.log4j.core.Appender appender : logger.getAppenders().values()) {
+             if (appender instanceof org.apache.logging.log4j.core.appender.ConsoleAppender) {
+@@ -114,6 +126,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
--        new Thread(new org.bukkit.craftbukkit.util.TerminalConsoleWriterThread(System.out, this.reader)).start();
--
+         new Thread(new org.bukkit.craftbukkit.util.TerminalConsoleWriterThread(System.out, this.reader)).start();
++        */
++        // Paper end
+ 
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
-         // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index d84f59da..8ca8fdce 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -315,7 +325,7 @@ index 463f5890..df6a75b0 100644
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 1cbcc3df..c3b2413a 100644
+index 66e72006..84872520 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -14,7 +14,7 @@ import java.util.logging.Logger;
@@ -588,15 +598,15 @@ index b6409711..00000000
 -    }
 -}
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 5cee8f00..f248d05f 100644
+index 5cee8f00..08b6bb7f 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
-@@ -1,12 +1,12 @@
+@@ -1,12 +1,11 @@
  <?xml version="1.0" encoding="UTF-8"?>
 -<Configuration status="WARN" packages="com.mojang.util">
 +<Configuration status="WARN">
      <Appenders>
-         <Console name="WINDOWS_COMPAT" target="SYSTEM_OUT"></Console>
+-        <Console name="WINDOWS_COMPAT" target="SYSTEM_OUT"></Console>
 -        <Queue name="TerminalConsole">
 -            <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />
 -        </Queue>
@@ -609,6 +619,14 @@ index 5cee8f00..f248d05f 100644
              <Policies>
                  <TimeBasedTriggeringPolicy />
                  <OnStartupTriggeringPolicy />
+@@ -19,7 +18,6 @@
+             <filters>
+                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
+             </filters>
+-            <AppenderRef ref="WINDOWS_COMPAT" level="info"/>
+             <AppenderRef ref="File"/>
+             <AppenderRef ref="TerminalConsole" level="info"/>
+         </Root>
 -- 
 2.13.1
 


### PR DESCRIPTION
It was originally added in Bukkit/CraftBukkit@6aafe7c as a workaround for BUKKIT-4956 to fix console output on Windows.

I believe the original issue was related to [LOG4J2-965](https://issues.apache.org/jira/browse/LOG4J2-965) and fixed in apache/logging-log4j2@d04659c. Minecraft 1.12 finally updated the Log4J version so this issue is no longer present.

Console output is still working fine on Windows after removing this.

**Note:** I've added this to the original console improvements patch added in #728 because I'm not entirely sure if this would be still needed if we weren't using TerminalConsoleAppender. I believe it's unrelated but it might be better to keep all the log4j changes together in one patch. I can move it to a separate patch if that would be preferred.