### PR TITLE
Add PlayerTriggerRaidEvent

### DIFF
--- a/Spigot-API-Patches/0183-Add-PlayerTriggerRaidEvent.patch
+++ b/Spigot-API-Patches/0183-Add-PlayerTriggerRaidEvent.patch
@@ -1,0 +1,72 @@
+From ac0dad41627f1c8dd614d22cc5bb78df61dbe13f Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 28 May 2019 02:24:10 -0700
+Subject: [PATCH] Add PlayerTriggerRaidEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerTriggerRaidEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerTriggerRaidEvent.java
+new file mode 100644
+index 00000000..303cbe36
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerTriggerRaidEvent.java
+@@ -0,0 +1,57 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when the server detects that a player has triggered a raid, but
++ * before the raid begins.
++ */
++public class PlayerTriggerRaidEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancel = false;
++
++    public PlayerTriggerRaidEvent(@NotNull final Player player) {
++        super(player);
++    }
++
++    /**
++     * Gets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     * <p>
++     * If a raid trigger event is cancelled, the player will still lose the
++     * Bad Omen effect that triggered the event.
++     *
++     * @return true if this event is cancelled
++     */
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    /**
++     * Sets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     * <p>
++     * If a raid trigger event is cancelled, the player will still lose the
++     * Bad Omen effect that triggered the event.
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.19.2
+

--- a/Spigot-Server-Patches/0397-Implement-PlayerTriggerRaidEvent.patch
+++ b/Spigot-Server-Patches/0397-Implement-PlayerTriggerRaidEvent.patch
@@ -1,0 +1,27 @@
+From 7e476463b967a71f27636b2b91ab2b8cccf39b5b Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 28 May 2019 02:30:16 -0700
+Subject: [PATCH] Implement PlayerTriggerRaidEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PersistentRaid.java b/src/main/java/net/minecraft/server/PersistentRaid.java
+index 6a8469d7..444703fd 100644
+--- a/src/main/java/net/minecraft/server/PersistentRaid.java
++++ b/src/main/java/net/minecraft/server/PersistentRaid.java
+@@ -73,6 +73,13 @@ public class PersistentRaid extends PersistentBase {
+                 Raid raid = this.a(entityplayer.getWorldServer(), (BlockPosition) optional.get());
+                 boolean flag = false;
+ 
++                // Paper start
++                if (!new com.destroystokyo.paper.event.player.PlayerTriggerRaidEvent(entityplayer.getBukkitEntity()).callEvent()) {
++                    entityplayer.removeEffect(MobEffects.BAD_OMEN);
++                    return null;
++                }
++                // Paper end
++
+                 if (!raid.j()) {
+                     if (!this.a.containsKey(raid.t())) {
+                         this.a.put(raid.t(), raid);
+-- 
+2.19.2
+


### PR DESCRIPTION
These patches add the event `PlayerRaidTriggerEvent` that is fired when a player enters a village with the *Bad Omen* effect.

While initially working on this, I noticed that while I was able to cancel the raid that it the raid continued to attempt to start because of the Player's *Bad Omen* status. I've duplicated the effect removal upwards to the conditional which tests if the event is canceled. In this way, the event is fired once per player who enters a village with the *Bad Omen* effect.

I'm having second thoughts about removing the effect and whether or not this should be deferred to an implementing plugin.

Sidenote: This is my first PR, so if I did something wrong or you need more information please let me know.

![Screenshot+2019-05-28+02 53 34](https://user-images.githubusercontent.com/19645494/58469637-c232de80-80f4-11e9-8d3e-51f417bbd634.png)
