### PR TITLE
Add source block to BlockPhysicsEvent

### DIFF
--- a/Spigot-API-Patches/0131-Add-source-block-to-BlockPhysicsEvent.patch
+++ b/Spigot-API-Patches/0131-Add-source-block-to-BlockPhysicsEvent.patch
@@ -1,0 +1,61 @@
+From a802db6737065697d3668b53a32d9eb5265fdab5 Mon Sep 17 00:00:00 2001
+From: Sotr <i@omc.hk>
+Date: Thu, 23 Aug 2018 16:14:25 +0800
+Subject: [PATCH] Add source block to BlockPhysicsEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java b/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
+index 01a545b4..d17e05ac 100644
+--- a/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
+@@ -12,6 +12,39 @@ public class BlockPhysicsEvent extends BlockEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final int changed;
+     private boolean cancel = false;
++    // Paper start - add source block
++    private int sourceX;
++    private int sourceY;
++    private int sourceZ;
++    private Block sourceBlock;
++
++    /**
++     *
++     * @deprecated Magic value
++     * @param block the block involved in this event
++     * @param changed the changed block's type id
++     * @param sourceX the x of the source block
++     * @param sourceY the y of the source block
++     * @param sourceZ the z of the source block
++     */
++    @Deprecated
++    public BlockPhysicsEvent(final Block block, final int changed, final int sourceX, final int sourceY, final int sourceZ) {
++        this(block, changed);
++        this.sourceX = sourceX;
++        this.sourceY = sourceY;
++        this.sourceZ = sourceZ;
++        this.sourceBlock = null;
++    }
++
++    /**
++     * Gets the source block, causing this event
++     *
++     * @return Source block
++     */
++    public Block getSourceBlock() {
++        return sourceBlock == null ? (sourceBlock = block.getWorld().getBlockAt(sourceX, sourceY, sourceZ)) : sourceBlock;
++    }
++    // Paper end
+ 
+     /**
+      *
+@@ -23,6 +56,7 @@ public class BlockPhysicsEvent extends BlockEvent implements Cancellable {
+     public BlockPhysicsEvent(final Block block, final int changed) {
+         super(block);
+         this.changed = changed;
++        this.sourceBlock = block; // Paper - add source block
+     }
+ 
+     /**
+-- 
+2.18.0.windows.1
+

--- a/Spigot-Server-Patches/0357-Add-source-block-to-BlockPhysicsEvent.patch
+++ b/Spigot-Server-Patches/0357-Add-source-block-to-BlockPhysicsEvent.patch
@@ -1,0 +1,22 @@
+From d81b977104ba95086af880aff9f93669ea99537f Mon Sep 17 00:00:00 2001
+From: Sotr <i@omc.hk>
+Date: Thu, 23 Aug 2018 16:14:12 +0800
+Subject: [PATCH] Add source block to BlockPhysicsEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 04d0fa1d..64d75934 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -590,7 +590,7 @@ public abstract class World implements IBlockAccess {
+                 // CraftBukkit start
+                 CraftWorld world = ((WorldServer) this).getWorld();
+                 if (world != null && !((WorldServer)this).stopPhysicsEvent) { // Paper
+-                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftMagicNumbers.getId(block));
++                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftMagicNumbers.getId(block), blockposition1.getX(), blockposition1.getY(), blockposition1.getZ()); // Paper - add source block
+                     this.getServer().getPluginManager().callEvent(event);
+ 
+                     if (event.isCancelled()) {
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
Resolves #1275 

For plants, the source block is itself, because the `changed` type is itself.