### PR TITLE
Offset Itemframe ticking

### DIFF
--- a/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
+++ b/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
@@ -13,7 +13,7 @@ index 3b282a18a..636a0bc4e 100644
          return entity instanceof EntityHanging;
      };
 -    private int e;
-+    private int e; { this.e = this.getId() % this.world.spigotConfig.hangingTickFrequency; }
++    private int e; { this.e = this.getId() % this.world.spigotConfig.hangingTickFrequency; } // Paper
      public BlockPosition blockPosition;
      protected EnumDirection direction;
  

--- a/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
+++ b/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
@@ -1,0 +1,27 @@
+From 076621f7e8b6ca21d6682dd53f006b3c283b8279 Mon Sep 17 00:00:00 2001
+From: kickash32 <kickash32@gmail.com>
+Date: Tue, 30 Jul 2019 03:17:16 +0500
+Subject: [PATCH] offset item frame ticking
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHanging.java b/src/main/java/net/minecraft/server/EntityHanging.java
+index 3b282a18a..f548e6a05 100644
+--- a/src/main/java/net/minecraft/server/EntityHanging.java
++++ b/src/main/java/net/minecraft/server/EntityHanging.java
+@@ -22,11 +22,13 @@ public abstract class EntityHanging extends Entity {
+     protected EntityHanging(EntityTypes<? extends EntityHanging> entitytypes, World world) {
+         super(entitytypes, world);
+         this.direction = EnumDirection.SOUTH;
++        this.e = this.getId() % this.world.spigotConfig.hangingTickFrequency; // Paper
+     }
+ 
+     protected EntityHanging(EntityTypes<? extends EntityHanging> entitytypes, World world, BlockPosition blockposition) {
+         this(entitytypes, world);
+         this.blockPosition = blockposition;
++        this.e = this.uniqueID.hashCode() % this.world.spigotConfig.hangingTickFrequency; // Paper
+     }
+ 
+     @Override
+-- 
+2.22.0
+

--- a/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
+++ b/Spigot-Server-Patches/0407-offset-item-frame-ticking.patch
@@ -1,27 +1,22 @@
-From 076621f7e8b6ca21d6682dd53f006b3c283b8279 Mon Sep 17 00:00:00 2001
+From 45d31e0fb763a4fdc9d96a959d88bff6877ccb50 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Tue, 30 Jul 2019 03:17:16 +0500
 Subject: [PATCH] offset item frame ticking
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHanging.java b/src/main/java/net/minecraft/server/EntityHanging.java
-index 3b282a18a..f548e6a05 100644
+index 3b282a18a..636a0bc4e 100644
 --- a/src/main/java/net/minecraft/server/EntityHanging.java
 +++ b/src/main/java/net/minecraft/server/EntityHanging.java
-@@ -22,11 +22,13 @@ public abstract class EntityHanging extends Entity {
-     protected EntityHanging(EntityTypes<? extends EntityHanging> entitytypes, World world) {
-         super(entitytypes, world);
-         this.direction = EnumDirection.SOUTH;
-+        this.e = this.getId() % this.world.spigotConfig.hangingTickFrequency; // Paper
-     }
+@@ -15,7 +15,7 @@ public abstract class EntityHanging extends Entity {
+     protected static final Predicate<Entity> b = (entity) -> {
+         return entity instanceof EntityHanging;
+     };
+-    private int e;
++    private int e; { this.e = this.getId() % this.world.spigotConfig.hangingTickFrequency; }
+     public BlockPosition blockPosition;
+     protected EnumDirection direction;
  
-     protected EntityHanging(EntityTypes<? extends EntityHanging> entitytypes, World world, BlockPosition blockposition) {
-         this(entitytypes, world);
-         this.blockPosition = blockposition;
-+        this.e = this.uniqueID.hashCode() % this.world.spigotConfig.hangingTickFrequency; // Paper
-     }
- 
-     @Override
 -- 
 2.22.0
 


### PR DESCRIPTION
This prevents item frames from all ticking at the same time, potentially saving the server from a lagspike every 5s (or however long the item-frame-ticking-frequency is) and instead spreads this load over many ticks. Each individual item frame still have the same ticking frequency.
Credit to @electronicboy for the idea.
Related: #2383 