### PR TITLE
Keep trying keepalive ping

### DIFF
--- a/Spigot-Server-Patches/0393-Keep-trying-keepalive-ping.patch
+++ b/Spigot-Server-Patches/0393-Keep-trying-keepalive-ping.patch
@@ -1,11 +1,11 @@
-From dba3e344923ef1f71d7fe71f3ed633e450e02258 Mon Sep 17 00:00:00 2001
+From a8af5f9ea6bee2dc73c358424cc486f28d6d0bac Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 14 Oct 2018 18:32:51 -0500
 Subject: [PATCH] Keep trying keepalive ping
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 1e5ac7185..a11cd2637 100644
+index 1e5ac7185..3751ca95d 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -74,6 +74,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
@@ -16,19 +16,18 @@ index 1e5ac7185..a11cd2637 100644
      // CraftBukkit start - multithreaded fields
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
-@@ -188,15 +189,22 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+@@ -188,15 +189,21 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
          long elapsedTime = currentTime - this.getLastPing();
  
          if (this.isPendingPing()) {
 -            if (!this.processedDisconnect && elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
 -                PlayerConnection.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getName()); // more info
 -                this.disconnect(new ChatMessage("disconnect.timeout", new Object[0]));
-+            if (!this.processedDisconnect) {
-+                if (elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
++            if (!this.processedDisconnect) { // don't fire if already disconnected
++                if (elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit
 +                    PlayerConnection.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getName()); // more info
 +                    this.disconnect(new ChatMessage("disconnect.timeout", new Object[0]));
-+                } else if (++lastPingAttempt > 20) {
-+                    // lets keep trying every 20 ticks instead of relying on a single packet
++                } else if (++lastPingAttempt > 20) { // keep trying every 20 ticks instead of relying on a single packet
 +                    lastPingAttempt = 0;
 +                    sendPacket(new PacketPlayOutKeepAlive(getKeepAliveID()));
 +                }

--- a/Spigot-Server-Patches/0393-Keep-trying-keepalive-ping.patch
+++ b/Spigot-Server-Patches/0393-Keep-trying-keepalive-ping.patch
@@ -1,0 +1,47 @@
+From dba3e344923ef1f71d7fe71f3ed633e450e02258 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 14 Oct 2018 18:32:51 -0500
+Subject: [PATCH] Keep trying keepalive ping
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 1e5ac7185..a11cd2637 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -74,6 +74,7 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+     private long f = SystemUtils.b(); private void setLastPing(long lastPing) { this.f = lastPing;}; private long getLastPing() { return this.f;}; // Paper - OBFHELPER - set ping to delay initial
+     private boolean g; private void setPendingPing(boolean isPending) { this.g = isPending;}; private boolean isPendingPing() { return this.g;}; // Paper - OBFHELPER
+     private long h; private void setKeepAliveID(long keepAliveID) { this.h = keepAliveID;}; private long getKeepAliveID() {return this.h; };  // Paper - OBFHELPER
++    private int lastPingAttempt; // Paper - number of ticks since last keepalive ping attempt
+     // CraftBukkit start - multithreaded fields
+     private volatile int chatThrottle;
+     private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
+@@ -188,15 +189,22 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+         long elapsedTime = currentTime - this.getLastPing();
+ 
+         if (this.isPendingPing()) {
+-            if (!this.processedDisconnect && elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
+-                PlayerConnection.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getName()); // more info
+-                this.disconnect(new ChatMessage("disconnect.timeout", new Object[0]));
++            if (!this.processedDisconnect) {
++                if (elapsedTime >= KEEPALIVE_LIMIT) { // check keepalive limit, don't fire if already disconnected
++                    PlayerConnection.LOGGER.warn("{} was kicked due to keepalive timeout!", this.player.getName()); // more info
++                    this.disconnect(new ChatMessage("disconnect.timeout", new Object[0]));
++                } else if (++lastPingAttempt > 20) {
++                    // lets keep trying every 20 ticks instead of relying on a single packet
++                    lastPingAttempt = 0;
++                    sendPacket(new PacketPlayOutKeepAlive(getKeepAliveID()));
++                }
+             }
+         } else {
+             if (elapsedTime >= 15000L) { // 15 seconds
+                 this.setPendingPing(true);
+                 this.setLastPing(currentTime);
+                 this.setKeepAliveID(currentTime);
++                lastPingAttempt = 0;
+                 this.sendPacket(new PacketPlayOutKeepAlive(this.getKeepAliveID()));
+ 
+             }
+-- 
+2.19.1
+


### PR DESCRIPTION
Mojang sends a single keepalive packet out and waits eternally for it's reply. If that packet gets dropped for any reason the player will get kicked, even if they are still connected and playing with all other packets working normally.

This change will keep sending the keepalive packet every 20 ticks until a response is received or the player is kicked.