### PR TITLE
Expose client protocol version and virtual host

### DIFF
--- a/Spigot-API-Patches/0071-Expose-client-protocol-version-and-virtual-host.patch
+++ b/Spigot-API-Patches/0071-Expose-client-protocol-version-and-virtual-host.patch
@@ -1,0 +1,72 @@
+From a5fb4cfb4fb3e299ad9d232c9fc6b815f56544d5 Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Tue, 10 Oct 2017 18:44:42 +0200
+Subject: [PATCH] Expose client protocol version and virtual host
+
+Add a NetworkClient interface that provides access to:
+  - The socket address
+  - The protocol version
+  - The virtual host (the hostname/port the client used to connect
+    to the server)
+
+diff --git a/src/main/java/com/destroystokyo/paper/network/NetworkClient.java b/src/main/java/com/destroystokyo/paper/network/NetworkClient.java
+new file mode 100644
+index 00000000..9072e384
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/network/NetworkClient.java
+@@ -0,0 +1,39 @@
++package com.destroystokyo.paper.network;
++
++import java.net.InetSocketAddress;
++
++import javax.annotation.Nullable;
++
++/**
++ * Represents a client connected to the server.
++ */
++public interface NetworkClient {
++
++    /**
++     * Returns the socket address of the client.
++     *
++     * @return The client's socket address
++     */
++    InetSocketAddress getAddress();
++
++    /**
++     * Returns the protocol version of the client.
++     *
++     * @return The client's protocol version, or {@code -1} if unknown
++     * @see <a href="http://wiki.vg/Protocol_version_numbers">List of protocol
++     *     version numbers</a>
++     */
++    int getProtocolVersion();
++
++    /**
++     * Returns the virtual host the client is connected to.
++     *
++     * <p>The virtual host refers to the hostname/port the client used to
++     * connect to the server.</p>
++     *
++     * @return The client's virtual host, or {@code null} if unknown
++     */
++    @Nullable
++    InetSocketAddress getVirtualHost();
++
++}
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 0c3eb03f..611a5be2 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -29,7 +29,7 @@ import org.bukkit.scoreboard.Scoreboard;
+ /**
+  * Represents a player, connected or not
+  */
+-public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient {
++public interface Player extends HumanEntity, Conversable, CommandSender, OfflinePlayer, PluginMessageRecipient, com.destroystokyo.paper.network.NetworkClient { // Paper - Extend NetworkClient
+ 
+     /**
+      * Gets the "friendly" name to display of this player. This may include
+-- 
+2.14.2
+

--- a/Spigot-Server-Patches/0245-Expose-client-protocol-version-and-virtual-host.patch
+++ b/Spigot-Server-Patches/0245-Expose-client-protocol-version-and-virtual-host.patch
@@ -1,0 +1,140 @@
+From e05a60bfd0fc59eff42a4ef78d2c2889019c0cd5 Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Tue, 10 Oct 2017 18:45:20 +0200
+Subject: [PATCH] Expose client protocol version and virtual host
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/network/PaperNetworkClient.java b/src/main/java/com/destroystokyo/paper/network/PaperNetworkClient.java
+new file mode 100644
+index 000000000..5caca6439
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/network/PaperNetworkClient.java
+@@ -0,0 +1,50 @@
++package com.destroystokyo.paper.network;
++
++import net.minecraft.server.NetworkManager;
++
++import java.net.InetSocketAddress;
++
++import javax.annotation.Nullable;
++
++public class PaperNetworkClient implements NetworkClient {
++
++    private final NetworkManager networkManager;
++
++    PaperNetworkClient(NetworkManager networkManager) {
++        this.networkManager = networkManager;
++    }
++
++    @Override
++    public InetSocketAddress getAddress() {
++        return (InetSocketAddress) this.networkManager.getSocketAddress();
++    }
++
++    @Override
++    public int getProtocolVersion() {
++        return this.networkManager.protocolVersion;
++    }
++
++    @Nullable
++    @Override
++    public InetSocketAddress getVirtualHost() {
++        return this.networkManager.virtualHost;
++    }
++
++    public static InetSocketAddress prepareVirtualHost(String host, int port) {
++        int len = host.length();
++
++        // FML appends a marker to the host to recognize FML clients (\0FML\0)
++        int pos = host.indexOf('\0');
++        if (pos >= 0) {
++            len = pos;
++        }
++
++        // When clients connect with a SRV record, their host contains a trailing '.'
++        if (len > 0 && host.charAt(len -  1) == '.') {
++            len--;
++        }
++
++        return InetSocketAddress.createUnresolved(host.substring(0, len), port);
++    }
++
++}
+diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
+index 309ab18df..c583ab7d9 100644
+--- a/src/main/java/net/minecraft/server/HandshakeListener.java
++++ b/src/main/java/net/minecraft/server/HandshakeListener.java
+@@ -15,6 +15,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+ 
+     private final MinecraftServer a;
+     private final NetworkManager b;
++    private NetworkManager getNetworkManager() { return b; } // Paper - OBFHELPER
+ 
+     public HandshakeListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
+         this.a = minecraftserver;
+@@ -130,6 +131,10 @@ public class HandshakeListener implements PacketHandshakingInListener {
+             throw new UnsupportedOperationException("Invalid intention " + packethandshakinginsetprotocol.a());
+         }
+ 
++        // Paper start - NetworkClient implementation
++        this.getNetworkManager().protocolVersion = packethandshakinginsetprotocol.getProtocolVersion();
++        this.getNetworkManager().virtualHost = com.destroystokyo.paper.network.PaperNetworkClient.prepareVirtualHost(packethandshakinginsetprotocol.hostname, packethandshakinginsetprotocol.port);
++        // Paper end
+     }
+ 
+     public void a(IChatBaseComponent ichatbasecomponent) {}
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index 2eddb68d7..b93a26e8f 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -75,6 +75,10 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+     private IChatBaseComponent n;
+     private boolean o;
+     private boolean p;
++    // Paper start - NetworkClient implementation
++    public int protocolVersion;
++    public java.net.InetSocketAddress virtualHost;
++    // Paper end
+ 
+     public NetworkManager(EnumProtocolDirection enumprotocoldirection) {
+         this.h = enumprotocoldirection;
+diff --git a/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java b/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java
+index aececa39d..1d4ba3b3d 100644
+--- a/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java
++++ b/src/main/java/net/minecraft/server/PacketHandshakingInSetProtocol.java
+@@ -33,6 +33,7 @@ public class PacketHandshakingInSetProtocol implements Packet<PacketHandshakingI
+         return this.d;
+     }
+ 
++    public int getProtocolVersion() { return b(); } // Paper - OBFHELPER
+     public int b() {
+         return this.a;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 6642001e7..4f28d75f5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -129,6 +129,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+     }
+ 
++    // Paper start - Implement NetworkClient
++    @Override
++    public int getProtocolVersion() {
++        if (getHandle().playerConnection == null) return -1;
++        return getHandle().playerConnection.networkManager.protocolVersion;
++    }
++
++    @Override
++    public InetSocketAddress getVirtualHost() {
++        if (getHandle().playerConnection == null) return null;
++        return getHandle().playerConnection.networkManager.virtualHost;
++    }
++    // Paper end
++
+     @Override
+     public double getEyeHeight() {
+         return getEyeHeight(false);
+-- 
+2.14.2
+


### PR DESCRIPTION
Add a `NetworkClient` interface that provides access to the socket address, protocol version and virtual host of a client connected to the server (not necessarily a player). I've added it as separate interface instead of in `Player` directly because I intend to use the same for an extended `ServerListPingEvent` in a future PR.

### Reason
It's already possible to obtain the protocol version and virtual host using ProtocolLib and/or NMS, however there is no standardized way in the API. Make the life easier for plugins without additional dependencies and expose it in the API.

It's often said that the protocol version is an implementation detail, but I don't think this is the case: We want to hide (breaking) changes in the protocol itself from plugins, but the protocol version is just a number that was added long ago. Essentially, an ID just like block IDs (either numerical or as string) that can be used to check which MC version a client is using.

It might not be too useful for the `Player` interface (since they will always have the same protocol version as the server), but for `ServerListPingEvent` it can be used to give players using older Minecraft versions a special warning in the MOTD (or similar). The same might be possible when using ViaVersion (e.g. to tell your players to upgrade if they're still using the old version).