### PR TITLE
Update to TerminalConsoleAppender 1.1.0, use async loggers

### DIFF
--- a/Spigot-Server-Patches/0210-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0210-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 0140f0a679cb39eb069e0ea08f22775885ee9a16 Mon Sep 17 00:00:00 2001
+From 0d577c1a44e062b5c0fb4d6d7abbca6cf737ccf6 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -15,12 +15,11 @@ New features:
     IntelliJ IDEA
 
 Other changes:
-  - Update JLine to 3.3.1 (from 2.12.1)
   - Server starts 1-2 seconds faster thanks to optimizations in Log4j
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 9d273c6d9..26775156b 100644
+index 9d273c6d9..13fa95891 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -53,12 +53,6 @@
@@ -44,12 +43,12 @@ index 9d273c6d9..26775156b 100644
 +        <dependency>
 +            <groupId>net.minecrell</groupId>
 +            <artifactId>terminalconsoleappender</artifactId>
-+            <version>1.0.0</version>
++            <version>1.1.0</version>
 +        </dependency>
 +        <dependency>
 +            <groupId>net.java.dev.jna</groupId>
 +            <artifactId>jna</artifactId>
-+            <version>4.4.0</version>
++            <version>4.5.2</version>
 +            <scope>runtime</scope>
 +        </dependency>
 +
@@ -88,6 +87,52 @@ index 9d273c6d9..26775156b 100644
              </plugin>
              <plugin>
                  <groupId>org.apache.maven.plugins</groupId>
+diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+new file mode 100644
+index 000000000..116d1b3bf
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
+@@ -0,0 +1,40 @@
++package com.destroystokyo.paper.console;
++
++import net.minecraft.server.DedicatedServer;
++import net.minecrell.terminalconsole.SimpleTerminalConsole;
++import org.bukkit.craftbukkit.command.ConsoleCommandCompleter;
++import org.jline.reader.LineReader;
++import org.jline.reader.LineReaderBuilder;
++
++public final class PaperConsole extends SimpleTerminalConsole {
++
++    private final DedicatedServer server;
++
++    public PaperConsole(DedicatedServer server) {
++        this.server = server;
++    }
++
++    @Override
++    protected LineReader buildReader(LineReaderBuilder builder) {
++        return super.buildReader(builder
++                .appName("Paper")
++                .completer(new ConsoleCommandCompleter(this.server))
++        );
++    }
++
++    @Override
++    protected boolean isRunning() {
++        return !this.server.isStopped() && this.server.isRunning();
++    }
++
++    @Override
++    protected void runCommand(String command) {
++        this.server.issueCommand(command, this.server);
++    }
++
++    @Override
++    protected void shutdown() {
++        this.server.safeShutdown();
++    }
++
++}
 diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
 new file mode 100644
 index 000000000..685deaa0e
@@ -111,108 +156,30 @@ index 000000000..685deaa0e
 +    }
 +
 +}
-diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
-new file mode 100644
-index 000000000..626bfeec8
---- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/console/TerminalHandler.java
-@@ -0,0 +1,61 @@
-+package com.destroystokyo.paper.console;
-+
-+import net.minecraft.server.DedicatedServer;
-+import net.minecrell.terminalconsole.TerminalConsoleAppender;
-+import org.bukkit.craftbukkit.command.ConsoleCommandCompleter;
-+import org.jline.reader.EndOfFileException;
-+import org.jline.reader.LineReader;
-+import org.jline.reader.LineReaderBuilder;
-+import org.jline.reader.UserInterruptException;
-+import org.jline.terminal.Terminal;
-+
-+public class TerminalHandler {
-+
-+    private TerminalHandler() {
-+    }
-+
-+    public static boolean handleCommands(DedicatedServer server) {
-+        final Terminal terminal = TerminalConsoleAppender.getTerminal();
-+        if (terminal == null) {
-+            return false;
-+        }
-+
-+        LineReader reader = LineReaderBuilder.builder()
-+                .appName("Paper")
-+                .terminal(terminal)
-+                .completer(new ConsoleCommandCompleter(server))
-+                .build();
-+        reader.setOpt(LineReader.Option.DISABLE_EVENT_EXPANSION);
-+        reader.unsetOpt(LineReader.Option.INSERT_TAB);
-+
-+        TerminalConsoleAppender.setReader(reader);
-+
-+        try {
-+            String line;
-+            while (!server.isStopped() && server.isRunning()) {
-+                try {
-+                    line = reader.readLine("> ");
-+                } catch (EndOfFileException ignored) {
-+                    // Continue reading after EOT
-+                    continue;
-+                }
-+
-+                if (line == null) {
-+                    break;
-+                }
-+
-+                line = line.trim();
-+                if (!line.isEmpty()) {
-+                    server.issueCommand(line, server);
-+                }
-+            }
-+        } catch (UserInterruptException e) {
-+            server.safeShutdown();
-+        } finally {
-+            TerminalConsoleAppender.setReader(null);
-+        }
-+
-+        return true;
-+    }
-+
-+}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 8f2afcc32..b3f1aa999 100644
+index 8f2afcc32..895ea0aad 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -73,7 +73,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -73,6 +73,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
                  if (!org.bukkit.craftbukkit.Main.useConsole) {
                      return;
                  }
