### PR TITLE
Re-add MC-94186 Fix dragon egg falling in lazy chunks

### DIFF
--- a/Spigot-Server-Patches/0307-MC-94186-Fix-dragon-egg-falling-in-lazy-chunks.patch
+++ b/Spigot-Server-Patches/0307-MC-94186-Fix-dragon-egg-falling-in-lazy-chunks.patch
@@ -1,0 +1,22 @@
+From 678c19922f25678469691fadc0cbe2a52203e27d Mon Sep 17 00:00:00 2001
+From: Hugo Manrique <hugmanrique@gmail.com>
+Date: Mon, 23 Jul 2018 19:18:37 +0200
+Subject: [PATCH] MC-94186 Fix dragon egg falling in lazy chunks
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockDragonEgg.java b/src/main/java/net/minecraft/server/BlockDragonEgg.java
+index bfee7ec2..ead8864f 100644
+--- a/src/main/java/net/minecraft/server/BlockDragonEgg.java
++++ b/src/main/java/net/minecraft/server/BlockDragonEgg.java
+@@ -53,7 +53,7 @@ public class BlockDragonEgg extends BlockFalling {
+                         world.addParticle(Particles.K, d1, d2, d3, (double) f, (double) f1, (double) f2);
+                     }
+                 } else {
+-                    world.setTypeAndData(blockposition1, iblockdata, 2);
++                    world.setTypeAndData(blockposition1.up(), iblockdata, 2); // Paper - fix dragon egg falling in lazy chunks
+                     world.setAir(blockposition);
+                 }
+ 
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
Fixes falling dragon eggs in lazy chunks fall to the block below the last empty block and replacing that block with them.

Although the original issue was resolved in 2017 (https://bugs.mojang.com/browse/MC-94186), the same FallingBlock logic is still overriden and the dragon egg can fall into the block just below the last empty block and replace it with it.