### PR TITLE
Add support for Velocity IP forwarding

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -1,4 +1,4 @@
-From b68fb842a8f61e937282e7393af67c24e18d0cd5 Mon Sep 17 00:00:00 2001
+From 2be9675602121d1f480cc4ef873000dd87698830 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 21:02:09 -0600
 Subject: [PATCH] Paper config files
@@ -6,7 +6,7 @@ Subject: [PATCH] Paper config files
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 new file mode 100644
-index 0000000000..961966e169
+index 000000000..961966e16
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -0,0 +1,237 @@
@@ -249,10 +249,10 @@ index 0000000000..961966e169
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000..812a04204c
+index 000000000..cde8ec432
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -0,0 +1,178 @@
+@@ -0,0 +1,184 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Throwables;
@@ -294,6 +294,7 @@ index 0000000000..812a04204c
 +    static int version;
 +    static Map<String, Command> commands;
 +    private static boolean verbose;
++    private static boolean fatalError;
 +    /*========================================================================*/
 +
 +    public static void init(File configFile) {
@@ -320,6 +321,11 @@ index 0000000000..812a04204c
 +
 +    protected static void logError(String s) {
 +        Bukkit.getLogger().severe(s);
++    }
++
++    protected static void fatal(String s) {
++        fatalError = true;
++        throw new RuntimeException("Fatal paper.yml config error: " + s);
 +    }
 +
 +    protected static void log(String s) {
@@ -433,7 +439,7 @@ index 0000000000..812a04204c
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000..a738657394
+index 000000000..a73865739
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -0,0 +1,67 @@
@@ -505,22 +511,27 @@ index 0000000000..a738657394
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 8b3988fc0a..d8535fdd9e 100644
+index 8b3988fc0..9c03cfd4b 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -192,6 +192,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -192,6 +192,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              org.spigotmc.SpigotConfig.init((File) options.valueOf("spigot-settings"));
              org.spigotmc.SpigotConfig.registerCommands();
              // Spigot end
 +            // Paper start
-+            com.destroystokyo.paper.PaperConfig.init((File) options.valueOf("paper-settings"));
++            try {
++                com.destroystokyo.paper.PaperConfig.init((File) options.valueOf("paper-settings"));
++            } catch (Exception e) {
++                DedicatedServer.LOGGER.error("Unable to load server configuration", e);
++                return false;
++            }
 +            com.destroystokyo.paper.PaperConfig.registerCommands();
 +            // Paper end
  
              DedicatedServer.LOGGER.info("Generating keypair");
              this.a(MinecraftEncryption.b());
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 3c7537d013..ffaa425ec8 100644
+index 3c7537d01..ffaa425ec 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -135,9 +135,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener {
@@ -537,7 +548,7 @@ index 3c7537d013..ffaa425ec8 100644
      public boolean impulse;
      public int portalCooldown;
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index c6434ec371..17bfa356f1 100644
+index c6434ec37..17bfa356f 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -561,7 +572,7 @@ index c6434ec371..17bfa356f1 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index ed77641e46..f381e23beb 100644
+index ed77641e4..f381e23be 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -134,6 +134,8 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
@@ -582,7 +593,7 @@ index ed77641e46..f381e23beb 100644
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e28ce05fb9..e659f3f339 100644
+index e28ce05fb..e659f3f33 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -750,6 +750,7 @@ public final class CraftServer implements Server {
@@ -637,7 +648,7 @@ index e28ce05fb9..e659f3f339 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 4a998593bd..e354245f73 100644
+index 4a998593b..e354245f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -128,6 +128,14 @@ public class Main {
@@ -656,7 +667,7 @@ index 4a998593bd..e354245f73 100644
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 95f7a9587a..87bc8e2d9c 100644
+index 95f7a9587..87bc8e2d9 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -39,31 +39,31 @@ public class SpigotWorldConfig
@@ -697,5 +708,5 @@ index 95f7a9587a..87bc8e2d9c 100644
          config.addDefault( "world-settings.default." + path, def );
          return config.getString( "world-settings." + worldName + "." + path, config.getString( "world-settings.default." + path ) );
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0005-Paper-Metrics.patch
+++ b/Spigot-Server-Patches/0005-Paper-Metrics.patch
@@ -1,4 +1,4 @@
-From f44c5ffb3178eb3b188681407b8b7c689cdc64c5 Mon Sep 17 00:00:00 2001
+From a67441f309fdc542158b62334ea269cc94e47738 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Fri, 24 Mar 2017 23:56:01 -0500
 Subject: [PATCH] Paper Metrics
@@ -15,7 +15,7 @@ decisions on behalf of the project.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 new file mode 100644
-index 0000000000..e257d6b36e
+index 000000000..e257d6b36
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
 @@ -0,0 +1,627 @@
@@ -647,18 +647,18 @@ index 0000000000..e257d6b36e
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 812a04204c..581105dce8 100644
+index cde8ec432..87a7b6980 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -40,6 +40,7 @@ public class PaperConfig {
-     static Map<String, Command> commands;
+@@ -41,6 +41,7 @@ public class PaperConfig {
      private static boolean verbose;
+     private static boolean fatalError;
      /*========================================================================*/
 +    private static boolean metricsStarted;
  
      public static void init(File configFile) {
          CONFIG_FILE = configFile;
-@@ -77,6 +78,11 @@ public class PaperConfig {
+@@ -83,6 +84,11 @@ public class PaperConfig {
          for (Map.Entry<String, Command> entry : commands.entrySet()) {
              MinecraftServer.getServer().server.getCommandMap().register(entry.getKey(), "Paper", entry.getValue());
          }
@@ -671,7 +671,7 @@ index 812a04204c..581105dce8 100644
  
      static void readConfig(Class<?> clazz, Object instance) {
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 9b40db46c2..9dca5aeda1 100644
+index 9b40db46c..9dca5aeda 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -84,6 +84,7 @@ public class SpigotConfig
@@ -691,5 +691,5 @@ index 9b40db46c2..9dca5aeda1 100644
  
      static void readConfig(Class<?> clazz, Object instance)
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1,4 +1,4 @@
-From 2f756f6ba7b34e3cddeac50bb873b9bcfa00a1f2 Mon Sep 17 00:00:00 2001
+From 29cc84ad8c41d02c850823836236b0377f7c1c28 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
@@ -6,7 +6,7 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 0000000000..a6292f1d74
+index 000000000..a6292f1d7
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -0,0 +1,132 @@
@@ -144,7 +144,7 @@ index 0000000000..a6292f1d74
 +}
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 new file mode 100644
-index 0000000000..145cb274b0
+index 000000000..145cb274b
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -0,0 +1,104 @@
@@ -253,7 +253,7 @@ index 0000000000..145cb274b0
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 581105dce8..8be079e26e 100644
+index 87a7b6980..2f17e5219 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,11 +14,14 @@ import java.util.concurrent.TimeUnit;
@@ -271,7 +271,7 @@ index 581105dce8..8be079e26e 100644
  
  public class PaperConfig {
  
-@@ -181,4 +184,24 @@ public class PaperConfig {
+@@ -187,4 +190,24 @@ public class PaperConfig {
          config.addDefault(path, def);
          return config.getString(path, config.getString(path));
      }
@@ -297,7 +297,7 @@ index 581105dce8..8be079e26e 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index 8811dbc9b3..7818a3b6a7 100644
+index 8811dbc9b..7818a3b6a 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -23,6 +23,15 @@ public class Block implements IMaterial {
@@ -317,7 +317,7 @@ index 8811dbc9b3..7818a3b6a7 100644
      private final float frictionFactor;
      protected final BlockStateList<Block, IBlockData> blockStateList;
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 9b9317167f..b81d379224 100644
+index 9b9317167..b81d37922 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -841,6 +841,7 @@ public class Chunk implements IChunkAccess {
@@ -337,7 +337,7 @@ index 9b9317167f..b81d379224 100644
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/ChunkMap.java b/src/main/java/net/minecraft/server/ChunkMap.java
-index 85a065f039..4b8b77710b 100644
+index 85a065f03..4b8b77710 100644
 --- a/src/main/java/net/minecraft/server/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/ChunkMap.java
 @@ -14,6 +14,7 @@ public class ChunkMap extends Long2ObjectOpenHashMap<Chunk> {
@@ -357,7 +357,7 @@ index 85a065f039..4b8b77710b 100644
  
          return chunk1;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 0c8c10b7a7..31ed3e43a5 100644
+index 0c8c10b7a..31ed3e43a 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -90,7 +90,7 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -398,7 +398,7 @@ index 0c8c10b7a7..31ed3e43a5 100644
              this.chunkLoader.saveChunk(this.world, ichunkaccess, unloaded); // Spigot
          } catch (IOException ioexception) {
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 1a32149dbf..43f77a3987 100644
+index 1a32149db..43f77a398 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -1,5 +1,6 @@
@@ -445,7 +445,7 @@ index 1a32149dbf..43f77a3987 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/CustomFunction.java b/src/main/java/net/minecraft/server/CustomFunction.java
-index b7cdc495a3..8b9b076ded 100644
+index b7cdc495a..8b9b076de 100644
 --- a/src/main/java/net/minecraft/server/CustomFunction.java
 +++ b/src/main/java/net/minecraft/server/CustomFunction.java
 @@ -13,12 +13,22 @@ public class CustomFunction {
@@ -472,7 +472,7 @@ index b7cdc495a3..8b9b076ded 100644
          return this.b;
      }
 diff --git a/src/main/java/net/minecraft/server/CustomFunctionData.java b/src/main/java/net/minecraft/server/CustomFunctionData.java
-index 4d7e151793..40ff72f725 100644
+index 4d7e15179..40ff72f72 100644
 --- a/src/main/java/net/minecraft/server/CustomFunctionData.java
 +++ b/src/main/java/net/minecraft/server/CustomFunctionData.java
 @@ -109,7 +109,7 @@ public class CustomFunctionData implements ITickable, IResourcePackListener {
@@ -485,7 +485,7 @@ index 4d7e151793..40ff72f725 100644
                  int j = 0;
                  CustomFunction.c[] acustomfunction_c = customfunction.b();
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index d8535fdd9e..22f3a08e98 100644
+index 9c03cfd4b..1afdf4be9 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -29,7 +29,7 @@ import org.apache.logging.log4j.Level;
@@ -497,7 +497,7 @@ index d8535fdd9e..22f3a08e98 100644
  import org.bukkit.event.server.ServerCommandEvent;
  import org.bukkit.craftbukkit.util.Waitable;
  import org.bukkit.event.server.RemoteServerCommandEvent;
-@@ -449,7 +449,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -454,7 +454,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
      }
  
      public void aU() {
@@ -506,7 +506,7 @@ index d8535fdd9e..22f3a08e98 100644
          while (!this.serverCommandQueue.isEmpty()) {
              ServerCommand servercommand = (ServerCommand) this.serverCommandQueue.remove(0);
  
-@@ -464,7 +464,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -469,7 +469,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              // CraftBukkit end
          }
  
@@ -515,7 +515,7 @@ index d8535fdd9e..22f3a08e98 100644
      }
  
      public boolean Q() {
-@@ -714,7 +714,20 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -719,7 +719,20 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
                  return remoteControlCommandListener.getMessages();
              }
          };
@@ -538,7 +538,7 @@ index d8535fdd9e..22f3a08e98 100644
              return waitable.get();
          } catch (java.util.concurrent.ExecutionException e) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index aa9e4ef5ee..320146783b 100644
+index aa9e4ef5e..320146783 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -29,7 +29,8 @@ import org.bukkit.command.CommandSender;
@@ -577,7 +577,7 @@ index aa9e4ef5ee..320146783b 100644
  
      protected float ab() {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 76cc9085bd..ce79887cf4 100644
+index 76cc9085b..ce79887cf 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -32,7 +32,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -653,7 +653,7 @@ index 76cc9085bd..ce79887cf4 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityTracker.java b/src/main/java/net/minecraft/server/EntityTracker.java
-index ae31935c48..70c9b1f50c 100644
+index ae31935c4..70c9b1f50 100644
 --- a/src/main/java/net/minecraft/server/EntityTracker.java
 +++ b/src/main/java/net/minecraft/server/EntityTracker.java
 @@ -168,7 +168,7 @@ public class EntityTracker {
@@ -684,7 +684,7 @@ index ae31935c48..70c9b1f50c 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ac534ea3ee..bb4d2cabfe 100644
+index ac534ea3e..bb4d2cabf 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1,5 +1,6 @@
@@ -837,7 +837,7 @@ index ac534ea3ee..bb4d2cabfe 100644
          this.methodProfiler.e();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index ac6d8cc6e6..d975c2ccf1 100644
+index ac6d8cc6e..d975c2ccf 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,5 +1,6 @@
@@ -931,7 +931,7 @@ index ac6d8cc6e6..d975c2ccf1 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 8db0b6a6db..fa20e1d26c 100644
+index 8db0b6a6d..fa20e1d26 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -59,6 +59,7 @@ import org.bukkit.inventory.CraftingInventory;
@@ -970,7 +970,7 @@ index 8db0b6a6db..fa20e1d26c 100644
          // this.minecraftServer.getCommandDispatcher().a(this.player.getCommandListener(), s);
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
-index 616797dc6e..3a5daf6705 100644
+index 616797dc6..3a5daf670 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 @@ -1,10 +1,16 @@
@@ -991,7 +991,7 @@ index 616797dc6e..3a5daf6705 100644
              throw CancelledPacketHandleException.INSTANCE;
          }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 6e5922a98c..ca129d221d 100644
+index 6e5922a98..ca129d221 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1015,7 +1015,7 @@ index 6e5922a98c..ca129d221d 100644
  
      public WhiteList getWhitelist() {
 diff --git a/src/main/java/net/minecraft/server/TickListServer.java b/src/main/java/net/minecraft/server/TickListServer.java
-index a07895935e..ee5c2421bb 100644
+index a07895935..ee5c2421b 100644
 --- a/src/main/java/net/minecraft/server/TickListServer.java
 +++ b/src/main/java/net/minecraft/server/TickListServer.java
 @@ -24,13 +24,19 @@ public class TickListServer<T> implements TickList<T> {
@@ -1069,7 +1069,7 @@ index a07895935e..ee5c2421bb 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index c69209497b..68ac014aab 100644
+index c69209497..68ac014aa 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -4,12 +4,13 @@ import javax.annotation.Nullable;
@@ -1089,7 +1089,7 @@ index c69209497b..68ac014aab 100644
      private final TileEntityTypes<?> e; public TileEntityTypes getTileEntityType() { return e; } // Paper - OBFHELPER
      protected World world;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f381e23beb..a934a4b307 100644
+index f381e23be..a934a4b30 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1,5 +1,6 @@
@@ -1204,7 +1204,7 @@ index f381e23beb..a934a4b307 100644
  
      public boolean a(@Nullable Entity entity, VoxelShape voxelshape) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 4be2d8d3c4..e4d03b6779 100644
+index 4be2d8d3c..e4d03b677 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1,5 +1,6 @@
@@ -1311,7 +1311,7 @@ index 4be2d8d3c4..e4d03b6779 100644
  
      // CraftBukkit start
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e659f3f339..944fca34c3 100644
+index e659f3f33..944fca34c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1896,12 +1896,31 @@ public final class CraftServer implements Server {
@@ -1348,7 +1348,7 @@ index e659f3f339..944fca34c3 100644
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java b/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 deleted file mode 100644
-index 4c8ab2bc97..0000000000
+index 4c8ab2bc9..000000000
 --- a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 +++ /dev/null
 @@ -1,174 +0,0 @@
@@ -1527,7 +1527,7 @@ index 4c8ab2bc97..0000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
-index 413dd35f06..52a8c48fa4 100644
+index 413dd35f0..52a8c48fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 +++ b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 @@ -1,6 +1,8 @@
@@ -1563,7 +1563,7 @@ index 413dd35f06..52a8c48fa4 100644
  
      public void callStage3(QueuedChunk queuedChunk, Chunk chunk, Runnable runnable) throws RuntimeException {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9f78f2c4ae..832d2de476 100644
+index 9f78f2c4a..832d2de47 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1715,6 +1715,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -1582,7 +1582,7 @@ index 9f78f2c4ae..832d2de476 100644
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index f11bd7545f..93b9134d6e 100644
+index f11bd7545..93b9134d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -14,6 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger;
@@ -1658,7 +1658,7 @@ index f11bd7545f..93b9134d6e 100644
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index 7e7ce9a81b..46029ce246 100644
+index 7e7ce9a81..46029ce24 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -1,8 +1,8 @@
@@ -1740,7 +1740,7 @@ index 7e7ce9a81b..46029ce246 100644
 -    // Spigot end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
-index e52ef47b78..3d90b34268 100644
+index e52ef47b7..3d90b3426 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 @@ -5,6 +5,7 @@ import org.bukkit.util.CachedServerIcon;
@@ -1752,7 +1752,7 @@ index e52ef47b78..3d90b34268 100644
          this.value = value;
      }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index e60fe5a920..f68e42c4d4 100644
+index e60fe5a92..f68e42c4d 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -30,7 +30,7 @@ import net.minecraft.server.EntityWither;
@@ -1813,5 +1813,5 @@ index e60fe5a920..f68e42c4d4 100644
      }
  }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0028-Lighting-Queue.patch
+++ b/Spigot-Server-Patches/0028-Lighting-Queue.patch
@@ -1,4 +1,4 @@
-From 2944b419d467efe317df621fe747cb22aaf5c30b Mon Sep 17 00:00:00 2001
+From 4b74d1d81eccd51be3808fa01847b44a306ac04b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 2 Mar 2016 00:52:31 -0600
 Subject: [PATCH] Lighting Queue
@@ -6,7 +6,7 @@ Subject: [PATCH] Lighting Queue
 This provides option to queue lighting updates to ensure they do not cause the server lag
 
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-index 145cb274b0..eff9dcf54f 100644
+index 145cb274b..eff9dcf54 100644
 --- a/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -50,6 +50,8 @@ public class WorldTimingsHandler {
@@ -28,10 +28,10 @@ index 145cb274b0..eff9dcf54f 100644
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8be079e26e..0968852922 100644
+index 2f17e5219..aa920c469 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -185,6 +185,13 @@ public class PaperConfig {
+@@ -191,6 +191,13 @@ public class PaperConfig {
          return config.getString(path, config.getString(path));
      }
  
@@ -46,7 +46,7 @@ index 8be079e26e..0968852922 100644
          boolean timings = getBoolean("timings.enabled", true);
          boolean verboseTimings = getBoolean("timings.verbose", true);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 39d565db1f..8f6f0288be 100644
+index 39d565db1..8f6f0288b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -130,4 +130,12 @@ public class PaperWorldConfig {
@@ -63,7 +63,7 @@ index 39d565db1f..8f6f0288be 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index af181d4bd7..6fa379e580 100644
+index af181d4bd..6fa379e58 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -90,6 +90,7 @@ public class Chunk implements IChunkAccess {
@@ -126,7 +126,7 @@ index af181d4bd7..6fa379e580 100644
  
          IMMEDIATE, QUEUED, CHECK;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 31ed3e43a5..0b03c6266a 100644
+index 31ed3e43a..0b03c6266 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -314,6 +314,7 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -138,7 +138,7 @@ index 31ed3e43a5..0b03c6266a 100644
          // Update neighbor counts
          for (int x = -2; x < 3; x++) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d6ea4ae532..5086fe4027 100644
+index d6ea4ae53..5086fe402 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -894,7 +894,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -160,7 +160,7 @@ index d6ea4ae532..5086fe4027 100644
      }
 diff --git a/src/main/java/net/minecraft/server/PaperLightingQueue.java b/src/main/java/net/minecraft/server/PaperLightingQueue.java
 new file mode 100644
-index 0000000000..5fabc5b55c
+index 000000000..5fabc5b55
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/PaperLightingQueue.java
 @@ -0,0 +1,98 @@
@@ -263,7 +263,7 @@ index 0000000000..5fabc5b55c
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 499d64ea2c..e06da6bef9 100644
+index 499d64ea2..e06da6bef 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -335,7 +335,7 @@ public abstract class World implements IEntityAccess, GeneratorAccess, IIBlockAc
@@ -276,5 +276,5 @@ index 499d64ea2c..e06da6bef9 100644
                  }
  
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0061-Chunk-save-queue-improvements.patch
+++ b/Spigot-Server-Patches/0061-Chunk-save-queue-improvements.patch
@@ -1,4 +1,4 @@
-From 5b15b220b15c6b7aeb79371ba68fe805fae1e828 Mon Sep 17 00:00:00 2001
+From 4b04c2b61a16280bc65656261c939ee5bb665606 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 4 Mar 2016 18:18:37 -0600
 Subject: [PATCH] Chunk save queue improvements
@@ -26,10 +26,10 @@ Then finally, Sleeping will by default be removed, but due to known issues with 
 But if sleeps are to remain enabled, we at least lower the sleep interval so it doesn't have as much negative impact.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 0968852922..e485c3053b 100644
+index aa920c469..4aad68a57 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -211,4 +211,10 @@ public class PaperConfig {
+@@ -217,4 +217,10 @@ public class PaperConfig {
                  " - Interval: " + timeSummary(Timings.getHistoryInterval() / 20) +
                  " - Length: " + timeSummary(Timings.getHistoryLength() / 20));
      }
@@ -41,7 +41,7 @@ index 0968852922..e485c3053b 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
-index d9608121b6..d7a6700936 100644
+index d9608121b..d7a670093 100644
 --- a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 +++ b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 @@ -19,6 +19,7 @@ public class ChunkCoordIntPair {
@@ -53,7 +53,7 @@ index d9608121b6..d7a6700936 100644
          return a(this.x, this.z);
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 43f77a3987..4a0f3989e6 100644
+index 43f77a398..4a0f3989e 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -22,6 +22,7 @@ import java.util.function.Consumer;
@@ -171,7 +171,7 @@ index 43f77a3987..4a0f3989e6 100644
                      NBTCompressedStreamTools.a(nbttagcompound, (DataOutput) dataoutputstream);
                      dataoutputstream.close();
 diff --git a/src/main/java/net/minecraft/server/FileIOThread.java b/src/main/java/net/minecraft/server/FileIOThread.java
-index a3aba244af..97917551a4 100644
+index a3aba244a..97917551a 100644
 --- a/src/main/java/net/minecraft/server/FileIOThread.java
 +++ b/src/main/java/net/minecraft/server/FileIOThread.java
 @@ -35,20 +35,21 @@ public class FileIOThread implements Runnable {
@@ -201,5 +201,5 @@ index a3aba244af..97917551a4 100644
  
          if (this.c.isEmpty()) {
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0063-Default-loading-permissions.yml-before-plugins.patch
+++ b/Spigot-Server-Patches/0063-Default-loading-permissions.yml-before-plugins.patch
@@ -1,4 +1,4 @@
-From e383ab3f226d1585906752bb2ace164f65bcd183 Mon Sep 17 00:00:00 2001
+From a2d01b6ada4ef03c7e6c096cabff8a52697c52a5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 18 Mar 2016 13:17:38 -0400
 Subject: [PATCH] Default loading permissions.yml before plugins
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e485c3053b..41762a461e 100644
+index 4aad68a57..dccd00127 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -217,4 +217,9 @@ public class PaperConfig {
+@@ -223,4 +223,9 @@ public class PaperConfig {
          enableFileIOThreadSleep = getBoolean("settings.sleep-between-chunk-saves", false);
          if (enableFileIOThreadSleep) Bukkit.getLogger().info("Enabled sleeping between chunk saves, beware of memory issues");
      }
@@ -30,7 +30,7 @@ index e485c3053b..41762a461e 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17fdc58bd0..385063d8aa 100644
+index 17fdc58bd..385063d8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -337,6 +337,7 @@ public final class CraftServer implements Server {
@@ -51,5 +51,5 @@ index 17fdc58bd0..385063d8aa 100644
              CraftDefaultPermissions.registerCorePermissions();
              helpMap.initializeCommands();
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0087-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/Spigot-Server-Patches/0087-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -1,4 +1,4 @@
-From a9fc3aa2020854829a249376f854ab39c42c19ca Mon Sep 17 00:00:00 2001
+From a4d11307f56bfb8d5f7559315844f5cbc64b6ae4 Mon Sep 17 00:00:00 2001
 From: Antony Riley <antony@cyberiantiger.org>
 Date: Tue, 29 Mar 2016 08:22:55 +0300
 Subject: [PATCH] Sanitise RegionFileCache and make configurable.
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 41762a461e..31b35b113c 100644
+index dccd00127..b4dba7247 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -222,4 +222,9 @@ public class PaperConfig {
+@@ -228,4 +228,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }
@@ -25,7 +25,7 @@ index 41762a461e..31b35b113c 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/RegionFileCache.java b/src/main/java/net/minecraft/server/RegionFileCache.java
-index 2217adf99c..c0ab543b91 100644
+index 2217adf99..c0ab543b9 100644
 --- a/src/main/java/net/minecraft/server/RegionFileCache.java
 +++ b/src/main/java/net/minecraft/server/RegionFileCache.java
 @@ -9,10 +9,12 @@ import java.io.IOException;
@@ -77,5 +77,5 @@ index 2217adf99c..c0ab543b91 100644
          Iterator iterator = RegionFileCache.a.values().iterator();
  
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0102-Configurable-Player-Collision.patch
+++ b/Spigot-Server-Patches/0102-Configurable-Player-Collision.patch
@@ -1,14 +1,14 @@
-From 1189b8519d5dfd48f1cd07d9fbfcf6d2cb476c3f Mon Sep 17 00:00:00 2001
+From 8a81ace7be6620adc628d1a87c46a27e47cf0e21 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 13 Apr 2016 02:10:49 -0400
 Subject: [PATCH] Configurable Player Collision
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 31b35b113c..7ebab47835 100644
+index b4dba7247..1d32b93c8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -227,4 +227,9 @@ public class PaperConfig {
+@@ -233,4 +233,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = getInt("settings.region-file-cache-size", 256);
      }
@@ -19,7 +19,7 @@ index 31b35b113c..7ebab47835 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8056dc40df..74c84dda69 100644
+index 8056dc40d..74c84dda6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -425,6 +425,19 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -43,7 +43,7 @@ index 8056dc40df..74c84dda69 100644
  
      protected void a(File file, WorldData worlddata) {
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutScoreboardTeam.java b/src/main/java/net/minecraft/server/PacketPlayOutScoreboardTeam.java
-index f7a9b9d885..7befd80cf5 100644
+index f7a9b9d88..7befd80cf 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutScoreboardTeam.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutScoreboardTeam.java
 @@ -92,7 +92,7 @@ public class PacketPlayOutScoreboardTeam implements Packet<PacketListenerPlayOut
@@ -56,7 +56,7 @@ index f7a9b9d885..7befd80cf5 100644
              packetdataserializer.a(this.c);
              packetdataserializer.a(this.d);
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 2154c0516c..baf870ac2a 100644
+index 2154c0516..baf870ac2 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -74,6 +74,7 @@ public abstract class PlayerList {
@@ -114,5 +114,5 @@ index 2154c0516c..baf870ac2a 100644
  
      // CraftBukkit start
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0113-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/Spigot-Server-Patches/0113-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -1,14 +1,14 @@
-From 2d545f8fa238dff23b600d2668147533f6bd57e3 Mon Sep 17 00:00:00 2001
+From b720608db74ef91858c50f2c572f66321b36f5ba Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 7 May 2016 23:33:08 -0400
 Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7ebab47835..a266328daf 100644
+index 1d32b93c8..c4d12c315 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -232,4 +232,9 @@ public class PaperConfig {
+@@ -238,4 +238,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }
@@ -19,7 +19,7 @@ index 7ebab47835..a266328daf 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PersistentScoreboard.java b/src/main/java/net/minecraft/server/PersistentScoreboard.java
-index f2e8eface3..895ea0eb41 100644
+index f2e8eface..895ea0eb4 100644
 --- a/src/main/java/net/minecraft/server/PersistentScoreboard.java
 +++ b/src/main/java/net/minecraft/server/PersistentScoreboard.java
 @@ -160,6 +160,7 @@ public class PersistentScoreboard extends PersistentBase {
@@ -31,5 +31,5 @@ index f2e8eface3..895ea0eb41 100644
              nbttagcompound.setString("Name", scoreboardteam.getName());
              nbttagcompound.setString("DisplayName", IChatBaseComponent.ChatSerializer.a(scoreboardteam.getDisplayName()));
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0129-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0129-Add-setting-for-proxy-online-mode-status.patch
@@ -1,14 +1,22 @@
-From fda3c64ab22491da226c15cf67f83b890348c93e Mon Sep 17 00:00:00 2001
+From 19909af8b5e757bb51adb4ddb9e7f0d65dfe1e22 Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Fri, 5 Aug 2016 01:03:08 +0200
 Subject: [PATCH] Add setting for proxy online mode status
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a266328daf..e1439ffe7d 100644
+index c4d12c315..1c1ef2dc2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -237,4 +237,9 @@ public class PaperConfig {
+@@ -22,6 +22,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import co.aikar.timings.Timings;
+ import co.aikar.timings.TimingsManager;
++import org.spigotmc.SpigotConfig;
+ 
+ public class PaperConfig {
+ 
+@@ -243,4 +244,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }
@@ -17,9 +25,13 @@ index a266328daf..e1439ffe7d 100644
 +    private static void bungeeOnlineMode() {
 +        bungeeOnlineMode = getBoolean("settings.bungee-online-mode", true);
 +    }
++
++    public static boolean isProxyOnlineMode() {
++        return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
++    }
  }
 diff --git a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
-index 58d971cf20..8a2ff6a413 100644
+index 58d971cf2..658f7be0d 100644
 --- a/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
 +++ b/src/main/java/net/minecraft/server/NameReferencingFileConverter.java
 @@ -60,7 +60,8 @@ public class NameReferencingFileConverter {
@@ -28,12 +40,12 @@ index 58d971cf20..8a2ff6a413 100644
  
 -        if (minecraftserver.getOnlineMode() || org.spigotmc.SpigotConfig.bungee) { // Spigot: bungee = online mode, for now.
 +        if (minecraftserver.getOnlineMode()
-+                || (org.spigotmc.SpigotConfig.bungee && com.destroystokyo.paper.PaperConfig.bungeeOnlineMode)) { // Spigot: bungee = online mode, for now.  // Paper - Handle via setting
++                || (com.destroystokyo.paper.PaperConfig.isProxyOnlineMode())) { // Spigot: bungee = online mode, for now.  // Paper - Handle via setting
              minecraftserver.getGameProfileRepository().findProfilesByNames(astring, Agent.MINECRAFT, profilelookupcallback);
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ffa6a46b78..fe2e22f67a 100644
+index ffa6a46b7..79378f21d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1408,7 +1408,8 @@ public final class CraftServer implements Server {
@@ -42,10 +54,10 @@ index ffa6a46b78..fe2e22f67a 100644
              // Only fetch an online UUID in online mode
 -            if ( MinecraftServer.getServer().getOnlineMode() || org.spigotmc.SpigotConfig.bungee )
 +            if ( MinecraftServer.getServer().getOnlineMode()
-+                    || (org.spigotmc.SpigotConfig.bungee && com.destroystokyo.paper.PaperConfig.bungeeOnlineMode)) // Paper - Handle via setting
++                    || com.destroystokyo.paper.PaperConfig.isProxyOnlineMode()) // Paper - Handle via setting
              {
                  profile = console.getUserCache().getProfile( name );
              }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0133-Configurable-packet-in-spam-threshold.patch
+++ b/Spigot-Server-Patches/0133-Configurable-packet-in-spam-threshold.patch
@@ -1,18 +1,18 @@
-From bd5f96c4adcd7cb7aa0b37fff20b01bb1b403bf2 Mon Sep 17 00:00:00 2001
+From d84e0a561e044f2e4ad8586dca7ee49908015c80 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Sun, 11 Sep 2016 14:30:57 -0500
 Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e1439ffe7d..57d19d3326 100644
+index 1c1ef2dc2..4c0a9f18c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -242,4 +242,13 @@ public class PaperConfig {
-     private static void bungeeOnlineMode() {
-         bungeeOnlineMode = getBoolean("settings.bungee-online-mode", true);
+@@ -253,4 +253,13 @@ public class PaperConfig {
+     public static boolean isProxyOnlineMode() {
+         return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }
-+    
++
 +    public static int packetInSpamThreshold = 300;
 +    private static void packetInSpamThreshold() {
 +        if (version < 11) {
@@ -23,7 +23,7 @@ index e1439ffe7d..57d19d3326 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index aad33272f0..598b747ec0 100644
+index aad33272f..598b747ec 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1201,13 +1201,14 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -44,5 +44,5 @@ index aad33272f0..598b747ec0 100644
              limitedPackets = 0;
              return true;
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0134-Configurable-flying-kick-messages.patch
+++ b/Spigot-Server-Patches/0134-Configurable-flying-kick-messages.patch
@@ -1,14 +1,14 @@
-From 3121456e3f2eeae6926ddcac212c3f0163efe28c Mon Sep 17 00:00:00 2001
+From cc2a6e2529e1158667ebe8d690cc8be63c0f5bec Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Tue, 20 Sep 2016 00:58:01 +0000
 Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 57d19d3326..44d8e99ff8 100644
+index 4c0a9f18c..c278ac98d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -251,4 +251,11 @@ public class PaperConfig {
+@@ -262,4 +262,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }
@@ -21,7 +21,7 @@ index 57d19d3326..44d8e99ff8 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 598b747ec0..552f1355ce 100644
+index 598b747ec..552f1355c 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -145,7 +145,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -43,5 +43,5 @@ index 598b747ec0..552f1355ce 100644
                  }
              } else {
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0135-Auto-Save-Improvements.patch
+++ b/Spigot-Server-Patches/0135-Auto-Save-Improvements.patch
@@ -1,4 +1,4 @@
-From bd52dfe82dc4a34ed3670bef25efdf3bb7e10a80 Mon Sep 17 00:00:00 2001
+From f397718c1bd2ed68e1dca5603ca882a4b087b7a9 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 19 Sep 2016 23:16:39 -0400
 Subject: [PATCH] Auto Save Improvements
@@ -12,10 +12,10 @@ Re-introduce a cap per tick for auto save (Spigot disabled the vanilla cap) and 
 Adds incremental player auto saving too
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 44d8e99ff8..b9acfaf51b 100644
+index c278ac98d..ae3d0f8f7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -258,4 +258,15 @@ public class PaperConfig {
+@@ -269,4 +269,15 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }
@@ -32,7 +32,7 @@ index 44d8e99ff8..b9acfaf51b 100644
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0cd15c17e8..c43152f456 100644
+index 0cd15c17e..c43152f45 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,6 +2,7 @@ package com.destroystokyo.paper;
@@ -64,7 +64,7 @@ index 0cd15c17e8..c43152f456 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 7e371c278f..a79b0b59d7 100644
+index 7e371c278..a79b0b59d 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -50,9 +50,9 @@ public class Chunk implements IChunkAccess {
@@ -96,7 +96,7 @@ index 7e371c278f..a79b0b59d7 100644
  
      public boolean isEmpty() {
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 719d5deb2c..69219b13a6 100644
+index 719d5deb2..69219b13a 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -241,7 +241,7 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -109,7 +109,7 @@ index 719d5deb2c..69219b13a6 100644
                      }
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 3d83900298..690cff8828 100644
+index 3d8390029..690cff882 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -37,6 +37,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -121,7 +121,7 @@ index 3d83900298..690cff8828 100644
      public final MinecraftServer server;
      public final PlayerInteractManager playerInteractManager;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 04d8c108b4..a547ee5ca1 100644
+index 04d8c108b..a547ee5ca 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -148,6 +148,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -168,7 +168,7 @@ index 04d8c108b4..a547ee5ca1 100644
          this.methodProfiler.a("snooper");
          if (getSnooperEnabled() && !this.i.d() && this.ticks > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index baf870ac2a..7d778ff3e0 100644
+index baf870ac2..7d778ff3e 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -342,6 +342,7 @@ public abstract class PlayerList {
@@ -207,7 +207,7 @@ index baf870ac2a..7d778ff3e0 100644
      public WhiteList getWhitelist() {
          return this.whitelist;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c5201697d5..ca2e027cda 100644
+index c5201697d..ca2e027cd 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -872,8 +872,9 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -230,5 +230,5 @@ index c5201697d5..ca2e027cda 100644
              timings.worldSaveChunks.startTiming(); // Paper
              chunkproviderserver.a(flag);
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0158-Add-option-to-remove-invalid-statistics.patch
+++ b/Spigot-Server-Patches/0158-Add-option-to-remove-invalid-statistics.patch
@@ -1,14 +1,14 @@
-From f138a3dadfcfb5aaa2676e5b2e3c15b8996aba6b Mon Sep 17 00:00:00 2001
+From 6a8062188a480ab5bc541016f54b972193b12045 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 20 Dec 2016 23:09:21 -0600
 Subject: [PATCH] Add option to remove invalid statistics
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b9acfaf51b..00ece7ec35 100644
+index ae3d0f8f7..6b92ea437 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -269,4 +269,13 @@ public class PaperConfig {
+@@ -280,4 +280,13 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }
@@ -23,7 +23,7 @@ index b9acfaf51b..00ece7ec35 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ServerStatisticManager.java b/src/main/java/net/minecraft/server/ServerStatisticManager.java
-index 6405f98e06..42e2f3d22b 100644
+index 6405f98e0..42e2f3d22 100644
 --- a/src/main/java/net/minecraft/server/ServerStatisticManager.java
 +++ b/src/main/java/net/minecraft/server/ServerStatisticManager.java
 @@ -83,6 +83,7 @@ public class ServerStatisticManager extends StatisticManager {
@@ -43,5 +43,5 @@ index 6405f98e06..42e2f3d22b 100644
                                                  this.a.put(statistic, nbttagcompound2.getInt(s2));
                                              }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0178-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0178-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -1,4 +1,4 @@
-From 3282f82616cd0b6f2acec705705b760500052e7f Mon Sep 17 00:00:00 2001
+From e05f5ac9c6cdbf5f654a3db6329ac6b516d5c67a Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Fri, 9 Jun 2017 07:24:34 -0700
 Subject: [PATCH] Add configuration option to prevent player names from being
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 00ece7ec35..56cd386f34 100644
+index 6b92ea437..963096fb3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -278,4 +278,9 @@ public class PaperConfig {
+@@ -289,4 +289,9 @@ public class PaperConfig {
          }
          removeInvalidStatistics = getBoolean("settings.remove-invalid-statistics", false);
      }
@@ -20,7 +20,7 @@ index 00ece7ec35..56cd386f34 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 73ab254aa0..849dd19dc0 100644
+index ec31ae0d9..cd925d0ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2051,5 +2051,10 @@ public final class CraftServer implements Server {
@@ -35,5 +35,5 @@ index 73ab254aa0..849dd19dc0 100644
      // Paper end
  }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0201-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/Spigot-Server-Patches/0201-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -1,4 +1,4 @@
-From 2e30a1f5ef931d524f5ef2f5299f5bae326b3226 Mon Sep 17 00:00:00 2001
+From 5adcf0eb891dd0cb7fd3980b018f32a89f05f63b Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Thu, 17 Aug 2017 16:08:20 -0700
 Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 56cd386f34..2d98052ad1 100644
+index 963096fb3..a499578db 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index 56cd386f34..2d98052ad1 100644
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -283,4 +284,9 @@ public class PaperConfig {
+@@ -294,4 +295,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }
@@ -27,7 +27,7 @@ index 56cd386f34..2d98052ad1 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
-index 8bbea96240..10c82107d4 100644
+index 8bbea9624..10c82107d 100644
 --- a/src/main/java/net/minecraft/server/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/LoginListener.java
 @@ -240,6 +240,10 @@ public class LoginListener implements PacketLoginInListener, ITickable {
@@ -42,5 +42,5 @@ index 8bbea96240..10c82107d4 100644
                              LoginListener.c.error("Couldn\'t verify username because servers are unavailable");
                          }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0245-Make-player-data-saving-configurable.patch
+++ b/Spigot-Server-Patches/0245-Make-player-data-saving-configurable.patch
@@ -1,14 +1,14 @@
-From 586681d2662bf0a7b2eb9f96d18cb536137cfa4e Mon Sep 17 00:00:00 2001
+From adc6a73d736b3ddf87d8e3a1954d3deec8e14f3f Mon Sep 17 00:00:00 2001
 From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
 Date: Mon, 26 Mar 2018 18:30:53 +0300
 Subject: [PATCH] Make player data saving configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2d98052ad1..588c626fbd 100644
+index a499578db..dc15bfcf8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -289,4 +289,13 @@ public class PaperConfig {
+@@ -300,4 +300,13 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
@@ -23,7 +23,7 @@ index 2d98052ad1..588c626fbd 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
-index 0fd6efec0b..7553280d21 100644
+index 0fd6efec0..7553280d2 100644
 --- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
 +++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
 @@ -141,6 +141,7 @@ public class WorldNBTStorage implements IDataManager, IPlayerFileData {
@@ -35,5 +35,5 @@ index 0fd6efec0b..7553280d21 100644
              NBTTagCompound nbttagcompound = entityhuman.save(new NBTTagCompound());
              File file = new File(this.playerDir, entityhuman.bu() + ".dat.tmp");
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0250-Load-version-history-at-server-start.patch
+++ b/Spigot-Server-Patches/0250-Load-version-history-at-server-start.patch
@@ -1,21 +1,21 @@
-From 1636fc154af5dadcd9d9ee7950506ceb41e0e973 Mon Sep 17 00:00:00 2001
+From 48922982dfb8b16328a8e5c3e730750a8d5c5e6d Mon Sep 17 00:00:00 2001
 From: Kyle Wood <demonwav@gmail.com>
 Date: Thu, 1 Mar 2018 19:38:14 -0600
 Subject: [PATCH] Load version history at server start
 
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 674609cad3..1a332909b2 100644
+index fe259e985..d9c6b1104 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -207,6 +207,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-             // Paper start
-             com.destroystokyo.paper.PaperConfig.init((File) options.valueOf("paper-settings"));
+@@ -212,6 +212,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+                 return false;
+             }
              com.destroystokyo.paper.PaperConfig.registerCommands();
 +            com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
              // Paper end
  
              DedicatedServer.LOGGER.info("Generating keypair");
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0268-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/Spigot-Server-Patches/0268-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -1,4 +1,4 @@
-From 01447432ca043b572785e28926545e2982e05c7d Mon Sep 17 00:00:00 2001
+From d22a1f553e1bce0ce91f494dfd9a4eb7af061df5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 15 Jun 2018 00:30:32 -0400
 Subject: [PATCH] Configurable Alternative LootPool Luck Formula
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 588c626fbd..ba5f21461f 100644
+index dc15bfcf8..f69a11ddf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -298,4 +298,12 @@ public class PaperConfig {
+@@ -309,4 +309,12 @@ public class PaperConfig {
                      "such as inventories, experience points, advancements and the like will not be saved when they log out.");
          }
      }
@@ -53,7 +53,7 @@ index 588c626fbd..ba5f21461f 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/LootSelectorEntry.java b/src/main/java/net/minecraft/server/LootSelectorEntry.java
-index 8daccdd6e9..c2a4ed6cf0 100644
+index 8daccdd6e..c2a4ed6cf 100644
 --- a/src/main/java/net/minecraft/server/LootSelectorEntry.java
 +++ b/src/main/java/net/minecraft/server/LootSelectorEntry.java
 @@ -13,8 +13,8 @@ import java.util.Collection;
@@ -104,5 +104,5 @@ index 8daccdd6e9..c2a4ed6cf0 100644
      public abstract void a(Collection<ItemStack> var1, Random var2, LootTableInfo var3);
  
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0312-Provide-option-to-use-a-versioned-world-folder-for-t.patch
+++ b/Spigot-Server-Patches/0312-Provide-option-to-use-a-versioned-world-folder-for-t.patch
@@ -1,4 +1,4 @@
-From c67e3a21f1ea66ff8358125b3f2307f4c4396dcf Mon Sep 17 00:00:00 2001
+From 67ac4c42d1317ff79e65bc9c7a01adb7283ddcac Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 29 Jul 2018 15:48:50 -0400
 Subject: [PATCH] Provide option to use a versioned world folder for testing
@@ -19,7 +19,7 @@ may be some delay there, but region files are only copied on demand.
 This is highly experiemental so backup your world before relying on this to not modify it
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ba5f21461f..29d1b89d8d 100644
+index f69a11ddf..c90148d8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -13,6 +13,7 @@ import java.util.List;
@@ -30,7 +30,7 @@ index ba5f21461f..29d1b89d8d 100644
  import java.util.regex.Pattern;
  
  import com.google.common.collect.Lists;
-@@ -306,4 +307,27 @@ public class PaperConfig {
+@@ -317,4 +318,27 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }
@@ -59,7 +59,7 @@ index ba5f21461f..29d1b89d8d 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index db5c6e0f74..b6ec518371 100644
+index db5c6e0f7..b6ec51837 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -59,8 +59,55 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
@@ -139,7 +139,7 @@ index db5c6e0f74..b6ec518371 100644
  
          if (nbttagcompound != null) {
 diff --git a/src/main/java/net/minecraft/server/RegionFileCache.java b/src/main/java/net/minecraft/server/RegionFileCache.java
-index 15666325ea..3501b87f75 100644
+index 15666325e..3501b87f7 100644
 --- a/src/main/java/net/minecraft/server/RegionFileCache.java
 +++ b/src/main/java/net/minecraft/server/RegionFileCache.java
 @@ -76,6 +76,13 @@ public class RegionFileCache {
@@ -157,7 +157,7 @@ index 15666325ea..3501b87f75 100644
  
      public static synchronized void a() {
 diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
-index ab085788ab..c84e6acdbe 100644
+index ab085788a..c84e6acdb 100644
 --- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
 +++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
 @@ -32,6 +32,58 @@ public class WorldNBTStorage implements IDataManager, IPlayerFileData {
@@ -220,5 +220,5 @@ index ab085788ab..c84e6acdbe 100644
          this.baseDir.mkdirs();
          this.playerDir = new File(this.baseDir, "playerdata");
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0318-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0318-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -1,4 +1,4 @@
-From 47ee93791bcc7201285fd2bdd7af8a2a538cb042 Mon Sep 17 00:00:00 2001
+From 40573b27e828db93f4250c6ff94e1364833a4b50 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 29 Jul 2018 05:02:15 +0100
 Subject: [PATCH] Break up and make tab spam limits configurable
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 29d1b89d8d..71894865fb 100644
+index c90148d8a..fad2f8f82 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -330,4 +330,18 @@ public class PaperConfig {
+@@ -341,4 +341,18 @@ public class PaperConfig {
              logger.log(Level.INFO, "******************************************************");
          }
      }
@@ -45,7 +45,7 @@ index 29d1b89d8d..71894865fb 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 05b5e23bf3..1e5ac7185e 100644
+index 05b5e23bf..1e5ac7185 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -77,6 +77,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -74,5 +74,5 @@ index 05b5e23bf3..1e5ac7185e 100644
              return;
          }
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0324-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0324-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -1,4 +1,4 @@
-From 66f9e55d387d524fca28f4315bc50a12684eee36 Mon Sep 17 00:00:00 2001
+From e6aeaaaf67788aca8b41ee04b7925e2ea7f815e9 Mon Sep 17 00:00:00 2001
 From: miclebrick <miclebrick@outlook.com>
 Date: Wed, 8 Aug 2018 15:30:52 -0400
 Subject: [PATCH] Add Early Warning Feature to WatchDog
@@ -9,19 +9,18 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 71894865fb..a739638c42 100644
+index fad2f8f82..4061073b2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -24,6 +24,8 @@ import org.bukkit.configuration.InvalidConfigurationException;
- import org.bukkit.configuration.file.YamlConfiguration;
+@@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
  import co.aikar.timings.Timings;
  import co.aikar.timings.TimingsManager;
-+import org.spigotmc.SpigotConfig;
+ import org.spigotmc.SpigotConfig;
 +import org.spigotmc.WatchdogThread;
  
  public class PaperConfig {
  
-@@ -331,6 +333,14 @@ public class PaperConfig {
+@@ -342,6 +343,14 @@ public class PaperConfig {
          }
      }
  
@@ -37,7 +36,7 @@ index 71894865fb..a739638c42 100644
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 18eeee5106..6fa54386e8 100644
+index 18eeee510..6fa54386e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -796,6 +796,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -49,7 +48,7 @@ index 18eeee5106..6fa54386e8 100644
                  long start = System.nanoTime(), curTime, wait, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index eed96c60c5..496c5cbdff 100644
+index eed96c60c..496c5cbdf 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -226,7 +226,7 @@ public class SpigotConfig
@@ -62,7 +61,7 @@ index eed96c60c5..496c5cbdff 100644
  
      public static boolean bungee;
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index 57a4748a30..19df383e06 100644
+index 57a4748a3..19df383e0 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -5,6 +5,7 @@ import java.lang.management.MonitorInfo;
@@ -164,5 +163,5 @@ index 57a4748a30..19df383e06 100644
              {
                  interrupt();
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0328-Use-a-Queue-for-Queueing-Commands.patch
+++ b/Spigot-Server-Patches/0328-Use-a-Queue-for-Queueing-Commands.patch
@@ -1,4 +1,4 @@
-From b63b770e39177d4c38bbdde408c5abe05ed28e5e Mon Sep 17 00:00:00 2001
+From cf9d4ec297f13b271cc00493324987e8da16e851 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 12 Aug 2018 02:33:39 -0400
 Subject: [PATCH] Use a Queue for Queueing Commands
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Queue for Queueing Commands
 Lists are bad as Queues mmmkay.
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 1a332909b2..9ad5d9dc60 100644
+index d9c6b1104..80576a929 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -39,7 +39,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -18,7 +18,7 @@ index 1a332909b2..9ad5d9dc60 100644
      private RemoteStatusListener j;
      public final RemoteControlCommandListener remoteControlCommandListener = new RemoteControlCommandListener(this);
      private RemoteControlListener l;
-@@ -463,8 +463,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -468,8 +468,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
  
      public void aU() {
          MinecraftTimings.serverCommandTimer.startTiming(); // Spigot
@@ -32,5 +32,5 @@ index 1a332909b2..9ad5d9dc60 100644
              // CraftBukkit start - ServerCommand for preprocessing
              ServerCommandEvent event = new ServerCommandEvent(console, servercommand.command);
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0368-Support-Overriding-World-Seeds.patch
+++ b/Spigot-Server-Patches/0368-Support-Overriding-World-Seeds.patch
@@ -1,4 +1,4 @@
-From 2d69b54c39dcac6f9dc38b249d8b945d03f80947 Mon Sep 17 00:00:00 2001
+From e91db311eb98eded90293aa8a8ffe59f4439fb27 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 17 Sep 2018 23:05:31 -0400
 Subject: [PATCH] Support Overriding World Seeds
@@ -15,7 +15,7 @@ This seed will end up being saved to the world data file, so it is
 a permanent change in that it won't go back if you remove it from paper.yml
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a739638c42..886e97fec5 100644
+index 4061073b2..b703e0848 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -11,6 +11,7 @@ import java.lang.reflect.Modifier;
@@ -34,7 +34,7 @@ index a739638c42..886e97fec5 100644
  import org.bukkit.configuration.InvalidConfigurationException;
  import org.bukkit.configuration.file.YamlConfiguration;
  import co.aikar.timings.Timings;
-@@ -354,4 +356,23 @@ public class PaperConfig {
+@@ -364,4 +366,23 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
@@ -59,7 +59,7 @@ index a739638c42..886e97fec5 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 81cda5df56..fb62320310 100644
+index 81cda5df5..fb6232031 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -350,7 +350,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -72,7 +72,7 @@ index 81cda5df56..fb62320310 100644
  
              if (j == 0) {
 diff --git a/src/main/java/net/minecraft/server/WorldData.java b/src/main/java/net/minecraft/server/WorldData.java
-index db07e5f9ec..1b188f96ef 100644
+index db07e5f9e..1b188f96e 100644
 --- a/src/main/java/net/minecraft/server/WorldData.java
 +++ b/src/main/java/net/minecraft/server/WorldData.java
 @@ -110,7 +110,7 @@ public class WorldData {
@@ -85,7 +85,7 @@ index db07e5f9ec..1b188f96ef 100644
              String s = nbttagcompound.getString("generatorName");
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 04a76802b8..23663ede9f 100644
+index 58811a73d..8f6c44a3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -982,7 +982,7 @@ public final class CraftServer implements Server {
@@ -98,5 +98,5 @@ index 04a76802b8..23663ede9f 100644
              if (parsedSettings.isJsonObject()) {
                  worldSettings.setGeneratorSettings(parsedSettings.getAsJsonObject());
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0375-Async-Chunk-Loading-and-Generation.patch
+++ b/Spigot-Server-Patches/0375-Async-Chunk-Loading-and-Generation.patch
@@ -1,4 +1,4 @@
-From 662563828cc23dfd798fb73fac09c21be18cce82 Mon Sep 17 00:00:00 2001
+From bbb24713a0d39852c5c6fd794be200e2324afb98 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 21 Jul 2018 16:55:04 -0400
 Subject: [PATCH] Async Chunk Loading and Generation
@@ -43,10 +43,10 @@ reading or writing to the chunk will be safe, so plugins still
 should not be touching chunks asynchronously!
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 886e97fec5..454ac2c091 100644
+index b703e0848..77d35ac99 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -375,4 +375,57 @@ public class PaperConfig {
+@@ -385,4 +385,57 @@ public class PaperConfig {
              }
          }
      }
@@ -106,7 +106,7 @@ index 886e97fec5..454ac2c091 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/util/PriorityQueuedExecutor.java b/src/main/java/com/destroystokyo/paper/util/PriorityQueuedExecutor.java
 new file mode 100644
-index 0000000000..5c77b6e8e1
+index 000000000..5c77b6e8e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/PriorityQueuedExecutor.java
 @@ -0,0 +1,281 @@
@@ -392,7 +392,7 @@ index 0000000000..5c77b6e8e1
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index edfcb107bd..cb99888707 100644
+index edfcb107b..cb9988870 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -184,6 +184,7 @@ public class Chunk implements IChunkAccess {
@@ -404,7 +404,7 @@ index edfcb107bd..cb99888707 100644
  
          Iterator iterator = protochunk.s().iterator();
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 958a4084e6..56a76e17ef 100644
+index 958a4084e..56a76e17e 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -38,9 +38,9 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -550,7 +550,7 @@ index 958a4084e6..56a76e17ef 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index c233b7e903..edd0742527 100644
+index c233b7e90..edd074252 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -120,7 +120,7 @@ public class ChunkRegionLoader implements IChunkLoader, IAsyncChunkSaver {
@@ -577,7 +577,7 @@ index c233b7e903..edd0742527 100644
                  completion = new Supplier<NBTTagCompound>() {
                      public NBTTagCompound get() {
 diff --git a/src/main/java/net/minecraft/server/ChunkSection.java b/src/main/java/net/minecraft/server/ChunkSection.java
-index bdfc7d81ff..a5c4564d60 100644
+index bdfc7d81f..a5c4564d6 100644
 --- a/src/main/java/net/minecraft/server/ChunkSection.java
 +++ b/src/main/java/net/minecraft/server/ChunkSection.java
 @@ -24,7 +24,17 @@ public class ChunkSection {
@@ -599,7 +599,7 @@ index bdfc7d81ff..a5c4564d60 100644
      public IBlockData getType(int i, int j, int k) {
          return this.blockIds.a(i, j, k);
 diff --git a/src/main/java/net/minecraft/server/ChunkTaskScheduler.java b/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
-index 34019bd1b3..fc9091c801 100644
+index 34019bd1b..fc9091c80 100644
 --- a/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
 +++ b/src/main/java/net/minecraft/server/ChunkTaskScheduler.java
 @@ -20,13 +20,14 @@ public class ChunkTaskScheduler extends Scheduler<ChunkCoordIntPair, ChunkStatus
@@ -670,7 +670,7 @@ index 34019bd1b3..fc9091c801 100644
  
      protected ProtoChunk a(ChunkCoordIntPair chunkcoordintpair, ChunkStatus chunkstatus, Map<ChunkCoordIntPair, ProtoChunk> map) {
 diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-index 71a3636be6..ff0fe25417 100644
+index 71a3636be..ff0fe2541 100644
 --- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
 +++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
 @@ -3,7 +3,7 @@ package net.minecraft.server;
@@ -755,7 +755,7 @@ index 71a3636be6..ff0fe25417 100644
  
      // Paper start - Anti-Xray - Support default methods
 diff --git a/src/main/java/net/minecraft/server/DefinedStructureManager.java b/src/main/java/net/minecraft/server/DefinedStructureManager.java
-index 271dc41d45..bd15534c23 100644
+index 271dc41d4..bd15534c2 100644
 --- a/src/main/java/net/minecraft/server/DefinedStructureManager.java
 +++ b/src/main/java/net/minecraft/server/DefinedStructureManager.java
 @@ -19,7 +19,7 @@ import org.apache.logging.log4j.Logger;
@@ -768,7 +768,7 @@ index 271dc41d45..bd15534c23 100644
      private final MinecraftServer d;
      private final java.nio.file.Path e;
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 0237049a40..cd601f29a3 100644
+index 0237049a4..cd601f29a 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -209,7 +209,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -781,7 +781,7 @@ index 0237049a40..cd601f29a3 100644
          this.aJ = Sets.newHashSet();
          this.aL = new double[] { 0.0D, 0.0D, 0.0D};
 diff --git a/src/main/java/net/minecraft/server/IChunkLoader.java b/src/main/java/net/minecraft/server/IChunkLoader.java
-index 4698ee99f8..dfb45cc4ea 100644
+index 4698ee99f..dfb45cc4e 100644
 --- a/src/main/java/net/minecraft/server/IChunkLoader.java
 +++ b/src/main/java/net/minecraft/server/IChunkLoader.java
 @@ -6,6 +6,8 @@ import javax.annotation.Nullable;
@@ -794,7 +794,7 @@ index 4698ee99f8..dfb45cc4ea 100644
      Chunk a(GeneratorAccess generatoraccess, int i, int j, Consumer<Chunk> consumer) throws IOException;
  
 diff --git a/src/main/java/net/minecraft/server/MathHelper.java b/src/main/java/net/minecraft/server/MathHelper.java
-index 49fba0979e..9ad646f8d4 100644
+index 49fba0979..9ad646f8d 100644
 --- a/src/main/java/net/minecraft/server/MathHelper.java
 +++ b/src/main/java/net/minecraft/server/MathHelper.java
 @@ -142,6 +142,7 @@ public class MathHelper {
@@ -806,7 +806,7 @@ index 49fba0979e..9ad646f8d4 100644
          fx = fx % 360.0F;
          if (fx >= 180.0F) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 98d182fdb8..487d98eb1b 100644
+index 98d182fdb..487d98eb1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -503,6 +503,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -904,7 +904,7 @@ index 98d182fdb8..487d98eb1b 100644
  
 diff --git a/src/main/java/net/minecraft/server/PaperAsyncChunkProvider.java b/src/main/java/net/minecraft/server/PaperAsyncChunkProvider.java
 new file mode 100644
-index 0000000000..5823917a65
+index 000000000..5823917a6
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/PaperAsyncChunkProvider.java
 @@ -0,0 +1,593 @@
@@ -1502,7 +1502,7 @@ index 0000000000..5823917a65
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 2c7c8adf7c..aabd107fe1 100644
+index 2c7c8adf7..aabd107fe 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -29,16 +29,62 @@ public class PlayerChunk {
@@ -1607,7 +1607,7 @@ index 2c7c8adf7c..aabd107fe1 100644
          }
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index d1a443ca8d..1504bd113b 100644
+index d1a443ca8..1504bd113 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -27,10 +27,10 @@ public class PlayerChunkMap {
@@ -1667,7 +1667,7 @@ index d1a443ca8d..1504bd113b 100644
  
      private void e() {
 diff --git a/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java b/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
-index 3c35c0f481..187ca2813a 100644
+index 3c35c0f48..187ca2813 100644
 --- a/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
 +++ b/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
 @@ -35,7 +35,7 @@ public class RegionLimitedWorldAccess implements GeneratorAccess {
@@ -1680,7 +1680,7 @@ index 3c35c0f481..187ca2813a 100644
          this.m = world.getChunkProvider().getChunkGenerator().getSettings();
          this.i = world.getSeaLevel();
 diff --git a/src/main/java/net/minecraft/server/SchedulerBatch.java b/src/main/java/net/minecraft/server/SchedulerBatch.java
-index d868149d1a..0d45d933ee 100644
+index d868149d1..0d45d933e 100644
 --- a/src/main/java/net/minecraft/server/SchedulerBatch.java
 +++ b/src/main/java/net/minecraft/server/SchedulerBatch.java
 @@ -9,6 +9,7 @@ public class SchedulerBatch<K, T extends SchedulerTask<K, T>, R> {
@@ -1735,7 +1735,7 @@ index d868149d1a..0d45d933ee 100644
      }
  }
 diff --git a/src/main/java/net/minecraft/server/StructurePiece.java b/src/main/java/net/minecraft/server/StructurePiece.java
-index a5cf017da1..def8730b86 100644
+index a5cf017da..def8730b8 100644
 --- a/src/main/java/net/minecraft/server/StructurePiece.java
 +++ b/src/main/java/net/minecraft/server/StructurePiece.java
 @@ -14,7 +14,7 @@ public abstract class StructurePiece {
@@ -1762,7 +1762,7 @@ index a5cf017da1..def8730b86 100644
          return null;
      }
 diff --git a/src/main/java/net/minecraft/server/StructureStart.java b/src/main/java/net/minecraft/server/StructureStart.java
-index f87182b5c4..574930f5fe 100644
+index f87182b5c..574930f5f 100644
 --- a/src/main/java/net/minecraft/server/StructureStart.java
 +++ b/src/main/java/net/minecraft/server/StructureStart.java
 @@ -6,7 +6,7 @@ import java.util.List;
@@ -1811,7 +1811,7 @@ index f87182b5c4..574930f5fe 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a2559f0c19..bbcedb8fc7 100644
+index a2559f0c1..bbcedb8fc 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -46,7 +46,7 @@ import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
@@ -1908,7 +1908,7 @@ index a2559f0c19..bbcedb8fc7 100644
          if (entity == null) return false;
          if (entity.valid) { MinecraftServer.LOGGER.error("Attempted Double World add on " + entity, new Throwable()); return true; } // Paper
 diff --git a/src/main/java/net/minecraft/server/WorldGenStronghold.java b/src/main/java/net/minecraft/server/WorldGenStronghold.java
-index fa99fe0146..4f49786aa3 100644
+index fa99fe014..4f49786aa 100644
 --- a/src/main/java/net/minecraft/server/WorldGenStronghold.java
 +++ b/src/main/java/net/minecraft/server/WorldGenStronghold.java
 @@ -9,24 +9,29 @@ import java.util.Random;
@@ -2055,7 +2055,7 @@ index fa99fe0146..4f49786aa3 100644
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index ad3fea9c97..0a76482638 100644
+index ad3fea9c9..0a7648263 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -731,7 +731,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
@@ -2068,7 +2068,7 @@ index ad3fea9c97..0a76482638 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cb2255a5d0..19f2f2bbd8 100644
+index 9c7b86a55..206cb30f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1014,8 +1014,12 @@ public final class CraftServer implements Server {
@@ -2096,7 +2096,7 @@ index cb2255a5d0..19f2f2bbd8 100644
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d0110070a9..02b6bf2990 100644
+index d0110070a..02b6bf299 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -157,6 +157,16 @@ public class CraftWorld implements World {
@@ -2134,7 +2134,7 @@ index d0110070a9..02b6bf2990 100644
                      if (isChunkLoaded(chunkCoordX + x, chunkCoordZ + z)) {
                          unloadChunk(chunkCoordX + x, chunkCoordZ + z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9e903159d9..4ead18b66c 100644
+index 9e903159d..4ead18b66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -78,6 +78,7 @@ public class CraftEventFactory {
@@ -2196,7 +2196,7 @@ index 9e903159d9..4ead18b66c 100644
  
          if (!event.isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
-index 9c2adb2351..62c197b80d 100644
+index 9c2adb235..62c197b80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
 @@ -21,6 +21,7 @@ public class CustomChunkGenerator extends InternalChunkGenerator<GeneratorSettin

--- a/Spigot-Server-Patches/0382-Configurable-connection-throttle-kick-message.patch
+++ b/Spigot-Server-Patches/0382-Configurable-connection-throttle-kick-message.patch
@@ -1,14 +1,14 @@
-From 74b6a933697fd43afd5340453412d5571fe1fa7d Mon Sep 17 00:00:00 2001
+From 4e8f913e813e7630d0b8658a19442a766bd98827 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Tue, 2 Oct 2018 09:57:50 +0100
 Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 454ac2c091..03c15e7c9f 100644
+index 77d35ac99..352166725 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -295,6 +295,11 @@ public class PaperConfig {
+@@ -305,6 +305,11 @@ public class PaperConfig {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
  
@@ -21,7 +21,7 @@ index 454ac2c091..03c15e7c9f 100644
      private static void savePlayerData() {
          savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
-index a02fa29217..7dc51fd995 100644
+index a02fa2921..7dc51fd99 100644
 --- a/src/main/java/net/minecraft/server/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/HandshakeListener.java
 @@ -37,7 +37,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -34,5 +34,5 @@ index a02fa29217..7dc51fd995 100644
                          this.b.close(chatmessage);
                          return;
 -- 
-2.19.0
+2.19.1
 

--- a/Spigot-Server-Patches/0399-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0399-Add-Velocity-IP-Forwarding-Support.patch
@@ -1,0 +1,282 @@
+From 43ace256826b0ea801936d572b0ca36b80dbb8b7 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Mon, 8 Oct 2018 14:36:14 -0400
+Subject: [PATCH] Add Velocity IP Forwarding Support
+
+While Velocity supports BungeeCord-style IP forwarding, it is not secure. Users
+have a lot of problems setting up firewalls or setting up plugins like IPWhitelist.
+Further, the BungeeCord IP forwarding protocol still retains essentially its original
+form, when there is brand new support for custom login plugin messages in 1.13.
+
+Velocity's modern IP forwarding uses an HMAC-SHA256 code to ensure authenticity
+of messages, is packed into a binary format that is smaller than BungeeCord's
+forwarding, and is integrated into the Minecraft login process by using the 1.13
+login plugin message packet.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 352166725..70f650bb2 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -8,6 +8,7 @@ import java.io.IOException;
+ import java.lang.reflect.InvocationTargetException;
+ import java.lang.reflect.Method;
+ import java.lang.reflect.Modifier;
++import java.nio.charset.StandardCharsets;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+@@ -256,7 +257,7 @@ public class PaperConfig {
+     }
+ 
+     public static boolean isProxyOnlineMode() {
+-        return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
++        return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode) || (velocitySupport && velocityOnlineMode);
+     }
+ 
+     public static int packetInSpamThreshold = 300;
+@@ -443,4 +444,18 @@ public class PaperConfig {
+             }
+         }
+     }
++
++    public static boolean velocitySupport;
++    public static boolean velocityOnlineMode;
++    public static byte[] velocitySecretKey;
++    private static void velocitySupport() {
++        velocitySupport = getBoolean("settings.velocity-support.enabled", false);
++        velocityOnlineMode = getBoolean("settings.velocity-support.online-mode", false);
++        String secret = getString("settings.velocity-support.secret", "");
++        if (velocitySupport && secret.isEmpty()) {
++            fatal("Velocity support is enabled, but no secret key was specified. A secret key is required!");
++        } else {
++            velocitySecretKey = secret.getBytes(StandardCharsets.UTF_8);
++        }
++    }
+ }
+diff --git a/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java b/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+new file mode 100644
+index 000000000..fdd8708f9
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/proxy/VelocityProxy.java
+@@ -0,0 +1,67 @@
++package com.destroystokyo.paper.proxy;
++
++import com.destroystokyo.paper.PaperConfig;
++import com.google.common.net.InetAddresses;
++import com.mojang.authlib.GameProfile;
++import com.mojang.authlib.properties.Property;
++import net.minecraft.server.MinecraftKey;
++import net.minecraft.server.PacketDataSerializer;
++
++import java.net.InetAddress;
++import java.security.InvalidKeyException;
++import java.security.MessageDigest;
++import java.security.NoSuchAlgorithmException;
++
++import javax.crypto.Mac;
++import javax.crypto.spec.SecretKeySpec;
++
++public class VelocityProxy {
++    private static final int SUPPORTED_FORWARDING_VERSION = 1;
++    public static final MinecraftKey PLAYER_INFO_CHANNEL = new MinecraftKey("velocity", "player_info");
++
++    public static boolean checkIntegrity(final PacketDataSerializer buf) {
++        final byte[] signature = new byte[32];
++        buf.readBytes(signature);
++
++        final byte[] data = new byte[buf.readableBytes()];
++        buf.getBytes(buf.readerIndex(), data);
++
++        try {
++            final Mac mac = Mac.getInstance("HmacSHA256");
++            mac.init(new SecretKeySpec(PaperConfig.velocitySecretKey, "HmacSHA256"));
++            final byte[] mySignature = mac.doFinal(data);
++            if (!MessageDigest.isEqual(signature, mySignature)) {
++                return false;
++            }
++        } catch (final InvalidKeyException | NoSuchAlgorithmException e) {
++            throw new AssertionError(e);
++        }
++
++        int version = buf.readVarInt();
++        if (version != SUPPORTED_FORWARDING_VERSION) {
++            throw new IllegalStateException("Unsupported forwarding version " + version + ", wanted " + SUPPORTED_FORWARDING_VERSION);
++        }
++
++        return true;
++    }
++
++    public static InetAddress readAddress(final PacketDataSerializer buf) {
++        return InetAddresses.forString(buf.readUTF(Short.MAX_VALUE));
++    }
++
++    public static GameProfile createProfile(final PacketDataSerializer buf) {
++        final GameProfile profile = new GameProfile(buf.readUUID(), buf.readUTF(16));
++        readProperties(buf, profile);
++        return profile;
++    }
++
++    private static void readProperties(final PacketDataSerializer buf, final GameProfile profile) {
++        final int properties = buf.readVarInt();
++        for (int i1 = 0; i1 < properties; i1++) {
++            final String name = buf.readUTF(Short.MAX_VALUE);
++            final String value = buf.readUTF(Short.MAX_VALUE);
++            final String signature = buf.readBoolean() ? buf.readUTF(Short.MAX_VALUE) : null;
++            profile.getProperties().put(name, new Property(name, value, signature));
++        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 5778a5201..b6a3992a3 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -43,6 +43,7 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+     private SecretKey loginKey;
+     private EntityPlayer l;
+     public String hostname = ""; // CraftBukkit - add field
++    private int velocityLoginMessageId = -1; // Paper - Velocity support
+ 
+     public LoginListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
+         this.g = LoginListener.EnumProtocolState.HELLO;
+@@ -187,6 +188,14 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+             this.g = LoginListener.EnumProtocolState.KEY;
+             this.networkManager.sendPacket(new PacketLoginOutEncryptionBegin("", this.server.E().getPublic(), this.e));
+         } else {
++            // Paper start - Velocity support
++            if (com.destroystokyo.paper.PaperConfig.velocitySupport) {
++                this.velocityLoginMessageId = java.util.concurrent.ThreadLocalRandom.current().nextInt();
++                PacketLoginOutCustomPayload packet = new PacketLoginOutCustomPayload(this.velocityLoginMessageId, com.destroystokyo.paper.proxy.VelocityProxy.PLAYER_INFO_CHANNEL, new PacketDataSerializer(io.netty.buffer.Unpooled.EMPTY_BUFFER));
++                this.networkManager.sendPacket(packet);
++                return;
++            }
++            // Paper end
+             // Spigot start
+             // Paper start - Cache authenticator threads
+             authenticatorPool.execute(new Runnable() {
+@@ -278,6 +287,12 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+     public class LoginHandler {
+ 
+         public void fireEvents() throws Exception {
++                            // Paper start - Velocity support
++                            if (LoginListener.this.velocityLoginMessageId == -1 && com.destroystokyo.paper.PaperConfig.velocitySupport) {
++                                disconnect("This server requires you to connect with Velocity.");
++                                return;
++                            }
++                            // Paper end
+                             String playerName = i.getName();
+                             java.net.InetAddress address = ((java.net.InetSocketAddress) networkManager.getSocketAddress()).getAddress();
+                             java.util.UUID uniqueId = i.getId();
+@@ -325,6 +340,35 @@ public class LoginListener implements PacketLoginInListener, ITickable {
+     // Spigot end
+ 
+     public void a(PacketLoginInCustomPayload packetloginincustompayload) {
++        // Paper start - Velocity support
++        if (com.destroystokyo.paper.PaperConfig.velocitySupport && packetloginincustompayload.getId() == this.velocityLoginMessageId) {
++            PacketDataSerializer buf = packetloginincustompayload.getBuf();
++            if (buf == null) {
++                this.disconnect("This server requires you to connect with Velocity.");
++                return;
++            }
++
++            if (!com.destroystokyo.paper.proxy.VelocityProxy.checkIntegrity(buf)) {
++                this.disconnect("Unable to verify player details");
++                return;
++            }
++
++            this.networkManager.setSpoofedRemoteAddress(new java.net.InetSocketAddress(com.destroystokyo.paper.proxy.VelocityProxy.readAddress(buf), ((java.net.InetSocketAddress) this.networkManager.getSocketAddress()).getPort()));
++
++            this.setGameProfile(com.destroystokyo.paper.proxy.VelocityProxy.createProfile(buf));
++
++            // Proceed with login
++            authenticatorPool.execute(() -> {
++                try {
++                    new LoginHandler().fireEvents();
++                } catch (Exception ex) {
++                    disconnect("Failed to verify username!");
++                    server.server.getLogger().log(java.util.logging.Level.WARNING, "Exception verifying " + i.getName(), ex);
++                }
++            });
++            return;
++        }
++        // Paper end
+         this.disconnect(new ChatMessage("multiplayer.disconnect.unexpected_query_response", new Object[0]));
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index b2afec5e4..97a9dffe6 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -48,7 +48,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+     private final ReentrantReadWriteLock j = new ReentrantReadWriteLock();
+     public Channel channel;
+     // Spigot Start // PAIL
+-    public SocketAddress l;
++    public SocketAddress l; public void setSpoofedRemoteAddress(SocketAddress address) { this.l = address; } // Paper - OBFHELPER
+     public java.util.UUID spoofedUUID;
+     public com.mojang.authlib.properties.Property[] spoofedProfile;
+     public boolean preparing = true;
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index cab837483..fb6e373f0 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -140,6 +140,7 @@ public class PacketDataSerializer extends ByteBuf {
+         return this.d(oenum.ordinal());
+     }
+ 
++    public int readVarInt() { return this.g(); } // Paper - OBFHELPER
+     public int g() {
+         int i = 0;
+         int j = 0;
+@@ -180,6 +181,7 @@ public class PacketDataSerializer extends ByteBuf {
+         return this;
+     }
+ 
++    public UUID readUUID() { return this.i(); } // Paper - OBFHELPER
+     public UUID i() {
+         return new UUID(this.readLong(), this.readLong());
+     }
+@@ -298,6 +300,7 @@ public class PacketDataSerializer extends ByteBuf {
+         }
+     }
+ 
++    public String readUTF(int maxLength) { return this.e(maxLength); } // Paper - OBFHELPER
+     public String e(int i) {
+         int j = this.g();
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+index e3c0094f7..edfd4a506 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
++++ b/src/main/java/net/minecraft/server/PacketLoginInCustomPayload.java
+@@ -3,8 +3,8 @@ package net.minecraft.server;
+ import java.io.IOException;
+ 
+ public class PacketLoginInCustomPayload implements Packet<PacketLoginInListener> {
+-    private int a;
+-    private PacketDataSerializer b;
++    private int a; public int getId() { return a; } // Paper - OBFHELPER
++    private PacketDataSerializer b; public PacketDataSerializer getBuf() { return b; } // Paper - OBFHELPER
+ 
+     public PacketLoginInCustomPayload() {
+     }
+diff --git a/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+index 9c5559ece..9de0421bb 100644
+--- a/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
++++ b/src/main/java/net/minecraft/server/PacketLoginOutCustomPayload.java
+@@ -10,6 +10,14 @@ public class PacketLoginOutCustomPayload implements Packet<PacketLoginOutListene
+     public PacketLoginOutCustomPayload() {
+     }
+ 
++    // Paper start
++    public PacketLoginOutCustomPayload(int id, MinecraftKey channel, PacketDataSerializer buf) {
++        this.a = id;
++        this.b = channel;
++        this.c = buf;
++    }
++    // Paper end
++
+     public void a(PacketDataSerializer packetdataserializer) throws IOException {
+         this.a = packetdataserializer.g();
+         this.b = packetdataserializer.l();
+-- 
+2.19.1
+


### PR DESCRIPTION
While Velocity already supports BungeeCord-style IP forwarding (which almost everyone supports now), it is not secure. Users have a lot of problems setting up firewalls or setting up plugins like iPWhitelist. Further, the BungeeCord IP forwarding protocol still retains essentially its original form, when there is brand new support for custom login plugin messages in 1.13.

Velocity's modern IP forwarding uses an HMAC-SHA256 code to ensure authenticity of messages (users have to set up an unique secret), is packed into a binary format that is smaller than BungeeCord's forwarding, and is integrated into the Minecraft login process by using the 1.13 login plugin message packet.

I have verified this with Velocity build 303 in online-mode.