### PR TITLE
Do less work if we have a custom Bukkit generator

### DIFF
--- a/Spigot-Server-Patches/0442-If-the-Bukkit-generator-already-has-a-spawn-use-it-i.patch
+++ b/Spigot-Server-Patches/0442-If-the-Bukkit-generator-already-has-a-spawn-use-it-i.patch
@@ -1,0 +1,42 @@
+From 6d9006bf1430e5f98cdddbacac9802d09fb0cd56 Mon Sep 17 00:00:00 2001
+From: Paul Sauve <paul@burngames.net>
+Date: Sun, 14 Jul 2019 20:51:08 -0500
+Subject: [PATCH] If the Bukkit generator already has a spawn, use it
+ immediately instead of spending time generating one that we won't use
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index ee071ba2..8af54019 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -769,12 +769,6 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         } else if (this.worldData.getType() == WorldType.DEBUG_ALL_BLOCK_STATES) {
+             this.worldData.setSpawn(BlockPosition.ZERO.up());
+         } else {
+-            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
+-            List<BiomeBase> list = worldchunkmanager.a();
+-            Random random = new Random(this.getSeed());
+-            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
+-            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
+-
+             // CraftBukkit start
+             if (this.generator != null) {
+                 Random rand = new Random(this.getSeed());
+@@ -791,6 +785,14 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+             }
+             // CraftBukkit end
+ 
++            // Paper start - this is useless if craftbukkit returns early
++            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
++            List<BiomeBase> list = worldchunkmanager.a();
++            Random random = new Random(this.getSeed());
++            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
++            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
++            // Paper end
++
+             if (blockposition == null) {
+                 WorldServer.a.warn("Unable to find spawn biome");
+             }
+-- 
+2.22.0
+


### PR DESCRIPTION
On my issue #2270 I investigated ways to generate worlds faster, this takes up a significant amount of time and brings the time taken to generating a skyblock-like world from 16ms to 8ms on my machine.

I looked into all the methods called in the code I moved and I don't believe any of the methods have side effects, so this is a simple optimization in the case of using custom generators.