### PR TITLE
Fix furnace cook multiplier not correctly using values between 0 and 1

### DIFF
--- a/Spigot-Server-Patches/0355-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/Spigot-Server-Patches/0355-Implement-furnace-cook-speed-multiplier-API.patch
@@ -1,4 +1,4 @@
-From e6278f7b1afddb39628b007f2f651679894c54e9 Mon Sep 17 00:00:00 2001
+From 1ff2de24d552ee3283e2af4d7ab2c6268744186c Mon Sep 17 00:00:00 2001
 From: Tassu <git@tassu.me>
 Date: Thu, 13 Sep 2018 08:45:21 +0300
 Subject: [PATCH] Implement furnace cook speed multiplier API
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement furnace cook speed multiplier API
 Signed-off-by: Tassu <git@tassu.me>
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityFurnace.java b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-index 5b6ccfa9f..bfbd35bbe 100644
+index 5b6ccfa9f..d606b3224 100644
 --- a/src/main/java/net/minecraft/server/TileEntityFurnace.java
 +++ b/src/main/java/net/minecraft/server/TileEntityFurnace.java
 @@ -9,6 +9,7 @@ import java.util.Map.Entry;
@@ -45,14 +45,12 @@ index 5b6ccfa9f..bfbd35bbe 100644
          ContainerUtil.a(nbttagcompound, this.items);
          nbttagcompound.setShort("RecipesUsedSize", (short) this.m.size());
          int i = 0;
-@@ -299,8 +307,8 @@ public class TileEntityFurnace extends TileEntityContainer implements IWorldInve
-                 }
+@@ -300,7 +308,7 @@ public class TileEntityFurnace extends TileEntityContainer implements IWorldInve
  
                  if (this.isBurning() && this.canBurn(irecipe)) {
--                    ++this.cookTime;
+                     ++this.cookTime;
 -                    if (this.cookTime == this.cookTimeTotal) {
-+                    this.cookTime += cookSpeedMultiplier; // Paper - cook speed multiplier API
-+                    if (this.cookTime >= this.cookTimeTotal) { // Paper - cook speed multiplier API
++                    if (this.cookTime >= this.cookTimeTotal / this.cookSpeedMultiplier) { // Paper - cook speed multiplier API
                          this.cookTime = 0;
                          this.cookTimeTotal = this.s();
                          this.burn(irecipe);
@@ -80,5 +78,5 @@ index c2eea8ce0..429c780ec 100644
 +    // Paper end
  }
 -- 
-2.21.0
+2.20.1
 


### PR DESCRIPTION
**Note:** _This entire patch is weird and out of place. It was [originally created for 1.7](https://github.com/IPVP-MC/Paper-1.7/commit/3516ae34efedacaf3ddd95776a9d3b1d721070fd) before CB had its own [furnace API to modify cook times](https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/block/Furnace.html). The two do not mutually go with each other. This can be seen in the current implementation modifying the `cookTime` when a multiplier is set resulting in `Furnace#getCookTime()` reporting the wrong amount of time it's been cooking for. After this PR that will be fixed but the `cookTimeTotal` will appear to be wrong in `Furnace#getCookTimeTotal()` if a multiplier is set. Etc etc._

**However, this PR does fix #1983 as reported.**

After this PR a multiplier value of 0.5 will result in a slower cook speed by half. A value of 2.0 will result in a faster cook speed by double. Etc etc.