### PR TITLE
Refresh player inventory when cancelling PlayerInteractEntityEvent

### DIFF
--- a/Spigot-Server-Patches/0329-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/Spigot-Server-Patches/0329-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -1,0 +1,32 @@
+From 2d88ccd486565ced7b650bed5f15c8d4bbf3c809 Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Fri, 13 Jul 2018 14:54:43 +0200
+Subject: [PATCH] Refresh player inventory when cancelling
+ PlayerInteractEntityEvent
+
+When interacting with entities with an item, the client will assume
+the interaction is successful, and update the held item on the
+client. However, if the interaction is cancelled on the server side,
+the client will still mistakenly remove/replace the item in hand.
+
+Examples for this are milking cows with a bucket or dyeing sheep.
+The bucket is replaced with milk and the dye removed from inventory.
+
+Refresh the player inventory when PlayerInteractEntityEvent is
+cancelled to avoid this problem.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index a54203c56..cc1152739 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1673,6 +1673,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+                     }
+ 
+                     if (event.isCancelled()) {
++                        this.player.updateInventory(this.player.activeContainer); // Paper - Refresh player inventory
+                         return;
+                     }
+                     // CraftBukkit end
+-- 
+2.18.0
+


### PR DESCRIPTION
When interacting with entities with an item, the client will assume
the interaction is successful, and update the held item on the
client. However, if the interaction is cancelled on the server side,
the client will still mistakenly remove/replace the item in hand.

Examples for this are milking cows with a bucket or dyeing sheep.
The bucket is replaced with milk and the dye removed from inventory.

Refresh the player inventory when PlayerInteractEntityEvent is
cancelled to avoid this problem.