### PR TITLE
Rework fix for MC-114618 so not break map maker's workflow. Fixes #2221

### DIFF
--- a/Spigot-Server-Patches/0396-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
+++ b/Spigot-Server-Patches/0396-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
@@ -1,4 +1,4 @@
-From 7e81c4e0469c1a263e792dd5657bae9e9d9f6e0e Mon Sep 17 00:00:00 2001
+From 74a90e209f5e47e996f4f6441a873acbadebfd10 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <blake.galbreath@gmail.com>
 Date: Mon, 27 May 2019 17:35:39 -0500
 Subject: [PATCH] MC-114618 - Fix EntityAreaEffectCloud from going negative
@@ -6,7 +6,7 @@ Subject: [PATCH] MC-114618 - Fix EntityAreaEffectCloud from going negative
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
-index 418c638d31..2eaed1cd63 100644
+index 418c638d3..315ba7a22 100644
 --- a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
 +++ b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
 @@ -163,6 +163,12 @@ public class EntityAreaEffectCloud extends Entity {
@@ -14,7 +14,7 @@ index 418c638d31..2eaed1cd63 100644
          boolean flag = this.l();
          float f = this.getRadius();
 +        // Paper start - fix MC-114618
-+        if (f < 0.5F) {
++        if (f < 0.0F) {
 +            this.die();
 +            return;
 +        }
@@ -22,23 +22,6 @@ index 418c638d31..2eaed1cd63 100644
  
          if (this.world.isClientSide) {
              ParticleParam particleparam = this.getParticle();
-@@ -232,10 +238,12 @@ public class EntityAreaEffectCloud extends Entity {
- 
-             if (this.radiusPerTick != 0.0F) {
-                 f += this.radiusPerTick;
--                if (f < 0.5F) {
--                    this.die();
--                    return;
--                }
-+                // Paper start - moved up - fix MC-114618
-+                //if (f < 0.5F) {
-+                //    this.die();
-+                //    return;
-+                //}
-+                // Paper end
- 
-                 this.setRadius(f);
-             }
 -- 
-2.21.0
+2.20.1
 


### PR DESCRIPTION
This puts the original check back into place, and adds a new check for negative radius. This will leave map maker's the ability to use 0.0 sized clouds intact.