### PR TITLE
Configurable chance of villager zombie infection

### DIFF
--- a/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
@@ -1,0 +1,52 @@
+From b64da6f0043d25574db3b36c417a48a2c2934b4b Mon Sep 17 00:00:00 2001
+From: Zero <zero@cock.li>
+Date: Sat, 22 Feb 2020 16:10:31 -0500
+Subject: [PATCH] Configurable chance of villager zombie infection
+
+This allows you to solve an issue in vanilla behavior where:
+* On easy difficulty your villagers will NEVER get infected, meaning they will always die.
+* On normal difficulty they will have a 50% of getting infected or dying.
+---
+ .../java/com/destroystokyo/paper/PaperWorldConfig.java |  5 +++++
+ src/main/java/net/minecraft/server/EntityZombie.java   | 10 +++++++---
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 7d408542..bd9b8838 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -658,4 +658,9 @@ public class PaperWorldConfig {
+     private void nerfNetherPortalPigmen() {
+         nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
+     }
++
++    public double zombieVillagerInfectionChance = -1.0;
++    private void zombieVillagerInfectionChance() {
++        zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
+index 8635d4f4..07ebc1d8 100644
+--- a/src/main/java/net/minecraft/server/EntityZombie.java
++++ b/src/main/java/net/minecraft/server/EntityZombie.java
+@@ -455,10 +455,14 @@ public class EntityZombie extends EntityMonster {
+     @Override
+     public void b(EntityLiving entityliving) {
+         super.b(entityliving);
+-        if ((this.world.getDifficulty() == EnumDifficulty.NORMAL || this.world.getDifficulty() == EnumDifficulty.HARD) && entityliving instanceof EntityVillager) {
+-            if (this.world.getDifficulty() != EnumDifficulty.HARD && this.random.nextBoolean()) {
++        // Paper start
++        if (world.paperConfig.zombieVillagerInfectionChance != 0.0 && (world.paperConfig.zombieVillagerInfectionChance != -1.0 || this.world.getDifficulty() == EnumDifficulty.NORMAL || this.world.getDifficulty() == EnumDifficulty.HARD) && entityliving instanceof EntityVillager) {
++            if (world.paperConfig.zombieVillagerInfectionChance == -1.0 && this.world.getDifficulty() != EnumDifficulty.HARD && this.random.nextBoolean()) {
++                 return;
++             }
++            if (world.paperConfig.zombieVillagerInfectionChance != -1.0 && (this.random.nextDouble() * 100.0) > world.paperConfig.zombieVillagerInfectionChance) {
+                 return;
+-            }
++            } // Paper end
+ 
+             EntityVillager entityvillager = (EntityVillager) entityliving;
+             EntityZombieVillager entityzombievillager = (EntityZombieVillager) EntityTypes.ZOMBIE_VILLAGER.a(this.world);
+-- 
+2.19.1.windows.1
+


### PR DESCRIPTION
This allows you to solve an issue in vanilla behavior where:
* On easy difficulty your villagers will NEVER get infected, meaning they will always die.
* On normal difficulty they will have a 50% of getting infected or dying.