### PR TITLE
Add ThrownEggHatchEvent

### DIFF
--- a/Spigot-API-Patches/0190-Add-ThrownEggHatchEvent.patch
+++ b/Spigot-API-Patches/0190-Add-ThrownEggHatchEvent.patch
@@ -1,0 +1,132 @@
+From 5b5364e4f30d273d16da7f11b3ec6551bba57bbe Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sun, 9 Feb 2020 00:19:08 -0600
+Subject: [PATCH] Add ThrownEggHatchEvent
+
+Adds a new event similar to PlayerEggThrowEvent, but without the Player requirement
+(dispensers can throw eggs to hatch them, too).
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java
+new file mode 100644
+index 00000000..2575775c
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/entity/ThrownEggHatchEvent.java
+@@ -0,0 +1,115 @@
++package com.destroystokyo.paper.event.entity;
++
++import org.bukkit.entity.*;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a thrown egg might hatch.
++ * <p>
++ * This event fires for all thrown eggs that may hatch, players, dispensers, etc.
++ */
++public class ThrownEggHatchEvent extends Event {
++    private static final HandlerList handlers = new HandlerList();
++    private final Egg egg;
++    private boolean hatching;
++    private EntityType hatchType;
++    private byte numHatches;
++
++    public ThrownEggHatchEvent(@NotNull final Egg egg, final boolean hatching, final byte numHatches, @NotNull final EntityType hatchingType) {
++        this.egg = egg;
++        this.hatching = hatching;
++        this.numHatches = numHatches;
++        this.hatchType = hatchingType;
++    }
++
++    /**
++     * Gets the egg involved in this event.
++     *
++     * @return the egg involved in this event
++     */
++    @NotNull
++    public Egg getEgg() {
++        return egg;
++    }
++
++    /**
++     * Gets whether the egg is hatching or not. Will be what the server
++     * would've done without interaction.
++     *
++     * @return boolean Whether the egg is going to hatch or not
++     */
++    public boolean isHatching() {
++        return hatching;
++    }
++
++    /**
++     * Sets whether the egg will hatch or not.
++     *
++     * @param hatching true if you want the egg to hatch, false if you want it
++     *     not to
++     */
++    public void setHatching(boolean hatching) {
++        this.hatching = hatching;
++    }
++
++    /**
++     * Get the type of the mob being hatched (EntityType.CHICKEN by default)
++     *
++     * @return The type of the mob being hatched by the egg
++     */
++    @NotNull
++    public EntityType getHatchingType() {
++        return hatchType;
++    }
++
++    /**
++     * Change the type of mob being hatched by the egg
++     *
++     * @param hatchType The type of the mob being hatched by the egg
++     */
++    public void setHatchingType(@NotNull EntityType hatchType) {
++        if (!hatchType.isSpawnable()) throw new IllegalArgumentException("Can't spawn that entity type from an egg!");
++        this.hatchType = hatchType;
++    }
++
++    /**
++     * Get the number of mob hatches from the egg. By default the number will
++     * be the number the server would've done
++     * <ul>
++     * <li>7/8 chance of being 0
++     * <li>31/256 ~= 1/8 chance to be 1
++     * <li>1/256 chance to be 4
++     * </ul>
++     *
++     * @return The number of mobs going to be hatched by the egg
++     */
++    public byte getNumHatches() {
++        return numHatches;
++    }
++
++    /**
++     * Change the number of mobs coming out of the hatched egg
++     * <p>
++     * The boolean hatching will override this number. Ie. If hatching =
++     * false, this number will not matter
++     *
++     * @param numHatches The number of mobs coming out of the egg
++     */
++    public void setNumHatches(byte numHatches) {
++        this.numHatches = numHatches;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.25.0
+

--- a/Spigot-Server-Patches/0438-Add-ThrownEggHatchEvent.patch
+++ b/Spigot-Server-Patches/0438-Add-ThrownEggHatchEvent.patch
@@ -1,0 +1,32 @@
+From 0e91125680ffd3e0b2782e0159543cd2cf3c44bb Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sun, 9 Feb 2020 00:19:05 -0600
+Subject: [PATCH] Add ThrownEggHatchEvent
+
+Adds a new event similar to PlayerEggThrowEvent, but without the Player requirement
+(dispensers can throw eggs to hatch them, too).
+
+diff --git a/src/main/java/net/minecraft/server/EntityEgg.java b/src/main/java/net/minecraft/server/EntityEgg.java
+index 970f9109d9..bdd82d052a 100644
+--- a/src/main/java/net/minecraft/server/EntityEgg.java
++++ b/src/main/java/net/minecraft/server/EntityEgg.java
+@@ -52,6 +52,16 @@ public class EntityEgg extends EntityProjectileThrowable {
+                     hatchingType = event.getHatchingType();
+                 }
+ 
++                // Paper start
++                com.destroystokyo.paper.event.entity.ThrownEggHatchEvent event = new com.destroystokyo.paper.event.entity.ThrownEggHatchEvent((org.bukkit.entity.Egg) getBukkitEntity(), hatching, b0, hatchingType);
++                event.callEvent();
++
++                b0 = event.getNumHatches();
++                hatching = event.isHatching();
++                hatchingType = event.getHatchingType();
++                // Paper end
++
++
+                 if (hatching) {
+                     for (int i = 0; i < b0; ++i) {
+                         Entity entity = world.getWorld().createEntity(new org.bukkit.Location(world.getWorld(), this.locX(), this.locY(), this.locZ(), this.yaw, 0.0F), hatchingType.getEntityClass());
+-- 
+2.25.0
+


### PR DESCRIPTION
Adds a new event similar to PlayerEggThrowEvent, but without the Player requirement (dispensers can throw eggs to hatch them, too).