### PR TITLE
Really fix JLine on Windows

### DIFF
--- a/Spigot-Server-Patches/0176-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0176-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From b6d424028e3980f33b12cf8b24fc51eaf7f3a613 Mon Sep 17 00:00:00 2001
+From 18d269264ab9d8f85258b52572ab5c03cb5e19dd Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 51cefc0a1b..2b73ec28a1 100644
+index 51cefc0a1..2b73ec28a 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -41,10 +41,27 @@
@@ -75,7 +75,7 @@ index 51cefc0a1b..2b73ec28a1 100644
                  <groupId>org.apache.maven.plugins</groupId>
 diff --git a/src/main/java/com/destroystokyo/paper/console/PaperConsole.java b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 new file mode 100644
-index 0000000000..688b4715eb
+index 000000000..688b4715e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/console/PaperConsole.java
 @@ -0,0 +1,40 @@
@@ -121,7 +121,7 @@ index 0000000000..688b4715eb
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
 new file mode 100644
-index 0000000000..685deaa0e5
+index 000000000..685deaa0e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/console/TerminalConsoleCommandSender.java
 @@ -0,0 +1,17 @@
@@ -143,7 +143,7 @@ index 0000000000..685deaa0e5
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 4e9ef43b45..5bb1ea880a 100644
+index 4e9ef43b4..5bb1ea880 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -79,6 +79,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -185,7 +185,7 @@ index 4e9ef43b45..5bb1ea880a 100644
          System.setOut(new PrintStream(new LoggerOutputStream(logger, Level.INFO), true));
          System.setErr(new PrintStream(new LoggerOutputStream(logger, Level.WARN), true));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index db511c1fe8..c6ecdf6e8e 100644
+index db511c1fe..c6ecdf6e8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -56,7 +56,6 @@ import org.apache.commons.lang3.Validate;
@@ -243,7 +243,7 @@ index db511c1fe8..c6ecdf6e8e 100644
  
      public KeyPair E() {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 9d44dcb3b2..8bb3fef21e 100644
+index 9d44dcb3b..8bb3fef21 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -77,8 +77,7 @@ public abstract class PlayerList {
@@ -257,7 +257,7 @@ index 9d44dcb3b2..8bb3fef21e 100644
  
          this.k = new GameProfileBanList(PlayerList.a);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 962170cd3f..7e4f42b3f4 100644
+index 962170cd3..7e4f42b3f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -146,8 +146,8 @@ import java.nio.ByteBuffer;
@@ -285,7 +285,7 @@ index 962170cd3f..7e4f42b3f4 100644
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 472a8070e7..4102e19700 100644
+index 472a8070e..daab48ed3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -14,7 +14,7 @@ import java.util.logging.Logger;
@@ -325,9 +325,18 @@ index 472a8070e7..4102e19700 100644
                  }
  
                  if (false && Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
+@@ -226,7 +236,7 @@ public class Main {
+                     System.out.println("Unable to read system info");
+                 }
+                 // Paper end
+-
++                System.setProperty( "library.jansi.version", "Paper" ); // Paper - set meaningless jansi version to prevent git builds from crashing on Windows
+                 System.out.println("Loading libraries, please wait...");
+                 MinecraftServer.main(options);
+             } catch (Throwable t) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java b/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
 deleted file mode 100644
-index 26a2fb8942..0000000000
+index 26a2fb894..000000000
 --- a/src/main/java/org/bukkit/craftbukkit/command/ColouredConsoleSender.java
 +++ /dev/null
 @@ -1,74 +0,0 @@
@@ -406,7 +415,7 @@ index 26a2fb8942..0000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
-index 33e8ea02c4..1e3aae3b8f 100644
+index 33e8ea02c..1e3aae3b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/ConsoleCommandCompleter.java
 @@ -8,17 +8,27 @@ import java.util.logging.Level;
@@ -485,7 +494,7 @@ index 33e8ea02c4..1e3aae3b8f 100644
      }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
-index 984df4083d..bbb5a84f36 100644
+index 984df4083..bbb5a84f3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/ServerShutdownThread.java
 @@ -20,7 +20,7 @@ public class ServerShutdownThread extends Thread {
@@ -499,7 +508,7 @@ index 984df4083d..bbb5a84f36 100644
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java b/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java
 deleted file mode 100644
-index b640971130..0000000000
+index b64097113..000000000
 --- a/src/main/java/org/bukkit/craftbukkit/util/TerminalConsoleWriterThread.java
 +++ /dev/null
 @@ -1,54 +0,0 @@
@@ -558,7 +567,7 @@ index b640971130..0000000000
 -    }
 -}
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 5cee8f00ef..08b6bb7f97 100644
+index 5cee8f00e..08b6bb7f9 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -1,12 +1,11 @@
@@ -588,5 +597,5 @@ index 5cee8f00ef..08b6bb7f97 100644
              <AppenderRef ref="TerminalConsole" level="info"/>
          </Root>
 -- 
-2.21.0
+2.22.0
 


### PR DESCRIPTION
The history of how paths work in Win32 is a sad story and shall not be documented here.
Needless to say, Windows hates the temporary file name for jansi's native code since it
includes the version. For git builds, it includes quotes around the actual version. But
alas, the issue apparently doesn't occur if you build on Windows since it removes the
quotes from the git commandline that is ultimately used to build the version string,
because of more Win32 sadness and shame.

Go look at Raymond Chen's blog, The Old New Thing. It's full of Windows oddities and
it will make you want to weep because almost 90% of the world uses this legacy OS from
the 1980s.

**tl;dr**: fixes builds from git built on sane *nix OSes so they can actually on Windows without disabling jline.