### PR TITLE
Fix patch "Faster redstone torch rapid clock removal"

### DIFF
--- a/Spigot-Server-Patches/0106-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/Spigot-Server-Patches/0106-Faster-redstone-torch-rapid-clock-removal.patch
@@ -1,4 +1,4 @@
-From 1d7fc3c3ce80240e99ea57a6c854b515b3880f3a Mon Sep 17 00:00:00 2001
+From d52d8059d6a382725261365b534a91ff351b17c2 Mon Sep 17 00:00:00 2001
 From: Martin Panzer <postremus1996@googlemail.com>
 Date: Mon, 23 May 2016 12:12:37 +0200
 Subject: [PATCH] Faster redstone torch rapid clock removal
@@ -6,29 +6,67 @@ Subject: [PATCH] Faster redstone torch rapid clock removal
 Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
-index a99f979ef..a79484e3e 100644
+index a99f979ef..919ba8a14 100644
 --- a/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
 +++ b/src/main/java/net/minecraft/server/BlockRedstoneTorch.java
-@@ -68,9 +68,17 @@ public class BlockRedstoneTorch extends BlockTorch {
+@@ -11,7 +11,7 @@ import org.bukkit.event.block.BlockRedstoneEvent; // CraftBukkit
+ public class BlockRedstoneTorch extends BlockTorch {
+ 
+     public static final BlockStateBoolean LIT = BlockProperties.r;
+-    private static final Map<IBlockAccess, List<BlockRedstoneTorch.RedstoneUpdateInfo>> b = new WeakHashMap();
++    // Paper - Move the mapped list to World
+ 
+     protected BlockRedstoneTorch(Block.Info block_info) {
+         super(block_info);
+@@ -66,11 +66,16 @@ public class BlockRedstoneTorch extends BlockTorch {
+     }
+ 
      public static void a(IBlockData iblockdata, World world, BlockPosition blockposition, Random random, boolean flag) {
-         List list = (List) BlockRedstoneTorch.b.get(world);
+-        List list = (List) BlockRedstoneTorch.b.get(world);
++        // Paper start
++        java.util.ArrayDeque<BlockRedstoneTorch.RedstoneUpdateInfo> redstoneUpdateInfos = world.redstoneUpdateInfos;
  
 -        while (list != null && !list.isEmpty() && world.getTime() - ((BlockRedstoneTorch.RedstoneUpdateInfo) list.get(0)).b > 60L) {
 -            list.remove(0);
-+        // Paper start
-+        if (list != null) {
-+            int index = 0;
-+            while (index < list.size() && world.getTime() - ((BlockRedstoneTorch.RedstoneUpdateInfo) list.get(index)).getTime() > 60L) {
-+                index++;
-+            }
-+            if (index > 0) {
-+                list.subList(0, index).clear();
++        if (redstoneUpdateInfos != null) {
++            BlockRedstoneTorch.RedstoneUpdateInfo curr;
++            while ((curr = redstoneUpdateInfos.peek()) != null && world.getTime() - curr.getTime() > 60L) {
++                redstoneUpdateInfos.poll();
 +            }
          }
 +        // Paper end
  
          // CraftBukkit start
          org.bukkit.plugin.PluginManager manager = world.getServer().getPluginManager();
+@@ -140,9 +145,12 @@ public class BlockRedstoneTorch extends BlockTorch {
+     }
+ 
+     private static boolean a(World world, BlockPosition blockposition, boolean flag) {
+-        List<BlockRedstoneTorch.RedstoneUpdateInfo> list = (List) BlockRedstoneTorch.b.computeIfAbsent(world, (iblockaccess) -> {
+-            return Lists.newArrayList();
+-        });
++        // Paper start
++        java.util.ArrayDeque<BlockRedstoneTorch.RedstoneUpdateInfo> list = world.redstoneUpdateInfos;
++        if (list == null) {
++            list = world.redstoneUpdateInfos = new java.util.ArrayDeque<>();
++        }
++
+ 
+         if (flag) {
+             list.add(new BlockRedstoneTorch.RedstoneUpdateInfo(blockposition.immutableCopy(), world.getTime()));
+@@ -150,9 +158,9 @@ public class BlockRedstoneTorch extends BlockTorch {
+ 
+         int i = 0;
+ 
+-        for (int j = 0; j < list.size(); ++j) {
+-            BlockRedstoneTorch.RedstoneUpdateInfo blockredstonetorch_redstoneupdateinfo = (BlockRedstoneTorch.RedstoneUpdateInfo) list.get(j);
+-
++        for (java.util.Iterator<BlockRedstoneTorch.RedstoneUpdateInfo> iterator = list.iterator(); iterator.hasNext();) {
++            BlockRedstoneTorch.RedstoneUpdateInfo blockredstonetorch_redstoneupdateinfo = iterator.next();
++            // Paper end
+             if (blockredstonetorch_redstoneupdateinfo.a.equals(blockposition)) {
+                 ++i;
+                 if (i >= 8) {
 @@ -167,7 +175,7 @@ public class BlockRedstoneTorch extends BlockTorch {
      public static class RedstoneUpdateInfo {
  
@@ -38,6 +76,18 @@ index a99f979ef..a79484e3e 100644
  
          public RedstoneUpdateInfo(BlockPosition blockposition, long i) {
              this.a = blockposition;
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index de09ed97e..3305e110c 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -99,6 +99,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+     private org.spigotmc.TickLimiter tileLimiter;
+     private int tileTickPosition;
+     public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
++    public java.util.ArrayDeque<BlockRedstoneTorch.RedstoneUpdateInfo> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here
+ 
+     public CraftWorld getWorld() {
+         return this.world;
 -- 
 2.21.0
 

--- a/Spigot-Server-Patches/0129-Optimize-World.isLoaded-BlockPosition-Z.patch
+++ b/Spigot-Server-Patches/0129-Optimize-World.isLoaded-BlockPosition-Z.patch
@@ -1,4 +1,4 @@
-From 40572ae9162a641bd6cea6dd281a7ef4faf25f38 Mon Sep 17 00:00:00 2001
+From 900048bc0a83882aa8c155c135a93c33851eba69 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 2 Dec 2016 00:11:43 -0500
 Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5637c3872..1286703bf 100644
+index 3305e110c..8ac081bef 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -208,6 +208,10 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -209,6 +209,10 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          return i < 0 || i >= 256;
      }
  

--- a/Spigot-Server-Patches/0172-Fix-MC-117075-TE-Unload-Lag-Spike.patch
+++ b/Spigot-Server-Patches/0172-Fix-MC-117075-TE-Unload-Lag-Spike.patch
@@ -1,14 +1,14 @@
-From 9bd0b46ac1dc7a48289ebe7365b4035cb30cf301 Mon Sep 17 00:00:00 2001
+From 4a06cdf0e8a73013b84c46cd67d12b3cec8cbfb4 Mon Sep 17 00:00:00 2001
 From: mezz <tehgeek@gmail.com>
 Date: Wed, 9 Aug 2017 17:51:22 -0500
 Subject: [PATCH] Fix MC-117075: TE Unload Lag Spike
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 9b9e969f52..ea8a6e557a 100644
+index 8ac081bef..f9413dd68 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -729,7 +729,11 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -730,7 +730,11 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          gameprofilerfiller.enter("blockEntities");
          timings.tileEntityTick.startTiming(); // Spigot
          if (!this.tileEntityListUnload.isEmpty()) {

--- a/Spigot-Server-Patches/0184-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/Spigot-Server-Patches/0184-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -1,4 +1,4 @@
-From 8cb1dec3a6a38ebdd4e4ae464789085dbc20e616 Mon Sep 17 00:00:00 2001
+From b1a18d2954d0e282cfb78fce638663d2afeadaba Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Tue, 31 Oct 2017 03:26:18 +0100
 Subject: [PATCH] Send attack SoundEffects only to players who can see the
@@ -6,7 +6,7 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 0f8100a05e..a30d88af81 100644
+index 0f8100a05..a30d88af8 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -941,6 +941,15 @@ public abstract class EntityHuman extends EntityLiving {
@@ -72,10 +72,10 @@ index 0f8100a05e..a30d88af81 100644
                              entity.extinguish();
                          }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index ea8a6e557a..b3a4b2ea97 100644
+index f9413dd68..8328b0125 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -666,6 +666,10 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -667,6 +667,10 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          this.a(entityhuman, (double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D, soundeffect, soundcategory, f, f1);
      }
  

--- a/Spigot-Server-Patches/0188-use-CB-BlockState-implementations-for-captured-block.patch
+++ b/Spigot-Server-Patches/0188-use-CB-BlockState-implementations-for-captured-block.patch
@@ -1,4 +1,4 @@
-From 4ce23a028026ea464b12623a787b7fd10a3de2bb Mon Sep 17 00:00:00 2001
+From 6372cbd4afa45ce3bb758f13529d5f38893d6947 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Thu, 16 Nov 2017 12:12:41 +0000
 Subject: [PATCH] use CB BlockState implementations for captured blocks
@@ -18,10 +18,10 @@ the blockstate that will be valid for restoration, as opposed to dropping
 information on restoration when the event is cancelled.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 0389ecadff..dd74f38038 100644
+index 8328b0125..c388a8261 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -343,7 +343,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -344,7 +344,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
              // CraftBukkit start - capture blockstates
              CraftBlockState blockstate = null;
              if (this.captureBlockStates) {

--- a/Spigot-Server-Patches/0249-Avoid-Chunk-Lookups-for-Entity-TileEntity-Current-Ch.patch
+++ b/Spigot-Server-Patches/0249-Avoid-Chunk-Lookups-for-Entity-TileEntity-Current-Ch.patch
@@ -1,4 +1,4 @@
-From f9d1477d080f592e85e7279932c397dba374cb13 Mon Sep 17 00:00:00 2001
+From 2b38cf192766111ee616781fcad9018b0ce05cbd Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 4 Jul 2018 03:39:51 -0400
 Subject: [PATCH] Avoid Chunk Lookups for Entity/TileEntity Current Chunk
@@ -10,10 +10,10 @@ to the object directly on the Entity/TileEntity object we can directly grab.
 Use that local value instead to reduce lookups in many hot places.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index edd8e7810f..5349a3a8bc 100644
+index c388a8261..463353bc7 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -761,7 +761,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -762,7 +762,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
              if (!tileentity.isRemoved() && tileentity.hasWorld()) {
                  BlockPosition blockposition = tileentity.getPosition();
  
@@ -23,7 +23,7 @@ index edd8e7810f..5349a3a8bc 100644
                      try {
                          gameprofilerfiller.a(() -> {
                              return String.valueOf(TileEntityTypes.a(tileentity.q()));
-@@ -795,7 +796,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -796,7 +797,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
                  this.tileEntityListTick.remove(tileTickPosition--);
                  // Spigot end
                  //this.tileEntityList.remove(tileentity); // Paper - remove unused list
@@ -32,7 +32,7 @@ index edd8e7810f..5349a3a8bc 100644
                      this.getChunkAtWorldCoords(tileentity.getPosition()).removeTileEntity(tileentity.getPosition());
                  }
              }
-@@ -816,8 +817,9 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -817,8 +818,9 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
                      }
                      // CraftBukkit end */
  
@@ -45,7 +45,7 @@ index edd8e7810f..5349a3a8bc 100644
  
                          chunk.setTileEntity(tileentity1.getPosition(), tileentity1);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 38d673d8fe..902aa562cc 100644
+index 0e559133f..1c92cf58a 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1068,7 +1068,7 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0265-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0265-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -1,11 +1,11 @@
-From 335b90c1a502709c87dbbb48859344d896977485 Mon Sep 17 00:00:00 2001
+From 5594979e93df19a7c1fad783524dd6c966cf351f Mon Sep 17 00:00:00 2001
 From: Hugo Manrique <hugmanrique@gmail.com>
 Date: Mon, 23 Jul 2018 12:57:39 +0200
 Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83e54cb904..f06bb3ae19 100644
+index 83e54cb90..f06bb3ae1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -326,6 +326,11 @@ public class PaperWorldConfig {
@@ -21,10 +21,10 @@ index 83e54cb904..f06bb3ae19 100644
      private void maxEntityCollision() {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a7e24ed725..5544c4dbf3 100644
+index 8c59ec41c..33f0d1cd8 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -868,6 +868,14 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -869,6 +869,14 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          // Spigot end
      }
  

--- a/Spigot-Server-Patches/0310-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
+++ b/Spigot-Server-Patches/0310-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
@@ -1,11 +1,11 @@
-From f29dcfd87c3bff303269693956d68e7e3cb8197d Mon Sep 17 00:00:00 2001
+From c81e2d8af2ab8dd4c2059c669964451c78c628be Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 10 Sep 2018 23:56:36 -0400
 Subject: [PATCH] Prevent Mob AI Rules from Loading Chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
-index ce9318c575..541d97344e 100644
+index ce9318c57..541d97344 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
 @@ -12,11 +12,13 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
@@ -53,7 +53,7 @@ index ce9318c575..541d97344e 100644
          return block == this.g && iworldreader.getType(blockposition.up()).isAir() && iworldreader.getType(blockposition.up(2)).isAir();
      }
 diff --git a/src/main/java/net/minecraft/server/RandomPositionGenerator.java b/src/main/java/net/minecraft/server/RandomPositionGenerator.java
-index 8340d6d25b..78eb1b39cf 100644
+index 8340d6d25..78eb1b39c 100644
 --- a/src/main/java/net/minecraft/server/RandomPositionGenerator.java
 +++ b/src/main/java/net/minecraft/server/RandomPositionGenerator.java
 @@ -93,6 +93,7 @@ public class RandomPositionGenerator {
@@ -74,10 +74,10 @@ index 8340d6d25b..78eb1b39cf 100644
      }
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5544c4dbf3..39d5a8f5e5 100644
+index 33f0d1cd8..acd1b856e 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -646,6 +646,16 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -647,6 +647,16 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
              return chunk.getType(blockposition);
          }
      }

--- a/Spigot-Server-Patches/0325-Add-sun-related-API.patch
+++ b/Spigot-Server-Patches/0325-Add-sun-related-API.patch
@@ -1,11 +1,11 @@
-From 424d5ef016abd8b3cc39723424efda13f1255740 Mon Sep 17 00:00:00 2001
+From 6f55238bc936a3be2d872c5f7a0b8c71b9832acf Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 7 Oct 2018 00:54:21 -0500
 Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index f1621a9e9d..a8318c88af 100644
+index f1621a9e9..a8318c88a 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -1330,6 +1330,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -17,10 +17,10 @@ index f1621a9e9d..a8318c88af 100644
          if (this.world.J() && !this.world.isClientSide) {
              float f = this.aE();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 39d5a8f5e5..2278c7c4ab 100644
+index acd1b856e..8bbcbbf89 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -668,6 +668,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -669,6 +669,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          }
      }
  
@@ -29,7 +29,7 @@ index 39d5a8f5e5..2278c7c4ab 100644
          return this.d < 4;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 28c5fd988d..ed646bc9db 100644
+index 583fc6f75..b9786909b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -740,6 +740,13 @@ public class CraftWorld implements World {
@@ -47,7 +47,7 @@ index 28c5fd988d..ed646bc9db 100644
      public boolean createExplosion(double x, double y, double z, float power) {
          return createExplosion(x, y, z, power, false, true);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
-index 53c2d154ed..56c233872b 100644
+index 53c2d154e..56c233872 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
 @@ -68,4 +68,11 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob {

--- a/Spigot-Server-Patches/0346-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0346-Optimize-redstone-algorithm.patch
@@ -1,4 +1,4 @@
-From f4ea90abc5bbe39acf0de2aa6de4801139e329ac Mon Sep 17 00:00:00 2001
+From 1befa1b4906acf0477abe19ae45aacfb4c3326a0 Mon Sep 17 00:00:00 2001
 From: theosib <millerti@172.16.221.1>
 Date: Thu, 27 Sep 2018 01:43:35 -0600
 Subject: [PATCH] Optimize redstone algorithm
@@ -19,7 +19,7 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ad793ffa38..ef882b897f 100644
+index ad793ffa3..ef882b897 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -439,4 +439,14 @@ public class PaperWorldConfig {
@@ -39,7 +39,7 @@ index ad793ffa38..ef882b897f 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 new file mode 100644
-index 0000000000..cf5661f1c5
+index 000000000..cf5661f1c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 @@ -0,0 +1,912 @@
@@ -956,7 +956,7 @@ index 0000000000..cf5661f1c5
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/BlockRedstoneWire.java b/src/main/java/net/minecraft/server/BlockRedstoneWire.java
-index da903f74b6..aa35e0d061 100644
+index da903f74b..aa35e0d06 100644
 --- a/src/main/java/net/minecraft/server/BlockRedstoneWire.java
 +++ b/src/main/java/net/minecraft/server/BlockRedstoneWire.java
 @@ -1,5 +1,7 @@
@@ -1124,10 +1124,10 @@ index da903f74b6..aa35e0d061 100644
                  c(iblockdata, world, blockposition);
                  world.a(blockposition, false);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 2278c7c4ab..4531adc268 100644
+index 8bbcbbf89..34d7b9314 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -547,6 +547,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -548,6 +548,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
  
      }
  
@@ -1135,7 +1135,7 @@ index 2278c7c4ab..4531adc268 100644
      public void a(BlockPosition blockposition, Block block, BlockPosition blockposition1) {
          if (!this.isClientSide) {
              IBlockData iblockdata = this.getType(blockposition);
-@@ -1308,6 +1309,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -1309,6 +1310,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          return this.getBlockFacePower(blockposition.down(), EnumDirection.DOWN) > 0 ? true : (this.getBlockFacePower(blockposition.up(), EnumDirection.UP) > 0 ? true : (this.getBlockFacePower(blockposition.north(), EnumDirection.NORTH) > 0 ? true : (this.getBlockFacePower(blockposition.south(), EnumDirection.SOUTH) > 0 ? true : (this.getBlockFacePower(blockposition.west(), EnumDirection.WEST) > 0 ? true : this.getBlockFacePower(blockposition.east(), EnumDirection.EAST) > 0))));
      }
  

--- a/Spigot-Server-Patches/0362-BlockDestroyEvent.patch
+++ b/Spigot-Server-Patches/0362-BlockDestroyEvent.patch
@@ -1,4 +1,4 @@
-From cd6a0cd2c5e568884667729120406fc27837e454 Mon Sep 17 00:00:00 2001
+From 7d73d345fb5c9ad84aa68fa7d80de4dcee6088a6 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 6 Feb 2019 00:20:33 -0500
 Subject: [PATCH] BlockDestroyEvent
@@ -11,10 +11,10 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 4531adc268..a7333de99a 100644
+index 34d7b9314..ab56086e1 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -477,8 +477,20 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -478,8 +478,20 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
              return false;
          } else {
              Fluid fluid = this.getFluid(blockposition);

--- a/Spigot-Server-Patches/0385-Optimize-Captured-TileEntity-Lookup.patch
+++ b/Spigot-Server-Patches/0385-Optimize-Captured-TileEntity-Lookup.patch
@@ -1,4 +1,4 @@
-From 56b3f4aeb4601cb80aaf0e66c2d97482e23e5ac8 Mon Sep 17 00:00:00 2001
+From d2b2e3091b3cf797a06a1fc5c86388e90d87f384 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 6 Apr 2019 10:16:48 -0400
 Subject: [PATCH] Optimize Captured TileEntity Lookup
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a7333de99a..235440c651 100644
+index ab56086e1..a1e660767 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1050,12 +1050,13 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -1051,12 +1051,13 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
              return null;
          } else {
              // CraftBukkit start

--- a/Spigot-Server-Patches/0386-Add-Heightmap-API.patch
+++ b/Spigot-Server-Patches/0386-Add-Heightmap-API.patch
@@ -1,14 +1,14 @@
-From 38a4833f0693fd44bd6be0fd00b32ad98af60dd0 Mon Sep 17 00:00:00 2001
+From 898e971f01f728b6ddddda340224e41a63a39a53 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Tue, 1 Jan 2019 02:22:01 -0800
 Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 235440c651..cae59ed377 100644
+index a1e660767..4caf5d9af 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -616,8 +616,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
+@@ -617,8 +617,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
          }
      }
  
@@ -20,7 +20,7 @@ index 235440c651..cae59ed377 100644
  
          if (i >= -30000000 && j >= -30000000 && i < 30000000 && j < 30000000) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ed646bc9db..d2c3ea0dc3 100644
+index b9786909b..cd3814cdd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -317,6 +317,29 @@ public class CraftWorld implements World {


### PR DESCRIPTION
Tux pointed out the patch still has O(n^2) time complexity since
the sublist class in arraylist does not override clear() from
AbstractList, which uses a forward moving iterator to clear
the list.

Resolved by using a peek and poll from ArrayDeque.

This patch also removes the useless WeakHashMap which holds
the list (it mapped world->list) and replaces it with a
field on World.