### PR TITLE
Prevent consuming the wrong itemstack

### DIFF
--- a/Spigot-Server-Patches/0413-Prevent-consuming-the-wrong-itemstack.patch
+++ b/Spigot-Server-Patches/0413-Prevent-consuming-the-wrong-itemstack.patch
@@ -1,0 +1,48 @@
+From a4b3835b873a9830e7ef1a652e229e06876214ce Mon Sep 17 00:00:00 2001
+From: kickash32 <kickash32@gmail.com>
+Date: Mon, 19 Aug 2019 19:42:35 +0500
+Subject: [PATCH] Prevent consuming the wrong itemstack
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 31d14b19b..f675ad2f5 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -2822,10 +2822,13 @@ public abstract class EntityLiving extends Entity {
+         this.datawatcher.set(EntityLiving.ar, (byte) j);
+     }
+ 
+-    public void c(EnumHand enumhand) {
++    // Paper start -- OBFHELPER and forwarder to method with forceUpdate parameter
++    public void c(EnumHand enumhand) { this.updateActiveItem(enumhand, false); }
++    public void updateActiveItem(EnumHand enumhand, boolean forceUpdate) {
++    // Paper end
+         ItemStack itemstack = this.b(enumhand);
+ 
+-        if (!itemstack.isEmpty() && !this.isHandRaised()) {
++        if (!itemstack.isEmpty() && !this.isHandRaised() || forceUpdate) { // Paper use override flag
+             this.activeItem = itemstack;
+             this.bo = itemstack.k();
+             if (!this.world.isClientSide) {
+@@ -2898,6 +2901,7 @@ public abstract class EntityLiving extends Entity {
+ 
+     protected void q() {
+         if (!this.activeItem.isEmpty() && this.isHandRaised()) {
++            this.updateActiveItem(this.getRaisedHand(), true); // Paper
+             PlayerItemConsumeEvent event = null; // Paper
+             this.b(this.activeItem, 16);
+             // CraftBukkit start - fire PlayerItemConsumeEvent
+@@ -2928,8 +2932,8 @@ public abstract class EntityLiving extends Entity {
+             this.a(this.getRaisedHand(), itemstack);
+             // CraftBukkit end
+             this.dp();
+-            // Paper start - if the replacement is anything but the default, update the client inventory
+-            if (this instanceof EntityPlayer && !com.google.common.base.Objects.equal(defaultReplacement, itemstack)) {
++            // Paper start
++            if (this instanceof EntityPlayer) {
+                 ((EntityPlayer) this).getBukkitEntity().updateInventory();
+             }
+             // Paper end
+-- 
+2.22.0
+


### PR DESCRIPTION
The change to the update inventory check is to unconditionally the update. This is intentional because it is the simplest way to prevent a client de-sync. If we wanted to check if the client had de-synced and then only send an update, it would likely be through checking incoming packets, however I'm not sure the client even sends such information.