### PR TITLE
Make player data saving configurable

### DIFF
--- a/Spigot-Server-Patches/0282-Make-player-data-saving-configurable.patch
+++ b/Spigot-Server-Patches/0282-Make-player-data-saving-configurable.patch
@@ -1,0 +1,39 @@
+From 42d1033fe2a9acf0cc1fd264f30267e7922783dd Mon Sep 17 00:00:00 2001
+From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
+Date: Mon, 26 Mar 2018 18:30:53 +0300
+Subject: [PATCH] Make player data saving configurable
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index ec89ecfca..b602bbf12 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -282,4 +282,13 @@ public class PaperConfig {
+     private static void authenticationServersDownKickMessage() {
+         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+     }
++
++    public static boolean savePlayerData = true;
++    private static void savePlayerData() {
++        savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
++        if(!savePlayerData) {
++            Bukkit.getLogger().log(Level.WARNING, "Player Data Saving is currently disabled. Any changes to your players data, " +
++                    "such as inventories, experience points, advancements and the like will not be saved when they log out.");
++        }
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
+index eba1228fd..4e33cc2f2 100644
+--- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
++++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
+@@ -142,6 +142,7 @@ public class WorldNBTStorage implements IDataManager, IPlayerFileData {
+     }
+ 
+     public void save(EntityHuman entityhuman) {
++        if(!com.destroystokyo.paper.PaperConfig.savePlayerData) return; // Paper - Make player data saving configurable
+         try {
+             NBTTagCompound nbttagcompound = entityhuman.save(new NBTTagCompound());
+             File file = new File(this.playerDir, entityhuman.bn() + ".dat.tmp");
+-- 
+2.16.3
+


### PR DESCRIPTION
Closes #1062

This PR just makes player data saving disableable, but does not touch loading. I left loading part untouched as I am not completely sure what making that no-op could possibly cause (besides desired functionality).