### PR TITLE
Add and implement PlayerRecipeBookClickEvent

### DIFF
--- a/Spigot-API-Patches/0183-Add-PlayerRecipeBookClickEvent.patch
+++ b/Spigot-API-Patches/0183-Add-PlayerRecipeBookClickEvent.patch
@@ -1,0 +1,99 @@
+From 0cb679354c57fbc05e175cd8f709bffc4f50b4e9 Mon Sep 17 00:00:00 2001
+From: LordKorea <lk97798@posteo.net>
+Date: Thu, 30 May 2019 20:56:11 +0200
+Subject: [PATCH] Add PlayerRecipeBookClickEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java
+new file mode 100644
+index 00000000..7fa937d3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerRecipeBookClickEvent.java
+@@ -0,0 +1,84 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.NamespacedKey;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a player clicks a recipe in the recipe book
++ */
++public class PlayerRecipeBookClickEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancel = false;
++    @NotNull private NamespacedKey recipe;
++    private boolean makeAll;
++
++    public PlayerRecipeBookClickEvent(@NotNull Player player, @NotNull NamespacedKey recipe, boolean makeAll) {
++        super(player);
++        this.recipe = recipe;
++        this.makeAll = makeAll;
++    }
++
++    /**
++     * Gets the namespaced key of the recipe that was clicked by the player
++     *
++     * @return The namespaced key of the recipe
++     */
++    @NotNull
++    public NamespacedKey getRecipe() {
++        return recipe;
++    }
++
++    /**
++     * Changes what recipe is requested. This sets the requested recipe to the recipe with the given key
++     *
++     * @param recipe The key of the recipe that should be requested
++     */
++    public void setRecipe(@NotNull NamespacedKey recipe) {
++        this.recipe = recipe;
++    }
++
++    /**
++     * Gets a boolean which indicates whether or not the player requested to make the maximum amount of results. This is
++     * true if shift is pressed while the recipe is clicked in the recipe book
++     *
++     * @return {@code true} if shift is pressed while the recipe is clicked
++     */
++    public boolean isMakeAll() {
++        return makeAll;
++    }
++
++    /**
++     * Sets whether or not the maximum amount of results should be made. If this is true, the request is handled as if
++     * the player had pressed shift while clicking on the recipe
++     *
++     * @param makeAll {@code true} if the request should attempt to make the maximum amount of results
++     */
++    public void setMakeAll(boolean makeAll) {
++        this.makeAll = makeAll;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.21.0
+

--- a/Spigot-Server-Patches/0399-Implement-PlayerRecipeBookClickEvent.patch
+++ b/Spigot-Server-Patches/0399-Implement-PlayerRecipeBookClickEvent.patch
@@ -1,0 +1,47 @@
+From f84fd883fdceed72fa1b4ab352ce6565c0ed5a58 Mon Sep 17 00:00:00 2001
+From: LordKorea <lk97798@posteo.net>
+Date: Thu, 30 May 2019 20:53:44 +0200
+Subject: [PATCH] Implement PlayerRecipeBookClickEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 01c268a58..3b6a4da30 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -28,6 +28,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.util.CraftChatMessage;
+ import org.bukkit.craftbukkit.util.CraftMagicNumbers;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey; // Paper
+ import org.bukkit.craftbukkit.util.LazyPlayerSet;
+ import org.bukkit.craftbukkit.util.Waitable;
+ import org.bukkit.entity.Player;
+@@ -61,6 +62,7 @@ import org.bukkit.inventory.InventoryView;
+ import org.bukkit.util.NumberConversions;
+ import com.destroystokyo.paper.event.player.IllegalPacketEvent; // Paper
+ import com.destroystokyo.paper.event.player.PlayerJumpEvent; // Paper
++import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent; // Paper
+ import co.aikar.timings.MinecraftTimings; // Paper
+ // CraftBukkit end
+ 
+@@ -2435,9 +2437,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         PlayerConnectionUtils.ensureMainThread(packetplayinautorecipe, this, this.player.getWorldServer());
+         this.player.resetIdleTimer();
+         if (!this.player.isSpectator() && this.player.activeContainer.windowId == packetplayinautorecipe.b() && this.player.activeContainer.c(this.player) && this.player.activeContainer instanceof ContainerRecipeBook) {
+-            this.minecraftServer.getCraftingManager().a(packetplayinautorecipe.c()).ifPresent((irecipe) -> {
+-                ((ContainerRecipeBook) this.player.activeContainer).a(packetplayinautorecipe.d(), irecipe, this.player);
+-            });
++            // Paper start - fire event for clicking recipes in the recipe book
++            PlayerRecipeBookClickEvent event = new PlayerRecipeBookClickEvent(player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(packetplayinautorecipe.c()), packetplayinautorecipe.d());
++            if (event.callEvent()) {
++                this.minecraftServer.getCraftingManager().a(CraftNamespacedKey.toMinecraft(event.getRecipe())).ifPresent((irecipe) -> {
++                    ((ContainerRecipeBook) this.player.activeContainer).a(event.isMakeAll(), irecipe, this.player);
++                });
++            }
++            // Paper end
+         }
+     }
+ 
+-- 
+2.21.0
+

