### PR TITLE
[WIP] Allow delegation to vanilla chunk gen

### DIFF
--- a/Spigot-API-Patches/0171-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-API-Patches/0171-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -1,0 +1,125 @@
+From 37f43ea770c69a2fc47267da8391d985517d76bc Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Sat, 9 Feb 2019 13:13:39 +0100
+Subject: [PATCH] Allow delegation to vanilla chunk gen
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+old mode 100644
+new mode 100755
+index 81f01c95..fe9a9801
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1213,6 +1213,21 @@ public final class Bukkit {
+         return server.createChunkData(world);
+     }
+ 
++    // Paper start
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    public static ChunkGenerator.ChunkData createVanillaChunkData(World world, int x, int z) {
++        return server.createVanillaChunkData(world, x, z);
++    }
++    // Paper stop
++
+     /**
+      * Creates a boss bar instance to display to players. The progress
+      * defaults to 1.0
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+old mode 100644
+new mode 100755
+index 6a3f3298..f764472e
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -994,6 +994,7 @@ public interface Server extends PluginMessageRecipient {
+      */
+     public int getIdleTimeout();
+ 
++    // Paper start
+     /**
+      * Create a ChunkData for use in a generator.
+      * 
+@@ -1004,6 +1005,18 @@ public interface Server extends PluginMessageRecipient {
+      * 
+      */
+     public ChunkGenerator.ChunkData createChunkData(World world);
++    // Paper end
++
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    public ChunkGenerator.ChunkData createVanillaChunkData(World world, int x, int z);
+ 
+     /**
+      * Creates a boss bar instance to display to players. The progress
+diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+old mode 100644
+new mode 100755
+index 6caef007..f7b2da2e
+--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
++++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+@@ -131,6 +131,48 @@ public abstract class ChunkGenerator {
+         return null;
+     }
+ 
++    // Paper start
++    /**
++     * Override this method and return true if you want to have vanilla world features in this generator
++     *
++     * @return if this custom chunk generator should add vanilla world features
++     */
++    public boolean shouldAddVanillaFeatures() {
++        return false;
++    }
++
++    /**
++     * Override this method and return true if you want to have vanilla world decorations in this generator
++     *
++     * @return if this custom chunk generator should add vanilla world decoration
++     */
++    public boolean shouldAddVanillaDecorations() {
++        return false;
++    }
++
++    /**
++     * Override this method and return true if you want to have vanilla mobs in this generator
++     *
++     * @return if this custom chunk generator should add vanilla mobs
++     */
++    public boolean shouldAddVanillaMobs() {
++        return false;
++    }
++
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    public ChunkData createVanillaChunkData(World world, int x, int z) {
++        return Bukkit.getServer().createVanillaChunkData(world, x, z);
++    }
++    // Paper end
++
+     /**
+      * Data for a Chunk.
+      */
+-- 
+2.17.1
+

--- a/Spigot-Server-Patches/0392-Don-t-sleep-after-profile-lookups-if-not-needed.patch
+++ b/Spigot-Server-Patches/0392-Don-t-sleep-after-profile-lookups-if-not-needed.patch
@@ -1,4 +1,4 @@
-From af705fcd4e7c9f933bc7f24c3ea4b1a11b6eb9f3 Mon Sep 17 00:00:00 2001
+From 72ab081b2dab0f9363085c1d5661f099e4afe9c7 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 23 Oct 2018 20:25:05 -0400
 Subject: [PATCH] Don't sleep after profile lookups if not needed
@@ -7,7 +7,7 @@ Mojang was sleeping even if we had no more requests to go after
 the current one finished, resulting in 100ms lost per profile lookup
 
 diff --git a/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java b/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
