### PR TITLE
Fix logging inconsistencies

### DIFF
--- a/Spigot-Server-Patches/0222-Fix-logging-inconsistencies.patch
+++ b/Spigot-Server-Patches/0222-Fix-logging-inconsistencies.patch
@@ -1,0 +1,43 @@
+From 092eeffab1b3e7b5d5829566efd9838e9497771e Mon Sep 17 00:00:00 2001
+From: Sweepyoface <github@sweepy.pw>
+Date: Tue, 2 Jan 2018 04:02:45 -0500
+Subject: [PATCH] Fix logging inconsistencies
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 2a5107f6..67b11c83 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -958,7 +958,8 @@ public final class CraftServer implements Server {
+         console.worlds.add(internal);
+ 
+         pluginManager.callEvent(new WorldInitEvent(internal.getWorld()));
+-        System.out.print("Preparing start region for level " + (console.worlds.size() - 1) + " (Seed: " + internal.getSeed() + ")");
++        // Paper - use logger
++        MinecraftServer.LOGGER.info("Preparing start region for level " + (console.worlds.size() - 1) + " (Seed: " + internal.getSeed() + ")");
+ 
+         if (internal.getWorld().getKeepSpawnInMemory()) {
+             short short1 = internal.paperConfig.keepLoadedRange; // Paper
+@@ -975,7 +976,8 @@ public final class CraftServer implements Server {
+                         int i1 = (short1 * 2 + 1) * (short1 * 2 + 1);
+                         int j1 = (j + short1) * (short1 * 2 + 1) + k + 1;
+ 
+-                        System.out.println("Preparing spawn area for " + name + ", " + (j1 * 100 / i1) + "%");
++                        // Paper - use logger
++                        MinecraftServer.LOGGER.info("Preparing spawn area for " + name + ", " + (j1 * 100 / i1) + "%");
+                         i = l;
+                     }
+ 
+@@ -1083,7 +1085,8 @@ public final class CraftServer implements Server {
+     public void addWorld(World world) {
+         // Check if a World already exists with the UID.
+         if (getWorld(world.getUID()) != null) {
+-            System.out.println("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
++            // Paper - use logger
++            MinecraftServer.LOGGER.info("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
+             return;
+         }
+         worlds.put(world.getName().toLowerCase(java.util.Locale.ENGLISH), world);
+-- 
+2.15.1
+

--- a/Spigot-Server-Patches/0222-Fix-logging-inconsistencies.patch
+++ b/Spigot-Server-Patches/0222-Fix-logging-inconsistencies.patch
@@ -1,11 +1,11 @@
-From 092eeffab1b3e7b5d5829566efd9838e9497771e Mon Sep 17 00:00:00 2001
+From 9d24fddf2d56316c7448818ce7ca0826c353f281 Mon Sep 17 00:00:00 2001
 From: Sweepyoface <github@sweepy.pw>
 Date: Tue, 2 Jan 2018 04:02:45 -0500
 Subject: [PATCH] Fix logging inconsistencies
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2a5107f6..67b11c83 100644
+index 2a5107f..86b9948 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -958,7 +958,8 @@ public final class CraftServer implements Server {
@@ -34,10 +34,10 @@ index 2a5107f6..67b11c83 100644
          if (getWorld(world.getUID()) != null) {
 -            System.out.println("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
 +            // Paper - use logger
-+            MinecraftServer.LOGGER.info("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
++            MinecraftServer.LOGGER.warn("World " + world.getName() + " is a duplicate of another world and has been prevented from loading. Please delete the uid.dat file from " + world.getName() + "'s world directory if you want to be able to load the duplicate world.");
              return;
          }
          worlds.put(world.getName().toLowerCase(java.util.Locale.ENGLISH), world);
 -- 
-2.15.1
+2.7.4
 


### PR DESCRIPTION
Fixes an issue where the "Preparing start region for level" message is printed without a line break resulting in many messages at once at the next proper output. Additionally, the logger is now used instead of System.out for all messages in this class.