### PR TITLE
The disconnect on packet spam must be called sync

### DIFF
--- a/Spigot-Server-Patches/0220-AsyncTabCompleteEvent.patch
+++ b/Spigot-Server-Patches/0220-AsyncTabCompleteEvent.patch
@@ -1,4 +1,4 @@
-From 5d8610763f3b1df0d07861d1b86ef8ad12480a81 Mon Sep 17 00:00:00 2001
+From 474e77dd7688cfb10ec153f6b1ce3580604e3818 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 26 Nov 2017 13:19:58 -0500
 Subject: [PATCH] AsyncTabCompleteEvent
@@ -14,7 +14,7 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 23c07ca5c..b04eae4bb 100644
+index 23c07ca5c..f8a47ceb9 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -10,6 +10,7 @@ import io.netty.util.concurrent.Future;
@@ -25,7 +25,7 @@ index 23c07ca5c..b04eae4bb 100644
  import java.util.Set;
  import java.util.function.Consumer;
  import javax.annotation.Nullable;
-@@ -507,10 +508,11 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -507,10 +508,10 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
      }
  
      public void a(PacketPlayInTabComplete packetplayintabcomplete) {
@@ -33,12 +33,12 @@ index 23c07ca5c..b04eae4bb 100644
 +        // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start
          if (chatSpamField.addAndGet(this, 1) > 500 && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) {
-             this.disconnect(new ChatMessage("disconnect.spam", new Object[0]));
+-            this.disconnect(new ChatMessage("disconnect.spam", new Object[0]));
 +            minecraftServer.postToMainThread(() -> this.disconnect(new ChatMessage("disconnect.spam", new Object[0]))); // Paper
              return;
          }
          // CraftBukkit end
-@@ -520,11 +522,57 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -520,11 +521,57 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
              stringreader.skip();
          }
  
@@ -158,5 +158,5 @@ index 1e3aae3b8..95d13c146 100644
          Waitable<List<String>> waitable = new Waitable<List<String>>() {
              @Override
 -- 
-2.18.0
+2.16.1.windows.1
 

--- a/Spigot-Server-Patches/0254-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/Spigot-Server-Patches/0254-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -1,14 +1,14 @@
-From afb4e25e1128b93702f63d86e60ca4fa6be40b7b Mon Sep 17 00:00:00 2001
+From 7e7b6875d33f889eb5f9833d99f4c87b1cbffa04 Mon Sep 17 00:00:00 2001
 From: 0x22 <0x22@futureclient.net>
 Date: Thu, 26 Apr 2018 04:41:11 -0400
 Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index b296f948ef..f735d97be2 100644
+index f8a47ceb9..4cdf79002 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2520,7 +2520,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -2519,7 +2519,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
              String[] lines = new String[4];
  
              for (int i = 0; i < astring.length; ++i) {
@@ -18,5 +18,5 @@ index b296f948ef..f735d97be2 100644
              SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.server.getPlayer(this.player), lines);
              this.server.getPluginManager().callEvent(event);
 -- 
-2.18.0
+2.16.1.windows.1
 

--- a/Spigot-Server-Patches/0284-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0284-InventoryCloseEvent-Reason-API.patch
@@ -1,4 +1,4 @@
-From 251f2f64caf0e0bb572e850306e472c82a3d2c08 Mon Sep 17 00:00:00 2001
+From b6161b8cf53fda783f69a0b388b054a8f217cc28 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 3 Jul 2018 21:56:23 -0400
 Subject: [PATCH] InventoryCloseEvent Reason API
@@ -110,10 +110,10 @@ index 3644fde3b..68f5842cf 100644
          this.m();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ad9053d23..d48f54592 100644
+index 4cdf79002..793174c51 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2056,7 +2056,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -2055,7 +2055,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
          PlayerConnectionUtils.ensureMainThread(packetplayinclosewindow, this, this.player.getWorldServer());
  
          if (this.player.isFrozen()) return; // CraftBukkit
@@ -193,5 +193,5 @@ index 29d8773f2..ea787a523 100644
          human.activeContainer.transferTo(human.defaultContainer, human.getBukkitEntity());
      }
 -- 
-2.19.0
+2.16.1.windows.1
 

--- a/Spigot-Server-Patches/0288-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/Spigot-Server-Patches/0288-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -1,4 +1,4 @@
-From e450d0aba6cb1b173316f615c8fea1401e7caff6 Mon Sep 17 00:00:00 2001
+From a23864b85e6201765fe2814e9a455a1a656c92eb Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 13 Jul 2018 14:54:43 +0200
 Subject: [PATCH] Refresh player inventory when cancelling
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 6fe79e9076..5b3d39133d 100644
+index 793174c51..f8ffc5832 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1970,6 +1970,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -1969,6 +1969,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
                      }
  
                      if (event.isCancelled()) {
@@ -28,5 +28,5 @@ index 6fe79e9076..5b3d39133d 100644
                      }
                      // CraftBukkit end
 -- 
-2.18.0
+2.16.1.windows.1
 

--- a/Spigot-Server-Patches/0322-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0322-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -1,4 +1,4 @@
-From a84037ad0b92321b75bb1c58d6ecbca64f46b9da Mon Sep 17 00:00:00 2001
+From 1169fa2305448868735666a735f52deda6682715 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 29 Jul 2018 05:02:15 +0100
 Subject: [PATCH] Break up and make tab spam limits configurable
@@ -45,7 +45,7 @@ index c457d0711..cc2e4ad3b 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 2eba21ba7..eea30af78 100644
+index f8ffc5832..452c27970 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -78,6 +78,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -70,9 +70,9 @@ index 2eba21ba7..eea30af78 100644
          // CraftBukkit start
 -        if (chatSpamField.addAndGet(this, 1) > 500 && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) {
 +        if (tabSpamLimiter.addAndGet(com.destroystokyo.paper.PaperConfig.tabSpamIncrement) > com.destroystokyo.paper.PaperConfig.tabSpamLimit && !this.minecraftServer.getPlayerList().isOp(this.player.getProfile())) { // Paper start - split and make configurable
-             this.disconnect(new ChatMessage("disconnect.spam", new Object[0]));
              minecraftServer.postToMainThread(() -> this.disconnect(new ChatMessage("disconnect.spam", new Object[0]))); // Paper
              return;
+         }
 -- 
-2.18.0
+2.16.1.windows.1
 


### PR DESCRIPTION
And it was called twice, probably forgotten in the patch.