### PR TITLE
Allowing Paper to be build on FreeBSD

### DIFF
--- a/scripts/remap.sh
+++ b/scripts/remap.sh
@@ -23,11 +23,11 @@ if [ ! -f  "$jarpath.jar" ]; then
     fi
 fi
 
-# OS X doesn't have md5sum, just md5 -r
-if [[ "$OSTYPE" == "darwin"* ]]; then
+# OS X & FreeBSD don't have md5sum, just md5 -r
+if [[ "$OSTYPE" == "darwin"* || "$(uname)" == "FreeBSD" ]]; then
    shopt -s expand_aliases
    alias md5sum='md5 -r'
-   echo "Using an alias for md5sum on macOS"
+   echo "Using an alias for md5sum on macOS and/or FreeBSD"
 fi
 
 checksum=$(md5sum "$jarpath.jar" | cut -d ' ' -f 1)


### PR DESCRIPTION
It's all in the comments. Both OS X and FreeBSD don't have md5sum but use md5 instead. The current settings for OS X also work on FreeBSD therefor I added an extra check so that remap.sh tests both the OSTYPE environment variable as well as the uname output.

Hope this can help.