### PR TITLE
Emancipate more features to PlayerHandshakeEvent

### DIFF
--- a/Spigot-API-Patches/0016-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-API-Patches/0016-Player-Tab-List-and-Title-APIs.patch
@@ -433,7 +433,7 @@ index 695d80d8aabdbb4a6553d5446a8f7ea766b52472..c12087cd9551ad254867c428139bdf38
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
-
+ 
  import java.net.InetSocketAddress;
  import java.util.UUID;
 +import com.destroystokyo.paper.Title; // Paper
@@ -555,5 +555,5 @@ index 695d80d8aabdbb4a6553d5446a8f7ea766b52472..c12087cd9551ad254867c428139bdf38
 +     */
 +    public void hideTitle();
      // Paper end
-
+ 
      /**

--- a/Spigot-Server-Patches/0087-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-Server-Patches/0087-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 
 diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
-index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..396c3f824968512e55987fd98d82d10e9cad6903 100644
+index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..4de8646811f25b6217cffcd31fc14bcf79151b1a 100644
 --- a/src/main/java/net/minecraft/server/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/HandshakeListener.java
 @@ -14,7 +14,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -37,8 +37,8 @@ index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..396c3f824968512e55987fd98d82d10e
 +                            return;
 +                        }
 +
-+                        packethandshakinginsetprotocol.hostname = event.getServerHostname();
-+                        this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), ((java.net.InetSocketAddress) this.getNetworkManager().getSocketAddress()).getPort());
++                        if (event.getServerHostname() != null) packethandshakinginsetprotocol.hostname = event.getServerHostname();
++                        if (event.getSocketAddressHostname() != null) this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), ((java.net.InetSocketAddress) this.getNetworkManager().getSocketAddress()).getPort());
 +                        this.getNetworkManager().spoofedUUID = event.getUniqueId();
 +                        this.getNetworkManager().spoofedProfile = gson.fromJson(event.getPropertiesJson(), com.mojang.authlib.properties.Property[].class);
 +                        handledByEvent = true; // Hooray, we did it!


### PR DESCRIPTION
* The hostname and socket address was not null when the event fired, but the event does not provide the value, the change allows plugins to use the old value.
* Since `proxyLogicEnabled` will be checked after the event fired, to check the config value will allow plugins to modify it during the event handling.