### PR TITLE
Improve backward compatibility of deprecated player sample API

### DIFF
--- a/Spigot-API-Patches/0091-Implement-deprecated-player-sample-API.patch
+++ b/Spigot-API-Patches/0091-Implement-deprecated-player-sample-API.patch
@@ -1,23 +1,22 @@
-From 13d00b73c9c88b40409ce727328ecc3555796068 Mon Sep 17 00:00:00 2001
+From d9f260928670e8d9910d4eede929f7eebd5a4028 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Mon, 27 Nov 2017 16:21:19 +0100
 Subject: [PATCH] Implement deprecated player sample API
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
-index dd1deafd..32cf9f01 100644
+index dd1deafd..db992df2 100644
 --- a/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
 +++ b/src/main/java/com/destroystokyo/paper/event/server/PaperServerListPingEvent.java
-@@ -4,6 +4,8 @@ import static java.util.Objects.requireNonNull;
+@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
  
  import com.destroystokyo.paper.network.StatusClient;
  import com.destroystokyo.paper.profile.PlayerProfile;
 +import com.google.common.base.Strings;
-+import com.google.common.collect.ImmutableList;
  import org.bukkit.Bukkit;
  import org.bukkit.entity.Player;
  import org.bukkit.event.Cancellable;
-@@ -316,4 +318,25 @@ public class PaperServerListPingEvent extends ServerListPingEvent implements Can
+@@ -316,4 +317,25 @@ public class PaperServerListPingEvent extends ServerListPingEvent implements Can
          }
      }
  
@@ -26,11 +25,11 @@ index dd1deafd..32cf9f01 100644
 +    @Override
 +    @Deprecated
 +    public List<String> getSampleText() {
-+        ImmutableList.Builder<String> sampleText = ImmutableList.builder();
++        List<String> sampleText = new ArrayList<>();
 +        for (PlayerProfile profile : getPlayerSample()) {
 +            sampleText.add(Strings.nullToEmpty(profile.getName()));
 +        }
-+        return sampleText.build();
++        return sampleText;
 +    }
 +
 +    @Override


### PR DESCRIPTION
Some plugins (e.g. older builds of EssentialsX) assume that `ServerListPingEvent.getSampleText()` returns a mutable copy of the player sample list. This was the case until it was refactored on top of the new API introduced in #980.

As a result, they may run into an error when trying to modify the returned list directly. Modify `getSampleText()` to return a mutable copy (a plain `ArrayList`) to mimic the old behavior.

Fixes https://github.com/EssentialsX/Essentials/issues/1924 and https://github.com/EssentialsX/Essentials/issues/1926 additionally from Paper's side.