### PR TITLE
Add BlockSoundGroup to Block & Implement

### DIFF
--- a/Spigot-API-Patches/0183-Add-BlockSoundGroup-interface.patch
+++ b/Spigot-API-Patches/0183-Add-BlockSoundGroup-interface.patch
@@ -1,0 +1,97 @@
+From 3d438aa9d1116637c19b621a1c35bdd28ac3d673 Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 28 May 2019 03:41:28 -0700
+Subject: [PATCH] Add BlockSoundGroup interface
+
+This PR adds the getSoundGroup() method in Block which returns a BlockSoundGroup
+
+diff --git a/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
+new file mode 100644
+index 00000000..8cf87d22
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/block/BlockSoundGroup.java
+@@ -0,0 +1,52 @@
++package com.destroystokyo.paper.block;
++
++import org.bukkit.Sound;
++import org.bukkit.block.Block;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Represents the sounds that a {@link Block} makes in certain situations
++ * <p>
++ * The sound group includes break, step, place, hit, and fall sounds.
++ */
++public interface BlockSoundGroup {
++    /**
++     * Gets the sound that plays when breaking this block
++     *
++     * @return The break sound
++     */
++    @NotNull
++    Sound getBreakSound();
++
++    /**
++     * Gets the sound that plays when stepping on this block
++     *
++     * @return The step sound
++     */
++    @NotNull
++    Sound getStepSound();
++
++    /**
++     * Gets the sound that plays when placing this block
++     *
++     * @return The place sound
++     */
++    @NotNull
++    Sound getPlaceSound();
++
++    /**
++     * Gets the sound that plays when hitting this block
++     *
++     * @return The hit sound
++     */
++    @NotNull
++    Sound getHitSound();
++
++    /**
++     * Gets the sound that plays when this block falls
++     *
++     * @return The fall sound
++     */
++    @NotNull
++    Sound getFallSound();
++}
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 87185a81..038de5a6 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.block;
+ 
+ import java.util.Collection;
++
+ import org.bukkit.Chunk;
+ import org.bukkit.FluidCollisionMode;
+ import org.bukkit.Location;
+@@ -527,4 +528,16 @@ public interface Block extends Metadatable {
+      */
+     @NotNull
+     BoundingBox getBoundingBox();
++
++    // Paper start
++    /**
++     * Gets the {@link com.destroystokyo.paper.block.BlockSoundGroup} for this block.
++     * <p>
++     * This object contains the block, step, place, hit, and fall sounds.
++     *
++     * @return the sound group for this block
++     */
++    @NotNull
++    com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();
++    // Paper end
+ }
+-- 
+2.19.2
+

