### PR TITLE
Fix PluginCommand to not wrap exceptions before ServerExceptionEvent can get to it

### DIFF
--- a/Spigot-API-Patches/0018-Add-exception-reporting-event.patch
+++ b/Spigot-API-Patches/0018-Add-exception-reporting-event.patch
@@ -1,4 +1,4 @@
-From 95df32df8d98c5ca8434f09312bade707628c21c Mon Sep 17 00:00:00 2001
+From b8567d82eae818cbf98656b6107c703d49d19916 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 20:24:35 -0600
 Subject: [PATCH] Add exception reporting event
@@ -458,7 +458,7 @@ index 00000000..5582999f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index bdc0de8c..762eb1d2 100644
+index bdc0de8c..4aea03c6 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
 @@ -10,6 +10,9 @@ import java.util.List;
@@ -471,7 +471,12 @@ index bdc0de8c..762eb1d2 100644
  import org.apache.commons.lang.Validate;
  import org.bukkit.Location;
  import org.bukkit.Server;
-@@ -152,7 +155,9 @@ public class SimpleCommandMap implements CommandMap {
+@@ -148,11 +151,14 @@ public class SimpleCommandMap implements CommandMap {
+             target.execute(sender, sentCommandLabel, Arrays.copyOfRange(args, 1, args.length));
+             target.timings.stopTiming(); // Spigot
+         } catch (CommandException ex) {
++            server.getPluginManager().callEvent(new ServerExceptionEvent(new ServerCommandException(ex, target, sender, args))); // Paper
+             target.timings.stopTiming(); // Spigot
              throw ex;
          } catch (Throwable ex) {
              target.timings.stopTiming(); // Spigot
@@ -482,7 +487,7 @@ index bdc0de8c..762eb1d2 100644
          }
  
          // return true as command was handled
-@@ -225,7 +230,9 @@ public class SimpleCommandMap implements CommandMap {
+@@ -225,7 +231,9 @@ public class SimpleCommandMap implements CommandMap {
          } catch (CommandException ex) {
              throw ex;
          } catch (Throwable ex) {
@@ -587,5 +592,5 @@ index 80c152ba..b88f31ca 100644
          }
      }
 -- 
-2.14.3
+2.17.0 (Apple Git-106)
 

--- a/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-API-Patches/0040-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From 9ef921b8843cc53222d4ebed32ea4992e95dee87 Mon Sep 17 00:00:00 2001
+From 4596b1efcb3648ea18ebf94eb07b49ee90c734e1 Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:16:39 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -55,10 +55,10 @@ index 30d60247..938959aa 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-index 762eb1d2..23d08336 100644
+index 4aea03c6..63d27392 100644
 --- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
 +++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
-@@ -281,4 +281,10 @@ public class SimpleCommandMap implements CommandMap {
+@@ -282,4 +282,10 @@ public class SimpleCommandMap implements CommandMap {
              }
          }
      }
@@ -97,5 +97,5 @@ index f331a442..a977045d 100644
                  confirmed = true;
              } else {
 -- 
-2.14.1
+2.17.0 (Apple Git-106)
 

--- a/Spigot-API-Patches/0051-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-API-Patches/0051-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -1,4 +1,4 @@
-From c1215b45d6da3da9cc9cbdee0f618551b80ebff0 Mon Sep 17 00:00:00 2001
+From 03b558d1228782283c1c47a75c174c19791f974d Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Fri, 9 Jun 2017 07:24:24 -0700
 Subject: [PATCH] Add configuration option to prevent player names from being
@@ -6,7 +6,7 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 498dfd33..4f27b9f2 100644
+index 5431b17b..ed403c33 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1206,6 +1206,16 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index 498dfd33..4f27b9f2 100644
  
      public static Server.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 4f077b7c..3a27e3ae 100644
+index 83b370e5..87ab9d2b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1032,4 +1032,14 @@ public interface Server extends PluginMessageRecipient {
@@ -46,7 +46,7 @@ index 4f077b7c..3a27e3ae 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/command/PluginCommand.java b/src/main/java/org/bukkit/command/PluginCommand.java
-index 3bfa31fc..dbbf0a42 100644
+index 2abe1208..c660c178 100644
 --- a/src/main/java/org/bukkit/command/PluginCommand.java
 +++ b/src/main/java/org/bukkit/command/PluginCommand.java
 @@ -145,6 +145,7 @@ public final class PluginCommand extends Command implements PluginIdentifiableCo
@@ -58,5 +58,5 @@ index 3bfa31fc..dbbf0a42 100644
          }
          return completions;
 -- 
-2.13.0.windows.1
+2.17.0 (Apple Git-106)
 


### PR DESCRIPTION
Currently the PluginCommand class wraps any exceptions into a CommandException which misses the catch-all throwable which would normally send the exception to the ServerExceptionEvent.

This remove the wrapping so that the event can handle it and then wrap it like normal.