### PR TITLE
Expose the internal current tick

### DIFF
--- a/Spigot-API-Patches/0183-Expose-the-internal-current-tick.patch
+++ b/Spigot-API-Patches/0183-Expose-the-internal-current-tick.patch
@@ -1,0 +1,41 @@
+From fa2ddb381a3ee826dfa76caf757b1c527959ef92 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 20 Apr 2019 19:47:29 -0500
+Subject: [PATCH] Expose the internal current tick
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 5ed9726c..bceccd00 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1631,6 +1631,10 @@ public final class Bukkit {
+     public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
+         return server.createProfile(uuid, name);
+     }
++
++    public static int getCurrentTick() {
++        return server.getCurrentTick();
++    }
+     // Paper end
+ 
+     @NotNull
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index eb23417b..2f89fd75 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1426,5 +1426,12 @@ public interface Server extends PluginMessageRecipient {
+      */
+     @NotNull
+     com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);
++
++    /**
++     * Get the current internal server tick
++     *
++     * @return Current tick
++     */
++    int getCurrentTick();
+     // Paper end
+ }
+-- 
+2.20.1
+

--- a/Spigot-Server-Patches/0440-Expose-the-internal-current-tick.patch
+++ b/Spigot-Server-Patches/0440-Expose-the-internal-current-tick.patch
@@ -1,0 +1,24 @@
+From e0bb09ed97a46ad27deee641825d6d2385e67b9d Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Sat, 20 Apr 2019 19:47:34 -0500
+Subject: [PATCH] Expose the internal current tick
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 9c5b79920..ee841bb01 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2207,5 +2207,10 @@ public final class CraftServer implements Server {
+         }
+         return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
+     }
++
++    @Override
++    public int getCurrentTick() {
++        return MinecraftServer.currentTick;
++    }
+     // Paper end
+ }
+-- 
+2.20.1
+


### PR DESCRIPTION
I've seen this requested a number of times recently.

Having this readily available prevents plugins from having to schedule their own task just to increment their own counter.