### PR TITLE
Do not schedule to main for getChunkImmediately type calls

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -1,4 +1,4 @@
-From 76ec5cd5870016019c709317fd0091bfd13f7d11 Mon Sep 17 00:00:00 2001
+From 740862772ad8504b5bd9badc779ff59c0e633b93 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:55:47 -0400
 Subject: [PATCH] MC Utils
@@ -167,10 +167,10 @@ index 857b2f8868..bbf136614c 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 36a89817f8..dd6e69a0f1 100644
+index 36a89817f8..baf3bd461b 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -77,6 +77,58 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -77,6 +77,37 @@ public class ChunkProviderServer extends IChunkProvider {
          this.cacheChunk[0] = ichunkaccess;
      }
  
@@ -178,24 +178,9 @@ index 36a89817f8..dd6e69a0f1 100644
 +    // Note: Partially copied from the getChunkAt method below
 +    @Nullable
 +    public Chunk getChunkAtIfCachedImmediately(int x, int z) {
-+        if (Thread.currentThread() != this.serverThread) {
-+            return CompletableFuture.supplyAsync(() -> {
-+                return this.getChunkAtIfCachedImmediately(x, z);
-+            }, this.serverThreadQueue).join();
-+        }
-+
 +        long k = ChunkCoordIntPair.pair(x, z);
 +
-+        IChunkAccess ichunkaccess;
-+
-+        for (int l = 0; l < 4; ++l) {
-+            if (k == this.cachePos[l] && ChunkStatus.FULL == this.cacheStatus[l]) {
-+                ichunkaccess = this.cacheChunk[l];
-+                if (ichunkaccess instanceof Chunk) { // CraftBukkit - the chunk can become accessible in the meantime TODO for non-null chunks it might also make sense to check that the chunk's state hasn't changed in the meantime
-+                    return (Chunk)ichunkaccess;
-+                }
-+            }
-+        }
++        // Note: Bypass cache to make this MT-Safe
 +
 +        PlayerChunk playerChunk = this.getChunk(k);
 +        if (playerChunk == null) {
@@ -207,15 +192,9 @@ index 36a89817f8..dd6e69a0f1 100644
 +
 +    @Nullable
 +    public Chunk getChunkAtIfLoadedImmediately(int x, int z) {
-+        if (Thread.currentThread() != this.serverThread) {
-+            return CompletableFuture.supplyAsync(() -> {
-+                return this.getChunkAtIfLoadedImmediately(x, z);
-+            }, this.serverThreadQueue).join();
-+        }
-+
 +        long k = ChunkCoordIntPair.pair(x, z);
 +
-+        // Note: Bypass cache since we need to check ticket level
++        // Note: Bypass cache since we need to check ticket level, and to make this MT-Safe
 +
 +        PlayerChunk playerChunk = this.getChunk(k);
 +        if (playerChunk == null) {
@@ -326,7 +305,7 @@ index 613d534aeb..f31a996aa5 100644
          // CraftBukkit start - fire event
          setGoalTarget(entityliving, EntityTargetEvent.TargetReason.UNKNOWN, true);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 35a67665a2..5c863860ae 100644
+index 9c3e95bbbc..dcbc4ea7e1 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -126,6 +126,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1,4 +1,4 @@
-From c1ee662cf3caa470950652abba88a1cb8be0a561 Mon Sep 17 00:00:00 2001
+From 98451ed1b8e477f1cbf7b5da71e9437d7e665207 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
@@ -358,10 +358,10 @@ index 3ed48be382..c4d989f702 100644
          }
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index dd6e69a0f1..978a9f9172 100644
+index baf3bd461b..f351d021dc 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -150,11 +150,13 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -129,11 +129,13 @@ public class ChunkProviderServer extends IChunkProvider {
                  }
              }
  
@@ -377,7 +377,7 @@ index dd6e69a0f1..978a9f9172 100644
              ichunkaccess = (IChunkAccess) ((Either) completablefuture.join()).map((ichunkaccess1) -> {
                  return ichunkaccess1;
              }, (playerchunk_failure) -> {
-@@ -346,7 +348,9 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -325,7 +327,9 @@ public class ChunkProviderServer extends IChunkProvider {
  
      public void save(boolean flag) {
          this.tickDistanceManager();
@@ -387,7 +387,7 @@ index dd6e69a0f1..978a9f9172 100644
      }
  
      @Override
-@@ -375,7 +379,9 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -354,7 +358,9 @@ public class ChunkProviderServer extends IChunkProvider {
          this.tickDistanceManager();
          this.world.timings.doChunkMap.stopTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("chunks");
@@ -397,7 +397,7 @@ index dd6e69a0f1..978a9f9172 100644
          this.world.timings.doChunkUnload.startTiming(); // Spigot
          this.world.getMethodProfiler().exitEnter("unload");
          this.playerChunkMap.unloadChunks(booleansupplier);
-@@ -400,10 +406,12 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -379,10 +385,12 @@ public class ChunkProviderServer extends IChunkProvider {
              boolean flag2 = world.ticksPerAnimalSpawns != 0L && worlddata.getTime() % world.ticksPerAnimalSpawns == 0L; // CraftBukkit // PAIL: TODO monster ticks
  
              this.world.getMethodProfiler().enter("naturalSpawnCount");
@@ -410,7 +410,7 @@ index dd6e69a0f1..978a9f9172 100644
              this.world.getMethodProfiler().exit();
              this.playerChunkMap.f().forEach((playerchunk) -> {
                  Optional<Chunk> optional = ((Either) playerchunk.b().getNow(PlayerChunk.UNLOADED_CHUNK)).left();
-@@ -412,7 +420,9 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -391,7 +399,9 @@ public class ChunkProviderServer extends IChunkProvider {
                      Chunk chunk = (Chunk) optional.get();
  
                      this.world.getMethodProfiler().enter("broadcast");
@@ -420,7 +420,7 @@ index dd6e69a0f1..978a9f9172 100644
                      this.world.getMethodProfiler().exit();
                      ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
  
-@@ -462,9 +472,9 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -441,9 +451,9 @@ public class ChunkProviderServer extends IChunkProvider {
                              this.world.getMethodProfiler().exit();
                          }
  
@@ -432,7 +432,7 @@ index dd6e69a0f1..978a9f9172 100644
                      }
                  }
              });
-@@ -477,9 +487,7 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -456,9 +466,7 @@ public class ChunkProviderServer extends IChunkProvider {
              this.world.getMethodProfiler().exit();
          }
  

--- a/Spigot-Server-Patches/0393-Actually-Limit-Natural-Spawns-To-Limit.patch
+++ b/Spigot-Server-Patches/0393-Actually-Limit-Natural-Spawns-To-Limit.patch
@@ -1,14 +1,14 @@
-From a8e90a3b3a47a66669c8268ab6fb2c90d2d35d8c Mon Sep 17 00:00:00 2001
+From 8dccf6997c9352637853343a52abcdd7a96950e5 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Sun, 2 Jun 2019 01:22:02 -0400
 Subject: [PATCH] Actually-Limit-Natural-Spawns-To-Limit
 
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 744fa825e6..3b7288c6cb 100644
+index a58cfc14bb..26216fe72c 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-@@ -465,8 +465,12 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -444,8 +444,12 @@ public class ChunkProviderServer extends IChunkProvider {
                                  if (enumcreaturetype != EnumCreatureType.MISC && (!enumcreaturetype.c() || this.allowAnimals) && (enumcreaturetype.c() || this.allowMonsters) && (!enumcreaturetype.d() || flag2)) {
                                      int k1 = limit * l / ChunkProviderServer.b; // CraftBukkit - use per-world limits
  

--- a/Spigot-Server-Patches/0398-Fix-World-isChunkGenerated-calls.patch
+++ b/Spigot-Server-Patches/0398-Fix-World-isChunkGenerated-calls.patch
@@ -1,4 +1,4 @@
-From 9108082620a7a637b10036ca535b3811d24048bf Mon Sep 17 00:00:00 2001
+From 953d244608fe975f003f54f61d9ba343187fe6d7 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 15 Jun 2019 08:54:33 -0700
 Subject: [PATCH] Fix World#isChunkGenerated calls
@@ -8,7 +8,7 @@ This patch also adds a chunk status cache on region files (note that
 its only purpose is to cache the status on DISK)
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 220cd197fa..775b5f7fe3 100644
+index 9765eaf24c..d714b8d01b 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -28,7 +28,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -20,31 +20,16 @@ index 220cd197fa..775b5f7fe3 100644
      public final PlayerChunkMap playerChunkMap;
      private final WorldPersistentData worldPersistentData;
      private long lastTickTime;
-@@ -130,6 +130,36 @@ public class ChunkProviderServer extends IChunkProvider {
+@@ -109,6 +109,21 @@ public class ChunkProviderServer extends IChunkProvider {
  
          return playerChunk.getFullChunk();
      }
 +
 +    @Nullable
 +    public IChunkAccess getChunkAtImmediately(int x, int z) {
-+        if (Thread.currentThread() != this.serverThread) {
-+            return CompletableFuture.supplyAsync(() -> {
-+                return this.getChunkAtImmediately(x, z);
-+            }, this.serverThreadQueue).join();
-+        }
-+
 +        long k = ChunkCoordIntPair.pair(x, z);
 +
-+        IChunkAccess ichunkaccess;
-+
-+        for (int l = 0; l < 4; ++l) {
-+            if (k == this.cachePos[l]) {
-+                ichunkaccess = this.cacheChunk[l];
-+                if (ichunkaccess != null) { // CraftBukkit - the chunk can become accessible in the meantime TODO for non-null chunks it might also make sense to check that the chunk's state hasn't changed in the meantime
-+                    return ichunkaccess;
-+                }
-+            }
-+        }
++        // Note: Bypass cache to make this MT-Safe
 +
 +        PlayerChunk playerChunk = this.getChunk(k);
 +        if (playerChunk == null) {


### PR DESCRIPTION
They are MT-Safe already. These changes reduce deadlock chances
given these calls are used in Entity#isValid(), and plugins
check this in packet handling...