### PR TITLE
Implement push hoppers logics on MinecartHoppers as well

### DIFF
--- a/Spigot-Server-Patches/0140-Make-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0140-Make-entities-look-for-hoppers.patch
@@ -1,4 +1,4 @@
-From 4f6df6a265dcf623e4c26b538d1e043369e8714f Mon Sep 17 00:00:00 2001
+From bf45939822a2609949e5e3eef0024f63236a3358 Mon Sep 17 00:00:00 2001
 From: Techcable <Techcable@outlook.com>
 Date: Sat, 18 Jun 2016 01:01:37 -0500
 Subject: [PATCH] Make entities look for hoppers
@@ -14,21 +14,25 @@ This patch may causes a decrease in the performance of dropped items, which is w
 
 diff --git a/src/main/java/com/destroystokyo/paper/HopperPusher.java b/src/main/java/com/destroystokyo/paper/HopperPusher.java
 new file mode 100644
-index 000000000..52457e3d8
+index 000000000..0da85a301
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/HopperPusher.java
-@@ -0,0 +1,60 @@
+@@ -0,0 +1,65 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.AxisAlignedBB;
 +import net.minecraft.server.BlockPosition;
++import net.minecraft.server.Entity;
++import net.minecraft.server.EntityItem;
++import net.minecraft.server.EntityMinecartHopper;
++import net.minecraft.server.IHopper;
 +import net.minecraft.server.MCUtil;
 +import net.minecraft.server.TileEntityHopper;
 +import net.minecraft.server.World;
 +
 +public interface HopperPusher {
 +
-+    default TileEntityHopper findHopper() {
++    default IHopper findHopper() {
 +        BlockPosition pos = new BlockPosition(getX(), getY(), getZ());
 +        int startX = pos.getX() - 1;
 +        int endX = pos.getX() + 1;
@@ -56,15 +60,16 @@ index 000000000..52457e3d8
 +                }
 +            }
 +        }
++
 +        adjacentPos.free();
 +        return null;
 +    }
 +
-+    boolean acceptItem(TileEntityHopper hopper);
++    boolean acceptItem(IHopper hopper);
 +
 +    default boolean tryPutInHopper() {
 +        if (!getWorld().paperConfig.isHopperPushBased) return false;
-+        TileEntityHopper hopper = findHopper();
++        IHopper hopper = findHopper();
 +        return hopper != null && hopper.canAcceptItems() && acceptItem(hopper);
 +    }
 +
@@ -157,10 +162,10 @@ index d46fb1d76..9ab892876 100644
      public double motY;
      public double motZ;
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 4d3aef96b..6593fc633 100644
+index 4d3aef96b..cb4639d6a 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -8,8 +8,15 @@ import org.apache.logging.log4j.Logger;
+@@ -8,8 +8,39 @@ import org.apache.logging.log4j.Logger;
  import org.bukkit.event.entity.EntityPickupItemEvent;
  import org.bukkit.event.player.PlayerPickupItemEvent;
  // CraftBukkit end
