### PR TITLE
Fix recursion in EntityFox

### DIFF
--- a/Spigot-Server-Patches/0300-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0300-Improve-death-events.patch
@@ -1,4 +1,4 @@
-From 5d6dc2bb82c80b978eaccdeb9e69dbf34d723805 Mon Sep 17 00:00:00 2001
+From 11a05d88ac3b775120ee4c8319d2c249400e45f2 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Tue, 21 Aug 2018 01:39:35 +0100
 Subject: [PATCH] Improve death events
@@ -61,7 +61,7 @@ index 627925e3ba..e516db2701 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityFox.java b/src/main/java/net/minecraft/server/EntityFox.java
-index 85231309fd..97059b8239 100644
+index 85231309fd..1da2f013fc 100644
 --- a/src/main/java/net/minecraft/server/EntityFox.java
 +++ b/src/main/java/net/minecraft/server/EntityFox.java
 @@ -597,15 +597,25 @@ public class EntityFox extends EntityAnimal {
@@ -74,7 +74,7 @@ index 85231309fd..97059b8239 100644
 +        ItemStack itemstack = this.getEquipment(EnumItemSlot.MAINHAND).cloneItemStack(); // Paper
 +
 +        // Paper start - Cancellable death event
-+        org.bukkit.event.entity.EntityDeathEvent deathEvent = super.processDeath(damagesource);
++        org.bukkit.event.entity.EntityDeathEvent deathEvent = super.d(damagesource);
 +
 +        // Below is code to drop
 +


### PR DESCRIPTION
I changed a method call without looking at the implications.
super.processDeath would re-invoke the unmapped method, whereas super.d
would call the super method.

Fixes #2417 