### PR TITLE
Add ray tracing methods to LivingEntity

### DIFF
--- a/Spigot-API-Patches/0147-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/Spigot-API-Patches/0147-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -1,0 +1,147 @@
+From 4619e236e860ee87fe96b25a8f0240ab16cfe797 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 3 Sep 2018 18:13:53 -0500
+Subject: [PATCH] Add ray tracing methods to LivingEntity
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java b/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java
+new file mode 100644
+index 00000000..fe43d955
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/block/TargetBlockInfo.java
+@@ -0,0 +1,50 @@
++package com.destroystokyo.paper.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockFace;
++
++/**
++ * Represents information about a targeted block
++ */
++public class TargetBlockInfo {
++    private final Block block;
++    private final BlockFace blockFace;
++
++    public TargetBlockInfo(Block block, BlockFace blockFace) {
++        this.block = block;
++        this.blockFace = blockFace;
++    }
++
++    /**
++     * Get the block that is targeted
++     *
++     * @return Targeted block
++     */
++    public Block getBlock() {
++        return block;
++    }
++
++    /**
++     * Get the targeted BlockFace
++     *
++     * @return Targeted blockface
++     */
++    public BlockFace getBlockFace() {
++        return blockFace;
++    }
++
++    /**
++     * Get the relative Block to the targeted block on the side it is targeted at
++     *
++     * @return Block relative to targeted block
++     */
++    public Block getRelativeBlock() {
++        return block.getRelative(blockFace);
++    }
++
++    public enum FluidMode {
++        NEVER,
++        SOURCE_ONLY,
++        ALWAYS
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index ac5bd8a5..62e45eda 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -71,6 +71,77 @@ public interface LivingEntity extends Attributable, Entity, Damageable, Projecti
+      */
+     public Block getTargetBlock(Set<Material> transparent, int maxDistance);
+ 
++    // Paper start
++    /**
++     * Gets the block that the living entity has targeted, ignoring fluids
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @return block that the living entity has targeted,
++     *     or null if no block is within maxDistance
++     */
++    @Nullable
++    public default Block getTargetBlock(int maxDistance) {
++        return getTargetBlock(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
++    }
++
++    /**
++     * Gets the block that the living entity has targeted
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @param fluidMode whether to check fluids or not
++     * @return block that the living entity has targeted,
++     *     or null if no block is within maxDistance
++     */
++    @Nullable
++    public Block getTargetBlock(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
++
++    /**
++     * Gets the blockface of that block that the living entity has targeted, ignoring fluids
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @return blockface of the block that the living entity has targeted,
++     *     or null if no block is targeted
++     */
++    @Nullable
++    public default org.bukkit.block.BlockFace getTargetBlockFace(int maxDistance) {
++        return getTargetBlockFace(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
++    }
++
++    /**
++     * Gets the blockface of that block that the living entity has targeted
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @param fluidMode whether to check fluids or not
++     * @return blockface of the block that the living entity has targeted,
++     *     or null if no block is targeted
++     */
++    @Nullable
++    public org.bukkit.block.BlockFace getTargetBlockFace(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
++
++    /**
++     * Gets information about the block the living entity has targeted, ignoring fluids
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @return TargetBlockInfo about the block the living entity has targeted,
++     *     or null if no block is targeted
++     */
++    @Nullable
++    public default com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance) {
++        return getTargetBlockInfo(maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode.NEVER);
++    }
++
++    /**
++     * Gets information about the block the living entity has targeted
++     *
++     * @param maxDistance this is the maximum distance to scan
++     * @param fluidMode whether to check fluids or not
++     * @return TargetBlockInfo about the block the living entity has targeted,
++     *     or null if no block is targeted
++     */
++    @Nullable
++    public com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode);
++    // Paper end
++
+     /**
+      * Gets the last two blocks along the living entity's line of sight.
+      * <p>
+-- 
+2.18.0
+

--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -1,11 +1,11 @@
-From b6ce2f5640a5c7c656e68e73f83951683fb93c38 Mon Sep 17 00:00:00 2001
+From d47f33ac66c41a28e7c99b00b17bf78e11c0e85c Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:55:47 -0400
 Subject: [PATCH] MC Utils
 
 
 diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
-index 6ffc535146..5ed34cf7e3 100644
+index 6ffc53514..5ed34cf7e 100644
 --- a/src/main/java/net/minecraft/server/BlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BlockPosition.java
 @@ -9,7 +9,7 @@ import org.apache.logging.log4j.Logger;
@@ -42,7 +42,7 @@ index 6ffc535146..5ed34cf7e3 100644
              return this.c(MathHelper.floor(d0), MathHelper.floor(d1), MathHelper.floor(d2));
          }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index fe5328ef47..b7c40d5ce6 100644
+index fe5328ef4..b7c40d5ce 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -28,7 +28,7 @@ import com.google.common.collect.Lists; // CraftBukkit
@@ -63,7 +63,7 @@ index fe5328ef47..b7c40d5ce6 100644
      public TileEntity a(BlockPosition blockposition, Chunk.EnumTileEntityState chunk_enumtileentitystate) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
-index 744762b8b9..d9608121b6 100644
+index 744762b8b..d9608121b 100644
 --- a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 +++ b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 @@ -23,6 +23,8 @@ public class ChunkCoordIntPair {
@@ -76,7 +76,7 @@ index 744762b8b9..d9608121b6 100644
          return (long)i & 4294967295L | ((long)j & 4294967295L) << 32;
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkTaskScheduler.java b/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
-index 3b6b3b9a99..22af9c1885 100644
+index 3b6b3b9a9..22af9c188 100644
 --- a/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
 +++ b/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
 @@ -16,7 +16,7 @@ import org.apache.logging.log4j.Logger;
@@ -89,7 +89,7 @@ index 3b6b3b9a99..22af9c1885 100644
      private final IChunkLoader e;
      private final IAsyncTaskHandler f;
 diff --git a/src/main/java/net/minecraft/server/DataBits.java b/src/main/java/net/minecraft/server/DataBits.java
-index 95ca5f6d80..0dc948a375 100644
+index 95ca5f6d8..0dc948a37 100644
 --- a/src/main/java/net/minecraft/server/DataBits.java
 +++ b/src/main/java/net/minecraft/server/DataBits.java
 @@ -54,6 +54,7 @@ public class DataBits {
@@ -101,7 +101,7 @@ index 95ca5f6d80..0dc948a375 100644
          return this.a;
      }
 diff --git a/src/main/java/net/minecraft/server/DataPalette.java b/src/main/java/net/minecraft/server/DataPalette.java
-index 7f905b1e09..fa5b9262b4 100644
+index 7f905b1e0..fa5b9262b 100644
 --- a/src/main/java/net/minecraft/server/DataPalette.java
 +++ b/src/main/java/net/minecraft/server/DataPalette.java
 @@ -3,10 +3,11 @@ package net.minecraft.server;
@@ -119,7 +119,7 @@ index 7f905b1e09..fa5b9262b4 100644
      void b(PacketDataSerializer var1);
  
 diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-index 304e47bf20..6e7454b134 100644
+index 304e47bf2..6e7454b13 100644
 --- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
 +++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
 @@ -7,7 +7,7 @@ import java.util.function.Function;
@@ -161,7 +161,7 @@ index 304e47bf20..6e7454b134 100644
          this.b();
          packetdataserializer.writeByte(this.i);
 diff --git a/src/main/java/net/minecraft/server/EntityCreature.java b/src/main/java/net/minecraft/server/EntityCreature.java
-index 2c6fbd1d6f..a5c147b989 100644
+index 2c6fbd1d6..a5c147b98 100644
 --- a/src/main/java/net/minecraft/server/EntityCreature.java
 +++ b/src/main/java/net/minecraft/server/EntityCreature.java
 @@ -6,6 +6,7 @@ import org.bukkit.event.entity.EntityUnleashEvent;
@@ -173,7 +173,7 @@ index 2c6fbd1d6f..a5c147b989 100644
      private float b;
  
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index ebb177927f..60b1dcd8ea 100644
+index ebb177927..60b1dcd8e 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -124,6 +124,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -185,7 +185,7 @@ index ebb177927f..60b1dcd8ea 100644
          // CraftBukkit start - fire event
          setGoalTarget(entityliving, EntityTargetEvent.TargetReason.UNKNOWN, true);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index fd050c5f32..8d33c16580 100644
+index fd050c5f3..8d33c1658 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -122,6 +122,7 @@ public abstract class EntityLiving extends Entity {
@@ -197,7 +197,7 @@ index fd050c5f32..8d33c16580 100644
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/server/EntityMonster.java b/src/main/java/net/minecraft/server/EntityMonster.java
-index c0f48bbc29..f3cc2cef0a 100644
+index c0f48bbc2..f3cc2cef0 100644
 --- a/src/main/java/net/minecraft/server/EntityMonster.java
 +++ b/src/main/java/net/minecraft/server/EntityMonster.java
 @@ -1,6 +1,8 @@
@@ -210,7 +210,7 @@ index c0f48bbc29..f3cc2cef0a 100644
          super(entitytypes, world);
          this.b_ = 5;
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 17bfa356f1..5c1ab6a0b6 100644
+index 17bfa356f..5c1ab6a0b 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -3,6 +3,7 @@ package net.minecraft.server;
@@ -261,7 +261,7 @@ index 17bfa356f1..5c1ab6a0b6 100644
      // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index c54275bc2f..318c4204df 100644
+index c54275bc2..318c4204d 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -26,6 +26,7 @@ import org.bukkit.TreeType;
@@ -292,17 +292,21 @@ index c54275bc2f..318c4204df 100644
      }
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 new file mode 100644
-index 0000000000..9f9341c98f
+index 000000000..faec94722
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -0,0 +1,296 @@
+@@ -0,0 +1,340 @@
 +package net.minecraft.server;
 +
++import com.destroystokyo.paper.block.TargetBlockInfo;
 +import com.google.common.util.concurrent.ThreadFactoryBuilder;
 +import org.bukkit.Location;
++import org.bukkit.block.BlockFace;
++import org.bukkit.craftbukkit.CraftWorld;
 +import org.bukkit.craftbukkit.util.Waitable;
 +import org.spigotmc.AsyncCatcher;
 +
++import javax.annotation.Nonnull;
 +import javax.annotation.Nullable;
 +import java.util.Queue;
 +import java.util.concurrent.CompletableFuture;
@@ -312,7 +316,6 @@ index 0000000000..9f9341c98f
 +import java.util.concurrent.TimeUnit;
 +import java.util.concurrent.TimeoutException;
 +import java.util.function.Supplier;
-+import java.util.regex.Pattern;
 +
 +public final class MCUtil {
 +    private static final Executor asyncExecutor = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("Paper Async Task Handler Thread - %1$d").build());
@@ -583,7 +586,7 @@ index 0000000000..9f9341c98f
 +    @Nullable
 +    public static TileEntityHopper getHopper(World world, BlockPosition pos) {
 +        Chunk chunk = world.getChunkIfLoaded(pos.getX() >> 4, pos.getZ() >> 4);
-+        if (chunk != null && chunk.getBlockData(pos).getBlock() == Blocks.HOPPER) {
++        if (chunk != null && chunk.getBlockData(pos.getX(), pos.getY(), pos.getZ()).getBlock() == Blocks.HOPPER) {
 +            TileEntity tileEntity = chunk.getTileEntityImmediately(pos);
 +            if (tileEntity instanceof TileEntityHopper) {
 +                return (TileEntityHopper) tileEntity;
@@ -591,9 +594,50 @@ index 0000000000..9f9341c98f
 +        }
 +        return null;
 +    }
++
++    @Nonnull
++    public static World getNMSWorld(@Nonnull org.bukkit.World world) {
++        return ((CraftWorld) world).getHandle();
++    }
++
++    public static World getNMSWorld(@Nonnull org.bukkit.entity.Entity entity) {
++        return getNMSWorld(entity.getWorld());
++    }
++
++    public static FluidCollisionOption getNMSFluidCollisionOption(TargetBlockInfo.FluidMode fluidMode) {
++        if (fluidMode == TargetBlockInfo.FluidMode.NEVER) {
++            return FluidCollisionOption.NEVER;
++        }
++        if (fluidMode == TargetBlockInfo.FluidMode.SOURCE_ONLY) {
++            return FluidCollisionOption.SOURCE_ONLY;
++        }
++        if (fluidMode == TargetBlockInfo.FluidMode.ALWAYS) {
++            return FluidCollisionOption.ALWAYS;
++        }
++        return null;
++    }
++
++    public static BlockFace toBukkitBlockFace(EnumDirection enumDirection) {
++        switch (enumDirection) {
++            case DOWN:
++                return BlockFace.DOWN;
++            case UP:
++                return BlockFace.UP;
++            case NORTH:
++                return BlockFace.NORTH;
++            case SOUTH:
++                return BlockFace.SOUTH;
++            case WEST:
++                return BlockFace.WEST;
++            case EAST:
++                return BlockFace.EAST;
++            default:
++                return null;
++        }
++    }
 +}
 diff --git a/src/main/java/net/minecraft/server/NBTTagCompound.java b/src/main/java/net/minecraft/server/NBTTagCompound.java
-index 41cd3ceabe..2a66a30264 100644
+index 41cd3ceab..2a66a3026 100644
 --- a/src/main/java/net/minecraft/server/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/server/NBTTagCompound.java
 @@ -23,7 +23,7 @@ import org.apache.logging.log4j.Logger;
@@ -638,7 +682,7 @@ index 41cd3ceabe..2a66a30264 100644
      }
  }
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index 0afaea8109..26da897243 100644
+index 0afaea810..26da89724 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -44,7 +44,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
@@ -679,7 +723,7 @@ index 0afaea8109..26da897243 100644
          public QueuedPacket(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
              this.a = packet;
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index d04afceb70..a63a5811d6 100644
+index d04afceb7..a63a5811d 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 @@ -33,6 +33,7 @@ public class PacketDataSerializer extends ByteBuf {
@@ -691,7 +735,7 @@ index d04afceb70..a63a5811d6 100644
          for (int j = 1; j < 5; ++j) {
              if ((i & -1 << j * 7) == 0) {
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
-index 12d6c99cf0..af382815f3 100644
+index 12d6c99cf..af382815f 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 @@ -11,7 +11,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
@@ -712,7 +756,7 @@ index 12d6c99cf0..af382815f3 100644
          int j = 0;
          ChunkSection[] achunksection = chunk.getSections();
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index d465608f37..1c57f6e738 100644
+index 8e4e6f3b9..996ffbdfa 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -68,9 +68,9 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -729,7 +773,7 @@ index d465608f37..1c57f6e738 100644
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
 diff --git a/src/main/java/net/minecraft/server/RegistryBlockID.java b/src/main/java/net/minecraft/server/RegistryBlockID.java
-index a21006290c..6c6f006f3a 100644
+index a21006290..6c6f006f3 100644
 --- a/src/main/java/net/minecraft/server/RegistryBlockID.java
 +++ b/src/main/java/net/minecraft/server/RegistryBlockID.java
 @@ -54,6 +54,7 @@ public class RegistryBlockID<T> implements Registry<T> {

--- a/Spigot-Server-Patches/0161-String-based-Action-Bar-API.patch
+++ b/Spigot-Server-Patches/0161-String-based-Action-Bar-API.patch
@@ -1,28 +1,22 @@
-From 20364ef3583380d8cbbf06c6259102eb37f0aa8c Mon Sep 17 00:00:00 2001
+From 484984d8d5db033b3c01d63f37d89011e3d4879b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 27 Dec 2016 15:02:42 -0500
 Subject: [PATCH] String based Action Bar API
 
 
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 9f9341c98f..966309a07d 100644
+index faec94722..dce1417af 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -1,10 +1,13 @@
- package net.minecraft.server;
+@@ -2,6 +2,7 @@ package net.minecraft.server;
  
+ import com.destroystokyo.paper.block.TargetBlockInfo;
  import com.google.common.util.concurrent.ThreadFactoryBuilder;
 +import org.apache.commons.lang.exception.ExceptionUtils;
  import org.bukkit.Location;
-+import org.bukkit.craftbukkit.CraftWorld;
- import org.bukkit.craftbukkit.util.Waitable;
- import org.spigotmc.AsyncCatcher;
- 
-+import javax.annotation.Nonnull;
- import javax.annotation.Nullable;
- import java.util.Queue;
- import java.util.concurrent.CompletableFuture;
-@@ -21,6 +24,24 @@ public final class MCUtil {
+ import org.bukkit.block.BlockFace;
+ import org.bukkit.craftbukkit.CraftWorld;
+@@ -24,6 +25,24 @@ public final class MCUtil {
  
      private MCUtil() {}
  
@@ -47,22 +41,8 @@ index 9f9341c98f..966309a07d 100644
  
      public static boolean isMainThread() {
          return MinecraftServer.getServer().isMainThread();
-@@ -293,4 +314,13 @@ public final class MCUtil {
-         }
-         return null;
-     }
-+
-+    @Nonnull
-+    public static World getNMSWorld(@Nonnull org.bukkit.World world) {
-+        return ((CraftWorld) world).getHandle();
-+    }
-+
-+    public static World getNMSWorld(@Nonnull org.bukkit.entity.Entity entity) {
-+        return getNMSWorld(entity.getWorld());
-+    }
- }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 291b664b66..478f027848 100644
+index 291b664b6..478f02784 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -209,6 +209,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0187-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0187-Basic-PlayerProfile-API.patch
@@ -1,4 +1,4 @@
-From 0051cf45fc5085978b49aa5a0895ccec4a0a1169 Mon Sep 17 00:00:00 2001
+From cc2c162eab13c1bfb74203f325929d95eb74355e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 15 Jan 2018 22:11:48 -0500
 Subject: [PATCH] Basic PlayerProfile API
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000..b151a13c1b
+index 000000000..b151a13c1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,280 @@
@@ -293,7 +293,7 @@ index 0000000000..b151a13c1b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 new file mode 100644
-index 0000000000..25836b975b
+index 000000000..25836b975
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 @@ -0,0 +1,30 @@
@@ -329,7 +329,7 @@ index 0000000000..25836b975b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 new file mode 100644
-index 0000000000..3bcdb8f93f
+index 000000000..3bcdb8f93
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 @@ -0,0 +1,17 @@
@@ -352,7 +352,7 @@ index 0000000000..3bcdb8f93f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 new file mode 100644
-index 0000000000..4b2a67423f
+index 000000000..4b2a67423
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 @@ -0,0 +1,29 @@
@@ -387,7 +387,7 @@ index 0000000000..4b2a67423f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 new file mode 100644
-index 0000000000..3aceb0ea8a
+index 000000000..3aceb0ea8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 @@ -0,0 +1,11 @@
@@ -403,20 +403,21 @@ index 0000000000..3aceb0ea8a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 966309a07d..e36e2e0a31 100644
+index dce1417af..f7856897f 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
-@@ -1,6 +1,9 @@
+@@ -1,7 +1,10 @@
  package net.minecraft.server;
  
+ import com.destroystokyo.paper.block.TargetBlockInfo;
 +import com.destroystokyo.paper.profile.CraftPlayerProfile;
 +import com.destroystokyo.paper.profile.PlayerProfile;
  import com.google.common.util.concurrent.ThreadFactoryBuilder;
 +import com.mojang.authlib.GameProfile;
  import org.apache.commons.lang.exception.ExceptionUtils;
  import org.bukkit.Location;
- import org.bukkit.craftbukkit.CraftWorld;
-@@ -157,6 +160,10 @@ public final class MCUtil {
+ import org.bukkit.block.BlockFace;
+@@ -158,6 +161,10 @@ public final class MCUtil {
          return run.get();
      }
  
@@ -428,7 +429,7 @@ index 966309a07d..e36e2e0a31 100644
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6aec7c31e3..014c923897 100644
+index 6aec7c31e..014c92389 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1181,7 +1181,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -449,7 +450,7 @@ index 6aec7c31e3..014c923897 100644
          return this.V;
      }
 diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
-index a47a51a412..4c476f757c 100644
+index a47a51a41..4c476f757 100644
 --- a/src/main/java/net/minecraft/server/UserCache.java
 +++ b/src/main/java/net/minecraft/server/UserCache.java
 @@ -44,7 +44,7 @@ public class UserCache {
@@ -485,7 +486,7 @@ index a47a51a412..4c476f757c 100644
  
          private UserCacheEntry(GameProfile gameprofile, Date date) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5c48430313..0eea57eb7d 100644
+index 5c4843031..0eea57eb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -155,6 +155,10 @@ import org.bukkit.craftbukkit.util.CraftNamespacedKey;

--- a/Spigot-Server-Patches/0359-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/Spigot-Server-Patches/0359-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -1,0 +1,76 @@
+From 53c450f0d30d97e0ddee7a1dfd43912b7a310a72 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Mon, 3 Sep 2018 18:20:03 -0500
+Subject: [PATCH] Add ray tracing methods to LivingEntity
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 904b67c26..890a3a02b 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -2810,6 +2810,22 @@ public abstract class EntityLiving extends Entity {
+     }
+ 
+     // Paper start
++    public MovingObjectPosition getRayTrace(int maxDistance) {
++        return getRayTrace(maxDistance, FluidCollisionOption.NEVER);
++    }
++
++    public MovingObjectPosition getRayTrace(int maxDistance, FluidCollisionOption fluidCollisionOption) {
++        if (maxDistance < 1 || maxDistance > 120) {
++            throw new IllegalArgumentException("maxDistance must be between 1-120");
++        }
++
++        Vec3D start = new Vec3D(locX, locY + getHeadHeight(), locZ);
++        org.bukkit.util.Vector dir = getBukkitEntity().getLocation().getDirection().multiply(maxDistance);
++        Vec3D end = new Vec3D(start.x + dir.getX(), start.y + dir.getY(), start.z + dir.getZ());
++
++        return world.rayTrace(start, end, fluidCollisionOption);
++    }
++
+     public int shieldBlockingDelay = world.paperConfig.shieldBlockingDelay;
+ 
+     public int getShieldBlockingDelay() {
+diff --git a/src/main/java/net/minecraft/server/MovingObjectPosition.java b/src/main/java/net/minecraft/server/MovingObjectPosition.java
+index 6d5dbe89a..a31f9f607 100644
+--- a/src/main/java/net/minecraft/server/MovingObjectPosition.java
++++ b/src/main/java/net/minecraft/server/MovingObjectPosition.java
+@@ -28,6 +28,7 @@ public class MovingObjectPosition {
+         this.pos = vec3d;
+     }
+ 
++    public BlockPosition getBlockPosition() { return a(); } // Paper - OBFHELPER
+     public BlockPosition a() {
+         return this.e;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 0860f2334..028495700 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -169,6 +169,23 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         return blocks.get(0);
+     }
+ 
++    // Paper start
++    public Block getTargetBlock(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode) {
++        net.minecraft.server.MovingObjectPosition rayTrace = getHandle().getRayTrace(maxDistance, net.minecraft.server.MCUtil.getNMSFluidCollisionOption(fluidMode));
++        return rayTrace == null ? null : org.bukkit.craftbukkit.block.CraftBlock.at(getHandle().world, rayTrace.getBlockPosition());
++    }
++
++    public org.bukkit.block.BlockFace getTargetBlockFace(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode) {
++        net.minecraft.server.MovingObjectPosition rayTrace = getHandle().getRayTrace(maxDistance, net.minecraft.server.MCUtil.getNMSFluidCollisionOption(fluidMode));
++        return rayTrace == null ? null : net.minecraft.server.MCUtil.toBukkitBlockFace(rayTrace.direction);
++    }
++
++    public com.destroystokyo.paper.block.TargetBlockInfo getTargetBlockInfo(int maxDistance, com.destroystokyo.paper.block.TargetBlockInfo.FluidMode fluidMode) {
++        net.minecraft.server.MovingObjectPosition rayTrace = getHandle().getRayTrace(maxDistance, net.minecraft.server.MCUtil.getNMSFluidCollisionOption(fluidMode));
++        return rayTrace == null ? null : new com.destroystokyo.paper.block.TargetBlockInfo(org.bukkit.craftbukkit.block.CraftBlock.at(getHandle().world, rayTrace.getBlockPosition()), net.minecraft.server.MCUtil.toBukkitBlockFace(rayTrace.direction));
++    }
++    // Paper end
++
+     public List<Block> getLastTwoTargetBlocks(Set<Material> transparent, int maxDistance) {
+         return getLineOfSight(transparent, maxDistance, 2);
+     }
+-- 
+2.18.0
+


### PR DESCRIPTION
This method will return the Block a player is looking at while taking into consideration the AABB of each block in the path.

For example, you can look through the 1/4 space of air in a Stair block and get the block behind it instead of the Stair block you are looking past.