### PR TITLE
Update to TerminalConsoleAppender 1.1.1

### DIFF
--- a/Spigot-Server-Patches/0210-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0210-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 0d577c1a44e062b5c0fb4d6d7abbca6cf737ccf6 Mon Sep 17 00:00:00 2001
+From 3a03d1fc7302369fb0ec00c3b677d3484ea8f58c Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 9d273c6d9..13fa95891 100644
+index 9d273c6d9..491887cf9 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -53,12 +53,6 @@
@@ -43,7 +43,7 @@ index 9d273c6d9..13fa95891 100644
 +        <dependency>
 +            <groupId>net.minecrell</groupId>
 +            <artifactId>terminalconsoleappender</artifactId>
-+            <version>1.1.0</version>
++            <version>1.1.1</version>
 +        </dependency>
 +        <dependency>
 +            <groupId>net.java.dev.jna</groupId>


### PR DESCRIPTION
Fixes empty lines in warnings/errors: https://korobi.io/network/spigot/channel/paper/logs/#L829-832

See https://github.com/Minecrell/TerminalConsoleAppender/releases/tag/1.1.1