### PR TITLE
Dont strip explicit leading color codes in chat components

### DIFF
--- a/Spigot-Server-Patches/0384-Dont-strip-explicit-leading-color-codes-in-chat-comp.patch
+++ b/Spigot-Server-Patches/0384-Dont-strip-explicit-leading-color-codes-in-chat-comp.patch
@@ -1,0 +1,22 @@
+From cc921fd1befdb375e09e13562d342b0e537616b5 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 30 Sep 2018 08:40:14 -0500
+Subject: [PATCH] Dont strip explicit leading color codes in chat components
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
+index 5e20a9a61..df627d955 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
+@@ -192,7 +192,7 @@ public final class CraftChatMessage {
+             }
+             out.append(c.getText());
+         }
+-        return out.toString().replaceFirst("^(" + defaultColor + ")*", "");
++        return out.toString().replaceFirst("^(" + defaultColor + ")", ""); // Paper - GH-1484
+     }
+ 
+     public static IChatBaseComponent fixComponent(IChatBaseComponent component) {
+-- 
+2.19.0
+


### PR DESCRIPTION
Fix #1484 