### PR TITLE
Fix itemframe sound on change

### DIFF
--- a/Spigot-Server-Patches/0441-Fix-sounds-when-item-frames-are-modified-MC-123450.patch
+++ b/Spigot-Server-Patches/0441-Fix-sounds-when-item-frames-are-modified-MC-123450.patch
@@ -1,0 +1,36 @@
+From f175505ce0a62b77390a9d7c83dfa52c309287a3 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Sat, 27 Apr 2019 20:00:43 +0100
+Subject: [PATCH] Fix sounds when item frames are modified (MC-123450)
+
+This also fixes the adding sound playing when the item frame direction is changed.
+
+diff --git a/src/main/java/net/minecraft/server/EntityItemFrame.java b/src/main/java/net/minecraft/server/EntityItemFrame.java
+index 964509a3..1b1e0838 100644
+--- a/src/main/java/net/minecraft/server/EntityItemFrame.java
++++ b/src/main/java/net/minecraft/server/EntityItemFrame.java
+@@ -186,7 +186,7 @@ public class EntityItemFrame extends EntityHanging {
+         }
+ 
+         this.getDataWatcher().set(EntityItemFrame.e, itemstack);
+-        if (!itemstack.isEmpty() && playSound) { // CraftBukkit
++        if (!itemstack.isEmpty() && flag && playSound) { // CraftBukkit // Paper - only play sound when update flag is set
+             this.a(SoundEffects.ENTITY_ITEM_FRAME_ADD_ITEM, 1.0F, 1.0F);
+         }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
+index 227a9ffa..d6328d2f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
+@@ -51,7 +51,7 @@ public class CraftItemFrame extends CraftHanging implements ItemFrame {
+         old.die();
+ 
+         EntityItemFrame frame = new EntityItemFrame(world,position,direction);
+-        frame.setItem(item);
++        frame.setItem(item, true, false); // Paper - fix itemframe sound
+         world.addEntity(frame);
+         this.entity = frame;
+     }
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
Previously item frames would make the item change sound when they where edited by using /data merge ([MC-123450](https://bugs.mojang.com/browse/MC-123450)) or even when the direction was changed by a plugin. This fixes that by passing false to the playSound and checking for the update flag (which doesn't get send by data merging) in order to not play that sound.