### PR TITLE
Fixes #2571

### DIFF
--- a/Spigot-Server-Patches/0444-Don-t-use-streams-for-VoxelShape-calls.patch
+++ b/Spigot-Server-Patches/0444-Don-t-use-streams-for-VoxelShape-calls.patch
@@ -176,7 +176,7 @@ index 175f242a8..c21f9c65d 100644
 -            });
 +            List<VoxelShape> shapes = new ArrayList<>();
 +            for (Entity e : this.getEntities(entity, axisalignedbb.g(0.25D))) {
-+                if (!set.contains(e) && (entity == null || !entity.x(e))) continue;
++                if (!(!set.contains(e) && (entity == null || !entity.x(e)))) continue;
 +
 +                List<AxisAlignedBB> alignedBBs = Arrays.asList(e.al(), entity == null ? null : entity.j(e));
 +                for (AxisAlignedBB axisAlignedBB : alignedBBs) {


### PR DESCRIPTION
This time the patch should be directly edited and formatted correctly. The rest of the logic seems fine, just a simple converting a filter method to its manual counterpart.

I don't know why Paperclip was updated since I only wanted to edit patch 0444.

I'm still really new to all of this so any help is much appreciated.