### PR TITLE
UUID support in CraftProfileBanList

### DIFF
--- a/Spigot-Server-Patches/0446-UUID-support-in-CraftProfileBanList.patch
+++ b/Spigot-Server-Patches/0446-UUID-support-in-CraftProfileBanList.patch
@@ -1,0 +1,85 @@
+From 95b343c1556c2acfc47a9102f8bfe6cb676a0a88 Mon Sep 17 00:00:00 2001
+From: pop4959 <pop4959@gmail.com>
+Date: Wed, 16 Oct 2019 18:59:15 -0700
+Subject: [PATCH] UUID support in CraftProfileBanList
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftProfileBanList.java b/src/main/java/org/bukkit/craftbukkit/CraftProfileBanList.java
+index 84a1f9c8..6494029c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftProfileBanList.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftProfileBanList.java
+@@ -14,6 +14,7 @@ import org.apache.commons.lang.Validate;
+ 
+ import com.google.common.collect.ImmutableSet;
+ import com.mojang.authlib.GameProfile;
++import java.util.UUID; // Paper
+ import java.util.logging.Level;
+ import org.bukkit.Bukkit;
+ 
+@@ -28,7 +29,14 @@ public class CraftProfileBanList implements org.bukkit.BanList {
+     public org.bukkit.BanEntry getBanEntry(String target) {
+         Validate.notNull(target, "Target cannot be null");
+ 
+-        GameProfile profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        // Paper start
++        GameProfile profile;
++        try {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(UUID.fromString(target));
++        } catch (IllegalArgumentException e) {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        }
++        // Paper end
+         if (profile == null) {
+             return null;
+         }
+@@ -45,7 +53,14 @@ public class CraftProfileBanList implements org.bukkit.BanList {
+     public org.bukkit.BanEntry addBan(String target, String reason, Date expires, String source) {
+         Validate.notNull(target, "Ban target cannot be null");
+ 
+-        GameProfile profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        // Paper start
++        GameProfile profile;
++        try {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(UUID.fromString(target));
++        } catch (IllegalArgumentException e) {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        }
++        // Paper end
+         if (profile == null) {
+             return null;
+         }
+@@ -81,7 +96,14 @@ public class CraftProfileBanList implements org.bukkit.BanList {
+     public boolean isBanned(String target) {
+         Validate.notNull(target, "Target cannot be null");
+ 
+-        GameProfile profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        // Paper start
++        GameProfile profile;
++        try {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(UUID.fromString(target));
++        } catch (IllegalArgumentException e) {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        }
++        // Paper end
+         if (profile == null) {
+             return false;
+         }
+@@ -93,7 +115,14 @@ public class CraftProfileBanList implements org.bukkit.BanList {
+     public void pardon(String target) {
+         Validate.notNull(target, "Target cannot be null");
+ 
+-        GameProfile profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        // Paper start
++        GameProfile profile;
++        try {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(UUID.fromString(target));
++        } catch (IllegalArgumentException e) {
++            profile = MinecraftServer.getServer().getUserCache().getProfile(target);
++        }
++        // Paper end
+         list.remove(profile);
+     }
+ }
+-- 
+2.16.2.windows.1
+


### PR DESCRIPTION
If UUIDs are supported, then it will be easier and less confusing to ban or pardon players who have changed their username. Currently, the profile-based ban list only actually supports getting a profile by username, instead of both username and UUID. It seems this is caused by passing target to UserCache::getProfile as a string, which will then only find the profile if it is a username. This PR modifies CraftProfileBanList to first attempt to convert target to a UUID and get the profile. If target is not a UUID, this will fail and it will proceed as it normally would.

Let me know if there's anything that needs to be fixed, as this is my first time contributing to Paper. :smile: 