### PR TITLE
Don't modify item tag if interaction is canceled

### DIFF
--- a/Spigot-Server-Patches/0401-Don-t-modify-item-tag-if-interaction-is-canceled.patch
+++ b/Spigot-Server-Patches/0401-Don-t-modify-item-tag-if-interaction-is-canceled.patch
@@ -1,0 +1,60 @@
+From 7ac07ac07ac07ac07ac07ac07ac07ac07ac07ac0 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Sat, 20 Oct 2018 03:45:34 +0200
+Subject: [PATCH] Don't modify item tag if interaction is canceled
+
+The item tag is stored before executing the interaction and restored before handling the
+resulting events. If the event was not canceled and the ItemStack is not modified in the
+event, the new tag is set back to the new one afterwards. This is similar to the handling
+of the item amount.
+
+This fixes a bug where tools lose durability when the interaction is canceled and another bug
+where tools become completely repaired when they should break but the interaction was canceled.
+
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index 7ac07ac07ac0..7ac07ac07ac0 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -168,6 +168,7 @@ public final class ItemStack {
+         } else {
+             // CraftBukkit start - handle all block place event logic here
+             int oldCount = this.getCount();
++            NBTTagCompound oldTag = this.tag != null ? this.tag.clone() : null; // Paper - capture old tag
+             World world = itemactioncontext.getWorld();
+ 
+             if (!(this.getItem() instanceof ItemBucket)) { // if not bucket
+@@ -180,7 +181,9 @@ public final class ItemStack {
+             Item item = this.getItem();
+             EnumInteractionResult enuminteractionresult = item.a(itemactioncontext);
+             int newCount = this.getCount();
++            NBTTagCompound newTag = this.tag != null ? this.tag.clone() : null; // Paper - capture modified tag
+             this.setCount(oldCount);
++            this.tag = oldTag; // Paper - restore old tag for the event
+             world.captureBlockStates = false;
+             if (enuminteractionresult == EnumInteractionResult.SUCCESS && world.captureTreeGeneration && world.capturedBlockStates.size() > 0) {
+                 world.captureTreeGeneration = false;
+@@ -202,8 +205,9 @@ public final class ItemStack {
+ 
+                 if (!fertilizeEvent.isCancelled()) {
+                     // Change the stack to its new contents if it hasn't been tampered with.
+-                    if (this.getCount() == oldCount) {
++                    if (this.getCount() == oldCount && java.util.Objects.equals(this.tag, oldTag)) { // Paper - compare the tag too
+                         this.setCount(newCount);
++                        this.tag = newTag; // Paper - restore modified tag
+                     }
+                     for (BlockState blockstate : blocks) {
+                         blockstate.update(true);
+@@ -249,8 +253,9 @@ public final class ItemStack {
+                     }
+                 } else {
+                     // Change the stack to its new contents if it hasn't been tampered with.
+-                    if (this.getCount() == oldCount) {
++                    if (this.getCount() == oldCount && java.util.Objects.equals(this.tag, oldTag)) { // Paper - compare the tag too
+                         this.setCount(newCount);
++                        this.tag = newTag; // Paper - restore modified tag
+                     }
+ 
+                     for (Map.Entry<BlockPosition, TileEntity> e : world.capturedTileEntities.entrySet()) {
+-- 
+2.16.1.windows.1
+


### PR DESCRIPTION
The item tag is stored before executing the interaction and restored before handling the
resulting events. If the event was not canceled and the ItemStack is not modified in the
event, the new tag is set back to the new one afterwards. This is similar to the handling
of the item amount.

This fixes a bug where tools lose durability when the interaction is canceled and another bug
where tools become completely repaired when they should break but the interaction was canceled.