### PR TITLE
Simple Biome Swapping and Flow Speed Disabling

### DIFF
--- a/Spigot-Server-Patches/0008-Configurable-cactus-and-reed-natural-growth-heights.patch
+++ b/Spigot-Server-Patches/0008-Configurable-cactus-and-reed-natural-growth-heights.patch
@@ -1,11 +1,11 @@
-From 2df13908f2a9a16aedcfb2d7c56fa578181ffb97 Mon Sep 17 00:00:00 2001
+From 7ad8376d929cf602c1256d936a68434ee67995d6 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 13:02:51 -0600
 Subject: [PATCH] Configurable cactus and reed natural growth heights
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f24839378..6228bc1f6 100644
+index f2483937..6228bc1f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -71,4 +71,13 @@ public class PaperWorldConfig {
@@ -23,7 +23,7 @@ index f24839378..6228bc1f6 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockCactus.java b/src/main/java/net/minecraft/server/BlockCactus.java
-index 3f579fbdb..a69a707aa 100644
+index 64b7d08f..d8fb87f7 100644
 --- a/src/main/java/net/minecraft/server/BlockCactus.java
 +++ b/src/main/java/net/minecraft/server/BlockCactus.java
 @@ -28,7 +28,7 @@ public class BlockCactus extends Block {
@@ -36,7 +36,7 @@ index 3f579fbdb..a69a707aa 100644
  
                  if (j >= (byte) range(3, ((100.0F / world.spigotConfig.cactusModifier) * 15) + 0.5F, 15)) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/BlockReed.java b/src/main/java/net/minecraft/server/BlockReed.java
-index 84014b1c7..9d1af2adc 100644
+index 57f24f55..d19dce83 100644
 --- a/src/main/java/net/minecraft/server/BlockReed.java
 +++ b/src/main/java/net/minecraft/server/BlockReed.java
 @@ -28,7 +28,7 @@ public class BlockReed extends Block {
@@ -49,5 +49,5 @@ index 84014b1c7..9d1af2adc 100644
  
                      if (j >= (byte) range(3, ((100.0F / world.spigotConfig.caneModifier) * 15) + 0.5F, 15)) { // Spigot
 -- 
-2.12.0.windows.1
+2.14.2
 

--- a/Spigot-Server-Patches/0009-Configurable-baby-zombie-movement-speed.patch
+++ b/Spigot-Server-Patches/0009-Configurable-baby-zombie-movement-speed.patch
@@ -1,11 +1,11 @@
-From 729eb0ea88be715b9a00822f01f963c86361ecd0 Mon Sep 17 00:00:00 2001
+From 8cc1fd42957937396705e90b95eaf4643c472a67 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 13:09:16 -0600
 Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6228bc1f6..fe9e7b342 100644
+index 6228bc1f..fe9e7b34 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -80,4 +80,10 @@ public class PaperWorldConfig {
@@ -20,7 +20,7 @@ index 6228bc1f6..fe9e7b342 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 36afc8f07..bf059a746 100644
+index 11c0f24f..277f1414 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
 @@ -16,7 +16,7 @@ public class EntityZombie extends EntityMonster {
@@ -45,5 +45,5 @@ index 36afc8f07..bf059a746 100644
          }
  
 -- 
-2.13.0
+2.14.2
 

--- a/Spigot-Server-Patches/0010-Configurable-fishing-time-ranges.patch
+++ b/Spigot-Server-Patches/0010-Configurable-fishing-time-ranges.patch
@@ -1,11 +1,11 @@
-From 16212de7e01256c4ac01f0e1fab71bcee9e1c7e8 Mon Sep 17 00:00:00 2001
+From 0497db65da1fe59ed4751992585e09ec59bdfd76 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 13:14:11 -0600
 Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fe9e7b342..22999f0d2 100644
+index fe9e7b34..22999f0d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -86,4 +86,12 @@ public class PaperWorldConfig {
@@ -22,7 +22,7 @@ index fe9e7b342..22999f0d2 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index 472f36774..0c528c699 100644
+index b4d3bcb4..339d1f1b 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
 @@ -381,7 +381,7 @@ public class EntityFishingHook extends Entity {
@@ -35,5 +35,5 @@ index 472f36774..0c528c699 100644
              }
          }
 -- 
-2.12.0.windows.1
+2.14.2
 

--- a/Spigot-Server-Patches/0011-Allow-nerfed-mobs-to-jump.patch
+++ b/Spigot-Server-Patches/0011-Allow-nerfed-mobs-to-jump.patch
@@ -1,11 +1,11 @@
-From 97ddf652daa2df0abdac972daa33a2bc9c3d3e85 Mon Sep 17 00:00:00 2001
+From ab6b68cccbff816b5fd1f615ea8cc209fffc25b7 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 13:24:16 -0600
 Subject: [PATCH] Allow nerfed mobs to jump
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 22999f0d2..5f13fbff3 100644
+index 22999f0d..5f13fbff 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -94,4 +94,9 @@ public class PaperWorldConfig {
@@ -19,7 +19,7 @@ index 22999f0d2..5f13fbff3 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ControllerJump.java b/src/main/java/net/minecraft/server/ControllerJump.java
-index 4f2fa59ac..8af52a61f 100644
+index 4f2fa59a..8af52a61 100644
 --- a/src/main/java/net/minecraft/server/ControllerJump.java
 +++ b/src/main/java/net/minecraft/server/ControllerJump.java
 @@ -13,6 +13,7 @@ public class ControllerJump {
@@ -31,7 +31,7 @@ index 4f2fa59ac..8af52a61f 100644
          this.b.l(this.a);
          this.a = false;
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 3c48d9463..7b02b253c 100644
+index 3c48d946..7b02b253 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -46,6 +46,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -56,7 +56,7 @@ index 3c48d9463..7b02b253c 100644
          }
          // Spigot End
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalFloat.java b/src/main/java/net/minecraft/server/PathfinderGoalFloat.java
-index b3b303b3b..fc8be86fd 100644
+index b3b303b3..fc8be86f 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalFloat.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalFloat.java
 @@ -6,6 +6,7 @@ public class PathfinderGoalFloat extends PathfinderGoal {
@@ -81,5 +81,5 @@ index b3b303b3b..fc8be86fd 100644
          if (this.a.getRandom().nextFloat() < 0.8F) {
              this.a.getControllerJump().a();
 -- 
-2.13.3
+2.14.2
 

--- a/Spigot-Server-Patches/0012-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/Spigot-Server-Patches/0012-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -1,11 +1,11 @@
-From dca2ae19f2d3a3f260e74471a5a53d7a9b019b67 Mon Sep 17 00:00:00 2001
+From be4a23fbf9bc80da57a9f90d42d6ce266051cc7d Mon Sep 17 00:00:00 2001
 From: Suddenly <suddenly@suddenly.coffee>
 Date: Tue, 1 Mar 2016 13:51:54 -0600
 Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5f13fbff3..4b64ccaa0 100644
+index 5f13fbff..4b64ccaa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -99,4 +99,20 @@ public class PaperWorldConfig {
@@ -30,7 +30,7 @@ index 5f13fbff3..4b64ccaa0 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 7b02b253c..94967e6b6 100644
+index 7b02b253..94967e6b 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -630,13 +630,13 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -51,5 +51,5 @@ index 7b02b253c..94967e6b6 100644
                  }
              }
 -- 
-2.13.3
+2.14.2
 

--- a/Spigot-Server-Patches/0013-Allow-for-toggling-of-spawn-chunks.patch
+++ b/Spigot-Server-Patches/0013-Allow-for-toggling-of-spawn-chunks.patch
@@ -1,11 +1,11 @@
-From 95f35af2f0cbcd086e82db7f001ed34265d28217 Mon Sep 17 00:00:00 2001
+From 9bd0a9c586630171affd74cca19153b8e3b72985 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Thu, 3 Mar 2016 03:53:43 -0600
 Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4b64ccaa0..7ac6a5f1f 100644
+index 4b64ccaa..7ac6a5f1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -115,4 +115,10 @@ public class PaperWorldConfig {
@@ -20,7 +20,7 @@ index 4b64ccaa0..7ac6a5f1f 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f06b82ec5..5c44e0ed4 100644
+index 57607f25..eb27d080 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -202,6 +202,7 @@ public abstract class World implements IBlockAccess {
@@ -32,5 +32,5 @@ index f06b82ec5..5c44e0ed4 100644
          this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
      }
 -- 
-2.13.3.windows.1
+2.14.2
 

--- a/Spigot-Server-Patches/0024-Prevent-tile-entity-and-entity-crashes.patch
+++ b/Spigot-Server-Patches/0024-Prevent-tile-entity-and-entity-crashes.patch
@@ -1,11 +1,11 @@
-From ea97aaf4fc101088eba933640867fb7b23fe90f7 Mon Sep 17 00:00:00 2001
+From 1e39a2ad5efc4226a12bfd4c41f9bf42e3b28d1c Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 1 Mar 2016 23:52:34 -0600
 Subject: [PATCH] Prevent tile entity and entity crashes
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index d2d4ff6fb..65297a761 100644
+index d2d4ff6f..65297a76 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -175,7 +175,12 @@ public abstract class TileEntity {
@@ -23,7 +23,7 @@ index d2d4ff6fb..65297a761 100644
                  public String a() throws Exception {
                      int i = Block.getId(TileEntity.this.world.getType(TileEntity.this.position).getBlock());
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 957e0101e..f29e518c7 100644
+index 957e0101..f29e518c 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1451,10 +1451,12 @@ public abstract class World implements IBlockAccess {
@@ -62,5 +62,5 @@ index 957e0101e..f29e518c7 100644
                      // Spigot start
                      finally {
 -- 
-2.14.1
+2.14.2
 

--- a/Spigot-Server-Patches/0025-Configurable-top-of-nether-void-damage.patch
+++ b/Spigot-Server-Patches/0025-Configurable-top-of-nether-void-damage.patch
@@ -1,11 +1,11 @@
-From 145fbb067892a319be146f8d65e5b89de7f1abb2 Mon Sep 17 00:00:00 2001
+From 8f781f6eec87e38071d619c6d369874cde2bd2f6 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 23:58:50 -0600
 Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62e6830aa..e524a464f 100644
+index 62e6830a..e524a464 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -137,4 +137,10 @@ public class PaperWorldConfig {
@@ -20,7 +20,7 @@ index 62e6830aa..e524a464f 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 3dff98596..e712ab370 100644
+index 3154f482..ba779727 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -444,9 +444,15 @@ public abstract class Entity implements ICommandListener {
@@ -67,7 +67,7 @@ index 3dff98596..e712ab370 100644
          this.die();
      }
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
-index f4ad25dae..4b1c7ad99 100644
+index 82795ee8..f8da1887 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
 @@ -204,9 +204,15 @@ public abstract class EntityMinecartAbstract extends Entity implements INamableT
@@ -87,5 +87,5 @@ index f4ad25dae..4b1c7ad99 100644
          int i;
  
 -- 
-2.13.0
+2.14.2
 

--- a/Spigot-Server-Patches/0026-Check-online-mode-before-converting-and-renaming-pla.patch
+++ b/Spigot-Server-Patches/0026-Check-online-mode-before-converting-and-renaming-pla.patch
@@ -1,11 +1,11 @@
-From 46e9f8769e155aa2e047d3f373c816b6880243f3 Mon Sep 17 00:00:00 2001
+From 1ac04d1a720b78cf38ecc4eb3aff650941ac5980 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Wed, 2 Mar 2016 00:03:55 -0600
 Subject: [PATCH] Check online mode before converting and renaming player data
 
 
 diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
-index b69c6cf97..eba1228fd 100644
+index b69c6cf9..eba1228f 100644
 --- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
 +++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
 @@ -167,7 +167,7 @@ public class WorldNBTStorage implements IDataManager, IPlayerFileData {
@@ -18,5 +18,5 @@ index b69c6cf97..eba1228fd 100644
                  file = new File( this.playerDir, UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + entityhuman.getName() ).getBytes( "UTF-8" ) ).toString() + ".dat");
                  if ( file.exists() )
 -- 
-2.13.1
+2.14.2
 

--- a/Spigot-Server-Patches/0027-Always-tick-falling-blocks.patch
+++ b/Spigot-Server-Patches/0027-Always-tick-falling-blocks.patch
@@ -1,11 +1,11 @@
-From b5310cf63d22fdf8714b2bfaea8ce9c66c3d5758 Mon Sep 17 00:00:00 2001
+From 1da0744b1e8ecccc58700c28ae34bdabadbb7118 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Wed, 2 Mar 2016 00:32:25 -0600
 Subject: [PATCH] Always tick falling blocks
 
 
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 5c2fb0058..c411ce886 100644
+index 38be7ed7..3265a6c2 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -13,6 +13,7 @@ import net.minecraft.server.EntityCreature;
@@ -25,5 +25,5 @@ index 5c2fb0058..c411ce886 100644
                  || entity instanceof EntityFireworks )
          {
 -- 
-2.12.2
+2.14.2
 

--- a/Spigot-Server-Patches/0247-Flow-speeds-can-be-disabled-with-1-value.patch
+++ b/Spigot-Server-Patches/0247-Flow-speeds-can-be-disabled-with-1-value.patch
@@ -1,0 +1,95 @@
+From 8ef4d1492147fbff9528d54d2889c52baf5df157 Mon Sep 17 00:00:00 2001
+From: June <junehanabi@gmail.com>
+Date: Thu, 19 Oct 2017 14:39:53 -0500
+Subject: [PATCH] Flow speeds can be disabled with -1 value
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 14f652d4..65353746 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -452,4 +452,11 @@ public class PaperWorldConfig {
+         replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList((Object) "stone", "planks"));
+         log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Chunk Edge Mode: " + chunkEdgeMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks");
+     }
++    
++    public int waterFlowSpeed;
++
++    private void waterFlowSpeed() {
++        waterFlowSpeed = getInt("water-flow-speed", 5);
++        log("Water flow speed: " + waterFlowSpeed);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/BlockFlowing.java b/src/main/java/net/minecraft/server/BlockFlowing.java
+index ff90e08e..2cf444df 100644
+--- a/src/main/java/net/minecraft/server/BlockFlowing.java
++++ b/src/main/java/net/minecraft/server/BlockFlowing.java
+@@ -23,6 +23,13 @@ public class BlockFlowing extends BlockFluids {
+     }
+ 
+     public void b(World world, BlockPosition blockposition, IBlockData iblockdata, Random random) {
++        
++        // Paper start - don't flow if disabled
++        if (this.isFlowDisabled(world, world.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), blockposition)) {
++            return;
++        }
++        // Paper end
++        
+         int i = ((Integer) iblockdata.get(BlockFlowing.LEVEL)).intValue();
+         byte b0 = 1;
+ 
+@@ -154,6 +161,42 @@ public class BlockFlowing extends BlockFluids {
+     private boolean canFlowTo(World world, org.bukkit.block.Block source, BlockFace face) {
+         return source.getWorld().isChunkLoaded((source.getX() + face.getModX()) >> 4, (source.getZ() + face.getModZ()) >> 4);
+     }
++    
++    private boolean isFlowDisabled(World world, org.bukkit.block.Block block,
++            BlockPosition blockposition) {
++
++        // Is lava disabled in nether?
++        if (this.material == Material.LAVA
++                && world.worldProvider.isSkyMissing()
++                && world.paperConfig.lavaFlowSpeedNether == -1) {
++            return true;
++        }
++
++        // Is lava disabled in overworld
++        if (this.material == Material.LAVA
++                && !world.worldProvider.isSkyMissing()
++                && world.paperConfig.lavaFlowSpeedNormal == -1) {
++            return true;
++        }
++
++        // Is water disabled over lava
++        if (this.material == Material.WATER
++                && (world.getType(blockposition.north(1)).getBlock().material == Material.LAVA
++                || world.getType(blockposition.south(1)).getBlock().material == Material.LAVA
++                || world.getType(blockposition.west(1)).getBlock().material == Material.LAVA
++                || world.getType(blockposition.east(1)).getBlock().material == Material.LAVA)
++                && world.paperConfig.waterOverLavaFlowSpeed == -1) {
++            return true;
++        }
++
++        // Is water disabled not over lava
++        if (this.material == Material.WATER
++                && world.paperConfig.waterFlowSpeed == -1) {
++            return true;
++        }
++
++        return false;
++    }
+     // Paper end
+ 
+     private void flow(World world, BlockPosition blockposition, IBlockData iblockdata, int i) {
+@@ -289,6 +332,8 @@ public class BlockFlowing extends BlockFluids {
+                         world.getType(blockposition.west(1)).getBlock().material == Material.LAVA ||
+                         world.getType(blockposition.east(1)).getBlock().material == Material.LAVA)) {
+             return world.paperConfig.waterOverLavaFlowSpeed;
++        } else if (this.material == Material.WATER) {
++            return world.paperConfig.waterFlowSpeed;
+         }
+         return super.a(world);
+     }
+-- 
+2.14.2
+

--- a/Spigot-Server-Patches/0248-Allow-biome-replacement-in-config-file.patch
+++ b/Spigot-Server-Patches/0248-Allow-biome-replacement-in-config-file.patch
@@ -1,0 +1,234 @@
+From 743cdc806b5d81634c4da8a7cda5b906487dc3db Mon Sep 17 00:00:00 2001
+From: June <junehanabi@gmail.com>
+Date: Sat, 21 Oct 2017 20:36:14 -0500
+Subject: [PATCH] Allow biome replacement in config file
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index f5cb9799b..0b1bd882d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import co.aikar.timings.Timings;
+ import co.aikar.timings.TimingsManager;
++import org.bukkit.configuration.ConfigurationSection;
+ 
+ public class PaperConfig {
+ 
+@@ -276,4 +277,13 @@ public class PaperConfig {
+     private static void authenticationServersDownKickMessage() {
+         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+     }
++    
++    public static ConfigurationSection biomeReplacements;
++
++    private static void biomeReplacements() {
++        // Set a default for the users to know about it and its structure
++        getString("biome-replacements.ocean", "ocean");
++
++        biomeReplacements = config.getConfigurationSection("biome-replacements");
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/Biomes.java b/src/main/java/net/minecraft/server/Biomes.java
+index 4165febc5..1faa8ae45 100644
+--- a/src/main/java/net/minecraft/server/Biomes.java
++++ b/src/main/java/net/minecraft/server/Biomes.java
+@@ -1,72 +1,85 @@
+ package net.minecraft.server;
+ 
++// Paper start
++import com.destroystokyo.paper.PaperConfig;
++// Paper end
++
+ public abstract class Biomes {
+ 
+-    public static final BiomeBase a;
+-    public static final BiomeBase b;
+-    public static final BiomeBase c;
+-    public static final BiomeBase d;
+-    public static final BiomeBase e;
+-    public static final BiomeBase f;
+-    public static final BiomeBase g;
+-    public static final BiomeBase h;
+-    public static final BiomeBase i;
+-    public static final BiomeBase j;
+-    public static final BiomeBase k;
+-    public static final BiomeBase l;
+-    public static final BiomeBase m;
+-    public static final BiomeBase n;
+-    public static final BiomeBase o;
+-    public static final BiomeBase p;
+-    public static final BiomeBase q;
+-    public static final BiomeBase r;
+-    public static final BiomeBase s;
+-    public static final BiomeBase t;
+-    public static final BiomeBase u;
+-    public static final BiomeBase v;
+-    public static final BiomeBase w;
+-    public static final BiomeBase x;
+-    public static final BiomeBase y;
+-    public static final BiomeBase z;
+-    public static final BiomeBase A;
+-    public static final BiomeBase B;
+-    public static final BiomeBase C;
+-    public static final BiomeBase D;
+-    public static final BiomeBase E;
+-    public static final BiomeBase F;
+-    public static final BiomeBase G;
+-    public static final BiomeBase H;
+-    public static final BiomeBase I;
+-    public static final BiomeBase J;
+-    public static final BiomeBase K;
+-    public static final BiomeBase L;
+-    public static final BiomeBase M;
+-    public static final BiomeBase N;
+-    public static final BiomeBase O;
+-    public static final BiomeBase P;
+-    public static final BiomeBase Q;
+-    public static final BiomeBase R;
+-    public static final BiomeBase S;
+-    public static final BiomeBase T;
+-    public static final BiomeBase U;
+-    public static final BiomeBase V;
+-    public static final BiomeBase W;
+-    public static final BiomeBase X;
+-    public static final BiomeBase Y;
+-    public static final BiomeBase Z;
+-    public static final BiomeBase aa;
+-    public static final BiomeBase ab;
+-    public static final BiomeBase ac;
+-    public static final BiomeBase ad;
+-    public static final BiomeBase ae;
+-    public static final BiomeBase af;
+-    public static final BiomeBase ag;
+-    public static final BiomeBase ah;
+-    public static final BiomeBase ai;
+-    public static final BiomeBase aj;
+-    public static final BiomeBase ak;
++    // Paper start - Remove final on biome members
++    public static BiomeBase a;
++    public static BiomeBase b;
++    public static BiomeBase c;
++    public static BiomeBase d;
++    public static BiomeBase e;
++    public static BiomeBase f;
++    public static BiomeBase g;
++    public static BiomeBase h;
++    public static BiomeBase i;
++    public static BiomeBase j;
++    public static BiomeBase k;
++    public static BiomeBase l;
++    public static BiomeBase m;
++    public static BiomeBase n;
++    public static BiomeBase o;
++    public static BiomeBase p;
++    public static BiomeBase q;
++    public static BiomeBase r;
++    public static BiomeBase s;
++    public static BiomeBase t;
++    public static BiomeBase u;
++    public static BiomeBase v;
++    public static BiomeBase w;
++    public static BiomeBase x;
++    public static BiomeBase y;
++    public static BiomeBase z;
++    public static BiomeBase A;
++    public static BiomeBase B;
++    public static BiomeBase C;
++    public static BiomeBase D;
++    public static BiomeBase E;
++    public static BiomeBase F;
++    public static BiomeBase G;
++    public static BiomeBase H;
++    public static BiomeBase I;
++    public static BiomeBase J;
++    public static BiomeBase K;
++    public static BiomeBase L;
++    public static BiomeBase M;
++    public static BiomeBase N;
++    public static BiomeBase O;
++    public static BiomeBase P;
++    public static BiomeBase Q;
++    public static BiomeBase R;
++    public static BiomeBase S;
++    public static BiomeBase T;
++    public static BiomeBase U;
++    public static BiomeBase V;
++    public static BiomeBase W;
++    public static BiomeBase X;
++    public static BiomeBase Y;
++    public static BiomeBase Z;
++    public static BiomeBase aa;
++    public static BiomeBase ab;
++    public static BiomeBase ac;
++    public static BiomeBase ad;
++    public static BiomeBase ae;
++    public static BiomeBase af;
++    public static BiomeBase ag;
++    public static BiomeBase ah;
++    public static BiomeBase ai;
++    public static BiomeBase aj;
++    public static BiomeBase ak;
++    // Paper end
+ 
+     private static BiomeBase a(String s) {
++        
++        // Paper start
++        if (PaperConfig.biomeReplacements != null) {
++            s = PaperConfig.biomeReplacements.getString(s, s).trim().toLowerCase();
++        }
++        // Paper end
++
+         BiomeBase biomebase = (BiomeBase) BiomeBase.REGISTRY_ID.get(new MinecraftKey(s));
+ 
+         if (biomebase == null) {
+@@ -75,8 +88,9 @@ public abstract class Biomes {
+             return biomebase;
+         }
+     }
+-
+-    static {
++    
++    // Paper start
++    public static void SetupBiomes() {
+         if (!DispenserRegistry.a()) {
+             throw new RuntimeException("Accessed Biomes before Bootstrap!");
+         } else {
+@@ -145,4 +159,9 @@ public abstract class Biomes {
+             ak = a("mutated_mesa_clear_rock");
+         }
+     }
++    // Paper end
++
++    static {
++        SetupBiomes(); // Paper
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 854455711..3492204e9 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -203,6 +203,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+             // Paper start
+             com.destroystokyo.paper.PaperConfig.init((File) options.valueOf("paper-settings"));
+             com.destroystokyo.paper.PaperConfig.registerCommands();
++            net.minecraft.server.Biomes.SetupBiomes(); // Ensure these are setup now that PaperConfig has loaded
+             // Paper end
+ 
+             DedicatedServer.LOGGER.info("Generating keypair");
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index b42f4e9ee..3eb227fbb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -751,6 +751,7 @@ public final class CraftServer implements Server {
+             world.spigotConfig.init(); // Spigot
+             world.paperConfig.init(); // Paper
+         }
++        net.minecraft.server.Biomes.SetupBiomes(); // Paper - Ensure these are setup now that PaperConfig has loaded
+ 
+         Plugin[] pluginClone = pluginManager.getPlugins().clone(); // Paper
+         pluginManager.clearPlugins();
+-- 
+2.14.2
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -37,6 +37,7 @@ function import {
 
 import AxisAlignedBB
 import BaseBlockPosition
+import Biomes
 import BiomeBase
 import BiomeJungle
 import BiomeMesa


### PR DESCRIPTION
1. A simple tweak at startup allows the user to add biome names to an array in the config with an alternate biome name that, upon startup, will replace the associated biome variable with a different named biome instead affecting world generation.

```yml
biome-replacements:
    taiga_cold: taiga # Taiga Cold will never generate, Taiga will always generate in its place
```

2. Allows -1 values to the flow speeds

```yml
lava-flow-speed:
    normal: -1 # Disable lava flow in the over-world
```