### PR TITLE
Apply spawner delay for cancelled pre spawn events

### DIFF
--- a/Spigot-Server-Patches/0261-PreCreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0261-PreCreatureSpawnEvent.patch
@@ -1,4 +1,4 @@
-From 0d9573cce034afcfd6b1f86fd955aeae30d06f30 Mon Sep 17 00:00:00 2001
+From 0ae51485d202666ce7a9cfdb15feb2a587c0c445 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 14 Jan 2018 17:01:31 -0500
 Subject: [PATCH] PreCreatureSpawnEvent
@@ -15,7 +15,7 @@ instead and save a lot of server resources.
 See: https://github.com/PaperMC/Paper/issues/917
 
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
-index 87fe4775f..9466bcdc7 100644
+index 87fe4775..94d0b8a3 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
 +++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
 @@ -1,6 +1,7 @@
@@ -26,7 +26,7 @@ index 87fe4775f..9466bcdc7 100644
  import java.util.Iterator;
  import java.util.List;
  import javax.annotation.Nullable;
-@@ -87,6 +88,27 @@ public abstract class MobSpawnerAbstract {
+@@ -87,6 +88,28 @@ public abstract class MobSpawnerAbstract {
                      double d3 = j >= 1 ? nbttaglist.f(0) : (double) blockposition.getX() + (world.random.nextDouble() - world.random.nextDouble()) * (double) this.spawnRange + 0.5D;
                      double d4 = j >= 2 ? nbttaglist.f(1) : (double) (blockposition.getY() + world.random.nextInt(3) - 1);
                      double d5 = j >= 3 ? nbttaglist.f(2) : (double) blockposition.getZ() + (world.random.nextDouble() - world.random.nextDouble()) * (double) this.spawnRange + 0.5D;
@@ -44,6 +44,7 @@ index 87fe4775f..9466bcdc7 100644
 +                                org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
 +                        );
 +                        if (!event.callEvent()) {
++                            flag = true;
 +                            if (event.shouldAbortSpawn()) {
 +                                break;
 +                            }
@@ -55,7 +56,7 @@ index 87fe4775f..9466bcdc7 100644
  
                      if (entity == null) {
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index 2cd063829..e217d3340 100644
+index ed22607d..5d633774 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
 @@ -184,6 +184,25 @@ public final class SpawnerCreature {
@@ -85,5 +86,5 @@ index 2cd063829..e217d3340 100644
  
                                                          try {
 -- 
-2.18.0
+2.16.2.windows.1
 


### PR DESCRIPTION
Setting the flag updates the spawner's delay which stops the spawner from trying to find a new spawn position each tick efter the event was cancelled/aborted which makes it usable for mob stackers/mergers and other plugins that don't actually want any mob to spawn in the spawner cycle but keep the overall behaviour close to vanilla.

This might slightly effect existing plugins that use this event but I doubt anyone really relied on this behaviour, the only possible use case that I can think of is cancelling the event until you find a suitable position in your plugin... and this should be handled by the plugin itself by cancelling and spawning at the position manually.