### PR TITLE
Add root/admin user detection

### DIFF
--- a/Spigot-Server-Patches/0441-fix-blockstate-capture-undoing.patch
+++ b/Spigot-Server-Patches/0441-fix-blockstate-capture-undoing.patch
@@ -1,4 +1,4 @@
-From a9c21212ccc71c68ef17076e300d53a23a7ed836 Mon Sep 17 00:00:00 2001
+From 6f341bdfd51609e529a4f9865f7775a57b1b4cc5 Mon Sep 17 00:00:00 2001
 From: Trigary <trigary0@gmail.com>
 Date: Mon, 17 Feb 2020 22:53:33 +0100
 Subject: [PATCH] fix blockstate capture undoing
@@ -28,5 +28,5 @@ index 3c966b4ab..baad98517 100644
                  }
                  // CraftBukkit end
 -- 
-2.16.1.windows.4
+2.25.0
 

--- a/Spigot-Server-Patches/0442-Add-root-admin-user-detection.patch
+++ b/Spigot-Server-Patches/0442-Add-root-admin-user-detection.patch
@@ -1,0 +1,86 @@
+From 2f25bc9579085e0c3d522e972c79c6e4ae15a2de Mon Sep 17 00:00:00 2001
+From: egg82 <eggys82@gmail.com>
+Date: Thu, 8 Aug 2019 14:12:48 -0600
+Subject: [PATCH] Add root/admin user detection
+
+This patch detects whether or not the server is currently executing as a privileged user and spits out a warning.
+The warning serves as a sort-of PSA for newer server admins who don't understand the risks of running as root.
+We've seen plenty of bad/malicious plugins hit markets, and there's been a few close-calls with exploits in the past.
+Hopefully this helps mitigate some potential damage to servers, even if it is just a warning.
+
+diff --git a/src/main/java/com/destroystokyo/paper/util/ServerEnvironment.java b/src/main/java/com/destroystokyo/paper/util/ServerEnvironment.java
+new file mode 100644
+index 000000000..76bfae177
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/util/ServerEnvironment.java
+@@ -0,0 +1,38 @@
++package com.destroystokyo.paper.util;
++
++import java.io.OutputStream;
++import java.io.PrintStream;
++import java.util.prefs.Preferences;
++
++public class ServerEnvironment {
++    private static final boolean runningAsRootOrAdmin;
++
++    static {
++        // https://stackoverflow.com/a/23538961
++        Preferences prefs = Preferences.systemRoot();
++        PrintStream err = System.err;
++        PrintStream emptyStream = new PrintStream(new OutputStream() {
++            @Override
++            public void write(int b) { }
++        });
++
++        System.err.flush();
++        System.setErr(emptyStream);
++
++        boolean retVal;
++        try {
++            prefs.put("papermc.priv_test", "This is a test performed by the Paper Minecraft server software."); // SecurityException
++            prefs.remove("papermc.priv_test");
++            prefs.flush(); // BackingStoreException
++            retVal = true;
++        } catch (Exception ignored) { // Windows = SecurityException, Linux = BackingStoreException
++            retVal = false;
++        }
++        runningAsRootOrAdmin = retVal;
++
++        System.err.flush();
++        System.setErr(err);
++    }
++
++    public static boolean userIsRootOrAdmin() { return runningAsRootOrAdmin; }
++}
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index af05f3c1e..2a0273074 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.craftbukkit;
+ 
++import com.destroystokyo.paper.util.ServerEnvironment; // Paper
+ import java.io.File;
+ import java.io.IOException;
+ import java.text.SimpleDateFormat;
+@@ -212,6 +213,17 @@ public class Main {
+                     System.setProperty(TerminalConsoleAppender.JLINE_OVERRIDE_PROPERTY, "false"); // Paper
+                 }
+ 
++                // Paper start - detect running as root
++                if (ServerEnvironment.userIsRootOrAdmin()) {
++                    System.err.println("****************************");
++                    System.err.println("YOU ARE RUNNING AS AN ADMINISTRATIVE OR ROOT USER. THIS IS NOT ADVISED.");
++                    System.err.println("YOU ARE OPENING YOURSELF UP TO POTENTIAL RISKS WHEN DOING THIS.");
++                    System.err.println("MALWARE, BAD PLUGINS, AND ATTACKERS WILL HAVE COMPLETE ACCESS AND CONTROL OF YOUR MACHINE.");
++                    System.err.println("****************************");
++                    System.err.println();
++                }
++                // Paper end
++
+                 if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
+                     Date buildDate = new SimpleDateFormat("yyyyMMdd-HHmm").parse(Main.class.getPackage().getImplementationVendor());
+ 
+-- 
+2.25.0
+


### PR DESCRIPTION
This patch detects whether or not the server is currently executing as a privileged user and spits out a warning. The warning serves as a sort-of PSA for newer server admins who don't understand the risks of running as root.

We've seen plenty of bad/malicious plugins hit markets, and there's been a few close-calls with exploits in the past. Hopefully this helps mitigate some potential damage to servers, even if it is just a warning.