### PR TITLE
Update TerminalConsoleAppender + JLine, use Jansi instead of JNA

### DIFF
--- a/Spigot-Server-Patches/0153-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0153-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From 48234569f5c6642bf40a3651bb0693c505a13a10 Mon Sep 17 00:00:00 2001
+From 21d4e267f8aeaa9764da1381e37d0d082e4a155a Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 04b0dd9a7..54d214a8c 100644
+index 04b0dd9a7..58b14a740 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -41,10 +41,27 @@
@@ -32,12 +32,12 @@ index 04b0dd9a7..54d214a8c 100644
 -            <scope>compile</scope>
 +            <groupId>net.minecrell</groupId>
 +            <artifactId>terminalconsoleappender</artifactId>
-+            <version>1.1.1</version>
++            <version>1.2.0</version>
 +        </dependency>
 +        <dependency>
-+            <groupId>net.java.dev.jna</groupId>
-+            <artifactId>jna</artifactId>
-+            <version>4.5.2</version>
++            <groupId>org.jline</groupId>
++            <artifactId>jline-terminal-jansi</artifactId>
++            <version>3.12.1</version>
 +            <scope>runtime</scope>
 +        </dependency>
 +        <!--
@@ -561,6 +561,13 @@ index f267f99f9..000000000
 -        }
 -    }
 -}
+diff --git a/src/main/resources/log4j2.component.properties b/src/main/resources/log4j2.component.properties
+new file mode 100644
+index 000000000..0694b2146
+--- /dev/null
++++ b/src/main/resources/log4j2.component.properties
+@@ -0,0 +1 @@
++log4j.skipJansi=true
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
 index 490a9acc7..08b6bb7f9 100644
 --- a/src/main/resources/log4j2.xml

--- a/Spigot-Server-Patches/0252-Use-asynchronous-Log4j-2-loggers.patch
+++ b/Spigot-Server-Patches/0252-Use-asynchronous-Log4j-2-loggers.patch
@@ -1,11 +1,11 @@
-From 36095dbce64ae8d5bba9f951d3841d8ce3f86ba6 Mon Sep 17 00:00:00 2001
+From d337a8321181811a8901b9a4c63c78474acb6db6 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Tue, 17 Jul 2018 16:42:17 +0200
 Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/pom.xml b/pom.xml
-index b7db74c9ba..0130272236 100644
+index 2990c04b8..beda5dc8a 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -74,6 +74,13 @@
@@ -24,7 +24,7 @@ index b7db74c9ba..0130272236 100644
              <artifactId>asm</artifactId>
 diff --git a/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java b/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java
 new file mode 100644
-index 0000000000..db652a1f7a
+index 000000000..db652a1f7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java
 @@ -0,0 +1,17 @@
@@ -46,14 +46,13 @@ index 0000000000..db652a1f7a
 +    }
 +}
 diff --git a/src/main/resources/log4j2.component.properties b/src/main/resources/log4j2.component.properties
-new file mode 100644
-index 0000000000..f72f7425c1
---- /dev/null
+index 0694b2146..30efeb5fa 100644
+--- a/src/main/resources/log4j2.component.properties
 +++ b/src/main/resources/log4j2.component.properties
-@@ -0,0 +1,2 @@
+@@ -1 +1,3 @@
 +Log4jContextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector
 +log4j2.AsyncQueueFullPolicy="com.destroystokyo.paper.log.LogFullPolicy"
-\ No newline at end of file
+ log4j.skipJansi=true
 -- 
 2.22.0
 


### PR DESCRIPTION
Fixes #1734. Fixes #1690 (?)

There were a few larger changes (new JLine/JNA version, changes in implementation of colors in TCA), so I am looking for some testing before I release the new version of TCA. @zachbr asked for a new release in https://github.com/Minecrell/TerminalConsoleAppender/issues/7, so maybe you'd like to help with testing on Paper. :)

It looks fine to me in IDE+Terminal on Arch GNU/Linux, but I cannot test on macOS or Windows at the moment.