### PR TITLE
Avoid dimension id collisions

### DIFF
--- a/Spigot-Server-Patches/0382-Avoid-dimension-id-collisions.patch
+++ b/Spigot-Server-Patches/0382-Avoid-dimension-id-collisions.patch
@@ -1,0 +1,25 @@
+From 39959f57410189de5a88d5ac20f101632c3a8c98 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Tue, 25 Sep 2018 06:53:43 +0200
+Subject: [PATCH] Avoid dimension id collisions
+
+getDimensionId() returns the dimension id - 1. So without this patch
+we would reuse an existing dimension id, if some other dimension was
+unloaded before.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 23663ede9..cb2255a5d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -968,7 +968,7 @@ public final class CraftServer implements Server {
+         boolean used = false;
+         do {
+             for (WorldServer server : console.getWorlds()) {
+-                used = server.dimension.getDimensionID() == dimension;
++                used = server.dimension.getDimensionID() + 1 == dimension; // Paper - getDimensionID returns the dimension - 1, so we have to add 1
+                 if (used) {
+                     dimension++;
+                     break;
+-- 
+2.16.1.windows.1
+


### PR DESCRIPTION
getDimensionId() returns the dimension id - 1. So without this patch
we would reuse an existing dimension id, if some other dimension was
unloaded before.

In Spigot this is nearly invisible because DimensionManager has no equals(),
so dimension id collisions just create 2 worlds with the same dimension.

The PaperWorldMap (Added in
https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0376-Optimize-Server-World-Map.patch ) changes this - Now the dimension is overwritten if there is some collision,
what causes players to teleport to incorrect worlds, World checks will no longer work
and many more evil things.