### PR TITLE
Fix nether portal creation

### DIFF
--- a/Spigot-Server-Patches/0416-Fix-nether-portal-creation.patch
+++ b/Spigot-Server-Patches/0416-Fix-nether-portal-creation.patch
@@ -1,0 +1,25 @@
+From 7c8a99570d2da9d5839045ba2d0e35eb44c74171 Mon Sep 17 00:00:00 2001
+From: Michael Himing <mhiming@gmail.com>
+Date: Mon, 9 Sep 2019 13:21:17 +1000
+Subject: [PATCH] Fix nether portal creation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
+index 88fbfc01b..f66f8b323 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/BlockStateListPopulator.java
+@@ -38,6 +38,11 @@ public class BlockStateListPopulator extends DummyGeneratorAccess {
+ 
+     @Override
+     public boolean setTypeAndData(BlockPosition position, IBlockData data, int flag) {
++        // Paper start
++        // When a LinkedHashMap entry is overwritten, it keeps its old position. Removing the entry here before adding
++        // a new one ensures that the nether portal blocks are placed last and are not destroyed by physics.
++        list.remove(position);
++        // Paper end
+         CraftBlockState state = CraftBlockState.getBlockState(world, position, flag);
+         state.setData(data);
+         list.put(position, state);
+-- 
+2.23.0.windows.1
+


### PR DESCRIPTION
Fixes creation of the portals with platform blocks, usually seen above oceans.
![2019-09-09_13 29 10](https://user-images.githubusercontent.com/2089783/64501753-11002f00-d306-11e9-9396-c53d8c74b4fb.png)