### PR TITLE
Add World.getEntity(UUID) API

### DIFF
--- a/Spigot-API-Patches/0121-Add-World.getEntity-UUID-API.patch
+++ b/Spigot-API-Patches/0121-Add-World.getEntity-UUID-API.patch
@@ -1,0 +1,30 @@
+From e19fe3a36b5abf507c209e4a4b43c7b18f27b938 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Tue, 3 Jul 2018 16:07:16 +0200
+Subject: [PATCH] Add World.getEntity(UUID) API
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 4ed7d2dc..4441a8e0 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -756,6 +756,16 @@ public interface World extends PluginMessageRecipient, Metadatable {
+      */
+     public Collection<Entity> getNearbyEntities(Location location, double x, double y, double z);
+ 
++    // Paper start - getEntity by UUID API
++    /**
++     * Gets an entity in this world by its UUID
++     *
++     * @param uuid the UUID of the entity
++     * @return the entity with the given UUID, or null if it isn't found
++     */
++    public Entity getEntity(UUID uuid);
++    // Paper end
++
+     /**
+      * Gets the unique name of this world
+      *
+-- 
+2.16.1.windows.1
+

--- a/Spigot-Server-Patches/0318-Implement-World.getEntity-UUID-API.patch
+++ b/Spigot-Server-Patches/0318-Implement-World.getEntity-UUID-API.patch
@@ -1,0 +1,28 @@
+From 45b9aa46ba5547e98975dacc52a5caefffdc5721 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Tue, 3 Jul 2018 16:08:14 +0200
+Subject: [PATCH] Implement World.getEntity(UUID) API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index e2da30d88..210e3bc4e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -791,6 +791,14 @@ public class CraftWorld implements World {
+         return list;
+     }
+ 
++    // Paper start - getEntity by UUID API
++    public Entity getEntity(UUID uuid) {
++        Validate.notNull(uuid, "UUID cannot be null");
++        net.minecraft.server.Entity entity = world.getEntity(uuid);
++        return entity == null ? null : entity.getBukkitEntity();
++    }
++    // Paper end
++
+     public void save() {
+     // Spigot start
+         save(true);
+-- 
+2.16.1.windows.1
+


### PR DESCRIPTION
This is the best way to get an entity when the world and its UUID are known. It is faster than Server.getEntity(UUID) because it does not have to iterate all worlds