@@ -170,14 +175,38 @@ index 4d3aef96b..6593fc633 100644
 +// Paper start - implement HopperPusher
 +public class EntityItem extends Entity implements HopperPusher {
 +    @Override
-+    public boolean acceptItem(TileEntityHopper hopper) {
++    public IHopper findHopper() {
++        IHopper hopper = HopperPusher.super.findHopper();
++        if (hopper != null) {
++            return hopper;
++        }
++
++        // Look for minecart hoppers
++        double x1 = locX - 1.5;
++        double x2 = locX + 1.5;
++        double y1 = Math.max(0, locY - 1.5);
++        double y2 = Math.min(255, locY + 1.5);
++        double z1 = locZ - 1.5;
++        double z2 = locZ + 1.5;
++
++        AxisAlignedBB bb = new AxisAlignedBB(x1, y1, z1, x2, y2, z2);
++        for (Entity entity : getWorld().getEntities(null, bb, null)) {
++            if (entity instanceof EntityMinecartHopper) {
++                return (IHopper) entity;
++            }
++        }
++
++        return null;
++    }
++    @Override
++    public boolean acceptItem(IHopper hopper) {
 +        return TileEntityHopper.putDropInInventory(null, hopper, this);
 +    }
 +// Paper end
  
      private static final Logger b = LogManager.getLogger();
      private static final DataWatcherObject<ItemStack> c = DataWatcher.a(EntityItem.class, DataWatcherRegistry.f);
-@@ -59,6 +66,7 @@ public class EntityItem extends Entity {
+@@ -59,6 +90,7 @@ public class EntityItem extends Entity {
              this.die();
          } else {
              super.B_();
@@ -185,7 +214,7 @@ index 4d3aef96b..6593fc633 100644
              // CraftBukkit start - Use wall time for pickup and despawn timers
              int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
              if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
-@@ -146,6 +154,7 @@ public class EntityItem extends Entity {
+@@ -146,6 +178,7 @@ public class EntityItem extends Entity {
      // Spigot start - copied from above
      @Override
      public void inactiveTick() {
@@ -194,7 +223,7 @@ index 4d3aef96b..6593fc633 100644
          int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
          if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartContainer.java b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
-index 50d7d34b8..15f392d23 100644
+index 50d7d34b8..006395c5a 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 @@ -7,6 +7,7 @@ import javax.annotation.Nullable;
@@ -205,7 +234,7 @@ index 50d7d34b8..15f392d23 100644
  import com.destroystokyo.paper.loottable.CraftLootableInventoryData; // Paper
  import com.destroystokyo.paper.loottable.CraftLootableInventory; // Paper
  import com.destroystokyo.paper.loottable.LootableInventory; // Paper
-@@ -15,7 +16,25 @@ import org.bukkit.entity.HumanEntity;
+@@ -15,9 +16,27 @@ import org.bukkit.entity.HumanEntity;
  import org.bukkit.inventory.InventoryHolder;
  // CraftBukkit end
  
@@ -213,7 +242,7 @@ index 50d7d34b8..15f392d23 100644
 +// Paper start - push into hoppers
 +public abstract class EntityMinecartContainer extends EntityMinecartAbstract implements ITileInventory, ILootable, CraftLootableInventory, HopperPusher { // Paper - CraftLootableInventory
 +    @Override
-+    public boolean acceptItem(TileEntityHopper hopper) {
++    public boolean acceptItem(IHopper hopper) {
 +        return TileEntityHopper.acceptItem(hopper, this);
 +    }
 +
@@ -230,13 +259,82 @@ index 50d7d34b8..15f392d23 100644
 +    }
 +    // Paper end
  
-     private NonNullList<ItemStack> items;
+-    private NonNullList<ItemStack> items;
++    protected NonNullList<ItemStack> items;
      private boolean b;
+     private MinecraftKey c;
+     private long d;public long getLootTableSeed() { return d; } // Paper - OBFHELPER
+diff --git a/src/main/java/net/minecraft/server/EntityMinecartHopper.java b/src/main/java/net/minecraft/server/EntityMinecartHopper.java
+index ae40759dd..e33656b38 100644
+--- a/src/main/java/net/minecraft/server/EntityMinecartHopper.java
++++ b/src/main/java/net/minecraft/server/EntityMinecartHopper.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import java.util.Iterator;
+ import java.util.List;
+ 
+ public class EntityMinecartHopper extends EntityMinecartContainer implements IHopper {
+@@ -7,6 +8,7 @@ public class EntityMinecartHopper extends EntityMinecartContainer implements IHo
+     private boolean a = true;
+     private int b = -1;
+     private final BlockPosition c;
++    private boolean canAcceptItems = false; // Paper - Push based hoppers
+ 
+     public EntityMinecartHopper(World world) {
+         super(world);
+@@ -75,6 +77,28 @@ public class EntityMinecartHopper extends EntityMinecartContainer implements IHo
+         return this.locZ;
+     }
+ 
++    // Paper start - Push based hoppers
++    @Override
++    public boolean canAcceptItems() {
++        return canAcceptItems;
++    }
++
++    public boolean checkCanAccept() {
++        Iterator iterator = this.items.iterator();
++        ItemStack itemstack;
++
++        do {
++            if (!iterator.hasNext()) {
++                return false;
++            }
++
++            itemstack = (ItemStack) iterator.next();
++        } while (!itemstack.isEmpty() && itemstack.getCount() == itemstack.getMaxStackSize());
++
++        return true;
++    }
++    // Paper end
++
+     public void B_() {
+         super.B_();
+         if (!this.world.isClientSide && this.isAlive() && this.isEnabled()) {
+@@ -86,6 +110,8 @@ public class EntityMinecartHopper extends EntityMinecartContainer implements IHo
+                 this.setCooldown(0);
+             }
+ 
++            canAcceptItems = checkCanAccept(); // Paper - Push based hoppers
++
+             if (!this.J()) {
+                 this.setCooldown(0);
+                 if (this.H()) {
+@@ -98,6 +124,8 @@ public class EntityMinecartHopper extends EntityMinecartContainer implements IHo
+     }
+ 
+     public boolean H() {
++        if (this.getWorld().paperConfig.isHopperPushBased) return false; // Paper - make MinecartHoppers behave like hoppers
++
+         if (TileEntityHopper.a((IHopper) this)) {
+             return true;
+         } else {
 diff --git a/src/main/java/net/minecraft/server/IHopper.java b/src/main/java/net/minecraft/server/IHopper.java
-index 804215a1c..e830d8390 100644
+index 804215a1c..76df4c597 100644
 --- a/src/main/java/net/minecraft/server/IHopper.java
 +++ b/src/main/java/net/minecraft/server/IHopper.java
-@@ -4,9 +4,9 @@ public interface IHopper extends IInventory {
+@@ -4,9 +4,11 @@ public interface IHopper extends IInventory {
  
      World getWorld();
  
@@ -248,9 +346,11 @@ index 804215a1c..e830d8390 100644
  
 -    double G();
 +    double G(); default double getZ() { return G(); } // Paper - OBFHELPER
++
++    boolean canAcceptItems(); // Paper - used for push-based hoppers
  }
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 53584b257..8ad081316 100644
+index 53584b257..610ba088c 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -126,6 +126,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -288,10 +388,10 @@ index 53584b257..8ad081316 100644
          return true;
      }
  
-+    // Paper start - split methods, and only do entity lookup if in pull mode
++    // Paper start - split methods, and only do entity lookup if in pull mode; make MinecartHopper work with push hoppers
      public static boolean a(IHopper ihopper) {
 -        IInventory iinventory = b(ihopper);
-+        IInventory iinventory = getInventory(ihopper, !(ihopper instanceof TileEntityHopper) || !ihopper.getWorld().paperConfig.isHopperPushBased);
++        IInventory iinventory = getInventory(ihopper, (!(ihopper instanceof TileEntityHopper) && !(ihopper instanceof EntityMinecartHopper)) || !ihopper.getWorld().paperConfig.isHopperPushBased);
 +
 +        return acceptItem(ihopper, iinventory);
 +    }
@@ -307,7 +407,7 @@ index 53584b257..8ad081316 100644
              }
 -        } else {
 -            Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator();
-+        } else if (!ihopper.getWorld().paperConfig.isHopperPushBased || !(ihopper instanceof TileEntityHopper)) { // Paper - only search for entities in 'pull mode'
++        } else if (!ihopper.getWorld().paperConfig.isHopperPushBased || (!(ihopper instanceof TileEntityHopper)) && !(ihopper instanceof EntityMinecartHopper)) { // Paper - only search for entities in 'pull mode'
 +            Iterator iterator = a(ihopper.getWorld(), ihopper.E(), ihopper.F(), ihopper.G()).iterator(); // Change getHopperLookupBoundingBox() if this ever changes
  
              while (iterator.hasNext()) {

--- a/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
+++ b/Spigot-Server-Patches/0211-Item-canEntityPickup.patch
@@ -1,11 +1,11 @@
-From 77dad6b547631f9f9d517ef2ef5f32010dbaa4c6 Mon Sep 17 00:00:00 2001
+From 17ce4f94bc63750853bacebd14c8d5afbf93f9cd Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Fri, 5 May 2017 03:57:17 -0500
 Subject: [PATCH] Item#canEntityPickup
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 5ea9f309..89e87836 100644
+index 5ea9f3097..89e878365 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -514,6 +514,12 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -22,10 +22,10 @@ index 5ea9f309..89e87836 100644
                      this.a(entityitem);
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 6593fc63..99dbb139 100644
+index cb4639d6a..124b2623b 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -22,6 +22,7 @@ public class EntityItem extends Entity implements HopperPusher {
+@@ -46,6 +46,7 @@ public class EntityItem extends Entity implements HopperPusher {
      private static final DataWatcherObject<ItemStack> c = DataWatcher.a(EntityItem.class, DataWatcherRegistry.f);
      private int age;
      public int pickupDelay;
@@ -34,7 +34,7 @@ index 6593fc63..99dbb139 100644
      private String g;
      private String h;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
-index a17a537d..1df17f09 100644
+index a17a537d6..1df17f09b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 @@ -37,6 +37,16 @@ public class CraftItem extends CraftEntity implements Item {

--- a/Spigot-Server-Patches/0212-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-Server-Patches/0212-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -1,14 +1,14 @@
-From 10af08536a0e2608485ac574bdb218e28afa388a Mon Sep 17 00:00:00 2001
+From ea20be3a0dbd5c05959a1fd338307441bb86dfd1 Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 7 May 2017 06:26:09 -0500
 Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 99dbb139..ae4910b4 100644
+index 124b2623b..fced35ea1 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -332,6 +332,7 @@ public class EntityItem extends Entity implements HopperPusher {
+@@ -356,6 +356,7 @@ public class EntityItem extends Entity implements HopperPusher {
              // CraftBukkit start - fire PlayerPickupItemEvent
              int canHold = entityhuman.inventory.canHold(itemstack);
              int remaining = i - canHold;
@@ -16,7 +16,7 @@ index 99dbb139..ae4910b4 100644
  
              if (this.pickupDelay <= 0 && canHold > 0) {
                  itemstack.setCount(canHold);
-@@ -339,7 +340,13 @@ public class EntityItem extends Entity implements HopperPusher {
+@@ -363,7 +364,13 @@ public class EntityItem extends Entity implements HopperPusher {
                  PlayerPickupItemEvent playerEvent = new PlayerPickupItemEvent((org.bukkit.entity.Player) entityhuman.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
                  playerEvent.setCancelled(!entityhuman.canPickUpLoot);
                  this.world.getServer().getPluginManager().callEvent(playerEvent);
@@ -30,7 +30,7 @@ index 99dbb139..ae4910b4 100644
                      return;
                  }
  
-@@ -359,7 +366,11 @@ public class EntityItem extends Entity implements HopperPusher {
+@@ -383,7 +390,11 @@ public class EntityItem extends Entity implements HopperPusher {
              // CraftBukkit end
  
              if (this.pickupDelay == 0 && (this.h == null || 6000 - this.age <= 200 || this.h.equals(entityhuman.getName())) && entityhuman.inventory.pickup(itemstack)) {

--- a/Spigot-Server-Patches/0213-PlayerAttemptPickupItemEvent.patch
+++ b/Spigot-Server-Patches/0213-PlayerAttemptPickupItemEvent.patch
@@ -1,11 +1,11 @@
-From 72f3e8ddfdc74bd4ad75e00bd849a540ec6e2041 Mon Sep 17 00:00:00 2001
+From 7c31f6f6a898e67260d52af6d7b0fc259176ed80 Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 11 Jun 2017 16:30:30 -0500
 Subject: [PATCH] PlayerAttemptPickupItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index ae4910b4..0b7fc327 100644
+index fced35ea1..6e69e4daa 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
 @@ -8,6 +8,7 @@ import org.apache.logging.log4j.Logger;
@@ -16,7 +16,7 @@ index ae4910b4..0b7fc327 100644
  import com.destroystokyo.paper.HopperPusher; // Paper
  
  // Paper start - implement HopperPusher
-@@ -334,6 +335,22 @@ public class EntityItem extends Entity implements HopperPusher {
+@@ -358,6 +359,22 @@ public class EntityItem extends Entity implements HopperPusher {
              int remaining = i - canHold;
              boolean flyAtPlayer = false; // Paper
  

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -65,6 +65,7 @@ import DefinedStructure
 import EnchantmentManager
 import Enchantments
 import EntityLlama
+import EntityMinecartHopper
 import EntitySquid
 import EntityTypes
 import EntityWaterAnimal


### PR DESCRIPTION
The `push-hoppers` configuration option changes the behaviour of hoppers so that drops would check if hoppers are below them, rather than hoppers checking for drops on top of themselves. This commit should apply the same logic to MinecartHoppers, making drops look for MinecartHoppers entities, check if they're full and get in the hoppers inventory if they aren't.