### PR TITLE
Fix DataPaletteBlock

### DIFF
--- a/Spigot-Server-Patches/0236-Fix-DataPaletteBlock.patch
+++ b/Spigot-Server-Patches/0236-Fix-DataPaletteBlock.patch
@@ -1,0 +1,21 @@
+From 4b29c396cabd5769d64e30e038e4003ec9ebf5ac Mon Sep 17 00:00:00 2001
+From: stonar96 <minecraft.stonar96@gmail.com>
+Date: Fri, 1 Sep 2017 23:19:15 +0200
+Subject: [PATCH] Fix DataPaletteBlock
+
+
+diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
+index 1f2fe87b..bc0a719a 100644
+--- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
++++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
+@@ -132,6 +132,6 @@ public class DataPaletteBlock implements DataPaletteExpandable {
+     }
+ 
+     public int a() {
+-        return 1 + this.c.a() + PacketDataSerializer.a(this.b.b()) + this.b.a().length * 8;
++        return 1 + this.c.a() + PacketDataSerializer.a(this.b.a().length) + this.b.a().length * 8; // Paper - replace this.b.b() with this.b.a().length (see b(PacketDataSerializer))
+     }
+ }
+-- 
+2.13.3.windows.1
+


### PR DESCRIPTION
`DataPaletteBlock#a()` is invoked in the `PacketPlayOutMapChunk` class to count the bytes to create the packet. After counting the bytes and creating the `byte[]` with the right size `DataPaletteBlock#b(PacketDataSerializer)` is invoked in the `PacketPlayOutMapChunk` class to write the data to the `byte[]`.

You can find the line `packetdataserializer.a(this.b.a());` inside `DataPaletteBlock#b(PacketDataSerializer)` which writes the `long[]` of the `DataBits` to the packet. Inside of `DataPaletteBlock#a()` these bytes are counted with `PacketDataSerializer.a(this.b.b()) + this.b.a().length * 8` but it should be `PacketDataSerializer.a(this.b.a().length) + this.b.a().length * 8`.

This PR fixes this minor vanilla inconsistency.