### PR TITLE
Fix World#getChunkAtAsync(Location) variants incorectly calculating chunk x

### DIFF
--- a/Spigot-API-Patches/0135-Async-Chunks-API.patch
+++ b/Spigot-API-Patches/0135-Async-Chunks-API.patch
@@ -1,4 +1,4 @@
-From 6dc478f219217b81d31c62ff433aaac40052ed7b Mon Sep 17 00:00:00 2001
+From c56c68eed04866793c411e6dc5eeeabe2f73ace1 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 29 Feb 2016 17:43:33 -0600
 Subject: [PATCH] Async Chunks API
@@ -8,7 +8,7 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 807bd7fc..61f2cd9a 100644
+index 807bd7fc..51cf7fd3 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -152,6 +152,352 @@ public interface World extends PluginMessageRecipient, Metadatable {
@@ -175,7 +175,7 @@ index 807bd7fc..61f2cd9a 100644
 +     *           will be executed synchronously
 +     */
 +    public default void getChunkAtAsync(Location loc, java.util.function.Consumer<Chunk> cb) {
-+        getChunkAtAsync((int)loc.getX() >> 4, (int)Math.floor(loc.getZ()) >> 4, true, cb);
++        getChunkAtAsync((int)Math.floor(loc.getX()) >> 4, (int)Math.floor(loc.getZ()) >> 4, true, cb);
 +    }
 +
 +    /**
@@ -197,7 +197,7 @@ index 807bd7fc..61f2cd9a 100644
 +     *           will be executed synchronously
 +     */
 +    public default void getChunkAtAsync(Location loc, boolean gen, java.util.function.Consumer<Chunk> cb) {
-+        getChunkAtAsync((int)loc.getX() >> 4, (int)Math.floor(loc.getZ()) >> 4, gen, cb);
++        getChunkAtAsync((int)Math.floor(loc.getX()) >> 4, (int)Math.floor(loc.getZ()) >> 4, gen, cb);
 +    }
 +
 +    /**
@@ -259,7 +259,7 @@ index 807bd7fc..61f2cd9a 100644
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    public default java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(Location loc) {
-+        return getChunkAtAsync((int)loc.getX() >> 4, (int)Math.floor(loc.getZ()) >> 4, true);
++        return getChunkAtAsync((int)Math.floor(loc.getX()) >> 4, (int)Math.floor(loc.getZ()) >> 4, true);
 +    }
 +
 +    /**
@@ -279,7 +279,7 @@ index 807bd7fc..61f2cd9a 100644
 +     * @return Future that will resolve when the chunk is loaded
 +     */
 +    public default java.util.concurrent.CompletableFuture<Chunk> getChunkAtAsync(Location loc, boolean gen) {
-+        return getChunkAtAsync((int)loc.getX() >> 4, (int)Math.floor(loc.getZ()) >> 4, gen);
++        return getChunkAtAsync((int)Math.floor(loc.getX()) >> 4, (int)Math.floor(loc.getZ()) >> 4, gen);
 +    }
 +
 +    /**
@@ -398,5 +398,5 @@ index 2dd7a03c..59787c47 100644
       * Returns a list of entities within a bounding box centered around this
       * entity
 -- 
-2.20.1
+2.21.0
 

--- a/Spigot-Server-Patches/0302-Add-some-Debug-to-Chunk-Entity-slices.patch
+++ b/Spigot-Server-Patches/0302-Add-some-Debug-to-Chunk-Entity-slices.patch
@@ -1,4 +1,4 @@
-From abf1bf94c272bcaf8daf2d6e5252e54a426bf936 Mon Sep 17 00:00:00 2001
+From c694fb42c86f64e9cda92745dd020ac0121d470a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 23 Jul 2018 22:44:23 -0400
 Subject: [PATCH] Add some Debug to Chunk Entity slices
@@ -9,7 +9,7 @@ This should hopefully avoid duplicate entities ever being created
 if the entity was to end up in 2 different chunk slices
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 42b76b2122..1c9e2cb1ce 100644
+index 42b76b2122..7dd59ee031 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -714,8 +714,27 @@ public class Chunk implements IChunkAccess {
@@ -22,7 +22,7 @@ index 42b76b2122..1c9e2cb1ce 100644
 +        List<Entity> entitySlice = this.entitySlices[k];
 +        boolean inThis = entitySlice.contains(entity);
 +        List<Entity> currentSlice = entity.entitySlice;
-+        if ((currentSlice != null && currentSlice.contains(entity)) || inThis) {
++        if (inThis || (currentSlice != null && currentSlice.contains(entity))) {
 +            if (currentSlice == entitySlice || inThis) {
 +                return;
 +            } else {
@@ -32,7 +32,7 @@ index 42b76b2122..1c9e2cb1ce 100644
 +                } else {
 +                    removeEntity(entity);
 +                }
-+                new Throwable().printStackTrace();
++                currentSlice.remove(entity); // Just incase the above did not remove from this target slice
 +            }
 +        }
 +        entity.entitySlice = entitySlice;


### PR DESCRIPTION
The blockX needs to be floored before converted to int, as float -> integer
operations are truncation. (i.e -0.5 -> 0, we want -0.5 -> -1)