### PR TITLE
Add a separate PreSpawnerSpawnEvent

### DIFF
--- a/Spigot-API-Patches/0153-PreSpawnerSpawnEvent.patch
+++ b/Spigot-API-Patches/0153-PreSpawnerSpawnEvent.patch
@@ -1,0 +1,46 @@
+From d9327f143f54e3033ee83fcda98323416dfc7325 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Tue, 18 Sep 2018 23:50:10 +0100
+Subject: [PATCH] PreSpawnerSpawnEvent
+
+This adds a separate event before an entity is spawned by a spawner
+which contains the location of the spawner too similarly to how the
+SpawnerSpawnEvent gets called instead of the CreatureSpawnEvent for
+spawners.
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java
+new file mode 100644
+index 00000000..d7221210
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/PreSpawnerSpawnEvent.java
+@@ -0,0 +1,27 @@
++package com.destroystokyo.paper.event.entity;
++
++
++import com.google.common.base.Preconditions;
++import org.bukkit.Location;
++import org.bukkit.entity.EntityType;
++import org.bukkit.event.entity.CreatureSpawnEvent;
++
++/**
++ * Called before an entity is spawned into a world by a spawner.
++ *
++ * This only includes the spawner's location and not the full BlockState snapshot for performance reasons.
++ * If you really need it you have to get the spawner yourself.
++ */
++
++public class PreSpawnerSpawnEvent extends PreCreatureSpawnEvent {
++    private final Location spawnerLocation;
++
++    public PreSpawnerSpawnEvent(Location location, EntityType type, Location spawnerLocation) {
++        super(location, type, CreatureSpawnEvent.SpawnReason.SPAWNER);
++        this.spawnerLocation = Preconditions.checkNotNull(spawnerLocation, "Spawner location may not be null");
++    }
++
++    public Location getSpawnerLocation() {
++        return spawnerLocation;
++    }
++}
+-- 
+2.18.0.windows.1
+

--- a/Spigot-Server-Patches/0376-PreSpawnerSpawnEvent.patch
+++ b/Spigot-Server-Patches/0376-PreSpawnerSpawnEvent.patch
@@ -1,0 +1,32 @@
+From 21b17560efb3a7b04602a4c44eb2bc7e36833939 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Tue, 18 Sep 2018 23:53:23 +0100
+Subject: [PATCH] PreSpawnerSpawnEvent
+
+This adds a separate event before an entity is spawned by a spawner
+which contains the location of the spawner too similarly to how the
+SpawnerSpawnEvent gets called instead of the CreatureSpawnEvent for
+spawners.
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+index 79600cd7..81d07606 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+@@ -102,11 +102,11 @@ public abstract class MobSpawnerAbstract {
+                     String key = this.getMobName().getKey();
+                     org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(key);
+                     if (type != null) {
+-                        com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
+-                        event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                        com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent event;
++                        event = new com.destroystokyo.paper.event.entity.PreSpawnerSpawnEvent(
+                                 MCUtil.toLocation(world, d3, d4, d5),
+                                 type,
+-                                org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.SPAWNER
++                                MCUtil.toLocation(world, blockposition)
+                         );
+                         if (!event.callEvent()) {
+                             flag = true;
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
This event extends the PreCreatureSpawnEvent and includes the position
of the spawner that spawned the entitiy. (similarly to how the
SpawnerSpawnEvent contains the spawner's BlockState).

This one doesn't include the state though as getting the block and
generating that snapshot is a bit wasteful.