### PR TITLE
MC-94186 Fix dragon egg falling in lazy chunks

### DIFF
--- a/Spigot-Server-Patches/0232-MC-94186-Fix-dragon-egg-falling-in-lazy-chunks.patch
+++ b/Spigot-Server-Patches/0232-MC-94186-Fix-dragon-egg-falling-in-lazy-chunks.patch
@@ -1,0 +1,25 @@
+From e9577b1f4799d717f92f48e7335c87ecd0148ac5 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Fri, 11 Aug 2017 03:29:26 +0200
+Subject: [PATCH] MC-94186 Fix dragon egg falling in lazy chunks
+
+Fixes falling dragon eggs in lazy chunks fall to the block below the last empty block and replacing that block with them.
+
+See also https://bugs.mojang.com/browse/MC-94186
+
+diff --git a/src/main/java/net/minecraft/server/BlockDragonEgg.java b/src/main/java/net/minecraft/server/BlockDragonEgg.java
+index ce186f8..521fa4a 100644
+--- a/src/main/java/net/minecraft/server/BlockDragonEgg.java
++++ b/src/main/java/net/minecraft/server/BlockDragonEgg.java
+@@ -44,7 +44,7 @@ public class BlockDragonEgg extends Block {
+                 }
+ 
+                 if (blockposition1.getY() > 0) {
+-                    world.setTypeAndData(blockposition1, this.getBlockData(), 2);
++                    world.setTypeAndData(blockposition1.up(), this.getBlockData(), 2);
+                 }
+             }
+ 
+-- 
+2.7.3.windows.1
+


### PR DESCRIPTION
Fixes falling dragon eggs in lazy chunks fall to the block below the last empty block and replacing that block with them.

See also https://bugs.mojang.com/browse/MC-94186