--- a/Spigot-Server-Patches/0399-Implement-PlayerRecipeBookClickEvent.patch
+++ b/Spigot-Server-Patches/0399-Implement-PlayerRecipeBookClickEvent.patch
@@ -1,30 +1,14 @@
-From f84fd883fdceed72fa1b4ab352ce6565c0ed5a58 Mon Sep 17 00:00:00 2001
+From 4c5a2b955171349d7806ef0b7c1dbfa7ad4bd9e4 Mon Sep 17 00:00:00 2001
 From: LordKorea <lk97798@posteo.net>
 Date: Thu, 30 May 2019 20:53:44 +0200
 Subject: [PATCH] Implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 01c268a58..3b6a4da30 100644
+index 01c268a58..e3708a69e 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -28,6 +28,7 @@ import org.bukkit.craftbukkit.event.CraftEventFactory;
- import org.bukkit.craftbukkit.inventory.CraftItemStack;
- import org.bukkit.craftbukkit.util.CraftChatMessage;
- import org.bukkit.craftbukkit.util.CraftMagicNumbers;
-+import org.bukkit.craftbukkit.util.CraftNamespacedKey; // Paper
- import org.bukkit.craftbukkit.util.LazyPlayerSet;
- import org.bukkit.craftbukkit.util.Waitable;
- import org.bukkit.entity.Player;
-@@ -61,6 +62,7 @@ import org.bukkit.inventory.InventoryView;
- import org.bukkit.util.NumberConversions;
- import com.destroystokyo.paper.event.player.IllegalPacketEvent; // Paper
- import com.destroystokyo.paper.event.player.PlayerJumpEvent; // Paper
-+import com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent; // Paper
- import co.aikar.timings.MinecraftTimings; // Paper
- // CraftBukkit end
- 
-@@ -2435,9 +2437,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2435,9 +2435,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinautorecipe, this, this.player.getWorldServer());
          this.player.resetIdleTimer();
          if (!this.player.isSpectator() && this.player.activeContainer.windowId == packetplayinautorecipe.b() && this.player.activeContainer.c(this.player) && this.player.activeContainer instanceof ContainerRecipeBook) {
@@ -32,9 +16,10 @@ index 01c268a58..3b6a4da30 100644
 -                ((ContainerRecipeBook) this.player.activeContainer).a(packetplayinautorecipe.d(), irecipe, this.player);
 -            });
 +            // Paper start - fire event for clicking recipes in the recipe book
-+            PlayerRecipeBookClickEvent event = new PlayerRecipeBookClickEvent(player.getBukkitEntity(), CraftNamespacedKey.fromMinecraft(packetplayinautorecipe.c()), packetplayinautorecipe.d());
++            com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent event = new com.destroystokyo.paper.event.player.PlayerRecipeBookClickEvent(
++                player.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftNamespacedKey.fromMinecraft(packetplayinautorecipe.c()), packetplayinautorecipe.d());
 +            if (event.callEvent()) {
-+                this.minecraftServer.getCraftingManager().a(CraftNamespacedKey.toMinecraft(event.getRecipe())).ifPresent((irecipe) -> {
++                this.minecraftServer.getCraftingManager().a(org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(event.getRecipe())).ifPresent((irecipe) -> {
 +                    ((ContainerRecipeBook) this.player.activeContainer).a(event.isMakeAll(), irecipe, this.player);
 +                });
 +            }


### PR DESCRIPTION
This adds and implements the event discussed in #1783. The event can be cancelled, the requested recipe can be changed, and whether or not the maximum amount of results should be attempted can be also changed.

I've also created a simple example plugin using the event: https://github.com/LordKorea/test-recipeplugin

This is my first PR for Paper, so if you need more info / changes to the patch let me know :)

Closes #1783