### PR TITLE
Cache block data strings

### DIFF
--- a/Spigot-Server-Patches/0575-Cache-block-data-strings.patch
+++ b/Spigot-Server-Patches/0575-Cache-block-data-strings.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: miclebrick <miclebrick@outlook.com>
+Date: Thu, 6 Dec 2018 19:52:50 -0500
+Subject: [PATCH] Cache block data strings
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index bbe793ca3667264eafa094bfea1c061011c73b92..65e8dc34029598ec84af66348f437f9d4b084bb4 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1825,6 +1825,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+             this.getPlayerList().reload();
+             this.customFunctionData.a(this.dataPackResources.a());
+             this.ak.a(this.dataPackResources.h());
++            org.bukkit.craftbukkit.block.data.CraftBlockData.reloadCache(); // Paper - cache block data strings, they can be defined by datapacks so refresh it here
+         }, this);
+ 
+         if (this.isMainThread()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+index bbded5671e986be34ebe3100e4c10ee0d5741764..7591159c25899fb7a58b25622c6b7241b788652e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
+@@ -520,9 +520,39 @@ public class CraftBlockData implements BlockData {
+         Preconditions.checkState(MAP.put(nms, bukkit) == null, "Duplicate mapping %s->%s", nms, bukkit);
+     }
+ 
++    // Paper start - cache block data strings
++    private static Map<String, CraftBlockData> stringDataCache = new HashMap<>();
++
++    static {
++        // cache all of the default states at startup, will not cache ones with the custom states inside of the
++        // brackets in a different order, though
++        reloadCache();
++    }
++
++    public static void reloadCache() {
++        stringDataCache.clear();
++        Block.REGISTRY_ID.forEach(blockData -> stringDataCache.put(blockData.toString(), blockData.createCraftBlockData()));
++    }
++    // Paper end
++
+     public static CraftBlockData newData(Material material, String data) {
+         Preconditions.checkArgument(material == null || material.isBlock(), "Cannot get data for not block %s", material);
+ 
++        // Paper start - cache block data strings
++        if (material != null) {
++            Block block = CraftMagicNumbers.getBlock(material);
++            if (block != null) {
++                net.minecraft.server.MinecraftKey key = IRegistry.BLOCK.getKey(block);
++                data = data == null ? key.toString() : key + data;
++            }
++        }
++
++        CraftBlockData cached = stringDataCache.computeIfAbsent(data, s -> createNewData(null, s));
++        return (CraftBlockData) cached.clone();
++    }
++
++    private static CraftBlockData createNewData(Material material, String data) {
++        // Paper end - cache block data strings
+         IBlockData blockData;
+         Block block = CraftMagicNumbers.getBlock(material);
+         Map<IBlockState<?>, Comparable<?>> parsed = null;


### PR DESCRIPTION
This way, repeatedly getting the same block state string will not cause it to parse it every time.