### PR TITLE
Fix javadoc warnings 

### DIFF
--- a/Spigot-API-Patches/0034-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-API-Patches/0034-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -1,4 +1,4 @@
-From 15b47a774783a9db24c742bb1fde6bb7c6404638 Mon Sep 17 00:00:00 2001
+From 3bac91384f39b6a374f2c3a1ef2a9622e78fc40b Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Wed, 13 Apr 2016 20:20:18 -0700
 Subject: [PATCH] Add handshake event to allow plugins to handle client
@@ -223,5 +223,5 @@ index 00000000..e44d03a2
 +    }
 +}
 -- 
-2.12.2
+2.13.2
 

--- a/Spigot-API-Patches/0035-Arrow-pickup-rule-API.patch
+++ b/Spigot-API-Patches/0035-Arrow-pickup-rule-API.patch
@@ -1,4 +1,4 @@
-From b3c6eea6591a465f977f69067e464599a533209b Mon Sep 17 00:00:00 2001
+From a3cf6f6205e8985b4c575a6028c5a4bbb5ca5ba7 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Fri, 4 Mar 2016 03:13:18 -0500
 Subject: [PATCH] Arrow pickup rule API
@@ -48,5 +48,5 @@ index 5850ab6c..a8d1826a 100644
 +    // Paper end
  }
 -- 
-2.13.0
+2.13.2
 

--- a/Spigot-API-Patches/0036-EntityRegainHealthEvent-isFastRegen-API.patch
+++ b/Spigot-API-Patches/0036-EntityRegainHealthEvent-isFastRegen-API.patch
@@ -1,11 +1,11 @@
-From 7d6cfc99f472097c25b7b7a2ea575724d7edaa5c Mon Sep 17 00:00:00 2001
+From 0d97df2900c479d7713b9b02c3eaeb6624c6a1c1 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Fri, 22 Apr 2016 01:43:11 -0500
 Subject: [PATCH] EntityRegainHealthEvent isFastRegen API
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java b/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
-index c7e9ba6f..3ffc7273 100644
+index 1dd50c56..74fc12e9 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityRegainHealthEvent.java
 @@ -13,12 +13,31 @@ public class EntityRegainHealthEvent extends EntityEvent implements Cancellable
@@ -41,5 +41,5 @@ index c7e9ba6f..3ffc7273 100644
      /**
       * Gets the amount of regained health
 -- 
-2.12.2
+2.13.2
 

--- a/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From 50003066efa98b371abd15832192860bd0142e93 Mon Sep 17 00:00:00 2001
+From f7bf3b52cb8544319a06bd35ffd803c7e488a6c2 Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:16:39 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -55,7 +55,7 @@ index 30d60247..938959aa 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 6e9fc84f..6f733fe0 100644
+index f1e9f200..c6613c0a 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
 @@ -280,4 +280,10 @@ public class SimpleCommandMap implements CommandMap {
@@ -97,5 +97,5 @@ index 040509c1..0069bcc0 100644
                  confirmed = true;
              } else {
 -- 
-2.13.0.windows.1
+2.13.2
 

--- a/Spigot-API-Patches/0057-Add-UnknownCommandEvent.patch
+++ b/Spigot-API-Patches/0057-Add-UnknownCommandEvent.patch
@@ -1,4 +1,4 @@
-From e044b4907713d4e48736de551bd97da999966ac1 Mon Sep 17 00:00:00 2001
+From d84e33b34c717e1200495f444aeb93582a7086e0 Mon Sep 17 00:00:00 2001
 From: Sweepyoface <github@sweepy.pw>
 Date: Sat, 17 Jun 2017 18:48:06 -0400
 Subject: [PATCH] Add UnknownCommandEvent
@@ -6,10 +6,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 diff --git a/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
 new file mode 100644
-index 00000000..73f99907
+index 00000000..19d634c3
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
-@@ -0,0 +1,75 @@
+@@ -0,0 +1,77 @@
 +package org.bukkit.event.command;
 +
 +import org.bukkit.command.CommandSender;
@@ -70,6 +70,8 @@ index 00000000..73f99907
 +     * Sets message that will be returned
 +     * <p>
 +     * Set to null to avoid any message being sent
++     *
++     * @param message the message to be returned, or null
 +     */
 +    public void setMessage(String message) {
 +        this.message = message;
@@ -86,5 +88,5 @@ index 00000000..73f99907
 +}
 +
 -- 
-2.13.0.windows.1
+2.13.2
 

--- a/Spigot-API-Patches/0059-Profile-Lookup-Events.patch
+++ b/Spigot-API-Patches/0059-Profile-Lookup-Events.patch
@@ -1,4 +1,4 @@
-From e9962451b7d9b18132004f808364cb76fc3fe0cb Mon Sep 17 00:00:00 2001
+From 6621b1acfb0898fa33bd6d3461ebff382a569465 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 17 Jun 2017 16:30:44 -0400
 Subject: [PATCH] Profile Lookup Events
@@ -26,10 +26,10 @@ index 862910e0..c2922a7b 100644
              <artifactId>fastutil-lite</artifactId>
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java
 new file mode 100644
