### PR TITLE
Remove lighting patches from spigot that cause more harm than good.

### DIFF
--- a/Spigot-Server-Patches/0243-Revert-Allow-Disabling-of-Random-Lighting-Updates.patch
+++ b/Spigot-Server-Patches/0243-Revert-Allow-Disabling-of-Random-Lighting-Updates.patch
@@ -1,0 +1,64 @@
+From ef411dffd985f22ec2d489a9af4354b2442d5e04 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Wed, 4 Oct 2017 04:19:51 +0100
+Subject: [PATCH] Revert "Allow Disabling of Random Lighting Updates"
+
+This patch by Spigot allows the disabling of chunks to be lit as they're ticked by server
+operators, the side effects of this is that there will potentially be chunks which are unlit
+with an invalid skymaps, this could have potential implications on plugins which care about
+this for checking the highest block in a region, as well as serves to just cause issues with
+invalid lighting in chunks which isn't accurately fixed.
+
+There is inherently nothing random about these light updates, they're there to ensure that
+the worlds lightmap is properly updated and disabling them only serves to cause sporadic
+lighting issues in the world.
+
+diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
+index ed5959559..d6e6f4d3e 100644
+--- a/src/main/java/net/minecraft/server/Chunk.java
++++ b/src/main/java/net/minecraft/server/Chunk.java
+@@ -1110,7 +1110,7 @@ public class Chunk {
+         }
+ 
+         this.r = true;
+-        if (!this.lit && this.done && this.world.spigotConfig.randomLightUpdates) { // Spigot - also use random light updates setting to determine if we should relight
++        if (!this.lit && this.done) {
+             this.o();
+         }
+ 
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index c03be509f..4318fe871 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -449,7 +449,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+ 
+     protected void i() {
+         this.methodProfiler.a("playerCheckLight");
+-        if (spigotConfig.randomLightUpdates && !this.players.isEmpty()) { // Spigot
++        if (!this.players.isEmpty()) {
+             int i = this.random.nextInt(this.players.size());
+             EntityHuman entityhuman = (EntityHuman) this.players.get(i);
+             int j = MathHelper.floor(entityhuman.locX) + this.random.nextInt(11) - 5;
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index 0b66f5e35..5234be42d 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -182,14 +182,7 @@ public class SpigotWorldConfig
+         hopperAmount = getInt( "hopper-amount", 1 );
+         log( "Hopper Transfer: " + hopperTransfer + " Hopper Check: " + hopperCheck + " Hopper Amount: " + hopperAmount );
+     }
+-
+-    public boolean randomLightUpdates;
+-    private void lightUpdates()
+-    {
+-        randomLightUpdates = getBoolean( "random-light-updates", false );
+-        log( "Random Lighting Updates: " + randomLightUpdates );
+-    }
+-
++    
+     public boolean saveStructureInfo;
+     private void structureInfo()
+     {
+-- 
+2.14.2
+

--- a/Spigot-Server-Patches/0244-Revert-Fix-some-chunks-not-being-sent-to-the-client.patch
+++ b/Spigot-Server-Patches/0244-Revert-Fix-some-chunks-not-being-sent-to-the-client.patch
@@ -1,0 +1,38 @@
+From 53b4f29fa7c90a534b8eed0c7e5819d81eaae968 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Wed, 4 Oct 2017 04:20:21 +0100
+Subject: [PATCH] Revert "Fix some chunks not being sent to the client"
+
+This patch actually allows chunks to be sent before lighting has been calculated in a chunk,
+causing lighting to be invalid on chunks sent to clients. as lighting is done during chunk
+population and the server tracks which chunks have been sent to the client, this is no longer
+an issue.
+
+as the server tracks what chunks have and haven't been sent to the client (and the original
+issue for this appears to have already been fixed in the server in 1.9), there is nothing
+that this patch is actually achieving as of now.
+
+diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
+index d6e6f4d3e..faa52c933 100644
+--- a/src/main/java/net/minecraft/server/Chunk.java
++++ b/src/main/java/net/minecraft/server/Chunk.java
+@@ -1128,15 +1128,7 @@ public class Chunk {
+     }
+ 
+     public boolean isReady() {
+-        // Spigot Start
+-        /*
+-         * As of 1.7, Mojang added a check to make sure that only chunks which have been lit are sent to the client.
+-         * Unfortunately this interferes with our modified chunk ticking algorithm, which will only tick chunks distant from the player on a very infrequent basis.
+-         * We cannot unfortunately do this lighting stage during chunk gen as it appears to put a lot more noticeable load on the server, than when it is done at play time.
+-         * For now at least we will simply send all chunks, in accordance with pre 1.7 behaviour.
+-         */
+-        return true;
+-        // Spigot End
++        return this.r && this.done && this.lit;
+     }
+ 
+     public boolean j() {
+-- 
+2.14.2
+


### PR DESCRIPTION
PR'ing these as I'm potentially going to leave this until #903, however as it stands the removal of these patches will likely have no effect on performance and correct rendering issues in newly generated chunks.

This commit removes two patches from spigot:
please review the patch messages for more information, however;

"Allow Disabling of Random Lighting Updates" potentially leaves chunk light maps in an invalid state, with
how often the server looks at these anyways, this patch really serves a questionable nature, the work is
going to be done, only it's being delayed and allowing the light map to be left in a potentially outdated
state.

"Fix some chunks not being sent to the client" sends chunks before their lighting has been calculated, this
means that the client will recieve chunks before they lighting has been calculated which can cause rendering
artifacts. The original issue around this patch appears to have already been fixed years ago.