### PR TITLE
Cached, local-class-supporting task names

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -37,4 +37,5 @@ Hugo Manrique <hugmanrique@gmail.com>
 Andrew Steinborn <git@steinborn.me>
 willies952002 <admin@domnian.com>
 MicleBrick <miclebrick@outlook.com>
+Trigary <trigary0@gmail.com>
 ```

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1,4 +1,4 @@
-From 353f4b4a2bb1ad9b48b72f6db5cbf5a61a2dd53c Mon Sep 17 00:00:00 2001
+From 4892ce2583def9198563d017a95c06ef0d086e60 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
@@ -6,17 +6,20 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 0000000000..1b33390de5
+index 00000000..c6405aa1
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,128 @@
 +package co.aikar.timings;
 +
++import com.google.common.collect.MapMaker;
 +import net.minecraft.server.*;
 +import org.bukkit.plugin.Plugin;
 +import org.bukkit.scheduler.BukkitTask;
 +
 +import org.bukkit.craftbukkit.scheduler.CraftTask;
++
++import java.util.Map;
 +
 +public final class MinecraftTimings {
 +
@@ -48,6 +51,8 @@ index 0000000000..1b33390de5
 +    public static final Timing antiXrayUpdateTimer = Timings.ofSafe("anti-xray - update");
 +    public static final Timing antiXrayObfuscateTimer = Timings.ofSafe("anti-xray - obfuscate");
 +
++    private static final Map<Class<? extends Runnable>, String> taskNameCache = new MapMaker().weakKeys().makeMap();
++
 +    private MinecraftTimings() {}
 +
 +    /**
@@ -71,12 +76,10 @@ index 0000000000..1b33390de5
 +            plugin = TimingsManager.getPluginByClassloader(taskClass);
 +        }
 +
-+        final String taskname;
-+        if (taskClass.isAnonymousClass()) {
-+            taskname = taskClass.getName();
-+        } else {
-+            taskname = taskClass.getCanonicalName();
-+        }
++        final String taskname = taskNameCache.computeIfAbsent(taskClass, clazz ->
++                clazz.isAnonymousClass() || clazz.isLocalClass()
++                        ? clazz.getName()
++                        : clazz.getCanonicalName());
 +
 +        StringBuilder name = new StringBuilder(64);
 +        name.append("Task: ").append(taskname);
@@ -137,7 +140,7 @@ index 0000000000..1b33390de5
 +}
 diff --git a/src/main/java/co/aikar/timings/TimedChunkGenerator.java b/src/main/java/co/aikar/timings/TimedChunkGenerator.java
 new file mode 100644
-index 0000000000..089154f626
+index 00000000..089154f6
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimedChunkGenerator.java
 @@ -0,0 +1,131 @@
@@ -274,7 +277,7 @@ index 0000000000..089154f626
 +}
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 new file mode 100644
-index 0000000000..e0ad559b74
+index 00000000..e0ad559b
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -0,0 +1,99 @@
@@ -378,7 +381,7 @@ index 0000000000..e0ad559b74
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5ab2cf6eec..b5795b6d34 100644
+index 5ab2cf6e..b5795b6d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,11 +14,14 @@ import java.util.concurrent.TimeUnit;
@@ -422,7 +425,7 @@ index 5ab2cf6eec..b5795b6d34 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index 2dca6dbcb9..3523109603 100644
+index 2dca6dbc..35231096 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -35,6 +35,15 @@ public class Block {
@@ -442,7 +445,7 @@ index 2dca6dbcb9..3523109603 100644
      public static int getId(Block block) {
          return Block.REGISTRY.a(block); // CraftBukkit - decompile error
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index e5f29d3c11..fe1fe28957 100644
+index 801dd26d..2c706f07 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -938,7 +938,7 @@ public class Chunk {
@@ -490,7 +493,7 @@ index e5f29d3c11..fe1fe28957 100644
  
      private void z() {
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 86973cb988..bd006ef741 100644
+index 86973cb9..bd006ef7 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -204,7 +204,7 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -503,7 +506,7 @@ index 86973cb988..bd006ef741 100644
              this.chunkLoader.saveChunk(this.world, chunk, unloaded); // Spigot
          } catch (IOException ioexception) {
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 50ec3adb87..a401dec60d 100644
+index 50ec3adb..a401dec6 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -423,7 +423,7 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
@@ -543,7 +546,7 @@ index 50ec3adb87..a401dec60d 100644
          // return chunk; // CraftBukkit
      }
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index e1cb96a88a..8f2afcc32f 100644
+index e1cb96a8..8f2afcc3 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -24,7 +24,7 @@ import java.io.PrintStream;
@@ -596,7 +599,7 @@ index e1cb96a88a..8f2afcc32f 100644
              return waitable.get();
          } catch (java.util.concurrent.ExecutionException e) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 0e3a94ab8c..c88143964b 100644
+index 0e3a94ab..c8814396 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -25,7 +25,8 @@ import org.bukkit.block.BlockFace;
@@ -635,7 +638,7 @@ index 0e3a94ab8c..c88143964b 100644
  
      public void recalcPosition() {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 0026f29d5f..d15cfdd763 100644
+index 0026f29d..d15cfdd7 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -31,7 +31,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -706,7 +709,7 @@ index 0026f29d5f..d15cfdd763 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityTracker.java b/src/main/java/net/minecraft/server/EntityTracker.java
-index ce01240204..a60f946085 100644
+index ce012402..a60f9460 100644
 --- a/src/main/java/net/minecraft/server/EntityTracker.java
 +++ b/src/main/java/net/minecraft/server/EntityTracker.java
 @@ -175,7 +175,7 @@ public class EntityTracker {
@@ -737,7 +740,7 @@ index ce01240204..a60f946085 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c1a8816b40..8d08b536a9 100644
+index c1a8816b..8d08b536 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -48,8 +48,8 @@ import org.bukkit.Bukkit;
@@ -884,7 +887,7 @@ index c1a8816b40..8d08b536a9 100644
          this.methodProfiler.b();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index eeac349987..e4ed2e9917 100644
+index eeac3499..e4ed2e99 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,5 +1,6 @@
@@ -984,7 +987,7 @@ index eeac349987..e4ed2e9917 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ec3e083368..dacf9261a7 100644
+index ec3e0833..dacf9261 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -56,6 +56,7 @@ import org.bukkit.inventory.CraftingInventory;
@@ -1032,7 +1035,7 @@ index ec3e083368..dacf9261a7 100644
          // CraftBukkit end
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
-index f74b067943..1fc632e0ce 100644
+index f74b0679..1fc632e0 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 @@ -1,15 +1,21 @@
@@ -1062,7 +1065,7 @@ index f74b067943..1fc632e0ce 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index d4acbed0cf..1d9f3e3ddc 100644
+index d4acbed0..1d9f3e3d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1086,7 +1089,7 @@ index d4acbed0cf..1d9f3e3ddc 100644
  
      public void addWhitelist(GameProfile gameprofile) {
 diff --git a/src/main/java/net/minecraft/server/StructureGenerator.java b/src/main/java/net/minecraft/server/StructureGenerator.java
-index 74e3f42cd0..66a80a7765 100644
+index 74e3f42c..66a80a77 100644
 --- a/src/main/java/net/minecraft/server/StructureGenerator.java
 +++ b/src/main/java/net/minecraft/server/StructureGenerator.java
 @@ -1,5 +1,7 @@
@@ -1128,7 +1131,7 @@ index 74e3f42cd0..66a80a7765 100644
          return flag;
      }
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 29069b753e..081e56f481 100644
+index 29069b75..081e56f4 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -4,12 +4,13 @@ import javax.annotation.Nullable;
@@ -1148,7 +1151,7 @@ index 29069b753e..081e56f481 100644
      private static final RegistryMaterials<MinecraftKey, Class<? extends TileEntity>> f = new RegistryMaterials();
      protected World world;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 843320ffbb..d902e2630b 100644
+index 843320ff..d902e263 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -19,11 +19,11 @@ import com.google.common.collect.Maps;
@@ -1254,7 +1257,7 @@ index 843320ffbb..d902e2630b 100644
  
      public boolean b(AxisAlignedBB axisalignedbb) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c891629bd4..95964c550a 100644
+index c891629b..95964c55 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -308,13 +308,13 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -1388,7 +1391,7 @@ index c891629bd4..95964c550a 100644
  
      // CraftBukkit start
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 14851a3a56..9042deed67 100644
+index 14851a3a..9042deed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1756,12 +1756,31 @@ public final class CraftServer implements Server {
@@ -1425,7 +1428,7 @@ index 14851a3a56..9042deed67 100644
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java b/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 deleted file mode 100644
-index 4c8ab2bc97..0000000000
+index 4c8ab2bc..00000000
 --- a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 +++ /dev/null
 @@ -1,174 +0,0 @@
@@ -1604,7 +1607,7 @@ index 4c8ab2bc97..0000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
-index 3a95b4465a..b5efb9c3f0 100644
+index 3a95b446..b5efb9c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 +++ b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 @@ -1,6 +1,8 @@
@@ -1648,7 +1651,7 @@ index 3a95b4465a..b5efb9c3f0 100644
  
      public void callStage3(QueuedChunk queuedChunk, Chunk chunk, Runnable runnable) throws RuntimeException {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 137b101a72..cd99801ffe 100644
+index 137b101a..cd99801f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -41,7 +41,7 @@ import org.bukkit.configuration.serialization.DelegateDeserialization;
@@ -1674,7 +1677,7 @@ index 137b101a72..cd99801ffe 100644
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index f11bd7545f..93b9134d6e 100644
+index f11bd754..93b9134d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
@@ -1750,7 +1753,7 @@ index f11bd7545f..93b9134d6e 100644
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index 7e7ce9a81b..46029ce246 100644
+index 7e7ce9a8..46029ce2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -1,8 +1,8 @@
@@ -1832,7 +1835,7 @@ index 7e7ce9a81b..46029ce246 100644
 -    // Spigot end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
-index e52ef47b78..3d90b34268 100644
+index e52ef47b..3d90b342 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 @@ -5,6 +5,7 @@ import org.bukkit.util.CachedServerIcon;
@@ -1844,7 +1847,7 @@ index e52ef47b78..3d90b34268 100644
          this.value = value;
      }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 2bd690fdf2..38be7ed71e 100644
+index 2bd690fd..38be7ed7 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -29,7 +29,7 @@ import net.minecraft.server.EntityWither;
@@ -1906,5 +1909,5 @@ index 2bd690fdf2..38be7ed71e 100644
      }
  }
 -- 
-2.18.0
+2.16.1.windows.4
 


### PR DESCRIPTION
Fixes issue #1177 

`MapMaker#weakKeys()` makes the `Map` use identity comparison for the keys, while also enabling the automatical removal of dropped classes from the cache.

The changes are the same as in #1399, except now the original patch is modified instead of a new one being created.