### PR TITLE
Fix server crash with piercing shots through vanished players

### DIFF
--- a/Spigot-Server-Patches/0131-Add-ProjectileCollideEvent.patch
+++ b/Spigot-Server-Patches/0131-Add-ProjectileCollideEvent.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java
 index 2b829abac..af0f5cb00 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
-@@ -184,6 +184,16 @@ public abstract class EntityArrow extends Entity implements IProjectile {
+@@ -184,6 +184,17 @@ public abstract class EntityArrow extends Entity implements IProjectile {
                      }
                  }
  
@@ -18,6 +18,7 @@ index 2b829abac..af0f5cb00 100644
 +                    com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileCollideEvent(this, (MovingObjectPositionEntity)object);
 +                    if (event.isCancelled()) {
 +                        object = null;
++                        movingobjectpositionentity = null;
 +                    }
 +                }
 +                // Paper end


### PR DESCRIPTION
Fixes #2381 
honestly just edited the patch by hand because I couldn't be bothered to check how to edit patches and rebuilding is ugly because Windows 👀

... looking a few lines above at how the collision is cancelled when the scoreboard team forbids it, the movingobjectpositionentity field should be set to null as well, resulting in a loop break a bit lower. Without, it just keeps looping, cancelling the ProjectileCollideEvent in the first check itself, new loop, ...

If this won't work without rebuilding (tho re-patching with this doesnt seem to break the classes other patches): at least you know where to fix it, yay! Just close this one and do it yourself pliz k thanks bye