### PR TITLE
New EnderDragon Events

### DIFF
--- a/Spigot-API-Patches/0121-New-EnderDragon-Events.patch
+++ b/Spigot-API-Patches/0121-New-EnderDragon-Events.patch
@@ -1,0 +1,209 @@
+From 1bcadb7d5f4b8aade713ab12fb9765e5ac22a60f Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 1 Jul 2018 11:49:51 -0500
+Subject: [PATCH] New EnderDragon Events
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
+new file mode 100644
+index 00000000..2ac57af3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFireballHitEvent.java
+@@ -0,0 +1,70 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.AreaEffectCloud;
++import org.bukkit.entity.DragonFireball;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++import java.util.Collection;
++
++/**
++ * Fired when a DragonFireball collides with a block/entity and spawns an AreaEffectCloud
++ */
++public class EnderDragonFireballHitEvent extends EntityEvent implements Cancellable {
++    private final Collection<LivingEntity> targets;
++    private final AreaEffectCloud areaEffectCloud;
++
++    public EnderDragonFireballHitEvent(DragonFireball fireball, Collection<LivingEntity> targets, AreaEffectCloud areaEffectCloud) {
++        super(fireball);
++        this.targets = targets;
++        this.areaEffectCloud = areaEffectCloud;
++    }
++
++    /**
++     * The fireball involved in this event
++     */
++    @Override
++    public DragonFireball getEntity() {
++        return (DragonFireball) super.getEntity();
++    }
++
++    /**
++     * The living entities hit by fireball
++     * <p></p>
++     * May be null if no entities were hit
++     */
++    public Collection<LivingEntity> getTargets() {
++        return targets;
++    }
++
++    /**
++     * The area effect cloud spawned in this collision
++     */
++    public AreaEffectCloud getAreaEffectCloud() {
++        return areaEffectCloud;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    private boolean cancelled = false;
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java
+new file mode 100644
+index 00000000..59f87633
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonFlameEvent.java
+@@ -0,0 +1,56 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.AreaEffectCloud;
++import org.bukkit.entity.EnderDragon;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++/**
++ * Fired when an EnderDragon spawns an AreaEffectCloud by shooting flames
++ */
++public class EnderDragonFlameEvent extends EntityEvent implements Cancellable {
++    private final AreaEffectCloud areaEffectCloud;
++
++    public EnderDragonFlameEvent(EnderDragon enderDragon, AreaEffectCloud areaEffectCloud) {
++        super(enderDragon);
++        this.areaEffectCloud = areaEffectCloud;
++    }
++
++    /**
++     * The enderdragon involved in this event
++     */
++    @Override
++    public EnderDragon getEntity() {
++        return (EnderDragon) super.getEntity();
++    }
++
++    /**
++     * The area effect cloud spawned in this collision
++     */
++    public AreaEffectCloud getAreaEffectCloud() {
++        return areaEffectCloud;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    private boolean cancelled = false;
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java
+new file mode 100644
+index 00000000..296ae244
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/EnderDragonShootFireballEvent.java
+@@ -0,0 +1,56 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.DragonFireball;
++import org.bukkit.entity.EnderDragon;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++
++/**
++ * Fired when an EnderDragon shoots a fireball
++ */
++public class EnderDragonShootFireballEvent extends EntityEvent implements Cancellable {
++    private final DragonFireball fireball;
++
++    public EnderDragonShootFireballEvent(EnderDragon entity, DragonFireball fireball) {
++        super(entity);
++        this.fireball = fireball;
++    }
++
++    /**
++     * The enderdragon shooting the fireball
++     */
++    @Override
++    public EnderDragon getEntity() {
++        return (EnderDragon) super.getEntity();
++    }
++
++    /**
++     * The fireball being shot
++     */
++    public DragonFireball getFireball() {
++        return fireball;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    private boolean cancelled = false;
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++}
+-- 
+2.11.0
+

--- a/Spigot-Server-Patches/0317-New-EnderDragon-Events.patch
+++ b/Spigot-Server-Patches/0317-New-EnderDragon-Events.patch
@@ -1,0 +1,60 @@
+From f228cfada9a151d03f42842a11b33ce602d3747d Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 1 Jul 2018 11:50:05 -0500
+Subject: [PATCH] New EnderDragon Events
+
+
+diff --git a/src/main/java/net/minecraft/server/DragonControllerLandedFlame.java b/src/main/java/net/minecraft/server/DragonControllerLandedFlame.java
+index deee5c4cc..ac719ce7d 100644
+--- a/src/main/java/net/minecraft/server/DragonControllerLandedFlame.java
++++ b/src/main/java/net/minecraft/server/DragonControllerLandedFlame.java
+@@ -63,7 +63,9 @@ public class DragonControllerLandedFlame extends AbstractDragonControllerLanded
+             this.d.setDuration(200);
+             this.d.setParticle(EnumParticle.DRAGON_BREATH);
+             this.d.a(new MobEffect(MobEffects.HARM));
++            if (new com.destroystokyo.paper.event.entity.EnderDragonFlameEvent((org.bukkit.entity.EnderDragon) this.a.getBukkitEntity(), (org.bukkit.entity.AreaEffectCloud) this.d.getBukkitEntity()).callEvent()) // Paper
+             this.a.world.addEntity(this.d);
++            else this.removeAreaEffect(); // Paper
+         }
+ 
+     }
+@@ -73,6 +75,7 @@ public class DragonControllerLandedFlame extends AbstractDragonControllerLanded
+         ++this.c;
+     }
+ 
++    public void removeAreaEffect() { this.e(); } // Paper - OBFHELPER
+     public void e() {
+         if (this.d != null) {
+             this.d.die();
+diff --git a/src/main/java/net/minecraft/server/DragonControllerStrafe.java b/src/main/java/net/minecraft/server/DragonControllerStrafe.java
+index c5b712f88..d229b16fa 100644
+--- a/src/main/java/net/minecraft/server/DragonControllerStrafe.java
++++ b/src/main/java/net/minecraft/server/DragonControllerStrafe.java
+@@ -67,7 +67,9 @@ public class DragonControllerStrafe extends AbstractDragonController {
+                         EntityDragonFireball entitydragonfireball = new EntityDragonFireball(this.a.world, this.a, d9, d10, d11);
+ 
+                         entitydragonfireball.setPositionRotation(d6, d7, d8, 0.0F, 0.0F);
++                        if (new com.destroystokyo.paper.event.entity.EnderDragonShootFireballEvent((org.bukkit.entity.EnderDragon) a.getBukkitEntity(), (org.bukkit.entity.DragonFireball) entitydragonfireball.getBukkitEntity()).callEvent()) // Paper
+                         this.a.world.addEntity(entitydragonfireball);
++                        else entitydragonfireball.die(); // Paper
+                         this.c = 0;
+                         if (this.d != null) {
+                             while (!this.d.b()) {
+diff --git a/src/main/java/net/minecraft/server/EntityDragonFireball.java b/src/main/java/net/minecraft/server/EntityDragonFireball.java
+index e776b9721..4696b97f7 100644
+--- a/src/main/java/net/minecraft/server/EntityDragonFireball.java
++++ b/src/main/java/net/minecraft/server/EntityDragonFireball.java
+@@ -45,8 +45,10 @@ public class EntityDragonFireball extends EntityFireball {
+                     }
+                 }
+ 
++                if (new com.destroystokyo.paper.event.entity.EnderDragonFireballHitEvent((org.bukkit.entity.DragonFireball) this.getBukkitEntity(), list, (org.bukkit.entity.AreaEffectCloud) entityareaeffectcloud.getBukkitEntity()).callEvent()) { // Paper
+                 this.world.triggerEffect(2006, new BlockPosition(this.locX, this.locY, this.locZ), 0);
+                 this.world.addEntity(entityareaeffectcloud);
++                } else entityareaeffectcloud.die(); // Paper
+                 this.die();
+             }
+ 
+-- 
+2.11.0
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -65,8 +65,10 @@ import DataInspectorBlockEntity
 import DataPalette
 import DefinedStructure
 import DragonControllerLandedFlame
+import DragonControllerStrafe
 import EnchantmentManager
 import Enchantments
+import EntityDragonFireball
 import EntityIllagerIllusioner
 import EntityLlama
 import EntitySquid


### PR DESCRIPTION
Add some new cancellable enderdragon events dealing with its fireball shooting and the areaeffectcloud it spawns. Based on [talking with someone with a specific use-case](https://www.spigotmc.org/threads/cancel-projectilehitevent.326466/) this was [confirmed to work](http://i.imgur.com/ezlfpKC.png) for them in PM.