### PR TITLE
Use ConcurrentHashMap in JsonList & Optimize (#471)

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+[*.java]
+charset=utf-8
+end_of_line=lf
+insert_final_newline=true
+indent_style=space
+indent_size=4

--- a/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
@@ -1,4 +1,4 @@
-From a3ff7e5e2422aaaee4d68c90397201107ef605f6 Mon Sep 17 00:00:00 2001
+From d5626a994903ac7997f1fd6e1efa7ede3d180588 Mon Sep 17 00:00:00 2001
 From: egg82 <phantom_zero@ymail.com>
 Date: Tue, 7 Aug 2018 01:24:23 -0600
 Subject: [PATCH] Use ConcurrentHashMap in JsonList
@@ -25,29 +25,28 @@ The point of this is readability, but does have a side-benefit of a small microp
 Finally, added a couple obfhelpers for the modified code
 
 diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
-index 0859c7eb2..05b3a1910 100644
+index 0859c7eb2..93111cc24 100644
 --- a/src/main/java/net/minecraft/server/JsonList.java
 +++ b/src/main/java/net/minecraft/server/JsonList.java
-@@ -26,6 +26,8 @@ import java.util.Collection;
+@@ -26,6 +26,7 @@ import java.util.Collection;
  import java.util.Iterator;
  import java.util.List;
  import java.util.Map;
-+import java.util.concurrent.ConcurrentMap;
 +
  import org.apache.commons.io.IOUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -35,7 +37,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -35,7 +36,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      protected static final Logger a = LogManager.getLogger();
      protected final Gson b;
      private final File c;
 -    private final Map<String, V> d = Maps.newHashMap();
 +    // Paper - replace HashMap is ConcurrentHashMap
-+    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap(); private final ConcurrentMap<String, V> getBackingMap() { return this.d; } // Paper - OBFHELPER
++    private final Map<String, V> d = Maps.newConcurrentMap(); private final Map<String, V> getBackingMap() { return this.d; } // Paper - OBFHELPER
      private boolean e = true;
      private static final ParameterizedType f = new ParameterizedType() {
          public Type[] getActualTypeArguments() {
-@@ -83,8 +86,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -83,8 +85,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      }
  
      public V get(K k0) {
@@ -63,7 +62,7 @@ index 0859c7eb2..05b3a1910 100644
      }
  
      public void remove(K k0) {
-@@ -109,9 +117,11 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -109,9 +116,11 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      // CraftBukkit end
  
      public boolean isEmpty() {
@@ -76,7 +75,7 @@ index 0859c7eb2..05b3a1910 100644
      protected String a(K k0) {
          return k0.toString();
      }
-@@ -120,8 +130,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -120,8 +129,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
          return this.d.containsKey(this.a(k0));
      }
  
@@ -88,7 +87,7 @@ index 0859c7eb2..05b3a1910 100644
          Iterator iterator = this.d.values().iterator();
  
          while (iterator.hasNext()) {
-@@ -138,8 +150,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -138,8 +149,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
              Object object = iterator.next();
  
              this.d.remove(object);
@@ -101,7 +100,7 @@ index 0859c7eb2..05b3a1910 100644
      }
  
      protected JsonListEntry<K> a(JsonObject jsonobject) {
-@@ -151,6 +165,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -151,6 +164,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      }
  
      public void save() throws IOException {

--- a/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
@@ -1,4 +1,4 @@
-From c5ad0647ed56042d20716ee08bf7e4593cc15f0d Mon Sep 17 00:00:00 2001
+From a3ff7e5e2422aaaee4d68c90397201107ef605f6 Mon Sep 17 00:00:00 2001
 From: egg82 <phantom_zero@ymail.com>
 Date: Tue, 7 Aug 2018 01:24:23 -0600
 Subject: [PATCH] Use ConcurrentHashMap in JsonList
@@ -25,22 +25,10 @@ The point of this is readability, but does have a side-benefit of a small microp
 Finally, added a couple obfhelpers for the modified code
 
 diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
-index 0859c7eb2..ad0ac4247 100644
+index 0859c7eb2..05b3a1910 100644
 --- a/src/main/java/net/minecraft/server/JsonList.java
 +++ b/src/main/java/net/minecraft/server/JsonList.java
-@@ -1,6 +1,5 @@
- package net.minecraft.server;
- 
--import com.google.common.collect.Lists;
- import com.google.common.collect.Maps;
- import com.google.common.io.Files;
- import com.google.gson.Gson;
-@@ -21,11 +20,12 @@ import java.io.Reader;
- import java.lang.reflect.ParameterizedType;
- import java.lang.reflect.Type;
- import java.nio.charset.StandardCharsets;
--import java.util.ArrayList;
- import java.util.Collection;
+@@ -26,6 +26,8 @@ import java.util.Collection;
  import java.util.Iterator;
  import java.util.List;
  import java.util.Map;
@@ -49,7 +37,7 @@ index 0859c7eb2..ad0ac4247 100644
  import org.apache.commons.io.IOUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -35,7 +35,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -35,7 +37,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      protected static final Logger a = LogManager.getLogger();
      protected final Gson b;
      private final File c;
@@ -59,7 +47,7 @@ index 0859c7eb2..ad0ac4247 100644
      private boolean e = true;
      private static final ParameterizedType f = new ParameterizedType() {
          public Type[] getActualTypeArguments() {
-@@ -83,8 +84,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -83,8 +86,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      }
  
      public V get(K k0) {
@@ -75,7 +63,7 @@ index 0859c7eb2..ad0ac4247 100644
      }
  
      public void remove(K k0) {
-@@ -109,9 +115,11 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -109,9 +117,11 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      // CraftBukkit end
  
      public boolean isEmpty() {
@@ -88,7 +76,7 @@ index 0859c7eb2..ad0ac4247 100644
      protected String a(K k0) {
          return k0.toString();
      }
-@@ -120,8 +128,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -120,8 +130,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
          return this.d.containsKey(this.a(k0));
      }
  
@@ -100,7 +88,7 @@ index 0859c7eb2..ad0ac4247 100644
          Iterator iterator = this.d.values().iterator();
  
          while (iterator.hasNext()) {
-@@ -138,8 +148,12 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -138,8 +150,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
              Object object = iterator.next();
  
              this.d.remove(object);
@@ -108,9 +96,7 @@ index 0859c7eb2..ad0ac4247 100644
 -
 +        }*/
 +        
-+        this.getBackingMap().values().removeIf((v) -> {
-+            return v.hasExpired();
-+        });
++        this.getBackingMap().values().removeIf((v) -> v.hasExpired());
 +        // Paper end
      }
  

--- a/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
@@ -1,4 +1,4 @@
-From 09180265677dc3536b84e281a36d040efdcbdaf7 Mon Sep 17 00:00:00 2001
+From 976042d34b38764c367ec887c03b76fa75ebf766 Mon Sep 17 00:00:00 2001
 From: egg82 <phantom_zero@ymail.com>
 Date: Tue, 7 Aug 2018 01:24:23 -0600
 Subject: [PATCH] Use ConcurrentHashMap in JsonList
@@ -18,51 +18,47 @@ Meaning the original function expired values unrelated to the current value with
 The h method was left for NMS/reflection so plugins/the server doesn't break
 However it was heavily modified to be much more efficient in its processing
 
-The e method now returns ConcurrentMap instead of Map.
-While I'm generally not for editing a function header this change shouldn't break anything because automatic casting exists
-This will allow anything using it to have the ability to use a more thread-safe map which can increase efficiency in future patches
+Modified isEmpty to use the isEmpty() method instead of the slightly confusing size() < 1
+The point of this is readability, but does have a side-benefit of a small microptimization
+
+Finally, added a couple obfhelpers for the modified code
 
 diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
-index 0859c7eb..3f80091b 100644
+index 0859c7eb..e92b4c7b 100644
 --- a/src/main/java/net/minecraft/server/JsonList.java
 +++ b/src/main/java/net/minecraft/server/JsonList.java
-@@ -1,6 +1,6 @@
+@@ -1,6 +1,5 @@
  package net.minecraft.server;
  
 -import com.google.common.collect.Lists;
-+// import com.google.common.collect.Lists; // Paper
  import com.google.common.collect.Maps;
  import com.google.common.io.Files;
  import com.google.gson.Gson;
-@@ -21,11 +21,13 @@ import java.io.Reader;
+@@ -21,11 +20,12 @@ import java.io.Reader;
  import java.lang.reflect.ParameterizedType;
  import java.lang.reflect.Type;
  import java.nio.charset.StandardCharsets;
 -import java.util.ArrayList;
-+// import java.util.ArrayList; // Paper
  import java.util.Collection;
  import java.util.Iterator;
  import java.util.List;
--import java.util.Map;
-+// import java.util.Map; // Paper
+ import java.util.Map;
 +import java.util.concurrent.ConcurrentMap;
 +
  import org.apache.commons.io.IOUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -35,7 +37,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -35,7 +35,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      protected static final Logger a = LogManager.getLogger();
      protected final Gson b;
      private final File c;
 -    private final Map<String, V> d = Maps.newHashMap();
-+    // Paper start
-+    // private final Map<String, V> d = Maps.newHashMap();
-+    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap();
-+    // Paper end
++    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap(); // Paper - replace HashMap is ConcurrentHashMap
++    private final ConcurrentMap<String, V> getBackingMap() { return this.d; } // Paper - OBFHELPER
      private boolean e = true;
      private static final ParameterizedType f = new ParameterizedType() {
          public Type[] getActualTypeArguments() {
-@@ -83,8 +88,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -83,8 +84,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      }
  
      public V get(K k0) {
@@ -71,14 +67,29 @@ index 0859c7eb..3f80091b 100644
 +        // Paper start
 +        // this.h();
 +        // return (V) this.d.get(this.a(k0)); // CraftBukkit - fix decompile error
-+        return (V) this.d.computeIfPresent(this.a(k0), (k, v) -> {
++        return (V) this.getBackingMap().computeIfPresent(this.getMappingKey(k0), (k, v) -> {
 +            return v.hasExpired() ? null : v;
 +        });
 +        // Paper end
      }
  
      public void remove(K k0) {
-@@ -121,7 +131,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -109,19 +115,22 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+     // CraftBukkit end
+ 
+     public boolean isEmpty() {
+-        return this.d.size() < 1;
++        // return this.d.size() < 1; // Paper
++        return this.getBackingMap().isEmpty(); // Paper - readability is the goal. As an aside, isEmpty() uses only sumCount() and a comparison. size() uses sumCount(), casts, and boolean logic
+     }
+ 
+     protected String a(K k0) {
+         return k0.toString();
+     }
++    protected final String getMappingKey(K k0) { return k0.toString(); } // Paper - OBFHELPER
+ 
+     protected boolean d(K k0) {
+         return this.d.containsKey(this.a(k0));
      }
  
      private void h() {
@@ -88,13 +99,13 @@ index 0859c7eb..3f80091b 100644
          Iterator iterator = this.d.values().iterator();
  
          while (iterator.hasNext()) {
-@@ -138,15 +149,22 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -138,8 +147,14 @@ public class JsonList<K, V extends JsonListEntry<K>> {
              Object object = iterator.next();
  
              this.d.remove(object);
 +        }*/
 +        
-+        for (Iterator<V> i = this.d.values().iterator(); i.hasNext();) {
++        for (Iterator<V> i = this.getBackingMap().values().iterator(); i.hasNext();) {
 +            if (i.next().hasExpired()) {
 +                i.remove();
 +            }
@@ -104,15 +115,6 @@ index 0859c7eb..3f80091b 100644
      }
  
      protected JsonListEntry<K> a(JsonObject jsonobject) {
-         return new JsonListEntry((Object) null, jsonobject);
-     }
- 
--    protected Map<String, V> e() {
-+    //protected Map<String, V> e() { // Paper
-+    protected ConcurrentMap<String, V> e() { // Paper
-         return this.d;
-     }
- 
 -- 
 2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
@@ -1,0 +1,118 @@
+From 09180265677dc3536b84e281a36d040efdcbdaf7 Mon Sep 17 00:00:00 2001
+From: egg82 <phantom_zero@ymail.com>
+Date: Tue, 7 Aug 2018 01:24:23 -0600
+Subject: [PATCH] Use ConcurrentHashMap in JsonList
+
+This is specifically aimed at fixing #471
+
+Using a ConcurrentHashMap because thread safety
+The performance benefit of Map over ConcurrentMap is negligabe at best in this scenaio, as most operations will be get and not add or remove
+Even without considering the use-case the benefits are still negligable
+
+Original ideas for the system included an expiration policy and/or handler
+The simpler solution was to use a computeIfPresent in the get method
+This will simultaneously have an O(1) lookup time and automatically expire any values
+Since the get method (nor other similar methods) don't seem to have a critical need to flush the map to disk at any of these points further processing is simply wasteful
+Meaning the original function expired values unrelated to the current value without actually having any explicit need to
+
+The h method was left for NMS/reflection so plugins/the server doesn't break
+However it was heavily modified to be much more efficient in its processing
+
+The e method now returns ConcurrentMap instead of Map.
+While I'm generally not for editing a function header this change shouldn't break anything because automatic casting exists
+This will allow anything using it to have the ability to use a more thread-safe map which can increase efficiency in future patches
+
+diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
+index 0859c7eb..3f80091b 100644
+--- a/src/main/java/net/minecraft/server/JsonList.java
++++ b/src/main/java/net/minecraft/server/JsonList.java
+@@ -1,6 +1,6 @@
+ package net.minecraft.server;
+ 
+-import com.google.common.collect.Lists;
++// import com.google.common.collect.Lists; // Paper
+ import com.google.common.collect.Maps;
+ import com.google.common.io.Files;
+ import com.google.gson.Gson;
+@@ -21,11 +21,13 @@ import java.io.Reader;
+ import java.lang.reflect.ParameterizedType;
+ import java.lang.reflect.Type;
+ import java.nio.charset.StandardCharsets;
+-import java.util.ArrayList;
++// import java.util.ArrayList; // Paper
+ import java.util.Collection;
+ import java.util.Iterator;
+ import java.util.List;
+-import java.util.Map;
++// import java.util.Map; // Paper
++import java.util.concurrent.ConcurrentMap;
++
+ import org.apache.commons.io.IOUtils;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+@@ -35,7 +37,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+     protected static final Logger a = LogManager.getLogger();
+     protected final Gson b;
+     private final File c;
+-    private final Map<String, V> d = Maps.newHashMap();
++    // Paper start
++    // private final Map<String, V> d = Maps.newHashMap();
++    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap();
++    // Paper end
+     private boolean e = true;
+     private static final ParameterizedType f = new ParameterizedType() {
+         public Type[] getActualTypeArguments() {
+@@ -83,8 +88,13 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+     }
+ 
+     public V get(K k0) {
+-        this.h();
+-        return (V) this.d.get(this.a(k0)); // CraftBukkit - fix decompile error
++        // Paper start
++        // this.h();
++        // return (V) this.d.get(this.a(k0)); // CraftBukkit - fix decompile error
++        return (V) this.d.computeIfPresent(this.a(k0), (k, v) -> {
++            return v.hasExpired() ? null : v;
++        });
++        // Paper end
+     }
+ 
+     public void remove(K k0) {
+@@ -121,7 +131,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+     }
+ 
+     private void h() {
+-        ArrayList arraylist = Lists.newArrayList();
++        // Paper start
++        /*ArrayList arraylist = Lists.newArrayList();
+         Iterator iterator = this.d.values().iterator();
+ 
+         while (iterator.hasNext()) {
+@@ -138,15 +149,22 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+             Object object = iterator.next();
+ 
+             this.d.remove(object);
++        }*/
++        
++        for (Iterator<V> i = this.d.values().iterator(); i.hasNext();) {
++            if (i.next().hasExpired()) {
++                i.remove();
++            }
+         }
+-
++        // Paper end
+     }
+ 
+     protected JsonListEntry<K> a(JsonObject jsonobject) {
+         return new JsonListEntry((Object) null, jsonobject);
+     }
+ 
+-    protected Map<String, V> e() {
++    //protected Map<String, V> e() { // Paper
++    protected ConcurrentMap<String, V> e() { // Paper
+         return this.d;
+     }
+ 
+-- 
+2.18.0.windows.1
+

--- a/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0349-Use-ConcurrentHashMap-in-JsonList.patch
@@ -1,4 +1,4 @@
-From 976042d34b38764c367ec887c03b76fa75ebf766 Mon Sep 17 00:00:00 2001
+From c5ad0647ed56042d20716ee08bf7e4593cc15f0d Mon Sep 17 00:00:00 2001
 From: egg82 <phantom_zero@ymail.com>
 Date: Tue, 7 Aug 2018 01:24:23 -0600
 Subject: [PATCH] Use ConcurrentHashMap in JsonList
@@ -15,8 +15,9 @@ This will simultaneously have an O(1) lookup time and automatically expire any v
 Since the get method (nor other similar methods) don't seem to have a critical need to flush the map to disk at any of these points further processing is simply wasteful
 Meaning the original function expired values unrelated to the current value without actually having any explicit need to
 
-The h method was left for NMS/reflection so plugins/the server doesn't break
-However it was heavily modified to be much more efficient in its processing
+The h method was heavily modified to be much more efficient in its processing
+Also instead of being called on every get, it's now called just before a save
+This will eliminate stale values being flushed to disk
 
 Modified isEmpty to use the isEmpty() method instead of the slightly confusing size() < 1
 The point of this is readability, but does have a side-benefit of a small microptimization
@@ -24,7 +25,7 @@ The point of this is readability, but does have a side-benefit of a small microp
 Finally, added a couple obfhelpers for the modified code
 
 diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
-index 0859c7eb..e92b4c7b 100644
+index 0859c7eb2..ad0ac4247 100644
 --- a/src/main/java/net/minecraft/server/JsonList.java
 +++ b/src/main/java/net/minecraft/server/JsonList.java
 @@ -1,6 +1,5 @@
@@ -53,8 +54,8 @@ index 0859c7eb..e92b4c7b 100644
      protected final Gson b;
      private final File c;
 -    private final Map<String, V> d = Maps.newHashMap();
-+    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap(); // Paper - replace HashMap is ConcurrentHashMap
-+    private final ConcurrentMap<String, V> getBackingMap() { return this.d; } // Paper - OBFHELPER
++    // Paper - replace HashMap is ConcurrentHashMap
++    private final ConcurrentMap<String, V> d = Maps.newConcurrentMap(); private final ConcurrentMap<String, V> getBackingMap() { return this.d; } // Paper - OBFHELPER
      private boolean e = true;
      private static final ParameterizedType f = new ParameterizedType() {
          public Type[] getActualTypeArguments() {
@@ -74,7 +75,7 @@ index 0859c7eb..e92b4c7b 100644
      }
  
      public void remove(K k0) {
-@@ -109,19 +115,22 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -109,9 +115,11 @@ public class JsonList<K, V extends JsonListEntry<K>> {
      // CraftBukkit end
  
      public boolean isEmpty() {
@@ -83,15 +84,15 @@ index 0859c7eb..e92b4c7b 100644
 +        return this.getBackingMap().isEmpty(); // Paper - readability is the goal. As an aside, isEmpty() uses only sumCount() and a comparison. size() uses sumCount(), casts, and boolean logic
      }
  
++    protected final String getMappingKey(K k0) { return a(k0); } // Paper - OBFHELPER
      protected String a(K k0) {
          return k0.toString();
      }
-+    protected final String getMappingKey(K k0) { return k0.toString(); } // Paper - OBFHELPER
- 
-     protected boolean d(K k0) {
+@@ -120,8 +128,10 @@ public class JsonList<K, V extends JsonListEntry<K>> {
          return this.d.containsKey(this.a(k0));
      }
  
++    private void removeStaleEntries() { h(); } // Paper - OBFHELPER
      private void h() {
 -        ArrayList arraylist = Lists.newArrayList();
 +        // Paper start
@@ -99,22 +100,30 @@ index 0859c7eb..e92b4c7b 100644
          Iterator iterator = this.d.values().iterator();
  
          while (iterator.hasNext()) {
-@@ -138,8 +147,14 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+@@ -138,8 +148,12 @@ public class JsonList<K, V extends JsonListEntry<K>> {
              Object object = iterator.next();
  
              this.d.remove(object);
+-        }
+-
 +        }*/
 +        
-+        for (Iterator<V> i = this.getBackingMap().values().iterator(); i.hasNext();) {
-+            if (i.next().hasExpired()) {
-+                i.remove();
-+            }
-         }
--
++        this.getBackingMap().values().removeIf((v) -> {
++            return v.hasExpired();
++        });
 +        // Paper end
      }
  
      protected JsonListEntry<K> a(JsonObject jsonobject) {
+@@ -151,6 +165,8 @@ public class JsonList<K, V extends JsonListEntry<K>> {
+     }
+ 
+     public void save() throws IOException {
++        this.removeStaleEntries(); // Paper - remove expired values before saving
++        
+         Collection collection = this.d.values();
+         String s = this.b.toJson(collection);
+         BufferedWriter bufferedwriter = null;
 -- 
 2.18.0.windows.1
 


### PR DESCRIPTION
Fixes #471 

Added benefits of using a ConcurrentHashMap here include the ability to check bans in the async pre-login event.

Pretty straightforward patch, tested and seems working.

Ultimately the idea was to use a computeIfPresent to keep the O(1) lookup time in the get method. Since none of the methods previously relating to this specific functionality seem to actually save the new map if a value is expired I didn't bother adding anything like that either.

Additionally I modified the function that actually iterates the map to remove values to be much more efficient. Although now unused in the current class, reflection/NMS stops me from removing it entirely and leads me to simply optimizing it instead.

Original ideas were to use an expiring map or cache of some kind, which is what I originally went with but then remembered computeIfPresent existed.

I used ConcurrentMap specifically so future patches can piggyback of its thread-safe ability to do more async. The usage of the new map type, in the vast majority of cases, will not have a performance detriment due to the fact that most calls will be to the get method and not add or remove.