--- a/Spigot-Server-Patches/0397-Implement-CraftBlockSoundGroup.patch
+++ b/Spigot-Server-Patches/0397-Implement-CraftBlockSoundGroup.patch
@@ -1,0 +1,116 @@
+From 2157beee53ff8518f7b5fd3e9e1662650481f7c4 Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 28 May 2019 03:48:51 -0700
+Subject: [PATCH] Implement CraftBlockSoundGroup
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
+new file mode 100644
+index 00000000..99f99330
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
+@@ -0,0 +1,38 @@
++package com.destroystokyo.paper.block;
++
++import net.minecraft.server.SoundEffectType;
++import org.bukkit.Sound;
++import org.bukkit.craftbukkit.CraftSound;
++
++public class CraftBlockSoundGroup implements BlockSoundGroup {
++    private final SoundEffectType soundEffectType;
++
++    public CraftBlockSoundGroup(SoundEffectType soundEffectType) {
++        this.soundEffectType = soundEffectType;
++    }
++
++    @Override
++    public Sound getBreakSound() {
++        return CraftSound.getSoundByEffect(soundEffectType.getBreakSound());
++    }
++
++    @Override
++    public Sound getStepSound() {
++        return CraftSound.getSoundByEffect(soundEffectType.getStepSound());
++    }
++
++    @Override
++    public Sound getPlaceSound() {
++        return CraftSound.getSoundByEffect(soundEffectType.getPlaceSound());
++    }
++
++    @Override
++    public Sound getHitSound() {
++        return CraftSound.getSoundByEffect(soundEffectType.getHitSound());
++    }
++
++    @Override
++    public Sound getFallSound() {
++        return CraftSound.getSoundByEffect(soundEffectType.getFallSound());
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/IBlockData.java b/src/main/java/net/minecraft/server/IBlockData.java
+index c66cabe8..709cc3d7 100644
+--- a/src/main/java/net/minecraft/server/IBlockData.java
++++ b/src/main/java/net/minecraft/server/IBlockData.java
+@@ -266,6 +266,7 @@ public class IBlockData extends BlockDataAbstract<Block, IBlockData> implements
+         return this.getBlock().isTicking(this);
+     }
+ 
++    public final SoundEffectType getStepSound() { return this.r(); } // Paper - OBFHELPER
+     public SoundEffectType r() {
+         return this.getBlock().getStepSound(this);
+     }
+diff --git a/src/main/java/net/minecraft/server/SoundEffectType.java b/src/main/java/net/minecraft/server/SoundEffectType.java
+index 5460d409..ccd5b052 100644
+--- a/src/main/java/net/minecraft/server/SoundEffectType.java
++++ b/src/main/java/net/minecraft/server/SoundEffectType.java
+@@ -26,10 +26,10 @@ public class SoundEffectType {
+     public static final SoundEffectType v = new SoundEffectType(1.0F, 1.0F, SoundEffects.BLOCK_LANTERN_BREAK, SoundEffects.BLOCK_LANTERN_STEP, SoundEffects.BLOCK_LANTERN_PLACE, SoundEffects.BLOCK_LANTERN_HIT, SoundEffects.BLOCK_LANTERN_FALL);
+     public final float w;
+     public final float x;
+-    private final SoundEffect y;
++    private final SoundEffect y; public final SoundEffect getBreakSound() { return this.y; } // Paper - OBFHELPER
+     private final SoundEffect z;
+     private final SoundEffect A;
+-    private final SoundEffect B;
++    private final SoundEffect B; public final SoundEffect getHitSound() { return this.B; } // Paper - OBFHELPER
+     private final SoundEffect C;
+ 
+     public SoundEffectType(float f, float f1, SoundEffect soundeffect, SoundEffect soundeffect1, SoundEffect soundeffect2, SoundEffect soundeffect3, SoundEffect soundeffect4) {
+@@ -50,14 +50,17 @@ public class SoundEffectType {
+         return this.x;
+     }
+ 
++    public final SoundEffect getStepSound() { return this.d(); } // Paper - OBFHELPER
+     public SoundEffect d() {
+         return this.z;
+     }
+ 
++    public final SoundEffect getPlaceSound() { return this.e(); } // Paper - OBFHELPER
+     public SoundEffect e() {
+         return this.A;
+     }
+ 
++    public final SoundEffect getFallSound() { return this.g(); } // Paper - OBFHELPER
+     public SoundEffect g() {
+         return this.C;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 166c918d..5296c6d9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -689,4 +689,11 @@ public class CraftBlock implements Block {
+         AxisAlignedBB aabb = shape.getBoundingBox();
+         return new BoundingBox(getX() + aabb.minX, getY() + aabb.minY, getZ() + aabb.minZ, getX() + aabb.maxX, getY() + aabb.maxY, getZ() + aabb.maxZ);
+     }
++
++    // Paper start
++    @Override
++    public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
++        return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMSBlock().getBlockData().getStepSound());
++    }
++    // Paper end
+ }
+-- 
+2.19.2
+


### PR DESCRIPTION
This PR aims to close #2045 by creating a new `BlockSoundGroup` interface in `org.bukkit.block` which exposes five methods *getBreakSound*, *getStepSound*, *getPlaceSound*, *getHitSound*, and *getFallSound*.

The interface is implemented in `CraftBlockSoundGroup` in `org.bukkit.craftbukkit.block` which accepts the `SoundEffectType` type. The implementation uses `CraftSound#getSoundByEffect` method to retrieve the Bukkit `Sound` object corresponding to each `SoundEffect` denoted by the provided `SoundEffectType`.

Some paper OBFHELPERs were added to `SoundEffectType` to clarify which methods correspond to which sound effect. Two methods, *getBreakSound* and *getHitSound*, were added, because the fields were private and no getters already existed. My IDE noted that they were unused at the current time.

`CraftBlock#getBlockSoundGroup` is implemented by creating a new `CraftBlockSoundGroup` and passing the NMS block's blockdata's `SoundEffectType` to the constructor. I believe this is the correct method to call, as `CraftBlock#getStepSound` accepts a blockdata parameter. This should have no effect to API users.

Still new to PRing, so would appreciate any comments/suggestions/fixups.