### PR TITLE
Add PistonPostExtendEvent

### DIFF
--- a/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
+++ b/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
@@ -1,4 +1,4 @@
-From 82f0740953bd81ddf86eff39d3bfba0aa4163cf2 Mon Sep 17 00:00:00 2001
+From 87b3145aed3a6a579c48ab519c6b490811017166 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 1 Apr 2016 00:02:47 -0400
 Subject: [PATCH] Add FastUtil to Bukkit
@@ -9,19 +9,19 @@ diff --git a/pom.xml b/pom.xml
 index 229fe559..412a6901 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -44,6 +44,12 @@
-     </pluginRepositories>
+@@ -45,6 +45,12 @@
  
      <dependencies>
-+        <dependency>
+         <dependency>
 +            <groupId>it.unimi.dsi</groupId>
 +            <artifactId>fastutil</artifactId>
 +            <version>8.2.2</version>
 +            <scope>provided</scope>
 +        </dependency>
-         <dependency>
++        <dependency>
              <groupId>commons-lang</groupId>
              <artifactId>commons-lang</artifactId>
+             <version>2.6</version>
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
+++ b/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
@@ -9,19 +9,19 @@ diff --git a/pom.xml b/pom.xml
 index 229fe559..412a6901 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -45,6 +45,12 @@
+@@ -44,6 +44,12 @@
+     </pluginRepositories>
  
      <dependencies>
-         <dependency>
++        <dependency>
 +            <groupId>it.unimi.dsi</groupId>
 +            <artifactId>fastutil</artifactId>
 +            <version>8.2.2</version>
 +            <scope>provided</scope>
 +        </dependency>
-+        <dependency>
+         <dependency>
              <groupId>commons-lang</groupId>
              <artifactId>commons-lang</artifactId>
-             <version>2.6</version>
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-API-Patches/0030-Add-MetadataStoreBase.removeAll-Plugin.patch
+++ b/Spigot-API-Patches/0030-Add-MetadataStoreBase.removeAll-Plugin.patch
@@ -1,4 +1,4 @@
-From 9a9ae4bff73c2649084dc753efa60f86ac91c2dd Mon Sep 17 00:00:00 2001
+From 64b577376bcf7ae33ec1174138d5a09e5f864dcf Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 16 Jul 2013 21:26:50 -0400
 Subject: [PATCH] Add MetadataStoreBase.removeAll(Plugin)
@@ -9,11 +9,10 @@ diff --git a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java b/src/main
 index 64c0f0a7..6da6abd8 100644
 --- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
 +++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
-@@ -124,6 +124,26 @@ public abstract class MetadataStoreBase<T> {
-         }
+@@ -125,6 +125,26 @@ public abstract class MetadataStoreBase<T> {
      }
  
