### PR TITLE
Fix nether portals (#1286)

### DIFF
--- a/Spigot-Server-Patches/0246-Call-PortalCreateEvent-for-exit-portals.patch
+++ b/Spigot-Server-Patches/0246-Call-PortalCreateEvent-for-exit-portals.patch
@@ -1,14 +1,14 @@
-From 1638f3ff3613a2cfefd5bb77b761ff9b96e46e8d Mon Sep 17 00:00:00 2001
+From cedf22782245c8cfa8dbfecc3a445dc2f31552b1 Mon Sep 17 00:00:00 2001
 From: MiniDigger <admin@minidigger.me>
 Date: Sun, 18 Mar 2018 15:44:44 +0100
 Subject: [PATCH] Call PortalCreateEvent for exit portals
 
 
 diff --git a/src/main/java/net/minecraft/server/PortalTravelAgent.java b/src/main/java/net/minecraft/server/PortalTravelAgent.java
-index 402d8d7d63..f363734500 100644
+index 402d8d7d..cd8b4b4a 100644
 --- a/src/main/java/net/minecraft/server/PortalTravelAgent.java
 +++ b/src/main/java/net/minecraft/server/PortalTravelAgent.java
-@@ -3,16 +3,23 @@ package net.minecraft.server;
+@@ -3,16 +3,24 @@ package net.minecraft.server;
  import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
  import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
  import it.unimi.dsi.fastutil.objects.ObjectIterator;
@@ -16,6 +16,7 @@ index 402d8d7d63..f363734500 100644
 +import java.util.Collection;
 +import java.util.HashMap;
 +import java.util.HashSet;
++import java.util.LinkedHashMap;
 +import java.util.Map;
  import java.util.Random;
  // CraftBukkit start
@@ -33,7 +34,7 @@ index 402d8d7d63..f363734500 100644
      public final WorldServer world; // Paper - private -> public
      private final Random c;
      private final Long2ObjectMap<PortalTravelAgent.ChunkCoordinatesPortal> d = new Long2ObjectOpenHashMap(4096);
-@@ -48,6 +55,9 @@ public class PortalTravelAgent {
+@@ -48,6 +56,9 @@ public class PortalTravelAgent {
              byte b0 = 1;
              byte b1 = 0;
  
@@ -43,7 +44,7 @@ index 402d8d7d63..f363734500 100644
              for (int l = -2; l <= 2; ++l) {
                  for (int i1 = -2; i1 <= 2; ++i1) {
                      for (int j1 = -1; j1 < 3; ++j1) {
-@@ -56,11 +66,22 @@ public class PortalTravelAgent {
+@@ -56,11 +67,22 @@ public class PortalTravelAgent {
                          int i2 = k + i1 * 0 - l * 1;
                          boolean flag2 = j1 < 0;
  
@@ -67,17 +68,17 @@ index 402d8d7d63..f363734500 100644
          // CraftBukkit start
          return new BlockPosition(i, k, k);
      }
-@@ -404,6 +425,9 @@ public class PortalTravelAgent {
+@@ -404,6 +426,9 @@ public class PortalTravelAgent {
              l5 = -l5;
          }
  
 +        Collection<Block> bukkitBlocks = new HashSet<>(); // Paper
-+        Map<BlockPosition, IBlockData> nmsBlocks = new HashMap<>(); // Paper
++        Map<BlockPosition, IBlockData> nmsBlocks = new LinkedHashMap<>(); // Paper
 +
          if (d0 < 0.0D) {
              i1 = MathHelper.clamp(i1, 70, this.world.aa() - 10);
              j5 = i1;
-@@ -416,8 +440,11 @@ public class PortalTravelAgent {
+@@ -416,8 +441,11 @@ public class PortalTravelAgent {
                          l3 = j2 + (l2 - 1) * l5 - k2 * k5;
                          boolean flag1 = i3 < 0;
  
@@ -91,7 +92,7 @@ index 402d8d7d63..f363734500 100644
                      }
                  }
              }
-@@ -427,7 +454,11 @@ public class PortalTravelAgent {
+@@ -427,7 +455,11 @@ public class PortalTravelAgent {
              for (l2 = -1; l2 < 4; ++l2) {
                  if (k2 == -1 || k2 == 2 || l2 == -1 || l2 == 3) {
                      blockposition_mutableblockposition.c(i5 + k2 * k5, j5 + l2, j2 + k2 * l5);
@@ -104,7 +105,7 @@ index 402d8d7d63..f363734500 100644
                  }
              }
          }
-@@ -437,10 +468,22 @@ public class PortalTravelAgent {
+@@ -437,10 +469,22 @@ public class PortalTravelAgent {
          for (l2 = 0; l2 < 2; ++l2) {
              for (i3 = 0; i3 < 3; ++i3) {
                  blockposition_mutableblockposition.c(i5 + l2 * k5, j5 + i3, j2 + l2 * l5);
@@ -129,5 +130,5 @@ index 402d8d7d63..f363734500 100644
      }
  
 -- 
-2.18.0
+2.12.2.windows.2
 


### PR DESCRIPTION
In vanilla/CB/spigot, the obsidian portal frame is placed before the nether_portal blocks inside. The paper patch places them afterwards from a HashMap, which is causing nether_portal blocks to disappear due to physics when the obsidian blocks are placed next to them. Fixed by using a LinkedHashMap instead.