### PR TITLE
Reset spawner timer when spawner event is cancelled

### DIFF
--- a/Spigot-Server-Patches/0230-Reset-spawner-timer-when-spawner-event-is-cancelled.patch
+++ b/Spigot-Server-Patches/0230-Reset-spawner-timer-when-spawner-event-is-cancelled.patch
@@ -1,0 +1,32 @@
+From 92617e0faa93936b619afc70bcc11c9f3d5e395e Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 31 Jul 2017 01:45:19 -0500
+Subject: [PATCH] Reset spawner timer when spawner event is cancelled
+
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+index a5b5ef0f..b5c9c28a 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+@@ -112,6 +112,9 @@ public abstract class MobSpawnerAbstract {
+                         {
+                             entity.fromMobSpawner = true;
+                         }
++
++                        flag = true; // Paper
++
+                         if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, blockposition).isCancelled()) {
+                             continue;
+                         }
+@@ -122,7 +125,7 @@ public abstract class MobSpawnerAbstract {
+                             entityinsentient.doSpawnEffect();
+                         }
+ 
+-                        flag = true;
++                        /*flag = true;*/ // Paper - moved up above cancellable event
+                     }
+                 }
+ 
+-- 
+2.11.0
+


### PR DESCRIPTION
When cancelling the SpawnerSpawnEvent this resets the timer used to trigger the next spawn attempt instead of spamming the event every tick.