### PR TITLE
Fix PreFillProfileEvent

### DIFF
--- a/Spigot-Server-Patches/0407-Fix-PreFillProfileEvent.patch
+++ b/Spigot-Server-Patches/0407-Fix-PreFillProfileEvent.patch
@@ -1,0 +1,24 @@
+From 510c7b25cfd7517fd29e1c76d1f124f06f58f8b2 Mon Sep 17 00:00:00 2001
+From: BlackHole <black-hole@live.com>
+Date: Thu, 8 Nov 2018 20:04:11 +0100
+Subject: [PATCH] Fix PreFillProfileEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
+index f83aa5ef0..61cfdf73c 100644
+--- a/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
++++ b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
+@@ -21,7 +21,9 @@ public class PaperMinecraftSessionService extends YggdrasilMinecraftSessionServi
+ 
+     @Override
+     public GameProfile fillProfileProperties(GameProfile profile, boolean requireSecure) {
+-        new PreFillProfileEvent(CraftPlayerProfile.asBukkitMirror(profile)).callEvent();
++        CraftPlayerProfile playerProfile = (CraftPlayerProfile) CraftPlayerProfile.asBukkitMirror(profile);
++        new PreFillProfileEvent(playerProfile).callEvent();
++        profile = playerProfile.getGameProfile();
+         if (profile.isComplete() && profile.getProperties().containsKey("textures")) {
+             return profile;
+         }
+-- 
+2.19.1.windows.1
+


### PR DESCRIPTION
The use case for this event is for plugins to fill in the name and textures on a PlayerProfile. The implementing class CraftPlayerProfile creates a new GameProfile on every call to setName() or setId(), so the used GameProfile has to updated after the event returns.