### PR TITLE
Re-implement treasure-maps-return-already-discovered for 1.14

### DIFF
--- a/Spigot-Server-Patches/0134-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0134-Configurable-Cartographer-Treasure-Maps.patch
@@ -1,4 +1,4 @@
-From ea4b1c7e6c9ea1cff1f6a48fa97087f63531c4d1 Mon Sep 17 00:00:00 2001
+From f3fbc261cc75b70ebd3722190f12e04ef7ef0f75 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 20 Dec 2016 15:26:27 -0500
 Subject: [PATCH] Configurable Cartographer Treasure Maps
@@ -28,17 +28,19 @@ index 11b0f11a8..46d525223 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/VillagerTrades.java b/src/main/java/net/minecraft/server/VillagerTrades.java
-index 2a4e4f785..0b6632369 100644
+index 8cee460bd..99374fe2a 100644
 --- a/src/main/java/net/minecraft/server/VillagerTrades.java
 +++ b/src/main/java/net/minecraft/server/VillagerTrades.java
-@@ -89,6 +89,7 @@ public class VillagerTrades {
+@@ -89,7 +89,8 @@ public class VillagerTrades {
          @Override
          public MerchantRecipe a(Entity entity, Random random) {
              World world = entity.world;
+-            BlockPosition blockposition = world.a(this.b, new BlockPosition(entity), 100, true);
 +            if (!world.paperConfig.enableTreasureMaps) return null; //Paper
-             BlockPosition blockposition = world.a(this.b, new BlockPosition(entity), 100, true);
++            BlockPosition blockposition = world.a(this.b, new BlockPosition(entity), 100, !world.paperConfig.treasureMapsAlreadyDiscovered); //Paper
  
              if (blockposition != null) {
+                 ItemStack itemstack = ItemWorldMap.createFilledMapView(world, blockposition.getX(), blockposition.getZ(), (byte) 2, true, true);
 -- 
-2.22.0
+2.23.0
 


### PR DESCRIPTION
This configuration option is currently unimplemented for 1.14 and this PR should implement it.

Also, move the `enableTreasureMaps` check earlier so we don't try to find the structure if we don't need to.

The function parameter I'm setting eventually resolves to `getNearestGeneratedFeature` in `StructureGenerator.java`. If the flag boolean is true it will return the closest undiscovered location, otherwise it will return the closest location.

You can test this patch by summoning a bunch of cartographers and checking if their map trades change or not (before and after generating the chunks that their map points to).

This should resolve #2321 (at least for 1.14)