### PR TITLE
Ocelot despawns should honor nametags and leash

### DIFF
--- a/Spigot-Server-Patches/0230-Ocelot-despawns-should-honor-nametags-and-leash.patch
+++ b/Spigot-Server-Patches/0230-Ocelot-despawns-should-honor-nametags-and-leash.patch
@@ -1,0 +1,22 @@
+From fff9aa7f3454f4c830481b7c206ec73af4ccf3d9 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 31 Jul 2017 01:54:40 -0500
+Subject: [PATCH] Ocelot despawns should honor nametags and leash
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityOcelot.java b/src/main/java/net/minecraft/server/EntityOcelot.java
+index 5a76821e..858bbef5 100644
+--- a/src/main/java/net/minecraft/server/EntityOcelot.java
++++ b/src/main/java/net/minecraft/server/EntityOcelot.java
+@@ -58,7 +58,7 @@ public class EntityOcelot extends EntityTameableAnimal {
+     }
+ 
+     protected boolean isTypeNotPersistent() {
+-        return !this.isTamed() /*&& this.ticksLived > 2400*/; // CraftBukkit
++        return !this.isTamed() && !this.hasCustomName() && !this.isLeashed() /*&& this.ticksLived > 2400*/; // CraftBukkit (ticks lived) - Paper (honor name and leash)
+     }
+ 
+     protected void initAttributes() {
+-- 
+2.11.0
+


### PR DESCRIPTION
This makes ocelots follow standard despawning conventions like all other living entities. If they have a custom name or are leashed they should not despawn.