### PR TITLE
Optimize boats by not ticking them when they are heavily stacked

### DIFF
--- a/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
+++ b/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
@@ -83,27 +83,6 @@ index 32b7f7805..37e7d8f60 100644
      }
  
      private void q() {
-diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 92601c581..261d53f33 100644
---- a/src/main/java/org/spigotmc/ActivationRange.java
-+++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -8,6 +8,7 @@ import net.minecraft.server.Entity;
- import net.minecraft.server.EntityAmbient;
- import net.minecraft.server.EntityAnimal;
- import net.minecraft.server.EntityArrow;
-+import net.minecraft.server.EntityBoat; // Paper
- import net.minecraft.server.EntityComplexPart;
- import net.minecraft.server.EntityCreature;
- import net.minecraft.server.EntityCreeper;
-@@ -191,7 +192,7 @@ public class ActivationRange
-     public static boolean checkEntityImmunities(Entity entity)
-     {
-         // quick checks.
--        if ( entity.inWater || entity.fireTicks > 0 )
-+        if ( (entity.inWater && !(entity instanceof EntityBoat)) || entity.fireTicks > 0 ) // Paper - exclude boats
-         {
-             return true;
-         }
 -- 
 2.22.0
 

--- a/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
+++ b/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
@@ -1,11 +1,11 @@
-From ca64f306ee9321385c9cf7738916b366b9c00084 Mon Sep 17 00:00:00 2001
+From 12fb454ef2c3d7ecdf5649d70e7ecbb913f4f9cd Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Sun, 4 Aug 2019 15:19:46 +0500
 Subject: [PATCH] Disable ticking of boats in crowded enclosures
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 318a470e..48267268 100644
+index 318a470ee..482672682 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -562,4 +562,9 @@ public class PaperWorldConfig {
@@ -19,7 +19,7 @@ index 318a470e..48267268 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
-index 32b7f780..e6c91d84 100644
+index 32b7f7805..c4de3b1ef 100644
 --- a/src/main/java/net/minecraft/server/EntityBoat.java
 +++ b/src/main/java/net/minecraft/server/EntityBoat.java
 @@ -53,6 +53,9 @@ public class EntityBoat extends Entity {
@@ -44,19 +44,34 @@ index 32b7f780..e6c91d84 100644
          this.aJ = this.aI;
          this.aI = this.s();
          if (this.aI != EntityBoat.EnumStatus.UNDER_WATER && this.aI != EntityBoat.EnumStatus.UNDER_FLOWING_WATER) {
-@@ -313,8 +321,10 @@ public class EntityBoat extends Entity {
+@@ -313,14 +321,17 @@ public class EntityBoat extends Entity {
              }
          }
  
 +
          this.checkBlockCollisions();
          List<Entity> list = this.world.getEntities(this, this.getBoundingBox().grow(0.20000000298023224D, -0.009999999776482582D, 0.20000000298023224D), IEntitySelector.a(this));
-+        if (list.size() < this.world.paperConfig.minBoatCollisionsToDisableTicking && this.machineActivatedTick == MinecraftServer.currentTick) { this.machineActivatedTick = MinecraftServer.currentTick + 20; } // Paper
  
++        int boatCollisions = 0; // Paper
          if (!list.isEmpty()) {
              boolean flag = !this.world.isClientSide && !(this.getRidingPassenger() instanceof EntityHuman);
+ 
+             for (int j = 0; j < list.size(); ++j) {
+                 Entity entity = (Entity) list.get(j);
++                if (entity instanceof EntityBoat) { boatCollisions++; } // Paper
+ 
+                 if (!entity.w(this)) {
+                     if (flag && this.getPassengers().size() < 2 && !entity.isPassenger() && entity.getWidth() < this.getWidth() && entity instanceof EntityLiving && !(entity instanceof EntityWaterAnimal) && !(entity instanceof EntityHuman)) {
+@@ -331,6 +342,7 @@ public class EntityBoat extends Entity {
+                 }
+             }
+         }
++        if (boatCollisions < this.world.paperConfig.minBoatCollisionsToDisableTicking && this.machineActivatedTick == MinecraftServer.currentTick) { this.machineActivatedTick = MinecraftServer.currentTick + 20; } // Paper
+ 
+     }
+ 
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 92601c58..261d53f3 100644
+index 92601c581..261d53f33 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -8,6 +8,7 @@ import net.minecraft.server.Entity;

--- a/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
+++ b/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
@@ -1,0 +1,81 @@
+From ca64f306ee9321385c9cf7738916b366b9c00084 Mon Sep 17 00:00:00 2001
+From: kickash32 <kickash32@gmail.com>
+Date: Sun, 4 Aug 2019 15:19:46 +0500
+Subject: [PATCH] Disable ticking of boats in crowded enclosures
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 318a470e..48267268 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -562,4 +562,9 @@ public class PaperWorldConfig {
+     private void disableRelativeProjectileVelocity() {
+         disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
+     }
++
++    public int minBoatCollisionsToDisableTicking;
++    private void minBoatCollisionsToDisableTicking() {
++        minBoatCollisionsToDisableTicking = getInt("min-boat-collisions-to-disable-ticking", 10);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
+index 32b7f780..e6c91d84 100644
+--- a/src/main/java/net/minecraft/server/EntityBoat.java
++++ b/src/main/java/net/minecraft/server/EntityBoat.java
+@@ -53,6 +53,9 @@ public class EntityBoat extends Entity {
+     public double unoccupiedDeceleration = -1;
+     public boolean landBoats = false;
+     // CraftBukkit end
++    // Paper start
++    private int machineActivatedTick = MinecraftServer.currentTick + 20;
++    // Paper end
+ 
+     public EntityBoat(EntityTypes<? extends EntityBoat> entitytypes, World world) {
+         super(entitytypes, world);
+@@ -234,6 +237,11 @@ public class EntityBoat extends Entity {
+     private Location lastLocation; // CraftBukkit
+     @Override
+     public void tick() {
++        // Paper start
++        if (machineActivatedTick < MinecraftServer.currentTick) {
++            return;
++        }
++        // Paper end
+         this.aJ = this.aI;
+         this.aI = this.s();
+         if (this.aI != EntityBoat.EnumStatus.UNDER_WATER && this.aI != EntityBoat.EnumStatus.UNDER_FLOWING_WATER) {
+@@ -313,8 +321,10 @@ public class EntityBoat extends Entity {
+             }
+         }
+ 
++
+         this.checkBlockCollisions();
+         List<Entity> list = this.world.getEntities(this, this.getBoundingBox().grow(0.20000000298023224D, -0.009999999776482582D, 0.20000000298023224D), IEntitySelector.a(this));
++        if (list.size() < this.world.paperConfig.minBoatCollisionsToDisableTicking && this.machineActivatedTick == MinecraftServer.currentTick) { this.machineActivatedTick = MinecraftServer.currentTick + 20; } // Paper
+ 
+         if (!list.isEmpty()) {
+             boolean flag = !this.world.isClientSide && !(this.getRidingPassenger() instanceof EntityHuman);
+diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
+index 92601c58..261d53f3 100644
+--- a/src/main/java/org/spigotmc/ActivationRange.java
++++ b/src/main/java/org/spigotmc/ActivationRange.java
+@@ -8,6 +8,7 @@ import net.minecraft.server.Entity;
+ import net.minecraft.server.EntityAmbient;
+ import net.minecraft.server.EntityAnimal;
+ import net.minecraft.server.EntityArrow;
++import net.minecraft.server.EntityBoat; // Paper
+ import net.minecraft.server.EntityComplexPart;
+ import net.minecraft.server.EntityCreature;
+ import net.minecraft.server.EntityCreeper;
+@@ -191,7 +192,7 @@ public class ActivationRange
+     public static boolean checkEntityImmunities(Entity entity)
+     {
+         // quick checks.
+-        if ( entity.inWater || entity.fireTicks > 0 )
++        if ( (entity.inWater && !(entity instanceof EntityBoat)) || entity.fireTicks > 0 ) // Paper - exclude boats
+         {
+             return true;
+         }
+-- 
+2.22.0
+

--- a/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
+++ b/Spigot-Server-Patches/0409-Disable-ticking-of-boats-in-crowded-enclosures.patch
@@ -1,25 +1,27 @@
-From 12fb454ef2c3d7ecdf5649d70e7ecbb913f4f9cd Mon Sep 17 00:00:00 2001
+From b1e77453ad5247342dad7d3b27ac048d32fb366c Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Sun, 4 Aug 2019 15:19:46 +0500
 Subject: [PATCH] Disable ticking of boats in crowded enclosures
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 318a470ee..482672682 100644
+index 318a470ee..9a93f27f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -562,4 +562,9 @@ public class PaperWorldConfig {
+@@ -562,4 +562,11 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
 +
 +    public int minBoatCollisionsToDisableTicking;
++    public int disabledBoatTickingPeriod;
 +    private void minBoatCollisionsToDisableTicking() {
 +        minBoatCollisionsToDisableTicking = getInt("min-boat-collisions-to-disable-ticking", 10);
++        disabledBoatTickingPeriod = getInt("disabled-boat-ticking-period", 1000);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
-index 32b7f7805..c4de3b1ef 100644
+index 32b7f7805..37e7d8f60 100644
 --- a/src/main/java/net/minecraft/server/EntityBoat.java
 +++ b/src/main/java/net/minecraft/server/EntityBoat.java
 @@ -53,6 +53,9 @@ public class EntityBoat extends Entity {
@@ -32,19 +34,25 @@ index 32b7f7805..c4de3b1ef 100644
  
      public EntityBoat(EntityTypes<? extends EntityBoat> entitytypes, World world) {
          super(entitytypes, world);
-@@ -234,6 +237,11 @@ public class EntityBoat extends Entity {
+@@ -234,6 +237,17 @@ public class EntityBoat extends Entity {
      private Location lastLocation; // CraftBukkit
      @Override
      public void tick() {
 +        // Paper start
-+        if (machineActivatedTick < MinecraftServer.currentTick) {
-+            return;
++        boolean tickedAnyway = false;
++        if (machineActivatedTick < MinecraftServer.currentTick){
++            if ((MinecraftServer.currentTick + this.getId()) % this.world.paperConfig.disabledBoatTickingPeriod == 0 || this.isBurning() || !this.passengers.isEmpty() || this.getDamage() < 40F) {
++                tickedAnyway = true;
++            }
++            else {
++                return;
++            }
 +        }
 +        // Paper end
          this.aJ = this.aI;
          this.aI = this.s();
          if (this.aI != EntityBoat.EnumStatus.UNDER_WATER && this.aI != EntityBoat.EnumStatus.UNDER_FLOWING_WATER) {
-@@ -313,14 +321,17 @@ public class EntityBoat extends Entity {
+@@ -313,14 +327,17 @@ public class EntityBoat extends Entity {
              }
          }
  
@@ -62,14 +70,19 @@ index 32b7f7805..c4de3b1ef 100644
  
                  if (!entity.w(this)) {
                      if (flag && this.getPassengers().size() < 2 && !entity.isPassenger() && entity.getWidth() < this.getWidth() && entity instanceof EntityLiving && !(entity instanceof EntityWaterAnimal) && !(entity instanceof EntityHuman)) {
-@@ -331,6 +342,7 @@ public class EntityBoat extends Entity {
+@@ -331,7 +348,11 @@ public class EntityBoat extends Entity {
                  }
              }
          }
-+        if (boatCollisions < this.world.paperConfig.minBoatCollisionsToDisableTicking && this.machineActivatedTick == MinecraftServer.currentTick) { this.machineActivatedTick = MinecraftServer.currentTick + 20; } // Paper
- 
+-
++        // Paper start
++        if (boatCollisions < this.world.paperConfig.minBoatCollisionsToDisableTicking || tickedAnyway) {
++            this.machineActivatedTick = MinecraftServer.currentTick + 20;
++        }
++        // Paper end
      }
  
+     private void q() {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
 index 92601c581..261d53f33 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java


### PR DESCRIPTION
This PR aim's to improve the performance of boats by ~~not activating them outside of the activation range and~~ by skipping their ticks when they are stacked more than a minimum amount (`min-boat-collisions-to-disable-ticking` defaults to 10).

Boats are disabled when they collide with the `min-boat-collisions-to-disable-ticking` amount of entities for more than 20 ticks. ~~Once they are disabled, they cannot tick again without destroying and placing them again or unloading and then loading the chunk. Any suggestions to efficiently reenable ticking again in certain circumstances are welcome but I feel this is good enough.~~ Boats will periodically (configurable with `disabled-boat-ticking-period`) unfreeze for 20 ticks and when they are generally interacted with (excluding collisions of course).

Checklist

- [x] [optional] find a way to efficiently unfreeze them forcefully by a player
- [x] [optional] find a way to efficiently unfreeze them when collisions are low again
- [x] Test freezing mechanics in all survival circumstances
~~- [ ] Test activation range changes with redstone builds~~

This aims to prevent lag from machines like the ones in this video https://www.youtube.com/watch?v=ulxM05wEN7o.