### PR TITLE
Stop natural spawning after limit has been reached

### DIFF
--- a/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -1,0 +1,93 @@
+From 4476be102ffcfe715d35f767098a99ae10a1bd49 Mon Sep 17 00:00:00 2001
+From: kickash32 <kickash32@gmail.com>
+Date: Sun, 2 Jun 2019 01:22:02 -0400
+Subject: [PATCH] Actually-Limit-Natural-Spawns-To-Limit
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index 0e941b52..282e9997 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -360,8 +360,12 @@ public class ChunkProviderServer extends IChunkProvider {
+                                 if (enumcreaturetype != EnumCreatureType.MISC && (!enumcreaturetype.c() || this.allowAnimals) && (enumcreaturetype.c() || this.allowMonsters) && (!enumcreaturetype.d() || flag2)) {
+                                     int k1 = limit * l / ChunkProviderServer.b; // CraftBukkit - use per-world limits
+ 
+-                                    if (object2intmap.getInt(enumcreaturetype) <= k1) {
+-                                        SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition);
++                                    // Paper start - only allow spawns upto the limit per chunk and update count afterwards
++                                    int difference = k1 - object2intmap.getInt(enumcreaturetype);
++                                    if (difference > 0) {
++                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference + 1);//paper
++                                        object2intmap.put(enumcreaturetype, object2intmap.getInt(enumcreaturetype) + tmp);
++                                    // Paper end
+                                     }
+                                 }
+                             }
+diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
+index 94d7bca0..070f6340 100644
+--- a/src/main/java/net/minecraft/server/SpawnerCreature.java
++++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
+@@ -16,13 +16,14 @@ public final class SpawnerCreature {
+ 
+     private static final Logger LOGGER = LogManager.getLogger();
+ 
+-    public static void a(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition) {
++    public static int a(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition, int maxSpawns) { // Paper - add maxSpawns parameter
+         ChunkGenerator<?> chunkgenerator = world.getChunkProvider().getChunkGenerator();
+         int i = 0;
+         BlockPosition blockposition1 = getRandomPosition(world, chunk);
+         int j = blockposition1.getX();
+         int k = blockposition1.getY();
+         int l = blockposition1.getZ();
++        int amountSpawned = 0; // Paper - keep track of mobs spawned
+ 
+         if (k >= 1) {
+             IBlockData iblockdata = world.getTypeIfLoadedAndInBounds(blockposition1);  // Paper - don't load chunks for mob spawn
+@@ -85,7 +86,7 @@ public final class SpawnerCreature {
+                                                         );
+                                                         if (!event.callEvent()) {
+                                                             if (event.shouldAbortSpawn()) {
+-                                                                return;
++                                                                return amountSpawned; // Paper
+                                                             }
+                                                             ++i2;
+                                                             continue;
+@@ -104,7 +105,7 @@ public final class SpawnerCreature {
+                                                     } catch (Exception exception) {
+                                                         SpawnerCreature.LOGGER.warn("Failed to create mob", exception);
+                                                         ServerInternalException.reportInternalException(exception); // Paper
+-                                                        return;
++                                                        return amountSpawned; // Paper
+                                                     }
+ 
+                                                     entityinsentient.setPositionRotation((double) f, (double) k, (double) f1, world.random.nextFloat() * 360.0F, 0.0F);
+@@ -114,10 +115,17 @@ public final class SpawnerCreature {
+                                                         if (world.addEntity(entityinsentient, SpawnReason.NATURAL)) {
+                                                             ++i;
+                                                             ++i2;
++                                                            // Paper start - stop when limit is reached
++                                                            amountSpawned++;
+                                                         }
++
++                                                        if (amountSpawned >= maxSpawns){
++                                                            return amountSpawned; // Paper
++                                                        }
++                                                        // Paper end
+                                                         // CraftBukkit end
+                                                         if (i >= entityinsentient.dC()) {
+-                                                            return;
++                                                            return amountSpawned; // Paper
+                                                         }
+ 
+                                                         if (entityinsentient.c(i2)) {
+@@ -142,6 +150,7 @@ public final class SpawnerCreature {
+ 
+             }
+         }
++        return amountSpawned; // Paper
+     }
+ 
+     @Nullable
+-- 
+2.19.0
+

--- a/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -1,14 +1,14 @@
-From a8992efca09ce35ba035907057f365248f6f4f65 Mon Sep 17 00:00:00 2001
+From 08b35ec086dade9cb81a66f70513b78cceb7050a Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Sun, 2 Jun 2019 01:22:02 -0400
 Subject: [PATCH] Actually-Limit-Natural-Spawns-To-Limit
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 0e941b52..887966f7 100644
+index 0e941b52..b2705faa 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -360,8 +360,13 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -360,8 +360,12 @@ public class ChunkProviderServer extends IChunkProvider {
                                  if (enumcreaturetype != EnumCreatureType.MISC && (!enumcreaturetype.c() || this.allowAnimals) && (enumcreaturetype.c() || this.allowMonsters) && (!enumcreaturetype.d() || flag2)) {
                                      int k1 = limit * l / ChunkProviderServer.b; // CraftBukkit - use per-world limits
  
@@ -18,22 +18,26 @@ index 0e941b52..887966f7 100644
 +                                    int currEntityCount = object2intmap.getInt(enumcreaturetype);
 +                                    int difference = k1 - currEntityCount;
 +                                    if (difference > 0) {
-+                                        int numSpawned = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference);
-+                                        object2intmap.put(enumcreaturetype, currEntityCount + numSpawned);
++                                        object2intmap.put(enumcreaturetype, currEntityCount + SpawnerCreature.spawnMobs(enumcreaturetype, world, chunk, blockposition, difference));
 +                                    // Paper end
                                      }
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index 94d7bca0..070f6340 100644
+index 94d7bca0..93fec168 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
-@@ -16,13 +16,14 @@ public final class SpawnerCreature {
+@@ -16,13 +16,20 @@ public final class SpawnerCreature {
  
      private static final Logger LOGGER = LogManager.getLogger();
  
--    public static void a(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition) {
-+    public static int a(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition, int maxSpawns) { // Paper - add maxSpawns parameter
++    // Paper start - add maxSpawns parameter and update counts
+     public static void a(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition) {
++        spawnMobs(enumcreaturetype, world, chunk, blockposition, Integer.MAX_VALUE);
++    }
++
++    public static int spawnMobs(EnumCreatureType enumcreaturetype, World world, Chunk chunk, BlockPosition blockposition, int maxSpawns) {
++    // Paper end
          ChunkGenerator<?> chunkgenerator = world.getChunkProvider().getChunkGenerator();
          int i = 0;
          BlockPosition blockposition1 = getRandomPosition(world, chunk);
@@ -44,7 +48,7 @@ index 94d7bca0..070f6340 100644
  
          if (k >= 1) {
              IBlockData iblockdata = world.getTypeIfLoadedAndInBounds(blockposition1);  // Paper - don't load chunks for mob spawn
-@@ -85,7 +86,7 @@ public final class SpawnerCreature {
+@@ -85,7 +92,7 @@ public final class SpawnerCreature {
                                                          );
                                                          if (!event.callEvent()) {
                                                              if (event.shouldAbortSpawn()) {
@@ -53,7 +57,7 @@ index 94d7bca0..070f6340 100644
                                                              }
                                                              ++i2;
                                                              continue;
-@@ -104,7 +105,7 @@ public final class SpawnerCreature {
+@@ -104,7 +111,7 @@ public final class SpawnerCreature {
                                                      } catch (Exception exception) {
                                                          SpawnerCreature.LOGGER.warn("Failed to create mob", exception);
                                                          ServerInternalException.reportInternalException(exception); // Paper
@@ -62,17 +66,17 @@ index 94d7bca0..070f6340 100644
                                                      }
  
                                                      entityinsentient.setPositionRotation((double) f, (double) k, (double) f1, world.random.nextFloat() * 360.0F, 0.0F);
-@@ -114,10 +115,17 @@ public final class SpawnerCreature {
+@@ -114,10 +121,17 @@ public final class SpawnerCreature {
                                                          if (world.addEntity(entityinsentient, SpawnReason.NATURAL)) {
                                                              ++i;
                                                              ++i2;
 +                                                            // Paper start - stop when limit is reached
 +                                                            amountSpawned++;
-                                                         }
++                                                        }
 +
 +                                                        if (amountSpawned >= maxSpawns){
 +                                                            return amountSpawned; // Paper
-+                                                        }
+                                                         }
 +                                                        // Paper end
                                                          // CraftBukkit end
                                                          if (i >= entityinsentient.dC()) {
@@ -81,7 +85,7 @@ index 94d7bca0..070f6340 100644
                                                          }
  
                                                          if (entityinsentient.c(i2)) {
-@@ -142,6 +150,7 @@ public final class SpawnerCreature {
+@@ -142,6 +156,7 @@ public final class SpawnerCreature {
  
              }
          }

--- a/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -17,7 +17,7 @@ index 0e941b52..282e9997 100644
 +                                    // Paper start - only allow spawns upto the limit per chunk and update count afterwards
 +                                    int difference = k1 - object2intmap.getInt(enumcreaturetype);
 +                                    if (difference > 0) {
-+                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference + 1);
++                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference);
 +                                        object2intmap.put(enumcreaturetype, object2intmap.getInt(enumcreaturetype) + tmp);
 +                                    // Paper end
                                      }

--- a/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -1,24 +1,25 @@
-From 4476be102ffcfe715d35f767098a99ae10a1bd49 Mon Sep 17 00:00:00 2001
+From a8992efca09ce35ba035907057f365248f6f4f65 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Sun, 2 Jun 2019 01:22:02 -0400
 Subject: [PATCH] Actually-Limit-Natural-Spawns-To-Limit
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 0e941b52..282e9997 100644
+index 0e941b52..887966f7 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -360,8 +360,12 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -360,8 +360,13 @@ public class ChunkProviderServer extends IChunkProvider {
                                  if (enumcreaturetype != EnumCreatureType.MISC && (!enumcreaturetype.c() || this.allowAnimals) && (enumcreaturetype.c() || this.allowMonsters) && (!enumcreaturetype.d() || flag2)) {
                                      int k1 = limit * l / ChunkProviderServer.b; // CraftBukkit - use per-world limits
  
 -                                    if (object2intmap.getInt(enumcreaturetype) <= k1) {
 -                                        SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition);
 +                                    // Paper start - only allow spawns upto the limit per chunk and update count afterwards
-+                                    int difference = k1 - object2intmap.getInt(enumcreaturetype);
++                                    int currEntityCount = object2intmap.getInt(enumcreaturetype);
++                                    int difference = k1 - currEntityCount;
 +                                    if (difference > 0) {
-+                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference);
-+                                        object2intmap.put(enumcreaturetype, object2intmap.getInt(enumcreaturetype) + tmp);
++                                        int numSpawned = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference);
++                                        object2intmap.put(enumcreaturetype, currEntityCount + numSpawned);
 +                                    // Paper end
                                      }
                                  }

--- a/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0398-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -17,7 +17,7 @@ index 0e941b52..282e9997 100644
 +                                    // Paper start - only allow spawns upto the limit per chunk and update count afterwards
 +                                    int difference = k1 - object2intmap.getInt(enumcreaturetype);
 +                                    if (difference > 0) {
-+                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference + 1);//paper
++                                        int tmp = SpawnerCreature.a(enumcreaturetype, (World) this.world, chunk, blockposition, difference + 1);
 +                                        object2intmap.put(enumcreaturetype, object2intmap.getInt(enumcreaturetype) + tmp);
 +                                    // Paper end
                                      }


### PR DESCRIPTION
First patch PR for me... so not sure if I did this right.
This patch changes natural mob spawning so that it only spawns up to the the limit specified per world without any overshooting. This prevents the notorious vanilla bug where in 300+ fish are spawned in an ocean while the limit is supposed to be set to 15.

If this patch is accepted, we should look into advising players to increase the watermob limit so they are not surprised by lowered spawn rates.

It accomplishes this by tracking the number of mobs spawned by each chunk, and stopping spawns once the world's mob limit is reached (for that type of mob).

This is a resubmission of #2119 