### PR TITLE
Entity Jump API

### DIFF
--- a/Spigot-API-Patches/0190-Entity-Jump-API.patch
+++ b/Spigot-API-Patches/0190-Entity-Jump-API.patch
@@ -1,0 +1,91 @@
+From a8b56634a5ca81cad0a7290711a6054000a28f7c Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sat, 8 Feb 2020 23:26:18 -0600
+Subject: [PATCH] Entity Jump API
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java
+new file mode 100644
+index 00000000..f0067c2e
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/EntityJumpEvent.java
+@@ -0,0 +1,46 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity jumps
++ * <p>
++ * Cancelling the event will stop the entity from jumping
++ */
++public class EntityJumpEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean canceled;
++
++    public EntityJumpEvent(@NotNull LivingEntity entity) {
++        super(entity);
++    }
++
++    @NotNull
++    @Override
++    public LivingEntity getEntity() {
++        return (LivingEntity) entity;
++    }
++
++    public boolean isCancelled() {
++        return canceled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        canceled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 240f276c..77f4246d 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -680,5 +680,25 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * @return Whether or not this entity is using or charging an attack (Bow pulled back, drinking potion, eating food)
+      */
+     boolean isHandRaised();
++
++    /**
++     * Get entity jump state.
++     * <p>
++     * Jump state will be true when the entity has been marked to jump.
++     *
++     * @return entity jump state.
++     */
++    boolean isJumping();
++
++    /**
++     * Set entity jump state
++     * <p>
++     * Setting to true will mark the entity to jump.
++     * <p>
++     * Setting to false will unmark the entity to jump but will not stop a jump already in-progress.
++     *
++     * @param jumping entity jump state
++     */
++    void setJumping(boolean jumping);
+     // Paper end
+ }
+-- 
+2.25.0
+

--- a/Spigot-Server-Patches/0438-Entity-Jump-API.patch
+++ b/Spigot-Server-Patches/0438-Entity-Jump-API.patch
@@ -1,11 +1,11 @@
-From 93fe829f7a7f1c18a7307f70ca9f0121eaa53756 Mon Sep 17 00:00:00 2001
+From 9911996a0ea1415b4aa0505bf54b15624235310e Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sat, 8 Feb 2020 23:26:11 -0600
 Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 1b9551ae0..1572ed34e 100644
+index 1b9551ae0..ad474500e 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -91,7 +91,7 @@ public abstract class EntityLiving extends Entity {
@@ -24,12 +24,12 @@ index 1b9551ae0..1572ed34e 100644
 +                if (new com.destroystokyo.paper.event.entity.EntityJumpEvent(getBukkitLivingEntity()).callEvent()) { // Paper
                  this.jump();
                  this.jumpTicks = 10;
-+                } // Paper
++                } else { this.setJumping(false); } // Paper - setJumping(false) stops a potential loop
              }
          } else {
              this.jumpTicks = 0;
 diff --git a/src/main/java/net/minecraft/server/EntityPanda.java b/src/main/java/net/minecraft/server/EntityPanda.java
-index cd41c80f1..32bfb4ef7 100644
+index cd41c80f1..f50ed1908 100644
 --- a/src/main/java/net/minecraft/server/EntityPanda.java
 +++ b/src/main/java/net/minecraft/server/EntityPanda.java
 @@ -438,7 +438,9 @@ public class EntityPanda extends EntityAnimal {
@@ -38,7 +38,7 @@ index cd41c80f1..32bfb4ef7 100644
              if (!entitypanda.isBaby() && entitypanda.onGround && !entitypanda.isInWater() && entitypanda.eL()) {
 +                if (new com.destroystokyo.paper.event.entity.EntityJumpEvent(getBukkitLivingEntity()).callEvent()) { // Paper
                  entitypanda.jump();
-+                } // Paper
++                } else { this.setJumping(false); } // Paper - setJumping(false) stops a potential loop
              }
          }
  

--- a/Spigot-Server-Patches/0438-Entity-Jump-API.patch
+++ b/Spigot-Server-Patches/0438-Entity-Jump-API.patch
@@ -1,0 +1,72 @@
+From 93fe829f7a7f1c18a7307f70ca9f0121eaa53756 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <Blake.Galbreath@GMail.com>
+Date: Sat, 8 Feb 2020 23:26:11 -0600
+Subject: [PATCH] Entity Jump API
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 1b9551ae0..1572ed34e 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -91,7 +91,7 @@ public abstract class EntityLiving extends Entity {
+     protected float aV;
+     protected int aW; protected int getKillCount() { return this.aW; } // Paper - OBFHELPER
+     public float lastDamage;
+-    protected boolean jumping;
++    public boolean jumping; // Paper - protected -> public
+     public float aZ;
+     public float ba;
+     public float bb;
+@@ -2605,8 +2605,10 @@ public abstract class EntityLiving extends Entity {
+             } else if (this.aH()) {
+                 this.c(TagsFluid.LAVA);
+             } else if ((this.onGround || this.N > 0.0D && this.N <= 0.4D) && this.jumpTicks == 0) {
++                if (new com.destroystokyo.paper.event.entity.EntityJumpEvent(getBukkitLivingEntity()).callEvent()) { // Paper
+                 this.jump();
+                 this.jumpTicks = 10;
++                } // Paper
+             }
+         } else {
+             this.jumpTicks = 0;
+diff --git a/src/main/java/net/minecraft/server/EntityPanda.java b/src/main/java/net/minecraft/server/EntityPanda.java
+index cd41c80f1..32bfb4ef7 100644
+--- a/src/main/java/net/minecraft/server/EntityPanda.java
++++ b/src/main/java/net/minecraft/server/EntityPanda.java
+@@ -438,7 +438,9 @@ public class EntityPanda extends EntityAnimal {
+             EntityPanda entitypanda = (EntityPanda) iterator.next();
+ 
+             if (!entitypanda.isBaby() && entitypanda.onGround && !entitypanda.isInWater() && entitypanda.eL()) {
++                if (new com.destroystokyo.paper.event.entity.EntityJumpEvent(getBukkitLivingEntity()).callEvent()) { // Paper
+                 entitypanda.jump();
++                } // Paper
+             }
+         }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index b27fd44dc..277eb54e7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -711,5 +711,20 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public boolean isHandRaised() {
+         return getHandle().isHandRaised();
+     }
++
++    @Override
++    public boolean isJumping() {
++        return getHandle().jumping;
++    }
++
++    @Override
++    public void setJumping(boolean jumping) {
++        getHandle().setJumping(jumping);
++        if (jumping && getHandle() instanceof EntityInsentient) {
++            // this is needed to actually make a mob jump
++            ((EntityInsentient) getHandle()).getControllerJump().jump();
++        }
++    }
++
+     // Paper end
+ }
+-- 
+2.25.0
+


### PR DESCRIPTION
This change exposes vanilla's jump state and add new event for when an entity jumps.

When an entity is marked ready to jump it's jump state is set to true. On the next tick, if conditions are met (on ground or in liquid, jump tick delay is 0, etc) the entity will jump. This state is reset to false every tick.

If vanilla conditions are met, the new jump event will fire with cancellation as its last condition before the entity actually jumps.