### PR TITLE
Fix chest logic being weird for coordinates that sum to 0 or a multiple of 200

### DIFF
--- a/Spigot-Server-Patches/0406-fixup-Optimize-TileEntity-Ticking.patch
+++ b/Spigot-Server-Patches/0406-fixup-Optimize-TileEntity-Ticking.patch
@@ -1,0 +1,22 @@
+From 6f1992e5ac2e92994e9dae8a36bb25a9044bbcb2 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Tue, 23 Jul 2019 21:11:30 -0700
+Subject: [PATCH] fixup! Optimize TileEntity Ticking
+
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityChest.java b/src/main/java/net/minecraft/server/TileEntityChest.java
+index 6c10f0eb89..4aa56e50e8 100644
+--- a/src/main/java/net/minecraft/server/TileEntityChest.java
++++ b/src/main/java/net/minecraft/server/TileEntityChest.java
+@@ -114,7 +114,7 @@ public class TileEntityChest extends TileEntityLootable { // Paper - Remove ITic
+         int j = this.position.getY();
+         int k = this.position.getZ();
+ 
+-        this.viewingCount = a(this.world, this, this.j, i, j, k, this.viewingCount);
++        //this.viewingCount = a(this.world, this, this.j, i, j, k, this.viewingCount); // Paper - check is faulty given our logic is called before active container set
+         this.b = this.a;
+         float f = 0.1F;
+ 
+-- 
+2.22.0
+


### PR DESCRIPTION
We were previously calling what looks like a legacy check for distance
away for the inventory. Unfortunately, with our logic, we called the
open logic before the active container was set. So the legacy check
would register 0 viewers and the logic would become bugged.

Note: Need to confirm that "checkReachable" on a player's active container is not shared across a chest.

Fixes #2354 