### PR TITLE
Do less work if we have a custom Bukkit generator

### DIFF
--- a/Spigot-Server-Patches/0408-If-the-Bukkit-generator-already-has-a-spawn-use-it-i.patch
+++ b/Spigot-Server-Patches/0408-If-the-Bukkit-generator-already-has-a-spawn-use-it-i.patch
@@ -1,0 +1,42 @@
+From e8e94040d7e6d683ec0d6374059a77fb40f2a743 Mon Sep 17 00:00:00 2001
+From: Paul Sauve <paul@burngames.net>
+Date: Sun, 14 Jul 2019 21:05:03 -0500
+Subject: [PATCH] If the Bukkit generator already has a spawn, use it
+ immediately instead of spending time generating one that we won't use
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 959fc99b..672be1e6 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -659,12 +659,6 @@ public class WorldServer extends World {
+         } else if (this.worldData.getType() == WorldType.DEBUG_ALL_BLOCK_STATES) {
+             this.worldData.setSpawn(BlockPosition.ZERO.up());
+         } else {
+-            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
+-            List<BiomeBase> list = worldchunkmanager.a();
+-            Random random = new Random(this.getSeed());
+-            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
+-            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
+-
+             // CraftBukkit start
+             if (this.generator != null) {
+                 Random rand = new Random(this.getSeed());
+@@ -681,6 +675,14 @@ public class WorldServer extends World {
+             }
+             // CraftBukkit end
+ 
++            // Paper start - this is useless if craftbukkit returns early
++            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
++            List<BiomeBase> list = worldchunkmanager.a();
++            Random random = new Random(this.getSeed());
++            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
++            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
++            // Paper end
++
+             if (blockposition == null) {
+                 WorldServer.LOGGER.warn("Unable to find spawn biome");
+             }
+-- 
+2.22.0
+


### PR DESCRIPTION
On my issue #2270 I investigated ways to generate worlds faster, this takes up a significant amount of time and brings the time taken to generating a skyblock-like world from 16ms to 8ms on my machine.

I looked into all the methods called in the code I moved and I don't believe any of the methods have side effects, so this is a simple optimization in the case of using custom generators.