### PR TITLE
Change the reserved channel check to be sensible

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -39,4 +39,5 @@ willies952002 <admin@domnian.com>
 MicleBrick <miclebrick@outlook.com>
 Trigary <trigary0@gmail.com>
 rickyboy320 <rickw320@hotmail.com>
+DoNotSpamPls <7570108+DoNotSpamPls@users.noreply.github.com>
 ```

--- a/Spigot-API-Patches/0167-Change-the-reserved-channel-check-to-be-sensible.patch
+++ b/Spigot-API-Patches/0167-Change-the-reserved-channel-check-to-be-sensible.patch
@@ -1,0 +1,37 @@
+From 7ac07ac07ac07ac07ac07ac07ac07ac07ac07ac0 Mon Sep 17 00:00:00 2001
+From: DoNotSpamPls <7570108+DoNotSpamPls@users.noreply.github.com>
+Date: Tue, 23 Oct 2018 19:32:55 +0300
+Subject: [PATCH] Change the reserved channel check to be sensible
+
+
+diff --git a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
+index 7ac07ac07ac0..7ac07ac07ac0 100644
+--- a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
++++ b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
+@@ -170,7 +170,7 @@ public class StandardMessenger implements Messenger {
+     public boolean isReservedChannel(String channel) {
+         channel = validateAndCorrectChannel(channel);
+ 
+-        return channel.contains("minecraft");
++        return channel.equals("minecraft:register") || channel.equals("minecraft:unregister"); // Paper
+     }
+ 
+     public void registerOutgoingPluginChannel(Plugin plugin, String channel) {
+diff --git a/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java b/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
+index 7ac07ac07ac0..7ac07ac07ac0 100644
+--- a/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
++++ b/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
+@@ -25,8 +25,8 @@ public class StandardMessengerTest {
+         assertTrue(messenger.isReservedChannel("minecraft:register"));
+         assertFalse(messenger.isReservedChannel("test:register"));
+         assertTrue(messenger.isReservedChannel("minecraft:unregister"));
+-        assertFalse(messenger.isReservedChannel("test:nregister"));
+-        assertTrue(messenger.isReservedChannel("minecraft:something"));
++        assertFalse(messenger.isReservedChannel("test:unregister"));
++        assertFalse(messenger.isReservedChannel("minecraft:something"));
+     }
+ 
+     @Test
+-- 
+2.19.1.windows.1
+

--- a/Spigot-API-Patches/0170-Change-the-reserved-channel-check-to-be-sensible.patch
+++ b/Spigot-API-Patches/0170-Change-the-reserved-channel-check-to-be-sensible.patch
@@ -1,24 +1,24 @@
-From 7ac07ac07ac07ac07ac07ac07ac07ac07ac07ac0 Mon Sep 17 00:00:00 2001
+From eb7842870179959eb5cec665ae4e51cda37da706 Mon Sep 17 00:00:00 2001
 From: DoNotSpamPls <7570108+DoNotSpamPls@users.noreply.github.com>
 Date: Tue, 23 Oct 2018 19:32:55 +0300
 Subject: [PATCH] Change the reserved channel check to be sensible
 
 
 diff --git a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
-index 7ac07ac07ac0..7ac07ac07ac0 100644
+index f21cae72..865028d3 100644
 --- a/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
 +++ b/src/main/java/org/bukkit/plugin/messaging/StandardMessenger.java
 @@ -170,7 +170,7 @@ public class StandardMessenger implements Messenger {
      public boolean isReservedChannel(String channel) {
          channel = validateAndCorrectChannel(channel);
  
--        return channel.contains("minecraft");
+-        return channel.contains("minecraft") && !channel.equals("minecraft:brand");
 +        return channel.equals("minecraft:register") || channel.equals("minecraft:unregister"); // Paper
      }
  
      public void registerOutgoingPluginChannel(Plugin plugin, String channel) {
 diff --git a/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java b/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
-index 7ac07ac07ac0..7ac07ac07ac0 100644
+index c15fa003..31ff2f61 100644
 --- a/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
 +++ b/src/test/java/org/bukkit/plugin/messaging/StandardMessengerTest.java
 @@ -25,8 +25,8 @@ public class StandardMessengerTest {
@@ -27,11 +27,11 @@ index 7ac07ac07ac0..7ac07ac07ac0 100644
          assertTrue(messenger.isReservedChannel("minecraft:unregister"));
 -        assertFalse(messenger.isReservedChannel("test:nregister"));
 -        assertTrue(messenger.isReservedChannel("minecraft:something"));
-+        assertFalse(messenger.isReservedChannel("test:unregister"));
-+        assertFalse(messenger.isReservedChannel("minecraft:something"));
++        assertFalse(messenger.isReservedChannel("test:unregister")); // Paper - fix typo
++        assertFalse(messenger.isReservedChannel("minecraft:something")); // Paper - now less strict
+         assertFalse(messenger.isReservedChannel("minecraft:brand"));
      }
  
-     @Test
 -- 
-2.19.1.windows.1
+2.19.1
 

--- a/Spigot-Server-Patches/0399-Don-t-sleep-after-profile-lookups-if-not-needed.patch
+++ b/Spigot-Server-Patches/0399-Don-t-sleep-after-profile-lookups-if-not-needed.patch
@@ -1,4 +1,4 @@
-From d92a33da313b20dcf7bfcf7a9070c403e961444e Mon Sep 17 00:00:00 2001
+From 59ba59cc95b4a0887b189efc1012a2c294a29e9d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 23 Oct 2018 20:25:05 -0400
 Subject: [PATCH] Don't sleep after profile lookups if not needed
@@ -7,7 +7,7 @@ Mojang was sleeping even if we had no more requests to go after
 the current one finished, resulting in 100ms lost per profile lookup
 
 diff --git a/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java b/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
-index 26a743722..6ed3199c3 100644
+index 71e48e87b..23f1447cf 100644
 --- a/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
 +++ b/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
 @@ -42,6 +42,7 @@ public class YggdrasilGameProfileRepository implements GameProfileRepository {
@@ -32,5 +32,5 @@ index 26a743722..6ed3199c3 100644
                      try {
                          Thread.sleep(DELAY_BETWEEN_PAGES);
 -- 
-2.19.2
+2.19.1
 


### PR DESCRIPTION
For whatever reason, Spigot blocks the registration of any channel that has "minecraft" in its name (funnily enough, even if it's after the namespace). This however, causes issues for plugins that want to use some of the plugin channels in the `minecraft` namespace, such as `minecraft:brand`.

For this reason, I've changed the check to only block the usage of the `register` and `unregister` channels, as those are reserved.