### PR TITLE
Fix "grep: repetition-operator operand invalid"

### DIFF
--- a/scripts/decompile.sh
+++ b/scripts/decompile.sh
@@ -25,8 +25,8 @@ versionjson="$workdir/Minecraft/$minecraftversion/$minecraftversion.json"
 if [ ! -f "$versionjson" ]; then
     echo "Downloading $minecraftversion JSON Data"
     verescaped=$(echo ${minecraftversion} | sed 's/\./\\./g')
-    verentry=$(curl -s "https://launchermeta.mojang.com/mc/game/version_manifest.json" | grep -oE "{\"id\": \"${verescaped}\".*?${verescaped}\.json")
-    jsonurl=$(echo $verentry | grep -oE https:\/\/.*?\.json)
+    verentry=$(curl -s "https://launchermeta.mojang.com/mc/game/version_manifest.json" | grep -oE "{\"id\": \"${verescaped}\".*${verescaped}\.json")
+    jsonurl=$(echo $verentry | grep -oE https:\/\/.*\.json)
     curl -o "$versionjson" "$jsonurl"
     echo "$versionjson - $jsonurl"
 fi


### PR DESCRIPTION
Some flavours of grep don't like '?' in their expressions (also `.*?` means "match zero or more times or maybe do not match at all" as far as I know).

Tested on:
- [x] (Arch) Linux
- [x] OpenBSD
- [x] FreeBSD
- [x] Windows ("git bash" environment)
- [x] OS X (tested on 10.13.6 High Sierra)

~~If someone could report if it's working on OS X and Windows, it'd be great :smile:~~