### PR TITLE
Apply workaround for patch application on Windows

### DIFF
--- a/scripts/applyPatches.sh
+++ b/scripts/applyPatches.sh
@@ -5,6 +5,10 @@ PS1="$"
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
 gpgsign="$(git config commit.gpgsign || echo "false")"
+applycmd="git am --3way --ignore-whitespace"
+# Windows detection to workaround ARG_MAX limitation
+windows="$([[ "$OSTYPE" == "cygwin" || "$OSTYPE" == "msys" ]] && echo "true" || echo "false")"
+
 echo "Rebuilding Forked projects.... "
 
 function applyPatch {
@@ -38,11 +42,30 @@ function applyPatch {
     echo "  Applying patches to $target..."
 
     git am --abort >/dev/null 2>&1
-    git am --3way --ignore-whitespace "$basedir/${what_name}-Patches/"*.patch
+
+    # Special case Windows handling because of ARG_MAX constraint
+    if [[ $windows == "true" ]]; then
+        echo "  Using workaround for Windows ARG_MAX constraint"
+        find "$basedir/${what_name}-Patches/"*.patch -print0 | xargs -0 $applycmd
+    else
+        $applycmd "$basedir/${what_name}-Patches/"*.patch
+    fi
+
     if [ "$?" != "0" ]; then
         echo "  Something did not apply cleanly to $target."
         echo "  Please review above details and finish the apply then"
         echo "  save the changes with rebuildPatches.sh"
+
+        # On Windows, finishing the patch apply will only fix the latest patch
+        # users will need to rebuild from that point and then re-run the patch
+        # process to continue
+        if [[ $windows == "true" ]]; then
+            echo ""
+            echo "  Because you're on Windows you'll need to finish the AM,"
+            echo "  rebuild all patches, and then re-run the patch apply again."
+            echo "  Consider using the scripts with Windows Subsystem for Linux."
+        fi
+
         exit 1
     else
         echo "  Patches applied cleanly to $target"


### PR DESCRIPTION
Supersedes GH-1095

This is not a perfect workaround but it seems to be the best solution
for the moment.

On Windows, this means that when a patch fails to apply, you would now
need to fix that patch, finish the apply (AM), then rebuild all patches,
and then finally re-run the patch apply procedure in order to continue.

This adds a small amount of overhead compared to the traditional method
(which will still work on *nix environments, including WSL). However, it
seems preferable to the build not working on Windows at all.

- [x] Arch Linux - bash 4.4
- [x] Windows 10 1803 - git-for-windows 2.17.0.windows.1 bash 4.4
- [x] Ubuntu 16.04 - bash 4.3
- [x] macOS 10.13 - bash 3.5 / zsh 5.5