### PR TITLE
Amend PlayerInteractAtEntityEvent javadoc for ArmorStands

### DIFF
--- a/Spigot-API-Patches/0184-Amend-PlayerInteractAtEntityEvent-javadoc-for-ArmorS.patch
+++ b/Spigot-API-Patches/0184-Amend-PlayerInteractAtEntityEvent-javadoc-for-ArmorS.patch
@@ -1,0 +1,23 @@
+From c02f688da65316acf628b036b704966fa9bf8dfe Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Thu, 11 Jul 2019 10:35:56 -0700
+Subject: [PATCH] Amend PlayerInteractAtEntityEvent javadoc for ArmorStands
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
+index 1075dbb8..3f24d302 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractAtEntityEvent.java
+@@ -13,6 +13,9 @@ import org.jetbrains.annotations.NotNull;
+  * <br>
+  * Note that the client may sometimes spuriously send this packet in addition to {@link PlayerInteractEntityEvent}.
+  * Users are advised to listen to this (parent) class unless specifically required.
++ * <br>
++ * Note that interacting with Armor Stands fires this event only and not its parent and as such users are expressly required
++ * to listen to this event for that scenario.
+  */
+ public class PlayerInteractAtEntityEvent extends PlayerInteractEntityEvent {
+     private static final HandlerList handlers = new HandlerList();
+-- 
+2.19.2
+


### PR DESCRIPTION
The javadoc for `PlayerInteractAtEntityEvent` is not very clear on the difference between the superclass `PlayerInteractEntityEvent` and itself. As it turns out, Armor Stands can only be interacted _at_ and not interacted _with_, and as such this class is fired and its parent is not.

We discussed in paper-dev a possible alternative that the event manager could check if the class to be fired has a valid fireable superclass, but this would break old plugins.

This PR simply adds some information to the javadoc for the _at_ interaction event to specifically call out the requirement to use this event over the parent for Armor Stands.