### PR TITLE
[CI-SKIP] set shwordsplit on zsh

### DIFF
--- a/paper
+++ b/paper
@@ -5,6 +5,10 @@ case "$(echo "$SHELL" | sed -E 's|/usr(/local)?||g')" in
     "/bin/zsh")
         RCPATH="$HOME/.zshrc"
         SOURCE="${BASH_SOURCE[0]:-${(%):-%N}}"
+        if [[ ! -o shwordsplit ]]; then
+            revertwordsplit=true
+            setopt shwordsplit
+        fi
     ;;
     *)
         RCPATH="$HOME/.bashrc"
@@ -183,6 +187,10 @@ case "$1" in
         echo "                      | Which will allow you to run 'example' instead."
     ;;
 esac
+
+if [[ ! -z "${revertwordsplit+x}" ]]; then
+   unsetopt shwordsplit
+fi
 
 unset RCPATH
 unset SOURCE


### PR DESCRIPTION
By default, zsh will not expand the spaces inside of the gitcmd
variable, and will attempt to execute as is, causing the git command
to fail. This patch fixes this by enabling the shwordsplit option
if not already enabled (and disables afterhand if it was enabled by us)