### PR TITLE
Make PlayerHandshakeEvent async

### DIFF
--- a/Spigot-API-Patches/0033-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-API-Patches/0033-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -1,4 +1,4 @@
-From a9b5a8389171801c37d2e93174582e96087d161f Mon Sep 17 00:00:00 2001
+From 09d30e91ba35eb1520c4f89087469bde676cced4 Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Wed, 13 Apr 2016 20:20:18 -0700
 Subject: [PATCH] Add handshake event to allow plugins to handle client
@@ -7,10 +7,10 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
 new file mode 100644
-index 00000000..46d6f6ad
+index 00000000..f0bb4e31
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
-@@ -0,0 +1,221 @@
+@@ -0,0 +1,222 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.apache.commons.lang.Validate;
@@ -49,6 +49,7 @@ index 00000000..46d6f6ad
 +     * @param cancelled if this event is enabled
 +     */
 +    public PlayerHandshakeEvent(@NotNull String originalHandshake, boolean cancelled) {
++        super(true);
 +        this.originalHandshake = originalHandshake;
 +        this.cancelled = cancelled;
 +    }
@@ -233,5 +234,5 @@ index 00000000..46d6f6ad
 +    }
 +}
 -- 
-2.21.0
+2.19.2
 


### PR DESCRIPTION
`PlayerHandshakeEvent` is fired asynchronously in `net.minecraft.server.HandshakeListener` and as a result in a recent patch (#2111) listening to this event causes an IllegalStateException noting that the event may only be triggered synchronously.

`/127.0.0.1:54963 lost connection: Internal Exception: java.lang.IllegalStateException: PlayerHandshakeEvent may only be triggered synchronously.`

The code testing this fails on paper 65:
`@EventHandler public void onHandshakeEvent(PlayerHandshakeEvent event) {}`

This patch should restore previous behavior for any users of this event.