### PR TITLE
Deprecate player sample list that includes only the player name

### DIFF
--- a/Spigot-API-Patches/0060-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
+++ b/Spigot-API-Patches/0060-Allow-Changing-of-Player-Sample-in-ServerListPingEve.patch
@@ -1,11 +1,11 @@
-From 19295da8c04248bdc579640f5931b9818f1a61a2 Mon Sep 17 00:00:00 2001
+From 15feb50af4d9bd5aa91a5f7206db294d15e141cc Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Thu, 20 Jul 2017 18:05:36 -0400
 Subject: [PATCH] Allow Changing of Player Sample in ServerListPingEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
-index 3c38d857..84de3ce4 100644
+index 3c38d857..cb8d0fcd 100644
 --- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 +++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
 @@ -2,6 +2,7 @@ package org.bukkit.event.server;
@@ -16,16 +16,26 @@ index 3c38d857..84de3ce4 100644
  
  import org.apache.commons.lang.Validate;
  import org.bukkit.entity.Player;
-@@ -145,4 +146,15 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+@@ -145,4 +146,25 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
      public Iterator<Player> iterator() throws UnsupportedOperationException {
          throw new UnsupportedOperationException();
      }
 +
 +    // Paper start
 +    private java.util.List<String> sample;
++
++    /**
++     * @deprecated Will be replaced in 1.13
++     */
++    @Deprecated
 +    public void setSampleText(java.util.List<String> sample) {
 +        this.sample = sample;
 +    }
++
++    /**
++     * @deprecated Will be replaced in 1.13
++     */
++    @Deprecated
 +    public java.util.List<String> getSampleText() {
 +        return sample;
 +    }
@@ -33,5 +43,5 @@ index 3c38d857..84de3ce4 100644
 +
  }
 -- 
-2.14.1
+2.14.2
 


### PR DESCRIPTION
As discussed on IRC, deprecate the current player sample list in `ServerListPingEvent` so we can replace it with a new version in 1.13.

Related to #884 