### PR TITLE
Disable watchdog early timeout for CraftServer#reload() invocations

### DIFF
--- a/Spigot-Server-Patches/0324-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0324-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -1,4 +1,4 @@
-From 92edd7342e31fb32f8cb5249c30aefb8570cd12b Mon Sep 17 00:00:00 2001
+From 4fcb18f366f3c6f24b150f1c5a192081e02866c3 Mon Sep 17 00:00:00 2001
 From: miclebrick <miclebrick@outlook.com>
 Date: Wed, 8 Aug 2018 15:30:52 -0400
 Subject: [PATCH] Add Early Warning Feature to WatchDog
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index fad2f8f822..4061073b22 100644
+index 59264969a..8e522e3aa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -36,7 +36,7 @@ index fad2f8f822..4061073b22 100644
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 498a0c4504..1166209840 100644
+index c3efb5e1b..ca72e6ad1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -796,6 +796,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -47,8 +47,28 @@ index 498a0c4504..1166209840 100644
                  Arrays.fill( recentTps, 20 );
                  long start = System.nanoTime(), curTime, wait, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 71d1929c1..93a8f4cdf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -750,6 +750,7 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public void reload() {
++        org.spigotmc.WatchdogThread.hasStarted = false; // Paper - Disable watchdog early timeout on reload
+         reloadCount++;
+         configuration = YamlConfiguration.loadConfiguration(getConfigFile());
+         commandsConfiguration = YamlConfiguration.loadConfiguration(getCommandsConfigFile());
+@@ -855,6 +856,7 @@ public final class CraftServer implements Server {
+         enablePlugins(PluginLoadOrder.STARTUP);
+         enablePlugins(PluginLoadOrder.POSTWORLD);
+         getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));
++        org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index eed96c60c5..496c5cbdff 100644
+index eed96c60c..496c5cbdf 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -226,7 +226,7 @@ public class SpigotConfig
@@ -61,7 +81,7 @@ index eed96c60c5..496c5cbdff 100644
  
      public static boolean bungee;
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index ed5f46bf6f..9dba9510f5 100644
+index ed5f46bf6..9dba9510f 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -5,6 +5,7 @@ import java.lang.management.MonitorInfo;
@@ -162,5 +182,5 @@ index ed5f46bf6f..9dba9510f5 100644
              {
                  interrupt();
 -- 
-2.19.1
+2.20.0
 

--- a/Spigot-Server-Patches/0364-Support-Overriding-World-Seeds.patch
+++ b/Spigot-Server-Patches/0364-Support-Overriding-World-Seeds.patch
@@ -1,4 +1,4 @@
-From 64d56663c66ec98c6757398ac107881d086953c1 Mon Sep 17 00:00:00 2001
+From 84ee7f41eaf438a751ebb46ee8f077a9e4b90cbe Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 17 Sep 2018 23:05:31 -0400
 Subject: [PATCH] Support Overriding World Seeds
@@ -15,7 +15,7 @@ This seed will end up being saved to the world data file, so it is
 a permanent change in that it won't go back if you remove it from paper.yml
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4061073b2..b703e0848 100644
+index 8e522e3aa..c54465a62 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -11,6 +11,7 @@ import java.lang.reflect.Modifier;
@@ -59,7 +59,7 @@ index 4061073b2..b703e0848 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2105fa50b..1f9e8a082 100644
+index 9b2703fd2..ef49fc258 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -350,7 +350,7 @@ public abstract class MinecraftServer implements IAsyncTaskHandler, IMojangStati
@@ -72,7 +72,7 @@ index 2105fa50b..1f9e8a082 100644
  
              if (j == 0) {
 diff --git a/src/main/java/net/minecraft/server/WorldData.java b/src/main/java/net/minecraft/server/WorldData.java
-index b3e1bee92..3ef1a7c2d 100644
+index 33d878378..b9cc0e898 100644
 --- a/src/main/java/net/minecraft/server/WorldData.java
 +++ b/src/main/java/net/minecraft/server/WorldData.java
 @@ -110,7 +110,7 @@ public class WorldData {
@@ -85,10 +85,10 @@ index b3e1bee92..3ef1a7c2d 100644
              String s = nbttagcompound.getString("generatorName");
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0eab17bd3..ef09846e8 100644
+index 93a8f4cdf..d43f8ce9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -985,7 +985,7 @@ public final class CraftServer implements Server {
+@@ -987,7 +987,7 @@ public final class CraftServer implements Server {
          WorldData worlddata = sdm.getWorldData();
          WorldSettings worldSettings = null;
          if (worlddata == null) {
@@ -98,5 +98,5 @@ index 0eab17bd3..ef09846e8 100644
              if (parsedSettings.isJsonObject()) {
                  worldSettings.setGeneratorSettings(parsedSettings.getAsJsonObject());
 -- 
-2.19.1
+2.20.0
 

--- a/Spigot-Server-Patches/0368-Avoid-dimension-id-collisions.patch
+++ b/Spigot-Server-Patches/0368-Avoid-dimension-id-collisions.patch
@@ -1,4 +1,4 @@
-From 8538f8531c0bfe13b5b47466adf2975571cf8341 Mon Sep 17 00:00:00 2001
+From 15e41014f6981d4507c5febfd4d6db708d44d35e Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Tue, 25 Sep 2018 06:53:43 +0200
 Subject: [PATCH] Avoid dimension id collisions
@@ -8,10 +8,10 @@ we would reuse an existing dimension id, if some other dimension was
 unloaded before.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ef09846e8..c56511abc 100644
+index d43f8ce9a..07f6580fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -971,7 +971,7 @@ public final class CraftServer implements Server {
+@@ -973,7 +973,7 @@ public final class CraftServer implements Server {
          boolean used = false;
          do {
              for (WorldServer server : console.getWorlds()) {
@@ -21,5 +21,5 @@ index ef09846e8..c56511abc 100644
                      dimension++;
                      break;
 -- 
-2.19.1
+2.20.0
 

--- a/Spigot-Server-Patches/0370-Async-Chunk-Loading-and-Generation.patch
+++ b/Spigot-Server-Patches/0370-Async-Chunk-Loading-and-Generation.patch
@@ -1,4 +1,4 @@
-From 8c80051f8c22caf7bcd9d9e5b7ccbbeaaa654ef6 Mon Sep 17 00:00:00 2001
+From e3d4d30667e9aa88b949627e4a10b59eee0db3b2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 21 Jul 2018 16:55:04 -0400
 Subject: [PATCH] Async Chunk Loading and Generation
@@ -43,7 +43,7 @@ reading or writing to the chunk will be safe, so plugins still
 should not be touching chunks asynchronously!
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b703e0848..73b0c2394 100644
+index c54465a62..aa26a7758 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -385,4 +385,57 @@ public class PaperConfig {
@@ -458,7 +458,7 @@ index 000000000..8f18c2869
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index a08e7ff2e..d86e12042 100644
+index 44d59d253..0bd975b6d 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -184,6 +184,7 @@ public class Chunk implements IChunkAccess {
@@ -2295,10 +2295,10 @@ index bab0c0e0f..af68074c1 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2a9ff6d59..5945e1a6d 100644
+index 07f6580fd..c79baa922 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1017,8 +1017,12 @@ public final class CraftServer implements Server {
+@@ -1019,8 +1019,12 @@ public final class CraftServer implements Server {
          if (internal.getWorld().getKeepSpawnInMemory()) {
              short short1 = internal.paperConfig.keepLoadedRange; // Paper
              long i = System.currentTimeMillis();
@@ -2313,7 +2313,7 @@ index 2a9ff6d59..5945e1a6d 100644
                      long l = System.currentTimeMillis();
  
                      if (l < i) {
-@@ -1034,7 +1038,7 @@ public final class CraftServer implements Server {
+@@ -1036,7 +1040,7 @@ public final class CraftServer implements Server {
                      }
  
                      BlockPosition chunkcoordinates = internal.getSpawn();
@@ -2451,5 +2451,5 @@ index 04e29f58c..5fae0c6ad 100644
          this.random = new Random(seed);
          this.chunkManager = world.worldProvider.getChunkGenerator().getWorldChunkManager();
 -- 
-2.19.2
+2.20.0
 

--- a/Spigot-Server-Patches/0410-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0410-Make-the-default-permission-message-configurable.patch
@@ -1,11 +1,11 @@
-From 7f38ad2f18a7a6661c4aeed9103a0c84a445e051 Mon Sep 17 00:00:00 2001
+From 9354006d8eb507b7dff8da600c0839b97084e76e Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 18 Nov 2018 19:49:56 +0000
 Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index beec4e33c..579726bb5 100644
+index 26e52ace4..7a2fddce9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -21,6 +21,7 @@ import java.util.regex.Pattern;
@@ -29,10 +29,10 @@ index beec4e33c..579726bb5 100644
      private static void savePlayerData() {
          savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 648ac4d18..645953a31 100644
+index c79baa922..352f86967 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2146,6 +2146,10 @@ public final class CraftServer implements Server {
+@@ -2148,6 +2148,10 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  
@@ -44,5 +44,5 @@ index 648ac4d18..645953a31 100644
          return createProfile(uuid, null);
      }
 -- 
-2.19.1
+2.20.0
 


### PR DESCRIPTION
Resolves #1381 
Note that a long timeout will still crash the server, but that was not an
issue in the first place. I've tested the patch with the following code:

https://gist.github.com/Spottedleaf/2f0e7185f53c451a4485d0372393a249

Server does not crash on startup (consistent with previous behaviour) and will crash on reload (consistent with previous behaviour), however without short timeout spam. 