### PR TITLE
Fix sign line capping check

### DIFF
--- a/Spigot-Server-Patches/0358-Limit-Client-Sign-length-more.patch
+++ b/Spigot-Server-Patches/0358-Limit-Client-Sign-length-more.patch
@@ -41,7 +41,7 @@ index 6030766099..b030269f0a 100644
 +                if (MAX_SIGN_LINE_LENGTH > 0 && astring[i].length() > MAX_SIGN_LINE_LENGTH) {
 +                    // This handles multibyte characters as 1
 +                    int offset = astring[i].codePoints().limit(MAX_SIGN_LINE_LENGTH).map(Character::charCount).sum();
-+                    if (offset > astring.length) {
++                    if (offset < astring[i].length()) {
 +                        astring[i] = astring[i].substring(0, offset);
 +                    }
 +                }


### PR DESCRIPTION
The check didn't produce a wrong outcome (unless you're funny enough to have the limit set from 0-3), but is still an error in logic

I think you could even get rid of the check, since the offset would only ever become smaller when stopping at the last character before the limit (if that is a codepoint beyond the complementary start) and thus stay inside the string boundaries, but meh (Edit: yeah just understood that it'll not be smaller, but greater in those cases, so ignore that paragraph)