### PR TITLE
Mob Pathfinding API

### DIFF
--- a/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
+++ b/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
@@ -1,4 +1,4 @@
-From ff4b1d675da0e4955bae805d7ed579f3e8fb9238 Mon Sep 17 00:00:00 2001
+From 68606cfdc559ec3b89b3704a24247fd6774e0cb3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 12:39:06 -0400
 Subject: [PATCH] Mob Pathfinding API
@@ -8,6 +8,8 @@ Adds an API to allow plugins to instruct a Mob to Pathfind to a Location or Enti
 This does not do anything to stop other AI rules from changing the location, so
 it is still up to the plugin to control that or override after another goal changed
 the location.
+
+You can use EntityPathfindEvent to cancel new pathfinds from overriding your current.
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644

--- a/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
+++ b/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
@@ -1,4 +1,4 @@
-From a9c06c0f1eecb397249a9e0c8881bf848e9168f3 Mon Sep 17 00:00:00 2001
+From ff4b1d675da0e4955bae805d7ed579f3e8fb9238 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 12:39:06 -0400
 Subject: [PATCH] Mob Pathfinding API
@@ -11,7 +11,7 @@ the location.
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644
-index 000000000..27b6bb696
+index 000000000..78230bd28
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 @@ -0,0 +1,168 @@
@@ -175,7 +175,7 @@ index 000000000..27b6bb696
 +         * @return Returns the index of the current point along the points returned in {@link #getPoints()} the entity
 +         * is trying to reach, or null if we are done with this pathfinding.
 +         */
-+        @Nullable Integer getNextPointIndex();
++        int getNextPointIndex();
 +
 +        /**
 +         * @return The next location in the path points the entity is trying to reach, or null if there is no next point

--- a/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
+++ b/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
@@ -1,0 +1,207 @@
+From a9c06c0f1eecb397249a9e0c8881bf848e9168f3 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Sun, 9 Sep 2018 12:39:06 -0400
+Subject: [PATCH] Mob Pathfinding API
+
+Adds an API to allow plugins to instruct a Mob to Pathfind to a Location or Entity
+
+This does not do anything to stop other AI rules from changing the location, so
+it is still up to the plugin to control that or override after another goal changed
+the location.
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
+new file mode 100644
+index 000000000..27b6bb696
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
+@@ -0,0 +1,168 @@
++package com.destroystokyo.paper.entity;
++
++import org.apache.commons.lang.Validate;
++import org.bukkit.Location;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Mob;
++
++import javax.annotation.Nonnull;
++import javax.annotation.Nullable;
++import java.util.List;
++
++/**
++ * Handles pathfinding operations for an Entity
++ */
++public interface Pathfinder {
++
++    /**
++     *
++     * @return The entity that is controlled by this pathfinder
++     */
++    Mob getEntity();
++
++    /**
++     * Instructs the Entity to stop trying to navigate to its current desired location
++     */
++    void stopPathfinding();
++
++    /**
++     * If the entity is currently trying to navigate to a destination, this will return true
++     * @return true if the entity is navigating to a destination
++     */
++    boolean hasDestination();
++
++    /**
++     * @return The location the entity is trying to navigate to, or null if there is no destination
++     */
++    @Nullable PathResult getCurrentDestination();
++
++    /**
++     * Calculates a destination for the Entity to navigate to, but does not set it
++     * as the current target. Useful for calculating what would happen before setting it.
++     * @param loc Location to navigate to
++     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
++     */
++    @Nullable PathResult calculateDestination(Location loc);
++
++    /**
++     * Calculates a destination for the Entity to navigate to to reach the target entity,
++     * but does not set it as the current target.
++     * Useful for calculating what would happen before setting it.
++     *
++     * The behavior of this PathResult is subject to the games pathfinding rules, and may
++     * result in the pathfinding automatically updating to follow the target Entity.
++     *
++     * However, this behavior is not guaranteed, and is subject to the games behavior.
++     *
++     * @param target the Entity to navigate to
++     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
++     */
++    @Nullable PathResult calculateDestination(LivingEntity target);
++
++    /**
++     * Calculates a destination for the Entity to navigate to, and sets it with default speed
++     * as the current target.
++     * @param loc Location to navigate to
++     * @return If the pathfinding was successfully started
++     */
++    default boolean setDestination(@Nonnull Location loc) {
++        return setDestination(loc, 1);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to, with desired speed
++     * as the current target.
++     * @param loc Location to navigate to
++     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
++     * @return If the pathfinding was successfully started
++     */
++    default boolean setDestination(@Nonnull Location loc, double speed) {
++        PathResult path = calculateDestination(loc);
++        return path != null && setDestination(path, speed);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to to reach the target entity,
++     * and sets it with default speed.
++     *
++     * The behavior of this PathResult is subject to the games pathfinding rules, and may
++     * result in the pathfinding automatically updating to follow the target Entity.
++     *
++     * However, this behavior is not guaranteed, and is subject to the games behavior.
++     *
++     * @param target the Entity to navigate to
++     * @return If the pathfinding was successfully started
++     */
++    default boolean setDestination(@Nonnull LivingEntity target) {
++        return setDestination(target, 1);
++    }
++
++    /**
++     * Calculates a destination for the Entity to navigate to to reach the target entity,
++     * and sets it with specified speed.
++     *
++     * The behavior of this PathResult is subject to the games pathfinding rules, and may
++     * result in the pathfinding automatically updating to follow the target Entity.
++     *
++     * However, this behavior is not guaranteed, and is subject to the games behavior.
++     *
++     * @param target the Entity to navigate to
++     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
++     * @return If the pathfinding was successfully started
++     */
++    default boolean setDestination(@Nonnull LivingEntity target, double speed) {
++        PathResult path = calculateDestination(target);
++        return path != null && setDestination(path, speed);
++    }
++
++    /**
++     * Takes the result of a previous pathfinding calculation and sets it
++     * as the active pathfinding with default speed.
++     *
++     * @param path The Path to start following
++     * @return If the pathfinding was successfully started
++     */
++    default boolean setDestination(@Nonnull PathResult path) {
++        return setDestination(path, 1);
++    }
++
++    /**
++     * Takes the result of a previous pathfinding calculation and sets it
++     * as the active pathfinding,
++     *
++     * @param path The Path to start following
++     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
++     * @return If the pathfinding was successfully started
++     */
++    boolean setDestination(@Nonnull PathResult path, double speed);
++
++    /**
++     * Represents the result of a pathfinding calculation
++     */
++    interface PathResult {
++
++        /**
++         * @return The closest point the path can get to the target location
++         */
++        @Nullable Location getLocation();
++
++        /**
++         * All currently calculated points to follow along the path to reach the destination location
++         *
++         * Will return points the entity has already moved past, see {@link #getNextPointIndex()}
++         * @return List of points
++         */
++        List<Location> getPoints();
++
++        /**
++         * @return Returns the index of the current point along the points returned in {@link #getPoints()} the entity
++         * is trying to reach, or null if we are done with this pathfinding.
++         */
++        @Nullable Integer getNextPointIndex();
++
++        /**
++         * @return The next location in the path points the entity is trying to reach, or null if there is no next point
++         */
++        @Nullable Location getNextPointLocation();
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java
+index d029d34ea..48eddcd30 100644
+--- a/src/main/java/org/bukkit/entity/Mob.java
++++ b/src/main/java/org/bukkit/entity/Mob.java
+@@ -7,6 +7,14 @@ import org.bukkit.loot.Lootable;
+  */
+ public interface Mob extends LivingEntity, Lootable {
+ 
++    // Paper start
++    /**
++     * Enables access to control the pathing of an Entity
++     * @return Pathfinding Manager for this entity
++     */
++    com.destroystokyo.paper.entity.Pathfinder getPathfinder();
++    // Paper end
++
+     /**
+      * Instructs this Mob to set the specified LivingEntity as its target.
+      * <p>
+-- 
+2.18.0
+

--- a/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
+++ b/Spigot-API-Patches/0150-Mob-Pathfinding-API.patch
@@ -1,4 +1,4 @@
-From 68606cfdc559ec3b89b3704a24247fd6774e0cb3 Mon Sep 17 00:00:00 2001
+From 9ba0ba25fa41114b804a030a64748707f3747b76 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 12:39:06 -0400
 Subject: [PATCH] Mob Pathfinding API
@@ -13,13 +13,12 @@ You can use EntityPathfindEvent to cancel new pathfinds from overriding your cur
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644
-index 000000000..78230bd28
+index 000000000..d6953b390
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
-@@ -0,0 +1,168 @@
+@@ -0,0 +1,167 @@
 +package com.destroystokyo.paper.entity;
 +
-+import org.apache.commons.lang.Validate;
 +import org.bukkit.Location;
 +import org.bukkit.entity.LivingEntity;
 +import org.bukkit.entity.Mob;
@@ -48,12 +47,12 @@ index 000000000..78230bd28
 +     * If the entity is currently trying to navigate to a destination, this will return true
 +     * @return true if the entity is navigating to a destination
 +     */
-+    boolean hasDestination();
++    boolean hasPath();
 +
 +    /**
 +     * @return The location the entity is trying to navigate to, or null if there is no destination
 +     */
-+    @Nullable PathResult getCurrentDestination();
++    @Nullable PathResult getCurrentPath();
 +
 +    /**
 +     * Calculates a destination for the Entity to navigate to, but does not set it
@@ -61,7 +60,7 @@ index 000000000..78230bd28
 +     * @param loc Location to navigate to
 +     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
 +     */
-+    @Nullable PathResult calculateDestination(Location loc);
++    @Nullable PathResult findPath(Location loc);
 +
 +    /**
 +     * Calculates a destination for the Entity to navigate to to reach the target entity,
@@ -76,7 +75,7 @@ index 000000000..78230bd28
 +     * @param target the Entity to navigate to
 +     * @return The closest Location the Entity can get to for this navigation, or null if no path could be calculated
 +     */
-+    @Nullable PathResult calculateDestination(LivingEntity target);
++    @Nullable PathResult findPath(LivingEntity target);
 +
 +    /**
 +     * Calculates a destination for the Entity to navigate to, and sets it with default speed
@@ -84,8 +83,8 @@ index 000000000..78230bd28
 +     * @param loc Location to navigate to
 +     * @return If the pathfinding was successfully started
 +     */
-+    default boolean setDestination(@Nonnull Location loc) {
-+        return setDestination(loc, 1);
++    default boolean moveTo(@Nonnull Location loc) {
++        return moveTo(loc, 1);
 +    }
 +
 +    /**
@@ -95,9 +94,9 @@ index 000000000..78230bd28
 +     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
 +     * @return If the pathfinding was successfully started
 +     */
-+    default boolean setDestination(@Nonnull Location loc, double speed) {
-+        PathResult path = calculateDestination(loc);
-+        return path != null && setDestination(path, speed);
++    default boolean moveTo(@Nonnull Location loc, double speed) {
++        PathResult path = findPath(loc);
++        return path != null && moveTo(path, speed);
 +    }
 +
 +    /**
@@ -112,8 +111,8 @@ index 000000000..78230bd28
 +     * @param target the Entity to navigate to
 +     * @return If the pathfinding was successfully started
 +     */
-+    default boolean setDestination(@Nonnull LivingEntity target) {
-+        return setDestination(target, 1);
++    default boolean moveTo(@Nonnull LivingEntity target) {
++        return moveTo(target, 1);
 +    }
 +
 +    /**
@@ -129,9 +128,9 @@ index 000000000..78230bd28
 +     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
 +     * @return If the pathfinding was successfully started
 +     */
-+    default boolean setDestination(@Nonnull LivingEntity target, double speed) {
-+        PathResult path = calculateDestination(target);
-+        return path != null && setDestination(path, speed);
++    default boolean moveTo(@Nonnull LivingEntity target, double speed) {
++        PathResult path = findPath(target);
++        return path != null && moveTo(path, speed);
 +    }
 +
 +    /**
@@ -141,8 +140,8 @@ index 000000000..78230bd28
 +     * @param path The Path to start following
 +     * @return If the pathfinding was successfully started
 +     */
-+    default boolean setDestination(@Nonnull PathResult path) {
-+        return setDestination(path, 1);
++    default boolean moveTo(@Nonnull PathResult path) {
++        return moveTo(path, 1);
 +    }
 +
 +    /**
@@ -153,17 +152,12 @@ index 000000000..78230bd28
 +     * @param speed Speed multiplier to navigate at, where 1 is 'normal'
 +     * @return If the pathfinding was successfully started
 +     */
-+    boolean setDestination(@Nonnull PathResult path, double speed);
++    boolean moveTo(@Nonnull PathResult path, double speed);
 +
 +    /**
 +     * Represents the result of a pathfinding calculation
 +     */
 +    interface PathResult {
-+
-+        /**
-+         * @return The closest point the path can get to the target location
-+         */
-+        @Nullable Location getLocation();
 +
 +        /**
 +         * All currently calculated points to follow along the path to reach the destination location
@@ -182,7 +176,12 @@ index 000000000..78230bd28
 +        /**
 +         * @return The next location in the path points the entity is trying to reach, or null if there is no next point
 +         */
-+        @Nullable Location getNextPointLocation();
++        @Nullable Location getNextPoint();
++
++        /**
++         * @return The closest point the path can get to the target location
++         */
++        @Nullable Location getFinalPoint();
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Mob.java b/src/main/java/org/bukkit/entity/Mob.java

--- a/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
+++ b/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
@@ -1,0 +1,251 @@
+From 9fbd992b34f5bd07d4390a00ab7e02a0520f22b6 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Sun, 9 Sep 2018 13:30:00 -0400
+Subject: [PATCH] Mob Pathfinding API
+
+Implements Pathfinding API for mobs
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
+new file mode 100644
+index 0000000000..5062594d62
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
+@@ -0,0 +1,115 @@
++package com.destroystokyo.paper.entity;
++
++import net.minecraft.server.EntityInsentient;
++import net.minecraft.server.PathEntity;
++import net.minecraft.server.PathPoint;
++import org.apache.commons.lang.Validate;
++import org.bukkit.Location;
++import org.bukkit.craftbukkit.entity.CraftLivingEntity;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Mob;
++
++import javax.annotation.Nonnull;
++import javax.annotation.Nullable;
++import java.util.ArrayList;
++import java.util.List;
++
++public class PaperPathfinder implements com.destroystokyo.paper.entity.Pathfinder {
++
++    private final EntityInsentient entity;
++
++    public PaperPathfinder(EntityInsentient entity) {
++        this.entity = entity;
++    }
++
++    @Override
++    public Mob getEntity() {
++        return entity.getBukkitMob();
++    }
++
++    @Override
++    public void stopPathfinding() {
++        entity.getNavigation().stopPathfinding();
++    }
++
++    @Override
++    public boolean hasDestination() {
++        return entity.getNavigation().getPathEntity() != null;
++    }
++
++    @Nullable
++    @Override
++    public PathResult getCurrentDestination() {
++        PathEntity path = entity.getNavigation().getPathEntity();
++        return path != null ? new PaperPathResult(path) : null;
++    }
++
++    @Nullable
++    @Override
++    public PathResult calculateDestination(Location loc) {
++        Validate.notNull(loc, "Location can not be null");
++        PathEntity path = entity.getNavigation().calculateDestination(loc.getX(), loc.getY(), loc.getZ());
++        return path != null ? new PaperPathResult(path) : null;
++    }
++
++    @Nullable
++    @Override
++    public PathResult calculateDestination(LivingEntity target) {
++        Validate.notNull(target, "Target can not be null");
++        PathEntity path = entity.getNavigation().calculateDestination(((CraftLivingEntity) target).getHandle());
++        return path != null ? new PaperPathResult(path) : null;
++    }
++
++    @Override
++    public boolean setDestination(@Nonnull PathResult path, double speed) {
++        Validate.notNull(path, "PathResult can not be null");
++        PathEntity pathEntity = ((PaperPathResult) path).path;
++        entity.getNavigation().setDestination(pathEntity, speed);
++        return false;
++    }
++
++    public class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {
++
++        private final PathEntity path;
++        PaperPathResult(PathEntity path) {
++            this.path = path;
++        }
++
++        @Nullable
++        @Override
++        public Location getLocation() {
++            PathPoint point = path.getFinalPoint();
++            return point != null ? toLoc(point) : null;
++        }
++
++        @Override
++        public List<Location> getPoints() {
++            int pathCount = path.getPathCount();
++            List<Location> points = new ArrayList<>();
++            PathPoint[] pathPoints = path.getPoints();
++            for (int i = 0; i < pathCount; i++) {
++                points.add(toLoc(pathPoints[i]));
++            }
++            return points;
++        }
++
++        @Nullable
++        @Override
++        public Integer getNextPointIndex() {
++            return path.getNextIndex();
++        }
++
++        @Nullable
++        @Override
++        public Location getNextPointLocation() {
++            if (!path.hasNext()) {
++                return null;
++            }
++            return toLoc(path.getPoints()[path.getNextIndex()]);
++        }
++    }
++
++    private Location toLoc(PathPoint point) {
++        return new Location(entity.world.getWorld(), point.getX(), point.getY(), point.getZ());
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/NavigationAbstract.java b/src/main/java/net/minecraft/server/NavigationAbstract.java
+index 452da80f11..4023253f42 100644
+--- a/src/main/java/net/minecraft/server/NavigationAbstract.java
++++ b/src/main/java/net/minecraft/server/NavigationAbstract.java
+@@ -63,7 +63,7 @@ public abstract class NavigationAbstract {
+     }
+ 
+     @Nullable
+-    public final PathEntity a(double d0, double d1, double d2) {
++    public final PathEntity calculateDestination(double d0, double d1, double d2) { return a(d0, d1, d2); } @Nullable public final PathEntity a(double d0, double d1, double d2) { // Paper - OBFHELPER
+         return this.b(new BlockPosition(d0, d1, d2));
+     }
+ 
+@@ -89,7 +89,7 @@ public abstract class NavigationAbstract {
+     }
+ 
+     @Nullable
+-    public PathEntity a(Entity entity) {
++    public PathEntity calculateDestination(Entity entity) { return a(entity); } @Nullable public PathEntity a(Entity entity) { // Paper - OBFHELPER
+         if (!this.b()) {
+             return null;
+         } else {
+@@ -138,6 +138,7 @@ public abstract class NavigationAbstract {
+     private int pathfindFailures = 0;
+     // Paper end
+ 
++    public boolean setDestination(@Nullable PathEntity pathentity, double speed) { return a(pathentity, speed); } // Paper - OBFHELPER
+     public boolean a(@Nullable PathEntity pathentity, double d0) {
+         if (pathentity == null) {
+             this.c = null;
+@@ -159,8 +160,7 @@ public abstract class NavigationAbstract {
+             }
+         }
+     }
+-
+-    @Nullable
++    @Nullable public PathEntity getPathEntity() { return m(); } @Nullable // Paper - OBFHELPER
+     public PathEntity m() {
+         return this.c;
+     }
+@@ -261,6 +261,7 @@ public abstract class NavigationAbstract {
+         return this.c == null || this.c.b();
+     }
+ 
++    public void stopPathfinding() { q(); } // Paper - OBFHELPER
+     public void q() {
+         this.pathfindFailures = 0; this.lastFailure = 0; // Paper - Pathfinding optimizations
+         this.c = null;
+diff --git a/src/main/java/net/minecraft/server/PathEntity.java b/src/main/java/net/minecraft/server/PathEntity.java
+index 5ffcda6d56..dae08cbbf8 100644
+--- a/src/main/java/net/minecraft/server/PathEntity.java
++++ b/src/main/java/net/minecraft/server/PathEntity.java
+@@ -3,12 +3,13 @@ package net.minecraft.server;
+ import javax.annotation.Nullable;
+ 
+ public class PathEntity {
+-    private final PathPoint[] a;
++    private final PathPoint[] a; public PathPoint[] getPoints() { return a; } // Paper - OBFHELPER
+     private PathPoint[] b = new PathPoint[0];
+     private PathPoint[] c = new PathPoint[0];
+     private PathPoint d;
+-    private int e;
+-    private int f;
++    private int e; public int getNextIndex() { return e; } // Paper - OBFHELPER
++    private int f; public int getPathCount() { return f; } // Paper - OBFHELPER
++    public boolean hasNext() { return getNextIndex() < getPathCount(); } // Paper
+ 
+     public PathEntity(PathPoint[] apathpoint) {
+         this.a = apathpoint;
+@@ -24,7 +25,7 @@ public class PathEntity {
+     }
+ 
+     @Nullable
+-    public PathPoint c() {
++    public PathPoint getFinalPoint() { return c(); } @Nullable public PathPoint c() { // Paper - OBFHELPER
+         return this.f > 0 ? this.a[this.f - 1] : null;
+     }
+ 
+@@ -63,7 +64,7 @@ public class PathEntity {
+         return this.a(entity, this.e);
+     }
+ 
+-    public Vec3D f() {
++    public Vec3D getNext() { return f(); } public Vec3D f() { // Paper - OBFHELPER
+         PathPoint pathpoint = this.a[this.e];
+         return new Vec3D((double)pathpoint.a, (double)pathpoint.b, (double)pathpoint.c);
+     }
+diff --git a/src/main/java/net/minecraft/server/PathPoint.java b/src/main/java/net/minecraft/server/PathPoint.java
+index 497f472233..7fd1eff0b5 100644
+--- a/src/main/java/net/minecraft/server/PathPoint.java
++++ b/src/main/java/net/minecraft/server/PathPoint.java
+@@ -1,9 +1,9 @@
+ package net.minecraft.server;
+ 
+ public class PathPoint {
+-    public final int a;
+-    public final int b;
+-    public final int c;
++    public final int a; public final int getX() { return a; } // Paper - OBFHELPER
++    public final int b; public final int getY() { return b; } // Paper - OBFHELPER
++    public final int c; public final int getZ() { return c; } // Paper - OBFHELPER
+     private final int n;
+     public int d = -1;
+     public float e;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+index 5bf1cd06fa..53c2d154ed 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
+@@ -12,8 +12,11 @@ import org.bukkit.loot.LootTable;
+ public abstract class CraftMob extends CraftLivingEntity implements Mob {
+     public CraftMob(CraftServer server, EntityInsentient entity) {
+         super(server, entity);
++         paperPathfinder = new com.destroystokyo.paper.entity.PaperPathfinder(entity); // Paper
+     }
+ 
++    private final com.destroystokyo.paper.entity.PaperPathfinder paperPathfinder; // Paper
++    @Override public com.destroystokyo.paper.entity.Pathfinder getPathfinder() { return paperPathfinder; } // Paper
+     @Override
+     public void setTarget(LivingEntity target) {
+         EntityInsentient entity = getHandle();
+-- 
+2.18.0
+

--- a/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
+++ b/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
@@ -1,4 +1,4 @@
-From 02345434a6ac0af81af23b6dc346d6e1efb0c2ee Mon Sep 17 00:00:00 2001
+From 3b72b5675437928e2fa39a540b2ea0644f173302 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 13:30:00 -0400
 Subject: [PATCH] Mob Pathfinding API
@@ -7,10 +7,10 @@ Implements Pathfinding API for mobs
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
 new file mode 100644
-index 0000000000..d166bcdd28
+index 0000000000..ed3d86ddd3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
-@@ -0,0 +1,114 @@
+@@ -0,0 +1,113 @@
 +package com.destroystokyo.paper.entity;
 +
 +import net.minecraft.server.EntityInsentient;
@@ -46,20 +46,20 @@ index 0000000000..d166bcdd28
 +    }
 +
 +    @Override
-+    public boolean hasDestination() {
++    public boolean hasPath() {
 +        return entity.getNavigation().getPathEntity() != null;
 +    }
 +
 +    @Nullable
 +    @Override
-+    public PathResult getCurrentDestination() {
++    public PathResult getCurrentPath() {
 +        PathEntity path = entity.getNavigation().getPathEntity();
 +        return path != null ? new PaperPathResult(path) : null;
 +    }
 +
 +    @Nullable
 +    @Override
-+    public PathResult calculateDestination(Location loc) {
++    public PathResult findPath(Location loc) {
 +        Validate.notNull(loc, "Location can not be null");
 +        PathEntity path = entity.getNavigation().calculateDestination(loc.getX(), loc.getY(), loc.getZ());
 +        return path != null ? new PaperPathResult(path) : null;
@@ -67,18 +67,17 @@ index 0000000000..d166bcdd28
 +
 +    @Nullable
 +    @Override
-+    public PathResult calculateDestination(LivingEntity target) {
++    public PathResult findPath(LivingEntity target) {
 +        Validate.notNull(target, "Target can not be null");
 +        PathEntity path = entity.getNavigation().calculateDestination(((CraftLivingEntity) target).getHandle());
 +        return path != null ? new PaperPathResult(path) : null;
 +    }
 +
 +    @Override
-+    public boolean setDestination(@Nonnull PathResult path, double speed) {
++    public boolean moveTo(@Nonnull PathResult path, double speed) {
 +        Validate.notNull(path, "PathResult can not be null");
 +        PathEntity pathEntity = ((PaperPathResult) path).path;
-+        entity.getNavigation().setDestination(pathEntity, speed);
-+        return false;
++        return entity.getNavigation().setDestination(pathEntity, speed);
 +    }
 +
 +    public class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {
@@ -90,7 +89,7 @@ index 0000000000..d166bcdd28
 +
 +        @Nullable
 +        @Override
-+        public Location getLocation() {
++        public Location getFinalPoint() {
 +            PathPoint point = path.getFinalPoint();
 +            return point != null ? toLoc(point) : null;
 +        }
@@ -113,7 +112,7 @@ index 0000000000..d166bcdd28
 +
 +        @Nullable
 +        @Override
-+        public Location getNextPointLocation() {
++        public Location getNextPoint() {
 +            if (!path.hasNext()) {
 +                return null;
 +            }

--- a/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
+++ b/Spigot-Server-Patches/0365-Mob-Pathfinding-API.patch
@@ -1,4 +1,4 @@
-From 9fbd992b34f5bd07d4390a00ab7e02a0520f22b6 Mon Sep 17 00:00:00 2001
+From 02345434a6ac0af81af23b6dc346d6e1efb0c2ee Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 13:30:00 -0400
 Subject: [PATCH] Mob Pathfinding API
@@ -7,10 +7,10 @@ Implements Pathfinding API for mobs
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
 new file mode 100644
-index 0000000000..5062594d62
+index 0000000000..d166bcdd28
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
-@@ -0,0 +1,115 @@
+@@ -0,0 +1,114 @@
 +package com.destroystokyo.paper.entity;
 +
 +import net.minecraft.server.EntityInsentient;
@@ -106,9 +106,8 @@ index 0000000000..5062594d62
 +            return points;
 +        }
 +
-+        @Nullable
 +        @Override
-+        public Integer getNextPointIndex() {
++        public int getNextPointIndex() {
 +            return path.getNextIndex();
 +        }
 +


### PR DESCRIPTION
Adds an API to allow plugins to instruct a Mob to Pathfind to a Location or Entity

This does not do anything to stop other AI rules from changing the location, so
it is still up to the plugin to control that or override after another goal changed
the location.

You can use EntityPathfindEvent to cancel new pathfinds from overriding your current.
