### PR TITLE
Add LootableInventoryFirstFillEvent

### DIFF
--- a/Spigot-API-Patches/0183-Add-LootableInventoryFirstFillEvent.patch
+++ b/Spigot-API-Patches/0183-Add-LootableInventoryFirstFillEvent.patch
@@ -1,0 +1,56 @@
+From 03a85d7236fd5dc56c117a8e916e0b51a524a2b4 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 13 Apr 2019 18:35:20 -0500
+Subject: [PATCH] Add LootableInventoryFirstFillEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryFirstFillEvent.java b/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryFirstFillEvent.java
+new file mode 100644
+index 00000000..ce95aeeb
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/loottable/LootableInventoryFirstFillEvent.java
+@@ -0,0 +1,41 @@
++package com.destroystokyo.paper.loottable;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++public class LootableInventoryFirstFillEvent extends Event {
++    @Nullable
++    private final Player player;
++    @NotNull
++    private final LootableInventory inventory;
++
++    public LootableInventoryFirstFillEvent(@Nullable Player player, @NotNull LootableInventory inventory) {
++        this.player = player;
++        this.inventory = inventory;
++    }
++
++    @Nullable
++    public Player getPlayer() {
++        return player;
++    }
++
++    @NotNull
++    public LootableInventory getInventory() {
++        return inventory;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.20.1
+

--- a/Spigot-Server-Patches/0438-Add-LootableInventoryFirstFillEvent.patch
+++ b/Spigot-Server-Patches/0438-Add-LootableInventoryFirstFillEvent.patch
@@ -1,0 +1,21 @@
+From aa21296609c7d2c563b470daab59e351302973eb Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 13 Apr 2019 18:35:25 -0500
+Subject: [PATCH] Add LootableInventoryFirstFillEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
+index b5401eaf9..ed728c972 100644
+--- a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
++++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
+@@ -49,6 +49,7 @@ public class PaperLootableInventoryData {
+ 
+         // ALWAYS process the first fill or if the feature is disabled
+         if (this.lastFill == -1 || !this.lootable.getNMSWorld().paperConfig.autoReplenishLootables) {
++            new LootableInventoryFirstFillEvent(player == null ? null : (Player) player.getBukkitEntity(), lootable.getAPILootableInventory());
+             return true;
+         }
+ 
+-- 
+2.20.1
+


### PR DESCRIPTION
`LootableInventoryReplinishEvent` does not fire (for good reason) on the first lootable fill. This adds a new event that fires *only* on the first fill.

Closes #1667 