### PR TITLE
Get placement block data

### DIFF
--- a/Spigot-API-Patches/0183-Add-getPlacementBlockData-to-World.patch
+++ b/Spigot-API-Patches/0183-Add-getPlacementBlockData-to-World.patch
@@ -1,0 +1,30 @@
+From 8b6dced81fb4df065a038f34da99b8de8893c6d5 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 13 Apr 2019 02:08:03 -0500
+Subject: [PATCH] Add getPlacementBlockData to World
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index dc9e8a76..18c3c05b 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1587,6 +1587,16 @@ public interface World extends PluginMessageRecipient, Metadatable {
+      * @return True if it is daytime
+      */
+     public boolean isDayTime();
++
++    /**
++     * Get the hypothetical BlockData that would apply if one tries to set the given BlockData
++     *
++     * @param blockData BlockData to try
++     * @param location Location to check
++     * @return Valid BlockData for location
++     */
++    @NotNull
++    public BlockData getPlacementBlockData(@NotNull BlockData blockData, @NotNull Location location);
+     // Paper end
+ 
+     /**
+-- 
+2.20.1
+

--- a/Spigot-Server-Patches/0438-Add-getPlacementBlockData-to-World.patch
+++ b/Spigot-Server-Patches/0438-Add-getPlacementBlockData-to-World.patch
@@ -1,0 +1,25 @@
+From 71fe73695915d4fffbbec2de30e9772c41f3e0c4 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 13 Apr 2019 02:08:10 -0500
+Subject: [PATCH] Add getPlacementBlockData to World
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 457aa5a3..3ef713cd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -564,6 +564,11 @@ public class CraftWorld implements World {
+     public boolean isDayTime() {
+         return getHandle().isDayTime();
+     }
++
++    public BlockData getPlacementBlockData(BlockData blockdata, Location location) {
++        IBlockData validData = net.minecraft.server.Block.getValidBlockForPosition(((CraftBlockData) blockdata).getState(), getHandle(), MCUtil.toBlockPosition(location));
++        return CraftBlockData.fromData(validData == null ? Blocks.AIR.getBlockData() : validData);
++    }
+     // Paper end
+ 
+     public boolean createExplosion(double x, double y, double z, float power) {
+-- 
+2.20.1
+


### PR DESCRIPTION
Adds the ability to test what BlockData will exist when placing a BlockData at a location.

Examples:

* Placing grass blockdata anywhere will return grass blockdata. If placed underneath a snow layer it will return grassy variant of snow block data.
* Placing torch blockdata will return torch blockdata **only** in the places torches can be placed. Placing a floating torch will return blockdata for air. Placing torches on leaves will return air. However, placing them in water will return torch blockdata (this same behavior can be seen in the game, as the torch will survive until the next tick when water flows to destroy it).
* Placing sugar cane will **only** return sugar cane block data when placed on top of grass or sand next to water source.

Video demonstration: https://youtu.be/A36Ot5Ug-0I

Test plugin from video: https://pastebin.com/5MJ95YVT

Closes #1921 