### PR TITLE
Add and implement Player#openBook API

### DIFF
--- a/Spigot-API-Patches/0184-Add-open-book-api.patch
+++ b/Spigot-API-Patches/0184-Add-open-book-api.patch
@@ -1,0 +1,27 @@
+From 34840f2420f562c828a5751c76fb6c26d3d7c24f Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 4 Jun 2019 02:15:47 -0700
+Subject: [PATCH] Add open book api
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index dea6130a..7ecf45a4 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1949,6 +1949,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * Reset the cooldown counter to 0, effectively starting the cooldown period.
+      */
+     void resetCooldown();
++
++    /**
++     * Open a {@link Material#WRITTEN_BOOK} for a Player
++     *
++     * @param book The book to open for this player
++     */
++    void openBook(@NotNull org.bukkit.inventory.ItemStack book);
+     // Paper end
+ 
+     // Spigot start
+-- 
+2.19.2
+

--- a/Spigot-Server-Patches/0400-Implement-open-book-api.patch
+++ b/Spigot-Server-Patches/0400-Implement-open-book-api.patch
@@ -1,0 +1,45 @@
+From cb02730d7ada720df6a87b5ffe8a51e5150dc37e Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Tue, 4 Jun 2019 02:11:52 -0700
+Subject: [PATCH] Implement open book api
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 691a2d094..5be72dc06 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -1185,8 +1185,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+         this.activeContainer.addSlotListener(this);
+     }
+ 
+-    @Override
+-    public void a(ItemStack itemstack, EnumHand enumhand) {
++    public final void openBook(ItemStack itemstack, EnumHand enumhand) { this.a(itemstack, enumhand); } // Paper - OBFHELPER
++    @Override public void a(ItemStack itemstack, EnumHand enumhand) {
+         Item item = itemstack.getItem();
+ 
+         if (item == Items.WRITTEN_BOOK) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9f267414d..ff3b59c34 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1972,6 +1972,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     public void setViewDistance(int viewDistance) {
+         throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement"); // TODO
+     }
++
++    @Override
++    public void openBook(org.bukkit.inventory.ItemStack book) {
++        Preconditions.checkArgument(book != null, "book");
++        Preconditions.checkState(book.getType() == Material.WRITTEN_BOOK, "Book must be Material.WRITTEN_BOOK");
++        org.bukkit.inventory.ItemStack oldHand = this.getInventory().getItemInMainHand();
++        this.getInventory().setItemInMainHand(book);
++        getHandle().openBook(net.minecraft.server.ItemStack.fromBukkitCopy(book), net.minecraft.server.EnumHand.MAIN_HAND);
++        this.getInventory().setItemInMainHand(oldHand);
++    }
+     //Paper end
+ 
+     // Spigot start
+-- 
+2.19.2
+


### PR DESCRIPTION
This PR adds an API to open books in `org.bukkit.entity.Player`. The `Player#openBook` method accepts an `org.bukkit.inventory.ItemStack` and is implemented in `org.bukkit.craftbukkit.CraftPlayer#openBook`. The method expects a non-null bukkit `ItemStack` with the material type `Material.WRITTEN_BOOK`.

`net.minecraft.server.EntityPlayer` was modified to include an OBFHELPER, forwarding the existing method `EntityPlayer#a(ItemStack itemstack, EnumHand enumhand)` to `EntityPlayer#openBook(...)`.

The implementation operates on the requirement for the book to be opened to be placed in the player's main hand (off hand ALSO works, but I did not include it in this PR; but can add.) Firstly, the item in the main hand is saved. Then, the requested book is placed into the Player's main hand. Thirdly, `EntityPlayer#openBook` is called with the book converted to an NMS copy. Finally, the player's original main hand is restored.

An alternative to passing in an ItemStack: the implementation could be modified to read the player's main hand and have a precondition on the `Material`.

Example:
```java
@EventHandler
public void onClick(InventoryClickEvent event) {
  Player player = (Player) event.whoClicked;
  ItemStack book = new ItemStack(Material.WRITTEN_BOOK);
  
  BookMeta meta = (BookMeta) book.getItemMeta();
  meta.spigot().addPage(
    new ComponentBuilder("You clicked and opened a book!")
      .color(ChatColor.RED)
      .bold(true)
      .event(
        ClickEvent.Action.OPEN_URL,
        "https://google.com"
      )).create()
  );

  book.setItemMeta(meta);
  player.openBook(book);
}
```
Preview:
https://i.imgur.com/RWI6DSN.gifv