### PR TITLE
Add missing coverages for getTileEntity in order to attempt to avoid exeptions when calling getTileEntity

### DIFF
--- a/Spigot-Server-Patches/0223-Add-missing-coverages-for-getTileEntity-in-order-to-.patch
+++ b/Spigot-Server-Patches/0223-Add-missing-coverages-for-getTileEntity-in-order-to-.patch
@@ -1,0 +1,28 @@
+From 2b0c67ca443f56e8348ac59c4c17d97904c2529b Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Sat, 22 Jul 2017 15:22:59 +0100
+Subject: [PATCH] Add missing coverages for getTileEntity in order to attempt
+ to avoid exeptions when calling getTileEntity
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index bde48b692..34a974617 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -234,6 +234,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+                 result = fixTileEntity(pos, type, result);
+             }
+         }
++        // Paper Start - add TE fix checks for shulkers, see nms.BlockShulkerBox
++        else if (type instanceof BlockShulkerBox) {
++            if (!(result instanceof TileEntityShulkerBox)) {
++                result = fixTileEntity(pos, type, result);
++            }
++        }
++        // Paper end
+ 
+         return result;
+     }
+-- 
+2.13.3
+


### PR DESCRIPTION
while looking over #791, I noticed that this method was missing the case in order to attempt to fix issues with shulker boxes. in specific, this patch will not fix #791 which I feel is a case of a plugin modifying the world async, but will aid in recovering any potential damage to the world that has occured once the causation has been removed from the server.

it's due to this logic, I cannot potentially see how #791 can even occur beyond something somehow slipping between bukkits getState() type lookup, and the type lookup that occurs in NMS while it actually grabs the TE from the world.

(This is also the fixed version of the commit, not the sleep deprived commit that ended up on my repo, oops)

I'm somewhat dubious on maintaining this due to the obfuscated fields, the fact that this really belongs up the stream and not down here, and the missing case for pistons which considering how long pistons have been in the game I can't see if it's just a case of "it was missed" or if it's intentional for some reason...