-+    /**
+     /**
 +     * Removes all metadata in the metadata store that originates from the
 +     * given plugin.
 +     *
@@ -33,9 +32,10 @@ index 64c0f0a7..6da6abd8 100644
 +        }
 +    }
 +
-     /**
++    /**
       * Creates a unique name for the object receiving metadata by combining
       * unique data from the subject with a metadataKey.
+      * <p>
 -- 
-2.18.0
+2.11.0
 

--- a/Spigot-API-Patches/0030-Add-MetadataStoreBase.removeAll-Plugin.patch
+++ b/Spigot-API-Patches/0030-Add-MetadataStoreBase.removeAll-Plugin.patch
@@ -9,10 +9,11 @@ diff --git a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java b/src/main
 index 64c0f0a7..6da6abd8 100644
 --- a/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
 +++ b/src/main/java/org/bukkit/metadata/MetadataStoreBase.java
-@@ -125,6 +125,26 @@ public abstract class MetadataStoreBase<T> {
+@@ -124,6 +124,26 @@ public abstract class MetadataStoreBase<T> {
+         }
      }
  
-     /**
++    /**
 +     * Removes all metadata in the metadata store that originates from the
 +     * given plugin.
 +     *
@@ -32,10 +33,9 @@ index 64c0f0a7..6da6abd8 100644
 +        }
 +    }
 +
-+    /**
+     /**
       * Creates a unique name for the object receiving metadata by combining
       * unique data from the subject with a metadataKey.
-      * <p>
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-API-Patches/0039-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-API-Patches/0039-Add-source-to-PlayerExpChangeEvent.patch
@@ -1,4 +1,4 @@
-From 47a6be4ee58f0b7650ee3f74933311d0e0dbab0e Mon Sep 17 00:00:00 2001
+From 1d4ee0026e437e93dd11aac9ffd277e2feb49042 Mon Sep 17 00:00:00 2001
 From: AlphaBlend <whizkid3000@hotmail.com>
 Date: Thu, 8 Sep 2016 08:47:08 -0700
 Subject: [PATCH] Add source to PlayerExpChangeEvent
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java b/s
 index f37491d7..30882559 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
-@@ -1,20 +1,42 @@
+@@ -1,21 +1,43 @@
  package org.bukkit.event.player;
  
 +import org.bukkit.entity.Entity; // Paper
@@ -37,7 +37,7 @@ index f37491d7..30882559 100644
           exp = expAmount;
      }
  
-+    /**
+     /**
 +     * Get the source that provided the experience.
 +     *
 +     * @return The source of the experience
@@ -48,9 +48,10 @@ index f37491d7..30882559 100644
 +    }
 +    // Paper end
 +
-     /**
++    /**
       * Get the amount of experience the player will receive
       *
+      * @return The amount of experience
 -- 
-2.18.0
+2.11.0
 

--- a/Spigot-API-Patches/0039-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-API-Patches/0039-Add-source-to-PlayerExpChangeEvent.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java b/s
 index f37491d7..30882559 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerExpChangeEvent.java
-@@ -1,21 +1,43 @@
+@@ -1,20 +1,42 @@
  package org.bukkit.event.player;
  
 +import org.bukkit.entity.Entity; // Paper
@@ -37,7 +37,7 @@ index f37491d7..30882559 100644
           exp = expAmount;
      }
  
-     /**
++    /**
 +     * Get the source that provided the experience.
 +     *
 +     * @return The source of the experience
@@ -48,10 +48,9 @@ index f37491d7..30882559 100644
 +    }
 +    // Paper end
 +
-+    /**
+     /**
       * Get the amount of experience the player will receive
       *
-      * @return The amount of experience
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-API-Patches/0140-isChunkGenerated-API.patch
+++ b/Spigot-API-Patches/0140-isChunkGenerated-API.patch
@@ -1,4 +1,4 @@
-From 5bc40b8e037de01dacf424153054ac40301efefa Mon Sep 17 00:00:00 2001
+From 53f383c8783e76793477df392463c3e7e1c2984d Mon Sep 17 00:00:00 2001
 From: cswhite2000 <18whitechristop@gmail.com>
 Date: Tue, 21 Aug 2018 19:39:46 -0700
 Subject: [PATCH] isChunkGenerated API
@@ -33,14 +33,13 @@ index 7e1ee875..9457832b 100644
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 1467debe..668c9b7a 100644
+index cd04d840..482c6080 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -184,6 +184,17 @@ public interface World extends PluginMessageRecipient, Metadatable {
-         return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
+@@ -185,6 +185,17 @@ public interface World extends PluginMessageRecipient, Metadatable {
      }
  
-+    /**
+     /**
 +     * Checks if a {@link Chunk} has been generated at the specified chunk key,
 +     * which is the X and Z packed into a long.
 +     *
@@ -51,9 +50,10 @@ index 1467debe..668c9b7a 100644
 +        return isChunkGenerated((int) chunkKey, (int) (chunkKey >> 32));
 +    }
 +
-     /**
++    /**
       * This is the Legacy API before Java 8 was supported. Java 8 Consumer is provided,
       * as well as future support
+      *
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-API-Patches/0140-isChunkGenerated-API.patch
+++ b/Spigot-API-Patches/0140-isChunkGenerated-API.patch
@@ -36,10 +36,11 @@ diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/Worl
 index cd04d840..482c6080 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -185,6 +185,17 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -184,6 +184,17 @@ public interface World extends PluginMessageRecipient, Metadatable {
+         return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }
  
-     /**
++    /**
 +     * Checks if a {@link Chunk} has been generated at the specified chunk key,
 +     * which is the X and Z packed into a long.
 +     *
@@ -50,10 +51,9 @@ index cd04d840..482c6080 100644
 +        return isChunkGenerated((int) chunkKey, (int) (chunkKey >> 32));
 +    }
 +
-+    /**
+     /**
       * This is the Legacy API before Java 8 was supported. Java 8 Consumer is provided,
       * as well as future support
-      *
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-API-Patches/0165-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-API-Patches/0165-Make-the-default-permission-message-configurable.patch
@@ -8,10 +8,11 @@ diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Buk
 index 233a7154..22ca2900 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1464,6 +1464,14 @@ public final class Bukkit {
+@@ -1463,6 +1463,14 @@ public final class Bukkit {
+         return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
-     /**
++    /**
 +     *
 +     * @return the default no permission message used on the server
 +     */
@@ -19,27 +20,26 @@ index 233a7154..22ca2900 100644
 +        return server.getPermissionMessage();
 +    }
 +
-+    /**
+     /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
-      * @return A PlayerProfile object
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 index b8076fc3..9c78f18f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1266,6 +1266,12 @@ public interface Server extends PluginMessageRecipient {
+@@ -1265,6 +1265,12 @@ public interface Server extends PluginMessageRecipient {
+      */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  
-     /**
++    /**
 +     *
 +     * @return the default no permission message used on the server
 +     */
 +    String getPermissionMessage();
 +
