### PR TITLE
Slime pathfinder stuff

### DIFF
--- a/Spigot-API-Patches/0115-Slime-pathfinder-additions.patch
+++ b/Spigot-API-Patches/0115-Slime-pathfinder-additions.patch
@@ -1,0 +1,211 @@
+From 671caae813ad145e3078e331561994b2beca48c8 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 18 Jun 2018 06:12:58 -0500
+Subject: [PATCH] Slime pathfinder additions
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
+new file mode 100644
+index 00000000..7293db14
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeChangeDirectionEvent.java
+@@ -0,0 +1,37 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.Slime;
++import org.bukkit.event.Cancellable;
++
++/**
++ * Fired when a Slime decides to change it's facing direction.
++ * <p>
++ * This event does not fire for the entities actual movement. Only when it
++ * is choosing to change direction.
++ */
++public class SlimeChangeDirectionEvent extends SlimePathfindEvent implements Cancellable {
++    private float yaw;
++
++    public SlimeChangeDirectionEvent(Slime slime, float yaw) {
++        super(slime);
++        this.yaw = yaw;
++    }
++
++    /**
++     * Get the new chosen yaw
++     *
++     * @return Chosen yaw
++     */
++    public float getNewYaw() {
++        return yaw;
++    }
++
++    /**
++     * Set the new chosen yaw
++     *
++     * @param yaw Chosen yaw
++     */
++    public void setNewYaw(float yaw) {
++        this.yaw = yaw;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java
+new file mode 100644
+index 00000000..2cdd5497
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimePathfindEvent.java
+@@ -0,0 +1,49 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.Slime;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++/**
++ * Fired when a Slime decides to start pathfinding.
++ * <p>
++ * This event does not fire for the entities actual movement. Only when it
++ * is choosing to start moving.
++ */
++public class SlimePathfindEvent extends EntityEvent implements Cancellable {
++    public SlimePathfindEvent(Slime slime) {
++        super(slime);
++    }
++
++    /**
++     * The Slime that is pathfinding.
++     *
++     * @return The Slime that is pathfinding.
++     */
++    public Slime getEntity() {
++        return (Slime) entity;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    private boolean cancelled = false;
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java
+new file mode 100644
+index 00000000..3939e5c3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeSwimEvent.java
+@@ -0,0 +1,16 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.Slime;
++import org.bukkit.event.Cancellable;
++
++/**
++ * Fired when a Slime decides to start jumping while swimming in water/lava.
++ * <p>
++ * This event does not fire for the entities actual movement. Only when it
++ * is choosing to start jumping.
++ */
++public class SlimeSwimEvent extends SlimeWanderEvent implements Cancellable {
++    public SlimeSwimEvent(Slime slime) {
++        super(slime);
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java
+new file mode 100644
+index 00000000..cbe87f75
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeTargetLivingEntityEvent.java
+@@ -0,0 +1,29 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Slime;
++import org.bukkit.event.Cancellable;
++
++/**
++ * Fired when a Slime decides to change direction to target a LivingEntity.
++ * <p>
++ * This event does not fire for the entities actual movement. Only when it
++ * is choosing to start moving.
++ */
++public class SlimeTargetLivingEntityEvent extends SlimePathfindEvent implements Cancellable {
++    private final LivingEntity target;
++
++    public SlimeTargetLivingEntityEvent(Slime slime, LivingEntity target) {
++        super(slime);
++        this.target = target;
++    }
++
++    /**
++     * Get the targeted entity
++     *
++     * @return Targeted entity
++     */
++    public LivingEntity getTarget() {
++        return target;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java
+new file mode 100644
+index 00000000..0ec7f486
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/SlimeWanderEvent.java
+@@ -0,0 +1,16 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.Slime;
++import org.bukkit.event.Cancellable;
++
++/**
++ * Fired when a Slime decides to start wandering.
++ * <p>
++ * This event does not fire for the entities actual movement. Only when it
++ * is choosing to start moving.
++ */
++public class SlimeWanderEvent extends SlimePathfindEvent implements Cancellable {
++    public SlimeWanderEvent(Slime slime) {
++        super(slime);
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/Slime.java b/src/main/java/org/bukkit/entity/Slime.java
+index d4eee19c..21288df7 100644
+--- a/src/main/java/org/bukkit/entity/Slime.java
++++ b/src/main/java/org/bukkit/entity/Slime.java
+@@ -29,4 +29,20 @@ public interface Slime extends LivingEntity, com.destroystokyo.paper.entity.Sent
+      * @return the current target, or null if no target exists.
+      */
+     public LivingEntity getTarget();
++
++    // Paper start
++    /**
++     * Get whether this slime can randomly wander/jump around on its own
++     *
++     * @return true if can wander
++     */
++    public boolean canWander();
++
++    /**
++     * Set whether this slime can randomly wander/jump around on its own
++     *
++     * @param canWander true if can wander
++     */
++    public void setWander(boolean canWander);
++    // Paper end
+ }
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0312-Slime-pathfinder-additions.patch
+++ b/Spigot-Server-Patches/0312-Slime-pathfinder-additions.patch
@@ -1,0 +1,136 @@
+From 1b8d64e3f604d04060cf1ffbe21f4b3ed284311c Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 18 Jun 2018 06:13:12 -0500
+Subject: [PATCH] Slime pathfinder additions
+
+
+diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
+index 3d3a9ca04..fddb736f8 100644
+--- a/src/main/java/net/minecraft/server/EntitySlime.java
++++ b/src/main/java/net/minecraft/server/EntitySlime.java
+@@ -2,6 +2,12 @@ package net.minecraft.server;
+ 
+ import javax.annotation.Nullable;
+ // CraftBukkit start
++import com.destroystokyo.paper.event.entity.SlimeChangeDirectionEvent;
++import com.destroystokyo.paper.event.entity.SlimeSwimEvent;
++import com.destroystokyo.paper.event.entity.SlimeTargetLivingEntityEvent;
++import com.destroystokyo.paper.event.entity.SlimeWanderEvent;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Slime;
+ import org.bukkit.event.entity.SlimeSplitEvent;
+ // CraftBukkit end
+ 
+@@ -306,7 +312,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         }
+ 
+         public boolean a() {
+-            return true;
++            return this.a.canWander && new SlimeWanderEvent((Slime) this.a.bukkitEntity).callEvent(); // Paper
+         }
+ 
+         public void e() {
+@@ -325,7 +331,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         }
+ 
+         public boolean a() {
+-            return this.a.isInWater() || this.a.au();
++            return (this.a.isInWater() || this.a.au()) && this.a.canWander && new SlimeSwimEvent((Slime) this.a.bukkitEntity).callEvent(); // Paper
+         }
+ 
+         public void e() {
+@@ -349,13 +355,17 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         }
+ 
+         public boolean a() {
+-            return this.a.getGoalTarget() == null && (this.a.onGround || this.a.isInWater() || this.a.au() || this.a.hasEffect(MobEffects.LEVITATION));
++            return this.a.canWander && this.a.getGoalTarget() == null && (this.a.onGround || this.a.isInWater() || this.a.au() || this.a.hasEffect(MobEffects.LEVITATION)); // Paper
+         }
+ 
+         public void e() {
+             if (--this.c <= 0) {
+                 this.c = 40 + this.a.getRandom().nextInt(60);
+-                this.b = (float) this.a.getRandom().nextInt(360);
++                // Paper start
++                SlimeChangeDirectionEvent event = new SlimeChangeDirectionEvent((Slime) this.a.bukkitEntity, (float) this.a.getRandom().nextInt(360));
++                if (!this.a.canWander || !event.callEvent()) return;
++                this.b = event.getNewYaw();
++                // Paper end
+             }
+ 
+             ((EntitySlime.ControllerMoveSlime) this.a.getControllerMove()).a(this.b, false);
+@@ -375,7 +385,16 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         public boolean a() {
+             EntityLiving entityliving = this.a.getGoalTarget();
+ 
+-            return entityliving == null ? false : (!entityliving.isAlive() ? false : !(entityliving instanceof EntityHuman) || !((EntityHuman) entityliving).abilities.isInvulnerable);
++            // Paper start
++            if (entityliving != null && entityliving.isAlive() && (!(entityliving instanceof EntityHuman) || !((EntityHuman) entityliving).abilities.isInvulnerable)) {
++                if (this.a.canWander && new SlimeTargetLivingEntityEvent((Slime) this.a.bukkitEntity, (LivingEntity) entityliving.bukkitEntity).callEvent()) {
++                    return true;
++                }
++                this.b = 0;
++                this.a.setGoalTarget(null);
++            }
++            return false;
++            // Paper end
+         }
+ 
+         public void c() {
+@@ -386,7 +405,16 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         public boolean b() {
+             EntityLiving entityliving = this.a.getGoalTarget();
+ 
+-            return entityliving == null ? false : (!entityliving.isAlive() ? false : (entityliving instanceof EntityHuman && ((EntityHuman) entityliving).abilities.isInvulnerable ? false : --this.b > 0));
++            // Paper start
++            if (entityliving != null && entityliving.isAlive() && (!(entityliving instanceof EntityHuman) || !((EntityHuman) entityliving).abilities.isInvulnerable) && --this.b > 0) {
++                if (this.a.canWander && new SlimeTargetLivingEntityEvent((Slime) this.a.bukkitEntity, (LivingEntity) entityliving.bukkitEntity).callEvent()) {
++                    return true;
++                }
++                this.b = 0;
++                this.a.setGoalTarget(null);
++            }
++            return false;
++            // Paper end
+         }
+ 
+         public void e() {
+@@ -450,4 +478,16 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+             }
+         }
+     }
++
++    // Paper start
++    private boolean canWander = true;
++
++    public boolean canWander() {
++        return canWander;
++    }
++
++    public void setWander(boolean canWander) {
++        this.canWander = canWander;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+index 6bf30c834..c56e1b98a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+@@ -48,4 +48,14 @@ public class CraftSlime extends CraftLivingEntity implements Slime {
+     public EntityType getType() {
+         return EntityType.SLIME;
+     }
++
++    // Paper start
++    public boolean canWander() {
++        return getHandle().canWander();
++    }
++
++    public void setWander(boolean canWander) {
++        getHandle().setWander(canWander);
++    }
++    // Paper end
+ }
+-- 
+2.11.0
+


### PR DESCRIPTION
Resolves #930 

Adds new slime pathfinder related events. All events can be cancelled.
- `SlimePathfindEvent` is the base event of all added events. Cancelling this event will cancel all pathfinders.
- `SlimeWanderEvent` is called when slimes wander around by either swimming or moving/jumping forward. Cancelling this event will prevent slimes from moving around and jumping, but they will still look around and target players.
- `SlimeSwimEvent`is called when slimes are swimming in water/lava. Cancelling will prevent the slimes from moving/jumping in water/lava.
- `SlimeChangeDirectionEvent` is called when a slime changes directions. It contains the new `yaw` position the slime wants to change to, and it can be set to another value. Cancelling this event will prevent slimes from changing directions (except for when targeting players).
- `SlimeTargetLivingEntityEvent` is called when a slime targets a player. NMS uses EntityLiving here so it is named this. Contains the LivingEntity the slime has targeted. Cancelling this event will prevent the slime from targeting the entity and will make it lose current focus.

Adds `Slime#canWander()` and `Slime#setWander(boolean)` for a more persistent control (does not persist server restarts) over all 4 pathfinder types without the spammy event having to be cancelled a bajillion times a second.

Video demonstration: https://youtu.be/8hcLqazmO28

Test plugin: https://pastebin.com/cFgcgdWV