### PR TITLE
Add support for OpenJ9 heap dumps in /paper heap

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -1,4 +1,4 @@
-From 16195dec72954ef5f6192e35ba8fdd451a097ecb Mon Sep 17 00:00:00 2001
+From 6a4a86c8afd583b7bdeaf3b93595924f84c5da6a Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 21:02:09 -0600
 Subject: [PATCH] Paper config files
@@ -6,10 +6,10 @@ Subject: [PATCH] Paper config files
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 new file mode 100644
-index 0000000000..b5f318c00d
+index 000000000..5626ae4e3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -0,0 +1,241 @@
+@@ -0,0 +1,244 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Functions;
@@ -227,11 +227,14 @@ index 0000000000..b5f318c00d
 +    }
 +
 +    private void dumpHeap(CommandSender sender) {
-+        File file = new File(new File(new File("."), "dumps"),
-+                "heap-dump-" + DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss").format(LocalDateTime.now()) + "-server.hprof");
-+        Command.broadcastCommandMessage(sender, ChatColor.YELLOW + "Writing JVM heap data to " + file);
-+        if (CraftServer.dumpHeap(file)) {
-+            Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Heap dump complete");
++        java.nio.file.Path dir = java.nio.file.Paths.get("./dumps");
++        String name = "heap-dump-" + DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss").format(LocalDateTime.now());
++
++        Command.broadcastCommandMessage(sender, ChatColor.YELLOW + "Writing JVM heap data...");
++
++        java.nio.file.Path file = CraftServer.dumpHeap(dir, name);
++        if (file != null) {
++            Command.broadcastCommandMessage(sender, ChatColor.GREEN + "Heap dump saved to " + file);
 +        } else {
 +            Command.broadcastCommandMessage(sender, ChatColor.RED + "Failed to write heap dump, see sever log for details");
 +        }
@@ -253,7 +256,7 @@ index 0000000000..b5f318c00d
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000..db79fe41b9
+index 000000000..db79fe41b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -0,0 +1,184 @@
@@ -443,7 +446,7 @@ index 0000000000..db79fe41b9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000..a738657394
+index 000000000..a73865739
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -0,0 +1,67 @@
@@ -515,7 +518,7 @@ index 0000000000..a738657394
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index e1ba833f3e..b60956218d 100644
+index e1ba833f3..b60956218 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -152,6 +152,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -535,7 +538,7 @@ index e1ba833f3e..b60956218d 100644
          this.setSpawnAnimals(dedicatedserverproperties.spawnAnimals);
          this.setSpawnNPCs(dedicatedserverproperties.spawnNpcs);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 3495d8ecdc..45e2ce618a 100644
+index 3495d8ecd..45e2ce618 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -134,9 +134,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener {
@@ -552,7 +555,7 @@ index 3495d8ecdc..45e2ce618a 100644
      public boolean impulse;
      public int portalCooldown;
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 659e0ea50a..8c918d0d68 100644
+index 659e0ea50..8c918d0d6 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -4,6 +4,7 @@ import com.mojang.datafixers.DataFixUtils;
@@ -575,7 +578,7 @@ index 659e0ea50a..8c918d0d68 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a8ac7be82b..91e50ccea1 100644
+index a8ac7be82..91e50ccea 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -86,6 +86,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -596,7 +599,7 @@ index a8ac7be82b..91e50ccea1 100644
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 95deac5b97..4413066eea 100644
+index 95deac5b9..3a8e64aa7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -751,6 +751,7 @@ public final class CraftServer implements Server {
@@ -623,35 +626,44 @@ index 95deac5b97..4413066eea 100644
          overrideAllCommandBlockCommands = commandsConfiguration.getStringList("command-block-overrides").contains("*");
          ignoreVanillaPermissions = commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -1953,4 +1956,26 @@ public final class CraftServer implements Server {
+@@ -1953,4 +1956,35 @@ public final class CraftServer implements Server {
      {
          return spigot;
      }
 +
 +    // Paper start
 +    @SuppressWarnings({"rawtypes", "unchecked"})
-+    public static boolean dumpHeap(File file) {
++    public static java.nio.file.Path dumpHeap(java.nio.file.Path dir, String name) {
 +        try {
-+            if (file.getParentFile() != null) {
-+                file.getParentFile().mkdirs();
++            java.nio.file.Files.createDirectories(dir);
++
++            javax.management.MBeanServer server = java.lang.management.ManagementFactory.getPlatformMBeanServer();
++            java.nio.file.Path file;
++
++            try {
++                Class clazz = Class.forName("openj9.lang.management.OpenJ9DiagnosticsMXBean");
++                Object openj9Mbean = java.lang.management.ManagementFactory.newPlatformMXBeanProxy(server, "openj9.lang.management:type=OpenJ9Diagnostics", clazz);
++                java.lang.reflect.Method m = clazz.getMethod("triggerDumpToFile", String.class, String.class);
++                file = dir.resolve(name + ".phd");
++                m.invoke(openj9Mbean, "heap", file.toString());
++            } catch (ClassNotFoundException e) {
++                Class clazz = Class.forName("com.sun.management.HotSpotDiagnosticMXBean");
++                Object hotspotMBean = java.lang.management.ManagementFactory.newPlatformMXBeanProxy(server, "com.sun.management:type=HotSpotDiagnostic", clazz);
++                java.lang.reflect.Method m = clazz.getMethod("dumpHeap", String.class, boolean.class);
++                file = dir.resolve(name + ".hprof");
++                m.invoke(hotspotMBean, file.toString(), true);
 +            }
 +
-+            Class clazz = Class.forName("com.sun.management.HotSpotDiagnosticMXBean");
-+            javax.management.MBeanServer server = java.lang.management.ManagementFactory.getPlatformMBeanServer();
-+            Object hotspotMBean = java.lang.management.ManagementFactory.newPlatformMXBeanProxy(server, "com.sun.management:type=HotSpotDiagnostic", clazz);
-+            java.lang.reflect.Method m = clazz.getMethod("dumpHeap", String.class, boolean.class);
-+            m.invoke(hotspotMBean, file.getPath(), true);
-+            return true;
++            return file;
 +        } catch (Throwable t) {
-+            Bukkit.getLogger().severe("Could not write heap to " + file);
-+            t.printStackTrace();
-+            return false;
++            Bukkit.getLogger().log(Level.SEVERE, "Could not write heap", t);
++            return null;
 +        }
 +    }
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index e17d914185..f406464ef8 100644
+index e17d91418..f406464ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -128,6 +128,14 @@ public class Main {
@@ -670,7 +682,7 @@ index e17d914185..f406464ef8 100644
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 3949e659e8..7f0adb70d1 100644
+index 3949e659e..7f0adb70d 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -39,36 +39,36 @@ public class SpigotWorldConfig
@@ -717,5 +729,5 @@ index 3949e659e8..7f0adb70d1 100644
          config.addDefault( "world-settings.default." + path, def );
          return config.getString( "world-settings." + worldName + "." + path, config.getString( "world-settings.default." + path ) );
 -- 
-2.21.0
+2.22.0.windows.1
 

--- a/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
@@ -1,4 +1,4 @@
-From aa99725aa32b3f98e8010d8df16276a55865b033 Mon Sep 17 00:00:00 2001
+From da88089bc0051a99ee9fac02d96b1c73a4c4c217 Mon Sep 17 00:00:00 2001
 From: William <admin@domnian.com>
 Date: Fri, 18 Mar 2016 03:30:17 -0400
 Subject: [PATCH] Allow Reloading of Custom Permissions
@@ -6,11 +6,11 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b58c7c8e8f..68a40c12a9 100644
+index 0bdee28ce..707313a29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2033,5 +2033,23 @@ public final class CraftServer implements Server {
-             return false;
+@@ -2042,5 +2042,23 @@ public final class CraftServer implements Server {
+             return null;
          }
      }
 +
@@ -34,5 +34,5 @@ index b58c7c8e8f..68a40c12a9 100644
      // Paper end
  }
 -- 
-2.21.0
+2.22.0
 

--- a/Spigot-Server-Patches/0129-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-Server-Patches/0129-Allow-Reloading-of-Command-Aliases.patch
@@ -1,4 +1,4 @@
-From a568035bf3c70af6e2ad638197aabd63838f185e Mon Sep 17 00:00:00 2001
+From 7a062ff681cbc396ec082939c1b38acc783f9515 Mon Sep 17 00:00:00 2001
 From: willies952002 <admin@domnian.com>
 Date: Mon, 28 Nov 2016 10:21:52 -0500
 Subject: [PATCH] Allow Reloading of Command Aliases
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d1c09b4513..56fa5a7b8a 100644
+index 337aea2dc..a63a3798c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2062,5 +2062,24 @@ public final class CraftServer implements Server {
+@@ -2071,5 +2071,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }
@@ -35,5 +35,5 @@ index d1c09b4513..56fa5a7b8a 100644
      // Paper end
  }
 -- 
-2.21.0
+2.22.0
 

--- a/Spigot-Server-Patches/0155-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0155-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -1,4 +1,4 @@
-From 8ecde071c14f248159d0a6e405b1d7906ca0b818 Mon Sep 17 00:00:00 2001
+From d62ac0b6e20553f8febf57002df663f4bd6e4bea Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Fri, 9 Jun 2017 07:24:34 -0700
 Subject: [PATCH] Add configuration option to prevent player names from being
@@ -6,7 +6,7 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 503e137750..56cea23b06 100644
+index b5a50afd2..11d2a1013 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -259,4 +259,9 @@ public class PaperConfig {
@@ -20,10 +20,10 @@ index 503e137750..56cea23b06 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 56fa5a7b8a..d80bed4544 100644
+index a63a3798c..84e0b5bc2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2081,5 +2081,10 @@ public final class CraftServer implements Server {
+@@ -2090,5 +2090,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }
@@ -35,5 +35,5 @@ index 56fa5a7b8a..d80bed4544 100644
      // Paper end
  }
 -- 
-2.21.0
+2.22.0
 

--- a/Spigot-Server-Patches/0162-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0162-Basic-PlayerProfile-API.patch
@@ -1,4 +1,4 @@
-From 36748d46988f68c6064aa62d427225fb5115e107 Mon Sep 17 00:00:00 2001
+From 2cf4de6d996010167423ced2f51e557dace53588 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 15 Jan 2018 22:11:48 -0500
 Subject: [PATCH] Basic PlayerProfile API
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000..b151a13c1b
+index 000000000..b151a13c1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,280 @@
@@ -293,7 +293,7 @@ index 0000000000..b151a13c1b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 new file mode 100644
-index 0000000000..25836b975b
+index 000000000..25836b975
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperAuthenticationService.java
 @@ -0,0 +1,30 @@
@@ -329,7 +329,7 @@ index 0000000000..25836b975b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 new file mode 100644
-index 0000000000..3bcdb8f93f
+index 000000000..3bcdb8f93
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperGameProfileRepository.java
 @@ -0,0 +1,17 @@
@@ -352,7 +352,7 @@ index 0000000000..3bcdb8f93f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 new file mode 100644
-index 0000000000..4b2a67423f
+index 000000000..4b2a67423
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperMinecraftSessionService.java
 @@ -0,0 +1,29 @@
@@ -387,7 +387,7 @@ index 0000000000..4b2a67423f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 new file mode 100644
-index 0000000000..3aceb0ea8a
+index 000000000..3aceb0ea8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/PaperUserAuthentication.java
 @@ -0,0 +1,11 @@
@@ -403,7 +403,7 @@ index 0000000000..3aceb0ea8a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 1f6a126329..6d278a0da5 100644
+index 1f6a12632..6d278a0da 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -1,7 +1,10 @@
@@ -429,7 +429,7 @@ index 1f6a126329..6d278a0da5 100644
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6b83f9769a..5817e94525 100644
+index 6b83f9769..5817e9452 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1246,7 +1246,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -450,7 +450,7 @@ index 6b83f9769a..5817e94525 100644
          return this.minecraftSessionService;
      }
 diff --git a/src/main/java/net/minecraft/server/UserCache.java b/src/main/java/net/minecraft/server/UserCache.java
-index b0d883d493..1d4bf64b1b 100644
+index b0d883d49..1d4bf64b1 100644
 --- a/src/main/java/net/minecraft/server/UserCache.java
 +++ b/src/main/java/net/minecraft/server/UserCache.java
 @@ -43,7 +43,7 @@ public class UserCache {
@@ -486,7 +486,7 @@ index b0d883d493..1d4bf64b1b 100644
  
          private UserCacheEntry(GameProfile gameprofile, Date date) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5e0118978d..455f52e3ea 100644
+index 656a21316..80f4ba11f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -196,6 +196,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -499,7 +499,7 @@ index 5e0118978d..455f52e3ea 100644
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2097,5 +2100,24 @@ public final class CraftServer implements Server {
+@@ -2106,5 +2109,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
@@ -525,5 +525,5 @@ index 5e0118978d..455f52e3ea 100644
      // Paper end
  }
 -- 
-2.21.0
+2.22.0
 

--- a/Spigot-Server-Patches/0345-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0345-Make-the-default-permission-message-configurable.patch
@@ -1,11 +1,11 @@
-From 5fa15318b3f79ba1cb1505b82d98b9cd0103eb65 Mon Sep 17 00:00:00 2001
+From 78c90f5bd28dbc9d1bd0da8a81a0975dfad903f1 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 18 Nov 2018 19:49:56 +0000
 Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e5e41c6621..8942a06bfe 100644
+index 8feb0efdc..81987e4ad 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -21,6 +21,7 @@ import java.util.regex.Pattern;
@@ -29,10 +29,10 @@ index e5e41c6621..8942a06bfe 100644
      private static void savePlayerData() {
          savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e667bfb70c..619f8dc819 100644
+index 19b831cdd..e56db1a0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2123,6 +2123,11 @@ public final class CraftServer implements Server {
+@@ -2132,6 +2132,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  
@@ -45,5 +45,5 @@ index e667bfb70c..619f8dc819 100644
      public com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nonnull UUID uuid) {
          return createProfile(uuid, null);
 -- 
-2.21.0
+2.22.0
 


### PR DESCRIPTION
OpenJ9 heap dumps are currently unsupported in Paper's heap dump command. This change adds support for calling into OpenJ9's diagnostic MXBean to basically do the same thing Paper already does with HotSpot.

For anyone who wants to try this, the heap dump format used by OpenJ9 is called "Portable Heap Dump" and you need to use [Eclipse Memory Analyzer](https://www.eclipse.org/mat/downloads.php) with [IBM's DTFJ plugin](https://help.eclipse.org/2018-09/index.jsp?topic=%2Forg.eclipse.mat.ui.help%2Ftasks%2FinstallDTFJ.html) to be able to open these dumps.