### PR TITLE
Add a flag, "disable-ghost-block-fix"

### DIFF
--- a/Spigot-Server-Patches/0406-Fixed-MC-156852.patch
+++ b/Spigot-Server-Patches/0406-Fixed-MC-156852.patch
@@ -1,4 +1,4 @@
-From 7cb4669fb5d991d54e6bfe922fa2e679e47af0d6 Mon Sep 17 00:00:00 2001
+From 7c8012468c1d9dd7c22fe824c36a43f9b4954e97 Mon Sep 17 00:00:00 2001
 From: TheGreatKetchup <TheGreatKetchup@users.noreply.github.com>
 Date: Thu, 1 Aug 2019 21:24:30 -0400
 Subject: [PATCH] Fixed MC-156852
@@ -11,18 +11,51 @@ issue in 1.8-1.12.
 
 Originally solved by Gnembon on MC-5694 at bugs.mojang.com
 
+From: Zean Rivera <zean@zean.org>
+Date: Sat, 7 Sep 2019 03:11:05 -0700
+Subject: [PATCH] Add a flag, "disable-ghost-block-fix", to allow for turning off the GhostBlockFix https://github.com/PaperMC/Paper/pull/2396
+
+The reason for this is that this fix re-introduces
+this bug https://bugs.mojang.com/browse/MC-156013
+
+This gives server owners a way to opt out of the GhostBlockFix.
+It defaults to false, which is keeping the GhostBlockFix.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 318a470ee..377b4dbaf 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -149,6 +149,11 @@ public class PaperWorldConfig {
+         disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
+         log("End credits disabled: " + disableEndCredits);
+     }
++    
++    public boolean disableGhostBlockFix;
++    private void disableGhostBlockFix() {
++        disableGhostBlockFix = getBoolean("disable-ghost-block-fix", false);
++    }
+ 
+     public boolean optimizeExplosions;
+     private void optimizeExplosions() {
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index e5e9de542..c96564a59 100644
+index e5e9de542..64865bac9 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -218,6 +218,7 @@ public class PlayerInteractManager {
+@@ -218,6 +218,14 @@ public class PlayerInteractManager {
                      int j = (int) (f * 10.0F);
  
                      this.world.a(this.player.getId(), blockposition, j);
-+                    this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition)); // Paper - fixes MC-156852
++                    
++                    // Paper start - The GhostBlockFix which fixes MC-156852 reintroduces the nudging bug in MC-156013
++                    boolean disableGhostBlockFix = this.world.paperConfig.disableGhostBlockFix;
++                    if (!disableGhostBlockFix) { 
++                        this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition)); // Paper - fixes MC-156852
++                    }
++                    // Paper end
++                    
                      this.player.playerConnection.sendPacket(new PacketPlayOutBlockBreak(blockposition, this.world.getType(blockposition), packetplayinblockdig_enumplayerdigtype, true));
                      this.l = j;
                  }
 -- 
-2.23.0
+2.23.0.windows.1
 

--- a/Spigot-Server-Patches/0407-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0407-Implement-alternative-item-despawn-rate.patch
@@ -1,11 +1,11 @@
-From ec3a80e16df92c21e4618cbf79b19fe53125a9da Mon Sep 17 00:00:00 2001
+From 021d3b1dd5c498a83ec8b7da7ea3698805a13e63 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Mon, 3 Jun 2019 02:02:39 -0400
 Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 318a470ee..e7bbeef74 100644
+index 377b4dbaf..714436ad4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,12 +1,17 @@
@@ -26,7 +26,7 @@ index 318a470ee..e7bbeef74 100644
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -562,4 +567,52 @@ public class PaperWorldConfig {
+@@ -567,4 +572,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
@@ -128,5 +128,5 @@ index bc7e706d1..df26cef6a 100644
      public Packet<?> N() {
          return new PacketPlayOutSpawnEntity(this);
 -- 
-2.23.0
+2.23.0.windows.1
 

--- a/Spigot-Server-Patches/0412-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0412-implement-optional-per-player-mob-spawns.patch
@@ -1,4 +1,4 @@
-From 838de9697614e9960cc0adf901811992c98cb71f Mon Sep 17 00:00:00 2001
+From 7a333ffc0e667d56d8112e2e09eb32ab72974f77 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Mon, 19 Aug 2019 01:27:58 +0500
 Subject: [PATCH] implement optional per player mob spawns
@@ -27,10 +27,10 @@ index f4d5db02f..24b4c6e6a 100644
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7bbeef74..246bb4b01 100644
+index 714436ad4..782a8f8d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -615,4 +615,9 @@ public class PaperWorldConfig {
+@@ -620,4 +620,9 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -547,7 +547,7 @@ index 000000000..4f13d3ff8
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 17f04fb81..bc5011312 100644
+index c8451afec..d0606ee74 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -555,7 +555,22 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -802,5 +802,5 @@ index 845575f52..ee3789b38 100644
  
      @Override
 -- 
-2.22.1
+2.23.0.windows.1
 


### PR DESCRIPTION
Add a flag, "disable-ghost-block-fix", to allow for turning off 
the GhostBlockFix https://github.com/PaperMC/Paper/pull/2396

The reason for this is that this fix re-introduces
this bug https://bugs.mojang.com/browse/MC-156013

This gives server owners a way to opt out of the GhostBlockFix.
It defaults to false, which is keeping the GhostBlockFix.

A friend of mine is able to reproduce this:
- disableGhostBlockFix false: https://www.youtube.com/watch?v=QIuc0EBtMfc
- disableGhostBlockFix true: https://www.youtube.com/watch?v=lWWHeHBkNLA