### PR TITLE
Sometimes World.save() did not save the whole world.

### DIFF
--- a/Spigot-Server-Patches/0143-Prevent-Auto-Save-if-Save-Queue-is-full.patch
+++ b/Spigot-Server-Patches/0143-Prevent-Auto-Save-if-Save-Queue-is-full.patch
@@ -1,4 +1,4 @@
-From 1558a2bb058ae4bc2efcdcbae2d89a789c093c7d Mon Sep 17 00:00:00 2001
+From be8e64ee4c08fbd849697a69c8d40d3773bdec21 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Nov 2016 21:52:22 -0400
 Subject: [PATCH] Prevent Auto Save if Save Queue is full
@@ -7,7 +7,7 @@ If the save queue already has 50 (configurable) of chunks pending,
 then avoid processing auto save (which would add more)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0d456bcbac..40746c13ef 100644
+index 0d456bcba..40746c13e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -327,6 +327,11 @@ public class PaperWorldConfig {
@@ -23,7 +23,7 @@ index 0d456bcbac..40746c13ef 100644
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 69219b13a6..5197062293 100644
+index 69219b13a..09c81e9ab 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -234,6 +234,13 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -33,7 +33,7 @@ index 69219b13a6..5197062293 100644
 +            // Paper start
 +            final ChunkRegionLoader chunkLoader = (ChunkRegionLoader) world.getChunkProviderServer().chunkLoader;
 +            final int queueSize = chunkLoader.getQueueSize();
-+            if (queueSize > world.paperConfig.queueSizeAutoSaveThreshold){
++            if (!flag && queueSize > world.paperConfig.queueSizeAutoSaveThreshold){
 +                return false;
 +            }
 +            // Paper end
@@ -41,7 +41,7 @@ index 69219b13a6..5197062293 100644
                  Chunk chunk = (Chunk) objectiterator.next();
  
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 695044b1b1..e86d47a05e 100644
+index 695044b1b..e86d47a05 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -152,6 +152,8 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
@@ -54,5 +54,5 @@ index 695044b1b1..e86d47a05e 100644
      @Nullable
      public Chunk a(GeneratorAccess generatoraccess, int i, int j, Consumer<Chunk> consumer) throws IOException {
 -- 
-2.19.0
+2.16.1.windows.1
 

--- a/Spigot-Server-Patches/0144-Chunk-Save-Stats-Debug-Option.patch
+++ b/Spigot-Server-Patches/0144-Chunk-Save-Stats-Debug-Option.patch
@@ -1,4 +1,4 @@
-From c4a4536232e95b7dcfed31e713690cfec7326ab6 Mon Sep 17 00:00:00 2001
+From 3a3142f6e641798f49064f6ad53110476408ef57 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 4 Nov 2016 02:12:10 -0400
 Subject: [PATCH] Chunk Save Stats Debug Option
@@ -8,7 +8,7 @@ Adds a command line flag to enable stats on how chunk saves are processing.
 Stats on current queue, how many was processed and how many were queued.
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 5197062293..e4d2a3a0b5 100644
+index 09c81e9ab..a94719d58 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -30,6 +30,11 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -50,11 +50,11 @@ index 5197062293..e4d2a3a0b5 100644
 +                    );
 +                }
 +            }
-             if (queueSize > world.paperConfig.queueSizeAutoSaveThreshold){
+             if (!flag && queueSize > world.paperConfig.queueSizeAutoSaveThreshold){
                  return false;
              }
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index e86d47a05e..ec328126cf 100644
+index e86d47a05..ec328126c 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -152,7 +152,13 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
@@ -89,5 +89,5 @@ index e86d47a05e..ec328126cf 100644
              if (nbttagcompound == null) {
                  return true;
 -- 
-2.19.0
+2.16.1.windows.1
 


### PR DESCRIPTION
flag = true is a force save of the whole world (for example World.save()), this should ignore the current chunk queue size.