### PR TITLE
MC-114618 - Fix EntityAreaEffectCloud from going negative size

### DIFF
--- a/Spigot-Server-Patches/0398-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
+++ b/Spigot-Server-Patches/0398-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
@@ -1,0 +1,44 @@
+From ac63e7e69a76ece9487793c7fd88d96c54d51f9e Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Mon, 27 May 2019 17:35:39 -0500
+Subject: [PATCH] MC-114618 - Fix EntityAreaEffectCloud from going negative
+ size
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
+index 418c638d3..2eaed1cd6 100644
+--- a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
++++ b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
+@@ -163,6 +163,12 @@ public class EntityAreaEffectCloud extends Entity {
+         super.tick();
+         boolean flag = this.l();
+         float f = this.getRadius();
++        // Paper start - fix MC-114618
++        if (f < 0.5F) {
++            this.die();
++            return;
++        }
++        // Paper end
+ 
+         if (this.world.isClientSide) {
+             ParticleParam particleparam = this.getParticle();
+@@ -232,10 +238,12 @@ public class EntityAreaEffectCloud extends Entity {
+ 
+             if (this.radiusPerTick != 0.0F) {
+                 f += this.radiusPerTick;
+-                if (f < 0.5F) {
+-                    this.die();
+-                    return;
+-                }
++                // Paper start - moved up - fix MC-114618
++                //if (f < 0.5F) {
++                //    this.die();
++                //    return;
++                //}
++                // Paper end
+ 
+                 this.setRadius(f);
+             }
+-- 
+2.20.1
+


### PR DESCRIPTION
This is a vanilla bug, https://bugs.mojang.com/browse/MC-114618

All cases of the EntityAreaEffectCloud spawning set a radius per tick to a non 0 value (they shrink over time), except for the case when a dragon is in SITTING_FLAMING phase. The EntityAreaEffectCloud itself checks for when the radius gets too small it will despawn itself, but _only_ in if the radius per tick is a non 0 value.

This change moves the radius size check outside the radius per tick check and to the top of the tick so it is despawned when it gets too small regardless of the radius per tick value.

_This can be backported to 1.13, 1.12, and 1.11_

Fixes #2088 