### PR TITLE
Fix CraftServer#isPrimaryThread

### DIFF
--- a/Spigot-Server-Patches/0393-Fix-CraftServer-isPrimaryThread.patch
+++ b/Spigot-Server-Patches/0393-Fix-CraftServer-isPrimaryThread.patch
@@ -1,0 +1,25 @@
+From 6895a8604cf3ee8ae64a698e1f5a4d298121c848 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Mon, 13 May 2019 21:10:59 -0700
+Subject: [PATCH] Fix CraftServer#isPrimaryThread
+
+md_5 changed it so he could shut down the server asynchronously
+from watchdog, although we have patches that prevent that type
+of behavior for this exact reason.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 56e8a613e9..22d53844c5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1663,7 +1663,7 @@ public final class CraftServer implements Server {
+ 
+     @Override
+     public boolean isPrimaryThread() {
+-        return Thread.currentThread().equals(console.serverThread) || console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
++        return Thread.currentThread().equals(console.serverThread); // Paper - Fix issues with detecting main thread properly
+     }
+ 
+     @Override
+-- 
+2.21.0
+


### PR DESCRIPTION
md_5 changed it so he could shut down the server asynchronously
from watchdog, although we have patches that prevent that type
of behavior for this exact reason.