### PR TITLE
Replace HashSet with fastutil's ObjectOpenHashSet in HashTreeSet

### DIFF
--- a/Spigot-Server-Patches/0247-Replace-HashSet-with-fastutil-s-ObjectOpenHashSet-in.patch
+++ b/Spigot-Server-Patches/0247-Replace-HashSet-with-fastutil-s-ObjectOpenHashSet-in.patch
@@ -1,0 +1,30 @@
+From a51fb3acd6b6d9b369d33f7802d2723145ec3e0b Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Fri, 20 Oct 2017 04:33:45 +0200
+Subject: [PATCH] Replace HashSet with fastutil's ObjectOpenHashSet in
+ HashTreeSet
+
+HashSet sometimes uses compareTo() instead of equals() and this breaks the comparison of net.minecraft.server.NextTickListEntry (the only place where HashTreeSet is used).
+
+In this cases duplicate entries could be added to the HashSet of HashTreeSet, because NextTickListEntry.compareTo() does not return 0, even if NextTickListEntry.equals() returns true.
+
+ObjectOpenHashSet never uses compareTo(), so the inconsistencies of NextTickListEntry cause no problems.
+
+Fixes https://github.com/PaperMC/Paper/issues/588
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/HashTreeSet.java b/src/main/java/org/bukkit/craftbukkit/util/HashTreeSet.java
+index 80a5c29..cd864c4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/HashTreeSet.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/HashTreeSet.java
+@@ -8,7 +8,7 @@ import java.util.TreeSet;
+ 
+ public class HashTreeSet<V> implements Set<V> {
+ 
+-    private HashSet<V> hash = new HashSet<V>();
++    private Set<V> hash = new it.unimi.dsi.fastutil.objects.ObjectOpenHashSet<V>(); //Paper - Replace java.util.HashSet with ObjectOpenHashSet
+     private TreeSet<V> tree = new TreeSet<V>();
+ 
+     public HashTreeSet() {
+-- 
+2.7.3.windows.1
+


### PR DESCRIPTION
HashSet sometimes uses compareTo() instead of equals() and this breaks the comparison of net.minecraft.server.NextTickListEntry (the only place where HashTreeSet is used).

In this cases duplicate entries could be added to the HashSet of HashTreeSet, because NextTickListEntry.compareTo() does not return 0, even if NextTickListEntry.equals() returns true.

ObjectOpenHashSet never uses compareTo(), so the inconsistencies of NextTickListEntry cause no problems.

Fixes https://github.com/PaperMC/Paper/issues/588