### PR TITLE
Block and Fluid TickEvents

### DIFF
--- a/Spigot-API-Patches/0157-BlockTickEvents.patch
+++ b/Spigot-API-Patches/0157-BlockTickEvents.patch
@@ -1,0 +1,158 @@
+From dbcdbb75888b03ba7eb4faea90e903637fa9fb89 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 28 Sep 2018 08:45:00 -0500
+Subject: [PATCH] BlockTickEvents
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockTickEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockTickEvent.java
+new file mode 100644
+index 00000000..858f9b99
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/block/BlockTickEvent.java
+@@ -0,0 +1,49 @@
++package com.destroystokyo.paper.event.block;
++
++import org.bukkit.World;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++
++/**
++ * Called when a block is ticked by the server.
++ */
++public class BlockTickEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final boolean isRandomTick;
++    private boolean cancelled;
++
++    public BlockTickEvent(World world, int x, int y, int z) {
++        this(world, x, y, z, false);
++    }
++
++    public BlockTickEvent(World world, int x, int y, int z, boolean isRandomTick) {
++        super(world.getBlockAt(x, y, z));
++        this.isRandomTick = isRandomTick;
++    }
++
++    /**
++     * Check if this is a random tick
++     *
++     * @return True if random
++     */
++    public boolean isRandomTick() {
++        return isRandomTick;
++    }
++
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/block/FluidTickEvent.java b/src/main/java/com/destroystokyo/paper/event/block/FluidTickEvent.java
+new file mode 100644
+index 00000000..b605c6fc
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/block/FluidTickEvent.java
+@@ -0,0 +1,49 @@
++package com.destroystokyo.paper.event.block;
++
++import org.bukkit.World;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++
++/**
++ * Called when a fluid is ticked by the server.
++ */
++public class FluidTickEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private final boolean isRandomTick;
++    private boolean cancelled;
++
++    public FluidTickEvent(World world, int x, int y, int z) {
++        this(world, x, y, z, false);
++    }
++
++    public FluidTickEvent(World world, int x, int y, int z, boolean isRandomTick) {
++        super(world.getBlockAt(x, y, z));
++        this.isRandomTick = isRandomTick;
++    }
++
++    /**
++     * Check if this is a random tick
++     *
++     * @return True if random
++     */
++    public boolean isRandomTick() {
++        return isRandomTick;
++    }
++
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 7bfe0b68..9a827fad 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1413,6 +1413,34 @@ public interface World extends PluginMessageRecipient, Metadatable {
+     public default boolean createExplosion(Location loc, float power, boolean setFire, boolean breakBlocks) {
+         return createExplosion(loc.getX(), loc.getY(), loc.getZ(), power, setFire, breakBlocks);
+     }
++
++    /**
++     * Get if {@link com.destroystokyo.paper.event.block.BlockTickEvent} is enabled for this world
++     *
++     * @return True if enabled
++     */
++    boolean isBlockTickEventEnabled();
++
++    /**
++     * Set if {@link com.destroystokyo.paper.event.block.BlockTickEvent} is enabled for this world
++     *
++     * @param enabled True to enable
++     */
++    void setBlockTickEventEnabled(boolean enabled);
++
++    /**
++     * Get if {@link com.destroystokyo.paper.event.block.FluidTickEvent} is enabled for this world
++     *
++     * @return True if enabled
++     */
++    boolean isFluidTickEventEnabled();
++
++    /**
++     * Set if {@link com.destroystokyo.paper.event.block.FluidTickEvent} is enabled for this world
++     *
++     * @param enabled True to enable
++     */
++    void setFluidTickEventEnabled(boolean enabled);
+     // Paper end
+ 
+     /**
+-- 
+2.19.0
+

--- a/Spigot-Server-Patches/0381-BlockTickEvents.patch
+++ b/Spigot-Server-Patches/0381-BlockTickEvents.patch
@@ -1,0 +1,97 @@
+From abeede1f6a33d91863fb14d7751c28fb8aac20e6 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Fri, 28 Sep 2018 08:45:10 -0500
+Subject: [PATCH] BlockTickEvents
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 4b4223a9f..95f845515 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -321,6 +321,13 @@ public class PaperWorldConfig {
+         skipEntityTickingInChunksScheduledForUnload = getBoolean("skip-entity-ticking-in-chunks-scheduled-for-unload", skipEntityTickingInChunksScheduledForUnload);
+     }
+ 
++    public boolean blockTickEvent = false;
++    public boolean fluidTickEvent = false;
++    private void tickEvents() {
++        blockTickEvent = getBoolean("block-tick-events", false);
++        fluidTickEvent = getBoolean("fluid-tick-events", false);
++    }
++
+     public int autoSavePeriod = -1;
+     private void autoSavePeriod() {
+         autoSavePeriod = getInt("auto-save-interval", -1);
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 409c7d6ee..f03d8be83 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -564,13 +564,16 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+                                 Fluid fluid = chunksection.b(i2, k2, j2);
+ 
+                                 this.methodProfiler.a("randomTick");
+-                                if (iblockdata.t()) {
+-                                    iblockdata.b((World) this, new BlockPosition(i2 + j, k2 + chunksection.getYPosition(), j2 + k), this.random);
++                                // Paper start
++                                BlockPosition pos = new BlockPosition(i2 + j, k2 + chunksection.getYPosition(), j2 + k);
++                                if (iblockdata.t() && (!paperConfig.blockTickEvent || new com.destroystokyo.paper.event.block.BlockTickEvent(getWorld(), pos.x, pos.y, pos.z, true).callEvent())) {
++                                    iblockdata.b(this, pos, this.random);
+                                 }
+ 
+-                                if (fluid.h()) {
+-                                    fluid.b(this, new BlockPosition(i2 + j, k2 + chunksection.getYPosition(), j2 + k), this.random);
++                                if (fluid.h() && (!paperConfig.fluidTickEvent || new com.destroystokyo.paper.event.block.FluidTickEvent(getWorld(), pos.x, pos.y, pos.z, true).callEvent())) {
++                                    fluid.b(this, pos, this.random);
+                                 }
++                                // Paper end
+ 
+                                 this.methodProfiler.e();
+                             }
+@@ -679,6 +682,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         Fluid fluid = this.b(nextticklistentry.a);
+ 
+         if (fluid.c() == nextticklistentry.a()) {
++            if (paperConfig.fluidTickEvent && !new com.destroystokyo.paper.event.block.FluidTickEvent(getWorld(), nextticklistentry.a.x, nextticklistentry.a.y, nextticklistentry.a.z).callEvent()) return; // Paper
+             fluid.a((World) this, nextticklistentry.a);
+         }
+ 
+@@ -688,6 +692,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         IBlockData iblockdata = this.getType(nextticklistentry.a);
+ 
+         if (iblockdata.getBlock() == nextticklistentry.a()) {
++            if (paperConfig.blockTickEvent && !new com.destroystokyo.paper.event.block.BlockTickEvent(getWorld(), nextticklistentry.a.x, nextticklistentry.a.y, nextticklistentry.a.z).callEvent()) return; // Paper
+             stopPhysicsEvent = !paperConfig.firePhysicsEventForRedstone && (iblockdata.getBlock() instanceof BlockDiodeAbstract || iblockdata.getBlock() instanceof BlockRedstoneTorch); // Paper
+             iblockdata.a((World) this, nextticklistentry.a, this.random);
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 02b6bf299..d08e0266c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -567,6 +567,24 @@ public class CraftWorld implements World {
+         return createExplosion(loc.getX(), loc.getY(), loc.getZ(), power, setFire);
+     }
+ 
++    // Paper start
++    public boolean isBlockTickEventEnabled() {
++        return getHandle().paperConfig.blockTickEvent;
++    }
++
++    public void setBlockTickEventEnabled(boolean enabled) {
++        getHandle().paperConfig.blockTickEvent = enabled;
++    }
++
++    public boolean isFluidTickEventEnabled() {
++        return getHandle().paperConfig.fluidTickEvent;
++    }
++
++    public void setFluidTickEventEnabled(boolean enabled) {
++        getHandle().paperConfig.fluidTickEvent = enabled;
++    }
++    // Paper end
++
+     public Environment getEnvironment() {
+         return environment;
+     }
+-- 
+2.19.0
+


### PR DESCRIPTION
This commit adds `BlockTickEvent` and `FluidTickEvent`.

From the little testing I've done I saw no major side effects or lag from these events firing (with or without listeners). However, I felt it was necessary to have a toggle to enable/disable these events from ever firing with the default set to disabled.

Plugins have API access to enable these events using `World#setBlockTickEventEnabled(boolean)` and `World#setFluidTickEventEnabled(boolean)` for a range of use cases. such use cases could include enabling the events only when needed, or to even disable the events if TPS is detected to drop below a threshold, etc.

There are 2 types of tick events, one being the random tick event and the other being a scheduled tick event. Plugins can use the `event#isRandomTick()` method to determine the difference.