--                jline.console.ConsoleReader bufferedreader = reader;
-+                // Paper start - Use TerminalConsoleAppender implementation
-+                if (com.destroystokyo.paper.console.TerminalHandler.handleCommands(DedicatedServer.this)) return;
-+                BufferedReader bufferedreader = new BufferedReader(new InputStreamReader(System.in, StandardCharsets.UTF_8));
-+                // Paper end
++                // Paper start - Use TerminalConsoleAppender
++                new com.destroystokyo.paper.console.PaperConsole(DedicatedServer.this).start();
++                /*
+                 jline.console.ConsoleReader bufferedreader = reader;
                  // CraftBukkit end
  
-                 String s;
-@@ -81,11 +84,17 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-                 try {
-                     // CraftBukkit start - JLine disabling compatibility
-                     while (!isStopped() && isRunning()) {
-+                        // Paper start - code is not used for jline
-+                        /*
-                         if (org.bukkit.craftbukkit.Main.useJline) {
-                             s = bufferedreader.readLine(">", null);
-                         } else {
-                             s = bufferedreader.readLine();
-                         }
-+                        */
-+                        s = bufferedreader.readLine();
-+                        // Paper end
-+
-                         if (s != null && s.trim().length() > 0) { // Trim to filter lines which are just spaces
-                             issueCommand(s, DedicatedServer.this);
-                         }
-@@ -106,6 +115,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -95,6 +98,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+                     DedicatedServer.LOGGER.error("Exception handling console input", ioexception);
+                 }
+ 
++                */
++                // Paper end
+             }
+         };
+ 
+@@ -106,6 +111,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
          global.addHandler(new org.bukkit.craftbukkit.util.ForwardLogHandler());
  
@@ -222,7 +189,7 @@ index 8f2afcc32..b3f1aa999 100644
          final org.apache.logging.log4j.core.Logger logger = ((org.apache.logging.log4j.core.Logger) LogManager.getRootLogger());
          for (org.apache.logging.log4j.core.Appender appender : logger.getAppenders().values()) {
              if (appender instanceof org.apache.logging.log4j.core.appender.ConsoleAppender) {
-@@ -114,6 +126,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -114,6 +122,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
          new Thread(new org.bukkit.craftbukkit.util.TerminalConsoleWriterThread(System.out, this.reader)).start();

--- a/Spigot-Server-Patches/0236-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
+++ b/Spigot-Server-Patches/0236-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
@@ -1,4 +1,4 @@
-From 8ea6c7c92ee771c81f1b19594919eda513a1c96e Mon Sep 17 00:00:00 2001
+From 3fee40b0e6af1b34a240c1229455387ca8b3965c Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Mon, 18 Sep 2017 12:00:03 +0200
 Subject: [PATCH] Use Log4j IOStreams to redirect System.out/err to logger
@@ -12,7 +12,7 @@ results in a separate line, even though it should not result in
 a line break. Log4j's implementation handles it correctly.
 
 diff --git a/pom.xml b/pom.xml
-index 26775156b..adf79de70 100644
+index 22b86c74a..acc4bdfa4 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -97,6 +97,13 @@
@@ -30,10 +30,10 @@ index 26775156b..adf79de70 100644
          <dependency>
              <groupId>junit</groupId>
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index b3f1aa999..854455711 100644
+index 895ea0aad..18d32ab76 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -129,8 +129,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -125,8 +125,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          */
          // Paper end
  

--- a/Spigot-Server-Patches/0289-Load-version-history-at-server-start.patch
+++ b/Spigot-Server-Patches/0289-Load-version-history-at-server-start.patch
@@ -1,14 +1,14 @@
-From d308df8c419762a2bef93e351ecded6ff14bbcce Mon Sep 17 00:00:00 2001
+From 0178b17d09c4e8e5d7c4cf65953b2fb44d23ae24 Mon Sep 17 00:00:00 2001
 From: Kyle Wood <demonwav@gmail.com>
 Date: Thu, 1 Mar 2018 19:38:14 -0600
 Subject: [PATCH] Load version history at server start
 
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 854455711..39a3d46ff 100644
+index 18d32ab76..292291592 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -203,6 +203,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -199,6 +199,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              // Paper start
              com.destroystokyo.paper.PaperConfig.init((File) options.valueOf("paper-settings"));
              com.destroystokyo.paper.PaperConfig.registerCommands();

--- a/Spigot-Server-Patches/0330-Use-asynchronous-Log4j-2-loggers.patch
+++ b/Spigot-Server-Patches/0330-Use-asynchronous-Log4j-2-loggers.patch
@@ -1,0 +1,35 @@
+From 9a854c07dd545cf8b4a1a9e6d121f4018acdc50a Mon Sep 17 00:00:00 2001
+From: Minecrell <minecrell@minecrell.net>
+Date: Tue, 17 Jul 2018 16:42:17 +0200
+Subject: [PATCH] Use asynchronous Log4j 2 loggers
+
+
+diff --git a/pom.xml b/pom.xml
+index 155896ffb..6f445dc9b 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -110,6 +110,14 @@
+             <version>2.8.1</version>
+         </dependency>
+ 
++        <!-- Paper - Async loggers -->
++        <dependency>
++            <groupId>com.lmax</groupId>
++            <artifactId>disruptor</artifactId>
++            <version>3.4.2</version>
++            <scope>runtime</scope>
++        </dependency>
++
+         <!-- testing -->
+         <dependency>
+             <groupId>junit</groupId>
+diff --git a/src/main/resources/log4j2.component.properties b/src/main/resources/log4j2.component.properties
+new file mode 100644
+index 000000000..ee7c90784
+--- /dev/null
++++ b/src/main/resources/log4j2.component.properties
+@@ -0,0 +1 @@
++Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
+-- 
+2.18.0
+


### PR DESCRIPTION
Update TerminalConsoleAppender and JLine to fix a race condition that may result in `IllegalStateException`s or duplicate input prompts. Switch to async loggers as an attempt to avoid #1176 in most cases, although it will only work as long the console is only temporary blocking - otherwise the queue will fill up and it will block again.

Fixes #1093, Fixes #1176 

Related changes for Waterfall: https://github.com/WaterfallMC/Waterfall/pull/249