### PR TITLE
Fix NPE when placing sign on tall grass block

### DIFF
--- a/Spigot-Server-Patches/0438-Fix-NPE-when-placing-sign-on-tall-grass-block.patch
+++ b/Spigot-Server-Patches/0438-Fix-NPE-when-placing-sign-on-tall-grass-block.patch
@@ -1,0 +1,29 @@
+From dbeb05b1241e3ca0585e875689a5f9e3e58d2e35 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 13 Apr 2019 15:13:19 -0500
+Subject: [PATCH] Fix NPE when placing sign on tall grass block
+
+
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index eb130c012..cea34865c 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -305,7 +305,14 @@ public final class ItemStack {
+                     // SPIGOT-4678
+                     if (this.item instanceof ItemSign && ItemSign.openSign) {
+                         ItemSign.openSign = false;
+-                        entityhuman.openSign((TileEntitySign) world.getTileEntity(new BlockActionContext(itemactioncontext).getClickPosition()));
++                        // Paper start
++                        BlockPosition pos = new BlockActionContext(itemactioncontext).getClickPosition();
++                        TileEntity te = world.getTileEntity(pos);
++                        if (te == null) {
++                            te = world.getTileEntity(pos.shift(itemactioncontext.getClickedFace().opposite()));
++                        }
++                        entityhuman.openSign((TileEntitySign) te);
++                        // Paper end
+                     }
+ 
+                     // SPIGOT-1288 - play sound stripped from ItemBlock
+-- 
+2.20.1
+


### PR DESCRIPTION
This might fix more cases than just tall grass.

Basically what's happening is md_5's [fix](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/51100db8215f28accb2eeb56f9ee3e661f362d1e) for whatever is in [SPIGOT-4678](https://hub.spigotmc.org/jira/browse/SPIGOT-4678) is using the item action context to determine where the sign is placed. This works fine for most blocks because it's grabbing the block next to the block that was clicked. However, in the case of tall grass the block is replaced with a sign instead of a sign set next to it, thus there is no TE where it thinks it is and you get an NPE.

This fix is a pretty generic catch-all, as it just checks if it found a TE at the neighboring position. If it didn't it checks for a TE at the clicked position.

This has been tested and does fix #1917 as reported.