-index 71e48e87b..23f1447cf 100644
+index 26a74372..6ed3199c 100644
 --- a/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
 +++ b/src/main/java/com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.java
 @@ -42,6 +42,7 @@ public class YggdrasilGameProfileRepository implements GameProfileRepository {
@@ -32,5 +32,5 @@ index 71e48e87b..23f1447cf 100644
                      try {
                          Thread.sleep(DELAY_BETWEEN_PAGES);
 -- 
-2.20.1
+2.17.1
 

--- a/Spigot-Server-Patches/0417-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-Server-Patches/0417-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -1,0 +1,102 @@
+From a63636c9d74292ca7be38a3dd45bca141b6c9273 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Sat, 9 Feb 2019 14:48:38 +0100
+Subject: [PATCH] Allow delegation to vanilla chunk gen
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkConverter.java b/src/main/java/net/minecraft/server/ChunkConverter.java
+index 3dd32a42..adeaf953 100755
+--- a/src/main/java/net/minecraft/server/ChunkConverter.java
++++ b/src/main/java/net/minecraft/server/ChunkConverter.java
+@@ -336,7 +336,7 @@ public class ChunkConverter {
+                         if ((Integer) iblockdata.get(BlockProperties.ab) >= j) {
+                             generatoraccess.setTypeAndData(blockposition, (IBlockData) iblockdata.set(BlockProperties.ab, j), 18);
+                             if (i != 7) {
+-                                EnumDirection[] aenumdirection = null.f;
++                                EnumDirection[] aenumdirection = f; // Paper - decomp fix
+                                 int k = aenumdirection.length;
+ 
+                                 for (int l = 0; l < k; ++l) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+old mode 100644
+new mode 100755
+index eeb2ddf7..33898f28
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1874,6 +1874,23 @@ public final class CraftServer implements Server {
+         return new CraftChunkData(world);
+     }
+ 
++    // Paper start
++    @Override
++    public ChunkGenerator.ChunkData createVanillaChunkData(World world, int x, int z) {
++        CraftChunkData data = (CraftChunkData) createChunkData(world);
++
++        // call vanilla generator
++        ProtoChunk protoChunk = new ProtoChunk(x, z, ChunkConverter.EMPTY);
++        ((org.bukkit.craftbukkit.CraftWorld) world).getHandle().worldProvider.getChunkGenerator().createChunk(protoChunk);
++
++        // copy over generated sections
++        data.setRawChunkData(protoChunk.getSections());
++
++        return data;
++    }
++    // Paper end
++
++
+     @Override
+     public BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag... flags) {
+         return new CraftBossBar(title, color, style, flags);
+diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+old mode 100644
+new mode 100755
+index 923d1b28..2253731a
+--- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
++++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+@@ -16,7 +16,7 @@ import org.bukkit.material.MaterialData;
+  */
+ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+     private final int maxHeight;
+-    private final ChunkSection[] sections;
++    private ChunkSection[] sections; // Paper - remove final
+     private World world; // Paper - Anti-Xray
+ 
+     public CraftChunkData(World world) {
+@@ -155,4 +155,10 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+     ChunkSection[] getRawChunkData() {
+         return sections;
+     }
++
++    // Paper start
++    public void setRawChunkData(ChunkSection[] sections) {
++        this.sections = sections;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
+old mode 100644
+new mode 100755
+index a299092a..5198f7ad
+--- a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
++++ b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
+@@ -113,14 +113,17 @@ public class CustomChunkGenerator extends InternalChunkGenerator<GeneratorSettin
+ 
+     @Override
+     public void addFeatures(RegionLimitedWorldAccess regionlimitedworldaccess, WorldGenStage.Features worldgenstage_features) {
++        if(generator.shouldAddVanillaFeatures()) world.worldProvider.getChunkGenerator().addFeatures(regionlimitedworldaccess, worldgenstage_features); //Paper
+     }
+ 
+     @Override
+     public void addDecorations(RegionLimitedWorldAccess regionlimitedworldaccess) {
++        if(generator.shouldAddVanillaDecorations()) world.worldProvider.getChunkGenerator().addDecorations(regionlimitedworldaccess); //Paper
+     }
+ 
+     @Override
+     public void addMobs(RegionLimitedWorldAccess regionlimitedworldaccess) {
++        if(generator.shouldAddVanillaMobs()) world.worldProvider.getChunkGenerator().addMobs(regionlimitedworldaccess); //Paper
+     }
+ 
+     @Override
+-- 
+2.17.1
+


### PR DESCRIPTION
This PR introduces the ability to delegate chunk generation (and population and stuff) to the vanilla chunk generator in a custom bukkit chunk generator.

example plugin: https://github.com/MiniDigger/worldgentest/blob/master/src/main/java/me/minidigger/worldgentest/PlusGenerator.kt
![https://i.imgur.com/K2x8Idh.png](https://i.imgur.com/K2x8Idh.png)

ToDos:
- [ ] make it work with papers async chunk generation