### PR TITLE
Make mcdev script work with spacey paths

### DIFF
--- a/scripts/makemcdevsrc.sh
+++ b/scripts/makemcdevsrc.sh
@@ -14,7 +14,7 @@ papernms="Paper-Server/src/main/java/net/minecraft/server"
 mcdevsrc="${decompiledir}/src/net/minecraft/server"
 rm -rf "${mcdevsrc}"
 mkdir -p "${mcdevsrc}"
-cp ${nms}/*.java "${mcdevsrc}/"
+cp "${nms}"/*.java "${mcdevsrc}/"
 
 for file in "${nms}/"*
 do


### PR DESCRIPTION
Using MINGW64 on Win10, cp command rejects the edited line.

I'm too lazy to open an issue