### PR TITLE
Avoid using System.out for colored messages

### DIFF
--- a/Spigot-Server-Patches/0211-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0211-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 8b416ec6a4a7b59a7f1c5cee2f6d1e4124b5fa62 Mon Sep 17 00:00:00 2001
+From 7a4bad77469763f9abade2275bb39ebead905f67 Mon Sep 17 00:00:00 2001
 From: Minecrell <dev@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -20,7 +20,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index cf00ee13d..96f87cb68 100644
+index cf00ee13..96f87cb6 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -47,12 +47,6 @@
@@ -96,26 +96,30 @@ index cf00ee13d..96f87cb68 100644
                  <groupId>org.apache.maven.plugins</groupId>
 diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
 new file mode 100644
-index 000000000..24f30efbb
+index 00000000..685deaa0
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,17 @@
 +package com.destroystokyo.paper.console;
 +
++import org.apache.logging.log4j.LogManager;
++import org.apache.logging.log4j.Logger;
 +import org.bukkit.craftbukkit.command.CraftConsoleCommandSender;
 +
 +public class TerminalConsoleCommandSender extends CraftConsoleCommandSender {
 +
++    private static final Logger LOGGER = LogManager.getRootLogger();
++
 +    @Override
 +    public void sendRawMessage(String message) {
-+        // Print message with colors
-+        System.out.println(message);
++        // TerminalConsoleAppender supports color codes directly in log messages
++        LOGGER.info(message);
 +    }
 +
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
 new file mode 100644
-index 000000000..d5bc61490
+index 00000000..d5bc6149
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
 @@ -0,0 +1,60 @@
@@ -180,7 +184,7 @@ index 000000000..d5bc61490
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 2feeb855b..3266df1f5 100644
+index 2feeb855..3266df1f 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -73,7 +73,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -233,7 +237,7 @@ index 2feeb855b..3266df1f5 100644
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d84f59da1..8ca8fdceb 100644
+index d84f59da..8ca8fdce 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -41,7 +41,6 @@ import org.apache.commons.lang3.Validate;
@@ -292,7 +296,7 @@ index d84f59da1..8ca8fdceb 100644
  
      public boolean a(int i, String s) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 0c3287823..ed0a749e1 100644
+index 0c328782..ed0a749e 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -76,8 +76,7 @@ public abstract class PlayerList {
@@ -306,7 +310,7 @@ index 0c3287823..ed0a749e1 100644
  
          this.k = new GameProfileBanList(PlayerList.a);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 463f58906..df6a75b05 100644
+index 463f5890..df6a75b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -127,7 +127,6 @@ import io.netty.buffer.ByteBuf;
@@ -332,7 +336,7 @@ index 463f58906..df6a75b05 100644
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 634cde14a..ff805c9ac 100644
+index 634cde14..ff805c9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -14,7 +14,7 @@ import java.util.logging.Logger;
@@ -374,7 +378,7 @@ index 634cde14a..ff805c9ac 100644
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java b/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
 deleted file mode 100644
-index 26a2fb894..000000000
+index 26a2fb89..00000000
 --- a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
 +++ /dev/null
 @@ -1,74 +0,0 @@
@@ -453,7 +457,7 @@ index 26a2fb894..000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
-index 33e8ea02c..1e3aae3b8 100644
+index 33e8ea02..1e3aae3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
 @@ -8,17 +8,27 @@ import java.util.logging.Level;
@@ -532,7 +536,7 @@ index 33e8ea02c..1e3aae3b8 100644
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
-index a0cdd2317..0a1812883 100644
+index a0cdd231..0a181288 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
 @@ -19,7 +19,7 @@ public class ServerShutdownThread extends Thread {
@@ -546,7 +550,7 @@ index a0cdd2317..0a1812883 100644
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java b/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java
 deleted file mode 100644
-index b64097113..000000000
+index b6409711..00000000
 --- a/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -605,7 +609,7 @@ index b64097113..000000000
 -    }
 -}
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 5cee8f00e..08b6bb7f9 100644
+index 5cee8f00..08b6bb7f 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -1,12 +1,11 @@
@@ -635,5 +639,5 @@ index 5cee8f00e..08b6bb7f9 100644
              <AppenderRef ref="TerminalConsole" level="info"/>
          </Root>
 -- 
-2.13.0
+2.13.1
 


### PR DESCRIPTION
Fixes #757 

Messages written to System.out are automatically redirected to the root logger by CraftBukkit. However, before the messages reach the logger, they are encoded and later decoded again using the standard system encoding.

On some systems (e.g. FreeBSD), the standard system encoding is `US-ASCII` by default, which doesn't support the section sign `§` that is used for the color codes. Consequently, they will never reach the formatter that translates them into ANSI escape codes.

There is no reason to write these messages to System.out - it just adds additional overhead and the encoding problems. We can just log the messages directly with the root logger.