### PR TITLE
Max exp value when merging orbs

### DIFF
--- a/Spigot-API-Patches/0054-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-API-Patches/0054-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -1,14 +1,14 @@
-From a53027c798480be3017e4e592c0f8667e63bc612 Mon Sep 17 00:00:00 2001
+From 409f5510dda42a7cfd18698436fc766df133c4e2 Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 7 May 2017 06:26:01 -0500
 Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
-index 29f03f5d..da19009b 100644
+index c76f423e..46c6d519 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerPickupItemEvent.java
-@@ -14,6 +14,7 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
+@@ -16,6 +16,7 @@ import org.bukkit.event.entity.EntityPickupItemEvent;
  public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
      private static final HandlerList handlers = new HandlerList();
      private final Item item;
@@ -16,7 +16,7 @@ index 29f03f5d..da19009b 100644
      private boolean cancel = false;
      private final int remaining;
  
-@@ -41,12 +42,34 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
+@@ -43,12 +44,34 @@ public class PlayerPickupItemEvent extends PlayerEvent implements Cancellable {
          return remaining;
      }
  
@@ -52,5 +52,5 @@ index 29f03f5d..da19009b 100644
  
      @Override
 -- 
-2.13.3
+2.13.0
 

--- a/Spigot-Server-Patches/0223-Fix-Recipe-Books.patch
+++ b/Spigot-Server-Patches/0223-Fix-Recipe-Books.patch
@@ -1,11 +1,11 @@
-From 9f86985393516537a52bbe0b3a899df08c65410e Mon Sep 17 00:00:00 2001
+From 69aecad8ffaaa88760f8c3b0b152cc80ec669eb0 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 26 Jul 2017 21:12:15 -0400
 Subject: [PATCH] Fix Recipe Books
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 682211cdd..5b9021939 100644
+index 682211cdd..034081cbe 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -2027,12 +2027,6 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -21,20 +21,29 @@ index 682211cdd..5b9021939 100644
          if (this.player.activeContainer.windowId == packetplayinautorecipe.a() && this.player.activeContainer.c(this.player)) {
              this.player.playerConnection.sendPacket(new PacketPlayOutTransaction(packetplayinautorecipe.a(), packetplayinautorecipe.b(), true));
              Iterator iterator;
-@@ -2046,7 +2040,11 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -2046,10 +2040,19 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                  while (iterator.hasNext()) {
                      packetplayinautorecipe_a = (PacketPlayInAutoRecipe.a) iterator.next();
                      itemstack = this.player.activeContainer.getSlot(packetplayinautorecipe_a.b).getItem();
 -                    if (this.a(packetplayinautorecipe_a.a, itemstack)) {
 +                    // Paper start - improve validation
-+                    ItemStack to = this.player.inventory.getItem(packetplayinautorecipe_a.c);
++                    int toSlot = packetplayinautorecipe_a.c;
++                    ItemStack to = toSlot != -1 ? this.player.inventory.getItem(toSlot) : ItemStack.a;
 +                    ItemStack ref = packetplayinautorecipe_a.a;
 +                    if (this.a(ref, itemstack) && (to.isEmpty() || this.a(ref, to)) && (ref.getCount() + to.getCount() <= ref.getMaxStackSize())) {
 +                        // Paper end
                          i = packetplayinautorecipe_a.a.getCount();
                          if (packetplayinautorecipe_a.c == -1) {
-                             this.player.drop(packetplayinautorecipe_a.a, true);
-@@ -2066,6 +2064,12 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+-                            this.player.drop(packetplayinautorecipe_a.a, true);
++                            // Paper start
++                            this.player.drop(itemstack, true);
++                            this.player.activeContainer.setItem(packetplayinautorecipe_a.b, ItemStack.a);
++                            continue;
++                            // Paper end
+                         } else {
+                             ItemStack itemstack1 = this.player.inventory.getItem(packetplayinautorecipe_a.c);
+ 
+@@ -2066,6 +2069,12 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                              itemstack.subtract(i);
                          }
                      }
@@ -47,7 +56,7 @@ index 682211cdd..5b9021939 100644
                  }
              }
  
-@@ -2075,7 +2079,11 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -2075,7 +2084,11 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                  while (iterator.hasNext()) {
                      packetplayinautorecipe_a = (PacketPlayInAutoRecipe.a) iterator.next();
                      itemstack = this.player.inventory.getItem(packetplayinautorecipe_a.c);
@@ -55,12 +64,12 @@ index 682211cdd..5b9021939 100644
 +                    // Paper start
 +                    ItemStack ref = packetplayinautorecipe_a.a;
 +                    ItemStack to = this.player.activeContainer.getSlot(packetplayinautorecipe_a.b).getItem();
-+                    if (this.a(ref, itemstack) && (ref.getCount() + to.getCount() <= ref.getMaxStackSize())) {
++                    if (this.a(ref, itemstack) && (to.isEmpty() || this.a(ref, to)) && (ref.getCount() + to.getCount() <= ref.getMaxStackSize())) {
 +                        // Paper end
                          i = packetplayinautorecipe_a.a.getCount();
                          if (itemstack.getCount() == i) {
                              this.player.inventory.splitWithoutUpdate(packetplayinautorecipe_a.c);
-@@ -2083,8 +2091,17 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -2083,8 +2096,17 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                              itemstack.subtract(i);
                          }
  
@@ -80,5 +89,5 @@ index 682211cdd..5b9021939 100644
              }
  
 -- 
-2.13.3
+2.13.0
 

--- a/Spigot-Server-Patches/0230-Max-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0230-Max-exp-value-when-merging-orbs.patch
@@ -1,0 +1,56 @@
+From 816afd86742abe7989370399ba2f49c486c39358 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 31 Jul 2017 01:35:54 -0500
+Subject: [PATCH] Max exp value when merging orbs
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 54d081fd..e0977149 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -428,4 +428,10 @@ public class PaperWorldConfig {
+         disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
+         log("Creeper lingering effect: " + disableCreeperLingeringEffect);
+     }
++
++    public int expMergeMaxValue;
++    private void expMergeMaxValue() {
++        expMergeMaxValue = getInt("exp-merge-max-value", 0);
++        log("Experience Merge Max Value: " + expMergeMaxValue);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 9dfc2b4d..2975649b 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1,4 +1,4 @@
+-	package net.minecraft.server;
++package net.minecraft.server;
+ 
+ import com.destroystokyo.paper.event.server.ServerExceptionEvent;
+ import com.destroystokyo.paper.exception.ServerInternalException;
+@@ -1146,12 +1146,20 @@ public abstract class World implements IBlockAccess {
+             EntityExperienceOrb xp = (EntityExperienceOrb) entity;
+             double radius = spigotConfig.expMerge;
+             if (radius > 0) {
++                int maxValue = paperConfig.expMergeMaxValue; // Paper
+                 List<Entity> entities = this.getEntities(entity, entity.getBoundingBox().grow(radius, radius, radius));
+                 for (Entity e : entities) {
+                     if (e instanceof EntityExperienceOrb) {
+                         EntityExperienceOrb loopItem = (EntityExperienceOrb) e;
+-                        if (!loopItem.dead) {
++                        if (!loopItem.dead && !(maxValue > 0 && loopItem.value >= maxValue)) { // Paper
+                             xp.value += loopItem.value;
++                            // Paper start
++                            if (maxValue > 0 && xp.value > maxValue) {
++                                loopItem.value = xp.value - maxValue;
++                                xp.value = maxValue;
++                                break;
++                            }
++                            // Paper end
+                             loopItem.die();
+                         }
+                     }
+-- 
+2.11.0
+


### PR DESCRIPTION
This makes it so there is a maximum value per exp orb when performing the merge task. This effectively fixes some scenarios where an explosion of exp orbs are desired, but still gain the benefits of merging too many exp orbs together. An example would be the explosion/shower of exp orbs when killing the ender dragon. Instead of having one orb worth thousands of points or thousands of orbs worth a few points, you can effectively have hundreds of orbs with hundreds of points.