### PR TITLE
Improve death events

### DIFF
--- a/Spigot-API-Patches/0130-Improve-death-events.patch
+++ b/Spigot-API-Patches/0130-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 50dbb0833562e99156610ecec420b84da2349cc8 Mon Sep 17 00:00:00 2001
+From b86fe574c68b575d7b24b8f893b3b472d6369fd0 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:32:28 +0100
 Subject: [PATCH] Improve death events
@@ -15,7 +15,7 @@ items and experience which is otherwise only properly possible by using
 internal code.
 
 diff --git a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
-index ab9e81fd..82cc0224 100644
+index ab9e81fd..a7b8f869 100644
 --- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
 @@ -8,10 +8,19 @@ import org.bukkit.inventory.ItemStack;
@@ -29,7 +29,7 @@ index ab9e81fd..82cc0224 100644
      private int dropExp = 0;
 +    // Paper start - make cancellable
 +    private boolean cancelled;
-+    private float reviveHealth = 0;
++    private double reviveHealth = 0;
 +    private boolean shouldPlayDeathSound;
 +    private org.bukkit.Sound deathSound;
 +    private org.bukkit.SoundCategory deathSoundCategory;
@@ -39,7 +39,7 @@ index ab9e81fd..82cc0224 100644
  
      public EntityDeathEvent(final LivingEntity entity, final List<ItemStack> drops) {
          this(entity, drops, 0);
-@@ -69,4 +78,127 @@ public class EntityDeathEvent extends EntityEvent {
+@@ -69,4 +78,132 @@ public class EntityDeathEvent extends EntityEvent {
      public static HandlerList getHandlerList() {
          return handlers;
      }
@@ -57,21 +57,26 @@ index ab9e81fd..82cc0224 100644
 +
 +    /**
 +     * Get the amount of health that the entity should revive with after cancelling the event.
-+     * 0 by default which will result in the entity getting healed to their max health.
++     * Set to the entity's max health by default.
 +     *
 +     * @return The amount of health
 +     */
-+    public float getReviveHealth() {
++    public double getReviveHealth() {
 +        return reviveHealth;
 +    }
 +
 +    /**
 +     * Set the amount of health that the entity should revive with after cancelling the event.
-+     * If this is 0 or less it will heal the entity to their max health.
++     * Revive health value must be between 0 (exclusive) and the entity's max health (inclusive).
 +     *
 +     * @param reviveHealth The amount of health
++     * @throws IllegalArgumentException Thrown if the health is {@literal <= 0 or >} max health
 +     */
-+    public void setReviveHealth(float reviveHealth) {
++    public void setReviveHealth(double reviveHealth) throws IllegalArgumentException {
++        double maxHealth = ((LivingEntity) entity).getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue();
++        if ((reviveHealth <= 0) || (reviveHealth > maxHealth)) {
++            throw new IllegalArgumentException("Health must be between 0 (exclusive) and " + maxHealth + " (inclusive), but was " + reviveHealth);
++        }
 +        this.reviveHealth = reviveHealth;
 +    }
 +

--- a/Spigot-API-Patches/0130-Improve-death-events.patch
+++ b/Spigot-API-Patches/0130-Improve-death-events.patch
@@ -56,7 +56,7 @@ index ab9e81fd..82cc0224 100644
 +    }
 +
 +    /**
-+     * Get the amount of health that the entity should review with after cancelling the event.
++     * Get the amount of health that the entity should revive with after cancelling the event.
 +     * 0 by default which will result in the entity getting healed to their max health.
 +     *
 +     * @return The amount of health

--- a/Spigot-API-Patches/0130-Improve-death-events.patch
+++ b/Spigot-API-Patches/0130-Improve-death-events.patch
@@ -1,0 +1,172 @@
+From 50dbb0833562e99156610ecec420b84da2349cc8 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Tue, 21 Aug 2018 01:32:28 +0100
+Subject: [PATCH] Improve death events
+
+This adds the ability to cancel the death events and to modify the sound
+an entity makes when dying. (In cases were no sound should it will be
+called with shouldPlaySound set to false allowing unsilencing of silent
+entities)
+
+It makes handling of entity deaths a lot nicer as you no longer need
+to listen on the damage event and calculate if the entity dies yourself
+to cancel the death which has the benefit of also receiving the dropped
+items and experience which is otherwise only properly possible by using
+internal code.
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
+index ab9e81fd..82cc0224 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityDeathEvent.java
+@@ -8,10 +8,19 @@ import org.bukkit.inventory.ItemStack;
+ /**
+  * Thrown whenever a LivingEntity dies
+  */
+-public class EntityDeathEvent extends EntityEvent {
++public class EntityDeathEvent extends EntityEvent implements org.bukkit.event.Cancellable {  // Paper - make cancellable
+     private static final HandlerList handlers = new HandlerList();
+     private final List<ItemStack> drops;
+     private int dropExp = 0;
++    // Paper start - make cancellable
++    private boolean cancelled;
++    private float reviveHealth = 0;
++    private boolean shouldPlayDeathSound;
++    private org.bukkit.Sound deathSound;
++    private org.bukkit.SoundCategory deathSoundCategory;
++    private float deathSoundVolume;
++    private float deathSoundPitch;
++    // Paper end
+ 
+     public EntityDeathEvent(final LivingEntity entity, final List<ItemStack> drops) {
+         this(entity, drops, 0);
+@@ -69,4 +78,127 @@ public class EntityDeathEvent extends EntityEvent {
+     public static HandlerList getHandlerList() {
+         return handlers;
+     }
++
++    // Paper start - make cancellable
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    /**
++     * Get the amount of health that the entity should review with after cancelling the event.
++     * 0 by default which will result in the entity getting healed to their max health.
++     *
++     * @return The amount of health
++     */
++    public float getReviveHealth() {
++        return reviveHealth;
++    }
++
++    /**
++     * Set the amount of health that the entity should revive with after cancelling the event.
++     * If this is 0 or less it will heal the entity to their max health.
++     *
++     * @param reviveHealth The amount of health
++     */
++    public void setReviveHealth(float reviveHealth) {
++        this.reviveHealth = reviveHealth;
++    }
++
++
++    /**
++     * Whether or not the death sound should play when the entity dies. If the event is cancelled it does not play!
++     *
++     * @return Whether or not the death sound should play. Event is called with this set to false if the entity is silent.
++     */
++    public boolean shouldPlayDeathSound() {
++        return shouldPlayDeathSound;
++    }
++
++    /**
++     * Set whether or not the death sound should play when the entity dies. If the event is cancelled it does not play!
++     *
++     * @param playDeathSound Enable or disable the death sound
++     */
++    public void setShouldPlayDeathSound(boolean playDeathSound) {
++        this.shouldPlayDeathSound = playDeathSound;
++    }
++
++    /**
++     * Get the sound that the entity makes when dying
++     *
++     * @return The sound that the entity makes
++     */
++    public org.bukkit.Sound getDeathSound() {
++        return deathSound;
++    }
++
++    /**
++     * Set the sound that the entity makes when dying
++     *
++     * @param sound The sound that the entity should make when dying
++     */
++    public void setDeathSound(org.bukkit.Sound sound) {
++        deathSound = sound;
++    }
++
++    /**
++     * Get the sound category that the death sound should play in
++     *
++     * @return The sound category
++     */
++    public org.bukkit.SoundCategory getDeathSoundCategory() {
++        return deathSoundCategory;
++    }
++
++    /**
++     * Set the sound category that the death sound should play in.
++     *
++     * @param soundCategory The sound category
++     */
++    public void setDeathSoundCategory(org.bukkit.SoundCategory soundCategory) {
++        this.deathSoundCategory = soundCategory;
++    }
++
++    /**
++     * Get the volume that the death sound will play at.
++     *
++     * @return The volume the death sound will play at
++     */
++    public float getDeathSoundVolume() {
++        return deathSoundVolume;
++    }
++
++    /**
++     * Set the volume the death sound should play at. If the event is cancelled this will not play the sound!
++     *
++     * @param volume The volume the death sound should play at
++     */
++    public void setDeathSoundVolume(float volume) {
++        this.deathSoundVolume = volume;
++    }
++
++    /**
++     * Get the pitch that the death sound will play with.
++     *
++     * @return The pitch the death sound will play with
++     */
++    public float getDeathSoundPitch() {
++        return deathSoundPitch;
++    }
++
++    /**
++     * GSetet the pitch that the death sound should play with.
++     *
++     * @param pitch The pitch the death sound should play with
++     */
++    public void setDeathSoundPitch(float pitch) {
++        this.deathSoundPitch = pitch;
++    }
++    // Paper end
+ }
+-- 
+2.18.0.windows.1
+

--- a/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
+++ b/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
@@ -1,4 +1,4 @@
-From f4214b8d94c5a9690fa2e41f7b547545dec26549 Mon Sep 17 00:00:00 2001
+From 00d132db37f8d96814d5ce793d584937c0a0f896 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 30 Mar 2016 19:36:20 -0400
 Subject: [PATCH] MC Dev fixes
@@ -110,19 +110,19 @@ index a540167d6..b2860555d 100644
              return this.a(jsonelement, type, jsondeserializationcontext);
          }
      }
+diff --git a/src/main/java/net/minecraft/server/Registry.java b/src/main/java/net/minecraft/server/Registry.java
+index 723372f26..c38c3768c 100644
+--- a/src/main/java/net/minecraft/server/Registry.java
++++ b/src/main/java/net/minecraft/server/Registry.java
+@@ -1,3 +1,3 @@
+ package net.minecraft.server;
+ 
+-public interface Registry extends Iterable {}
++public interface Registry<T> extends Iterable<T> {} // Paper - decompile fix
 diff --git a/src/main/java/net/minecraft/server/RegistryBlockID.java b/src/main/java/net/minecraft/server/RegistryBlockID.java
-index 58f47d0de..8860a0129 100644
+index 58f47d0de..03894df54 100644
 --- a/src/main/java/net/minecraft/server/RegistryBlockID.java
 +++ b/src/main/java/net/minecraft/server/RegistryBlockID.java
-@@ -8,7 +8,7 @@ import java.util.Iterator;
- import java.util.List;
- import javax.annotation.Nullable;
- 
--public class RegistryBlockID<T> implements Registry<T> {
-+public class RegistryBlockID<T> implements Registry { // Paper - Fix decompile error
- 
-     private final IdentityHashMap<T, Integer> a;
-     private final List<T> b;
 @@ -26,7 +26,7 @@ public class RegistryBlockID<T> implements Registry<T> {
          this.a.put(t0, Integer.valueOf(i));
  
@@ -252,5 +252,5 @@ index f5bcbdbe1..3190cadfc 100644
          for (ZipEntry clazzEntry; (clazzEntry = nmsZipStream.getNextEntry()) != null; ) {
              final String entryName = clazzEntry.getName();
 -- 
-2.17.1
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0356-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0356-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 3b079599d0b63cbce7a9d151b23084babe37a272 Mon Sep 17 00:00:00 2001
+From b8c6e5d80cd3b21db5b3d9a031439d37143eb467 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -343,7 +343,7 @@ index 5f480ac06..d59d86efc 100644
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cce4acc0b..72d85b53f 100644
+index cce4acc0b..f1a3ca950 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -392,9 +392,16 @@ public class CraftEventFactory {
@@ -386,7 +386,7 @@ index cce4acc0b..72d85b53f 100644
 +    // Paper start - helper methods for making death event cancellable
 +    // Add information to death event
 +    private static void populateFields(EntityLiving victim, EntityDeathEvent event) {
-+        event.setReviveHealth(victim.getMaxHealth());
++        event.setReviveHealth(event.getEntity().getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue());
 +        event.setShouldPlayDeathSound(!victim.silentDeath && !victim.isSilent());
 +        SoundEffect soundEffect = victim.getDeathSoundEffect();
 +        event.setDeathSound(soundEffect != null ? org.bukkit.craftbukkit.CraftSound.getSoundByEffect(soundEffect) : null);

--- a/Spigot-Server-Patches/0356-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0356-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 65dc5d30526a18fff354befbc991920e89fd96c5 Mon Sep 17 00:00:00 2001
+From 730cb5642f2699dd9728c5e5cfc4c422b9d9f935 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -14,11 +14,48 @@ to cancel the death which has the benefit of also receiving the dropped
 items and experience which is otherwise only properly possible by using
 internal code.
 
+diff --git a/src/main/java/net/minecraft/server/CombatTracker.java b/src/main/java/net/minecraft/server/CombatTracker.java
+index 7a076f3e4..9fefa3d03 100644
+--- a/src/main/java/net/minecraft/server/CombatTracker.java
++++ b/src/main/java/net/minecraft/server/CombatTracker.java
+@@ -37,7 +37,7 @@ public class CombatTracker {
+     }
+ 
+     public void trackDamage(DamageSource damagesource, float f, float f1) {
+-        this.g();
++        this.reset(); // Paper
+         this.a();
+         CombatEntry combatentry = new CombatEntry(damagesource, this.b.ticksLived, f, f1, this.h, this.b.fallDistance);
+ 
+@@ -175,6 +175,7 @@ public class CombatTracker {
+         this.h = null;
+     }
+ 
++    public void reset() { this.g(); } // Paper - OBFHELPER
+     public void g() {
+         int i = this.f ? 300 : 100;
+ 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index b0b49f4f..3f940348 100644
+index b0b49f4ff..d0dcce945 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2965,6 +2965,7 @@ public abstract class Entity implements ICommandListener, KeyedObject { // Paper
+@@ -1471,6 +1471,7 @@ public abstract class Entity implements ICommandListener, KeyedObject { // Paper
+         return false;
+     }
+ 
++    public void runKillTrigger(Entity entity, int kills, DamageSource damageSource) { this.a(entity, kills, damageSource); } // Paper - OBFHELPER
+     public void a(Entity entity, int i, DamageSource damagesource) {
+         if (entity instanceof EntityPlayer) {
+             CriterionTriggers.c.a((EntityPlayer) entity, this, damagesource);
+@@ -2267,6 +2268,7 @@ public abstract class Entity implements ICommandListener, KeyedObject { // Paper
+ 
+     }
+ 
++    public void onKill(EntityLiving entityLiving) { this.b(entityLiving); } // Paper - OBFHELPER
+     public void b(EntityLiving entityliving) {}
+ 
+     protected boolean i(double d0, double d1, double d2) {
+@@ -2965,6 +2967,7 @@ public abstract class Entity implements ICommandListener, KeyedObject { // Paper
          return EnumPistonReaction.NORMAL;
      }
  
@@ -27,7 +64,7 @@ index b0b49f4f..3f940348 100644
          return SoundCategory.NEUTRAL;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index dca49707..454c1e7d 100644
+index dca497072..454c1e7d0 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -641,7 +641,8 @@ public class EntityArmorStand extends EntityLiving {
@@ -40,10 +77,53 @@ index dca49707..454c1e7d 100644
          this.die();
      }
  
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 67ba72fc1..c06511eab 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -207,7 +207,7 @@ public class EntityCreeper extends EntityMonster {
+             ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
+             this.world.getServer().getPluginManager().callEvent(event);
+             if (!event.isCancelled()) {
+-                this.aU = true;
++                this.setDying(true); // Paper
+                 this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), flag);
+                 this.die();
+                 this.ds();
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index d6a1933ad..9a2dac90c 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -507,7 +507,7 @@ public abstract class EntityInsentient extends EntityLiving {
+     public void n() {
+         super.n();
+         this.world.methodProfiler.a("looting");
+-        if (!this.world.isClientSide && this.cX() && !this.aU && this.world.getGameRules().getBoolean("mobGriefing")) {
++        if (!this.world.isClientSide && this.cX() && !this.isDying() && this.world.getGameRules().getBoolean("mobGriefing")) { // Paper
+             List list = this.world.a(EntityItem.class, this.getBoundingBox().grow(1.0D, 0.0D, 1.0D));
+             Iterator iterator = list.iterator();
+ 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 14637be4..9f1088c9 100644
+index 14637be49..571fc3484 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -75,14 +75,14 @@ public abstract class EntityLiving extends Entity {
+     public float aR;
+     public EntityHuman killer;
+     public int lastDamageByPlayerTime; // Paper - public
+-    protected boolean aU;
++    protected boolean aU; protected void setDying(boolean dying) { this.aU = dying; } protected boolean isDying() { return this.aU; } // Paper - OBFHELPER
+     protected int ticksFarFromPlayer;
+     protected float aW;
+     protected float aX;
+     protected float aY;
+     protected float aZ;
+     protected float ba;
+-    protected int bb;
++    protected int bb; protected int getKillCount() { return this.bb; } // Paper - OBFHELPER
+     public float lastDamage;
+     protected boolean bd;
+     public float be;
 @@ -117,6 +117,7 @@ public abstract class EntityLiving extends Entity {
      public org.bukkit.craftbukkit.attribute.CraftAttributeMap craftAttributes;
      public boolean collides = true;
@@ -52,18 +132,20 @@ index 14637be4..9f1088c9 100644
  
      @Override
      public float getBukkitYaw() {
-@@ -970,13 +971,19 @@ public abstract class EntityLiving extends Entity {
+@@ -970,13 +971,17 @@ public abstract class EntityLiving extends Entity {
  
                  if (this.getHealth() <= 0.0F) {
                      if (!this.e(damagesource)) {
-+                        // Paper start - cancellable death event
-+                        /*
-                         SoundEffect soundeffect = this.cf();
+-                        SoundEffect soundeffect = this.cf();
++                        // Paper start - moved into CraftEventFactory event caller for cancellable death event
++                        //SoundEffect soundeffect = this.cf();
  
-                         if (flag1 && soundeffect != null) {
-                             this.a(soundeffect, this.cq(), this.cr());
-                         }
-+                        */
+-                        if (flag1 && soundeffect != null) {
+-                            this.a(soundeffect, this.cq(), this.cr());
+-                        }
++                        //if (flag1 && soundeffect != null) {
++                        //    this.a(soundeffect, this.cq(), this.cr());
++                        //}
 +                        this.silentDeath = !flag1; // mark entity as dying silently
 +                        // Paper end
  
@@ -72,26 +154,41 @@ index 14637be4..9f1088c9 100644
                      }
                  } else if (flag1) {
                      this.c(damagesource);
-@@ -1114,6 +1121,8 @@ public abstract class EntityLiving extends Entity {
+@@ -1110,20 +1115,24 @@ public abstract class EntityLiving extends Entity {
+     }
+ 
+     public void die(DamageSource damagesource) {
+-        if (!this.aU) {
++        if (!this.isDying()) { // Paper
              Entity entity = damagesource.getEntity();
              EntityLiving entityliving = this.ci();
  
+-            if (this.bb >= 0 && entityliving != null) {
+-                entityliving.a(this, this.bb, damagesource);
+-            }
 +            // Paper start - move down to make death event cancellable
-+            /*
-             if (this.bb >= 0 && entityliving != null) {
-                 entityliving.a(this, this.bb, damagesource);
-             }
-@@ -1124,6 +1133,9 @@ public abstract class EntityLiving extends Entity {
++            //if (this.bb >= 0 && entityliving != null) {
++            //    entityliving.a(this, this.bb, damagesource);
++            //}
  
-             this.aU = true;
-             this.getCombatTracker().g();
-+            */
+-            if (entity != null) {
+-                entity.b(this);
+-            }
++            //if (entity != null) {
++            //    entity.b(this);
++            //}
+ 
+-            this.aU = true;
+-            this.getCombatTracker().g();
++            //this.aU = true;
++            //this.getCombatTracker().g();
++
 +            org.bukkit.event.entity.EntityDeathEvent deathEvent = null;
 +            //Paper end
              if (!this.world.isClientSide) {
                  int i = 0;
  
-@@ -1136,15 +1148,32 @@ public abstract class EntityLiving extends Entity {
+@@ -1136,15 +1145,32 @@ public abstract class EntityLiving extends Entity {
  
                      this.a(flag, i, damagesource);
                      // CraftBukkit start - Call death event
@@ -109,16 +206,16 @@ index 14637be4..9f1088c9 100644
 +            // Paper start - cancellable death event
 +            if (deathEvent == null || !deathEvent.isCancelled()) {
 +                // triggers and stats got moved down
-+                if (this.bb >= 0 && entityliving != null) {
-+                    entityliving.a(this, this.bb, damagesource);
++                if (this.getKillCount() >= 0 && entityliving != null) {
++                    entityliving.runKillTrigger(this, this.getKillCount(), damagesource);
 +                }
 +
 +                if (entity != null) {
-+                    entity.b(this);
++                    entity.onKill(this);
 +                }
 +
-+                this.getCombatTracker().g();
-+                this.aU = true; // OBFHELPER - isDying
++                this.getCombatTracker().reset();
++                this.setDying(true);
 +                this.world.broadcastEntityEffect(this, (byte) 3);
 +            } else {
 +                this.setHealth(deathEvent.getReviveHealth() > 0 ? deathEvent.getReviveHealth() : this.getMaxHealth());
@@ -127,7 +224,7 @@ index 14637be4..9f1088c9 100644
          }
      }
  
-@@ -1198,6 +1227,7 @@ public abstract class EntityLiving extends Entity {
+@@ -1198,6 +1224,7 @@ public abstract class EntityLiving extends Entity {
          return SoundEffects.bX;
      }
  
@@ -135,7 +232,7 @@ index 14637be4..9f1088c9 100644
      @Nullable
      protected SoundEffect cf() {
          return SoundEffects.bS;
-@@ -1583,10 +1613,12 @@ public abstract class EntityLiving extends Entity {
+@@ -1583,10 +1610,12 @@ public abstract class EntityLiving extends Entity {
  
      }
  
@@ -148,46 +245,232 @@ index 14637be4..9f1088c9 100644
      protected float cr() {
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
+@@ -1979,7 +2008,7 @@ public abstract class EntityLiving extends Entity {
+             }
+ 
+             if (this.ticksLived % 20 == 0) {
+-                this.getCombatTracker().g();
++                this.getCombatTracker().reset(); // Paper
+             }
+ 
+             if (!this.glowing) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 4ff505cf..58bebd45 100644
+index 4ff505cfa..a0d4a2166 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -436,9 +436,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -79,6 +79,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     }
+     // Paper end
+     private int containerUpdateDelay; // Paper
++    // Paper start - cancellable death event
++    public boolean queueHealthUpdatePacket = false;
++    public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
++    // Paper end
+ 
+     // CraftBukkit start
+     public String displayName;
+@@ -436,9 +440,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public void die(DamageSource damagesource) {
          boolean flag = this.world.getGameRules().getBoolean("showDeathMessages");
  
 -        this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag));
-+        //this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down to cancellable death event
++        //this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down for cancellable death event
          // CraftBukkit start - fire PlayerDeathEvent
          if (this.dead) {
-+            this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down to cancellable death event
++            this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down for cancellable death event
              return;
          }
          java.util.List<org.bukkit.inventory.ItemStack> loot = new java.util.ArrayList<org.bukkit.inventory.ItemStack>(this.inventory.getSize());
-@@ -456,6 +457,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -456,6 +461,16 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
          String deathmessage = chatmessage.toPlainText();
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
 +        // Paper start - cancellable death event
 +        if (event.isCancelled()) {
++            // make compatible with plugins that might have already set the health in an event listener
++            if (event.getEntity().getHealth() <= 0) {
++                event.getEntity().setHealth(event.getReviveHealth() > 0 ? event.getReviveHealth() : this.getMaxHealth());
++            }
 +            return;
 +        }
 +        this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag));
-+        // Paper end - cancellable death event
++        // Paper end
  
          String deathMessage = event.getDeathMessage();
  
+@@ -506,14 +521,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+                 this.b(entitytypes_monsteregginfo.killedByEntityStatistic);
+             }
+ 
+-            entityliving.a(this, this.bb, damagesource);
++            entityliving.runKillTrigger(this, this.getKillCount(), damagesource); // Paper
+         }
+ 
+         this.b(StatisticList.A);
+         this.a(StatisticList.h);
+         this.extinguish();
+         this.setFlag(0, false);
+-        this.getCombatTracker().g();
++        this.getCombatTracker().reset(); // Paper
+     }
+ 
+     public void a(Entity entity, int i, DamageSource damagesource) {
+@@ -608,8 +623,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+                         }
+                     }
+                 }
+-
+-                return super.damageEntity(damagesource, f);
++                // Paper start - cancellable death events
++                //return super.damageEntity(damagesource, f);
++                this.queueHealthUpdatePacket = true;
++                boolean damaged = super.damageEntity(damagesource, f);
++                this.queueHealthUpdatePacket = false;
++                if (this.queuedHealthUpdatePacket != null) {
++                    this.playerConnection.sendPacket(this.queuedHealthUpdatePacket);
++                    this.queuedHealthUpdatePacket = null;
++                }
++                return damaged;
++                // Paper end
+             }
+         }
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
+index 2359b31f4..28e8bb963 100644
+--- a/src/main/java/net/minecraft/server/EntityTypes.java
++++ b/src/main/java/net/minecraft/server/EntityTypes.java
+@@ -34,7 +34,7 @@ public class EntityTypes {
+ 
+     @Nullable
+     public static MinecraftKey getName(Class<? extends Entity> oclass) {
+-        return (MinecraftKey) EntityTypes.b.b(oclass);
++        return (MinecraftKey) EntityTypes.b.getByValue(oclass); // Paper
+     }
+ 
+     @Nullable
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index 6521bb508..31df23887 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -322,7 +322,7 @@ public final class ItemStack {
+     }
+ 
+     public NBTTagCompound save(NBTTagCompound nbttagcompound) {
+-        MinecraftKey minecraftkey = (MinecraftKey) Item.REGISTRY.b(this.item);
++        MinecraftKey minecraftkey = (MinecraftKey) Item.REGISTRY.getByValue(this.item); // Paper
+ 
+         nbttagcompound.setString("id", minecraftkey == null ? "minecraft:air" : minecraftkey.toString());
+         nbttagcompound.setByte("Count", (byte) this.count);
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
+index 29c1bc763..205b9dde5 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
+@@ -55,7 +55,7 @@ public class PathfinderGoalPanic extends PathfinderGoal {
+     public boolean b() {
+         // CraftBukkit start - introduce a temporary timeout hack until this is fixed properly
+         if ((this.a.ticksLived - this.a.hurtTimestamp) > 100) {
+-            this.a.b((EntityLiving) null);
++            this.a.onKill((EntityLiving) null); // Paper
+             return false;
+         }
+         // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/RecipeBookServer.java b/src/main/java/net/minecraft/server/RecipeBookServer.java
+index f65e74ebd..0204dbc25 100644
+--- a/src/main/java/net/minecraft/server/RecipeBookServer.java
++++ b/src/main/java/net/minecraft/server/RecipeBookServer.java
+@@ -64,7 +64,7 @@ public class RecipeBookServer extends RecipeBook {
+             IRecipe irecipe = (IRecipe) iterator.next();
+ 
+             // Paper start - ignore missing recipes
+-            MinecraftKey key = CraftingManager.recipes.b(irecipe);
++            MinecraftKey key = CraftingManager.recipes.getByValue(irecipe); // Paper
+             if (key == null) continue;
+             nbttaglist.add(new NBTTagString(key.toString()));
+             // Paper end
+@@ -78,7 +78,7 @@ public class RecipeBookServer extends RecipeBook {
+             // Paper start - ignore missing recipes
+             IRecipe irecipe = (IRecipe) iterator1.next();
+ 
+-            MinecraftKey key = CraftingManager.recipes.b(irecipe);
++            MinecraftKey key = CraftingManager.recipes.getByValue(irecipe); // Paper
+             if (key == null) continue;
+             nbttaglist1.add(new NBTTagString(key.toString()));
+             // Paper end
+diff --git a/src/main/java/net/minecraft/server/RegistryMaterials.java b/src/main/java/net/minecraft/server/RegistryMaterials.java
+index d26abb419..aaedbc3b7 100644
+--- a/src/main/java/net/minecraft/server/RegistryMaterials.java
++++ b/src/main/java/net/minecraft/server/RegistryMaterials.java
+@@ -29,6 +29,7 @@ public class RegistryMaterials<K, V> extends RegistrySimple<K, V> implements Reg
+         return super.get(k0);
+     }
+ 
++    @Nullable public K getByValue(V value) { return this.b(value); } // Paper - OBFHELPER
+     @Nullable
+     public K b(V v0) {
+         return this.b.get(v0);
+diff --git a/src/main/java/net/minecraft/server/SoundEffect.java b/src/main/java/net/minecraft/server/SoundEffect.java
+index ec37e237f..c379bc68c 100644
+--- a/src/main/java/net/minecraft/server/SoundEffect.java
++++ b/src/main/java/net/minecraft/server/SoundEffect.java
+@@ -2,7 +2,7 @@ package net.minecraft.server;
+ 
+ public class SoundEffect {
+ 
+-    public static final RegistryMaterials<MinecraftKey, SoundEffect> a = new RegistryMaterials();
++    public static final RegistryMaterials<MinecraftKey, SoundEffect> a = new RegistryMaterials(); public static RegistryMaterials<MinecraftKey, SoundEffect> getRegistry() { return a; }// Paper - OBFHELPER
+     private final MinecraftKey b;
+     private static int c;
+ 
+@@ -565,6 +565,6 @@ public class SoundEffect {
+     private static void a(String s) {
+         MinecraftKey minecraftkey = new MinecraftKey(s);
+ 
+-        SoundEffect.a.a(SoundEffect.c++, minecraftkey, new SoundEffect(minecraftkey));
++        SoundEffect.getRegistry().a(SoundEffect.c++, minecraftkey, new SoundEffect(minecraftkey)); // Paper
+     }
+ }
+diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
+index 54bfbfc6b..b417000cd 100644
+--- a/src/main/java/net/minecraft/server/TileEntity.java
++++ b/src/main/java/net/minecraft/server/TileEntity.java
+@@ -57,7 +57,7 @@ public abstract class TileEntity implements KeyedObject {
+     }
+     @Nullable public static MinecraftKey getKey(Class<? extends TileEntity> oclass) { return a(oclass); } // Paper - OBFHELPER
+     @Nullable public static MinecraftKey a(Class<? extends TileEntity> oclass) {
+-        return (MinecraftKey) TileEntity.f.b(oclass);
++        return (MinecraftKey) TileEntity.f.getByValue(oclass); // Paper
+     }
+ 
+     static boolean IGNORE_TILE_UPDATES = false; // Paper
+@@ -82,7 +82,7 @@ public abstract class TileEntity implements KeyedObject {
+     }
+ 
+     private NBTTagCompound c(NBTTagCompound nbttagcompound) {
+-        MinecraftKey minecraftkey = (MinecraftKey) TileEntity.f.b(this.getClass());
++        MinecraftKey minecraftkey = (MinecraftKey) TileEntity.f.getByValue(this.getClass()); // Paper
+ 
+         if (minecraftkey == null) {
+             throw new RuntimeException(this.getClass() + " is missing a mapping! This is a bug!");
+@@ -196,7 +196,7 @@ public abstract class TileEntity implements KeyedObject {
+     public void a(CrashReportSystemDetails crashreportsystemdetails) {
+         crashreportsystemdetails.a("Name", new CrashReportCallable() {
+             public String a() throws Exception {
+-                return TileEntity.f.b(TileEntity.this.getClass()) + " // " + TileEntity.this.getClass().getCanonicalName();
++                return TileEntity.f.getByValue(TileEntity.this.getClass()) + " // " + TileEntity.this.getClass().getCanonicalName(); // Paper
+             }
+ 
+             public Object call() throws Exception {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-index 8871c6f3..8b578a07 100644
+index 8871c6f3a..d0e4034f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-@@ -560,6 +560,23 @@ public enum CraftSound {
+@@ -560,6 +560,22 @@ public enum CraftSound {
      WEATHER_RAIN_ABOVE("weather.rain.above");
      private final String minecraftKey;
  
 +    // Paper start - cancellable death event
 +    public static CraftSound getBySoundEffect(final SoundEffect effect) {
-+        MinecraftKey key = SoundEffect.a.b(effect);
++        MinecraftKey key = SoundEffect.getRegistry().getByValue(effect); // Paper
 +        Preconditions.checkArgument(key != null, "Key for sound effect %s not found?", effect.toString());
 +
 +        return valueOf(key.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH));
@@ -201,12 +484,54 @@ index 8871c6f3..8b578a07 100644
 +        return getSoundEffect(getSound(sound));
 +    }
 +    // Paper end
-+
      CraftSound(String minecraftKey) {
          this.minecraftKey = minecraftKey;
      }
+@@ -571,7 +587,7 @@ public enum CraftSound {
+     }
+ 
+     public static SoundEffect getSoundEffect(String s) {
+-        SoundEffect effect = SoundEffect.a.get(new MinecraftKey(s));
++        SoundEffect effect = SoundEffect.getRegistry().get(new MinecraftKey(s)); // Paper
+         Preconditions.checkArgument(effect != null, "Sound effect %s does not exist", s);
+ 
+         return effect;
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index a9d3f12bc..f25f64021 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -375,7 +375,7 @@ public class CraftBlock implements Block {
+             return null;
+         }
+ 
+-        return Biome.valueOf(BiomeBase.REGISTRY_ID.b(base).getKey().toUpperCase(java.util.Locale.ENGLISH));
++        return Biome.valueOf(BiomeBase.REGISTRY_ID.getByValue(base).getKey().toUpperCase(java.util.Locale.ENGLISH)); // Paper
+     }
+ 
+     public static BiomeBase biomeToBiomeBase(Biome bio) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 5f480ac06..d59d86efc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1612,7 +1612,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+ 
+     public void sendHealthUpdate() {
+-        getHandle().playerConnection.sendPacket(new PacketPlayOutUpdateHealth(getScaledHealth(), getHandle().getFoodData().getFoodLevel(), getHandle().getFoodData().getSaturationLevel()));
++        // Paper start - cancellable death event
++        //getHandle().playerConnection.sendPacket(new PacketPlayOutUpdateHealth(getScaledHealth(), getHandle().getFoodData().getFoodLevel(), getHandle().getFoodData().getSaturationLevel()));
++        PacketPlayOutUpdateHealth packet = new PacketPlayOutUpdateHealth(getScaledHealth(), getHandle().getFoodData().getFoodLevel(), getHandle().getFoodData().getSaturationLevel());
++        if (this.getHandle().queueHealthUpdatePacket) {
++            this.getHandle().queuedHealthUpdatePacket = packet;
++        } else {
++            this.getHandle().playerConnection.sendPacket(packet);
++        }
++        // Paper end
+     }
+ 
+     public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cce4acc0..d129d284 100644
+index cce4acc0b..9fd8e1859 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -392,9 +392,16 @@ public class CraftEventFactory {
@@ -242,7 +567,7 @@ index cce4acc0..d129d284 100644
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -432,6 +446,31 @@ public class CraftEventFactory {
+@@ -432,6 +446,30 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -270,10 +595,22 @@ index cce4acc0..d129d284 100644
 +        }
 +    }
 +    // Paper end
-+
      /**
       * Server methods
       */
+diff --git a/src/test/java/org/bukkit/SoundTest.java b/src/test/java/org/bukkit/SoundTest.java
+index 942cb4ea3..9d0846ec0 100644
+--- a/src/test/java/org/bukkit/SoundTest.java
++++ b/src/test/java/org/bukkit/SoundTest.java
+@@ -20,7 +20,7 @@ public class SoundTest {
+ 
+     @Test
+     public void testReverse() {
+-        for (MinecraftKey effect : SoundEffect.a.keySet()) {
++        for (MinecraftKey effect : SoundEffect.getRegistry().keySet()) { // Paper
+             assertNotNull(effect + "", Sound.valueOf(effect.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH)));
+         }
+     }
 -- 
 2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0356-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0356-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 119a38cd778eb71f9d7f1fe6d5ad7e035b030461 Mon Sep 17 00:00:00 2001
+From 3b079599d0b63cbce7a9d151b23084babe37a272 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -69,7 +69,7 @@ index dca497072..454c1e7d0 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 14637be49..6301a207a 100644
+index 14637be49..dec4b442c 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -75,14 +75,14 @@ public abstract class EntityLiving extends Entity {
@@ -178,7 +178,7 @@ index 14637be49..6301a207a 100644
 +                this.setDying(true);
 +                this.world.broadcastEntityEffect(this, (byte) 3);
 +            } else {
-+                this.setHealth(deathEvent.getReviveHealth() > 0 ? deathEvent.getReviveHealth() : this.getMaxHealth());
++                this.setHealth((float) deathEvent.getReviveHealth());
 +            }
 +            // Paper end
          }
@@ -206,7 +206,7 @@ index 14637be49..6301a207a 100644
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 4ff505cfa..8bfcece8a 100644
+index 4ff505cfa..6afb6cf7b 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -79,6 +79,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -239,8 +239,8 @@ index 4ff505cfa..8bfcece8a 100644
 +        // Paper start - cancellable death event
 +        if (event.isCancelled()) {
 +            // make compatible with plugins that might have already set the health in an event listener
-+            if (event.getEntity().getHealth() <= 0) {
-+                event.getEntity().setHealth(event.getReviveHealth() > 0 ? event.getReviveHealth() : this.getMaxHealth());
++            if (this.getHealth() <= 0) {
++                this.setHealth((float) event.getReviveHealth());
 +            }
 +            return;
 +        }
@@ -343,14 +343,14 @@ index 5f480ac06..d59d86efc 100644
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cce4acc0b..9fd8e1859 100644
+index cce4acc0b..72d85b53f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -392,9 +392,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(EntityLiving victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
-+        setupSound(victim, event); // Paper - make cancellable
++        populateFields(victim, event); // Paper - make cancellable
          CraftWorld world = (CraftWorld) entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
  
@@ -367,7 +367,7 @@ index cce4acc0b..9fd8e1859 100644
          CraftPlayer entity = victim.getBukkitEntity();
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
          event.setKeepInventory(keepInventory);
-+        setupSound(victim, event); // Paper - make cancellable
++        populateFields(victim, event); // Paper - make cancellable
          org.bukkit.World world = entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
 +        // Paper start - make cancellable
@@ -379,13 +379,14 @@ index cce4acc0b..9fd8e1859 100644
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -432,6 +446,30 @@ public class CraftEventFactory {
+@@ -432,6 +446,31 @@ public class CraftEventFactory {
          return event;
      }
  
 +    // Paper start - helper methods for making death event cancellable
-+    // Add sound information to death event
-+    private static void setupSound(EntityLiving victim, EntityDeathEvent event) {
++    // Add information to death event
++    private static void populateFields(EntityLiving victim, EntityDeathEvent event) {
++        event.setReviveHealth(victim.getMaxHealth());
 +        event.setShouldPlayDeathSound(!victim.silentDeath && !victim.isSilent());
 +        SoundEffect soundEffect = victim.getDeathSoundEffect();
 +        event.setDeathSound(soundEffect != null ? org.bukkit.craftbukkit.CraftSound.getSoundByEffect(soundEffect) : null);

--- a/Spigot-Server-Patches/0356-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0356-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 730cb5642f2699dd9728c5e5cfc4c422b9d9f935 Mon Sep 17 00:00:00 2001
+From 119a38cd778eb71f9d7f1fe6d5ad7e035b030461 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -15,18 +15,9 @@ items and experience which is otherwise only properly possible by using
 internal code.
 
 diff --git a/src/main/java/net/minecraft/server/CombatTracker.java b/src/main/java/net/minecraft/server/CombatTracker.java
-index 7a076f3e4..9fefa3d03 100644
+index 7a076f3e4..bddd66e79 100644
 --- a/src/main/java/net/minecraft/server/CombatTracker.java
 +++ b/src/main/java/net/minecraft/server/CombatTracker.java
-@@ -37,7 +37,7 @@ public class CombatTracker {
-     }
- 
-     public void trackDamage(DamageSource damagesource, float f, float f1) {
--        this.g();
-+        this.reset(); // Paper
-         this.a();
-         CombatEntry combatentry = new CombatEntry(damagesource, this.b.ticksLived, f, f1, this.h, this.b.fallDistance);
- 
 @@ -175,6 +175,7 @@ public class CombatTracker {
          this.h = null;
      }
@@ -77,34 +68,8 @@ index dca497072..454c1e7d0 100644
          this.die();
      }
  
-diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 67ba72fc1..c06511eab 100644
---- a/src/main/java/net/minecraft/server/EntityCreeper.java
-+++ b/src/main/java/net/minecraft/server/EntityCreeper.java
-@@ -207,7 +207,7 @@ public class EntityCreeper extends EntityMonster {
-             ExplosionPrimeEvent event = new ExplosionPrimeEvent(this.getBukkitEntity(), this.explosionRadius * f, false);
-             this.world.getServer().getPluginManager().callEvent(event);
-             if (!event.isCancelled()) {
--                this.aU = true;
-+                this.setDying(true); // Paper
-                 this.world.createExplosion(this, this.locX, this.locY, this.locZ, event.getRadius(), event.getFire(), flag);
-                 this.die();
-                 this.ds();
-diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index d6a1933ad..9a2dac90c 100644
---- a/src/main/java/net/minecraft/server/EntityInsentient.java
-+++ b/src/main/java/net/minecraft/server/EntityInsentient.java
-@@ -507,7 +507,7 @@ public abstract class EntityInsentient extends EntityLiving {
-     public void n() {
-         super.n();
-         this.world.methodProfiler.a("looting");
--        if (!this.world.isClientSide && this.cX() && !this.aU && this.world.getGameRules().getBoolean("mobGriefing")) {
-+        if (!this.world.isClientSide && this.cX() && !this.isDying() && this.world.getGameRules().getBoolean("mobGriefing")) { // Paper
-             List list = this.world.a(EntityItem.class, this.getBoundingBox().grow(1.0D, 0.0D, 1.0D));
-             Iterator iterator = list.iterator();
- 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 14637be49..571fc3484 100644
+index 14637be49..6301a207a 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -75,14 +75,14 @@ public abstract class EntityLiving extends Entity {
@@ -154,12 +119,7 @@ index 14637be49..571fc3484 100644
                      }
                  } else if (flag1) {
                      this.c(damagesource);
-@@ -1110,20 +1115,24 @@ public abstract class EntityLiving extends Entity {
-     }
- 
-     public void die(DamageSource damagesource) {
--        if (!this.aU) {
-+        if (!this.isDying()) { // Paper
+@@ -1114,16 +1119,20 @@ public abstract class EntityLiving extends Entity {
              Entity entity = damagesource.getEntity();
              EntityLiving entityliving = this.ci();
  
@@ -245,17 +205,8 @@ index 14637be49..571fc3484 100644
      protected float cr() {
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
-@@ -1979,7 +2008,7 @@ public abstract class EntityLiving extends Entity {
-             }
- 
-             if (this.ticksLived % 20 == 0) {
--                this.getCombatTracker().g();
-+                this.getCombatTracker().reset(); // Paper
-             }
- 
-             if (!this.glowing) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 4ff505cfa..a0d4a2166 100644
+index 4ff505cfa..8bfcece8a 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -79,6 +79,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -298,23 +249,6 @@ index 4ff505cfa..a0d4a2166 100644
  
          String deathMessage = event.getDeathMessage();
  
-@@ -506,14 +521,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
-                 this.b(entitytypes_monsteregginfo.killedByEntityStatistic);
-             }
- 
--            entityliving.a(this, this.bb, damagesource);
-+            entityliving.runKillTrigger(this, this.getKillCount(), damagesource); // Paper
-         }
- 
-         this.b(StatisticList.A);
-         this.a(StatisticList.h);
-         this.extinguish();
-         this.setFlag(0, false);
--        this.getCombatTracker().g();
-+        this.getCombatTracker().reset(); // Paper
-     }
- 
-     public void a(Entity entity, int i, DamageSource damagesource) {
 @@ -608,8 +623,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                          }
                      }
@@ -335,67 +269,6 @@ index 4ff505cfa..a0d4a2166 100644
              }
          }
      }
-diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 2359b31f4..28e8bb963 100644
---- a/src/main/java/net/minecraft/server/EntityTypes.java
-+++ b/src/main/java/net/minecraft/server/EntityTypes.java
-@@ -34,7 +34,7 @@ public class EntityTypes {
- 
-     @Nullable
-     public static MinecraftKey getName(Class<? extends Entity> oclass) {
--        return (MinecraftKey) EntityTypes.b.b(oclass);
-+        return (MinecraftKey) EntityTypes.b.getByValue(oclass); // Paper
-     }
- 
-     @Nullable
-diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index 6521bb508..31df23887 100644
---- a/src/main/java/net/minecraft/server/ItemStack.java
-+++ b/src/main/java/net/minecraft/server/ItemStack.java
-@@ -322,7 +322,7 @@ public final class ItemStack {
-     }
- 
-     public NBTTagCompound save(NBTTagCompound nbttagcompound) {
--        MinecraftKey minecraftkey = (MinecraftKey) Item.REGISTRY.b(this.item);
-+        MinecraftKey minecraftkey = (MinecraftKey) Item.REGISTRY.getByValue(this.item); // Paper
- 
-         nbttagcompound.setString("id", minecraftkey == null ? "minecraft:air" : minecraftkey.toString());
-         nbttagcompound.setByte("Count", (byte) this.count);
-diff --git a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
-index 29c1bc763..205b9dde5 100644
---- a/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
-+++ b/src/main/java/net/minecraft/server/PathfinderGoalPanic.java
-@@ -55,7 +55,7 @@ public class PathfinderGoalPanic extends PathfinderGoal {
-     public boolean b() {
-         // CraftBukkit start - introduce a temporary timeout hack until this is fixed properly
-         if ((this.a.ticksLived - this.a.hurtTimestamp) > 100) {
--            this.a.b((EntityLiving) null);
-+            this.a.onKill((EntityLiving) null); // Paper
-             return false;
-         }
-         // CraftBukkit end
-diff --git a/src/main/java/net/minecraft/server/RecipeBookServer.java b/src/main/java/net/minecraft/server/RecipeBookServer.java
-index f65e74ebd..0204dbc25 100644
---- a/src/main/java/net/minecraft/server/RecipeBookServer.java
-+++ b/src/main/java/net/minecraft/server/RecipeBookServer.java
-@@ -64,7 +64,7 @@ public class RecipeBookServer extends RecipeBook {
-             IRecipe irecipe = (IRecipe) iterator.next();
- 
-             // Paper start - ignore missing recipes
--            MinecraftKey key = CraftingManager.recipes.b(irecipe);
-+            MinecraftKey key = CraftingManager.recipes.getByValue(irecipe); // Paper
-             if (key == null) continue;
-             nbttaglist.add(new NBTTagString(key.toString()));
-             // Paper end
-@@ -78,7 +78,7 @@ public class RecipeBookServer extends RecipeBook {
-             // Paper start - ignore missing recipes
-             IRecipe irecipe = (IRecipe) iterator1.next();
- 
--            MinecraftKey key = CraftingManager.recipes.b(irecipe);
-+            MinecraftKey key = CraftingManager.recipes.getByValue(irecipe); // Paper
-             if (key == null) continue;
-             nbttaglist1.add(new NBTTagString(key.toString()));
-             // Paper end
 diff --git a/src/main/java/net/minecraft/server/RegistryMaterials.java b/src/main/java/net/minecraft/server/RegistryMaterials.java
 index d26abb419..aaedbc3b7 100644
 --- a/src/main/java/net/minecraft/server/RegistryMaterials.java
@@ -409,7 +282,7 @@ index d26abb419..aaedbc3b7 100644
      public K b(V v0) {
          return this.b.get(v0);
 diff --git a/src/main/java/net/minecraft/server/SoundEffect.java b/src/main/java/net/minecraft/server/SoundEffect.java
-index ec37e237f..c379bc68c 100644
+index ec37e237f..8e0da7bd7 100644
 --- a/src/main/java/net/minecraft/server/SoundEffect.java
 +++ b/src/main/java/net/minecraft/server/SoundEffect.java
 @@ -2,7 +2,7 @@ package net.minecraft.server;
@@ -421,47 +294,8 @@ index ec37e237f..c379bc68c 100644
      private final MinecraftKey b;
      private static int c;
  
-@@ -565,6 +565,6 @@ public class SoundEffect {
-     private static void a(String s) {
-         MinecraftKey minecraftkey = new MinecraftKey(s);
- 
--        SoundEffect.a.a(SoundEffect.c++, minecraftkey, new SoundEffect(minecraftkey));
-+        SoundEffect.getRegistry().a(SoundEffect.c++, minecraftkey, new SoundEffect(minecraftkey)); // Paper
-     }
- }
-diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 54bfbfc6b..b417000cd 100644
---- a/src/main/java/net/minecraft/server/TileEntity.java
-+++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -57,7 +57,7 @@ public abstract class TileEntity implements KeyedObject {
-     }
-     @Nullable public static MinecraftKey getKey(Class<? extends TileEntity> oclass) { return a(oclass); } // Paper - OBFHELPER
-     @Nullable public static MinecraftKey a(Class<? extends TileEntity> oclass) {
--        return (MinecraftKey) TileEntity.f.b(oclass);
-+        return (MinecraftKey) TileEntity.f.getByValue(oclass); // Paper
-     }
- 
-     static boolean IGNORE_TILE_UPDATES = false; // Paper
-@@ -82,7 +82,7 @@ public abstract class TileEntity implements KeyedObject {
-     }
- 
-     private NBTTagCompound c(NBTTagCompound nbttagcompound) {
--        MinecraftKey minecraftkey = (MinecraftKey) TileEntity.f.b(this.getClass());
-+        MinecraftKey minecraftkey = (MinecraftKey) TileEntity.f.getByValue(this.getClass()); // Paper
- 
-         if (minecraftkey == null) {
-             throw new RuntimeException(this.getClass() + " is missing a mapping! This is a bug!");
-@@ -196,7 +196,7 @@ public abstract class TileEntity implements KeyedObject {
-     public void a(CrashReportSystemDetails crashreportsystemdetails) {
-         crashreportsystemdetails.a("Name", new CrashReportCallable() {
-             public String a() throws Exception {
--                return TileEntity.f.b(TileEntity.this.getClass()) + " // " + TileEntity.this.getClass().getCanonicalName();
-+                return TileEntity.f.getByValue(TileEntity.this.getClass()) + " // " + TileEntity.this.getClass().getCanonicalName(); // Paper
-             }
- 
-             public Object call() throws Exception {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-index 8871c6f3a..d0e4034f2 100644
+index 8871c6f3a..84f4cb91e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 @@ -560,6 +560,22 @@ public enum CraftSound {
@@ -470,7 +304,7 @@ index 8871c6f3a..d0e4034f2 100644
  
 +    // Paper start - cancellable death event
 +    public static CraftSound getBySoundEffect(final SoundEffect effect) {
-+        MinecraftKey key = SoundEffect.getRegistry().getByValue(effect); // Paper
++        MinecraftKey key = SoundEffect.getRegistry().getByValue(effect);
 +        Preconditions.checkArgument(key != null, "Key for sound effect %s not found?", effect.toString());
 +
 +        return valueOf(key.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH));
@@ -487,28 +321,6 @@ index 8871c6f3a..d0e4034f2 100644
      CraftSound(String minecraftKey) {
          this.minecraftKey = minecraftKey;
      }
-@@ -571,7 +587,7 @@ public enum CraftSound {
-     }
- 
-     public static SoundEffect getSoundEffect(String s) {
--        SoundEffect effect = SoundEffect.a.get(new MinecraftKey(s));
-+        SoundEffect effect = SoundEffect.getRegistry().get(new MinecraftKey(s)); // Paper
-         Preconditions.checkArgument(effect != null, "Sound effect %s does not exist", s);
- 
-         return effect;
-diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index a9d3f12bc..f25f64021 100644
---- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-+++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -375,7 +375,7 @@ public class CraftBlock implements Block {
-             return null;
-         }
- 
--        return Biome.valueOf(BiomeBase.REGISTRY_ID.b(base).getKey().toUpperCase(java.util.Locale.ENGLISH));
-+        return Biome.valueOf(BiomeBase.REGISTRY_ID.getByValue(base).getKey().toUpperCase(java.util.Locale.ENGLISH)); // Paper
-     }
- 
-     public static BiomeBase biomeToBiomeBase(Biome bio) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index 5f480ac06..d59d86efc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -598,19 +410,6 @@ index cce4acc0b..9fd8e1859 100644
      /**
       * Server methods
       */
-diff --git a/src/test/java/org/bukkit/SoundTest.java b/src/test/java/org/bukkit/SoundTest.java
-index 942cb4ea3..9d0846ec0 100644
---- a/src/test/java/org/bukkit/SoundTest.java
-+++ b/src/test/java/org/bukkit/SoundTest.java
-@@ -20,7 +20,7 @@ public class SoundTest {
- 
-     @Test
-     public void testReverse() {
--        for (MinecraftKey effect : SoundEffect.a.keySet()) {
-+        for (MinecraftKey effect : SoundEffect.getRegistry().keySet()) { // Paper
-             assertNotNull(effect + "", Sound.valueOf(effect.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH)));
-         }
-     }
 -- 
 2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0356-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0356-Improve-death-events.patch
@@ -1,0 +1,279 @@
+From 65dc5d30526a18fff354befbc991920e89fd96c5 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Tue, 21 Aug 2018 01:39:35 +0100
+Subject: [PATCH] Improve death events
+
+This adds the ability to cancel the death events and to modify the sound
+an entity makes when dying. (In cases were no sound should it will be
+called with shouldPlaySound set to false allowing unsilencing of silent
+entities)
+
+It makes handling of entity deaths a lot nicer as you no longer need
+to listen on the damage event and calculate if the entity dies yourself
+to cancel the death which has the benefit of also receiving the dropped
+items and experience which is otherwise only properly possible by using
+internal code.
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index b0b49f4f..3f940348 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2965,6 +2965,7 @@ public abstract class Entity implements ICommandListener, KeyedObject { // Paper
+         return EnumPistonReaction.NORMAL;
+     }
+ 
++    public SoundCategory getDeathSoundCategory() { return bK();} // Paper - OBFHELPER
+     public SoundCategory bK() {
+         return SoundCategory.NEUTRAL;
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
+index dca49707..454c1e7d 100644
+--- a/src/main/java/net/minecraft/server/EntityArmorStand.java
++++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
+@@ -641,7 +641,8 @@ public class EntityArmorStand extends EntityLiving {
+     }
+ 
+     public void killEntity() {
+-        org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, drops); // CraftBukkit - call event
++        org.bukkit.event.entity.EntityDeathEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityDeathEvent(this, drops); // CraftBukkit - call event // Paper - make cancellable
++        if (event.isCancelled()) return; // Paper - make cancellable
+         this.die();
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 14637be4..9f1088c9 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -117,6 +117,7 @@ public abstract class EntityLiving extends Entity {
+     public org.bukkit.craftbukkit.attribute.CraftAttributeMap craftAttributes;
+     public boolean collides = true;
+     public boolean canPickUpLoot;
++    public boolean silentDeath = false; // Paper - mark entity as dying silently for cancellable death event
+ 
+     @Override
+     public float getBukkitYaw() {
+@@ -970,13 +971,19 @@ public abstract class EntityLiving extends Entity {
+ 
+                 if (this.getHealth() <= 0.0F) {
+                     if (!this.e(damagesource)) {
++                        // Paper start - cancellable death event
++                        /*
+                         SoundEffect soundeffect = this.cf();
+ 
+                         if (flag1 && soundeffect != null) {
+                             this.a(soundeffect, this.cq(), this.cr());
+                         }
++                        */
++                        this.silentDeath = !flag1; // mark entity as dying silently
++                        // Paper end
+ 
+                         this.die(damagesource);
++                        this.silentDeath = false; // Paper - cancellable death event - reset to default
+                     }
+                 } else if (flag1) {
+                     this.c(damagesource);
+@@ -1114,6 +1121,8 @@ public abstract class EntityLiving extends Entity {
+             Entity entity = damagesource.getEntity();
+             EntityLiving entityliving = this.ci();
+ 
++            // Paper start - move down to make death event cancellable
++            /*
+             if (this.bb >= 0 && entityliving != null) {
+                 entityliving.a(this, this.bb, damagesource);
+             }
+@@ -1124,6 +1133,9 @@ public abstract class EntityLiving extends Entity {
+ 
+             this.aU = true;
+             this.getCombatTracker().g();
++            */
++            org.bukkit.event.entity.EntityDeathEvent deathEvent = null;
++            //Paper end
+             if (!this.world.isClientSide) {
+                 int i = 0;
+ 
+@@ -1136,15 +1148,32 @@ public abstract class EntityLiving extends Entity {
+ 
+                     this.a(flag, i, damagesource);
+                     // CraftBukkit start - Call death event
+-                    CraftEventFactory.callEntityDeathEvent(this, this.drops);
++                    deathEvent = CraftEventFactory.callEntityDeathEvent(this, this.drops); // Paper - cancellable death event
+                     this.drops = new ArrayList<org.bukkit.inventory.ItemStack>();
+                 } else {
+-                    CraftEventFactory.callEntityDeathEvent(this);
++                    deathEvent = CraftEventFactory.callEntityDeathEvent(this); // Paper - cancellable death event
+                     // CraftBukkit end
+                 }
+             }
+ 
+-            this.world.broadcastEntityEffect(this, (byte) 3);
++            // Paper start - cancellable death event
++            if (deathEvent == null || !deathEvent.isCancelled()) {
++                // triggers and stats got moved down
++                if (this.bb >= 0 && entityliving != null) {
++                    entityliving.a(this, this.bb, damagesource);
++                }
++
++                if (entity != null) {
++                    entity.b(this);
++                }
++
++                this.getCombatTracker().g();
++                this.aU = true; // OBFHELPER - isDying
++                this.world.broadcastEntityEffect(this, (byte) 3);
++            } else {
++                this.setHealth(deathEvent.getReviveHealth() > 0 ? deathEvent.getReviveHealth() : this.getMaxHealth());
++            }
++            // Paper end
+         }
+     }
+ 
+@@ -1198,6 +1227,7 @@ public abstract class EntityLiving extends Entity {
+         return SoundEffects.bX;
+     }
+ 
++    @Nullable public SoundEffect getDeathSoundEffect() { return cf();} // Paper - OBFHELPER
+     @Nullable
+     protected SoundEffect cf() {
+         return SoundEffects.bS;
+@@ -1583,10 +1613,12 @@ public abstract class EntityLiving extends Entity {
+ 
+     }
+ 
++    public float getDeathSoundVolume() { return cq();} // Paper - OBFHELPER
+     protected float cq() {
+         return 1.0F;
+     }
+ 
++    public float getDeathSoundPitch() { return cr();} // Paper - OBFHELPER
+     protected float cr() {
+         return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 4ff505cf..58bebd45 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -436,9 +436,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public void die(DamageSource damagesource) {
+         boolean flag = this.world.getGameRules().getBoolean("showDeathMessages");
+ 
+-        this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag));
++        //this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down to cancellable death event
+         // CraftBukkit start - fire PlayerDeathEvent
+         if (this.dead) {
++            this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag)); // Paper - moved down to cancellable death event
+             return;
+         }
+         java.util.List<org.bukkit.inventory.ItemStack> loot = new java.util.ArrayList<org.bukkit.inventory.ItemStack>(this.inventory.getSize());
+@@ -456,6 +457,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+ 
+         String deathmessage = chatmessage.toPlainText();
+         org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
++        // Paper start - cancellable death event
++        if (event.isCancelled()) {
++            return;
++        }
++        this.playerConnection.sendPacket(new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, flag));
++        // Paper end - cancellable death event
+ 
+         String deathMessage = event.getDeathMessage();
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
+index 8871c6f3..8b578a07 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
+@@ -560,6 +560,23 @@ public enum CraftSound {
+     WEATHER_RAIN_ABOVE("weather.rain.above");
+     private final String minecraftKey;
+ 
++    // Paper start - cancellable death event
++    public static CraftSound getBySoundEffect(final SoundEffect effect) {
++        MinecraftKey key = SoundEffect.a.b(effect);
++        Preconditions.checkArgument(key != null, "Key for sound effect %s not found?", effect.toString());
++
++        return valueOf(key.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH));
++    }
++
++    public static Sound getSoundByEffect(final SoundEffect effect) {
++        return Sound.valueOf(getBySoundEffect(effect).name());
++    }
++
++    public static SoundEffect getSoundEffect(final Sound sound) {
++        return getSoundEffect(getSound(sound));
++    }
++    // Paper end
++
+     CraftSound(String minecraftKey) {
+         this.minecraftKey = minecraftKey;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index cce4acc0..d129d284 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -392,9 +392,16 @@ public class CraftEventFactory {
+     public static EntityDeathEvent callEntityDeathEvent(EntityLiving victim, List<org.bukkit.inventory.ItemStack> drops) {
+         CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
+         EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
++        setupSound(victim, event); // Paper - make cancellable
+         CraftWorld world = (CraftWorld) entity.getWorld();
+         Bukkit.getServer().getPluginManager().callEvent(event);
+ 
++        // Paper start - make cancellable
++        if (event.isCancelled()) {
++            return event;
++        }
++        playDeathSound(victim, event);
++        // Paper end
+         victim.expToDrop = event.getDroppedExp();
+ 
+         for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
+@@ -410,8 +417,15 @@ public class CraftEventFactory {
+         CraftPlayer entity = victim.getBukkitEntity();
+         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
+         event.setKeepInventory(keepInventory);
++        setupSound(victim, event); // Paper - make cancellable
+         org.bukkit.World world = entity.getWorld();
+         Bukkit.getServer().getPluginManager().callEvent(event);
++        // Paper start - make cancellable
++        if (event.isCancelled()) {
++            return event;
++        }
++        playDeathSound(victim, event);
++        // Paper end
+ 
+         victim.keepLevel = event.getKeepLevel();
+         victim.newLevel = event.getNewLevel();
+@@ -432,6 +446,31 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
++    // Paper start - helper methods for making death event cancellable
++    // Add sound information to death event
++    private static void setupSound(EntityLiving victim, EntityDeathEvent event) {
++        event.setShouldPlayDeathSound(!victim.silentDeath && !victim.isSilent());
++        SoundEffect soundEffect = victim.getDeathSoundEffect();
++        event.setDeathSound(soundEffect != null ? org.bukkit.craftbukkit.CraftSound.getSoundByEffect(soundEffect) : null);
++        event.setDeathSoundCategory(org.bukkit.SoundCategory.valueOf(victim.getDeathSoundCategory().name()));
++        event.setDeathSoundVolume(victim.getDeathSoundVolume());
++        event.setDeathSoundPitch(victim.getDeathSoundPitch());
++    }
++
++    // Play death sound manually
++    private static void playDeathSound(EntityLiving victim, EntityDeathEvent event) {
++        if (event.shouldPlayDeathSound() && event.getDeathSound() != null && event.getDeathSoundCategory() != null) {
++            EntityHuman source = victim instanceof EntityHuman ? (EntityHuman) victim : null;
++            double x = event.getEntity().getLocation().getX();
++            double y = event.getEntity().getLocation().getY();
++            double z = event.getEntity().getLocation().getZ();
++            SoundEffect soundEffect = org.bukkit.craftbukkit.CraftSound.getSoundEffect(event.getDeathSound());
++            SoundCategory soundCategory = SoundCategory.valueOf(event.getDeathSoundCategory().name());
++            victim.world.sendSoundEffect(source, x, y, z, soundEffect, soundCategory, event.getDeathSoundVolume(), event.getDeathSoundPitch());
++        }
++    }
++    // Paper end
++
+     /**
+      * Server methods
+      */
+-- 
+2.18.0.windows.1
+

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -56,6 +56,7 @@ import ChunkCoordIntPair
 import ChunkProviderFlat
 import ChunkProviderGenerate
 import ChunkProviderHell
+import CombatTracker
 import CommandAbstract
 import CommandScoreboard
 import CommandWhitelist
@@ -103,10 +104,13 @@ import PersistentScoreboard
 import PersistentVillage
 import PlayerConnectionUtils
 import RegionFile
+import Registry
 import RegistryBlockID
+import RegistryMaterials
 import RemoteControlListener
 import RecipeBookServer
 import ServerPing
+import SoundEffect
 import StructureBoundingBox
 import StructurePiece
 import StructureStart


### PR DESCRIPTION
This adds the ability to cancel the events and to specify the sound.

It should make handling of entity and player deaths a lot better than trying to fiddle with the damage event, especially as that has no ability to get the actual drops of an entity (or the proper death sound). There also is a method to set the health that the entity (or player) revives with (by default it will just use the maxhealth) which is also compatible with plugins that might set the health directly in the listener for whatever reason.