### PR TITLE
Add LZ4 support for region files

### DIFF
--- a/Spigot-Server-Patches/0406-Add-LZ4-support-for-region-files.patch
+++ b/Spigot-Server-Patches/0406-Add-LZ4-support-for-region-files.patch
@@ -1,0 +1,147 @@
+From 822d6e522e4779a517df87e7e7d4c6bb515b93b0 Mon Sep 17 00:00:00 2001
+From: egg82 <eggys82@gmail.com>
+Date: Fri, 26 Jul 2019 12:27:13 -0600
+Subject: [PATCH] Add LZ4 support for region files
+
+Using lz4-java: https://github.com/lz4/lz4-java
+There's a new option in PaperConfig for this which defaults to false.
+Since the patch hooks Mojang's versioning system for new compression methods, it
+should be internally consistent, easily-updatable, and reversible with a force-upgrade.
+
+This will likely conflict with plugins and programs expecting region files to be compressed using the current standard.
+
+diff --git a/pom.xml b/pom.xml
+index beda5dc8..181ec637 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -106,6 +106,12 @@
+             <version>5.1.47</version>
+             <scope>runtime</scope>
+         </dependency>
++        <!-- Paper - lz4 for region files -->
++        <dependency>
++            <groupId>org.lz4</groupId>
++            <artifactId>lz4-java</artifactId>
++            <version>1.6.0</version>
++        </dependency>
+         <!-- testing -->
+         <dependency>
+             <groupId>junit</groupId>
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 5942c343..ac77440c 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -388,4 +388,9 @@ public class PaperConfig {
+         maxBookPageSize = getInt("settings.book-size.page-max", maxBookPageSize);
+         maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
+     }
++
++    public static boolean useLZ4Compression = false;
++    private static void useLZ4Compression() {
++        useLZ4Compression = getBoolean("settings.use-lz4-compression", false);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/RegionFile.java b/src/main/java/net/minecraft/server/RegionFile.java
+index 41f1e15c..5b02e54a 100644
+--- a/src/main/java/net/minecraft/server/RegionFile.java
++++ b/src/main/java/net/minecraft/server/RegionFile.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.PaperConfig;
+ import com.destroystokyo.paper.exception.ServerInternalException;
+ import com.google.common.collect.Lists;
+ import java.io.BufferedInputStream;
+@@ -172,7 +173,16 @@ public class RegionFile implements AutoCloseable {
+                             abyte = new byte[l - 1];
+                             this.b.read(abyte);
+                             return new DataInputStream(new BufferedInputStream(new InflaterInputStream(new ByteArrayInputStream(abyte))));
+-                        } else {
++                        }
++                        // Paper start - LZ4 support
++                        else if (b0 == 255) {
++                            abyte = new byte[l - 1];
++                            this.b.read(abyte);
++
++                            return new DataInputStream(new BufferedInputStream(new net.jpountz.lz4.LZ4FrameInputStream(new ByteArrayInputStream(abyte))));
++                        }
++                        // Paper end
++                        else {
+                             return null;
+                         }
+                     }
+@@ -302,7 +312,13 @@ public class RegionFile implements AutoCloseable {
+     private void writeChunkData(final int sectorOffset, final byte[] data, final int dataLength) throws IOException { this.a(sectorOffset, data, dataLength); } // Paper - OBFHELPER
+     private void a(int i, byte[] abyte, int j) throws IOException {
+         this.b.seek((long) (i * 4096));
+-        this.writeIntAndByte(j + 1, (byte)2); // Paper - Avoid 4 io write calls
++        // Paper start - LZ4 support
++        if (PaperConfig.useLZ4Compression) {
++            this.writeIntAndByte(j + 1, (byte)255); // Paper - Avoid 4 io write calls
++        } else {
++            this.writeIntAndByte(j + 1, (byte)2); // Paper - Avoid 4 io write calls
++        }
++        // Paper end
+         this.b.write(abyte, 0, j);
+     }
+ 
+@@ -487,6 +503,13 @@ public class RegionFile implements AutoCloseable {
+ 
+     void writeOversizedData(int x, int z, NBTTagCompound oversizedData) throws IOException {
+         File file = getOversizedFile(x, z);
++        // Paper start - LZ4 support
++        if (PaperConfig.useLZ4Compression) {
++            try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new net.jpountz.lz4.LZ4FrameOutputStream(new java.io.FileOutputStream(file)), 32 * 1024))) {
++                NBTCompressedStreamTools.writeNBT(oversizedData, out);
++            }
++        }
++        // Paper end
+         try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new DeflaterOutputStream(new java.io.FileOutputStream(file), new java.util.zip.Deflater(java.util.zip.Deflater.BEST_COMPRESSION), 32 * 1024), 32 * 1024))) {
+             NBTCompressedStreamTools.writeNBT(oversizedData, out);
+         }
+@@ -496,6 +519,13 @@ public class RegionFile implements AutoCloseable {
+ 
+     synchronized NBTTagCompound getOversizedData(int x, int z) throws IOException {
+         File file = getOversizedFile(x, z);
++        // Paper start - LZ4 support
++        if (PaperConfig.useLZ4Compression) {
++            try (DataInputStream out = new DataInputStream(new BufferedInputStream(new net.jpountz.lz4.LZ4FrameInputStream(new java.io.FileInputStream(file))))) {
++                return NBTCompressedStreamTools.readNBT(out);
++            }
++        }
++        // Paper end
+         try (DataInputStream out = new DataInputStream(new BufferedInputStream(new InflaterInputStream(new java.io.FileInputStream(file))))) {
+             return NBTCompressedStreamTools.readNBT(out);
+         }
+@@ -555,6 +585,28 @@ public class RegionFile implements AutoCloseable {
+     private static final java.util.zip.Deflater deflater = new java.util.zip.Deflater();
+     // since file IO is single threaded, no benefit to using per-region file buffers/synchronization, we can change that later if it becomes viable.
+     private static DirectByteArrayOutputStream compressData(byte[] buf, int length) throws IOException {
++        // Paper start - LZ4 support
++        if (PaperConfig.useLZ4Compression) {
++            try (
++                ByteArrayOutputStream rawOut = new ByteArrayOutputStream(length);
++                net.jpountz.lz4.LZ4FrameOutputStream compressedOut = new net.jpountz.lz4.LZ4FrameOutputStream(rawOut)
++            ) {
++                compressedOut.write(buf);
++
++                try (
++                    ByteArrayInputStream rawIn = new ByteArrayInputStream(rawOut.toByteArray());
++                    DirectByteArrayOutputStream out = new DirectByteArrayOutputStream(rawIn.available())
++                ) {
++                    int bytesRead;
++                    while ((bytesRead = rawIn.read(compressionBuffer)) > -1) {
++                        out.write(compressionBuffer, 0, bytesRead);
++                    }
++                    return out;
++                }
++            }
++        }
++        // Paper end
++
+         synchronized (deflater) {
+             deflater.setInput(buf, 0, length);
+             deflater.finish();
+-- 
+2.22.0.windows.1
+


### PR DESCRIPTION
Using lz4-java: https://github.com/lz4/lz4-java
There's a new option in PaperConfig for this which defaults to false.
Since the patch hooks Mojang's versioning system for new compression methods, it
should be internally consistent, easily-updatable, and reversible with a force-upgrade.

This will likely conflict with plugins and programs expecting region files to be compressed using the current standard.