### PR TITLE
Suppress offline mode warning if unnecessary

### DIFF
--- a/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
+++ b/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
@@ -1,0 +1,22 @@
+From 9a16f45a9065fc4d0d52bbf71af17159f3713684 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joshua=20Dean=20K=C3=BCpper?= <admin@joshua-kuepper.de>
+Date: Sat, 7 Oct 2017 23:49:07 +0200
+Subject: [PATCH] Suppress offline-mode-warning if unnecessary
+
+
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 85445571..95a89e4f 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -226,7 +226,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+             server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
+             // CraftBukkit end
+ 
+-            if (!this.getOnlineMode()) {
++            if (!this.getOnlineMode() && (!org.spigotmc.SpigotConfig.bungee || inetaddress == null || !inetaddress.isLoopbackAddress())) { // Paper
+                 DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
+                 DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
+                 // Spigot start
+-- 
+2.14.1.windows.1
+

--- a/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
+++ b/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
@@ -1,22 +1,46 @@
-From 9a16f45a9065fc4d0d52bbf71af17159f3713684 Mon Sep 17 00:00:00 2001
+From 2c8f657b9ec4199fac6d55c19f77466c8d54f3f6 Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joshua=20Dean=20K=C3=BCpper?= <admin@joshua-kuepper.de>
 Date: Sat, 7 Oct 2017 23:49:07 +0200
 Subject: [PATCH] Suppress offline-mode-warning if unnecessary
 
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 85445571..95a89e4f 100644
+index 85445571..1fc78976 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -226,7 +226,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-             server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
+@@ -227,17 +227,23 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              // CraftBukkit end
  
--            if (!this.getOnlineMode()) {
-+            if (!this.getOnlineMode() && (!org.spigotmc.SpigotConfig.bungee || inetaddress == null || !inetaddress.isLoopbackAddress())) { // Paper
-                 DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
-                 DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
-                 // Spigot start
+             if (!this.getOnlineMode()) {
+-                DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
+-                DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
+-                // Spigot start
+-                if (org.spigotmc.SpigotConfig.bungee) {
+-                    DedicatedServer.LOGGER.warn("Whilst this makes it possible to use BungeeCord, unless access to your server is properly restricted, it also opens up the ability for hackers to connect with any username they choose.");
+-                    DedicatedServer.LOGGER.warn("Please see http://www.spigotmc.org/wiki/firewall-guide/ for further information.");
++                if (!org.spigotmc.SpigotConfig.bungee || inetaddress == null || !inetaddress.isLoopbackAddress()) { // Paper
++                    DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
++                    DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
++                    // Spigot start
++                    if (org.spigotmc.SpigotConfig.bungee) {
++                        DedicatedServer.LOGGER.warn("Whilst this makes it possible to use BungeeCord, unless access to your server is properly restricted, it also opens up the ability for hackers to connect with any username they choose.");
++                        DedicatedServer.LOGGER.warn("Please see http://www.spigotmc.org/wiki/firewall-guide/ for further information.");
++                    } else {
++                        DedicatedServer.LOGGER.warn("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");
++                    }
++                    // Spigot end
++                    DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
++                // Paper start
+                 } else {
+-                    DedicatedServer.LOGGER.warn("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");
++                    DedicatedServer.LOGGER.info("This server is running behind BungeeCord.");
+                 }
+-                // Spigot end
+-                DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
++                // Paper end
+             }
+ 
+             if (this.aS()) {
 -- 
 2.14.1.windows.1
 

--- a/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
+++ b/Spigot-Server-Patches/0243-Suppress-offline-mode-warning-if-unnecessary.patch
@@ -1,39 +1,30 @@
-From 2c8f657b9ec4199fac6d55c19f77466c8d54f3f6 Mon Sep 17 00:00:00 2001
+From 621f09692a01cf44ac3e3e0103239adab60b0c9b Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Joshua=20Dean=20K=C3=BCpper?= <admin@joshua-kuepper.de>
 Date: Sat, 7 Oct 2017 23:49:07 +0200
 Subject: [PATCH] Suppress offline-mode-warning if unnecessary
 
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 85445571..1fc78976 100644
+index 85445571..72a20b50 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -227,17 +227,23 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -227,17 +227,16 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              // CraftBukkit end
  
              if (!this.getOnlineMode()) {
 -                DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
 -                DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
 -                // Spigot start
--                if (org.spigotmc.SpigotConfig.bungee) {
++                // Paper start
+                 if (org.spigotmc.SpigotConfig.bungee) {
 -                    DedicatedServer.LOGGER.warn("Whilst this makes it possible to use BungeeCord, unless access to your server is properly restricted, it also opens up the ability for hackers to connect with any username they choose.");
 -                    DedicatedServer.LOGGER.warn("Please see http://www.spigotmc.org/wiki/firewall-guide/ for further information.");
-+                if (!org.spigotmc.SpigotConfig.bungee || inetaddress == null || !inetaddress.isLoopbackAddress()) { // Paper
++                    DedicatedServer.LOGGER.info("This server is running behind BungeeCord.");
+                 } else {
 +                    DedicatedServer.LOGGER.warn("**** SERVER IS RUNNING IN OFFLINE/INSECURE MODE!");
 +                    DedicatedServer.LOGGER.warn("The server will make no attempt to authenticate usernames. Beware.");
-+                    // Spigot start
-+                    if (org.spigotmc.SpigotConfig.bungee) {
-+                        DedicatedServer.LOGGER.warn("Whilst this makes it possible to use BungeeCord, unless access to your server is properly restricted, it also opens up the ability for hackers to connect with any username they choose.");
-+                        DedicatedServer.LOGGER.warn("Please see http://www.spigotmc.org/wiki/firewall-guide/ for further information.");
-+                    } else {
-+                        DedicatedServer.LOGGER.warn("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");
-+                    }
-+                    // Spigot end
+                     DedicatedServer.LOGGER.warn("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");
 +                    DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
-+                // Paper start
-                 } else {
--                    DedicatedServer.LOGGER.warn("While this makes the game possible to play without internet access, it also opens up the ability for hackers to connect with any username they choose.");
-+                    DedicatedServer.LOGGER.info("This server is running behind BungeeCord.");
                  }
 -                // Spigot end
 -                DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");


### PR DESCRIPTION
The offline-mode-message takes a whopping 4-5 Lines of log-output which is why we should care about only displaying it if it's necessary/fitting. If Bungee is enabled and the server is bound to a loopback-address (127.0.0.x), the warning is completely redundant.