-index 00000000..b46a1878
+index 00000000..6074ecde
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/LookupProfileEvent.java
-@@ -0,0 +1,44 @@
+@@ -0,0 +1,43 @@
 +package com.destroystokyo.paper.event.profile;
 +
 +import com.mojang.authlib.GameProfile;
@@ -41,7 +41,6 @@ index 00000000..b46a1878
 +
 +/**
 + * Allows a plugin to be notified anytime AFTER a Profile has been looked up from the Mojang API
-+ *
 + * This is an opportunity to view the response and potentially cache things.
 + *
 + * No guarantees are made about thread execution context for this event. If you need to know, check
@@ -59,7 +58,7 @@ index 00000000..b46a1878
 +    }
 +
 +    /**
-+     * The profile that was recently looked up. This profile can be mutated
++     * @return The profile that was recently looked up. This profile can be mutated
 +     */
 +    @Nonnull
 +    public GameProfile getProfile() {
@@ -76,10 +75,10 @@ index 00000000..b46a1878
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java
 new file mode 100644
-index 00000000..16f43b0f
+index 00000000..750b9334
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/PreLookupProfileEvent.java
-@@ -0,0 +1,152 @@
+@@ -0,0 +1,155 @@
 +package com.destroystokyo.paper.event.profile;
 +
 +import com.google.common.collect.Multimap;
@@ -123,8 +122,7 @@ index 00000000..16f43b0f
 +    }
 +
 +    /**
-+     * Name of the player to look up a profile for
-+     * @return
++     * @return Name of the profile
 +     */
 +    @Nonnull
 +    public String getName() {
@@ -132,7 +130,7 @@ index 00000000..16f43b0f
 +    }
 +
 +    /**
-+     * The UUID of the profile if it has already been provided by a plugin
++     *  @return The UUID of the profile if it has already been provided by a plugin
 +     *
 +     * If this value is left null by the completion of the event call, then the server will
 +     * trigger a call to the Mojang API to look up the UUID (Network Request), and subsequently, fire a
@@ -147,6 +145,8 @@ index 00000000..16f43b0f
 +     * Sets the UUID for this player name. This will skip the initial API call to find the players UUID.
 +     *
 +     * However, if Profile Properties are needed by the server, you must also set them or else an API call will still be made.
++     *
++     * @param uuid the UUID to set on the {@link GameProfile} or null to reset
 +     */
 +    public void setUUID(@Nullable UUID uuid) {
 +        this.uuid = uuid;
@@ -154,6 +154,8 @@ index 00000000..16f43b0f
 +
 +    /**
 +     * Get the properties for this profile
++     *
++     * @return the property map to attach to the new {@link GameProfile}
 +     */
 +    @Nonnull
 +    public Multimap<String, Property> getProperties() {
@@ -162,7 +164,7 @@ index 00000000..16f43b0f
 +
 +    /**
 +     * Completely replaces all Properties with the new provided properties
-+     * @param properties
++     * @param properties the properties to set on the new profile
 +     */
 +    public void setProperties(Multimap<String, Property> properties) {
 +        this.properties = new PropertyMap();
@@ -171,7 +173,7 @@ index 00000000..16f43b0f
 +
 +    /**
 +     * Adds additional properties, without removing the original properties
-+     * @param properties
++     * @param properties the properties to add to the existing properties
 +     */
 +    public void addProperties(Multimap<String, Property> properties) {
 +        this.properties.putAll(properties);
@@ -185,7 +187,7 @@ index 00000000..16f43b0f
 +        return handlers;
 +    }
 +
-+    /**
++    /*
 +     * Wraps the Profile Repository so we can intercept all lookups
 +     */
 +    public static GameProfileRepository wrapProfileRepository(final GameProfileRepository orig) {
@@ -233,5 +235,5 @@ index 00000000..16f43b0f
 +    }
 +}
 -- 
-2.13.0
+2.13.2
 

--- a/Spigot-Server-Patches/0083-Use-a-Shared-Random-for-Entities.patch
+++ b/Spigot-Server-Patches/0083-Use-a-Shared-Random-for-Entities.patch
@@ -1,4 +1,4 @@
-From a5dc590c23d883f4eda7cd93a563cdf3646b04da Mon Sep 17 00:00:00 2001
+From 19fdfda935458294c463662d6fe7826d4a3dbe36 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 22 Mar 2016 00:33:47 -0400
 Subject: [PATCH] Use a Shared Random for Entities
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index f26a438a..8aba80c0 100644
+index f26a438af..8aba80c07 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -46,6 +46,7 @@ public abstract class Entity implements ICommandListener {
@@ -27,5 +27,5 @@ index f26a438a..8aba80c0 100644
          this.justCreated = true;
          this.uniqueID = MathHelper.a(this.random);
 -- 
-2.13.1.windows.2
+2.13.2
 

--- a/Spigot-Server-Patches/0084-Don-t-teleport-dead-entities.patch
+++ b/Spigot-Server-Patches/0084-Don-t-teleport-dead-entities.patch
@@ -1,4 +1,4 @@
-From 2dfb489e7082a288341115f352fa8f1ceaac2390 Mon Sep 17 00:00:00 2001
+From c3c56b603e7a6e484edc30051a35ec44d8e4ce24 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 22 Mar 2016 00:55:23 -0400
 Subject: [PATCH] Don't teleport dead entities
@@ -7,7 +7,7 @@ Had some issue with this in past, and this is the vanilla logic.
 Potentially an old CB change that's no longer needed.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 8aba80c0..9bd55e6a 100644
+index 8aba80c07..9bd55e6a4 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2344,7 +2344,7 @@ public abstract class Entity implements ICommandListener {
@@ -20,5 +20,5 @@ index 8aba80c0..9bd55e6a 100644
              WorldServer worldserver1 = ((CraftWorld) exit.getWorld()).getHandle();
              int i = worldserver1.dimension;
 -- 
-2.13.1.windows.2
+2.13.2
 

--- a/Spigot-Server-Patches/0089-Access-items-by-EquipmentSlot.patch
+++ b/Spigot-Server-Patches/0089-Access-items-by-EquipmentSlot.patch
@@ -1,11 +1,11 @@
-From 285fe26f0a72087b51c40caee4383d985340d523 Mon Sep 17 00:00:00 2001
+From 1c3f66e29a58bdc85e459e793173d4febc431df3 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Sun, 20 Mar 2016 06:45:01 -0400
 Subject: [PATCH] Access items by EquipmentSlot
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
-index 67c54899..3f58c34e 100644
+index 67c54899d..3f58c34e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 @@ -267,4 +267,54 @@ public class CraftInventoryPlayer extends CraftInventory implements org.bukkit.i
@@ -64,5 +64,5 @@ index 67c54899..3f58c34e 100644
 +    // Paper end
  }
 -- 
-2.13.1.windows.2
+2.13.2
 

--- a/Spigot-Server-Patches/0137-Ensure-Chunks-never-ever-load-async.patch
+++ b/Spigot-Server-Patches/0137-Ensure-Chunks-never-ever-load-async.patch
@@ -1,4 +1,4 @@
-From 7b4cbe6b40ee2d8ac0d77cf139660f6c6a14c67c Mon Sep 17 00:00:00 2001
+From 9730d2878ba52d008ec23a7a90d9f29d7e5c3c58 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 27 May 2016 21:41:26 -0400
 Subject: [PATCH] Ensure Chunks never ever load async
@@ -6,7 +6,7 @@ Subject: [PATCH] Ensure Chunks never ever load async
 Safely pushes the operation to main thread, then back to the posting thread
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java
-index 7b7a3d01..9aaca21a 100644
+index 7b7a3d01b..9aaca21a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java
 +++ b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOExecutor.java
 @@ -4,6 +4,7 @@ import com.destroystokyo.paper.PaperConfig;
@@ -27,7 +27,7 @@ index 7b7a3d01..9aaca21a 100644
  
      public static void queueChunkLoad(World world, ChunkRegionLoader loader, ChunkProviderServer provider, int x, int z, Runnable runnable) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
-index b5efb9c3..ef9529ad 100644
+index b5efb9c3f..ef9529add 100644
 --- a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 +++ b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 @@ -35,8 +35,8 @@ class ChunkIOProvider implements AsynchronousExecutor.CallBackProvider<QueuedChu
@@ -42,5 +42,5 @@ index b5efb9c3..ef9529ad 100644
              return;
          }
 -- 
-2.13.1.windows.2
+2.13.2
 

--- a/Spigot-Server-Patches/0163-Don-t-load-Chunks-from-Hoppers-and-other-things.patch
+++ b/Spigot-Server-Patches/0163-Don-t-load-Chunks-from-Hoppers-and-other-things.patch
@@ -1,4 +1,4 @@
-From cf363a68d18e65658c23d194ed1afde9d6003559 Mon Sep 17 00:00:00 2001
+From d0208ddeb0656fc10f3a833b77b3d2b495d304b7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Nov 2016 20:28:12 -0400
 Subject: [PATCH] Don't load Chunks from Hoppers and other things
@@ -13,7 +13,7 @@ This of course is undesirable, so just return the loaded side as "primary"
 and treat it as a single chest if the other sides are unloaded
 
 diff --git a/src/main/java/net/minecraft/server/BlockChest.java b/src/main/java/net/minecraft/server/BlockChest.java
-index bc398ec5..90267a1f 100644
+index bc398ec52..90267a1fb 100644
 --- a/src/main/java/net/minecraft/server/BlockChest.java
 +++ b/src/main/java/net/minecraft/server/BlockChest.java
 @@ -339,7 +339,13 @@ public class BlockChest extends BlockTileEntity {
@@ -32,5 +32,5 @@ index bc398ec5..90267a1f 100644
                      if (block == this) {
                          if (this.e(world, blockposition1)) {
 -- 
-2.13.1.windows.2
+2.13.2
 


### PR DESCRIPTION
Because the irony of 0052-Fix-upstream-javadoc-warnings-and-errors.patch was killing me