### PR TITLE
performance improvement for CraftChunk.getEntities()

### DIFF
--- a/Spigot-Server-Patches/0419-Performance-improvement-for-Chunk.getEntities.patch
+++ b/Spigot-Server-Patches/0419-Performance-improvement-for-Chunk.getEntities.patch
@@ -1,4 +1,4 @@
-From b9f79b55d41d863857ddec3b37bc148f2767b926 Mon Sep 17 00:00:00 2001
+From 62af6667746cc668375eb2e6f02352fbcded8c7c Mon Sep 17 00:00:00 2001
 From: wea_ondara <wea_ondara@alpenblock.net>
 Date: Thu, 10 Oct 2019 11:29:42 +0200
 Subject: [PATCH] Performance improvement for Chunk.getEntities
@@ -10,22 +10,23 @@ operation. This patch will reduce the load of plugins which for example
 implement custom moblimits and depend on Chunk.getEntities().
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index b4551614..db758164 100644
+index b4551614..373bea4b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -110,14 +110,11 @@ public class CraftChunk implements Chunk {
+@@ -110,14 +110,14 @@ public class CraftChunk implements Chunk {
          Entity[] entities = new Entity[count];
  
          for (int i = 0; i < 16; i++) {
 -
 -            for (Object obj : chunk.entitySlices[i].toArray()) {
 -                if (!(obj instanceof net.minecraft.server.Entity)) {
--                    continue;
--                }
--
--                entities[index++] = ((net.minecraft.server.Entity) obj).getBukkitEntity();
 +            // Paper start - speed up (was with chunk.entitySlices[i].toArray() and cast checks which costs a lot of performance if called often)
 +            for (net.minecraft.server.Entity entity : chunk.entitySlices[i]) {
++                if (entity == null) {
+                     continue;
+                 }
+-
+-                entities[index++] = ((net.minecraft.server.Entity) obj).getBukkitEntity();
 +                entities[index++] = entity.getBukkitEntity();
              }
 +            // Paper end

--- a/Spigot-Server-Patches/0419-Performance-improvement-for-Chunk.getEntities.patch
+++ b/Spigot-Server-Patches/0419-Performance-improvement-for-Chunk.getEntities.patch
@@ -1,0 +1,37 @@
+From b9f79b55d41d863857ddec3b37bc148f2767b926 Mon Sep 17 00:00:00 2001
+From: wea_ondara <wea_ondara@alpenblock.net>
+Date: Thu, 10 Oct 2019 11:29:42 +0200
+Subject: [PATCH] Performance improvement for Chunk.getEntities
+
+This patch aims to reduce performance cost used by collecting the
+entities of a chunk. Previously the entitySlices were copied into an
+extra array with List.toArray() with is a costly and unneccessary
+operation. This patch will reduce the load of plugins which for example
+implement custom moblimits and depend on Chunk.getEntities().
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+index b4551614..db758164 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+@@ -110,14 +110,11 @@ public class CraftChunk implements Chunk {
+         Entity[] entities = new Entity[count];
+ 
+         for (int i = 0; i < 16; i++) {
+-
+-            for (Object obj : chunk.entitySlices[i].toArray()) {
+-                if (!(obj instanceof net.minecraft.server.Entity)) {
+-                    continue;
+-                }
+-
+-                entities[index++] = ((net.minecraft.server.Entity) obj).getBukkitEntity();
++            // Paper start - speed up (was with chunk.entitySlices[i].toArray() and cast checks which costs a lot of performance if called often)
++            for (net.minecraft.server.Entity entity : chunk.entitySlices[i]) {
++                entities[index++] = entity.getBukkitEntity();
+             }
++            // Paper end
+         }
+ 
+         return entities;
+-- 
+2.23.0
+


### PR DESCRIPTION
Removed an unneccessary List.toArray() call and cast checks which consumes a lot of performance when called multiple times per tick.