### PR TITLE
Prevent fireworks from loading chunks

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -33,4 +33,5 @@ MiniDigger <admin@minidigger.me>
 Brokkonaut <hannos17@gmx.de>
 vemacs <d@nkmem.es>
 stonar96 <minecraft.stonar96@gmail.com>
+Hugo Manrique <git@hugmanrique.me>
 ```

--- a/Spigot-Server-Patches/0330-Prevent-fireworks-from-loading-chunks.patch
+++ b/Spigot-Server-Patches/0330-Prevent-fireworks-from-loading-chunks.patch
@@ -1,0 +1,29 @@
+From 8d6ac3f8b8b27b531475e1705e306166a6d4e9d7 Mon Sep 17 00:00:00 2001
+From: Hugo Manrique <hugmanrique@gmail.com>
+Date: Sun, 15 Jul 2018 22:09:30 +0200
+Subject: [PATCH] Prevent fireworks from loading chunks
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityFireworks.java b/src/main/java/net/minecraft/server/EntityFireworks.java
+index bd0ec95f..1e823c8d 100644
+--- a/src/main/java/net/minecraft/server/EntityFireworks.java
++++ b/src/main/java/net/minecraft/server/EntityFireworks.java
+@@ -236,4 +236,15 @@ public class EntityFireworks extends Entity {
+     public boolean bd() {
+         return false;
+     }
++
++    // Paper start - Prevent chunk loading
++    @Override
++    public boolean au() {
++        if (!world.isChunkLoaded(getChunkX(), getChunkZ(), false)) {
++            return false;
++        }
++
++        return super.au();
++    }
++    // Paper end
+ }
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
Closes #860. When the `tickEntities` method of `World` gets called, the following methods get called:

- `void Entity.B_()`
- `void Entity.Y()`
- `boolean Entity.au()`
- `boolean World.a(AxisAlignedBB, Material)`
- `IBlockData getType(BlockPosition)`
- `Chunk ChunkProviderServer.getChunkAt(int, int)`

The later method will load the chunk synchronously if it isn't yet, seen on the timings report as `syncChunkLoad`.

I just overrided the `au()` method on the firework entity to only check if the chunk is loaded.

I'm sorry for making the change on a commit with a completely different message, this was my first time contributing and didn't know I had to manually commit the patch (after commiting on the `Paper-Server` module).