-+    /**
+     /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
-      * @return A PlayerProfile object
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
 index 4a479627..77171cd1 100644
 --- a/src/main/java/org/bukkit/command/Command.java
@@ -54,5 +54,5 @@ index 4a479627..77171cd1 100644
              for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
                  target.sendMessage(line);
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-API-Patches/0165-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-API-Patches/0165-Make-the-default-permission-message-configurable.patch
@@ -1,4 +1,4 @@
-From 7a729003770c77b436b94759d729f350a35ab14e Mon Sep 17 00:00:00 2001
+From 7f1206a319cc6f6a98c21f8296062c8be6410da8 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 18 Nov 2018 19:44:54 +0000
 Subject: [PATCH] Make the default permission message configurable
@@ -8,11 +8,10 @@ diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Buk
 index 233a7154..22ca2900 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1463,6 +1463,14 @@ public final class Bukkit {
-         return server.suggestPlayerNamesWhenNullTabCompletions();
+@@ -1464,6 +1464,14 @@ public final class Bukkit {
      }
  
-+    /**
+     /**
 +     *
 +     * @return the default no permission message used on the server
 +     */
@@ -20,26 +19,27 @@ index 233a7154..22ca2900 100644
 +        return server.getPermissionMessage();
 +    }
 +
-     /**
++    /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
+      * @return A PlayerProfile object
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
 index b8076fc3..9c78f18f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1265,6 +1265,12 @@ public interface Server extends PluginMessageRecipient {
-      */
+@@ -1266,6 +1266,12 @@ public interface Server extends PluginMessageRecipient {
      boolean suggestPlayerNamesWhenNullTabCompletions();
  
-+    /**
+     /**
 +     *
 +     * @return the default no permission message used on the server
 +     */
 +    String getPermissionMessage();
 +
-     /**
++    /**
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
+      * @return A PlayerProfile object
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
 index 4a479627..77171cd1 100644
 --- a/src/main/java/org/bukkit/command/Command.java
@@ -54,5 +54,5 @@ index 4a479627..77171cd1 100644
              for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
                  target.sendMessage(line);
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-API-Patches/0171-Add-PistonPostExtendEvent.patch
+++ b/Spigot-API-Patches/0171-Add-PistonPostExtendEvent.patch
@@ -1,0 +1,77 @@
+From 9a05eee7eafc87e3d077ff82a469dd9c09619411 Mon Sep 17 00:00:00 2001
+From: Gabriele C <sgdc3.mail@gmail.com>
+Date: Sat, 5 Jan 2019 20:55:18 +0100
+Subject: [PATCH] Add PistonPostExtendEvent
+
+This event is invoked when a piston has extended.
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java b/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java
+new file mode 100644
+index 00000000..cff6a1f3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java
+@@ -0,0 +1,61 @@
++package com.destroystokyo.paper.event.block;
++
++import org.bukkit.Material;
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockFace;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++
++import java.util.List;
++
++/**
++ * Called when a piston has extended.
++ */
++public class PistonPostExtendEvent extends BlockEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private final BlockFace direction;
++    private List<Block> blocks;
++
++    public PistonPostExtendEvent(final Block block, final List<Block> blocks, final BlockFace direction) {
++        super(block);
++        this.direction = direction;
++        this.blocks = blocks;
++    }
++
++    /**
++     * Returns true if the Piston in the event is sticky.
++     *
++     * @return stickiness of the piston
++     */
++    public boolean isSticky() {
++        return block.getType() == Material.STICKY_PISTON || block.getType() == Material.MOVING_PISTON;
++    }
++
++    /**
++     * Return the direction in which the piston operates.
++     *
++     * @return direction of the piston
++     */
++    public BlockFace getDirection() {
++        return direction;
++    }
++
++    /**
++     * Get an immutable list of the blocks which have been moved by the
++     * extending.
++     *
++     * @return Immutable list of the moved blocks.
++     */
++    public List<Block> getBlocks() {
++        return blocks;
++    }
++
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.19.2.windows.1
+

--- a/Spigot-API-Patches/0171-Add-PistonPostExtendEvent.patch
+++ b/Spigot-API-Patches/0171-Add-PistonPostExtendEvent.patch
@@ -1,4 +1,4 @@
-From 9a05eee7eafc87e3d077ff82a469dd9c09619411 Mon Sep 17 00:00:00 2001
+From 89d4a985e8d054d948d0e9b8940939db6d8bc676 Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Sat, 5 Jan 2019 20:55:18 +0100
 Subject: [PATCH] Add PistonPostExtendEvent
@@ -7,7 +7,7 @@ This event is invoked when a piston has extended.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java b/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java
 new file mode 100644
-index 00000000..cff6a1f3
+index 00000000..61ab2c36
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/PistonPostExtendEvent.java
 @@ -0,0 +1,61 @@
@@ -27,7 +27,7 @@ index 00000000..cff6a1f3
 +public class PistonPostExtendEvent extends BlockEvent {
 +    private static final HandlerList handlers = new HandlerList();
 +    private final BlockFace direction;
-+    private List<Block> blocks;
++    private final List<Block> blocks;
 +
 +    public PistonPostExtendEvent(final Block block, final List<Block> blocks, final BlockFace direction) {
 +        super(block);
@@ -73,5 +73,5 @@ index 00000000..cff6a1f3
 +    }
 +}
 -- 
-2.19.2.windows.1
+2.11.0
 

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1317,7 +1317,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index a3c07fba..da57751f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1945,6 +1945,7 @@ public final class CraftServer implements Server {
+@@ -1945,12 +1945,31 @@ public final class CraftServer implements Server {
      private final Spigot spigot = new Spigot()
      {
  
@@ -1325,10 +1325,10 @@ index a3c07fba..da57751f 100644
          @Override
          public YamlConfiguration getConfig()
          {
-@@ -1952,6 +1953,24 @@ public final class CraftServer implements Server {
+             return org.spigotmc.SpigotConfig.config;
          }
  
-         @Override
++        @Override
 +        public YamlConfiguration getBukkitConfig()
 +        {
 +            return configuration;
@@ -1346,10 +1346,9 @@ index a3c07fba..da57751f 100644
 +            return com.destroystokyo.paper.PaperConfig.config;
 +        }
 +
-+        @Override
+         @Override
          public void restart() {
              org.spigotmc.RestartCommand.restart();
-         }
 diff --git a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java b/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 deleted file mode 100644
 index 2ab4b11a..00000000
@@ -1807,5 +1806,5 @@ index c1071c92..a99c0cea 100644
      }
  }
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1,4 +1,4 @@
-From 3305cca437fb506e78cd2a486e9d2ed24786d7d0 Mon Sep 17 00:00:00 2001
+From 328c86800d5fccb85da24ac912c04ed7df11323b Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
@@ -6,7 +6,7 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 000000000..66d02e048
+index 00000000..66d02e04
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -0,0 +1,132 @@
@@ -144,7 +144,7 @@ index 000000000..66d02e048
 +}
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 new file mode 100644
-index 000000000..145cb274b
+index 00000000..145cb274
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -0,0 +1,104 @@
@@ -253,7 +253,7 @@ index 000000000..145cb274b
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 255b8bed0..fe148495b 100644
+index 255b8bed..fe148495 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,11 +14,14 @@ import java.util.concurrent.TimeUnit;
@@ -297,7 +297,7 @@ index 255b8bed0..fe148495b 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index c09961be9..dbf1089ba 100644
+index c09961be..dbf1089b 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -22,6 +22,15 @@ public class Block implements IMaterial {
@@ -317,7 +317,7 @@ index c09961be9..dbf1089ba 100644
      private final float frictionFactor;
      protected final BlockStateList<Block, IBlockData> blockStateList;
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 23dee9b56..eca1284cc 100644
+index 23dee9b5..eca1284c 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -854,6 +854,7 @@ public class Chunk implements IChunkAccess {
@@ -337,7 +337,7 @@ index 23dee9b56..eca1284cc 100644
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/ChunkMap.java b/src/main/java/net/minecraft/server/ChunkMap.java
-index df2711a5f..732c8793e 100644
+index df2711a5..732c8793 100644
 --- a/src/main/java/net/minecraft/server/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/ChunkMap.java
 @@ -14,6 +14,7 @@ public class ChunkMap extends Long2ObjectOpenHashMap<Chunk> {
@@ -357,7 +357,7 @@ index df2711a5f..732c8793e 100644
  
          return chunk1;
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index a8cdcb7da..eb83e20d5 100644
+index a8cdcb7d..eb83e20d 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -88,7 +88,7 @@ public class ChunkProviderServer implements IChunkProvider {
@@ -398,7 +398,7 @@ index a8cdcb7da..eb83e20d5 100644
              this.chunkLoader.saveChunk(this.world, ichunkaccess, unloaded); // Spigot
          } catch (IOException ioexception) {
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 8e5ce6c18..35976a26f 100644
+index 8e5ce6c1..35976a26 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -1,5 +1,6 @@
@@ -445,7 +445,7 @@ index 8e5ce6c18..35976a26f 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/CustomFunction.java b/src/main/java/net/minecraft/server/CustomFunction.java
-index 65574eb2e..bc87cfc4b 100644
+index 65574eb2..bc87cfc4 100644
 --- a/src/main/java/net/minecraft/server/CustomFunction.java
 +++ b/src/main/java/net/minecraft/server/CustomFunction.java
 @@ -12,12 +12,22 @@ public class CustomFunction {
@@ -472,7 +472,7 @@ index 65574eb2e..bc87cfc4b 100644
          return this.b;
      }
 diff --git a/src/main/java/net/minecraft/server/CustomFunctionData.java b/src/main/java/net/minecraft/server/CustomFunctionData.java
-index f28f4f3cd..6b417be1d 100644
+index f28f4f3c..6b417be1 100644
 --- a/src/main/java/net/minecraft/server/CustomFunctionData.java
 +++ b/src/main/java/net/minecraft/server/CustomFunctionData.java
 @@ -100,7 +100,7 @@ public class CustomFunctionData implements ITickable, IResourcePackListener {
@@ -485,7 +485,7 @@ index f28f4f3cd..6b417be1d 100644
                  int j = 0;
                  CustomFunction.c[] acustomfunction_c = customfunction.b();
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 197d116c6..0ebada490 100644
+index 197d116c..0ebada49 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -29,7 +29,7 @@ import org.apache.logging.log4j.Level;
@@ -538,7 +538,7 @@ index 197d116c6..0ebada490 100644
              return waitable.get();
          } catch (java.util.concurrent.ExecutionException e) {
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 48ec5e047..f36ab639f 100644
+index 48ec5e04..f36ab639 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -27,7 +27,8 @@ import org.bukkit.command.CommandSender;
@@ -577,7 +577,7 @@ index 48ec5e047..f36ab639f 100644
  
      protected float ab() {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index ed859ccf9..31bbbbd96 100644
+index ed859ccf..31bbbbd9 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -32,7 +32,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -653,7 +653,7 @@ index ed859ccf9..31bbbbd96 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityTracker.java b/src/main/java/net/minecraft/server/EntityTracker.java
-index cd462f7df..45ab33d1a 100644
+index cd462f7d..45ab33d1 100644
 --- a/src/main/java/net/minecraft/server/EntityTracker.java
 +++ b/src/main/java/net/minecraft/server/EntityTracker.java
 @@ -168,7 +168,7 @@ public class EntityTracker {
@@ -684,7 +684,7 @@ index cd462f7df..45ab33d1a 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 963c7e777..edb1748fd 100644
+index 963c7e77..edb1748f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1,5 +1,6 @@
@@ -837,7 +837,7 @@ index 963c7e777..edb1748fd 100644
          this.methodProfiler.exit();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index c24f4a8fe..e01222ad2 100644
+index c24f4a8f..e01222ad 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,5 +1,6 @@
@@ -929,7 +929,7 @@ index c24f4a8fe..e01222ad2 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index f0e87416e..723fce204 100644
+index f0e87416..723fce20 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -58,6 +58,7 @@ import org.bukkit.inventory.CraftingInventory;
@@ -984,7 +984,7 @@ index f0e87416e..723fce204 100644
          // this.minecraftServer.getCommandDispatcher().a(this.player.getCommandListener(), s);
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
-index 6c88d0c86..8bf94c1b9 100644
+index 6c88d0c8..8bf94c1b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 @@ -1,11 +1,17 @@
@@ -1006,7 +1006,7 @@ index 6c88d0c86..8bf94c1b9 100644
              throw CancelledPacketHandleException.INSTANCE;
          }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 54e44cba3..3a83819d5 100644
+index 54e44cba..3a83819d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1030,7 +1030,7 @@ index 54e44cba3..3a83819d5 100644
  
      public WhiteList getWhitelist() {
 diff --git a/src/main/java/net/minecraft/server/TickListServer.java b/src/main/java/net/minecraft/server/TickListServer.java
-index 0da57948a..6571fc595 100644
+index 0da57948..6571fc59 100644
 --- a/src/main/java/net/minecraft/server/TickListServer.java
 +++ b/src/main/java/net/minecraft/server/TickListServer.java
 @@ -24,13 +24,19 @@ public class TickListServer<T> implements TickList<T> {
@@ -1084,7 +1084,7 @@ index 0da57948a..6571fc595 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index c69209497..68ac014aa 100644
+index c6920949..68ac014a 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -4,12 +4,13 @@ import javax.annotation.Nullable;
@@ -1104,7 +1104,7 @@ index c69209497..68ac014aa 100644
      private final TileEntityTypes<?> e; public TileEntityTypes getTileEntityType() { return e; } // Paper - OBFHELPER
      protected World world;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5531f5205..209091a9c 100644
+index 5531f520..209091a9 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1,5 +1,6 @@
@@ -1212,7 +1212,7 @@ index 5531f5205..209091a9c 100644
  
      public boolean a(@Nullable Entity entity, VoxelShape voxelshape) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 0a32a767e..60939cc33 100644
+index 0a32a767..60939cc3 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1,5 +1,6 @@
@@ -1314,10 +1314,10 @@ index 0a32a767e..60939cc33 100644
  
      // CraftBukkit start
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a3c07fbac..da57751f7 100644
+index a3c07fba..da57751f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1945,12 +1945,31 @@ public final class CraftServer implements Server {
+@@ -1945,6 +1945,7 @@ public final class CraftServer implements Server {
      private final Spigot spigot = new Spigot()
      {
  
@@ -1325,10 +1325,10 @@ index a3c07fbac..da57751f7 100644
          @Override
          public YamlConfiguration getConfig()
          {
-             return org.spigotmc.SpigotConfig.config;
+@@ -1952,6 +1953,24 @@ public final class CraftServer implements Server {
          }
  
-+        @Override
+         @Override
 +        public YamlConfiguration getBukkitConfig()
 +        {
 +            return configuration;
@@ -1346,12 +1346,13 @@ index a3c07fbac..da57751f7 100644
 +            return com.destroystokyo.paper.PaperConfig.config;
 +        }
 +
-         @Override
++        @Override
          public void restart() {
              org.spigotmc.RestartCommand.restart();
+         }
 diff --git a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java b/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 deleted file mode 100644
-index 2ab4b11a8..000000000
+index 2ab4b11a..00000000
 --- a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 +++ /dev/null
 @@ -1,173 +0,0 @@
@@ -1529,7 +1530,7 @@ index 2ab4b11a8..000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
-index 413dd35f0..52a8c48fa 100644
+index 413dd35f..52a8c48f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 +++ b/src/main/java/org/bukkit/craftbukkit/chunkio/ChunkIOProvider.java
 @@ -1,6 +1,8 @@
@@ -1565,7 +1566,7 @@ index 413dd35f0..52a8c48fa 100644
  
      public void callStage3(QueuedChunk queuedChunk, Chunk chunk, Runnable runnable) throws RuntimeException {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 51f7cc31c..704acf738 100644
+index 51f7cc31..704acf73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1695,6 +1695,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -1584,7 +1585,7 @@ index 51f7cc31c..704acf738 100644
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 2f5d7a2a6..311c4f5ca 100644
+index 2f5d7a2a..311c4f5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -15,6 +15,7 @@ import java.util.concurrent.atomic.AtomicReference;
@@ -1651,7 +1652,7 @@ index 2f5d7a2a6..311c4f5ca 100644
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index 3f55381c1..f32e66010 100644
+index 3f55381c..f32e6601 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -2,8 +2,8 @@ package org.bukkit.craftbukkit.scheduler;
@@ -1733,7 +1734,7 @@ index 3f55381c1..f32e66010 100644
 -    // Spigot end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
-index e52ef47b7..3d90b3426 100644
+index e52ef47b..3d90b342 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 @@ -5,6 +5,7 @@ import org.bukkit.util.CachedServerIcon;
@@ -1745,7 +1746,7 @@ index e52ef47b7..3d90b3426 100644
          this.value = value;
      }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index c1071c92e..a99c0cea0 100644
+index c1071c92..a99c0cea 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -30,7 +30,7 @@ import net.minecraft.server.EntityWither;
@@ -1806,5 +1807,5 @@ index c1071c92e..a99c0cea0 100644
      }
  }
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-Server-Patches/0159-String-based-Action-Bar-API.patch
+++ b/Spigot-Server-Patches/0159-String-based-Action-Bar-API.patch
@@ -45,10 +45,11 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/
 index ecef2a6a..35eb4279 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -208,6 +208,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -207,6 +207,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
  
      // Paper start
-     @Override
++    @Override
 +    public void sendActionBar(String message) {
 +        if (getHandle().playerConnection == null || message == null || message.isEmpty()) return;
 +        getHandle().playerConnection.sendPacket(new PacketPlayOutChat(new net.minecraft.server.ChatComponentText(message), net.minecraft.server.ChatMessageType.GAME_INFO));
@@ -60,10 +61,9 @@ index ecef2a6a..35eb4279 100644
 +        sendActionBar(org.bukkit.ChatColor.translateAlternateColorCodes(alternateChar, message));
 +    }
 +
-+    @Override
+     @Override
      public void setPlayerListHeaderFooter(BaseComponent[] header, BaseComponent[] footer) {
           if (header != null) {
-              String headerJson = net.md_5.bungee.chat.ComponentSerializer.toString(header);
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-Server-Patches/0159-String-based-Action-Bar-API.patch
+++ b/Spigot-Server-Patches/0159-String-based-Action-Bar-API.patch
@@ -1,11 +1,11 @@
-From aa230590808b0776260e52ea7018c88bb1462324 Mon Sep 17 00:00:00 2001
+From 359c4bb2126f6a0fb20269116746a8080b6473f1 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 27 Dec 2016 15:02:42 -0500
 Subject: [PATCH] String based Action Bar API
 
 
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index c97e116aaf..e1af5c4885 100644
+index c97e116a..e1af5c48 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -2,6 +2,7 @@ package net.minecraft.server;
@@ -42,14 +42,13 @@ index c97e116aaf..e1af5c4885 100644
      public static boolean isMainThread() {
          return MinecraftServer.getServer().isMainThread();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ecef2a6ad6..35eb4279ec 100644
+index ecef2a6a..35eb4279 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -207,6 +207,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-     }
+@@ -208,6 +208,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      // Paper start
-+    @Override
+     @Override
 +    public void sendActionBar(String message) {
 +        if (getHandle().playerConnection == null || message == null || message.isEmpty()) return;
 +        getHandle().playerConnection.sendPacket(new PacketPlayOutChat(new net.minecraft.server.ChatComponentText(message), net.minecraft.server.ChatMessageType.GAME_INFO));
@@ -61,9 +60,10 @@ index ecef2a6ad6..35eb4279ec 100644
 +        sendActionBar(org.bukkit.ChatColor.translateAlternateColorCodes(alternateChar, message));
 +    }
 +
-     @Override
++    @Override
      public void setPlayerListHeaderFooter(BaseComponent[] header, BaseComponent[] footer) {
           if (header != null) {
+              String headerJson = net.md_5.bungee.chat.ComponentSerializer.toString(header);
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-Server-Patches/0202-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
+++ b/Spigot-Server-Patches/0202-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
@@ -15,18 +15,18 @@ diff --git a/pom.xml b/pom.xml
 index 1512ff96..f861eda9 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -64,6 +64,11 @@
+@@ -63,6 +63,11 @@
+             <version>2.8.1</version>
              <scope>runtime</scope>
          </dependency>
-         <dependency>
++        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-iostreams</artifactId>
 +            <version>2.8.1</version>
 +        </dependency>
-+        <dependency>
+         <dependency>
              <groupId>org.ow2.asm</groupId>
              <artifactId>asm</artifactId>
-             <version>7.0</version>
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
 index be7030d5..71d1c0b2 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
@@ -45,5 +45,5 @@ index be7030d5..71d1c0b2 100644
  
          thread.setDaemon(true);
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-Server-Patches/0202-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
+++ b/Spigot-Server-Patches/0202-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
@@ -1,4 +1,4 @@
-From 10515690ebe575594d71dc39cd76069716e6b5c9 Mon Sep 17 00:00:00 2001
+From 624158deecae3381cd30426a8a4f15faece31b94 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Mon, 18 Sep 2017 12:00:03 +0200
 Subject: [PATCH] Use Log4j IOStreams to redirect System.out/err to logger
@@ -12,23 +12,23 @@ results in a separate line, even though it should not result in
 a line break. Log4j's implementation handles it correctly.
 
 diff --git a/pom.xml b/pom.xml
-index 1512ff969..f861eda9d 100644
+index 1512ff96..f861eda9 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -63,6 +63,11 @@
-             <version>2.8.1</version>
+@@ -64,6 +64,11 @@
              <scope>runtime</scope>
          </dependency>
-+        <dependency>
+         <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-iostreams</artifactId>
 +            <version>2.8.1</version>
 +        </dependency>
-         <dependency>
++        <dependency>
              <groupId>org.ow2.asm</groupId>
              <artifactId>asm</artifactId>
+             <version>7.0</version>
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index be7030d56..71d1c0b25 100644
+index be7030d5..71d1c0b2 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -131,8 +131,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -45,5 +45,5 @@ index be7030d56..71d1c0b25 100644
  
          thread.setDaemon(true);
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-Server-Patches/0204-Include-Log4J2-SLF4J-implementation.patch
+++ b/Spigot-Server-Patches/0204-Include-Log4J2-SLF4J-implementation.patch
@@ -8,19 +8,19 @@ diff --git a/pom.xml b/pom.xml
 index ed6cd441..75f98f79 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -65,6 +65,12 @@
+@@ -63,6 +63,12 @@
+             <version>2.8.1</version>
+             <scope>compile</scope>
          </dependency>
-         <dependency>
-             <groupId>org.apache.logging.log4j</groupId>
++        <dependency>
++            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-slf4j-impl</artifactId>
 +            <version>2.8.1</version>
 +            <scope>runtime</scope>
 +        </dependency>
-+        <dependency>
-+            <groupId>org.apache.logging.log4j</groupId>
+         <dependency>
+             <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-iostreams</artifactId>
-             <version>2.8.1</version>
-         </dependency>
 -- 
-2.11.0
+2.20.1
 

--- a/Spigot-Server-Patches/0204-Include-Log4J2-SLF4J-implementation.patch
+++ b/Spigot-Server-Patches/0204-Include-Log4J2-SLF4J-implementation.patch
@@ -1,26 +1,26 @@
-From 0a0de210e103b80fd30452bb7312732d35cb96d1 Mon Sep 17 00:00:00 2001
+From 0f52c33f7298c91ed30fcac757da22f4a977a9ca Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Thu, 21 Sep 2017 16:33:35 +0200
 Subject: [PATCH] Include Log4J2 SLF4J implementation
 
 
 diff --git a/pom.xml b/pom.xml
-index ed6cd4416..75f98f79a 100644
+index ed6cd441..75f98f79 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -63,6 +63,12 @@
-             <version>2.8.1</version>
-             <scope>compile</scope>
+@@ -65,6 +65,12 @@
          </dependency>
-+        <dependency>
-+            <groupId>org.apache.logging.log4j</groupId>
+         <dependency>
+             <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-slf4j-impl</artifactId>
 +            <version>2.8.1</version>
 +            <scope>runtime</scope>
 +        </dependency>
-         <dependency>
-             <groupId>org.apache.logging.log4j</groupId>
++        <dependency>
++            <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-iostreams</artifactId>
+             <version>2.8.1</version>
+         </dependency>
 -- 
-2.20.1
+2.11.0
 

--- a/Spigot-Server-Patches/0415-Add-PistonPostExtendEvent.patch
+++ b/Spigot-Server-Patches/0415-Add-PistonPostExtendEvent.patch
@@ -1,0 +1,26 @@
+From df4db1ec36eb09f3066e85edf34c2b7ee732abc3 Mon Sep 17 00:00:00 2001
+From: Gabriele C <sgdc3.mail@gmail.com>
+Date: Sat, 5 Jan 2019 20:56:08 +0100
+Subject: [PATCH] Add PistonPostExtendEvent
+
+This event is invoked when a piston has extended.
+
+diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
+index dbe0ff33..281a50ad 100644
+--- a/src/main/java/net/minecraft/server/BlockPiston.java
++++ b/src/main/java/net/minecraft/server/BlockPiston.java
+@@ -403,6 +403,11 @@ public class BlockPiston extends BlockDirectional {
+                 world.applyPhysics(blockposition1, Blocks.PISTON_HEAD);
+             }
+ 
++            // Paper start - Add PistonPostExtendEvent
++            new com.destroystokyo.paper.event.block.PistonPostExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(enumdirection1))
++                .callEvent();
++            // Paper end
++
+             return true;
+         }
+     }
+-- 
+2.19.2.windows.1
+

--- a/Spigot-Server-Patches/0415-Add-PistonPostExtendEvent.patch
+++ b/Spigot-Server-Patches/0415-Add-PistonPostExtendEvent.patch
@@ -1,4 +1,4 @@
-From df4db1ec36eb09f3066e85edf34c2b7ee732abc3 Mon Sep 17 00:00:00 2001
+From 56e1902bbc670952e801a2f73daef579da727949 Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Sat, 5 Jan 2019 20:56:08 +0100
 Subject: [PATCH] Add PistonPostExtendEvent
@@ -6,21 +6,33 @@ Subject: [PATCH] Add PistonPostExtendEvent
 This event is invoked when a piston has extended.
 
 diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
-index dbe0ff33..281a50ad 100644
+index dbe0ff33..61ad5426 100644
 --- a/src/main/java/net/minecraft/server/BlockPiston.java
 +++ b/src/main/java/net/minecraft/server/BlockPiston.java
-@@ -403,6 +403,11 @@ public class BlockPiston extends BlockDirectional {
+@@ -403,6 +403,23 @@ public class BlockPiston extends BlockDirectional {
                  world.applyPhysics(blockposition1, Blocks.PISTON_HEAD);
              }
  
 +            // Paper start - Add PistonPostExtendEvent
-+            new com.destroystokyo.paper.event.block.PistonPostExtendEvent(bblock, blocks, CraftBlock.notchToBlockFace(enumdirection1))
-+                .callEvent();
++            org.bukkit.block.BlockFace facing = CraftBlock.notchToBlockFace(enumdirection1);
++            List<org.bukkit.block.Block> destinationBlocks = new AbstractList<org.bukkit.block.Block>() {
++
++                @Override
++                public int size() {
++                    return blocks.size();
++                }
++
++                @Override
++                public org.bukkit.block.Block get(int index) {
++                    return blocks.get(index).getRelative(facing);
++                }
++            };
++            new com.destroystokyo.paper.event.block.PistonPostExtendEvent(bblock, destinationBlocks, facing).callEvent();
 +            // Paper end
 +
              return true;
          }
      }
 -- 
-2.19.2.windows.1
+2.20.1
 


### PR DESCRIPTION
This event is invoked when a piston has extended.
The main purpose of this event is to allow plugins to change blocks right after a piston has extended, atm this is only possible by delaying the block material change by 1 tick.