### PR TITLE
Continue reading from console input after EOT

### DIFF
--- a/Spigot-Server-Patches/0212-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0212-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 54a6c5e33ce7d79a8bf8110a35cf9b9ec1b26e60 Mon Sep 17 00:00:00 2001
+From fcc7f8f2c0855af3b719cc6eae27e308dbb2f69e Mon Sep 17 00:00:00 2001
 From: Minecrell <dev@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -115,15 +115,16 @@ index 00000000..24f30efb
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
 new file mode 100644
-index 00000000..dcd31fbc
+index 00000000..d5bc6149
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,60 @@
 +package com.destroystokyo.paper.console;
 +
 +import net.minecraft.server.DedicatedServer;
 +import net.minecrell.terminalconsole.TerminalConsoleAppender;
 +import org.bukkit.craftbukkit.command.ConsoleCommandCompleter;
++import org.jline.reader.EndOfFileException;
 +import org.jline.reader.LineReader;
 +import org.jline.reader.LineReaderBuilder;
 +import org.jline.reader.UserInterruptException;
@@ -152,7 +153,13 @@ index 00000000..dcd31fbc
 +        try {
 +            String line;
 +            while (!server.isStopped() && server.isRunning()) {
-+                line = reader.readLine("> ");
++                try {
++                    line = reader.readLine("> ");
++                } catch (EndOfFileException ignored) {
++                    // Continue reading after EOT
++                    continue;
++                }
++
 +                if (line == null) {
 +                    break;
 +                }


### PR DESCRIPTION
There is usually no reason to stop reading from the console, so preventing console input after EOT can be extremely confusing.

To prevent this, we can simply ignore the exception thrown by JLine and continue reading normally.