### PR TITLE
Prevent logins from being processed when the player has disconnected

### DIFF
--- a/Spigot-Server-Patches/0252-Prevent-logins-from-being-processed-when-the-player-.patch
+++ b/Spigot-Server-Patches/0252-Prevent-logins-from-being-processed-when-the-player-.patch
@@ -1,0 +1,27 @@
+From f2bbc719f2f539d22ba2bfc991578d5263d834ae Mon Sep 17 00:00:00 2001
+From: killme <killme-git@ibts.me>
+Date: Sun, 12 Nov 2017 19:40:01 +0100
+Subject: [PATCH] Prevent logins from being processed when the player has
+ disconnected
+
+
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 75df928..eaac25d 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -60,7 +60,11 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+         }
+         // Paper end
+         if (this.g == LoginListener.EnumProtocolState.READY_TO_ACCEPT) {
+-            this.b();
++            // Paper start - prevent logins to be processed even though disconnect was called
++            if (networkManager.isConnected()) {
++                this.b();
++            }
++            // Paper end
+         } else if (this.g == LoginListener.EnumProtocolState.DELAY_ACCEPT) {
+             EntityPlayer entityplayer = this.server.getPlayerList().a(this.i.getId());
+ 
+-- 
+2.7.4
+


### PR DESCRIPTION
Even when cancelling the AsyncPreLoginEvent or the LoginEvent, the server proceeds to call `b()` on the next tick. This causes a `Player` object to be created and inventory data to be loaded (sync even).

This patch prevents `b()` from ever being called when `disconnect` is called first. This is safe as `g`, which usually calls `b()` to be called, is assigned *after* disconnect is called.

Suggestions and/or feedback is appreciated.