### PR TITLE
Optimize GameRules to use LinkedHashMap

### DIFF
--- a/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
+++ b/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
@@ -1,4 +1,4 @@
-From 7ad9c299e87d66f79104c9f21043392b0d60700d Mon Sep 17 00:00:00 2001
+From 30a67e448eb304db37ace97ac0cc0f1347cd5bb6 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 30 Mar 2016 19:36:20 -0400
 Subject: [PATCH] MC Dev fixes
@@ -18,7 +18,7 @@ index bcb4b5e5c..c399bdecc 100644
  
      public static <C extends WorldGenFeatureConfiguration> WorldGenCarverWrapper<C> a(WorldGenCarver<C> worldgencarver, C c0) {
 diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
-index bd2a67cfc..330f5d0c1 100644
+index 16bca7942..13dc7abc5 100644
 --- a/src/main/java/net/minecraft/server/BlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BlockPosition.java
 @@ -10,7 +10,7 @@ import org.apache.logging.log4j.Logger;
@@ -146,6 +146,28 @@ index 66b168396..83db94c4a 100644
          }
  
          public Iterator<IBlockData> iterator() {
+diff --git a/src/main/java/net/minecraft/server/GameRules.java b/src/main/java/net/minecraft/server/GameRules.java
+index d954b94c3..fd2a4f1b8 100644
+--- a/src/main/java/net/minecraft/server/GameRules.java
++++ b/src/main/java/net/minecraft/server/GameRules.java
+@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
+ 
+ public class GameRules {
+ 
+-    private static final TreeMap<String, GameRules.GameRuleDefinition> a = (TreeMap) SystemUtils.a((Object) (new TreeMap()), (treemap) -> {
++    private static final TreeMap<String, GameRules.GameRuleDefinition> a = SystemUtils.a(new TreeMap(), (treemap) -> { // Paper - decompile fix
+         treemap.put("doFireTick", new GameRules.GameRuleDefinition("true", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+         treemap.put("mobGriefing", new GameRules.GameRuleDefinition("true", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+         treemap.put("keepInventory", new GameRules.GameRuleDefinition("false", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+@@ -133,7 +133,7 @@ public class GameRules {
+         private final Supplier<ArgumentType<?>> d;
+         private final BiFunction<CommandContext<CommandListenerWrapper>, String, String> e;
+ 
+-        private EnumGameRuleType(Supplier supplier, BiFunction bifunction) {
++        private EnumGameRuleType(Supplier supplier, BiFunction<CommandContext<CommandListenerWrapper>, String, String> bifunction) { // Paper - decompile fix
+             this.d = supplier;
+             this.e = bifunction;
+         }
 diff --git a/src/main/java/net/minecraft/server/NBTBase.java b/src/main/java/net/minecraft/server/NBTBase.java
 index 1425584ed..b2757aad8 100644
 --- a/src/main/java/net/minecraft/server/NBTBase.java
@@ -263,5 +285,5 @@ index c01a05b25..478bf4997 100644
                      this.data.put(s, persistentbase);
                  }
 -- 
-2.20.1
+2.21.0
 

--- a/Spigot-Server-Patches/0435-Optimize-GameRules-to-use-LinkedHashMap.patch
+++ b/Spigot-Server-Patches/0435-Optimize-GameRules-to-use-LinkedHashMap.patch
@@ -1,0 +1,66 @@
+From 14952f6e3e04fbfb6be1ae4e959b0cefe58681b5 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Thu, 4 Apr 2019 17:55:05 -0700
+Subject: [PATCH] Optimize GameRules to use LinkedHashMap
+
+Previously TreeMap was used which has poor get(K) performance.
+
+diff --git a/src/main/java/net/minecraft/server/GameRules.java b/src/main/java/net/minecraft/server/GameRules.java
+index fd2a4f1b8c..0bd5e02a28 100644
+--- a/src/main/java/net/minecraft/server/GameRules.java
++++ b/src/main/java/net/minecraft/server/GameRules.java
+@@ -17,7 +17,17 @@ import javax.annotation.Nullable;
+ 
+ public class GameRules {
+ 
+-    private static final TreeMap<String, GameRules.GameRuleDefinition> a = SystemUtils.a(new TreeMap(), (treemap) -> { // Paper - decompile fix
++    // Paper start - Optimize GameRules
++    private static final int RULES_SIZE = 256;
++
++    private static <K, V> java.util.LinkedHashMap<K, V> linkedMapOf(final int capacity, final TreeMap<K, V> map) {
++        final java.util.LinkedHashMap<K, V> ret = new java.util.LinkedHashMap<>(capacity);
++        ret.putAll(map);
++        return ret;
++    }
++
++    private static final java.util.LinkedHashMap<String, GameRuleDefinition> a = GameRules.linkedMapOf(RULES_SIZE, SystemUtils.a(new TreeMap(), (treemap) -> { // Paper - decompile fix
++        // Paper end
+         treemap.put("doFireTick", new GameRules.GameRuleDefinition("true", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+         treemap.put("mobGriefing", new GameRules.GameRuleDefinition("true", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+         treemap.put("keepInventory", new GameRules.GameRuleDefinition("false", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+@@ -51,8 +61,8 @@ public class GameRules {
+         treemap.put("doLimitedCrafting", new GameRules.GameRuleDefinition("false", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+         treemap.put("maxCommandChainLength", new GameRules.GameRuleDefinition("65536", GameRules.EnumGameRuleType.NUMERICAL_VALUE));
+         treemap.put("announceAdvancements", new GameRules.GameRuleDefinition("true", GameRules.EnumGameRuleType.BOOLEAN_VALUE));
+-    });
+-    private final TreeMap<String, GameRules.GameRuleValue> b = new TreeMap();
++    })); // Paper - Optimize GameRules
++    private final java.util.LinkedHashMap<String, GameRuleValue> b = new java.util.LinkedHashMap<>(RULES_SIZE); // Paper - Optimize GameRules
+ 
+     public GameRules() {
+         Iterator iterator = GameRules.a.entrySet().iterator();
+@@ -116,7 +126,7 @@ public class GameRules {
+         return (GameRules.GameRuleValue) this.b.get(s);
+     }
+ 
+-    public static TreeMap<String, GameRules.GameRuleDefinition> getGameRules() {
++    public static java.util.LinkedHashMap<String, GameRuleDefinition> getGameRules() { // Paper - Optimize GameRules
+         return GameRules.a;
+     }
+ 
+diff --git a/src/test/java/org/bukkit/GameRuleTest.java b/src/test/java/org/bukkit/GameRuleTest.java
+index 1ed0f4cf2b..40edb8d668 100644
+--- a/src/test/java/org/bukkit/GameRuleTest.java
++++ b/src/test/java/org/bukkit/GameRuleTest.java
+@@ -21,7 +21,7 @@ public class GameRuleTest {
+ 
+     @Test
+     public void testMinecraftRules() {
+-        TreeMap<String, GameRules.GameRuleDefinition> minecraftRules = GameRules.getGameRules();
++        Map<String, GameRules.GameRuleDefinition> minecraftRules = GameRules.getGameRules(); // Paper - Optimize GameRules
+ 
+         for (Map.Entry<String, GameRules.GameRuleDefinition> entry : minecraftRules.entrySet()) {
+             GameRule<?> bukkitRule = GameRule.getByName(entry.getKey());
+-- 
+2.21.0
+


### PR DESCRIPTION
Previously TreeMap was used which has poor get(K) performance.

Using LinkedHashMap we can get the performance benefit of HashMap and the iteration order given by TreeMap.