### PR TITLE
Dead entities cannot use portals

### DIFF
--- a/Spigot-Server-Patches/0414-Dead-entities-cannot-use-portals.patch
+++ b/Spigot-Server-Patches/0414-Dead-entities-cannot-use-portals.patch
@@ -1,0 +1,26 @@
+From 0877c97e29c6cc86505236f21291b146b158a5d5 Mon Sep 17 00:00:00 2001
+From: TheMolkaPL <themolkapl@gmail.com>
+Date: Wed, 28 Aug 2019 16:33:41 +0200
+Subject: [PATCH] Dead entities cannot use portals
+
+Before this change, entities could use nether or end portals while they
+were marked dead. Players could use llamas or horses with chests to copy
+items by killing them in lava and teleporting to different
+dimension in the same server tick.
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index e8def7f81..f1fc5b29a 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2680,7 +2680,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public boolean canPortal() {
+-        return true;
++        return !this.dead; // Paper - dead entities cannot use portals
+     }
+ 
+     public float a(Explosion explosion, IBlockAccess iblockaccess, BlockPosition blockposition, IBlockData iblockdata, Fluid fluid, float f) {
+-- 
+2.19.2.windows.1
+


### PR DESCRIPTION
Before this change, entities could use nether or end portals while they were marked dead. Players could use llamas or horses with chests to copy items by killing them in lava and teleporting to different
dimension in the same server tick.

Here is a YouTube video showing how llama was duplicated before this change: https://www.youtube.com/watch?v=EiNw29bWlMs