### PR TITLE
Allow chests to be placed with NBT

### DIFF
--- a/Spigot-Server-Patches/0364-Allow-chests-to-be-placed-with-NBT-data.patch
+++ b/Spigot-Server-Patches/0364-Allow-chests-to-be-placed-with-NBT-data.patch
@@ -1,0 +1,22 @@
+From 2778cdcac727ba60b80f7a3222f863e7bdb8dfc9 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sat, 8 Sep 2018 18:43:31 -0500
+Subject: [PATCH] Allow chests to be placed with NBT data
+
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityChest.java b/src/main/java/net/minecraft/server/TileEntityChest.java
+index 9573a4ecd..7594c16e9 100644
+--- a/src/main/java/net/minecraft/server/TileEntityChest.java
++++ b/src/main/java/net/minecraft/server/TileEntityChest.java
+@@ -305,7 +305,7 @@ public class TileEntityChest extends TileEntityLootable { // Paper - Remove ITic
+     // CraftBukkit start
+     @Override
+     public boolean isFilteredNBT() {
+-        return true;
++        return false; // Paper
+     }
+     // CraftBukkit end
+ }
+-- 
+2.18.0
+


### PR DESCRIPTION
~~This adds a new option to paper.yml to bring back the vanilla behavior of allowing non-op and non-creative users to place blocks with BlockEntityTag NBT data on them.~~

~~This was snuffed out in CraftBukkit for being considered "exploitable" but I don't see any harm in letting server owners decide for themselves if they want this or not.~~

~~The default option is `false` to leave it snuffed out the way CraftBukkit has it.~~

This allows chests with NBT to be placed into the world by any player regardless of op status or gamemode.