### PR TITLE
Handle gpg signing better

### DIFF
--- a/paper
+++ b/paper
@@ -23,6 +23,7 @@ while [ -h "$SOURCE" ]; do # resolve $SOURCE until the file is no longer a symli
 done
 SOURCE=$([[ "$SOURCE" = /* ]] && echo "$SOURCE" || echo "$PWD/${SOURCE#./}")
 basedir=$(dirname "$SOURCE")
+gitcmd="git -c commit.gpgsign=false"
 
 source "$basedir/scripts/functions.sh"
 
@@ -104,7 +105,7 @@ case "$1" in
                 set -e
 
                 paperstash
-                git rebase -i upstream/upstream
+                $gitcmd rebase -i upstream/upstream
                 paperunstash
             )
             ;;
@@ -115,7 +116,7 @@ case "$1" in
                 set -e
 
                 paperstash
-                git rebase -i upstream/upstream
+                $gitcmd rebase -i upstream/upstream
                 paperunstash
             )
             ;;
@@ -125,9 +126,9 @@ case "$1" in
             (
                 set -e
 
-                git add .
-                git commit --amend
-                git rebase --continue
+                $gitcmd add .
+                $gitcmd commit --amend
+                $gitcmd rebase --continue
 
                 cd "$basedir"
                 scripts/rebuildPatches.sh "$basedir"

--- a/scripts/apatch.sh
+++ b/scripts/apatch.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+gitcmd="git -c commit.gpgsign=false"
+
 noapply=1
 isreject=0
 if [[ $1 == "--noapplied" ]]; then
@@ -18,18 +21,18 @@ else
 fi
 applied=$(echo $file | sed 's/.patch$/-applied\.patch/g')
 if [ "$1" == "--reset" ]; then
-	git am --abort
-	git reset --hard
-	git clean -f
+	$gitcmd am --abort
+	$gitcmd reset --hard
+	$gitcmd clean -f
 	exit 0
 fi
 
 
-(test "$isreject" != "1" && git am -3 $file) || (
+(test "$isreject" != "1" && $gitcmd am -3 $file) || (
 	echo "Failures - Wiggling"
-	git reset --hard
-	git clean -f
-	errors=$(git apply --rej $file 2>&1)
+	$gitcmd reset --hard
+	$gitcmd clean -f
+	errors=$($gitcmd apply --rej $file 2>&1)
 	echo "$errors" >> ~/patch.log
 	export missingfiles=""
 	export summaryfail=""
@@ -44,12 +47,12 @@ fi
 			missingfiles="$missingfiles\n$base"
 		fi
 	done
-	for i in $(git status --porcelain | awk '{print $2}'); do
+	for i in $($gitcmd status --porcelain | awk '{print $2}'); do
 		filedata=$(cat "$i")
 		if [ -f "$file" ] && [[ "$filedata" == *"<<<<<"* ]]; then
 			export summaryfail="$summaryfail\nFAILED TO APPLY: $i"
 		else
-			git add "$i"
+			$gitcmd add "$i"
 			export summarygood="$summarygood\nAPPLIED CLEAN: $i"
 		fi
 	done
@@ -64,8 +67,8 @@ fi
 		echo " "
 		echo "===========================";
 	fi
-	git status
-	git diff
+	$gitcmd status
+	$gitcmd diff
 )
 if [[ "$noapply" != "1" ]] && [[ "$file" != *-applied.patch ]]; then
 	mv "$file" "$applied"

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -3,12 +3,13 @@
 (
 set -e
 basedir="$(cd "$1" && pwd -P)"
+gitcmd="git -c commit.gpgsign=false"
 
-(git submodule update --init && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir") || (
-	echo "Failed to build Paper"
-	exit 1
+($gitcmd submodule update --init && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir") || (
+    echo "Failed to build Paper"
+    exit 1
 ) || exit 1
 if [ "$2" == "--jar" ]; then
-	mvn clean install && ./scripts/paperclip.sh "$basedir"
+    mvn clean install && ./scripts/paperclip.sh "$basedir"
 fi
 )

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+gitcmd="git -c commit.gpgsign=false"
+
 color() {
     if [ $2 ]; then
             echo -e "\e[$1;$2m"
@@ -12,11 +14,11 @@ colorend() {
 }
 
 paperstash() {
-    STASHED=$(git stash  2>/dev/null|| return 0) # errors are ok
+    STASHED=$($gitcmd stash  2>/dev/null|| return 0) # errors are ok
 }
 
 paperunstash() {
     if [[ "$STASHED" != "No local changes to save" ]] ; then
-        git stash pop 2>/dev/null|| return 0 # errors are ok
+        $gitcmd stash pop 2>/dev/null|| return 0 # errors are ok
     fi
 }

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -6,6 +6,7 @@ nms="net/minecraft/server"
 export MODLOG=""
 PS1="$"
 basedir="$(cd "$1" && pwd -P)"
+gitcmd="git -c commit.gpgsign=false"
 
 workdir="$basedir/work"
 minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
@@ -13,26 +14,26 @@ decompiledir="$workdir/Minecraft/$minecraftversion"
 
 export importedmcdev=""
 function import {
-	export importedmcdev="$importedmcdev $1"
-	file="${1}.java"
-	target="$workdir/Spigot/Spigot-Server/src/main/java/$nms/$file"
-	base="$decompiledir/$nms/$file"
+    export importedmcdev="$importedmcdev $1"
+    file="${1}.java"
+    target="$workdir/Spigot/Spigot-Server/src/main/java/$nms/$file"
+    base="$decompiledir/$nms/$file"
 
-	if [[ ! -f "$target" ]]; then
-		export MODLOG="$MODLOG  Imported $file from mc-dev\n";
-		echo "Copying $base to $target"
-		cp "$base" "$target"
-	else
-		echo "UN-NEEDED IMPORT: $file"
-	fi
+    if [[ ! -f "$target" ]]; then
+        export MODLOG="$MODLOG  Imported $file from mc-dev\n";
+        echo "Copying $base to $target"
+        cp "$base" "$target"
+    else
+        echo "UN-NEEDED IMPORT: $file"
+    fi
 }
 
 (
-	cd "$workdir/Spigot/Spigot-Server/"
-	lastlog=$(git log -1 --oneline)
-	if [[ "$lastlog" = *"mc-dev Imports"* ]]; then
-		git reset --hard HEAD^
-	fi
+    cd "$workdir/Spigot/Spigot-Server/"
+    lastlog=$($gitcmd log -1 --oneline)
+    if [[ "$lastlog" = *"mc-dev Imports"* ]]; then
+        $gitcmd reset --hard HEAD^
+    fi
 )
 
 import AxisAlignedBB
@@ -110,6 +111,6 @@ import WorldProvider
 
 cd "$workdir/Spigot/Spigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1
-git add . -A >/dev/null 2>&1
-echo -e "mc-dev Imports\n\n$MODLOG" | git commit . -F -
+$gitcmd add . -A >/dev/null 2>&1
+echo -e "mc-dev Imports\n\n$MODLOG" | $gitcmd commit . -F -
 )

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -9,23 +9,16 @@ minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion |
 decompiledir="$workdir/Minecraft/$minecraftversion"
 nms="$decompiledir/net/minecraft/server"
 cb="src/main/java/net/minecraft/server"
-gpgsign="$(git config commit.gpgsign || echo "false")"
-
+gitcmd="git -c commit.gpgsign=false"
 
 patch=$(which patch 2>/dev/null)
 if [ "x$patch" == "x" ]; then
     patch="$basedir/hctap.exe"
 fi
 
-function enableCommitSigningIfNeeded {
-    if [[ "$gpgsign" == "true" ]]; then
-        git config commit.gpgsign true
-    fi
-}
-
 echo "Applying CraftBukkit patches to NMS..."
 cd "$workdir/CraftBukkit"
-git checkout -B patched HEAD >/dev/null 2>&1
+$gitcmd checkout -B patched HEAD >/dev/null 2>&1
 rm -rf "$cb"
 mkdir -p "$cb"
 for file in $(ls nms-patches)
@@ -42,11 +35,7 @@ do
     "$patch" -s -d src/main/java/ "net/minecraft/server/$file" < "$patchFile"
 done
 
-git add src
-# We don't need to sign an automated commit
-# All it does is make you input your key passphrase mid-patch
-git config commit.gpgsign false
-git commit -m "CraftBukkit $ $(date)" --author="Auto <auto@mated.null>"
-enableCommitSigningIfNeeded
-git checkout -f HEAD^
+$gitcmd add src
+$gitcmd commit -m "CraftBukkit $ $(date)" --author="Auto <auto@mated.null>"
+$gitcmd checkout -f HEAD^
 )

--- a/scripts/rebuildPatches.sh
+++ b/scripts/rebuildPatches.sh
@@ -4,15 +4,16 @@
 PS1="$"
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
+gitcmd="git -c commit.gpgsign=false -c core.safecrlf=false"
+
 echo "Rebuilding patch files from current fork state..."
-git config core.safecrlf false
 
 function cleanupPatches {
     cd "$1"
     for patch in *.patch; do
         echo "$patch"
         gitver=$(tail -n 2 "$patch" | grep -ve "^$" | tail -n 1)
-        diffs=$(git diff --staged "$patch" | grep -E "^(\+|\-)" | grep -Ev "(From [a-z0-9]{32,}|\-\-\- a|\+\+\+ b|.index)")
+        diffs=$($gitcmd diff --staged "$patch" | grep -E "^(\+|\-)" | grep -Ev "(From [a-z0-9]{32,}|\-\-\- a|\+\+\+ b|.index)")
 
         testver=$(echo "$diffs" | tail -n 2 | grep -ve "^$" | tail -n 1 | grep "$gitver")
         if [ "x$testver" != "x" ]; then
@@ -20,8 +21,8 @@ function cleanupPatches {
         fi
 
         if [ "x$diffs" == "x" ] ; then
-            git reset HEAD "$patch" >/dev/null
-            git checkout -- "$patch" >/dev/null
+            $gitcmd reset HEAD "$patch" >/dev/null
+            $gitcmd checkout -- "$patch" >/dev/null
         fi
     done
 }
@@ -50,9 +51,9 @@ function savePatches {
 
     cd "$basedir/$target"
 
-    git format-patch --no-stat -N -o "$basedir/${what_name}-Patches/" upstream/upstream >/dev/null
+    $gitcmd format-patch --no-stat -N -o "$basedir/${what_name}-Patches/" upstream/upstream >/dev/null
     cd "$basedir"
-    git add -A "$basedir/${what_name}-Patches"
+    $gitcmd add -A "$basedir/${what_name}-Patches"
     cleanupPatches "$basedir/${what_name}-Patches"
     echo "  Patches saved for $what to $what_name-Patches/"
 }

--- a/scripts/testServer.sh
+++ b/scripts/testServer.sh
@@ -6,7 +6,7 @@ basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
 minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/Minecraft/$minecraftversion"
-
+gitcmd="git -c commit.gpgsign=false"
 
 #
 # FUNCTIONS
@@ -15,7 +15,7 @@ decompiledir="$workdir/Minecraft/$minecraftversion"
 
 updateTest() {
     paperstash
-    git reset --hard origin/master
+    $gitcmd reset --hard origin/master
     paperunstash
 }
 
@@ -29,9 +29,9 @@ cd "$papertestdir"
 #
 
 if [ ! -d .git ]; then
-    git init
-    git remote add origin ${PAPER_TEST_SKELETON:-https://github.com/PaperMC/PaperTestServer}
-    git fetch origin
+    $gitcmd init
+    $gitcmd remote add origin ${PAPER_TEST_SKELETON:-https://github.com/PaperMC/PaperTestServer}
+    $gitcmd fetch origin
     updateTest
 elif [ "$2" == "update" ] || [ "$3" == "update" ]; then
     updateTest

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -5,12 +5,13 @@ set -e
 PS1="$"
 basedir="$(cd "$1" && pwd -P)"
 workdir="$basedir/work"
+gitcmd="git -c commit.gpgsign=false"
 
 function update {
     cd "$workdir/$1"
-    git fetch && git reset --hard origin/master
+    $gitcmd fetch && $gitcmd reset --hard origin/master
     cd ../
-    git add $1
+    $gitcmd add $1
 }
 
 update Bukkit


### PR DESCRIPTION
Instead of checking whether it was set previously, setting it to false, then setting it back to true if it was true before, just use the command-line argument in git to override the config for that command. Using a variable makes it pretty painless to do.

I have only tested on Linux, and would like others that are able to test on Windows. I won't be able to test macOS until tomorrow.

- [x] Arch Linux - bash 4.4
- [x] Windows 10 1803 - git-for-windows 2.17.0.windows.1 bash 4.4
- [x] Ubuntu 16.04 - bash 4.3
- [x] macOS 10.13 - bash 3.5 / zsh 5.5