### PR TITLE
Fix chunks refusing to save

### DIFF
--- a/Spigot-Server-Patches/0401-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0401-incremental-chunk-saving.patch
@@ -1,4 +1,4 @@
-From 8a7bd2adcb94574ef8d8d22d1a34e142d2403eda Mon Sep 17 00:00:00 2001
+From 6a4af6a95a364d2804bdec0453be09cdc7590ad5 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 9 Jun 2019 03:53:22 +0100
 Subject: [PATCH] incremental chunk saving
@@ -86,10 +86,10 @@ index 184f1b00f0..3dbe83c7ea 100644
          this.methodProfiler.enter("snooper");
          if (((DedicatedServer) this).getDedicatedServerProperties().snooperEnabled && !this.snooper.d() && this.ticks > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 7d48b580ac..86831c3526 100644
+index 7d48b580ac..b71f98b0c5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -295,15 +295,29 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -295,15 +295,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              });
              PlayerChunkMap.LOGGER.info("ThreadedAnvilChunkStorage ({}): All chunks are saved", this.x.getName());
          } else {
@@ -103,28 +103,32 @@ index 7d48b580ac..86831c3526 100644
  
                  if (ichunkaccess instanceof ProtoChunkExtension || ichunkaccess instanceof Chunk) {
 -                    this.saveChunk(ichunkaccess);
+-                    playerchunk.l();
+-                }
 +                    // paper start
 +                    boolean shouldSave = true;
-+
+ 
+-            });
 +                    if (ichunkaccess instanceof Chunk) {
 +                        shouldSave = ((Chunk) ichunkaccess).lastSaved + world.paperConfig.autoSavePeriod <= world.getTime();
 +                    }
 +
-+                    if (shouldSave && this.saveChunk(ichunkaccess)) ++savedThisTick;
-                     playerchunk.l();
++                    if (shouldSave && this.saveChunk(ichunkaccess)) {
++                        ++savedThisTick;
++                        playerchunk.l();
++                    }
++
 +                    if (savedThisTick >= world.paperConfig.maxAutoSaveChunksPerTick) {
 +                        return;
 +                    }
-                 }
--
--            });
++                }
 +            };
 +            // paper end
          }
  
      }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 92aad060ef..1c3815a9c4 100644
+index 40b3d96edd..135ec94c6f 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -755,8 +755,9 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0403-Fix-World-isChunkGenerated-calls.patch
+++ b/Spigot-Server-Patches/0403-Fix-World-isChunkGenerated-calls.patch
@@ -1,4 +1,4 @@
-From c51e28b104b1df742a48f6ad8cbe6e655bd714bb Mon Sep 17 00:00:00 2001
+From 66c4bd93d02eff2e8d86242544bf26e251af3adc Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 15 Jun 2019 08:54:33 -0700
 Subject: [PATCH] Fix World#isChunkGenerated calls
@@ -134,10 +134,10 @@ index 806d225aaa..97040528a0 100644
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 86831c3526..f4bdb2eda3 100644
+index b71f98b0c5..e89738a08d 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -808,10 +808,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -811,10 +811,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      @Nullable
@@ -252,7 +252,7 @@ index 6f34d8aea0..d1323891fa 100644
                      printOversizedLog("ChunkTooLarge even after reduction. Trying in overzealous mode.", regionfile.file, chunkX, chunkZ);
                      // Eek, major fail. We have retry logic, so reduce threshholds and fall back
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0cdf723480..4026edabc2 100644
+index e0d89cc533..53d4f46d45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -387,8 +387,20 @@ public class CraftWorld implements World {
@@ -305,7 +305,7 @@ index 0cdf723480..4026edabc2 100644
      }
  
      @Override
-@@ -2125,21 +2131,11 @@ public class CraftWorld implements World {
+@@ -2127,21 +2133,11 @@ public class CraftWorld implements World {
  
      // Paper start
      private Chunk getChunkAtGen(int x, int z, boolean gen) {

--- a/Spigot-Server-Patches/0404-Show-blockstate-location-if-we-failed-to-read-it.patch
+++ b/Spigot-Server-Patches/0404-Show-blockstate-location-if-we-failed-to-read-it.patch
@@ -1,11 +1,11 @@
-From dd703d1aa219e991a2d305e780ed3fba30c12049 Mon Sep 17 00:00:00 2001
+From 04c4f0e5dc5048071fb5fc42dac2a2302091c670 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 15 Jun 2019 10:28:25 -0700
 Subject: [PATCH] Show blockstate location if we failed to read it
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 7cb4c3e503..c3405950d8 100644
+index 7cb4c3e503..a593882988 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 @@ -20,6 +20,8 @@ public class CraftBlockEntityState<T extends TileEntity> extends CraftBlockState


### PR DESCRIPTION
We should only set hasBeenLoaded to false potentially after saving a chunk
otherwise we will not save it later. The method to do this is
PlayerChunk#l(), which we were potentially calling for chunks we were not saving.

Resolves #2194 