### PR TITLE
Fix silk touch and fortune enchantments not working on last use (MC-136865)

### DIFF
--- a/Spigot-Server-Patches/0402-MC-136865-Pass-original-itemstack-for-enchantment-ch.patch
+++ b/Spigot-Server-Patches/0402-MC-136865-Pass-original-itemstack-for-enchantment-ch.patch
@@ -1,0 +1,36 @@
+From 59536510426e4b5b939dcc937a244b20491d48ae Mon Sep 17 00:00:00 2001
+From: MisterVector <whizkid3000@hotmail.com>
+Date: Thu, 1 Nov 2018 14:50:05 -0700
+Subject: [PATCH] MC-136865: Use valid item for enchantment checks on block break
+
+When an itemstack runs out of durability, the amount is reduced to
+0 which then marks the item as invalid. This causes the last unit
+of durability to not apply enchantments as the enchantment level
+check sees the item as a dud.
+
+keep the clone of the item used to a non empty value so it represents
+the item used.
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+index 23fc4d8e..dbbd1f33 100644
+--- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
++++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+@@ -378,8 +378,13 @@ public class PlayerInteractManager {
+                     itemstack1.a(this.world, iblockdata, blockposition, this.player);
+                     // CraftBukkit start - Check if block should drop items
+                     if (flag && flag1 && event.isDropItems()) {
+-                        ItemStack itemstack2 = itemstack1.isEmpty() ? ItemStack.a : itemstack1.cloneItemStack();
++                        // Paper start - fixes MC-136865
++                        ItemStack itemstack2 = itemstack1.cloneItemStack(true);
+ 
++                        if (itemstack2.isEmpty()) {
++                            itemstack2.add(1);
++                        }
++                        // Paper end
+                         iblockdata.getBlock().a(this.world, this.player, blockposition, iblockdata, tileentity, itemstack2);
+                     }
+                     // CraftBukkit end
+-- 
+2.16.1.windows.4
+


### PR DESCRIPTION
Fix for MC-136865. Addresses #1631

The problem was that items with only one use left were not applying the silk touch/fortune enchantments. The issue is because while processing the item's last use, the item count was set to 0. After this point, NMS code ended up cloning the item stack, but because the count had already been set to 0, a null item stack was given. This was before determining the item entity to be spawned in the world once a block was broken. It is at this point that the enchantments were already discarded prior to determining the drop.

The fix was to clone the original item stack and give it a count of 1. The proper logic of checking the enchantments would then be correct.