### PR TITLE
Check Version when using CLI Version Flag

### DIFF
--- a/Spigot-API-Patches/0065-Expose-VersionCommand-getDistance.patch
+++ b/Spigot-API-Patches/0065-Expose-VersionCommand-getDistance.patch
@@ -1,0 +1,22 @@
+From 5f91c4d15842d290b05d0a0852beeb08a2254e71 Mon Sep 17 00:00:00 2001
+From: willies952002 <admin@domnian.com>
+Date: Sat, 29 Jul 2017 12:12:58 -0400
+Subject: [PATCH] Expose VersionCommand#getDistance()
+
+
+diff --git a/src/main/java/org/bukkit/command/defaults/VersionCommand.java b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
+index aae605e9..5e0ea390 100644
+--- a/src/main/java/org/bukkit/command/defaults/VersionCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/VersionCommand.java
+@@ -242,7 +242,7 @@ public class VersionCommand extends BukkitCommand {
+     }
+ 
+     // Paper start
+-    private static int getDistance(String repo, String verInfo) {
++    public static int getDistance(String repo, String verInfo) { // PR-841 private -> public
+         try {
+             int currentVer = Integer.decode(verInfo);
+             return getFromJenkins(currentVer);
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0041-Send-absolute-position-the-first-time-an-entity-is-s.patch
+++ b/Spigot-Server-Patches/0041-Send-absolute-position-the-first-time-an-entity-is-s.patch
@@ -1,11 +1,11 @@
-From e2339144ecaec2b719659708e3567d04d491cdb3 Mon Sep 17 00:00:00 2001
+From 06ff7f09fcb37de6a762125302344e26ad81de30 Mon Sep 17 00:00:00 2001
 From: Jedediah Smith <jedediah@silencegreys.com>
 Date: Wed, 2 Mar 2016 23:13:07 -0600
 Subject: [PATCH] Send absolute position the first time an entity is seen
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
-index 1493f9ab3..f542bf491 100644
+index d864c7745..4c6eb6ed1 100644
 --- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 +++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 @@ -41,7 +41,12 @@ public class EntityTrackerEntry {
@@ -76,5 +76,5 @@ index 1493f9ab3..f542bf491 100644
  
                      entityplayer.playerConnection.sendPacket(packet);
 -- 
-2.12.2
+2.11.0
 

--- a/Spigot-Server-Patches/0042-Add-BeaconEffectEvent.patch
+++ b/Spigot-Server-Patches/0042-Add-BeaconEffectEvent.patch
@@ -1,11 +1,11 @@
-From 3308547d075d0d0e431b0273cfba7fcc8d38444b Mon Sep 17 00:00:00 2001
+From aed1459f48f786768591800ff0941d837e906d44 Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Wed, 2 Mar 2016 23:30:53 -0600
 Subject: [PATCH] Add BeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityBeacon.java b/src/main/java/net/minecraft/server/TileEntityBeacon.java
-index 6f2fcd22e..71ecc5493 100644
+index 0810d48bd..37b837123 100644
 --- a/src/main/java/net/minecraft/server/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/server/TileEntityBeacon.java
 @@ -16,6 +16,14 @@ import org.bukkit.entity.HumanEntity;
@@ -69,5 +69,5 @@ index 6f2fcd22e..71ecc5493 100644
          }
  
 -- 
-2.12.2
+2.11.0
 

--- a/Spigot-Server-Patches/0230-Check-Verison-when-using-CLI-Version-Flag.patch
+++ b/Spigot-Server-Patches/0230-Check-Verison-when-using-CLI-Version-Flag.patch
@@ -1,0 +1,53 @@
+From 814e728cc82bfcac24ab95113048459a2c8840f3 Mon Sep 17 00:00:00 2001
+From: willies952002 <admin@domnian.com>
+Date: Sat, 29 Jul 2017 12:13:51 -0400
+Subject: [PATCH] Check Verison when using CLI Version Flag
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index d3d848f8c..c3edb95a2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -15,6 +15,9 @@ import joptsimple.OptionParser;
+ import joptsimple.OptionSet;
+ import net.minecraft.server.MinecraftServer;
+ import net.minecrell.terminalconsole.TerminalConsoleAppender; // Paper
++import org.bukkit.Bukkit;
++import org.bukkit.command.defaults.VersionCommand;
++import org.bukkit.craftbukkit.util.Versioning;
+ 
+ public class Main {
+     public static boolean useJline = true;
+@@ -160,7 +163,28 @@ public class Main {
+                 Logger.getLogger(Main.class.getName()).log(Level.SEVERE, null, ex);
+             }
+         } else if (options.has("v")) {
+-            System.out.println(CraftServer.class.getPackage().getImplementationVersion());
++            // Paper start - Check version when doing --version
++            String version = CraftServer.class.getPackage().getImplementationVersion();
++            if (version == null) version = "Custom";
++            System.out.println("Current Version: " + version);
++            if (version.startsWith("git-Paper-")) {
++                String[] parts = version.substring("git-Paper-".length()).split("[-\\s]");
++                int distance = VersionCommand.getDistance(null, parts[0]);
++                switch (distance) {
++                    case -1:
++                        System.out.println("Error obtaining version information");
++                        break;
++                    case 0:
++                        System.out.println("You are running the latest version");
++                        break;
++                    case -2:
++                        System.out.println("Unknown version");
++                        break;
++                    default:
++                        System.out.println("You are " + distance + " version(s) behind");
++                }
++            }
++            // Paper end
+         } else {
+             // Do you love Java using + and ! as string based identifiers? I sure do!
+             String path = new File(".").getAbsolutePath();
+-- 
+2.11.0
+


### PR DESCRIPTION
A small, but possibly useful change. Instead of having to start the server to do ```/ver[sion]``` to see how far behind you are in versions, make it so when someone does uses the ```--version``` flag, it also does a version check.