### PR TITLE
Fix verified-loaded-count being off for chunk debug command

### DIFF
--- a/Spigot-Server-Patches/0400-Chunk-debug-command.patch
+++ b/Spigot-Server-Patches/0400-Chunk-debug-command.patch
@@ -1,4 +1,4 @@
-From 878ec799f4aadb09f197f1148d474ae97c5d17f0 Mon Sep 17 00:00:00 2001
+From cce4b2b070940e20ff814808cb6f0e0b986f2151 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 1 Jun 2019 13:00:55 -0700
 Subject: [PATCH] Chunk debug command
@@ -32,7 +32,7 @@ https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528273&page=com.atlass
 https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528577&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-528577
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 352a39dcb3..c808adaddf 100644
+index 352a39dcb3..97a5dbc4e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -28,14 +28,14 @@ public class PaperCommand extends Command {
@@ -211,7 +211,7 @@ index ca1e4b90ba..d83eec0d76 100644
      public final ChunkGenerator<?> chunkGenerator;
      private final WorldServer world;
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index ec3732193f..fa0763cd9c 100644
+index ec3732193f..23d1935dd5 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -4,7 +4,13 @@ import com.destroystokyo.paper.block.TargetBlockInfo;
@@ -320,7 +320,7 @@ index ec3732193f..fa0763cd9c 100644
 +            int fullLoadedChunks = 0;
 +
 +            for (PlayerChunk chunk : allChunks) {
-+                if (chunk.getFullChunk() != null) {
++                if (chunk.getFullChunkIfCached() != null) {
 +                    ++fullLoadedChunks;
 +                }
 +            }


### PR DESCRIPTION
We need to bypass ticket checks when counting.

Forgot to do this after spigot added that change