### PR TITLE
PlayerItemCooldownEvent

### DIFF
--- a/Spigot-API-Patches/0185-PlayerItemCooldownEvent.patch
+++ b/Spigot-API-Patches/0185-PlayerItemCooldownEvent.patch
@@ -1,0 +1,91 @@
+From 45cbd2e2c576301c24b23b3b5cb5482d0048afcd Mon Sep 17 00:00:00 2001
+From: KennyTV <28825609+KennyTV@users.noreply.github.com>
+Date: Sat, 31 Aug 2019 17:39:47 +0200
+Subject: [PATCH] PlayerItemCooldownEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerItemCooldownEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerItemCooldownEvent.java
+new file mode 100644
+index 00000000..6ae9fae4
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerItemCooldownEvent.java
+@@ -0,0 +1,76 @@
++package com.destroystokyo.paper.event.player;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.Material;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Fired when a player receives an item cooldown.
++ */
++public class PlayerItemCooldownEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    @NotNull private final Material type;
++    private boolean cancelled;
++    private int cooldown;
++
++    public PlayerItemCooldownEvent(@NotNull Player player, @NotNull Material type, int cooldown) {
++        super(player);
++        this.type = type;
++        this.cooldown = cooldown;
++    }
++
++    /**
++     * Get the material affected by the cooldown.
++     *
++     * @return material affected by the cooldown
++     */
++    @NotNull
++    public Material getType() {
++        return type;
++    }
++
++    /**
++     * Gets the cooldown in ticks.
++     *
++     * @return cooldown in ticks
++     */
++    public int getCooldown() {
++        return cooldown;
++    }
++
++    /**
++     * Sets the cooldown of the material in ticks.
++     * Setting the cooldown to 0 results in removing an already existing cooldown for the material.
++     *
++     * @param cooldown cooldown in ticks, has to be a positive number
++     */
++    public void setCooldown(int cooldown) {
++        Preconditions.checkArgument(cooldown >= 0, "The cooldown has to be equal to or greater than 0!");
++        this.cooldown = cooldown;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.13.0.windows.1
+

--- a/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
+++ b/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
@@ -1,22 +1,29 @@
-From 7c18a8a1743c61ca7b69cc03de58b9ff3ff973d5 Mon Sep 17 00:00:00 2001
+From 7585779843be41b1aeb714e2d19768a1d2d845e3 Mon Sep 17 00:00:00 2001
 From: KennyTV <28825609+KennyTV@users.noreply.github.com>
 Date: Sat, 31 Aug 2019 17:40:04 +0200
 Subject: [PATCH] PlayerItemCooldownEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
-index 27cde8c15..894cefdbc 100644
+index 27cde8c15..a5014e42f 100644
 --- a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
 +++ b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
-@@ -8,6 +8,17 @@ public class ItemCooldownPlayer extends ItemCooldown {
+@@ -2,12 +2,23 @@ package net.minecraft.server;
+ 
+ public class ItemCooldownPlayer extends ItemCooldown {
+ 
+-    private final EntityPlayer a;
++    private final EntityPlayer a; public EntityPlayer getEntityPlayer() { return a; } // Paper - OBFHELPER
+ 
+     public ItemCooldownPlayer(EntityPlayer entityplayer) {
          this.a = entityplayer;
      }
  
 +    // Paper start
 +    @Override
-+    public void setCooldown(Item item, int i) {
++    public void setCooldown(Item item, int ticks) {
 +        com.destroystokyo.paper.event.player.PlayerItemCooldownEvent event =
-+            new com.destroystokyo.paper.event.player.PlayerItemCooldownEvent(a.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), i);
++            new com.destroystokyo.paper.event.player.PlayerItemCooldownEvent(getEntityPlayer().getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), ticks);
 +        if (!event.callEvent()) return;
 +
 +        super.setCooldown(item, event.getCooldown());

--- a/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
+++ b/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
@@ -1,11 +1,11 @@
-From d111f0bceadd009d0ff1fda2397803d2398617ba Mon Sep 17 00:00:00 2001
+From d639f4b302aed66f6b321de4aeee058d9790ec2d Mon Sep 17 00:00:00 2001
 From: KennyTV <28825609+KennyTV@users.noreply.github.com>
 Date: Sat, 31 Aug 2019 17:40:04 +0200
 Subject: [PATCH] PlayerItemCooldownEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
-index 27cde8c15..60ad165a3 100644
+index 27cde8c15..19ddb7258 100644
 --- a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
 +++ b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
 @@ -1,5 +1,8 @@
@@ -17,21 +17,23 @@ index 27cde8c15..60ad165a3 100644
  public class ItemCooldownPlayer extends ItemCooldown {
  
      private final EntityPlayer a;
-@@ -9,6 +12,14 @@ public class ItemCooldownPlayer extends ItemCooldown {
+@@ -8,6 +11,16 @@ public class ItemCooldownPlayer extends ItemCooldown {
+         this.a = entityplayer;
      }
  
-     @Override
++    // Paper start
++    @Override
 +    public void setCooldown(Item item, int i) {
 +        PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(a.getBukkitEntity(), CraftMagicNumbers.getMaterial(item), i);
 +        if (!event.callEvent()) return;
 +
 +        super.setCooldown(item, event.getCooldown());
 +    }
++    // Paper end
 +
-+    @Override
+     @Override
      protected void b(Item item, int i) {
          super.b(item, i);
-         this.a.playerConnection.sendPacket(new PacketPlayOutSetCooldown(item, i));
 -- 
 2.13.0.windows.1
 

--- a/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
+++ b/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
@@ -1,30 +1,22 @@
-From d639f4b302aed66f6b321de4aeee058d9790ec2d Mon Sep 17 00:00:00 2001
+From 7c18a8a1743c61ca7b69cc03de58b9ff3ff973d5 Mon Sep 17 00:00:00 2001
 From: KennyTV <28825609+KennyTV@users.noreply.github.com>
 Date: Sat, 31 Aug 2019 17:40:04 +0200
 Subject: [PATCH] PlayerItemCooldownEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
-index 27cde8c15..19ddb7258 100644
+index 27cde8c15..894cefdbc 100644
 --- a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
 +++ b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
-@@ -1,5 +1,8 @@
- package net.minecraft.server;
- 
-+import com.destroystokyo.paper.event.player.PlayerItemCooldownEvent;
-+import org.bukkit.craftbukkit.util.CraftMagicNumbers;
-+
- public class ItemCooldownPlayer extends ItemCooldown {
- 
-     private final EntityPlayer a;
-@@ -8,6 +11,16 @@ public class ItemCooldownPlayer extends ItemCooldown {
+@@ -8,6 +8,17 @@ public class ItemCooldownPlayer extends ItemCooldown {
          this.a = entityplayer;
      }
  
 +    // Paper start
 +    @Override
 +    public void setCooldown(Item item, int i) {
-+        PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(a.getBukkitEntity(), CraftMagicNumbers.getMaterial(item), i);
++        com.destroystokyo.paper.event.player.PlayerItemCooldownEvent event =
++            new com.destroystokyo.paper.event.player.PlayerItemCooldownEvent(a.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), i);
 +        if (!event.callEvent()) return;
 +
 +        super.setCooldown(item, event.getCooldown());

--- a/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
+++ b/Spigot-Server-Patches/0414-PlayerItemCooldownEvent.patch
@@ -1,0 +1,37 @@
+From d111f0bceadd009d0ff1fda2397803d2398617ba Mon Sep 17 00:00:00 2001
+From: KennyTV <28825609+KennyTV@users.noreply.github.com>
+Date: Sat, 31 Aug 2019 17:40:04 +0200
+Subject: [PATCH] PlayerItemCooldownEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
+index 27cde8c15..60ad165a3 100644
+--- a/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
++++ b/src/main/java/net/minecraft/server/ItemCooldownPlayer.java
+@@ -1,5 +1,8 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.event.player.PlayerItemCooldownEvent;
++import org.bukkit.craftbukkit.util.CraftMagicNumbers;
++
+ public class ItemCooldownPlayer extends ItemCooldown {
+ 
+     private final EntityPlayer a;
+@@ -9,6 +12,14 @@ public class ItemCooldownPlayer extends ItemCooldown {
+     }
+ 
+     @Override
++    public void setCooldown(Item item, int i) {
++        PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(a.getBukkitEntity(), CraftMagicNumbers.getMaterial(item), i);
++        if (!event.callEvent()) return;
++
++        super.setCooldown(item, event.getCooldown());
++    }
++
++    @Override
+     protected void b(Item item, int i) {
+         super.b(item, i);
+         this.a.playerConnection.sendPacket(new PacketPlayOutSetCooldown(item, i));
+-- 
+2.13.0.windows.1
+


### PR DESCRIPTION
see #2504 

... semantically, it might be worth instead infering the event in the superclass `ItemCooldown` class (for the humanentity) and adding the human instance into the constructor there.. but then someone else would have to re(do) the pr, since (once more) I can't be bothered to go through the shitton of unnecessarily modified patches my sexy Windows system would modify on rebuilding changes in a class like the HumanEntity one 👀

If needed/wanted, I'd also add a potential cooldown cause (natural vs. plugin induced)