### PR TITLE
PlayerAdvancementGrantEvent

### DIFF
--- a/Spigot-API-Patches/0085-PlayerAdvancementCriterionGrantEvent.patch
+++ b/Spigot-API-Patches/0085-PlayerAdvancementCriterionGrantEvent.patch
@@ -1,0 +1,73 @@
+From 4d81773878266032eac2dc2a2eb15ad862c71b13 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 19 Jan 2018 08:15:14 -0600
+Subject: [PATCH] PlayerAdvancementCriterionGrantEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java
+new file mode 100644
+index 00000000..b65ee9e5
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementCriterionGrantEvent.java
+@@ -0,0 +1,58 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.advancement.Advancement;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++
++/**
++ * Called when a player is granted a criteria in an advancement.
++ */
++public class PlayerAdvancementCriterionGrantEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final Advancement advancement;
++    private final String criterion;
++    private boolean cancel = false;
++
++    public PlayerAdvancementCriterionGrantEvent(Player who, Advancement advancement, String criterion) {
++        super(who);
++        this.advancement = advancement;
++        this.criterion = criterion;
++    }
++
++    /**
++     * Get the advancement which has been affected.
++     *
++     * @return affected advancement
++     */
++    public Advancement getAdvancement() {
++        return advancement;
++    }
++
++    /**
++     * Get the criterion which has been granted.
++     *
++     * @return granted criterion
++     */
++    public String getCriterion() {
++        return criterion;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0267-PlayerAdvancementCriterionGrantEvent.patch
+++ b/Spigot-Server-Patches/0267-PlayerAdvancementCriterionGrantEvent.patch
@@ -1,0 +1,26 @@
+From 7dcca0ffd7f69ff6634cb8cdffc4180fda1975aa Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 19 Jan 2018 08:15:29 -0600
+Subject: [PATCH] PlayerAdvancementCriterionGrantEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index 6896b709..8913e274 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -196,6 +196,12 @@ public class AdvancementDataPlayer {
+         boolean flag1 = advancementprogress.isDone();
+ 
+         if (advancementprogress.a(s)) {
++            // Paper start
++            if (!new com.destroystokyo.paper.event.player.PlayerAdvancementCriterionGrantEvent(this.player.getBukkitEntity(), advancement.bukkit, s).callEvent()) {
++                advancementprogress.b(s);
++                return false;
++            }
++            // Paper end
+             this.d(advancement);
+             this.i.add(advancement);
+             flag = true;
+-- 
+2.11.0
+


### PR DESCRIPTION
This adds a new cancellable event, PlayerAdvancementCriterionGrantEvent, that fires when a player is granted an advancement criterion (not necessarily when the advancement is done, like the upstream related event, PlayerAdvancementDoneEvent).