### PR TITLE
Use a regular boxed primitive map in the DataWatcher optimization

### DIFF
--- a/Spigot-Server-Patches/0079-Use-Optimized-Collections.patch
+++ b/Spigot-Server-Patches/0079-Use-Optimized-Collections.patch
@@ -1,4 +1,4 @@
-From b82a8f1e62534de6c4f4bfceeda56a580ca0eaa6 Mon Sep 17 00:00:00 2001
+From c0be431869fabc22a5e48865f5c096df55a63a99 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 30 Mar 2016 02:13:24 -0400
 Subject: [PATCH] Use Optimized Collections
@@ -13,7 +13,7 @@ These collections are super fast as seen
 http://java-performance.info/hashmap-overview-jdk-fastutil-goldman-sachs-hppc-koloboke-trove-january-2015/
 
 diff --git a/src/main/java/net/minecraft/server/DataWatcher.java b/src/main/java/net/minecraft/server/DataWatcher.java
-index 79a240cd1d..f224043d8e 100644
+index 79a240cd1..6c259effb 100644
 --- a/src/main/java/net/minecraft/server/DataWatcher.java
 +++ b/src/main/java/net/minecraft/server/DataWatcher.java
 @@ -12,6 +12,7 @@ import java.util.Map;
@@ -29,7 +29,7 @@ index 79a240cd1d..f224043d8e 100644
      private static final Map<Class<? extends Entity>, Integer> b = Maps.newHashMap();
      private final Entity c;
 -    private final Map<Integer, DataWatcher.Item<?>> d = Maps.newHashMap();
-+    private final Int2ObjectOpenHashMap<DataWatcher.Item<?>> d = new Int2ObjectOpenHashMap<>(); // Paper
++    private final Map<Integer, DataWatcher.Item<?>> d = new Int2ObjectOpenHashMap<>(); // Paper
      private final ReadWriteLock e = new ReentrantReadWriteLock();
      private boolean f = true;
      private boolean g;

--- a/Spigot-Server-Patches/0393-Elide-lock-in-DataWatcher.patch
+++ b/Spigot-Server-Patches/0393-Elide-lock-in-DataWatcher.patch
@@ -1,4 +1,4 @@
-From 8cb44a97224fca86ef23ca29a80cbadb9d4ea1d3 Mon Sep 17 00:00:00 2001
+From 124dff59342bfcc16baf82c177892b1c8ef32357 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 11 May 2019 08:19:27 -0700
 Subject: [PATCH] Elide lock in DataWatcher
@@ -17,13 +17,13 @@ of the Entity, the further readlocks are actually
 useless (which get obtained on set, get, etc calls).
 
 diff --git a/src/main/java/net/minecraft/server/DataWatcher.java b/src/main/java/net/minecraft/server/DataWatcher.java
-index f224043d8e..bbea8ef726 100644
+index 6c259effb..496c46095 100644
 --- a/src/main/java/net/minecraft/server/DataWatcher.java
 +++ b/src/main/java/net/minecraft/server/DataWatcher.java
 @@ -23,7 +23,7 @@ public class DataWatcher {
      private static final Map<Class<? extends Entity>, Integer> b = Maps.newHashMap();
      private final Entity c;
-     private final Int2ObjectOpenHashMap<DataWatcher.Item<?>> d = new Int2ObjectOpenHashMap<>(); // Paper
+     private final Map<Integer, DataWatcher.Item<?>> d = new Int2ObjectOpenHashMap<>(); // Paper
 -    private final ReadWriteLock e = new ReentrantReadWriteLock();
 +    //private final ReadWriteLock e = new ReentrantReadWriteLock(); // Paper - not required
      private boolean f = true;


### PR DESCRIPTION
Yes, it's yet another brain-damaged plugin preventing us from optimizing this further. The (dis)honor of the brain-damaged plugin goes to [TAB](https://www.spigotmc.org/resources/tab-1-8-x-1-14-1-reborn.57806/), which think it's a swell idea to just replace the internal DataWatcher map with whatever it wants.

This reverts a small portion of #2029, keeping the lock elision intact.

[Relevant console log](https://pastebin.com/cHq65nTr)