### PR TITLE
Fix PlayerEditBookEvent

### DIFF
--- a/Spigot-Server-Patches/0414-Fix-PlayerEditBookEvent.patch
+++ b/Spigot-Server-Patches/0414-Fix-PlayerEditBookEvent.patch
@@ -1,0 +1,35 @@
+From f5a53959e7ce070ed2b23bf2975d54d81d338dc4 Mon Sep 17 00:00:00 2001
+From: Michael Himing <mhiming@gmail.com>
+Date: Sun, 16 Dec 2018 13:07:33 +1100
+Subject: [PATCH] Fix PlayerEditBookEvent
+
+- Updating book writing (not signing) mutated the original item, making
+it impossible to properly cancel the event or modify the book meta
+
+- When the event was cancelled, the client's book would keep the
+cancelled writing
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 21659a0e7..b7f536fe5 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -816,10 +816,13 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+ 
+                             this.player.setSlot(enumitemslot, CraftEventFactory.handleEditBookEvent(player, enumitemslot, itemstack1, itemstack2)); // CraftBukkit
+                         } else {
+-                            ItemStack old = itemstack1.cloneItemStack(); // CraftBukkit
+-                            itemstack1.a("pages", (NBTBase) itemstack.getTag().getList("pages", 8));
+-                            CraftEventFactory.handleEditBookEvent(player, enumitemslot, old, itemstack1); // CraftBukkit
++                            // Paper start - dont mutate players current item, set it from the event
++                            ItemStack newBook = itemstack1.cloneItemStack();
++                            newBook.a("pages", (NBTBase) itemstack.getTag().getList("pages", 8));
++                            this.player.setSlot(enumitemslot, CraftEventFactory.handleEditBookEvent(player, enumitemslot, itemstack1, newBook));
++                            // Paper end
+                         }
++                        player.getBukkitEntity().updateInventory(); // Paper - fix client desync when event is cancelled
+                     }
+ 
+                 }
+-- 
+2.20.1.windows.1
+


### PR DESCRIPTION
- Updating book writing (not signing) mutated the original item, making
it impossible to properly cancel the event or modify the book meta
- When the event was cancelled, the client's book would keep the
cancelled writing