### PR TITLE
Fix some api and commands returning information on inactive chunks

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -1,4 +1,4 @@
-From c1950775d3e3996cd0c5525df5195bdc8c292ad0 Mon Sep 17 00:00:00 2001
+From 5e18e2daec98e2f74e083d7f2d9e3c0fee32f327 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 21:02:09 -0600
 Subject: [PATCH] Paper config files
@@ -6,10 +6,10 @@ Subject: [PATCH] Paper config files
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 new file mode 100644
-index 0000000000..5626ae4e3a
+index 000000000..db899937b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -0,0 +1,244 @@
+@@ -0,0 +1,247 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Functions;
@@ -187,6 +187,9 @@ index 0000000000..5626ae4e3a
 +
 +                Collection<Entity> entities = world.entitiesById.values();
 +                entities.forEach(e -> {
++                    if (!e.isChunkLoaded()) {
++                        return;
++                    }
 +                    MinecraftKey key = new MinecraftKey(""); // TODO: update in next patch
 +
 +                    MutablePair<Integer, Map<ChunkCoordIntPair, Integer>> info = list.computeIfAbsent(key, k -> MutablePair.of(0, Maps.newHashMap()));
@@ -256,7 +259,7 @@ index 0000000000..5626ae4e3a
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000..db79fe41b9
+index 000000000..db79fe41b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -0,0 +1,184 @@
@@ -446,7 +449,7 @@ index 0000000000..db79fe41b9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000..a738657394
+index 000000000..a73865739
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -0,0 +1,67 @@
@@ -518,7 +521,7 @@ index 0000000000..a738657394
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index e02e003006..e6cf90484c 100644
+index e02e00300..e6cf90484 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -162,6 +162,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -538,7 +541,7 @@ index e02e003006..e6cf90484c 100644
          this.setSpawnAnimals(dedicatedserverproperties.spawnAnimals);
          this.setSpawnNPCs(dedicatedserverproperties.spawnNpcs);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 9eea61fc2b..d4dff91586 100644
+index 9eea61fc2..d4dff9158 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -134,9 +134,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener {
@@ -555,7 +558,7 @@ index 9eea61fc2b..d4dff91586 100644
      public boolean impulse;
      public int portalCooldown;
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index e34ef4531c..43d207ae59 100644
+index e34ef4531..43d207ae5 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -3,6 +3,7 @@ package net.minecraft.server;
@@ -578,7 +581,7 @@ index e34ef4531c..43d207ae59 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index bec64d7f28..7f648dbbc9 100644
+index bec64d7f2..7f648dbbc 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -86,6 +86,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -599,7 +602,7 @@ index bec64d7f28..7f648dbbc9 100644
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 305b6eaa93..dce5bde54f 100644
+index 305b6eaa9..dce5bde54 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -756,6 +756,7 @@ public final class CraftServer implements Server {
@@ -663,7 +666,7 @@ index 305b6eaa93..dce5bde54f 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 87088cf691..d28530051d 100644
+index fd5bc0fec..0e33cb367 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -128,6 +128,14 @@ public class Main {
@@ -682,7 +685,7 @@ index 87088cf691..d28530051d 100644
          };
  
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index dd8cb8e5bb..2551339031 100644
+index 6ae3b3185..8c7dd0133 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
 @@ -39,36 +39,36 @@ public class SpigotWorldConfig

--- a/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
+++ b/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
@@ -1,4 +1,4 @@
-From 507180a0d4b214f63b2fcb17c7b21ad5d90a1902 Mon Sep 17 00:00:00 2001
+From 134dd7a13348a225d87c34327bef514765fd2a3e Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 4 Jul 2018 01:40:13 -0400
 Subject: [PATCH] Add MinecraftKey Information to Objects
@@ -6,20 +6,20 @@ Subject: [PATCH] Add MinecraftKey Information to Objects
 Stores the reference to the objects respective MinecraftKey
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 5626ae4e3a..360abc05e4 100644
+index db899937b..eecf27370 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -175,7 +175,7 @@ public class PaperCommand extends Command {
- 
-                 Collection<Entity> entities = world.entitiesById.values();
-                 entities.forEach(e -> {
+@@ -178,7 +178,7 @@ public class PaperCommand extends Command {
+                     if (!e.isChunkLoaded()) {
+                         return;
+                     }
 -                    MinecraftKey key = new MinecraftKey(""); // TODO: update in next patch
 +                    MinecraftKey key = e.getMinecraftKey();
  
                      MutablePair<Integer, Map<ChunkCoordIntPair, Integer>> info = list.computeIfAbsent(key, k -> MutablePair.of(0, Maps.newHashMap()));
                      ChunkCoordIntPair chunk = new ChunkCoordIntPair(e.getChunkX(), e.getChunkZ());
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d4dff91586..1519e481fb 100644
+index d4dff9158..1519e481f 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -49,7 +49,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;
@@ -65,7 +65,7 @@ index d4dff91586..1519e481fb 100644
  
      protected abstract void a(NBTTagCompound nbttagcompound);
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 335877889a..a7fc34f850 100644
+index 335877889..a7fc34f85 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -236,6 +236,7 @@ public class EntityTypes<T extends Entity> {
@@ -78,7 +78,7 @@ index 335877889a..a7fc34f850 100644
      }
 diff --git a/src/main/java/net/minecraft/server/KeyedObject.java b/src/main/java/net/minecraft/server/KeyedObject.java
 new file mode 100644
-index 0000000000..743142d030
+index 000000000..743142d03
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/KeyedObject.java
 @@ -0,0 +1,9 @@
@@ -92,7 +92,7 @@ index 0000000000..743142d030
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 33dec830ea..7f480b3b3e 100644
+index 33dec830e..7f480b3b3 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -11,7 +11,7 @@ import org.bukkit.inventory.InventoryHolder;

--- a/Spigot-Server-Patches/0141-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/Spigot-Server-Patches/0141-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -1,4 +1,4 @@
-From 0e442d6b5fbc3a3a88968a73c8df876d1a6a386d Mon Sep 17 00:00:00 2001
+From 5d5f94cde1d2c983ddce06a462201aec17641069 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 7 Jan 2017 15:24:46 -0500
 Subject: [PATCH] Provide E/TE/Chunk count stat methods
@@ -7,17 +7,22 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9b8fb80a4..b07e3fe26 100644
+index 13f2dbdd6..2087a38a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -271,6 +271,35 @@ public class CraftWorld implements World {
+@@ -271,6 +271,48 @@ public class CraftWorld implements World {
      private int waterAnimalSpawn = -1;
      private int ambientSpawn = -1;
  
 +    // Paper start - Provide fast information methods
-+    // TODO review these changes
 +    public int getEntityCount() {
-+        return world.entitiesById.size();
++        int ret = 0;
++        for (net.minecraft.server.Entity entity : world.entitiesById.values()) {
++            if (entity.isChunkLoaded()) {
++                ++ret;
++            }
++        }
++        return ret;
 +    }
 +    public int getTileEntityCount() {
 +        // We don't use the full world tile entity list, so we must iterate chunks
@@ -36,7 +41,15 @@ index 9b8fb80a4..b07e3fe26 100644
 +        return world.tileEntityListTick.size();
 +    }
 +    public int getChunkCount() {
-+        return world.getChunkProvider().playerChunkMap.visibleChunks.size();
++        int ret = 0;
++
++        for (PlayerChunk chunkHolder : world.getChunkProvider().playerChunkMap.visibleChunks.values()) {
++            if (chunkHolder.getChunk() != null) {
++                ++ret;
++            }
++        }
++
++        return ret;
 +    }
 +    public int getPlayerCount() {
 +        return world.players.size();

--- a/Spigot-Server-Patches/0144-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/Spigot-Server-Patches/0144-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -1,4 +1,4 @@
-From 9c5efdb0aa5c3b84136139050c0cf19e1376ac8d Mon Sep 17 00:00:00 2001
+From 529b4e1d50dad36076a1ea5b36cab867575597cf Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 19 Dec 2017 16:31:46 -0500
 Subject: [PATCH] ExperienceOrbs API for Reason/Source/Triggering player
@@ -147,7 +147,7 @@ index 758559d35..2a351701b 100644
                      // CraftBukkit end
                      if (itemstack1.getItem().a(TagsItem.FISHES)) {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 34c7dab97..106e54f7a 100644
+index 5fa937aea..6ba5e9840 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -385,7 +385,8 @@ public abstract class EntityLiving extends Entity {
@@ -265,10 +265,10 @@ index 0cb2e6d87..2bbd3663a 100644
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6a212e8ee..72e54b08e 100644
+index 2087a38a2..bbfd498b3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1697,7 +1697,7 @@ public class CraftWorld implements World {
+@@ -1710,7 +1710,7 @@ public class CraftWorld implements World {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new EntityTNTPrimed(world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/Spigot-Server-Patches/0222-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-Server-Patches/0222-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -1,4 +1,4 @@
-From f9776c7737fa08d7cbc81cca89ed9fb1fe9ebbb0 Mon Sep 17 00:00:00 2001
+From f1000a5e7302c9c519427dd4470064675c90a442 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 15 Aug 2017 22:29:12 -0400
 Subject: [PATCH] Expand World.spawnParticle API and add Builder
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 18e0455a37..55bb019eaa 100644
+index 18e0455a3..55bb019ea 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -52,7 +52,7 @@ public class WorldServer extends World {
@@ -43,10 +43,10 @@ index 18e0455a37..55bb019eaa 100644
  
              if (this.a(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 72e54b08e9..3ef9893460 100644
+index bbfd498b3..0014efeb2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2163,11 +2163,17 @@ public class CraftWorld implements World {
+@@ -2176,11 +2176,17 @@ public class CraftWorld implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/Spigot-Server-Patches/0226-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/Spigot-Server-Patches/0226-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -1,4 +1,4 @@
-From cb17a03b8e605212fcb5bacfd881087d50f109c1 Mon Sep 17 00:00:00 2001
+From c91fae677ab0f60417fb6feb8cb4ddd3b242e1ae Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 4 Jun 2018 20:39:20 -0400
 Subject: [PATCH] Allow spawning Item entities with World.spawnEntity
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c3dffc1e44..0b632a0e2e 100644
+index 0014efeb2..26ddf4a6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1391,6 +1391,10 @@ public class CraftWorld implements World {
+@@ -1404,6 +1404,10 @@ public class CraftWorld implements World {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new EntityBoat(world, x, y, z);
              entity.setPositionRotation(x, y, z, yaw, pitch);

--- a/Spigot-Server-Patches/0240-Expand-Explosions-API.patch
+++ b/Spigot-Server-Patches/0240-Expand-Explosions-API.patch
@@ -1,4 +1,4 @@
-From b87f3fe0260cbb5d07929f3bf568d91f843e2d77 Mon Sep 17 00:00:00 2001
+From bb27e2b2e5c4fbae7612e8fd0b57e9ba8fc9c731 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 20 Jun 2018 23:17:24 -0400
 Subject: [PATCH] Expand Explosions API
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0b632a0e2e..ad0f2d4399 100644
+index 26ddf4a6c..61732ae8d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -838,6 +838,11 @@ public class CraftWorld implements World {
+@@ -851,6 +851,11 @@ public class CraftWorld implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks) {
          return !world.createExplosion(null, x, y, z, power, setFire, breakBlocks ? Explosion.Effect.BREAK : Explosion.Effect.NONE).wasCanceled;
      }

--- a/Spigot-Server-Patches/0244-Implement-World.getEntity-UUID-API.patch
+++ b/Spigot-Server-Patches/0244-Implement-World.getEntity-UUID-API.patch
@@ -1,14 +1,14 @@
-From 530fe99e55cf5e67d1eeedd7bd2f9903b7ec1ec4 Mon Sep 17 00:00:00 2001
+From 93c339952640cc2620a03bb3e0b0f1c55c74413b Mon Sep 17 00:00:00 2001
 From: Brokkonaut <hannos17@gmx.de>
 Date: Tue, 3 Jul 2018 16:08:14 +0200
 Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ad0f2d4399..0c190e5f49 100644
+index 61732ae8d..601265fb5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1194,6 +1194,15 @@ public class CraftWorld implements World {
+@@ -1207,6 +1207,15 @@ public class CraftWorld implements World {
          return list;
      }
  

--- a/Spigot-Server-Patches/0268-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0268-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -1,4 +1,4 @@
-From e34810a399ed8289a4615e526122c360569ca345 Mon Sep 17 00:00:00 2001
+From 70028bc603ddfaa666f1043c99ad384c882dd250 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 28 Jul 2018 12:18:27 -0400
 Subject: [PATCH] Ignore Dead Entities in entityList iteration
@@ -11,19 +11,19 @@ This will ensure that dead entities are skipped from iteration since
 they shouldn't of been in the list in the first place.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 360abc05e4..391726d99c 100644
+index eecf27370..d704fc79c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -176,6 +176,7 @@ public class PaperCommand extends Command {
-                 Collection<Entity> entities = world.entitiesById.values();
-                 entities.forEach(e -> {
+@@ -179,6 +179,7 @@ public class PaperCommand extends Command {
+                         return;
+                     }
                      MinecraftKey key = e.getMinecraftKey();
 +                    if (e.shouldBeRemoved) return; // Paper
  
                      MutablePair<Integer, Map<ChunkCoordIntPair, Integer>> info = list.computeIfAbsent(key, k -> MutablePair.of(0, Maps.newHashMap()));
                      ChunkCoordIntPair chunk = new ChunkCoordIntPair(e.getChunkX(), e.getChunkZ());
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index a74e389d14..09e010e670 100644
+index a74e389d1..09e010e67 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -678,6 +678,7 @@ public class Chunk implements IChunkAccess {
@@ -51,7 +51,7 @@ index a74e389d14..09e010e670 100644
                  if (oclass.isInstance(t0) && t0.getBoundingBox().c(axisalignedbb) && (predicate == null || predicate.test(t0))) { // Spigot - instance check
                      list.add(t0);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 701090c11e..7d579c119b 100644
+index 701090c11..7d579c119 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -126,6 +126,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -63,7 +63,7 @@ index 701090c11e..7d579c119b 100644
      private float av;
      private float aw;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 97049aba9d..24f1a64420 100644
+index 97049aba9..24f1a6442 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -851,7 +851,7 @@ public class WorldServer extends World {
@@ -92,10 +92,10 @@ index 97049aba9d..24f1a64420 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ced1ab2a3a..6a32480663 100644
+index 601265fb5..4ed4dfdde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -931,6 +931,7 @@ public class CraftWorld implements World {
+@@ -944,6 +944,7 @@ public class CraftWorld implements World {
          for (Object o : world.entitiesById.values()) {
              if (o instanceof net.minecraft.server.Entity) {
                  net.minecraft.server.Entity mcEnt = (net.minecraft.server.Entity) o;
@@ -103,7 +103,7 @@ index ced1ab2a3a..6a32480663 100644
                  Entity bukkitEntity = mcEnt.getBukkitEntity();
  
                  // Assuming that bukkitEntity isn't null
-@@ -950,6 +951,7 @@ public class CraftWorld implements World {
+@@ -963,6 +964,7 @@ public class CraftWorld implements World {
          for (Object o : world.entitiesById.values()) {
              if (o instanceof net.minecraft.server.Entity) {
                  net.minecraft.server.Entity mcEnt = (net.minecraft.server.Entity) o;
@@ -111,7 +111,7 @@ index ced1ab2a3a..6a32480663 100644
                  Entity bukkitEntity = mcEnt.getBukkitEntity();
  
                  // Assuming that bukkitEntity isn't null
-@@ -976,6 +978,7 @@ public class CraftWorld implements World {
+@@ -989,6 +991,7 @@ public class CraftWorld implements World {
  
          for (Object entity: world.entitiesById.values()) {
              if (entity instanceof net.minecraft.server.Entity) {
@@ -119,7 +119,7 @@ index ced1ab2a3a..6a32480663 100644
                  Entity bukkitEntity = ((net.minecraft.server.Entity) entity).getBukkitEntity();
  
                  if (bukkitEntity == null) {
-@@ -999,6 +1002,7 @@ public class CraftWorld implements World {
+@@ -1012,6 +1015,7 @@ public class CraftWorld implements World {
  
          for (Object entity: world.entitiesById.values()) {
              if (entity instanceof net.minecraft.server.Entity) {

--- a/Spigot-Server-Patches/0286-Send-nearby-packets-from-world-player-list-not-serve.patch
+++ b/Spigot-Server-Patches/0286-Send-nearby-packets-from-world-player-list-not-serve.patch
@@ -1,11 +1,11 @@
-From a2ec2aff517ee056460a4c687877ec5589cf80dd Mon Sep 17 00:00:00 2001
+From 1a129cf6f70425f43daa049512ac51538a11e780 Mon Sep 17 00:00:00 2001
 From: Mystiflow <mystiflow@gmail.com>
 Date: Fri, 6 Jul 2018 13:21:30 +0100
 Subject: [PATCH] Send nearby packets from world player list not server list
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 9e5cd22d7d..049d702cb9 100644
+index 9e5cd22d7..049d702cb 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -922,8 +922,25 @@ public abstract class PlayerList {
@@ -46,7 +46,7 @@ index 9e5cd22d7d..049d702cb9 100644
                  double d5 = d1 - entityplayer.locY;
                  double d6 = d2 - entityplayer.locZ;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 24f1a64420..0025e4ecfc 100644
+index 24f1a6442..0025e4ecf 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1205,7 +1205,7 @@ public class WorldServer extends World {
@@ -68,10 +68,10 @@ index 24f1a64420..0025e4ecfc 100644
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6a32480663..267402c0d8 100644
+index 4ed4dfdde..80d75bf02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1998,7 +1998,7 @@ public class CraftWorld implements World {
+@@ -2011,7 +2011,7 @@ public class CraftWorld implements World {
          double z = loc.getZ();
  
          PacketPlayOutCustomSoundEffect packet = new PacketPlayOutCustomSoundEffect(new MinecraftKey(sound), SoundCategory.valueOf(category.name()), new Vec3D(x, y, z), volume, pitch);

--- a/Spigot-Server-Patches/0297-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/Spigot-Server-Patches/0297-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -1,4 +1,4 @@
-From 5ded262f63d602ec63e363e0f3a3a179aa32df13 Mon Sep 17 00:00:00 2001
+From 5a13dc15364bbaa85ab22e5e84b53db16e953ed1 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sun, 2 Sep 2018 19:34:33 -0700
 Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9a7b0076f..12ee5926e 100644
+index 80d75bf02..35266e22e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -483,7 +483,7 @@ public class CraftWorld implements World {
+@@ -496,7 +496,7 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/Spigot-Server-Patches/0318-Add-sun-related-API.patch
+++ b/Spigot-Server-Patches/0318-Add-sun-related-API.patch
@@ -1,11 +1,11 @@
-From 811a5c3f01989aa0b3f734892a7629850562aff4 Mon Sep 17 00:00:00 2001
+From 50b3fb0d0ba696c8beab8c69d65176a992a2f8fa Mon Sep 17 00:00:00 2001
 From: BillyGalbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 7 Oct 2018 00:54:21 -0500
 Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index a14d490ade..09112a8b0e 100644
+index a14d490ad..09112a8b0 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -1327,6 +1327,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -17,7 +17,7 @@ index a14d490ade..09112a8b0e 100644
          if (this.world.J() && !this.world.isClientSide) {
              float f = this.aF();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index c60279da8f..1c3285f5c0 100644
+index c60279da8..1c3285f5c 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -705,6 +705,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -29,10 +29,10 @@ index c60279da8f..1c3285f5c0 100644
          return this.u < 4;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 51bc40c014..a08366d360 100644
+index 35266e22e..c3b43783b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -824,6 +824,13 @@ public class CraftWorld implements World {
+@@ -837,6 +837,13 @@ public class CraftWorld implements World {
          }
      }
  
@@ -47,7 +47,7 @@ index 51bc40c014..a08366d360 100644
      public boolean createExplosion(double x, double y, double z, float power) {
          return createExplosion(x, y, z, power, false, true);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
-index 53c2d154ed..56c233872b 100644
+index 53c2d154e..56c233872 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMob.java
 @@ -68,4 +68,11 @@ public abstract class CraftMob extends CraftLivingEntity implements Mob {

--- a/Spigot-Server-Patches/0376-Add-Heightmap-API.patch
+++ b/Spigot-Server-Patches/0376-Add-Heightmap-API.patch
@@ -1,11 +1,11 @@
-From 8f924f033228ae4dc6f0d8f624ce93b136be4a44 Mon Sep 17 00:00:00 2001
+From b6785908cc19749b88052d1099b8ef5ab429a620 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Tue, 1 Jan 2019 02:22:01 -0800
 Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index dd2a9c6e59..e3b4e30e65 100644
+index dd2a9c6e5..e3b4e30e6 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -663,8 +663,8 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -20,10 +20,10 @@ index dd2a9c6e59..e3b4e30e65 100644
  
          if (i >= -30000000 && j >= -30000000 && i < 30000000 && j < 30000000) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6bf7eded56..0d4e38d0f4 100644
+index c3b43783b..5bb567f0b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -323,6 +323,29 @@ public class CraftWorld implements World {
+@@ -336,6 +336,29 @@ public class CraftWorld implements World {
          return world.getHighestBlockYAt(HeightMap.Type.MOTION_BLOCKING, new BlockPosition(x, 0, z)).getY();
      }
  

--- a/Spigot-Server-Patches/0380-Async-Chunk-placeholder.patch
+++ b/Spigot-Server-Patches/0380-Async-Chunk-placeholder.patch
@@ -1,4 +1,4 @@
-From c483347dde3241d7cb904e22a3fdd7bc3637381a Mon Sep 17 00:00:00 2001
+From db9bf66ea58111702713d10357614deaf3928378 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Mon, 6 May 2019 12:29:24 -0700
 Subject: [PATCH] Async Chunk placeholder
@@ -6,7 +6,7 @@ Subject: [PATCH] Async Chunk placeholder
 Until we figure out Mojang's ticket system.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5984e70c..4822687f 100644
+index 5bb567f0b..447b4324f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -18,6 +18,7 @@ import java.util.Objects;
@@ -17,7 +17,7 @@ index 5984e70c..4822687f 100644
  import java.util.function.Predicate;
  import it.unimi.dsi.fastutil.longs.Long2ObjectMap;
  import it.unimi.dsi.fastutil.objects.ObjectSortedSet;
-@@ -2243,6 +2244,40 @@ public class CraftWorld implements World {
+@@ -2256,6 +2257,40 @@ public class CraftWorld implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/Spigot-Server-Patches/0386-improve-CraftWorld-isChunkLoaded.patch
+++ b/Spigot-Server-Patches/0386-improve-CraftWorld-isChunkLoaded.patch
@@ -1,4 +1,4 @@
-From b5079bb58d1c535dc36ee860218926d43f818f48 Mon Sep 17 00:00:00 2001
+From 62a24d634c1218c35dea6fae2583e2706974ab65 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Tue, 21 May 2019 02:34:04 +0100
 Subject: [PATCH] improve CraftWorld#isChunkLoaded
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 74f7b046ac..f613ae1da4 100644
+index 447b4324f..3d62debc7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -388,14 +388,13 @@ public class CraftWorld implements World {
+@@ -401,14 +401,13 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/Spigot-Server-Patches/0387-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0387-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -1,4 +1,4 @@
-From e7c28cec58c772e07bd9ddb778afd32f1c9c41c5 Mon Sep 17 00:00:00 2001
+From 9f5f6ac6b0166e90304a955d9a3709d19547c319 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 13 Sep 2014 23:14:43 -0400
 Subject: [PATCH] Configurable Keep Spawn Loaded range per world
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d8bb13693d..de11a91af6 100644
+index d8bb13693..de11a91af 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -483,4 +483,10 @@ public class PaperWorldConfig {
@@ -21,7 +21,7 @@ index d8bb13693d..de11a91af6 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c70ab3caf0..c58f6f50d3 100644
+index c70ab3caf..c58f6f50d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -577,6 +577,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -61,7 +61,7 @@ index c70ab3caf0..c58f6f50d3 100644
          // CraftBukkit start
          // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListener.java b/src/main/java/net/minecraft/server/WorldLoadListener.java
-index d6762d3853..7b6f5b2da0 100644
+index d6762d385..7b6f5b2da 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListener.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListener.java
 @@ -9,4 +9,6 @@ public interface WorldLoadListener {
@@ -72,7 +72,7 @@ index d6762d3853..7b6f5b2da0 100644
 +    void setChunkRadius(int radius); // Paper - allow changing chunk radius
  }
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
-index 3868572aed..ae77805f71 100644
+index 3868572ae..ae77805f7 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 @@ -7,16 +7,24 @@ import org.apache.logging.log4j.Logger;
@@ -103,7 +103,7 @@ index 3868572aed..ae77805f71 100644
      @Override
      public void a(ChunkCoordIntPair chunkcoordintpair) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index a6d0635ec1..8ac49d8b91 100644
+index a6d0635ec..8ac49d8b9 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1513,13 +1513,85 @@ public class WorldServer extends World {
@@ -196,10 +196,10 @@ index a6d0635ec1..8ac49d8b91 100644
  
      public LongSet getForceLoadedChunks() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f613ae1da4..ceb256222f 100644
+index 3d62debc7..6c6b98cf0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1837,15 +1837,21 @@ public class CraftWorld implements World {
+@@ -1850,15 +1850,21 @@ public class CraftWorld implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/Spigot-Server-Patches/0396-Fix-World-isChunkGenerated-calls.patch
+++ b/Spigot-Server-Patches/0396-Fix-World-isChunkGenerated-calls.patch
@@ -1,4 +1,4 @@
-From a281cd55109105f08246f47bb9517a48feab713a Mon Sep 17 00:00:00 2001
+From c4982ae721beaa4917a1342d166d4d4bc2a3b718 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 15 Jun 2019 08:54:33 -0700
 Subject: [PATCH] Fix World#isChunkGenerated calls
@@ -8,7 +8,7 @@ This patch also adds a chunk status cache on region files (note that
 its only purpose is to cache the status on DISK)
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index ca5963b11a..3894b04342 100644
+index ca5963b11..3894b0434 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -28,7 +28,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -43,7 +43,7 @@ index ca5963b11a..3894b04342 100644
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index e778c2e857..73f93e4948 100644
+index e778c2e85..73f93e494 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -410,6 +410,17 @@ public class ChunkRegionLoader {
@@ -65,7 +65,7 @@ index e778c2e857..73f93e4948 100644
          if (nbttagcompound != null) {
              ChunkStatus chunkstatus = ChunkStatus.a(nbttagcompound.getCompound("Level").getString("Status"));
 diff --git a/src/main/java/net/minecraft/server/ChunkStatus.java b/src/main/java/net/minecraft/server/ChunkStatus.java
-index dd1822d6ff..e324989b46 100644
+index dd1822d6f..e324989b4 100644
 --- a/src/main/java/net/minecraft/server/ChunkStatus.java
 +++ b/src/main/java/net/minecraft/server/ChunkStatus.java
 @@ -176,6 +176,7 @@ public class ChunkStatus {
@@ -95,7 +95,7 @@ index dd1822d6ff..e324989b46 100644
          return (ChunkStatus) IRegistry.CHUNK_STATUS.get(MinecraftKey.a(s));
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 14a176d61d..98590e233a 100644
+index 14a176d61..98590e233 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -70,6 +70,19 @@ public class PlayerChunk {
@@ -119,7 +119,7 @@ index 14a176d61d..98590e233a 100644
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 2be6fa0f07..bdadbd436e 100644
+index 2be6fa0f0..bdadbd436 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -891,11 +891,61 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -187,7 +187,7 @@ index 2be6fa0f07..bdadbd436e 100644
      boolean isOutsideOfRange(ChunkCoordIntPair chunkcoordintpair) {
          // Spigot start
 diff --git a/src/main/java/net/minecraft/server/RegionFile.java b/src/main/java/net/minecraft/server/RegionFile.java
-index 86ae53fed3..e6e412b7c1 100644
+index ccc3d6c7a..b487e8060 100644
 --- a/src/main/java/net/minecraft/server/RegionFile.java
 +++ b/src/main/java/net/minecraft/server/RegionFile.java
 @@ -31,6 +31,30 @@ public class RegionFile implements AutoCloseable {
@@ -246,7 +246,7 @@ index 86ae53fed3..e6e412b7c1 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/RegionFileCache.java b/src/main/java/net/minecraft/server/RegionFileCache.java
-index 6f34d8aea0..d2b3289450 100644
+index 6f34d8aea..d2b328945 100644
 --- a/src/main/java/net/minecraft/server/RegionFileCache.java
 +++ b/src/main/java/net/minecraft/server/RegionFileCache.java
 @@ -47,6 +47,12 @@ public abstract class RegionFileCache implements AutoCloseable {
@@ -279,10 +279,10 @@ index 6f34d8aea0..d2b3289450 100644
                      printOversizedLog("ChunkTooLarge even after reduction. Trying in overzealous mode.", regionfile.file, chunkX, chunkZ);
                      // Eek, major fail. We have retry logic, so reduce threshholds and fall back
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ceb256222f..21f1530138 100644
+index 6c6b98cf0..78e018caa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -393,8 +393,22 @@ public class CraftWorld implements World {
+@@ -406,8 +406,22 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -306,7 +306,7 @@ index ceb256222f..21f1530138 100644
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -506,20 +520,49 @@ public class CraftWorld implements World {
+@@ -519,20 +533,49 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
@@ -366,7 +366,7 @@ index ceb256222f..21f1530138 100644
      }
  
      @Override
-@@ -2251,21 +2294,44 @@ public class CraftWorld implements World {
+@@ -2264,21 +2307,44 @@ public class CraftWorld implements World {
  
      // Paper start
      private Chunk getChunkAtGen(int x, int z, boolean gen) {


### PR DESCRIPTION
/paper entity will no longer report entities in inactive chunks
World#getEntityCount and World#getChunkCount will report only
in active chunks