### PR TITLE
LivingEntity#setKiller

### DIFF
--- a/Spigot-API-Patches/0065-LivingEntity-setKiller.patch
+++ b/Spigot-API-Patches/0065-LivingEntity-setKiller.patch
@@ -1,0 +1,38 @@
+From 7931a0efec0fa1fb23a09836863f5961b2dbf7c4 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 31 Jul 2017 01:49:43 -0500
+Subject: [PATCH] LivingEntity#setKiller
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index d6597ca7..5e2fa46c 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -14,6 +14,8 @@ import org.bukkit.potion.PotionEffect;
+ import org.bukkit.potion.PotionEffectType;
+ import org.bukkit.projectiles.ProjectileSource;
+ 
++import javax.annotation.Nullable;
++
+ /**
+  * Represents a living entity, such as a monster or player
+  */
+@@ -198,6 +200,15 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+      */
+     public Player getKiller();
+ 
++    // Paper start
++    /**
++     * Sets the player identified as the killer of the living entity.
++     *
++     * @param killer player
++     */
++    public void setKiller(@Nullable Player killer);
++    // Paper end
++
+     /**
+      * Adds the given {@link PotionEffect} to the living entity.
+      * <p>
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0230-LivingEntity-setKiller.patch
+++ b/Spigot-Server-Patches/0230-LivingEntity-setKiller.patch
@@ -1,0 +1,30 @@
+From f6ced6606afb1efd02705d46f52280d4f4732c07 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 31 Jul 2017 01:49:48 -0500
+Subject: [PATCH] LivingEntity#setKiller
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 3c3e8b87..640ade4f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -293,6 +293,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         return getHandle().killer == null ? null : (Player) getHandle().killer.getBukkitEntity();
+     }
+ 
++    // Paper start
++    @Override
++    public void setKiller(Player killer) {
++        EntityPlayer entityPlayer = killer == null ? null : ((CraftPlayer) killer).getHandle();
++        getHandle().killer = entityPlayer;
++        getHandle().lastDamager = entityPlayer;
++        getHandle().lastDamageByPlayerTime = entityPlayer == null ? 0 : 100;
++    }
++    // Paper end
++
+     public boolean addPotionEffect(PotionEffect effect) {
+         return addPotionEffect(effect, false);
+     }
+-- 
+2.11.0
+


### PR DESCRIPTION
Allow plugins to set the killer of a LivingEntity.

This is useful for when plugins remove entities manually but still want other plugins to register it as killed by a player, etc.