### PR TITLE
Add BellRingEvent for village bells

### DIFF
--- a/Spigot-API-Patches/0221-Add-BellRingEvent.patch
+++ b/Spigot-API-Patches/0221-Add-BellRingEvent.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eearslya Sleiarion <eearslya@gmail.com>
+Date: Mon, 24 Jun 2019 21:27:39 -0700
+Subject: [PATCH] Add BellRingEvent
+
+Add a new event, BellRingEvent, to trigger whenever a player rings a
+village bell. Passes along the bell block and the player who rang it.
+
+diff --git a/src/main/java/io/papermc/paper/event/block/BellRingEvent.java b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..881e545df51409e6101b4bb49f699655a744f13f
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/BellRingEvent.java
+@@ -0,0 +1,55 @@
++package io.papermc.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.bukkit.potion.PotionEffect;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a bell is rung.
++ */
++public class BellRingEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++    private final Entity entity;
++
++    public BellRingEvent(@NotNull Block block, @Nullable Entity entity) {
++        super(block);
++        this.entity = entity;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    /**
++     * Gets the entity that rang the bell.
++     *
++     * @return the ringer or null if none
++     */
++    @Nullable
++    public Entity getEntity() {
++        return entity;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0565-Add-BellRingEvent.patch
+++ b/Spigot-Server-Patches/0565-Add-BellRingEvent.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Eearslya Sleiarion <eearslya@gmail.com>
+Date: Sun, 23 Aug 2020 13:04:02 +0200
+Subject: [PATCH] Add BellRingEvent
+
+Add a new event, BellRingEvent, to trigger whenever a player rings a
+village bell. Passes along the bell block and the player who rang it.
+
+diff --git a/src/main/java/net/minecraft/server/BlockBell.java b/src/main/java/net/minecraft/server/BlockBell.java
+index 2ef899c761120a9fd6a9edcca23dea62d58688e6..25c72672eb2c5268d0dc13e29b30efbb9b519cd4 100644
+--- a/src/main/java/net/minecraft/server/BlockBell.java
++++ b/src/main/java/net/minecraft/server/BlockBell.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.server;
+ 
++import io.papermc.paper.event.block.BellRingEvent;
++
+ import javax.annotation.Nullable;
+ 
+ public class BlockBell extends BlockTileEntity {
+@@ -58,7 +60,7 @@ public class BlockBell extends BlockTileEntity {
+         boolean flag1 = !flag || this.a(iblockdata, enumdirection, movingobjectpositionblock.getPos().y - (double) blockposition.getY());
+ 
+         if (flag1) {
+-            boolean flag2 = this.a(world, blockposition, enumdirection);
++            boolean flag2 = this.handleBellRing(world, blockposition, enumdirection, entityhuman); // Paper
+ 
+             if (flag2 && entityhuman != null) {
+                 entityhuman.a(StatisticList.BELL_RING);
+@@ -92,6 +94,11 @@ public class BlockBell extends BlockTileEntity {
+     }
+ 
+     public boolean a(World world, BlockPosition blockposition, @Nullable EnumDirection enumdirection) {
++        // Paper start - add ringer param
++        return this.handleBellRing(world, blockposition, enumdirection, null);
++    }
++    public boolean handleBellRing(World world, BlockPosition blockposition, @Nullable EnumDirection enumdirection, @Nullable Entity ringer) {
++        // Paper end
+         TileEntity tileentity = world.getTileEntity(blockposition);
+ 
+         if (!world.isClientSide && tileentity instanceof TileEntityBell) {
+@@ -99,6 +106,7 @@ public class BlockBell extends BlockTileEntity {
+                 enumdirection = (EnumDirection) world.getType(blockposition).get(BlockBell.a);
+             }
+ 
++            if (!new BellRingEvent(world.getWorld().getBlockAt(MCUtil.toLocation(world, blockposition)), ringer == null ? null : ringer.getBukkitEntity()).callEvent()) return false; // Paper - BellRingEvent
+             ((TileEntityBell) tileentity).a(enumdirection);
+             world.playSound((EntityHuman) null, blockposition, SoundEffects.BLOCK_BELL_USE, SoundCategory.BLOCKS, 2.0F, 1.0F);
+             return true;


### PR DESCRIPTION
Add a new event, BellRingEvent, to trigger whenever a player rings a village bell. Passes along the bell block and the player who rang it.

First PR, just trying to get my feet wet and familiar with the Paper codebase. Any feedback is appreciated!