### PR TITLE
Fix missing thread check in SimplePluginManager#callEvent

### DIFF
--- a/Spigot-API-Patches/0129-Remove-deadlock-risk-in-firing-async-events.patch
+++ b/Spigot-API-Patches/0129-Remove-deadlock-risk-in-firing-async-events.patch
@@ -1,4 +1,4 @@
-From 2817ea0cd2b735fcf41d322476b4b1d6c97f39a4 Mon Sep 17 00:00:00 2001
+From 9336ffd4a2dd66cca922c7bd5aeb6620ec41a347 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 9 Sep 2018 00:32:05 -0400
 Subject: [PATCH] Remove deadlock risk in firing async events
@@ -16,7 +16,7 @@ which results in a hard crash.
 This change removes the synchronize and adds some protection around enable/disable
 
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index adca48f1..2d3cee14 100644
+index adca48f18..2d3cee140 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -28,7 +28,7 @@ import org.jetbrains.annotations.Nullable;
@@ -29,7 +29,7 @@ index adca48f1..2d3cee14 100644
       *
       * @return a new copy of Location containing the position of this entity
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index da3cd63b..583f8ee4 100644
+index da3cd63ba..5eefb4b5b 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -398,7 +398,7 @@ public final class SimplePluginManager implements PluginManager {
@@ -67,7 +67,7 @@ index da3cd63b..583f8ee4 100644
  
      /**
       * Calls an event with the given details.
-@@ -516,25 +517,11 @@ public final class SimplePluginManager implements PluginManager {
+@@ -516,25 +517,13 @@ public final class SimplePluginManager implements PluginManager {
       */
      @Override
      public void callEvent(@NotNull Event event) {
@@ -88,7 +88,9 @@ index da3cd63b..583f8ee4 100644
 -            }
 +        // Paper - replace callEvent by merging to below method
 +        if (event.isAsynchronous() && server.isPrimaryThread()) {
-+            throw new IllegalStateException(event.getEventName() + " cannot be triggered asynchronously from primary server thread.");
++            throw new IllegalStateException(event.getEventName() + " may only be triggered asynchronously.");
++        } else if (!event.isAsynchronous() && !server.isPrimaryThread()) {
++            throw new IllegalStateException(event.getEventName() + " may only be triggered synchronously.");
          }
 -    }
  
@@ -97,7 +99,7 @@ index da3cd63b..583f8ee4 100644
          RegisteredListener[] listeners = handlers.getRegisteredListeners();
  
 diff --git a/src/test/java/org/bukkit/plugin/PluginManagerTest.java b/src/test/java/org/bukkit/plugin/PluginManagerTest.java
-index 17dbe913..bae26ce7 100644
+index 17dbe9139..bae26ce73 100644
 --- a/src/test/java/org/bukkit/plugin/PluginManagerTest.java
 +++ b/src/test/java/org/bukkit/plugin/PluginManagerTest.java
 @@ -17,7 +17,7 @@ public class PluginManagerTest {


### PR DESCRIPTION
We need to check if we're attempting to fire a synchronous event off of the main thread.
Also make the exception message make sense

Server didn't blow up in testing so it looks like this works