### PR TITLE
Fix view distance API

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -38,4 +38,5 @@ Andrew Steinborn <git@steinborn.me>
 willies952002 <admin@domnian.com>
 MicleBrick <miclebrick@outlook.com>
 Trigary <trigary0@gmail.com>
+rickyboy320 <rickw320@hotmail.com>
 ```

--- a/Spigot-Server-Patches/0032-Add-player-view-distance-API.patch
+++ b/Spigot-Server-Patches/0032-Add-player-view-distance-API.patch
@@ -1,17 +1,17 @@
-From 8cf00241b984108b5fa89837e961d8c767833922 Mon Sep 17 00:00:00 2001
+From fd5b90921efcc1fcbdf8390c356af04e3bda7190 Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Wed, 2 Mar 2016 14:35:27 -0600
 Subject: [PATCH] Add player view distance API
 
 
-diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 9f23c0d2c2..b44d056651 100644
---- a/src/main/java/net/minecraft/server/EntityPlayer.java
-+++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -71,6 +71,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
-     public boolean f;
-     public int ping;
-     public boolean viewingCredits;
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 89f3d17f2..6c4c19244 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -75,6 +75,15 @@ public abstract class EntityHuman extends EntityLiving {
+     // Paper start
+     public boolean affectsSpawning = true;
+     // Paper end
 +    // Paper start - Player view distance API
 +    private int viewDistance = -1;
 +    public int getViewDistance() {
@@ -23,9 +23,34 @@ index 9f23c0d2c2..b44d056651 100644
 +    // Paper end
  
      // CraftBukkit start
-     public String displayName;
+     public boolean fauxSleeping;
+diff --git a/src/main/java/net/minecraft/server/EntityTracker.java b/src/main/java/net/minecraft/server/EntityTracker.java
+index 70c9b1f50..0ea639228 100644
+--- a/src/main/java/net/minecraft/server/EntityTracker.java
++++ b/src/main/java/net/minecraft/server/EntityTracker.java
+@@ -200,6 +200,7 @@ public class EntityTracker {
+ 
+     }
+ 
++    public void updatePlayer(EntityPlayer entityplayer) { a(entityplayer); } // Paper - OBFHELPER
+     public void a(EntityPlayer entityplayer) {
+         Iterator iterator = this.c.iterator();
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+index 8478a81f5..5dbd493f4 100644
+--- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
++++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+@@ -435,7 +435,7 @@ public class EntityTrackerEntry {
+     public boolean c(EntityPlayer entityplayer) {
+         double d0 = entityplayer.locX - (double) this.xLoc / 4096.0D;
+         double d1 = entityplayer.locZ - (double) this.zLoc / 4096.0D;
+-        int i = Math.min(this.e, this.f);
++        int i = Math.min(this.e, (entityplayer.getViewDistance() - 1) * 16); // Paper - Use player view distance API
+ 
+         return d0 >= (double) (-i) && d0 <= (double) i && d1 >= (double) (-i) && d1 <= (double) i && this.tracker.a(entityplayer);
+     }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index d975c2ccf1..6ece565c51 100644
+index d975c2ccf..fb593529e 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -35,7 +35,7 @@ public class PlayerChunkMap {
@@ -65,27 +90,17 @@ index d975c2ccf1..6ece565c51 100644
                  PlayerChunk playerchunk = this.getChunk(k, l);
  
                  if (playerchunk != null) {
-@@ -316,7 +322,9 @@ public class PlayerChunkMap {
+@@ -316,7 +322,8 @@ public class PlayerChunkMap {
          if (d2 >= 64.0D) {
              int k = (int) entityplayer.d >> 4;
              int l = (int) entityplayer.e >> 4;
 -            int i1 = this.j;
-+            final int viewDistance = entityplayer.getViewDistance(); // Paper - Player view distance API
-+            int i1 = Math.max(getViewDistance(), viewDistance); // Paper - Player view distance API
++            int i1 = entityplayer.getViewDistance(); // Paper - Player view distance API
 +
              int j1 = i - k;
              int k1 = j - l;
  
-@@ -325,7 +333,7 @@ public class PlayerChunkMap {
-             if (j1 != 0 || k1 != 0) {
-                 for (int l1 = i - i1; l1 <= i + i1; ++l1) {
-                     for (int i2 = j - i1; i2 <= j + i1; ++i2) {
--                        if (!this.a(l1, i2, k, l, i1)) {
-+                        if (!this.a(l1, i2, k, l, viewDistance)) { // Paper - Player view distance API
-                             // this.c(l1, i2).a(entityplayer);
-                             chunksToLoad.add(new ChunkCoordIntPair(l1, i2)); // CraftBukkit
-                         }
-@@ -360,6 +368,8 @@ public class PlayerChunkMap {
+@@ -360,6 +367,8 @@ public class PlayerChunkMap {
          return playerchunk != null && playerchunk.d(entityplayer) && playerchunk.e();
      }
  
@@ -94,7 +109,7 @@ index d975c2ccf1..6ece565c51 100644
      public void a(int i) {
          i = MathHelper.clamp(i, 3, 32);
          if (i != this.j) {
-@@ -369,36 +379,55 @@ public class PlayerChunkMap {
+@@ -369,36 +378,55 @@ public class PlayerChunkMap {
  
              while (iterator.hasNext()) {
                  EntityPlayer entityplayer = (EntityPlayer) iterator.next();
@@ -172,7 +187,7 @@ index d975c2ccf1..6ece565c51 100644
  
      private void e() {
          this.l = true;
-@@ -477,4 +506,29 @@ public class PlayerChunkMap {
+@@ -477,4 +505,32 @@ public class PlayerChunkMap {
          }
      }
      // CraftBukkit end
@@ -198,12 +213,28 @@ index d975c2ccf1..6ece565c51 100644
 +            // Order matters
 +            this.setViewDistance(player, toSet);
 +            player.setViewDistance(playerViewDistance);
++
++            //Force update entity trackers
++            this.getWorld().getTracker().updatePlayer(player);
 +        }
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
+index 9e24b77ad..50b1175cc 100644
+--- a/src/main/java/net/minecraft/server/SpawnerCreature.java
++++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
+@@ -44,7 +44,7 @@ public final class SpawnerCreature {
+                     boolean flag3 = true;
+                     // Spigot Start
+                     byte b0 = worldserver.spigotConfig.mobSpawnRange;
+-                    b0 = ( b0 > worldserver.spigotConfig.viewDistance ) ? (byte) worldserver.spigotConfig.viewDistance : b0;
++                    b0 = ( b0 > entityhuman.getViewDistance() ) ? (byte) entityhuman.getViewDistance() : b0; // Paper - Use player view distance API
+                     b0 = ( b0 > 8 ) ? 8 : b0;
+ 
+                     for (int i1 = -b0; i1 <= b0; ++i1) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8ecef3ff96..3cc16b6923 100644
+index 8ecef3ff9..3cc16b692 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1641,6 +1641,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -223,6 +254,27 @@ index 8ecef3ff96..3cc16b6923 100644
      // Paper end
  
      @Override
+diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
+index 1aade75f3..f52de1023 100644
+--- a/src/main/java/org/spigotmc/ActivationRange.java
++++ b/src/main/java/org/spigotmc/ActivationRange.java
+@@ -108,13 +108,13 @@ public class ActivationRange
+ 
+         int maxRange = Math.max( monsterActivationRange, animalActivationRange );
+         maxRange = Math.max( maxRange, miscActivationRange );
+-        maxRange = Math.min( ( world.spigotConfig.viewDistance << 4 ) - 8, maxRange );
++        //maxRange = Math.min( ( world.spigotConfig.viewDistance << 4 ) - 8, maxRange ); Paper - Use player view distance API below instead
+ 
+         for ( EntityHuman player : world.players )
+         {
+-
++            int playerMaxRange = maxRange = Math.min( ( player.getViewDistance() << 4 ) - 8, maxRange ); // Paper - Use player view distance API
+             player.activatedTick = MinecraftServer.currentTick;
+-            maxBB = player.getBoundingBox().grow( maxRange, 256, maxRange );
++            maxBB = player.getBoundingBox().grow( playerMaxRange, 256, playerMaxRange ); // Paper - Use player view distance API
+             miscBB = player.getBoundingBox().grow( miscActivationRange, 256, miscActivationRange );
+             animalBB = player.getBoundingBox().grow( animalActivationRange, 256, animalActivationRange );
+             monsterBB = player.getBoundingBox().grow( monsterActivationRange, 256, monsterActivationRange );
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
+++ b/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
@@ -1,11 +1,11 @@
-From 3ddade42184d1b9996b47cf251dd031f40beb530 Mon Sep 17 00:00:00 2001
+From 6cc696059b4b3ef049c573f7387d240db3bcff54 Mon Sep 17 00:00:00 2001
 From: Sudzzy <originmc@outlook.com>
 Date: Wed, 2 Mar 2016 23:34:44 -0600
 Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 59bd3e28f0..f8d2aae082 100644
+index 77ad8687..34007dbf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -168,4 +168,9 @@ public class PaperWorldConfig {
@@ -19,18 +19,18 @@ index 59bd3e28f0..f8d2aae082 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index b44d056651..a9b08dcb0e 100644
+index 95ab3d2c..a279bf93 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -80,6 +80,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
-         this.viewDistance = viewDistance;
-     }
-     // Paper end
+@@ -71,6 +71,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public boolean f;
+     public int ping;
+     public boolean viewingCredits;
 +    private int containerUpdateDelay; // Paper
  
      // CraftBukkit start
      public String displayName;
-@@ -343,7 +344,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -334,7 +335,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              --this.noDamageTicks;
          }
  
@@ -45,5 +45,5 @@ index b44d056651..a9b08dcb0e 100644
              this.closeInventory();
              this.activeContainer = this.defaultContainer;
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0075-Catch-Async-PlayerChunkMap-operations.patch
+++ b/Spigot-Server-Patches/0075-Catch-Async-PlayerChunkMap-operations.patch
@@ -1,14 +1,14 @@
-From afaa481d091edf3f654b0f5aafa4f01ba92499b1 Mon Sep 17 00:00:00 2001
+From e67d8424ff946ac6c96671f0a2b1fd6843ec7320 Mon Sep 17 00:00:00 2001
 From: Daniel Ennis <dennis@icontact.com>
 Date: Sun, 20 Mar 2016 15:22:42 -0400
 Subject: [PATCH] Catch Async PlayerChunkMap operations
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 6ece565c51..4d888d6d4f 100644
+index 44f1ad90..174389e8 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -443,10 +443,12 @@ public class PlayerChunkMap {
+@@ -442,10 +442,12 @@ public class PlayerChunkMap {
      }
  
      public void a(PlayerChunk playerchunk) {
@@ -22,5 +22,5 @@ index 6ece565c51..4d888d6d4f 100644
          long i = d(chunkcoordintpair.x, chunkcoordintpair.z);
  
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0106-Implement-PlayerLocaleChangeEvent.patch
+++ b/Spigot-Server-Patches/0106-Implement-PlayerLocaleChangeEvent.patch
@@ -1,11 +1,11 @@
-From c85e00652bfa381d89b531ac65e3bb3fffac1d1f Mon Sep 17 00:00:00 2001
+From 27132f8d0653a6c8339c9bd68854275ed45e12f8 Mon Sep 17 00:00:00 2001
 From: Isaac Moore <rmsy@me.com>
 Date: Tue, 19 Apr 2016 14:09:31 -0500
 Subject: [PATCH] Implement PlayerLocaleChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index a9b08dcb0e..68e71a2f9d 100644
+index a279bf93..a9fbb20f 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -36,7 +36,7 @@ import org.bukkit.inventory.MainHand;
@@ -17,7 +17,7 @@ index a9b08dcb0e..68e71a2f9d 100644
      public PlayerConnection playerConnection;
      public final MinecraftServer server;
      public final PlayerInteractManager playerInteractManager;
-@@ -1259,12 +1259,19 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1250,12 +1250,19 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(getBukkitEntity(), getMainHand() == EnumMainHand.LEFT ? MainHand.LEFT : MainHand.RIGHT);
              this.server.server.getPluginManager().callEvent(event);
          }
@@ -39,7 +39,7 @@ index a9b08dcb0e..68e71a2f9d 100644
          this.ct = packetplayinsettings.e();
          this.getDataWatcher().set(EntityPlayer.bx, Byte.valueOf((byte) packetplayinsettings.f()));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0c8cfd5fb9..291b664b66 100644
+index 0c8cfd5f..291b664b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1736,8 +1736,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -65,5 +65,5 @@ index 0c8cfd5fb9..291b664b66 100644
  
          @Override
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0110-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/Spigot-Server-Patches/0110-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -1,4 +1,4 @@
-From 9b8549b5f833b30bec269a67c7335f5140ce545e Mon Sep 17 00:00:00 2001
+From 8824eb040551062e405769e77f5b114da7a136f5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 29 Apr 2016 20:02:00 -0400
 Subject: [PATCH] Improve Maps (in item frames) performance and bug fixes
@@ -13,10 +13,10 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 63f78924cb..79233fe463 100644
+index 6c4c1924..ad9e7f7b 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -610,6 +610,12 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -619,6 +619,12 @@ public abstract class EntityHuman extends EntityLiving {
                  return null;
              }
              // CraftBukkit end
@@ -30,7 +30,7 @@ index 63f78924cb..79233fe463 100644
              ItemStack itemstack1 = this.a(entityitem);
  
 diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
-index 63dfede645..cce2ce9397 100644
+index 5c75d494..6120c63a 100644
 --- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 +++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 @@ -90,7 +90,7 @@ public class EntityTrackerEntry {
@@ -43,7 +43,7 @@ index 63dfede645..cce2ce9397 100644
              ItemStack itemstack = entityitemframe.getItem();
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 3ce6058d4c..8005b0c110 100644
+index a4237b30..caf75ee3 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1109,6 +1109,7 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
@@ -55,7 +55,7 @@ index 3ce6058d4c..8005b0c110 100644
                              }
                          }
 diff --git a/src/main/java/net/minecraft/server/WorldMap.java b/src/main/java/net/minecraft/server/WorldMap.java
-index aa58e34c6f..f26b91b407 100644
+index aa58e34c..f26b91b4 100644
 --- a/src/main/java/net/minecraft/server/WorldMap.java
 +++ b/src/main/java/net/minecraft/server/WorldMap.java
 @@ -30,6 +30,7 @@ public class WorldMap extends PersistentBase {
@@ -127,7 +127,7 @@ index aa58e34c6f..f26b91b407 100644
              for ( org.bukkit.map.MapCursor cursor : render.cursors) {
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/map/RenderData.java b/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
-index 256a131781..5768cd512e 100644
+index 256a1317..5768cd51 100644
 --- a/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
 @@ -5,7 +5,7 @@ import org.bukkit.map.MapCursor;
@@ -140,5 +140,5 @@ index 256a131781..5768cd512e 100644
  
      public RenderData() {
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0113-Entity-Tracking-Improvements.patch
+++ b/Spigot-Server-Patches/0113-Entity-Tracking-Improvements.patch
@@ -1,4 +1,4 @@
-From 3f75cb9ef3269d4e9c93f8e2dd9ad32598408488 Mon Sep 17 00:00:00 2001
+From 60c4be3205cfad9d5c5253c083705fdfee0dd2be Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 17 Jun 2013 01:24:00 -0400
 Subject: [PATCH] Entity Tracking Improvements
@@ -7,7 +7,7 @@ If any part of a Vehicle/Passenger relationship is visible to a player,
 send all passenger/vehicles to the player in the chain.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d070d68d7c..4d2e978894 100644
+index d070d68d..4d2e9788 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -72,6 +72,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -19,7 +19,7 @@ index d070d68d7c..4d2e978894 100644
          if (bukkitEntity == null) {
              bukkitEntity = CraftEntity.getEntity(world.getServer(), this);
 diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
-index cce2ce9397..4dbc5eca34 100644
+index 6120c63a..a9d51641 100644
 --- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 +++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 @@ -49,6 +49,7 @@ public class EntityTrackerEntry {
@@ -89,7 +89,7 @@ index cce2ce9397..4dbc5eca34 100644
 +        // Paper end
          double d0 = entityplayer.locX - (double) this.xLoc / 4096.0D;
          double d1 = entityplayer.locZ - (double) this.zLoc / 4096.0D;
-         int i = Math.min(this.e, this.f);
+         int i = Math.min(this.e, (entityplayer.getViewDistance() - 1) * 16); // Paper - Use player view distance API
 @@ -597,6 +640,7 @@ public class EntityTrackerEntry {
              this.trackedPlayers.remove(entityplayer);
              this.tracker.c(entityplayer);
@@ -99,5 +99,5 @@ index cce2ce9397..4dbc5eca34 100644
  
      }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0116-Optimize-EAR.patch
+++ b/Spigot-Server-Patches/0116-Optimize-EAR.patch
@@ -1,11 +1,11 @@
-From 822622ef17b37a841d57067697dd95d5598f5ced Mon Sep 17 00:00:00 2001
+From 1849db3a56ff8dff0d6eb4a6bd2825648e393a95 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 13 May 2016 01:38:06 -0400
 Subject: [PATCH] Optimize EAR
 
 
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 1aade75f34..a9b84fdec4 100644
+index 27ec0f1d..454c1a58 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -2,6 +2,8 @@ package org.spigotmc;
@@ -47,12 +47,12 @@ index 1aade75f34..a9b84fdec4 100644
  {
 @@ -110,6 +111,7 @@ public class ActivationRange
          maxRange = Math.max( maxRange, miscActivationRange );
-         maxRange = Math.min( ( world.spigotConfig.viewDistance << 4 ) - 8, maxRange );
+         //maxRange = Math.min( ( world.spigotConfig.viewDistance << 4 ) - 8, maxRange ); Paper - Use player view distance API below instead
  
 +        Chunk chunk; // Paper
          for ( EntityHuman player : world.players )
          {
- 
+             int playerMaxRange = maxRange = Math.min( ( player.getViewDistance() << 4 ) - 8, maxRange ); // Paper - Use player view distance API
 @@ -128,9 +130,9 @@ public class ActivationRange
              {
                  for ( int j1 = k; j1 <= l; ++j1 )
@@ -66,5 +66,5 @@ index 1aade75f34..a9b84fdec4 100644
                  }
              }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0124-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0124-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -1,4 +1,4 @@
-From 633810714b9d75cdaabfc1a4d2e687046ecb2bc5 Mon Sep 17 00:00:00 2001
+From 6488a8930089b7cbdec16f6b93efd1328a4976c3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 18 Jun 2016 23:22:12 -0400
 Subject: [PATCH] Delay Chunk Unloads based on Player Movement
@@ -17,7 +17,7 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f8102d9f07..547ab09627 100644
+index f8102d9f..547ab096 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -288,4 +288,18 @@ public class PaperWorldConfig {
@@ -40,7 +40,7 @@ index f8102d9f07..547ab09627 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 0ef1a8c7d3..2efb870dd6 100644
+index 5390396d..3c9c3cd4 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -37,6 +37,7 @@ public class Chunk implements IChunkAccess {
@@ -52,7 +52,7 @@ index 0ef1a8c7d3..2efb870dd6 100644
      public final int locZ;
      private boolean l;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 1a1daf36b7..7417660e4d 100644
+index 1a1daf36..7417660e 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -306,6 +306,19 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -76,7 +76,7 @@ index 1a1daf36b7..7417660e4d 100644
              this.chunkScheduler.a(booleansupplier);
          }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index ac0e90eeca..3f4a8f21c0 100644
+index ac0e90ee..3f4a8f21 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -33,8 +33,16 @@ public class PlayerChunk {
@@ -113,10 +113,10 @@ index ac0e90eeca..3f4a8f21c0 100644
          }
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 4d888d6d4f..cf5c76a78e 100644
+index 174389e8..eb9d454a 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -461,7 +461,13 @@ public class PlayerChunkMap {
+@@ -460,7 +460,13 @@ public class PlayerChunkMap {
          Chunk chunk = playerchunk.f();
  
          if (chunk != null) {
@@ -132,7 +132,7 @@ index 4d888d6d4f..cf5c76a78e 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8005b0c110..c6fa54848e 100644
+index caf75ee3..b4f31c93 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1329,7 +1329,13 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
@@ -151,7 +151,7 @@ index 8005b0c110..c6fa54848e 100644
                          this.methodProfiler.a(() -> {
                              return String.valueOf(TileEntityTypes.a(tileentity.C()));
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9637c98994..6b3b45f94a 100644
+index 9637c989..6b3b45f9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1620,7 +1620,7 @@ public class CraftWorld implements World {
@@ -164,7 +164,7 @@ index 9637c98994..6b3b45f94a 100644
              }
  
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index a9b84fdec4..34d2f11f4f 100644
+index 454c1a58..79f053a7 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -284,6 +284,11 @@ public class ActivationRange
@@ -180,5 +180,5 @@ index a9b84fdec4..34d2f11f4f 100644
      }
  }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0129-Re-track-players-that-dismount-from-other-players.patch
+++ b/Spigot-Server-Patches/0129-Re-track-players-that-dismount-from-other-players.patch
@@ -1,14 +1,14 @@
-From e40481987760664b379e4efcc9079ce2d8b314ba Mon Sep 17 00:00:00 2001
+From 3002b444e87e300c27e8e24b59baeff172044525 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Sun, 31 Jul 2016 16:33:03 -0500
 Subject: [PATCH] Re-track players that dismount from other players
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 68e71a2f9d..96d7be49d8 100644
+index a9fbb20f..3d839002 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -760,6 +760,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -751,6 +751,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          if (entity1 != entity && this.playerConnection != null) {
              this.playerConnection.a(this.locX, this.locY, this.locZ, this.yaw, this.pitch);
          }
@@ -23,5 +23,5 @@ index 68e71a2f9d..96d7be49d8 100644
      }
  
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0139-Auto-fix-bad-Y-levels-on-player-login.patch
+++ b/Spigot-Server-Patches/0139-Auto-fix-bad-Y-levels-on-player-login.patch
@@ -1,4 +1,4 @@
-From bbb2e472449e6a5bf3508c1fb0548ef3eda51957 Mon Sep 17 00:00:00 2001
+From fb7929aeefa445661d7c290db0bdc3c30bbd1095 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 21 Sep 2016 23:48:39 -0400
 Subject: [PATCH] Auto fix bad Y levels on player login
@@ -6,10 +6,10 @@ Subject: [PATCH] Auto fix bad Y levels on player login
 Bring down to a saner Y level if super high, as this can cause the server to crash
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 2c4fc9f3e6..47cf068a1e 100644
+index 690cff88..d9ea222c 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -198,6 +198,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -189,6 +189,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      public void a(NBTTagCompound nbttagcompound) {
          super.a(nbttagcompound);
@@ -18,5 +18,5 @@ index 2c4fc9f3e6..47cf068a1e 100644
              if (this.bK().getForceGamemode()) {
                  this.playerInteractManager.setGameMode(this.bK().getGamemode());
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0148-Optimise-removeQueue.patch
+++ b/Spigot-Server-Patches/0148-Optimise-removeQueue.patch
@@ -1,11 +1,11 @@
-From 8c714223164c2a6d6bc14adf7b4a518befb239b9 Mon Sep 17 00:00:00 2001
+From 1398fea4cc7fbff0f8178802a4c3b39a6be0bfb7 Mon Sep 17 00:00:00 2001
 From: Alfie Cleveland <alfeh@me.com>
 Date: Fri, 25 Nov 2016 13:22:40 +0000
 Subject: [PATCH] Optimise removeQueue
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 47cf068a1e..d8299a5759 100644
+index d9ea222c..e3ac9eb7 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -5,8 +5,10 @@ import com.mojang.authlib.GameProfile;
@@ -28,7 +28,7 @@ index 47cf068a1e..d8299a5759 100644
      private final AdvancementDataPlayer cf;
      private final ServerStatisticManager cg;
      private float ch = Float.MIN_VALUE;
-@@ -360,13 +362,20 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -351,13 +353,20 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          while (!this.removeQueue.isEmpty()) {
              int i = Math.min(this.removeQueue.size(), Integer.MAX_VALUE);
              int[] aint = new int[i];
@@ -51,7 +51,7 @@ index 47cf068a1e..d8299a5759 100644
  
              this.playerConnection.sendPacket(new PacketPlayOutEntityDestroy(aint));
          }
-@@ -1146,7 +1155,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1137,7 +1146,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.lastHealthSent = -1.0F;
          this.co = -1;
          // this.cy.a((RecipeBook) entityplayer.cy); // CraftBukkit
@@ -68,5 +68,5 @@ index 47cf068a1e..d8299a5759 100644
          this.cC = entityplayer.cC;
          this.setShoulderEntityLeft(entityplayer.getShoulderEntityLeft());
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0160-Properly-fix-item-duplication-bug.patch
+++ b/Spigot-Server-Patches/0160-Properly-fix-item-duplication-bug.patch
@@ -1,4 +1,4 @@
-From 6e85901d729d461b68f4dd77f52d5bc6e8227021 Mon Sep 17 00:00:00 2001
+From 8f7d709d7d915e21562e03de560842df5581c139 Mon Sep 17 00:00:00 2001
 From: Alfie Cleveland <alfeh@me.com>
 Date: Tue, 27 Dec 2016 01:57:57 +0000
 Subject: [PATCH] Properly fix item duplication bug
@@ -6,10 +6,10 @@ Subject: [PATCH] Properly fix item duplication bug
 Credit to prplz for figuring out the real issue
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index d8299a5759..49470bf5f0 100644
+index e3ac9eb7..3644fde3 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -1559,7 +1559,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1550,7 +1550,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      @Override
      protected boolean isFrozen() {
@@ -19,7 +19,7 @@ index d8299a5759..49470bf5f0 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 77f12b4d1d..9de392315e 100644
+index 37b3dd69..316fed5b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -2515,7 +2515,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -32,5 +32,5 @@ index 77f12b4d1d..9de392315e 100644
      // CraftBukkit end
  }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0179-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0179-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -1,4 +1,4 @@
-From 4ce968e99445a133ff9bf1e0512572b0295b7436 Mon Sep 17 00:00:00 2001
+From e62bc03a0b8b6195c0dd66807a67c4132544d034 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 16 May 2017 21:29:08 -0500
 Subject: [PATCH] Add option to make parrots stay on shoulders despite movement
@@ -11,7 +11,7 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8923454524..0094f6ab98 100644
+index 89234545..0094f6ab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -353,4 +353,10 @@ public class PaperWorldConfig {
@@ -26,10 +26,10 @@ index 8923454524..0094f6ab98 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 79233fe463..f6600ce515 100644
+index ad9e7f7b..0f00eece 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -460,7 +460,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -469,7 +469,7 @@ public abstract class EntityHuman extends EntityLiving {
          this.j(this.getShoulderEntityLeft());
          this.j(this.getShoulderEntityRight());
          if (!this.world.isClientSide && (this.fallDistance > 0.5F || this.isInWater() || this.isPassenger()) || this.abilities.isFlying) {
@@ -39,7 +39,7 @@ index 79233fe463..f6600ce515 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7f61da1cd3..7e06e5bc67 100644
+index e09f2f5b..8c7428c0 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1757,6 +1757,13 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -57,5 +57,5 @@ index 7f61da1cd3..7e06e5bc67 100644
  
          case STOP_SNEAKING:
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0188-Shoulder-Entities-Release-API.patch
+++ b/Spigot-Server-Patches/0188-Shoulder-Entities-Release-API.patch
@@ -1,14 +1,14 @@
-From 5e6237bf393b237fb0d675d4c93d1f99f64aa081 Mon Sep 17 00:00:00 2001
+From 3cef55a977f376a4e9670dcc437303c452b6d436 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 17 Jun 2017 15:18:30 -0400
 Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 47a286a48..3ab03dd04 100644
+index 0f00eece..504c9ad4 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1815,21 +1815,48 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1824,21 +1824,48 @@ public abstract class EntityHuman extends EntityLiving {
          }
          // CraftBukkit end
      }
@@ -62,7 +62,7 @@ index 47a286a48..3ab03dd04 100644
      public abstract boolean isSpectator();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 289e267bd..38a886fbd 100644
+index 289e267b..38a886fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -455,6 +455,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -99,5 +99,5 @@ index 289e267bd..38a886fbd 100644
      public org.bukkit.entity.Entity getShoulderEntityLeft() {
          if (!getHandle().getShoulderEntityLeft().isEmpty()) {
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0209-Add-PlayerJumpEvent.patch
+++ b/Spigot-Server-Patches/0209-Add-PlayerJumpEvent.patch
@@ -1,14 +1,14 @@
-From bd89e2276d0e37b52f6a1cb3513780fc39db0f56 Mon Sep 17 00:00:00 2001
+From 80c3e9f2c71f29c8d955b0fee18ee43a3290d0cc Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Thu, 28 Sep 2017 17:21:44 -0400
 Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 3ab03dd04..fcfc8299f 100644
+index 504c9ad4..4ac310ba 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1467,6 +1467,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1476,6 +1476,7 @@ public abstract class EntityHuman extends EntityLiving {
          return 0;
      }
  
@@ -17,7 +17,7 @@ index 3ab03dd04..fcfc8299f 100644
          super.cH();
          this.a(StatisticList.JUMP);
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 5df7e4972..c9534f237 100644
+index 8c7428c0..1294ce56 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -59,6 +59,8 @@ import org.bukkit.inventory.CraftingInventory;
@@ -66,5 +66,5 @@ index 5df7e4972..c9534f237 100644
  
                              this.player.move(EnumMoveType.PLAYER, d7, d8, d9);
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0214-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/Spigot-Server-Patches/0214-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -1,4 +1,4 @@
-From a83ee4ce9aa0e78f0b29c856904762ca759710f6 Mon Sep 17 00:00:00 2001
+From ee464e6d1ed11829ed08eb96e5b0deaf4614a74e Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Tue, 31 Oct 2017 03:26:18 +0100
 Subject: [PATCH] Send attack SoundEffects only to players who can see the
@@ -6,10 +6,10 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 9a71fa1e94..380192501e 100644
+index 4ac310ba..1b7adbf4 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -987,6 +987,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -996,6 +996,15 @@ public abstract class EntityHuman extends EntityLiving {
          this.k = 0;
      }
  
@@ -25,7 +25,7 @@ index 9a71fa1e94..380192501e 100644
      public void attack(Entity entity) {
          if (entity.bk()) {
              if (!entity.t(this)) {
-@@ -1011,7 +1020,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1020,7 +1029,7 @@ public abstract class EntityHuman extends EntityLiving {
                      int i = b0 + EnchantmentManager.b((EntityLiving) this);
  
                      if (this.isSprinting() && flag) {
@@ -34,7 +34,7 @@ index 9a71fa1e94..380192501e 100644
                          ++i;
                          flag1 = true;
                      }
-@@ -1089,7 +1098,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1098,7 +1107,7 @@ public abstract class EntityHuman extends EntityLiving {
                                  }
                              }
  
@@ -43,7 +43,7 @@ index 9a71fa1e94..380192501e 100644
                              this.dl();
                          }
  
-@@ -1119,15 +1128,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1128,15 +1137,15 @@ public abstract class EntityHuman extends EntityLiving {
                          }
  
                          if (flag2) {
@@ -62,7 +62,7 @@ index 9a71fa1e94..380192501e 100644
                              }
                          }
  
-@@ -1183,7 +1192,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1192,7 +1201,7 @@ public abstract class EntityHuman extends EntityLiving {
  
                          this.applyExhaustion(world.spigotConfig.combatExhaustion); // Spigot - Change to use configurable value
                      } else {
@@ -72,7 +72,7 @@ index 9a71fa1e94..380192501e 100644
                              entity.extinguish();
                          }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 109e718118..9f6027d5e4 100644
+index 94e91d6e..3c8af077 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -948,6 +948,12 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
@@ -89,5 +89,5 @@ index 109e718118..9f6027d5e4 100644
          for (int i = 0; i < this.v.size(); ++i) {
              ((IWorldAccess) this.v.get(i)).a(entityhuman, soundeffect, soundcategory, d0, d1, d2, f, f1);
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0229-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/Spigot-Server-Patches/0229-PlayerNaturallySpawnCreaturesEvent.patch
@@ -1,4 +1,4 @@
-From 92f50e4fd12ec1dd767f7aae96d08be76115976d Mon Sep 17 00:00:00 2001
+From 653f60768615a9e92c287b1e712a3a0764b4086c Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 14 Jan 2018 17:36:02 -0500
 Subject: [PATCH] PlayerNaturallySpawnCreaturesEvent
@@ -9,12 +9,12 @@ from triggering monster spawns on a server.
 Also a highly more effecient way to blanket block spawns in a world
 
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index 4a2153b68f..32808558bb 100644
+index 3f6bcbbd..95d98b65 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
 @@ -47,6 +47,15 @@ public final class SpawnerCreature {
                      byte b0 = worldserver.spigotConfig.mobSpawnRange;
-                     b0 = ( b0 > worldserver.spigotConfig.viewDistance ) ? (byte) worldserver.spigotConfig.viewDistance : b0;
+                     b0 = ( b0 > entityhuman.getViewDistance() ) ? (byte) entityhuman.getViewDistance() : b0; // Paper - Use player view distance API
                      b0 = ( b0 > 8 ) ? 8 : b0;
 +                    // Paper start
 +                    com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent event;
@@ -29,5 +29,5 @@ index 4a2153b68f..32808558bb 100644
                      for (int i1 = -b0; i1 <= b0; ++i1) {
                          for (k = -b0; k <= b0; ++k) {
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0236-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/Spigot-Server-Patches/0236-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -1,11 +1,11 @@
-From 61310ad17ed62e2a1061f2f39d730a46519374c1 Mon Sep 17 00:00:00 2001
+From 82fab6bbd13fbb89a23009a1f8d5c98cc13d98f0 Mon Sep 17 00:00:00 2001
 From: MiniDigger <admin@minidigger.me>
 Date: Sat, 10 Mar 2018 00:50:24 +0100
 Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 63f8f566cb..c9a44863cc 100644
+index 63f8f566..c9a44863 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -180,6 +180,11 @@ public class PaperWorldConfig {
@@ -21,10 +21,10 @@ index 63f8f566cb..c9a44863cc 100644
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 380192501e..fcb5f07d78 100644
+index 1b7adbf4..a728507c 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1027,6 +1027,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1036,6 +1036,7 @@ public abstract class EntityHuman extends EntityLiving {
  
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.z_() && !this.isInWater() && !this.hasEffect(MobEffects.BLINDNESS) && !this.isPassenger() && entity instanceof EntityLiving;
  
@@ -33,5 +33,5 @@ index 380192501e..fcb5f07d78 100644
                      if (flag2) {
                          f *= 1.5F;
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0253-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0253-Configurable-sprint-interruption-on-attack.patch
@@ -1,4 +1,4 @@
-From 186f491a1291ca298b08c2d9367c3e3e9963d3ef Mon Sep 17 00:00:00 2001
+From 04010471fd6283265d586eb38347d7a4abbe8b88 Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Sat, 14 Apr 2018 20:20:46 +0200
 Subject: [PATCH] Configurable sprint interruption on attack
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c9a44863cc..9ff73d531c 100644
+index c9a44863..9ff73d53 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -401,4 +401,9 @@ public class PaperWorldConfig {
@@ -20,10 +20,10 @@ index c9a44863cc..9ff73d531c 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 0551ae2290..6ae76477c0 100644
+index 5975578b..5e13cb06 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1079,7 +1079,11 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1088,7 +1088,11 @@ public abstract class EntityHuman extends EntityLiving {
  
                              this.motX *= 0.6D;
                              this.motZ *= 0.6D;
@@ -37,5 +37,5 @@ index 0551ae2290..6ae76477c0 100644
  
                          if (flag3) {
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0284-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0284-InventoryCloseEvent-Reason-API.patch
@@ -1,4 +1,4 @@
-From 94376469b993be635f0f17cfc06dda9bdfeefec8 Mon Sep 17 00:00:00 2001
+From af423c1e2d1f13fb504985d95afaa7790728e375 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 3 Jul 2018 21:56:23 -0400
 Subject: [PATCH] InventoryCloseEvent Reason API
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 6bbb737df7..614fce4447 100644
+index 6bbb737d..614fce44 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -900,7 +900,7 @@ public class Chunk implements IChunkAccess {
@@ -29,10 +29,10 @@ index 6bbb737df7..614fce4447 100644
                      }
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index c8bf8832bd..6e5ffe4da7 100644
+index 5e13cb06..c7dc6fe0 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -153,7 +153,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -162,7 +162,7 @@ public abstract class EntityHuman extends EntityLiving {
          this.dg();
          super.tick();
          if (!this.world.isClientSide && this.activeContainer != null && !this.activeContainer.canUse(this)) {
@@ -41,7 +41,7 @@ index c8bf8832bd..6e5ffe4da7 100644
              this.activeContainer = this.defaultContainer;
          }
  
-@@ -355,6 +355,13 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -364,6 +364,13 @@ public abstract class EntityHuman extends EntityLiving {
          return this.getHealth() <= 0.0F || this.isSleeping();
      }
  
@@ -56,10 +56,10 @@ index c8bf8832bd..6e5ffe4da7 100644
          this.activeContainer = this.defaultContainer;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 49470bf5f0..781c8abc39 100644
+index 3644fde3..68f5842c 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -355,7 +355,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -346,7 +346,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
          // Paper end
          if (!this.world.isClientSide && !this.activeContainer.canUse(this)) {
@@ -68,7 +68,7 @@ index 49470bf5f0..781c8abc39 100644
              this.activeContainer = this.defaultContainer;
          }
  
-@@ -561,7 +561,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -552,7 +552,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              this.inventory.clear();
          }
  
@@ -77,7 +77,7 @@ index 49470bf5f0..781c8abc39 100644
          this.setSpectatorTarget(this); // Remove spectated target
          // CraftBukkit end
  
-@@ -873,7 +873,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -864,7 +864,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              this.a((new ChatMessage("container.spectatorCantOpen", new Object[0])).a(EnumChatFormat.RED), true);
          } else {
              if (this.activeContainer != this.defaultContainer) {
@@ -86,7 +86,7 @@ index 49470bf5f0..781c8abc39 100644
              }
  
              if (iinventory instanceof ITileInventory) {
-@@ -939,7 +939,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -930,7 +930,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
          // CraftBukkit end
          if (this.activeContainer != this.defaultContainer) {
@@ -95,7 +95,7 @@ index 49470bf5f0..781c8abc39 100644
          }
  
          this.nextContainerCounter();
-@@ -1004,7 +1004,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -995,7 +995,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      }
  
      public void closeInventory() {
@@ -110,7 +110,7 @@ index 49470bf5f0..781c8abc39 100644
          this.m();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 16af56fd18..6563785042 100644
+index 5199c1fe..06709e0c 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -2056,7 +2056,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -123,7 +123,7 @@ index 16af56fd18..6563785042 100644
          this.player.m();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 304cae655d..6d511b6230 100644
+index 304cae65..6d511b62 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -422,7 +422,7 @@ public abstract class PlayerList {
@@ -136,7 +136,7 @@ index 304cae655d..6d511b6230 100644
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
          cserver.getPluginManager().callEvent(playerQuitEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 92fe80316f..70a4dbe26b 100644
+index 92fe8031..70a4dbe2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -412,8 +412,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -155,7 +155,7 @@ index 92fe80316f..70a4dbe26b 100644
      public boolean isBlocking() {
          return getHandle().isBlocking();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 40b590da36..f372f19dec 100644
+index 40b590da..f372f19d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -740,7 +740,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -168,7 +168,7 @@ index 40b590da36..f372f19dec 100644
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d6ff3f3303..1cc17c29c9 100644
+index d6ff3f33..1cc17c29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -915,8 +915,19 @@ public class CraftEventFactory {
@@ -193,5 +193,5 @@ index d6ff3f3303..1cc17c29c9 100644
          human.activeContainer.transferTo(human.defaultContainer, human.getBukkitEntity());
      }
 -- 
-2.18.0
+2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0363-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0363-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 9e11f1b5d8df4fc2b1854ef5aa361dd4b00b3fe1 Mon Sep 17 00:00:00 2001
+From bbba4ba76f40f8d71ffd3706870f4ebe8a9e9942 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -15,7 +15,7 @@ items and experience which is otherwise only properly possible by using
 internal code.
 
 diff --git a/src/main/java/net/minecraft/server/CombatTracker.java b/src/main/java/net/minecraft/server/CombatTracker.java
-index 63bdb96db8..96dd1a7fa4 100644
+index 63bdb96db..96dd1a7fa 100644
 --- a/src/main/java/net/minecraft/server/CombatTracker.java
 +++ b/src/main/java/net/minecraft/server/CombatTracker.java
 @@ -163,6 +163,7 @@ public class CombatTracker {
@@ -27,7 +27,7 @@ index 63bdb96db8..96dd1a7fa4 100644
          int i = this.f ? 300 : 100;
          if (this.g && (!this.b.isAlive() || this.b.ticksLived - this.c > i)) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 1fae9aa074..3e69bac9ad 100644
+index 1fae9aa07..3e69bac9a 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1538,6 +1538,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -55,7 +55,7 @@ index 1fae9aa074..3e69bac9ad 100644
          return SoundCategory.NEUTRAL;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index 35afffedef..e8e7413748 100644
+index 35afffede..e8e741374 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -629,7 +629,8 @@ public class EntityArmorStand extends EntityLiving {
@@ -69,7 +69,7 @@ index 35afffedef..e8e7413748 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 890a3a02bd..fec7bf0a5d 100644
+index 890a3a02b..fec7bf0a5 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -76,14 +76,14 @@ public abstract class EntityLiving extends Entity {
@@ -206,12 +206,12 @@ index 890a3a02bd..fec7bf0a5d 100644
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 334400a4ee..e2b8c70008 100644
+index 68f5842cf..5ab4e01ed 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
-@@ -84,6 +84,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
-     }
-     // Paper end
+@@ -75,6 +75,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public int ping;
+     public boolean viewingCredits;
      private int containerUpdateDelay; // Paper
 +    // Paper start - cancellable death event
 +    public boolean queueHealthUpdatePacket = false;
@@ -220,7 +220,7 @@ index 334400a4ee..e2b8c70008 100644
  
      // CraftBukkit start
      public String displayName;
-@@ -517,6 +521,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -508,6 +512,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
          String deathmessage = defaultMessage.getString();
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
@@ -236,7 +236,7 @@ index 334400a4ee..e2b8c70008 100644
  
          String deathMessage = event.getDeathMessage();
  
-@@ -644,8 +657,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -635,8 +648,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                          }
                      }
                  }
@@ -257,7 +257,7 @@ index 334400a4ee..e2b8c70008 100644
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-index 17fab031b4..ee8219e3ba 100644
+index 17fab031b..ee8219e3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
 @@ -674,6 +674,22 @@ public enum CraftSound {
@@ -284,7 +284,7 @@ index 17fab031b4..ee8219e3ba 100644
          this.minecraftKey = minecraftKey;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b6cf96e187..96232aa078 100644
+index b6cf96e18..96232aa07 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1711,7 +1711,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -305,7 +305,7 @@ index b6cf96e187..96232aa078 100644
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 64b34d2623..dc8c3ea758 100644
+index 64b34d262..dc8c3ea75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -412,9 +412,16 @@ public class CraftEventFactory {
@@ -374,5 +374,5 @@ index 64b34d2623..dc8c3ea758 100644
       * Server methods
       */
 -- 
-2.18.0
+2.18.0.windows.1
 


### PR DESCRIPTION
Aims to fix #1349 by properly using the view distance API in the EntityTracker.
Also removed the Math.max line which caused the (original) issue of not being able to set the distance lower than spigot's view distance, and replaced more occurrences of the spigot viewdistance with the API. (I believe I've got them all, directly or indirectly)

