### PR TITLE
Don't update snapshot blockstates

### DIFF
--- a/Spigot-Server-Patches/0384-Don-t-update-snapshot-blockstates.patch
+++ b/Spigot-Server-Patches/0384-Don-t-update-snapshot-blockstates.patch
@@ -1,0 +1,26 @@
+From 8f65d43074c599c7455f0e4fc6d1de2a722e3716 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Fri, 5 Oct 2018 15:46:46 +1000
+Subject: [PATCH] Don't update snapshot blockstates
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+index d4d9c5fc..f5c6dbd8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+@@ -131,7 +131,11 @@ public class CraftBlockEntityState<T extends TileEntity> extends CraftBlockState
+             TileEntity tile = getTileEntityFromWorld();
+ 
+             if (isApplicable(tile)) {
+-                applyTo(tileEntityClass.cast(tile));
++                // Paper start
++                if (!snapshotDisabled) {
++                    applyTo(tileEntityClass.cast(tile));
++                }
++                // Paper end
+                 tile.update();
+             }
+         }
+-- 
+2.19.0.windows.1
+


### PR DESCRIPTION
Following this comment on PaperLib, https://github.com/PaperMC/PaperLib/pull/2#discussion_r222761017

I've made non-snapshot TE's not update when they receive the update call. They still do the rest of the update, just not the applying of the TE data. This is to still allow forced physics updates etc. Also in the case of Jukeboxes, updating the properties