### PR TITLE
Fix custom permissions reloading

### DIFF
--- a/Spigot-Server-Patches/0065-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0065-Allow-Reloading-of-Custom-Permissions.patch
@@ -1,4 +1,4 @@
-From 9a16f2eedd5904b6a73453ff98fec4295322fced Mon Sep 17 00:00:00 2001
+From 26f80b0fe03d973057cf7c96d6df8a2133b56c26 Mon Sep 17 00:00:00 2001
 From: William <admin@domnian.com>
 Date: Fri, 18 Mar 2016 03:30:17 -0400
 Subject: [PATCH] Allow Reloading of Custom Permissions
@@ -6,30 +6,33 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ed823bef1..6c5357cd1 100644
+index ed823bef1..4dd49110a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1946,5 +1946,20 @@ public final class CraftServer implements Server {
+@@ -1946,5 +1946,23 @@ public final class CraftServer implements Server {
              return false;
          }
      }
 +
 +    @Override
 +    public void reloadPermissions() {
-+        ((SimplePluginManager) pluginManager).clearPermissions();
-+        loadCustomPermissions();
++        pluginManager.clearPermissions();
++        if (com.destroystokyo.paper.PaperConfig.loadPermsBeforePlugins) loadCustomPermissions();
 +        for (Plugin plugin : pluginManager.getPlugins()) {
-+            plugin.getDescription().getPermissions().forEach((perm) -> {
++            for (Permission perm : plugin.getDescription().getPermissions()) {
 +                try {
 +                    pluginManager.addPermission(perm);
 +                } catch (IllegalArgumentException ex) {
 +                    getLogger().log(Level.WARNING, "Plugin " + plugin.getDescription().getFullName() + " tried to register permission '" + perm.getName() + "' but it's already registered", ex);
 +                }
-+            });
++            }
 +        }
++        if (!com.destroystokyo.paper.PaperConfig.loadPermsBeforePlugins) loadCustomPermissions();
++        DefaultPermissions.registerCorePermissions();
++        CraftDefaultPermissions.registerCorePermissions();
 +    }
      // Paper end
  }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0151-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-Server-Patches/0151-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From 62fe788b0effcd22b0855348cf12920c3d3b9c91 Mon Sep 17 00:00:00 2001
+From 6b1234acfc9dbcc893b4603eec81edac1d7de627 Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:21:52 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -6,12 +6,12 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a7617750e..6470135f77 100644
+index a869757b9..84057ebfb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1972,5 +1972,24 @@ public final class CraftServer implements Server {
-             });
-         }
+@@ -1975,5 +1975,24 @@ public final class CraftServer implements Server {
+         DefaultPermissions.registerCorePermissions();
+         CraftDefaultPermissions.registerCorePermissions();
      }
 +
 +    @Override
@@ -35,5 +35,5 @@ index 7a7617750e..6470135f77 100644
      // Paper end
  }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0182-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0182-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -1,4 +1,4 @@
-From 63c522730c8175d870a29e856abf59d886a6cb8c Mon Sep 17 00:00:00 2001
+From e32b31d90d3275f26b4e922daa18285627ab0af1 Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Fri, 9 Jun 2017 07:24:34 -0700
 Subject: [PATCH] Add configuration option to prevent player names from being
@@ -6,7 +6,7 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 9f1182c723..e97dbaf8e3 100644
+index 9f1182c72..e97dbaf8e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -275,4 +275,9 @@ public class PaperConfig {
@@ -20,10 +20,10 @@ index 9f1182c723..e97dbaf8e3 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6470135f77..f1a4f4529c 100644
+index 84057ebfb..18829f303 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1991,5 +1991,10 @@ public final class CraftServer implements Server {
+@@ -1994,5 +1994,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }
@@ -35,5 +35,5 @@ index 6470135f77..f1a4f4529c 100644
      // Paper end
  }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0189-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0189-Basic-PlayerProfile-API.patch
@@ -1,4 +1,4 @@
-From d7cf0a4d66360b40292de3fd0f041488468a958a Mon Sep 17 00:00:00 2001
+From dfa3768143418b2dc33a403bf37cdc2fe4042f93 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 15 Jan 2018 22:11:48 -0500
 Subject: [PATCH] Basic PlayerProfile API
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000..b151a13c1b
+index 000000000..b151a13c1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,280 @@
@@ -293,7 +293,7 @@ index 0000000000..b151a13c1b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 new file mode 100644
-index 0000000000..25836b975b
+index 000000000..25836b975
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 @@ -0,0 +1,30 @@
@@ -329,7 +329,7 @@ index 0000000000..25836b975b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 new file mode 100644
-index 0000000000..3bcdb8f93f
+index 000000000..3bcdb8f93
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 @@ -0,0 +1,17 @@
@@ -352,7 +352,7 @@ index 0000000000..3bcdb8f93f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 new file mode 100644
-index 0000000000..4b2a67423f
+index 000000000..4b2a67423
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 @@ -0,0 +1,29 @@
@@ -387,7 +387,7 @@ index 0000000000..4b2a67423f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 new file mode 100644
-index 0000000000..3aceb0ea8a
+index 000000000..3aceb0ea8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 @@ -0,0 +1,11 @@
@@ -403,7 +403,7 @@ index 0000000000..3aceb0ea8a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 381542e0d2..80927de08b 100644
+index 381542e0d..80927de08 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -1,6 +1,9 @@
@@ -428,7 +428,7 @@ index 381542e0d2..80927de08b 100644
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f88ba7db7f..a2e685acf7 100644
+index 5635997d0..02b621880 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1162,7 +1162,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -449,7 +449,7 @@ index f88ba7db7f..a2e685acf7 100644
          return this.V;
      }
 diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
-index a47a51a412..4c476f757c 100644
+index a47a51a41..4c476f757 100644
 --- a/src/main/java/net/minecraft/server/UserCache.java
 +++ b/src/main/java/net/minecraft/server/UserCache.java
 @@ -44,7 +44,7 @@ public class UserCache {
@@ -485,7 +485,7 @@ index a47a51a412..4c476f757c 100644
  
          private UserCacheEntry(GameProfile gameprofile, Date date) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 237d7696c7..7157a5b136 100644
+index 79524885d..ee7f16ca3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -153,6 +153,10 @@ import org.bukkit.craftbukkit.util.CraftNamespacedKey;
@@ -499,7 +499,7 @@ index 237d7696c7..7157a5b136 100644
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2007,5 +2011,21 @@ public final class CraftServer implements Server {
+@@ -2010,5 +2014,21 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -522,5 +522,5 @@ index 237d7696c7..7157a5b136 100644
      // Paper end
  }
 -- 
-2.18.0
+2.18.0.windows.1
 


### PR DESCRIPTION
The permissions reloading patch didn't respect the `loadPermsBeforePlugins` setting or register default perms. I have changed it to more closely match `enablePlugins`