### PR TITLE
Fixes #1415 - Llama setCarryingChest() don't refresh to other players

### DIFF
--- a/Spigot-Server-Patches/0423-Fixes-issues-with-player-interaction-preventing-meta.patch
+++ b/Spigot-Server-Patches/0423-Fixes-issues-with-player-interaction-preventing-meta.patch
@@ -1,0 +1,26 @@
+From a8bad4b792c02be640779fe77493013256ff4cd8 Mon Sep 17 00:00:00 2001
+From: AgentTroll <woodyc40@gmail.com>
+Date: Fri, 22 Mar 2019 22:24:03 -0700
+Subject: [PATCH] Fixes issues with player interaction preventing metadata from
+ being updated for other players
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index c4edb5b8..d2dd5d5b 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1974,7 +1974,10 @@ public class PlayerConnection implements PacketListenerPlayIn, ITickable {
+ 
+                     if (event.isCancelled() || this.player.inventory.getItemInHand() == null || this.player.inventory.getItemInHand().getItem() != origItem) {
+                         // Refresh the current entity metadata
+-                        this.sendPacket(new PacketPlayOutEntityMetadata(entity.getId(), entity.datawatcher, true));
++                        // Paper start - update entity for all players
++                        // this.sendPacket(new PacketPlayOutEntityMetadata(entity.getId(), entity.datawatcher, true));
++                        entity.tracker.track(worldserver.players);
++                        // Paper end
+                     }
+ 
+                     if (event.isCancelled()) {
+-- 
+2.11.0
+


### PR DESCRIPTION
Fixes #1415.

~~Cancelling the interaction event causes a metadata packet to be sent to the player that performs the interaction, which in turn causes the "dirty" flag for the `DataWatcher` to be reset to `false`.

I noticed that `DataWatcher#e()` clears the "dirty" flag. I concluded that the intent for the `flag` variable in the constructor must probably have been something to do with whether or not the dirty flag is cleared, where `true` means that it should not be cleared, and `false` meaning that it should be cleared. 

By commenting out the call to `DataWatcher#e()`, the contents of the `DataWatcher` should be encoded without undirtying. When the player is sent `PacketPlayOutEntityMetadata` after the event is cancelled, the `DataWatcher` remains dirty and the metadata of the entity will then be broadcasted the next time the entity tracker runs.

I'm still not exactly sure why the flag is undirtyed in the first place here, I can only assume it must be a mistake. At worst, I'd think that the entity would simply just keep being updated for the players tracking it, but otherwise I don't see any negative impacts coming from this change.~~

**Demo**
https://streamable.com/r2zsq