### PR TITLE
Remove unused fire-physics-event-for-redstone config option

### DIFF
--- a/Spigot-Server-Patches/0076-Configurable-Chunk-Inhabited-Time.patch
+++ b/Spigot-Server-Patches/0076-Configurable-Chunk-Inhabited-Time.patch
@@ -1,4 +1,4 @@
-From 99d5651836848cb09b7cce734a3b374a8990faa6 Mon Sep 17 00:00:00 2001
+From 0610987b996606ad326ce15bff8d14a3db5d5457 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:46:14 -0400
 Subject: [PATCH] Configurable Chunk Inhabited Time
@@ -11,18 +11,13 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2a71381dae..e43866991c 100644
+index 2a71381d..bcf4dc52 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -229,4 +229,19 @@ public class PaperWorldConfig {
+@@ -229,4 +229,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }
-+
-+    public boolean firePhysicsEventForRedstone = false;
-+    private void firePhysicsEventForRedstone() {
-+        firePhysicsEventForRedstone = getBoolean("fire-physics-event-for-redstone", firePhysicsEventForRedstone);
-+    }
 +
 +    public int fixedInhabitedTime;
 +    private void fixedInhabitedTime() {
@@ -35,7 +30,7 @@ index 2a71381dae..e43866991c 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 591c823b39..3d366ddeb2 100644
+index 591c823b..3d366dde 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -839,7 +839,7 @@ public class Chunk implements IChunkAccess {

--- a/Spigot-Server-Patches/0085-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/Spigot-Server-Patches/0085-Configurable-Grass-Spread-Tick-Rate.patch
@@ -1,14 +1,14 @@
-From eed0be3ec997ddf96892c2eaca81e22a47e21135 Mon Sep 17 00:00:00 2001
+From 4666ae7ccda402cbd3e5a985180fd1066802a8ee Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 3 Apr 2016 16:28:17 -0400
 Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e43866991c..59d11e68c9 100644
+index bcf4dc52..27141033 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -244,4 +244,10 @@ public class PaperWorldConfig {
+@@ -239,4 +239,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }
@@ -20,7 +20,7 @@ index e43866991c..59d11e68c9 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java b/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
-index ddca19b46b..377a57c89a 100644
+index ddca19b4..377a57c8 100644
 --- a/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
 +++ b/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
 @@ -29,6 +29,7 @@ public abstract class BlockDirtSnowSpreadable extends BlockDirtSnow {

--- a/Spigot-Server-Patches/0088-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0088-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -1,4 +1,4 @@
-From 8efc844d4ce68b3300fdc8f67a64e94f222fe277 Mon Sep 17 00:00:00 2001
+From b591eede0c629fce99e6ab697f74c4e6f78205f9 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Wed, 6 Apr 2016 01:04:23 -0500
 Subject: [PATCH] Option to use vanilla per-world scoreboard coloring on names
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 59d11e68c9..1da7ffab5d 100644
+index 27141033..aeeb7c24 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -250,4 +250,9 @@ public class PaperWorldConfig {
+@@ -245,4 +245,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }
@@ -26,7 +26,7 @@ index 59d11e68c9..1da7ffab5d 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 41a6204022..bbc5acd7fe 100644
+index 41a62040..bbc5acd7 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1660,7 +1660,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -48,7 +48,7 @@ index 41a6204022..bbc5acd7fe 100644
                  if (((LazyPlayerSet) event.getRecipients()).isLazy()) {
                      for (Object recipient : minecraftServer.getPlayerList().players) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index cce5305fbe..d368b39751 100644
+index cce5305f..d368b397 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -177,7 +177,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0098-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/Spigot-Server-Patches/0098-Add-ability-to-configure-frosted_ice-properties.patch
@@ -1,14 +1,14 @@
-From 8f972d58363549dd92afa7f5235a050ae00b65c1 Mon Sep 17 00:00:00 2001
+From 89826be687bb81888aa5e4bf0be877287f761010 Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Thu, 21 Apr 2016 23:51:55 -0700
 Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1da7ffab5d..377f4983b7 100644
+index aeeb7c24..409a84b5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -255,4 +255,14 @@ public class PaperWorldConfig {
+@@ -250,4 +250,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }
@@ -24,7 +24,7 @@ index 1da7ffab5d..377f4983b7 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockIceFrost.java b/src/main/java/net/minecraft/server/BlockIceFrost.java
-index 1a0c2eeaa4..39c3bbc9cf 100644
+index 1a0c2eea..39c3bbc9 100644
 --- a/src/main/java/net/minecraft/server/BlockIceFrost.java
 +++ b/src/main/java/net/minecraft/server/BlockIceFrost.java
 @@ -13,6 +13,7 @@ public class BlockIceFrost extends BlockIce {

--- a/Spigot-Server-Patches/0101-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0101-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -1,4 +1,4 @@
-From 9530d1108b28a11ca02b7c70caa8963318cff90a Mon Sep 17 00:00:00 2001
+From 9dc70e4cace81b617c78f19fe2eb4dfdaa6a3600 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 1 May 2016 21:19:14 -0400
 Subject: [PATCH] LootTable API & Replenishable Lootables Feature
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 377f4983b7..805aa56999 100644
+index 409a84b5..134c4f7a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -265,4 +265,26 @@ public class PaperWorldConfig {
+@@ -260,4 +260,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }
@@ -43,7 +43,7 @@ index 377f4983b7..805aa56999 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
 new file mode 100644
-index 0000000000..d6fce3112e
+index 00000000..d6fce311
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableBlockInventory.java
 @@ -0,0 +1,33 @@
@@ -82,7 +82,7 @@ index 0000000000..d6fce3112e
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java
 new file mode 100644
-index 0000000000..5e637782d5
+index 00000000..5e637782
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableEntityInventory.java
 @@ -0,0 +1,28 @@
@@ -116,7 +116,7 @@ index 0000000000..5e637782d5
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java
 new file mode 100644
-index 0000000000..856843fc91
+index 00000000..856843fc
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventory.java
 @@ -0,0 +1,71 @@
@@ -193,7 +193,7 @@ index 0000000000..856843fc91
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 new file mode 100644
-index 0000000000..b5401eaf97
+index 00000000..b5401eaf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperLootableInventoryData.java
 @@ -0,0 +1,179 @@
@@ -378,7 +378,7 @@ index 0000000000..b5401eaf97
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperMinecartLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperMinecartLootableInventory.java
 new file mode 100644
-index 0000000000..f9fbc221bd
+index 00000000..f9fbc221
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperMinecartLootableInventory.java
 @@ -0,0 +1,64 @@
@@ -448,7 +448,7 @@ index 0000000000..f9fbc221bd
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
 new file mode 100644
-index 0000000000..d50410532c
+index 00000000..d5041053
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/loottable/PaperTileEntityLootableInventory.java
 @@ -0,0 +1,67 @@
@@ -520,7 +520,7 @@ index 0000000000..d50410532c
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 865dfa2b05..b91eaebc0e 100644
+index 8fa8c7ff..f4b7f3a5 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -72,6 +72,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -532,7 +532,7 @@ index 865dfa2b05..b91eaebc0e 100644
  
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartContainer.java b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
-index c223e18125..cf1c5d754c 100644
+index c223e181..cf1c5d75 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 @@ -15,10 +15,11 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
@@ -591,7 +591,7 @@ index c223e18125..cf1c5d754c 100644
  
              if (entityhuman != null) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityLootable.java b/src/main/java/net/minecraft/server/TileEntityLootable.java
-index 39ebc7218c..a346eba52b 100644
+index 39ebc721..a346eba5 100644
 --- a/src/main/java/net/minecraft/server/TileEntityLootable.java
 +++ b/src/main/java/net/minecraft/server/TileEntityLootable.java
 @@ -6,8 +6,9 @@ import javax.annotation.Nullable;
@@ -646,7 +646,7 @@ index 39ebc7218c..a346eba52b 100644
  
              if (entityhuman != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 57443ca6f0..d8b3d2f3d5 100644
+index 57443ca6..d8b3d2f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 @@ -65,7 +65,7 @@ public class CraftBlockEntityState<T extends TileEntity> extends CraftBlockState
@@ -659,7 +659,7 @@ index 57443ca6f0..d8b3d2f3d5 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index 6beb992622..019fa71181 100644
+index 6beb9926..019fa711 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 @@ -11,8 +11,9 @@ import org.bukkit.craftbukkit.CraftWorld;
@@ -674,7 +674,7 @@ index 6beb992622..019fa71181 100644
      public CraftChest(final Block block) {
          super(block, TileEntityChest.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
-index e1ad26a242..678aa09d47 100644
+index e1ad26a2..678aa09d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
 @@ -1,5 +1,6 @@
@@ -703,7 +703,7 @@ index e1ad26a242..678aa09d47 100644
          getSnapshot().setLootTable(key, seed);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
-index e05624e643..ab4807b2cd 100644
+index e05624e6..ab4807b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
 @@ -1,5 +1,6 @@
@@ -723,7 +723,7 @@ index e05624e643..ab4807b2cd 100644
  
      public CraftMinecartChest(CraftServer server, EntityMinecartChest entity) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
-index 2d776b520b..fcc9787848 100644
+index 2d776b52..fcc97878 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartContainer.java
 @@ -47,7 +47,7 @@ public abstract class CraftMinecartContainer extends CraftMinecart implements Lo
@@ -736,7 +736,7 @@ index 2d776b520b..fcc9787848 100644
          getHandle().setLootTable(newKey, seed);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
-index 334bd5bb3f..f5b31237fc 100644
+index 334bd5bb..f5b31237 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartHopper.java
 @@ -1,5 +1,6 @@

--- a/Spigot-Server-Patches/0106-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0106-Optional-TNT-doesn-t-move-in-water.patch
@@ -1,11 +1,11 @@
-From ad12912df3204334e006aa4d5a73bcf41331fe08 Mon Sep 17 00:00:00 2001
+From 13bfa4ab4602ad7cafd5dc611b7ac9e63e4fb0fa Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Sun, 22 May 2016 20:20:55 -0500
 Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 805aa56999..92ab55182f 100644
+index 134c4f7a..241149c9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,7 +2,6 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 805aa56999..92ab55182f 100644
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -287,4 +286,14 @@ public class PaperWorldConfig {
+@@ -282,4 +281,14 @@ public class PaperWorldConfig {
              );
          }
      }
@@ -32,7 +32,7 @@ index 805aa56999..92ab55182f 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index b91eaebc0e..44709d5d46 100644
+index f4b7f3a5..574e04d2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2694,6 +2694,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -49,7 +49,7 @@ index b91eaebc0e..44709d5d46 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index f2ee53ab90..dc0d944ea0 100644
+index f2ee53ab..dc0d944e 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 @@ -80,7 +80,27 @@ public class EntityTNTPrimed extends Entity {
@@ -94,7 +94,7 @@ index f2ee53ab90..dc0d944ea0 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
-index f04a9d18c4..cd7e0299ac 100644
+index f04a9d18..cd7e0299 100644
 --- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 +++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
 @@ -36,7 +36,7 @@ public class EntityTrackerEntry {

--- a/Spigot-Server-Patches/0122-Option-to-remove-corrupt-tile-entities.patch
+++ b/Spigot-Server-Patches/0122-Option-to-remove-corrupt-tile-entities.patch
@@ -1,14 +1,14 @@
-From 83b2f4fb5840f8237a3c42bf09ead19888c0d422 Mon Sep 17 00:00:00 2001
+From 36120b6b82c98025a294225f8ffe6b837a3c3c1c Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Wed, 5 Oct 2016 16:27:36 -0500
 Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 92ab55182f..eed454bf40 100644
+index 241149c9..849872f6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -296,4 +296,9 @@ public class PaperWorldConfig {
+@@ -291,4 +291,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }
@@ -19,7 +19,7 @@ index 92ab55182f..eed454bf40 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 3d366ddeb2..cacef3ac9f 100644
+index 3d366dde..cacef3ac 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -533,6 +533,12 @@ public class Chunk implements IChunkAccess {

--- a/Spigot-Server-Patches/0125-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/Spigot-Server-Patches/0125-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -1,11 +1,11 @@
-From 245b1105e503637337735834ddea9ee8015defb3 Mon Sep 17 00:00:00 2001
+From 0aff1d3524bc0a9c96f8b913c3d382a4803bc2da Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Sat, 12 Nov 2016 23:25:22 -0600
 Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eed454bf40..4892113a15 100644
+index 849872f6..11b0f11a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,6 +2,7 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index eed454bf40..4892113a15 100644
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -301,4 +302,12 @@ public class PaperWorldConfig {
+@@ -296,4 +297,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }
@@ -30,7 +30,7 @@ index eed454bf40..4892113a15 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
-index 9d86beda9e..44dd99ea21 100644
+index 9d86beda..44dd99ea 100644
 --- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
 @@ -232,6 +232,15 @@ public class EntityFallingBlock extends Entity {

--- a/Spigot-Server-Patches/0135-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0135-Configurable-Cartographer-Treasure-Maps.patch
@@ -1,4 +1,4 @@
-From 7ed82a5f1625536217b8d9d482843c3b44fc24dc Mon Sep 17 00:00:00 2001
+From 55c729d5270871627095d17fdf129e70801059ce Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 20 Dec 2016 15:26:27 -0500
 Subject: [PATCH] Configurable Cartographer Treasure Maps
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4892113a15..406bc611c1 100644
+index 11b0f11a..46d52522 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -310,4 +310,14 @@ public class PaperWorldConfig {
+@@ -305,4 +305,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }
@@ -28,7 +28,7 @@ index 4892113a15..406bc611c1 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/VillagerTrades.java b/src/main/java/net/minecraft/server/VillagerTrades.java
-index 2a4e4f7859..0b66323698 100644
+index 2a4e4f78..0b663236 100644
 --- a/src/main/java/net/minecraft/server/VillagerTrades.java
 +++ b/src/main/java/net/minecraft/server/VillagerTrades.java
 @@ -89,6 +89,7 @@ public class VillagerTrades {

--- a/Spigot-Server-Patches/0147-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0147-Cap-Entity-Collisions.patch
@@ -1,4 +1,4 @@
-From 25f86fbad228623411fc3764317edb52bc2c879a Mon Sep 17 00:00:00 2001
+From 62fd9a8d1859a5ac7cddfefd35368fc9ed0135a8 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 22 Jan 2017 18:07:56 -0500
 Subject: [PATCH] Cap Entity Collisions
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 406bc611c1..58fe5a8c4d 100644
+index 46d52522..de8362dd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -320,4 +320,10 @@ public class PaperWorldConfig {
+@@ -315,4 +315,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }
@@ -27,7 +27,7 @@ index 406bc611c1..58fe5a8c4d 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index f541011a34..187441e87d 100644
+index 5407b3f1..a5b9cd6b 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -184,6 +184,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -39,7 +39,7 @@ index f541011a34..187441e87d 100644
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index cb2f3eb458..7695404790 100644
+index cb2f3eb4..76954047 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2559,8 +2559,11 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0153-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0153-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -1,4 +1,4 @@
-From c4b698b1aad2c729f5fd134247b4ae2d1d272cf0 Mon Sep 17 00:00:00 2001
+From 46521311a789974ef5c4375a1988382829afac90 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 16 May 2017 21:29:08 -0500
 Subject: [PATCH] Add option to make parrots stay on shoulders despite movement
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 58fe5a8c4d..a341214952 100644
+index de8362dd..54d67994 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -326,4 +326,10 @@ public class PaperWorldConfig {
+@@ -321,4 +321,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }
@@ -26,7 +26,7 @@ index 58fe5a8c4d..a341214952 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 1a1b1dd1e8..0974135c65 100644
+index 1a1b1dd1..0974135c 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -436,7 +436,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -39,7 +39,7 @@ index 1a1b1dd1e8..0974135c65 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ac8ab28a35..175f685d27 100644
+index ac8ab28a..175f685d 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1787,6 +1787,13 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0156-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0156-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -1,4 +1,4 @@
-From 3e86d99e5f3c5d4e37b9b33d28490c32fd29e009 Mon Sep 17 00:00:00 2001
+From 6a546b2872c9a2453e19103de1ed5486393914d8 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 11 Jun 2017 21:01:18 +0100
 Subject: [PATCH] provide a configurable option to disable creeper lingering
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a341214952..abc967d3f5 100644
+index 54d67994..4d0d4cbe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -332,4 +332,10 @@ public class PaperWorldConfig {
+@@ -327,4 +327,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }
@@ -21,7 +21,7 @@ index a341214952..abc967d3f5 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index e1374d2398..0503af5af3 100644
+index e1374d23..0503af5a 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
 @@ -225,7 +225,7 @@ public class EntityCreeper extends EntityMonster {

--- a/Spigot-Server-Patches/0185-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0185-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -1,14 +1,14 @@
-From 483471325dc8eb5956f2fbb3c00ff4100a5e08e3 Mon Sep 17 00:00:00 2001
+From 03fed9dc5253768447be963f64d68a5b6d878c5e Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Fri, 10 Nov 2017 23:03:12 -0500
 Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index abc967d3f5..2a50d6babf 100644
+index 4d0d4cbe..b3d8fe9c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -338,4 +338,10 @@ public class PaperWorldConfig {
+@@ -333,4 +333,10 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
@@ -20,7 +20,7 @@ index abc967d3f5..2a50d6babf 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a33a9fd792..85a9dd5abb 100644
+index a33a9fd7..85a9dd5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -529,16 +529,32 @@ public class CraftEventFactory {

--- a/Spigot-Server-Patches/0195-Make-max-squid-spawn-height-configurable.patch
+++ b/Spigot-Server-Patches/0195-Make-max-squid-spawn-height-configurable.patch
@@ -1,4 +1,4 @@
-From c31588b927c0c2dca1232e2888ce57f58ef85a32 Mon Sep 17 00:00:00 2001
+From 0fb85f0712c4d30a3f74b2b493c14509356e2289 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Thu, 11 Jan 2018 16:47:28 -0600
 Subject: [PATCH] Make max squid spawn height configurable
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2a50d6babf..c3e61bdfe3 100644
+index b3d8fe9c..7287bf7d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -344,4 +344,9 @@ public class PaperWorldConfig {
+@@ -339,4 +339,9 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }
@@ -21,7 +21,7 @@ index 2a50d6babf..c3e61bdfe3 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySquid.java b/src/main/java/net/minecraft/server/EntitySquid.java
-index 338c203b33..aafb7df0c8 100644
+index 338c203b..aafb7df0 100644
 --- a/src/main/java/net/minecraft/server/EntitySquid.java
 +++ b/src/main/java/net/minecraft/server/EntitySquid.java
 @@ -171,7 +171,8 @@ public class EntitySquid extends EntityWaterAnimal {

--- a/Spigot-Server-Patches/0219-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0219-Configurable-sprint-interruption-on-attack.patch
@@ -1,4 +1,4 @@
-From 632a6f79df52ad7e946488db55cc098e501fab2f Mon Sep 17 00:00:00 2001
+From ec69b4b3607d31885183b742038210348c9d7afc Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Sat, 14 Apr 2018 20:20:46 +0200
 Subject: [PATCH] Configurable sprint interruption on attack
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 32bfe0e462..7024336c3a 100644
+index 94ffba97..0b6e812d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -354,4 +354,9 @@ public class PaperWorldConfig {
+@@ -349,4 +349,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }
@@ -20,7 +20,7 @@ index 32bfe0e462..7024336c3a 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 1c73572c40..4ff6cba65e 100644
+index 1c73572c..4ff6cba6 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -1030,7 +1030,11 @@ public abstract class EntityHuman extends EntityLiving {

--- a/Spigot-Server-Patches/0223-Block-Enderpearl-Travel-Exploit.patch
+++ b/Spigot-Server-Patches/0223-Block-Enderpearl-Travel-Exploit.patch
@@ -1,4 +1,4 @@
-From 399ddc1100ef6e2a9b49082f8661764395ebeb50 Mon Sep 17 00:00:00 2001
+From 15bbcdbb65b854e61ee1c7a96a1d4793eece540d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 30 Apr 2018 17:15:26 -0400
 Subject: [PATCH] Block Enderpearl Travel Exploit
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7024336c3a..fe9415b1de 100644
+index 0b6e812d..da105500 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -359,4 +359,10 @@ public class PaperWorldConfig {
+@@ -354,4 +354,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }
@@ -27,7 +27,7 @@ index 7024336c3a..fe9415b1de 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityProjectile.java b/src/main/java/net/minecraft/server/EntityProjectile.java
-index 5f0cb4c33d..f2f4b2d929 100644
+index 5f0cb4c3..f2f4b2d9 100644
 --- a/src/main/java/net/minecraft/server/EntityProjectile.java
 +++ b/src/main/java/net/minecraft/server/EntityProjectile.java
 @@ -205,6 +205,7 @@ public abstract class EntityProjectile extends Entity implements IProjectile {

--- a/Spigot-Server-Patches/0236-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0236-Make-shield-blocking-delay-configurable.patch
@@ -1,14 +1,14 @@
-From 5733d372277edc71bed1de0535f4c5d10f42a7f5 Mon Sep 17 00:00:00 2001
+From 15cc3fe7111bbbb9164ccaa54d99e98420353c27 Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sat, 16 Jun 2018 01:18:16 -0500
 Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fe9415b1de..ce17447faf 100644
+index da105500..182ac2e7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -365,4 +365,9 @@ public class PaperWorldConfig {
+@@ -360,4 +360,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }
@@ -19,7 +19,7 @@ index fe9415b1de..ce17447faf 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 1157a9eb63..d4c38ae462 100644
+index 1157a9eb..d4c38ae4 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2921,7 +2921,7 @@ public abstract class EntityLiving extends Entity {
@@ -48,7 +48,7 @@ index 1157a9eb63..d4c38ae462 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 42cc158824..513b3fac7f 100644
+index 42cc1588..513b3fac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -619,5 +619,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/Spigot-Server-Patches/0245-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/Spigot-Server-Patches/0245-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -1,14 +1,14 @@
-From 6e95295db6a2ad40cdd96833b30205b0d2c980c3 Mon Sep 17 00:00:00 2001
+From 8c685f678bfae7ef7f734ea87f19bec2e179032f Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Fri, 22 Jun 2018 10:38:31 -0500
 Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ce17447faf..3294fbbeaf 100644
+index 182ac2e7..b7e819d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -370,4 +370,9 @@ public class PaperWorldConfig {
+@@ -365,4 +365,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }
@@ -19,7 +19,7 @@ index ce17447faf..3294fbbeaf 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EnderDragonBattle.java b/src/main/java/net/minecraft/server/EnderDragonBattle.java
-index 88a8e4abd0..6700c8c658 100644
+index 88a8e4ab..6700c8c6 100644
 --- a/src/main/java/net/minecraft/server/EnderDragonBattle.java
 +++ b/src/main/java/net/minecraft/server/EnderDragonBattle.java
 @@ -28,10 +28,10 @@ public class EnderDragonBattle {

--- a/Spigot-Server-Patches/0248-Configurable-Bed-Search-Radius.patch
+++ b/Spigot-Server-Patches/0248-Configurable-Bed-Search-Radius.patch
@@ -1,4 +1,4 @@
-From c2ec9dece225f34798c3314e94f3e0dda39b52b4 Mon Sep 17 00:00:00 2001
+From cea94f31f82514021682c12a0969ff2efc85ea2d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 4 Jul 2018 15:22:06 -0400
 Subject: [PATCH] Configurable Bed Search Radius
@@ -10,10 +10,10 @@ player at their bed should it of became obstructed.
 Defaults to vanilla 1.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3294fbbeaf..83e54cb904 100644
+index b7e819d6..fc045593 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -375,4 +375,15 @@ public class PaperWorldConfig {
+@@ -370,4 +370,15 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
@@ -30,7 +30,7 @@ index 3294fbbeaf..83e54cb904 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockBed.java b/src/main/java/net/minecraft/server/BlockBed.java
-index c49eb0ecb3..35cf3c3aca 100644
+index c49eb0ec..35cf3c3a 100644
 --- a/src/main/java/net/minecraft/server/BlockBed.java
 +++ b/src/main/java/net/minecraft/server/BlockBed.java
 @@ -171,6 +171,10 @@ public class BlockBed extends BlockFacingHorizontal implements ITileEntity {

--- a/Spigot-Server-Patches/0262-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0262-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -1,14 +1,14 @@
-From ba41ae8e160eb3ee2acd9bdb3e56228e35fac954 Mon Sep 17 00:00:00 2001
+From 6741b23c5a16fce7f2ac61cceab4d2dcb5b2ebd8 Mon Sep 17 00:00:00 2001
 From: Hugo Manrique <hugmanrique@gmail.com>
 Date: Mon, 23 Jul 2018 12:57:39 +0200
 Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83e54cb90..f06bb3ae1 100644
+index fc045593..09607fb4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -326,6 +326,11 @@ public class PaperWorldConfig {
+@@ -321,6 +321,11 @@ public class PaperWorldConfig {
          }
      }
  
@@ -21,7 +21,7 @@ index 83e54cb90..f06bb3ae1 100644
      private void maxEntityCollision() {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f476f326f..d08bd6d96 100644
+index f476f326..d08bd6d9 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -873,6 +873,14 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose

--- a/Spigot-Server-Patches/0286-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0286-Allow-disabling-armour-stand-ticking.patch
@@ -1,14 +1,14 @@
-From a840fe7244538c921ee95d7646f4949a6e0f5fac Mon Sep 17 00:00:00 2001
+From df1c89331821d93afc05a37ba065cabe2f7ca626 Mon Sep 17 00:00:00 2001
 From: kashike <kashike@vq.lc>
 Date: Wed, 15 Aug 2018 01:26:09 -0700
 Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f06bb3ae19..a5b4f99901 100644
+index 09607fb4..5832c3e8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -391,4 +391,10 @@ public class PaperWorldConfig {
+@@ -386,4 +386,10 @@ public class PaperWorldConfig {
              log("Bed Search Radius: " + bedSearchRadius);
          }
      }
@@ -20,7 +20,7 @@ index f06bb3ae19..a5b4f99901 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index 25afd95542..19eb40db93 100644
+index 25afd955..19eb40db 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -44,6 +44,11 @@ public class EntityArmorStand extends EntityLiving {
@@ -140,7 +140,7 @@ index 25afd95542..19eb40db93 100644
  
      public Vector3f r() {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 1500e43eee..32c51a941b 100644
+index 1500e43e..32c51a94 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2265,52 +2265,7 @@ public abstract class EntityLiving extends Entity {
@@ -256,7 +256,7 @@ index 1500e43eee..32c51a941b 100644
          float f2 = MathHelper.g(f - this.aK);
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 9f5c3b92e3..07ce93f17c 100644
+index 9f5c3b92..07ce93f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 @@ -297,5 +297,15 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {

--- a/Spigot-Server-Patches/0290-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0290-Optimize-Hoppers.patch
@@ -1,4 +1,4 @@
-From a85602b67990d6af6c2ee7bbe85df8095c148225 Mon Sep 17 00:00:00 2001
+From 1646a4df73af327ff5f6ef528b24ad8a9931cb5f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 27 Apr 2016 22:09:52 -0400
 Subject: [PATCH] Optimize Hoppers
@@ -11,10 +11,10 @@ Subject: [PATCH] Optimize Hoppers
 * Skip subsequent InventoryMoveItemEvents if a plugin does not use the item after first event fire for an iteration
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a5b4f99901..2b5402b009 100644
+index 5832c3e8..ede558d0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -360,6 +360,15 @@ public class PaperWorldConfig {
+@@ -355,6 +355,15 @@ public class PaperWorldConfig {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }
  
@@ -31,7 +31,7 @@ index a5b4f99901..2b5402b009 100644
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index b9c5af51f5..ab66dbf885 100644
+index b9c5af51..ab66dbf8 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -482,8 +482,9 @@ public final class ItemStack {
@@ -47,7 +47,7 @@ index b9c5af51f5..ab66dbf885 100644
          itemstack.d(this.C());
          if (this.tag != null) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index fe8647bbc6..6c7ce47c5a 100644
+index fe8647bb..6c7ce47c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1127,6 +1127,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -59,7 +59,7 @@ index fe8647bbc6..6c7ce47c5a 100644
                  this.methodProfiler.a(() -> {
                      return worldserver.getWorldData().getName() + " " + IRegistry.DIMENSION_TYPE.getKey(worldserver.worldProvider.getDimensionManager());
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 90cc57b46e..f5ef368cf8 100644
+index 90cc57b4..f5ef368c 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -62,6 +62,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
@@ -79,7 +79,7 @@ index 90cc57b46e..f5ef368cf8 100644
              this.world.b(this.position, this);
              if (!this.c.isAir()) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 1ba98bf736..6f6519f6c5 100644
+index 1ba98bf7..6f6519f6 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -189,6 +189,154 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi

--- a/Spigot-Server-Patches/0294-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/Spigot-Server-Patches/0294-Configurable-speed-for-water-flowing-over-lava.patch
@@ -1,14 +1,14 @@
-From f90fac0128f6c87402d290d649ffaad7fa877d4e Mon Sep 17 00:00:00 2001
+From d64163642709d3bb120d110b032b2e9ae51b924d Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Wed, 8 Aug 2018 16:33:21 -0600
 Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2b5402b009..2c27be63ea 100644
+index ede558d0..7e031d18 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -401,6 +401,12 @@ public class PaperWorldConfig {
+@@ -396,6 +396,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -22,7 +22,7 @@ index 2b5402b009..2c27be63ea 100644
      private void armorStandTick() {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
 diff --git a/src/main/java/net/minecraft/server/BlockFluids.java b/src/main/java/net/minecraft/server/BlockFluids.java
-index cccdd13988..56bf0b1d81 100644
+index cccdd139..56bf0b1d 100644
 --- a/src/main/java/net/minecraft/server/BlockFluids.java
 +++ b/src/main/java/net/minecraft/server/BlockFluids.java
 @@ -70,11 +70,27 @@ public class BlockFluids extends Block implements IFluidSource {

--- a/Spigot-Server-Patches/0324-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0324-Limit-lightning-strike-effect-distance.patch
@@ -1,11 +1,11 @@
-From 6f7a825520d7f9f9056ade41c80a461b5aaab2b9 Mon Sep 17 00:00:00 2001
+From 8ba844393ca690aeda331914d6dfe84d054f5335 Mon Sep 17 00:00:00 2001
 From: Trigary <trigary0@gmail.com>
 Date: Fri, 14 Sep 2018 17:42:08 +0200
 Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2c27be63ea..fb44fccc92 100644
+index 7e031d18..63f313a9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -234,6 +234,28 @@ public class PaperWorldConfig {
@@ -35,10 +35,10 @@ index 2c27be63ea..fb44fccc92 100644
 +        }
 +    }
  
-     public boolean firePhysicsEventForRedstone = false;
-     private void firePhysicsEventForRedstone() {
+     public int fixedInhabitedTime;
+     private void fixedInhabitedTime() {
 diff --git a/src/main/java/net/minecraft/server/EntityLightning.java b/src/main/java/net/minecraft/server/EntityLightning.java
-index 0169f261c6..da85786046 100644
+index 0169f261..da857860 100644
 --- a/src/main/java/net/minecraft/server/EntityLightning.java
 +++ b/src/main/java/net/minecraft/server/EntityLightning.java
 @@ -64,6 +64,17 @@ public class EntityLightning extends Entity {
@@ -69,7 +69,7 @@ index 0169f261c6..da85786046 100644
  
          --this.lifeTicks;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 990c0afb85..2870236108 100644
+index 990c0afb..28702361 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1187,7 +1187,7 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0330-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0330-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -1,4 +1,4 @@
-From 9ac75ccc8697bdf94a61b282f594734203917711 Mon Sep 17 00:00:00 2001
+From 1464f3e3f5e675b5b08a747973bc847afb234b14 Mon Sep 17 00:00:00 2001
 From: Gabriele C <sgdc3.mail@gmail.com>
 Date: Mon, 22 Oct 2018 17:34:10 +0200
 Subject: [PATCH] Add option to prevent players from moving into unloaded
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fb44fccc92..ad793ffa38 100644
+index 63f313a9..2299860b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -434,4 +434,9 @@ public class PaperWorldConfig {
+@@ -429,4 +429,9 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }
@@ -20,7 +20,7 @@ index fb44fccc92..ad793ffa38 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index c43b1aca1e..806eb626cb 100644
+index c43b1aca..806eb626 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -347,6 +347,13 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0341-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0341-Optimize-redstone-algorithm.patch
@@ -1,4 +1,4 @@
-From 0a37d54595867494a092afeb118b11fa7c3b51a5 Mon Sep 17 00:00:00 2001
+From 8565eed0a4de2941afd0ac2f3b8d2654f0197e23 Mon Sep 17 00:00:00 2001
 From: theosib <millerti@172.16.221.1>
 Date: Thu, 27 Sep 2018 01:43:35 -0600
 Subject: [PATCH] Optimize redstone algorithm
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ad793ffa3..ef882b897 100644
+index 2299860b..91c809b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -439,4 +439,14 @@ public class PaperWorldConfig {
+@@ -434,4 +434,14 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
@@ -39,7 +39,7 @@ index ad793ffa3..ef882b897 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 new file mode 100644
-index 000000000..cf5661f1c
+index 00000000..cf5661f1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/RedstoneWireTurbo.java
 @@ -0,0 +1,912 @@
@@ -956,7 +956,7 @@ index 000000000..cf5661f1c
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/BlockRedstoneWire.java b/src/main/java/net/minecraft/server/BlockRedstoneWire.java
-index 7ce9cdb85..6b5015ce5 100644
+index 7ce9cdb8..6b5015ce 100644
 --- a/src/main/java/net/minecraft/server/BlockRedstoneWire.java
 +++ b/src/main/java/net/minecraft/server/BlockRedstoneWire.java
 @@ -1,5 +1,7 @@
@@ -1124,7 +1124,7 @@ index 7ce9cdb85..6b5015ce5 100644
                  c(iblockdata, world, blockposition);
                  world.a(blockposition, false);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 26f3b4720..1eb689c62 100644
+index 26f3b472..1eb689c6 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -594,6 +594,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose

--- a/Spigot-Server-Patches/0390-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0390-Duplicate-UUID-Resolve-Option.patch
@@ -1,4 +1,4 @@
-From 50110b70eb4b23d4d3519e78343b95b13b38f7ac Mon Sep 17 00:00:00 2001
+From db3d1c9c003a9ed64a4a847660668b7e5aa9b42a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 21 Jul 2018 14:27:34 -0400
 Subject: [PATCH] Duplicate UUID Resolve Option
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ef882b897f..385b3ac0ce 100644
+index 91c809b7..d8bb1369 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -449,4 +449,43 @@ public class PaperWorldConfig {
+@@ -444,4 +444,43 @@ public class PaperWorldConfig {
              log("Using vanilla redstone algorithm.");
          }
      }
@@ -81,7 +81,7 @@ index ef882b897f..385b3ac0ce 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 099f0ad78b..5bf781bb63 100644
+index 099f0ad7..5bf781bb 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -397,6 +397,7 @@ public class Chunk implements IChunkAccess {
@@ -93,7 +93,7 @@ index 099f0ad78b..5bf781bb63 100644
  
          int k = MathHelper.floor(entity.locY / 16.0D);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index a5f80de34e..69bfa19274 100644
+index b5b08101..858d291d 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2724,6 +2724,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -105,7 +105,7 @@ index a5f80de34e..69bfa19274 100644
          this.uniqueID = uuid;
          this.ap = this.uniqueID.toString();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index b38bc77c93..9102bf8b60 100644
+index b38bc77c..9102bf8b 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,6 +1,7 @@
@@ -195,7 +195,7 @@ index b38bc77c93..9102bf8b60 100644
  
                      if (list != null) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index d47ef7efa0..52a0e0a37f 100644
+index d47ef7ef..52a0e0a3 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;

--- a/Spigot-Server-Patches/0392-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0392-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -1,4 +1,4 @@
-From 60f3741a0bdd4680cbcacab20e299a26e6f91c42 Mon Sep 17 00:00:00 2001
+From 1bbc5c28e88afb1b898c6499fe01ff219e17dc21 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 13 Sep 2014 23:14:43 -0400
 Subject: [PATCH] Configurable Keep Spawn Loaded range per world
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 385b3ac0ce..b854061983 100644
+index d8bb1369..de11a91a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -488,4 +488,10 @@ public class PaperWorldConfig {
+@@ -483,4 +483,10 @@ public class PaperWorldConfig {
                  break;
          }
      }
@@ -21,7 +21,7 @@ index 385b3ac0ce..b854061983 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8136a97f44..d6c99ce897 100644
+index 8136a97f..d6c99ce8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -569,6 +569,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -61,7 +61,7 @@ index 8136a97f44..d6c99ce897 100644
          // CraftBukkit start
          // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListener.java b/src/main/java/net/minecraft/server/WorldLoadListener.java
-index d6762d3853..7b6f5b2da0 100644
+index d6762d38..7b6f5b2d 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListener.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListener.java
 @@ -9,4 +9,6 @@ public interface WorldLoadListener {
@@ -72,7 +72,7 @@ index d6762d3853..7b6f5b2da0 100644
 +    void setChunkRadius(int radius); // Paper - allow changing chunk radius
  }
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
-index 3868572aed..ae77805f71 100644
+index 3868572a..ae77805f 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 @@ -7,16 +7,24 @@ import org.apache.logging.log4j.Logger;
@@ -103,7 +103,7 @@ index 3868572aed..ae77805f71 100644
      @Override
      public void a(ChunkCoordIntPair chunkcoordintpair) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 52a0e0a37f..2e697675e2 100644
+index 52a0e0a3..2e697675 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1495,13 +1495,85 @@ public class WorldServer extends World {
@@ -196,7 +196,7 @@ index 52a0e0a37f..2e697675e2 100644
  
      public LongSet getForceLoadedChunks() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 57071e84fc..3444c19b0f 100644
+index 57071e84..3444c19b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1749,15 +1749,21 @@ public class CraftWorld implements World {

--- a/Spigot-Server-Patches/0399-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0399-incremental-chunk-saving.patch
@@ -1,14 +1,14 @@
-From 454f8b5f99337406d4fbea161d48624e6f4dcb5f Mon Sep 17 00:00:00 2001
+From 77e6256fbc0e0e44a9662b2761563b70a957aac8 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 9 Jun 2019 03:53:22 +0100
 Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b854061983..58109e1308 100644
+index de11a91a..4d3c6c6b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -494,4 +494,19 @@ public class PaperWorldConfig {
+@@ -489,4 +489,19 @@ public class PaperWorldConfig {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }
@@ -29,7 +29,7 @@ index b854061983..58109e1308 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 5bf781bb63..e2a48695df 100644
+index 5bf781bb..e2a48695 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -42,7 +42,7 @@ public class Chunk implements IChunkAccess {
@@ -42,7 +42,7 @@ index 5bf781bb63..e2a48695df 100644
      private long t;
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d6c99ce897..2b99fdc630 100644
+index d6c99ce8..2b99fdc6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -155,6 +155,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -86,7 +86,7 @@ index d6c99ce897..2b99fdc630 100644
          this.methodProfiler.enter("snooper");
          if (((DedicatedServer) this).getDedicatedServerProperties().snooperEnabled && !this.snooper.d() && this.ticks > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index d85220b66c..c4ad039ffd 100644
+index d85220b6..c4ad039f 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -293,15 +293,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -126,7 +126,7 @@ index d85220b66c..c4ad039ffd 100644
  
      }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 2e697675e2..ccc129525a 100644
+index 2e697675..ccc12952 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -755,8 +755,9 @@ public class WorldServer extends World {


### PR DESCRIPTION
`fire-physics-event-for-redstone` doesn't seem to do anything in the configuration, so this PR removes it. I think this was left over from https://github.com/PaperMC/Paper/commit/0a76e7d1aabc4d531e85251c6f6fca75524ca7d1