### PR TITLE
Fix server deadlock when loading some chunks

### DIFF
--- a/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
+++ b/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
@@ -1,4 +1,4 @@
-From 742264d273660d238ce3a7fa3bd46201db8a82fb Mon Sep 17 00:00:00 2001
+From f2d34c86bd53eb3e3340d7c5a568f9f28263f330 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 30 Mar 2016 19:36:20 -0400
 Subject: [PATCH] MC Dev fixes
@@ -189,19 +189,6 @@ index efa496fcc0..70a4509055 100644
              return true;
          }
      }
-diff --git a/src/main/java/net/minecraft/server/IBlockAccess.java b/src/main/java/net/minecraft/server/IBlockAccess.java
-index 2ed6119804..6e365f402c 100644
---- a/src/main/java/net/minecraft/server/IBlockAccess.java
-+++ b/src/main/java/net/minecraft/server/IBlockAccess.java
-@@ -96,7 +96,7 @@ public interface IBlockAccess {
-                 double d13 = d10 * (i1 > 0 ? 1.0D - MathHelper.h(d4) : MathHelper.h(d4));
-                 double d14 = d11 * (j1 > 0 ? 1.0D - MathHelper.h(d5) : MathHelper.h(d5));
- 
--                Object object;
-+                T object; // Paper - decompile fix
- 
-                 do {
-                     if (d12 > 1.0D && d13 > 1.0D && d14 > 1.0D) {
 diff --git a/src/main/java/net/minecraft/server/IBlockData.java b/src/main/java/net/minecraft/server/IBlockData.java
 index fa51b372c1..3328a84792 100644
 --- a/src/main/java/net/minecraft/server/IBlockData.java

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1,4 +1,4 @@
-From f5d52df1a55728a0d946c38bc9dc8c7db216fe75 Mon Sep 17 00:00:00 2001
+From 11dc8e1f66a697395be40b58e2249371b50e1e59 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 3 Mar 2016 04:00:11 -0600
 Subject: [PATCH] Timings v2
@@ -6,7 +6,7 @@ Subject: [PATCH] Timings v2
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
 new file mode 100644
-index 000000000..c6818bc86
+index 0000000000..c6818bc86a
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -0,0 +1,135 @@
@@ -147,7 +147,7 @@ index 000000000..c6818bc86
 +}
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 new file mode 100644
-index 000000000..3a79cde59
+index 0000000000..3a79cde595
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -0,0 +1,130 @@
@@ -282,7 +282,7 @@ index 000000000..3a79cde59
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5518ec1e5..0c65afccf 100644
+index 5518ec1e54..0c65afccfd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,11 +14,14 @@ import java.util.concurrent.TimeUnit;
@@ -329,7 +329,7 @@ index 5518ec1e5..0c65afccf 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index abba434da..1426bd01a 100644
+index abba434dac..1426bd01ad 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -31,6 +31,15 @@ public class Block implements IMaterial {
@@ -349,7 +349,7 @@ index abba434da..1426bd01a 100644
      private final float frictionFactor;
      protected final BlockStateList<Block, IBlockData> blockStateList;
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 3ed48be38..c4d989f70 100644
+index 3ed48be382..c4d989f702 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -573,6 +573,7 @@ public class Chunk implements IChunkAccess {
@@ -369,7 +369,7 @@ index 3ed48be38..c4d989f70 100644
          }
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 3b785a3ad..15480a8df 100644
+index 3b785a3ade..15480a8dfb 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -129,11 +129,13 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -481,7 +481,7 @@ index 3b785a3ad..15480a8df 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 28bf9e14d..03be77299 100644
+index 28bf9e14d6..03be77299b 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -1,5 +1,6 @@
@@ -519,7 +519,7 @@ index 28bf9e14d..03be77299 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/CustomFunction.java b/src/main/java/net/minecraft/server/CustomFunction.java
-index 12885cbd6..49de6e997 100644
+index 12885cbd60..49de6e997a 100644
 --- a/src/main/java/net/minecraft/server/CustomFunction.java
 +++ b/src/main/java/net/minecraft/server/CustomFunction.java
 @@ -13,12 +13,22 @@ public class CustomFunction {
@@ -546,7 +546,7 @@ index 12885cbd6..49de6e997 100644
          return this.b;
      }
 diff --git a/src/main/java/net/minecraft/server/CustomFunctionData.java b/src/main/java/net/minecraft/server/CustomFunctionData.java
-index 53735b52a..721839b4c 100644
+index 53735b52a3..721839b4c6 100644
 --- a/src/main/java/net/minecraft/server/CustomFunctionData.java
 +++ b/src/main/java/net/minecraft/server/CustomFunctionData.java
 @@ -101,7 +101,7 @@ public class CustomFunctionData implements IResourcePackListener {
@@ -559,7 +559,7 @@ index 53735b52a..721839b4c 100644
                  int j = 0;
                  CustomFunction.c[] acustomfunction_c = customfunction.b();
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index e6cf90484..ce3ca4830 100644
+index e6cf90484c..ce3ca4830e 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -19,6 +19,8 @@ import java.util.Collections;
@@ -647,7 +647,7 @@ index e6cf90484..ce3ca4830 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d4954801c..fd4712c71 100644
+index d4954801cb..fd4712c710 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -29,7 +29,8 @@ import org.bukkit.command.CommandSender;
@@ -686,7 +686,7 @@ index d4954801c..fd4712c71 100644
  
      protected Vec3D a(Vec3D vec3d, EnumMoveType enummovetype) {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 2b13f4c9f..47379046d 100644
+index 2b13f4c9f9..47379046dc 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -35,7 +35,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -762,7 +762,7 @@ index 2b13f4c9f..47379046d 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cec3794cd..c76f262db 100644
+index cec3794cd4..c76f262db9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -63,7 +63,7 @@ import org.bukkit.craftbukkit.CraftServer;
@@ -934,7 +934,7 @@ index cec3794cd..c76f262db 100644
          this.methodProfiler.exit();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index e41d21f91..cf3d291af 100644
+index e41d21f915..cf3d291af8 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,7 +1,9 @@
@@ -1012,7 +1012,7 @@ index e41d21f91..cf3d291af 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 301b1c082..36c56773f 100644
+index 301b1c0829..36c56773f3 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -58,6 +58,7 @@ import org.bukkit.inventory.CraftingInventory;
@@ -1067,7 +1067,7 @@ index 301b1c082..36c56773f 100644
          // this.minecraftServer.getCommandDispatcher().a(this.player.getCommandListener(), s);
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
-index a677ec74d..e928525b8 100644
+index a677ec74d4..e928525b8f 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -1094,7 +1094,7 @@ index a677ec74d..e928525b8 100644
                      PlayerConnectionUtils.LOGGER.debug("Ignoring packet due to disconnection: " + packet);
                  }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index ee22d6c81..fb6b48e3f 100644
+index ee22d6c81a..fb6b48e3fe 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1118,7 +1118,7 @@ index ee22d6c81..fb6b48e3f 100644
  
      public WhiteList getWhitelist() {
 diff --git a/src/main/java/net/minecraft/server/TickListServer.java b/src/main/java/net/minecraft/server/TickListServer.java
-index 00bbd34b6..f533860bb 100644
+index 00bbd34b6a..f533860bbe 100644
 --- a/src/main/java/net/minecraft/server/TickListServer.java
 +++ b/src/main/java/net/minecraft/server/TickListServer.java
 @@ -28,13 +28,18 @@ public class TickListServer<T> implements TickList<T> {
@@ -1168,7 +1168,7 @@ index 00bbd34b6..f533860bb 100644
              this.g.clear();
          }
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 2efaf516f..22a8ea916 100644
+index 2efaf516ff..22a8ea916a 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -9,11 +9,12 @@ import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
@@ -1187,7 +1187,7 @@ index 2efaf516f..22a8ea916 100644
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
      public CraftPersistentDataContainer persistentDataContainer;
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 1d5e4c512..60c222b12 100644
+index a71d7a80c2..67cfcdd602 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1,5 +1,7 @@
@@ -1242,7 +1242,7 @@ index 1d5e4c512..60c222b12 100644
              CrashReport crashreport = CrashReport.a(throwable, "Ticking entity");
              CrashReportSystemDetails crashreportsystemdetails = crashreport.a("Entity being ticked");
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index b1b85e9ce..5320bdad9 100644
+index f4cefa00fa..ef9abdc28d 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1,5 +1,7 @@
@@ -1274,7 +1274,7 @@ index b1b85e9ce..5320bdad9 100644
          this.H = Sets.newHashSet();
          this.I = new ObjectLinkedOpenHashSet();
          this.dataManager = worldnbtstorage;
-@@ -288,24 +289,28 @@ public class WorldServer extends World {
+@@ -291,24 +292,28 @@ public class WorldServer extends World {
          this.M();
          this.a();
          gameprofilerfiller.exitEnter("chunkSource");
@@ -1305,7 +1305,7 @@ index b1b85e9ce..5320bdad9 100644
  
          gameprofilerfiller.exitEnter("blockEvents");
          timings.doSounds.startTiming(); // Spigot
-@@ -348,6 +353,7 @@ public class WorldServer extends World {
+@@ -351,6 +356,7 @@ public class WorldServer extends World {
  
              org.spigotmc.ActivationRange.activateEntities(this); // Spigot
              timings.entityTick.startTiming(); // Spigot
@@ -1313,7 +1313,7 @@ index b1b85e9ce..5320bdad9 100644
              while (objectiterator.hasNext()) {
                  Entry<Entity> entry = (Entry) objectiterator.next();
                  Entity entity1 = (Entity) entry.getValue();
-@@ -374,6 +380,7 @@ public class WorldServer extends World {
+@@ -377,6 +383,7 @@ public class WorldServer extends World {
                  gameprofilerfiller.enter("tick");
                  if (!entity1.dead && !(entity1 instanceof EntityComplexPart)) {
                      this.a(this::entityJoinedWorld, entity1);
@@ -1321,7 +1321,7 @@ index b1b85e9ce..5320bdad9 100644
                  }
  
                  gameprofilerfiller.exit();
-@@ -390,9 +397,11 @@ public class WorldServer extends World {
+@@ -393,9 +400,11 @@ public class WorldServer extends World {
  
              this.tickingEntities = false;
  
@@ -1333,7 +1333,7 @@ index b1b85e9ce..5320bdad9 100644
  
              gameprofilerfiller.exit();
              timings.tickEntities.stopTiming(); // Spigot
-@@ -451,6 +460,7 @@ public class WorldServer extends World {
+@@ -454,6 +463,7 @@ public class WorldServer extends World {
          }
  
          gameprofilerfiller.exitEnter("tickBlocks");
@@ -1341,7 +1341,7 @@ index b1b85e9ce..5320bdad9 100644
          if (i > 0) {
              ChunkSection[] achunksection = chunk.getSections();
              int l = achunksection.length;
-@@ -482,7 +492,7 @@ public class WorldServer extends World {
+@@ -485,7 +495,7 @@ public class WorldServer extends World {
                  }
              }
          }
@@ -1350,7 +1350,7 @@ index b1b85e9ce..5320bdad9 100644
          gameprofilerfiller.exit();
      }
  
-@@ -777,6 +787,7 @@ public class WorldServer extends World {
+@@ -780,6 +790,7 @@ public class WorldServer extends World {
  
          if (!flag1) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(getWorld())); // CraftBukkit
@@ -1358,7 +1358,7 @@ index b1b85e9ce..5320bdad9 100644
              if (iprogressupdate != null) {
                  iprogressupdate.a(new ChatMessage("menu.savingLevel", new Object[0]));
              }
-@@ -786,7 +797,10 @@ public class WorldServer extends World {
+@@ -789,7 +800,10 @@ public class WorldServer extends World {
                  iprogressupdate.c(new ChatMessage("menu.savingChunks", new Object[0]));
              }
  
@@ -1370,7 +1370,7 @@ index b1b85e9ce..5320bdad9 100644
  
          // CraftBukkit start - moved from MinecraftServer.saveChunks
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dce5bde54..a59f61e73 100644
+index dce5bde54f..a59f61e73a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1932,12 +1932,31 @@ public final class CraftServer implements Server {
@@ -1407,7 +1407,7 @@ index dce5bde54..a59f61e73 100644
              org.spigotmc.RestartCommand.restart();
 diff --git a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java b/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 deleted file mode 100644
-index b98a7b56a..000000000
+index b98a7b56a4..0000000000
 --- a/src/main/java/org/bukkit/craftbukkit/SpigotTimings.java
 +++ /dev/null
 @@ -1,164 +0,0 @@
@@ -1576,7 +1576,7 @@ index b98a7b56a..000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e434738cb..9f5080b23 100644
+index e434738cb1..9f5080b233 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1749,6 +1749,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -1595,7 +1595,7 @@ index e434738cb..9f5080b23 100644
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index b90979c7b..8823f94f7 100644
+index b90979c7ba..8823f94f7b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -1,5 +1,6 @@
@@ -1661,7 +1661,7 @@ index b90979c7b..8823f94f7 100644
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index 3f55381c1..0d9a46680 100644
+index 3f55381c15..0d9a466809 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -1,9 +1,11 @@
@@ -1746,7 +1746,7 @@ index 3f55381c1..0d9a46680 100644
 -    // Spigot end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
-index e52ef47b7..3d90b3426 100644
+index e52ef47b78..3d90b34268 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftIconCache.java
 @@ -5,6 +5,7 @@ import org.bukkit.util.CachedServerIcon;
@@ -1758,7 +1758,7 @@ index e52ef47b7..3d90b3426 100644
          this.value = value;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index dd602243d..924ab7f54 100644
+index dd602243d3..924ab7f541 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -288,6 +288,13 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -1776,7 +1776,7 @@ index dd602243d..924ab7f54 100644
       * This helper class represents the different NBT Tags.
       * <p>
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index ca7789b5e..442383969 100644
+index ca7789b5e0..4423839697 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -31,7 +31,7 @@ import net.minecraft.server.EntityWither;
@@ -1837,5 +1837,5 @@ index ca7789b5e..442383969 100644
      }
  }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0025-Entity-Origin-API.patch
+++ b/Spigot-Server-Patches/0025-Entity-Origin-API.patch
@@ -1,11 +1,11 @@
-From fb38403a4cbabfe7fae4fb22f87cf076ed9e07b6 Mon Sep 17 00:00:00 2001
+From 8d953fb5d7e9a7f2f2435cf9b8c31ab55f8bd634 Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Tue, 1 Mar 2016 23:45:08 -0600
 Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 40dcb3125..5f85eb2ba 100644
+index 40dcb31258..5f85eb2ba2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -163,6 +163,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -51,7 +51,7 @@ index 40dcb3125..5f85eb2ba 100644
          NBTTagList nbttaglist = new NBTTagList();
          double[] adouble1 = adouble;
 diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
-index f8d8d8f35..0f9fa4113 100644
+index f8d8d8f353..0f9fa41133 100644
 --- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
 @@ -254,6 +254,14 @@ public class EntityFallingBlock extends Entity {
@@ -70,7 +70,7 @@ index f8d8d8f35..0f9fa4113 100644
  
      public void a(boolean flag) {
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index e988abd67..f2ee53ab9 100644
+index e988abd67c..f2ee53ab90 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 @@ -104,6 +104,14 @@ public class EntityTNTPrimed extends Entity {
@@ -89,7 +89,7 @@ index e988abd67..f2ee53ab9 100644
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/NBTTagList.java b/src/main/java/net/minecraft/server/NBTTagList.java
-index ce510c486..b7c94fe23 100644
+index ce510c4867..b7c94fe238 100644
 --- a/src/main/java/net/minecraft/server/NBTTagList.java
 +++ b/src/main/java/net/minecraft/server/NBTTagList.java
 @@ -161,6 +161,7 @@ public class NBTTagList extends NBTList<NBTBase> {
@@ -101,10 +101,10 @@ index ce510c486..b7c94fe23 100644
          if (i >= 0 && i < this.list.size()) {
              NBTBase nbtbase = (NBTBase) this.list.get(i);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 5320bdad9..809b17589 100644
+index ef9abdc28d..c13f92011e 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1153,6 +1153,11 @@ public class WorldServer extends World {
+@@ -1156,6 +1156,11 @@ public class WorldServer extends World {
                  this.H.add(((EntityInsentient) entity).getNavigation());
              }
              entity.valid = true; // CraftBukkit
@@ -117,7 +117,7 @@ index 5320bdad9..809b17589 100644
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 824becd27..7d9d0a1f7 100644
+index 824becd272..7d9d0a1f77 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1010,4 +1010,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -134,5 +134,5 @@ index 824becd27..7d9d0a1f7 100644
 +    // Paper end
  }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0034-Disable-thunder.patch
+++ b/Spigot-Server-Patches/0034-Disable-thunder.patch
@@ -1,11 +1,11 @@
-From 88643ab4d4256bf3554a9a2bccdf101c6a73c6f9 Mon Sep 17 00:00:00 2001
+From f4a563b9bb6fc4c886f4a499de3e11b0928e78d3 Mon Sep 17 00:00:00 2001
 From: Sudzzy <originmc@outlook.com>
 Date: Wed, 2 Mar 2016 14:52:43 -0600
 Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6a307d5dd..bf0cd6a8b 100644
+index 6a307d5dd6..bf0cd6a8b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -156,4 +156,9 @@ public class PaperWorldConfig {
@@ -19,10 +19,10 @@ index 6a307d5dd..bf0cd6a8b 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 809b17589..90826bc16 100644
+index c13f92011e..2d84c5e6f9 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -421,7 +421,7 @@ public class WorldServer extends World {
+@@ -424,7 +424,7 @@ public class WorldServer extends World {
          gameprofilerfiller.enter("thunder");
          BlockPosition blockposition;
  
@@ -32,5 +32,5 @@ index 809b17589..90826bc16 100644
              if (this.isRainingAt(blockposition)) {
                  DifficultyDamageScaler difficultydamagescaler = this.getDamageScaler(blockposition);
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
+++ b/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
@@ -1,11 +1,11 @@
-From 8aec945998fe44928e9fa013625fd6993908cdce Mon Sep 17 00:00:00 2001
+From 10e783b966965f109ce7d8edf94c773a7fff2267 Mon Sep 17 00:00:00 2001
 From: Sudzzy <originmc@outlook.com>
 Date: Wed, 2 Mar 2016 14:57:24 -0600
 Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bf0cd6a8b..8db5c3f3f 100644
+index bf0cd6a8b4..8db5c3f3fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -161,4 +161,9 @@ public class PaperWorldConfig {
@@ -19,10 +19,10 @@ index bf0cd6a8b..8db5c3f3f 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 90826bc16..b87d4d1bd 100644
+index 2d84c5e6f9..9928e5aab7 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -441,7 +441,7 @@ public class WorldServer extends World {
+@@ -444,7 +444,7 @@ public class WorldServer extends World {
          }
  
          gameprofilerfiller.exitEnter("iceandsnow");
@@ -32,5 +32,5 @@ index 90826bc16..b87d4d1bd 100644
              BlockPosition blockposition1 = blockposition.down();
              BiomeBase biomebase = this.getBiome(blockposition);
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0050-Change-implementation-of-tile-entity-removal-list.patch
+++ b/Spigot-Server-Patches/0050-Change-implementation-of-tile-entity-removal-list.patch
@@ -1,4 +1,4 @@
-From 1eccbe939abff45b26650e89f4db915f53c5b36b Mon Sep 17 00:00:00 2001
+From dd0db11122691ff1924e355426213c49f300506d Mon Sep 17 00:00:00 2001
 From: Joseph Hirschfeld <joe@ibj.io>
 Date: Thu, 3 Mar 2016 02:39:54 -0600
 Subject: [PATCH] Change implementation of (tile)entity removal list
@@ -6,7 +6,7 @@ Subject: [PATCH] Change implementation of (tile)entity removal list
 use sets for faster removal
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f5590f5ab2..d80497e993 100644
+index da049cefe4..76704abda1 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -40,7 +40,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -16,8 +16,8 @@ index f5590f5ab2..d80497e993 100644
 -    protected final List<TileEntity> tileEntityListUnload = Lists.newArrayList();
 +    protected final java.util.Set<TileEntity> tileEntityListUnload = com.google.common.collect.Sets.newHashSet(); // Paper
      private final long b = 16777215L;
-     private final Thread serverThread;
+     final Thread serverThread; // CraftBukkit - package private
      private int u;
 -- 
-2.22.0
+2.22.1
 

--- a/Spigot-Server-Patches/0066-Add-World-Util-Methods.patch
+++ b/Spigot-Server-Patches/0066-Add-World-Util-Methods.patch
@@ -1,4 +1,4 @@
-From b049e61067c54dcf37d13269adc3c886c08ed1b7 Mon Sep 17 00:00:00 2001
+From 85561da6e86d037f623b9cf78ca338fe3ba56913 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 18 Mar 2016 20:16:03 -0400
 Subject: [PATCH] Add World Util Methods
@@ -18,13 +18,13 @@ index 6c13ae3bae..77d6d5e6eb 100644
          return this.a(blockposition, i, this.world.getWorldProvider().g());
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 6e7f72a1a4..b1a3717d30 100644
+index ce723c62e1..ea5905817a 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -46,7 +46,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
      protected final java.util.Set<TileEntity> tileEntityListUnload = com.google.common.collect.Sets.newHashSet(); // Paper
      private final long b = 16777215L;
-     private final Thread serverThread;
+     final Thread serverThread; // CraftBukkit - package private
 -    private int u;
 +    private int u; public int getSkylightSubtracted() { return this.u; } public void setSkylightSubtracted(int value) { this.u = value;} // Paper - OBFHELPER
      protected int i = (new Random()).nextInt();
@@ -98,5 +98,5 @@ index 4cf31207e0..1388610a7b 100644
          return (double) (blockposition.getX() + 1) > this.c() && (double) blockposition.getX() < this.e() && (double) (blockposition.getZ() + 1) > this.d() && (double) blockposition.getZ() < this.f();
      }
 -- 
-2.22.0
+2.22.1
 

--- a/Spigot-Server-Patches/0071-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/Spigot-Server-Patches/0071-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -1,11 +1,11 @@
-From c07780fbe52b9fed4ef5c94b4b2b7a30b22c81f1 Mon Sep 17 00:00:00 2001
+From 6be5c15bf9056637e470005f923c1a23563cb389 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 22 Mar 2016 12:04:28 -0500
 Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 98049567f..2a71381da 100644
+index 98049567f4..2a71381dae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -221,4 +221,12 @@ public class PaperWorldConfig {
@@ -22,10 +22,10 @@ index 98049567f..2a71381da 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index b87d4d1bd..df3a9340a 100644
+index 9928e5aab7..d3039c2fd9 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -425,7 +425,7 @@ public class WorldServer extends World {
+@@ -428,7 +428,7 @@ public class WorldServer extends World {
              blockposition = this.a(this.a(j, 0, k, 15));
              if (this.isRainingAt(blockposition)) {
                  DifficultyDamageScaler difficultydamagescaler = this.getDamageScaler(blockposition);
@@ -35,5 +35,5 @@ index b87d4d1bd..df3a9340a 100644
                  if (flag1) {
                      EntityHorseSkeleton entityhorseskeleton = (EntityHorseSkeleton) EntityTypes.SKELETON_HORSE.a((World) this);
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0075-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/Spigot-Server-Patches/0075-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -1,14 +1,14 @@
-From b5102f4d7cba9a8db55efeaf0e9cacbf0b7357bc Mon Sep 17 00:00:00 2001
+From 2db5f37a634e2d54cf102d794fa1628bcf79f4a3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:32:58 -0400
 Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 559dee777..00b1f21f7 100644
+index dfb8a70a2c..835428e839 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1121,7 +1121,7 @@ public class WorldServer extends World {
+@@ -1124,7 +1124,7 @@ public class WorldServer extends World {
          if (entity instanceof EntityInsentient) {
              this.H.remove(((EntityInsentient) entity).getNavigation());
          }
@@ -17,7 +17,7 @@ index 559dee777..00b1f21f7 100644
          entity.valid = false; // CraftBukkit
      }
  
-@@ -1159,6 +1159,7 @@ public class WorldServer extends World {
+@@ -1162,6 +1162,7 @@ public class WorldServer extends World {
                  entity.origin = entity.getBukkitEntity().getLocation();
              }
              // Paper end
@@ -26,5 +26,5 @@ index 559dee777..00b1f21f7 100644
  
      }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0089-Remove-unused-World-Tile-Entity-List.patch
+++ b/Spigot-Server-Patches/0089-Remove-unused-World-Tile-Entity-List.patch
@@ -1,4 +1,4 @@
-From 1cb90c9495b0cf6d32c6ef54bc903254dc6e868d Mon Sep 17 00:00:00 2001
+From 0ee56a69b369639630bf92c98b166b3171579e94 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 13 Apr 2016 00:25:28 -0400
 Subject: [PATCH] Remove unused World Tile Entity List
@@ -6,7 +6,7 @@ Subject: [PATCH] Remove unused World Tile Entity List
 Massive hit to performance and it is completely unnecessary.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 07d150586..ebeb48f6d 100644
+index 38abe7cf34..fccc85ff82 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -40,7 +40,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -67,10 +67,10 @@ index 07d150586..ebeb48f6d 100644
              }
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 00b1f21f7..f9398af90 100644
+index 835428e839..5a6b82dbc3 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1607,7 +1607,7 @@ public class WorldServer extends World {
+@@ -1610,7 +1610,7 @@ public class WorldServer extends World {
              }
  
              bufferedwriter.write(String.format("entities: %d\n", this.entitiesById.size()));
@@ -79,7 +79,7 @@ index 00b1f21f7..f9398af90 100644
              bufferedwriter.write(String.format("block_ticks: %d\n", this.getBlockTickList().a()));
              bufferedwriter.write(String.format("fluid_ticks: %d\n", this.getFluidTickList().a()));
              bufferedwriter.write("distance_manager: " + playerchunkmap.e().c() + "\n");
-@@ -1770,7 +1770,7 @@ public class WorldServer extends World {
+@@ -1773,7 +1773,7 @@ public class WorldServer extends World {
  
      private void a(Writer writer) throws IOException {
          CSVWriter csvwriter = CSVWriter.a().a("x").a("y").a("z").a("type").a(writer);
@@ -89,5 +89,5 @@ index 00b1f21f7..f9398af90 100644
          while (iterator.hasNext()) {
              TileEntity tileentity = (TileEntity) iterator.next();
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0099-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/Spigot-Server-Patches/0099-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -1,4 +1,4 @@
-From 1d9603e1481c68275addf827aab56a2c08b0d6ef Mon Sep 17 00:00:00 2001
+From 4a24d933c3d86830cce8e1c055cf62512d538e5d Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 29 Apr 2016 20:02:00 -0400
 Subject: [PATCH] Improve Maps (in item frames) performance and bug fixes
@@ -13,7 +13,7 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 9bddbd8a8..4ceac0a2f 100644
+index 9bddbd8a88..4ceac0a2ff 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -605,6 +605,12 @@ public abstract class EntityHuman extends EntityLiving {
@@ -30,7 +30,7 @@ index 9bddbd8a8..4ceac0a2f 100644
              return entityitem;
          }
 diff --git a/src/main/java/net/minecraft/server/WorldMap.java b/src/main/java/net/minecraft/server/WorldMap.java
-index fc0815893..090d3dbd3 100644
+index fc08158937..090d3dbd31 100644
 --- a/src/main/java/net/minecraft/server/WorldMap.java
 +++ b/src/main/java/net/minecraft/server/WorldMap.java
 @@ -31,6 +31,7 @@ public class WorldMap extends PersistentBase {
@@ -102,10 +102,10 @@ index fc0815893..090d3dbd3 100644
              for ( org.bukkit.map.MapCursor cursor : render.cursors) {
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index caa281087..d7166d983 100644
+index 5a6b82dbc3..d50e804102 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1083,6 +1083,7 @@ public class WorldServer extends World {
+@@ -1086,6 +1086,7 @@ public class WorldServer extends World {
                          {
                              if ( iter.next().trackee == entity )
                              {
@@ -114,7 +114,7 @@ index caa281087..d7166d983 100644
                              }
                          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/map/RenderData.java b/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
-index 256a13178..5768cd512 100644
+index 256a131781..5768cd512e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/map/RenderData.java
 @@ -5,7 +5,7 @@ import org.bukkit.map.MapCursor;
@@ -127,5 +127,5 @@ index 256a13178..5768cd512 100644
  
      public RenderData() {
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0109-Fix-Double-World-Add-issues.patch
+++ b/Spigot-Server-Patches/0109-Fix-Double-World-Add-issues.patch
@@ -1,4 +1,4 @@
-From 55cfafe4a286ad5817f1d099776dd1ebd3dab855 Mon Sep 17 00:00:00 2001
+From 55251a666bc4d1120c00d23ad77ee7caf7d757ed Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 21 Jun 2016 22:54:34 -0400
 Subject: [PATCH] Fix Double World Add issues
@@ -8,10 +8,10 @@ Vanilla will double add Spider Jockeys to the world, so ignore already added.
 Also add debug if something else tries to, and abort before world gets bad state
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index d7166d983..3adb43b35 100644
+index d50e804102..71130dd2e4 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -972,6 +972,7 @@ public class WorldServer extends World {
+@@ -975,6 +975,7 @@ public class WorldServer extends World {
      // CraftBukkit start
      private boolean addEntity0(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
          org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot
@@ -20,5 +20,5 @@ index d7166d983..3adb43b35 100644
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getName(entity.getEntityType())); // CraftBukkit
              return false;
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0118-Chunk-registration-fixes.patch
+++ b/Spigot-Server-Patches/0118-Chunk-registration-fixes.patch
@@ -1,4 +1,4 @@
-From 85b0ff96e3129966a8c942376e83a27e0671342d Mon Sep 17 00:00:00 2001
+From 63e3abede167a6ad15b8d1038272539970038de2 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 21 Sep 2016 22:54:28 -0400
 Subject: [PATCH] Chunk registration fixes
@@ -8,10 +8,10 @@ World checks and the Chunk Add logic are inconsistent on how Y > 256, < 0, is tr
 Keep them consistent
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 3adb43b35..5d529fccf 100644
+index 71130dd2e4..491c9c9170 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -661,7 +661,7 @@ public class WorldServer extends World {
+@@ -664,7 +664,7 @@ public class WorldServer extends World {
      public void chunkCheck(Entity entity) {
          this.getMethodProfiler().enter("chunkCheck");
          int i = MathHelper.floor(entity.locX / 16.0D);
@@ -21,5 +21,5 @@ index 3adb43b35..5d529fccf 100644
  
          if (!entity.inChunk || entity.chunkX != i || entity.chunkY != j || entity.chunkZ != k) {
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0200-Extend-Player-Interact-cancellation.patch
+++ b/Spigot-Server-Patches/0200-Extend-Player-Interact-cancellation.patch
@@ -1,4 +1,4 @@
-From 690247761e27ecdc269add52468d5858c76a571e Mon Sep 17 00:00:00 2001
+From 834cacda9a16782a8247a1e451c3debe61526423 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 11 Feb 2018 10:43:46 +0000
 Subject: [PATCH] Extend Player Interact cancellation
@@ -13,7 +13,7 @@ Update adjacent blocks of doors, double plants, pistons and beds
 when cancelling interaction.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index bce3844dd..8b30b7d4e 100644
+index 10aa7da31f..aa139aee0e 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -136,6 +136,11 @@ public class PlayerInteractManager {
@@ -28,7 +28,7 @@ index bce3844dd..8b30b7d4e 100644
                      this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition));
                      // Update any tile entity data for this block
                      TileEntity tileentity = this.world.getTileEntity(blockposition);
-@@ -440,7 +445,25 @@ public class PlayerInteractManager {
+@@ -439,7 +444,25 @@ public class PlayerInteractManager {
                  ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, bottom ? blockposition.up() : blockposition.down()));
              } else if (iblockdata.getBlock() instanceof BlockCake) {
                  ((EntityPlayer) entityhuman).getBukkitEntity().sendHealthUpdate(); // SPIGOT-1341 - reset health for cake
@@ -55,5 +55,5 @@ index bce3844dd..8b30b7d4e 100644
              enuminteractionresult = (event.useItemInHand() != Event.Result.ALLOW) ? EnumInteractionResult.SUCCESS : EnumInteractionResult.PASS;
          } else if (this.gamemode == EnumGamemode.SPECTATOR) {
 -- 
-2.22.0
+2.22.1
 

--- a/Spigot-Server-Patches/0222-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-Server-Patches/0222-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -1,4 +1,4 @@
-From 4d5c45c92d173a5b81f4304e5f4be3910499c7f1 Mon Sep 17 00:00:00 2001
+From df81ea15793dde7a234a4e8941be57a3bab1d646 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 15 Aug 2017 22:29:12 -0400
 Subject: [PATCH] Expand World.spawnParticle API and add Builder
@@ -10,7 +10,7 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 6c02e7782..86470d9b9 100644
+index 491c9c9170..b9015cb8a7 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -53,7 +53,7 @@ public class WorldServer extends World {
@@ -22,7 +22,7 @@ index 6c02e7782..86470d9b9 100644
      boolean tickingEntities;
      private final MinecraftServer server;
      private final WorldNBTStorage dataManager;
-@@ -1379,12 +1379,17 @@ public class WorldServer extends World {
+@@ -1382,12 +1382,17 @@ public class WorldServer extends World {
      }
  
      public <T extends ParticleParam> int sendParticles(EntityPlayer sender, T t0, double d0, double d1, double d2, int i, double d3, double d4, double d5, double d6, boolean force) {
@@ -43,7 +43,7 @@ index 6c02e7782..86470d9b9 100644
  
              if (this.a(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0e4f4cda0..3726f240c 100644
+index 0e4f4cda0b..3726f240ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2199,11 +2199,17 @@ public class CraftWorld implements World {
@@ -66,5 +66,5 @@ index 0e4f4cda0..3726f240c 100644
                  x, y, z, // Position
                  count,  // Count
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0245-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0245-InventoryCloseEvent-Reason-API.patch
@@ -1,4 +1,4 @@
-From 8c2f7bec5aa112c73e48a639cb1d54e7b8850060 Mon Sep 17 00:00:00 2001
+From b9340661c573f178bfcce53125e5a3346d06a830 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Tue, 3 Jul 2018 21:56:23 -0400
 Subject: [PATCH] InventoryCloseEvent Reason API
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index e1bd10579..89915b359 100644
+index e1bd10579e..89915b3599 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -164,7 +164,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -34,7 +34,7 @@ index e1bd10579..89915b359 100644
          this.activeContainer = this.defaultContainer;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 88bc8b531..1bb580e0e 100644
+index 88bc8b5312..1bb580e0e7 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -362,7 +362,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -88,7 +88,7 @@ index 88bc8b531..1bb580e0e 100644
          this.m();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 89beac63a..b9793d4cc 100644
+index 89beac63aa..b9793d4cc6 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -2025,7 +2025,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -101,7 +101,7 @@ index 89beac63a..b9793d4cc 100644
          this.player.m();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index a167843bf..9e5cd22d7 100644
+index a167843bfb..9e5cd22d7d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -402,7 +402,7 @@ public abstract class PlayerList {
@@ -114,10 +114,10 @@ index a167843bf..9e5cd22d7 100644
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
          cserver.getPluginManager().callEvent(playerQuitEvent);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index a7a6e01d2..ef4ce57cc 100644
+index b9015cb8a7..6ca7c88583 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1025,7 +1025,7 @@ public class WorldServer extends World {
+@@ -1028,7 +1028,7 @@ public class WorldServer extends World {
                  {
                      if ( h instanceof org.bukkit.craftbukkit.entity.CraftHumanEntity )
                      {
@@ -126,7 +126,7 @@ index a7a6e01d2..ef4ce57cc 100644
                      }
                  }
              }
-@@ -1048,7 +1048,7 @@ public class WorldServer extends World {
+@@ -1051,7 +1051,7 @@ public class WorldServer extends World {
                      {
                          if ( h instanceof org.bukkit.craftbukkit.entity.CraftHumanEntity )
                          {
@@ -136,7 +136,7 @@ index a7a6e01d2..ef4ce57cc 100644
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 77efc43a5..81cf5f47a 100644
+index 77efc43a5d..81cf5f47a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -619,8 +619,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -155,7 +155,7 @@ index 77efc43a5..81cf5f47a 100644
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e610c8aae..ce35e6bbc 100644
+index e610c8aaed..ce35e6bbc2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -781,7 +781,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -168,7 +168,7 @@ index e610c8aae..ce35e6bbc 100644
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8bd1dedcc..ade1d42f7 100644
+index 8bd1dedcca..ade1d42f7e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1288,8 +1288,19 @@ public class CraftEventFactory {
@@ -193,5 +193,5 @@ index 8bd1dedcc..ade1d42f7 100644
          human.activeContainer.transferTo(human.defaultContainer, human.getBukkitEntity());
      }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0250-Re-add-vanilla-entity-warnings-for-duplicates.patch
+++ b/Spigot-Server-Patches/0250-Re-add-vanilla-entity-warnings-for-duplicates.patch
@@ -1,4 +1,4 @@
-From 65273b49cfa0d43498b5dd362069fbdd3f52b684 Mon Sep 17 00:00:00 2001
+From 6b56755e6bff6f4dab389d70ca877f4b0d2ee376 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Thu, 19 Jul 2018 01:08:05 -0400
 Subject: [PATCH] Re-add vanilla entity warnings for duplicates
@@ -8,10 +8,10 @@ These are a critical sign that somethin went wrong, and you've lost some data...
 We should kind of know about these things you know.
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index ef4ce57cc..b00247fb4 100644
+index 6ca7c88583..3671b44feb 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1010,7 +1010,8 @@ public class WorldServer extends World {
+@@ -1013,7 +1013,8 @@ public class WorldServer extends World {
          if (entity1 == null) {
              return false;
          } else {
@@ -22,5 +22,5 @@ index ef4ce57cc..b00247fb4 100644
          }
      }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0254-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/Spigot-Server-Patches/0254-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -1,4 +1,4 @@
-From bcf3e971af575b53e22af78ec5267ba758d35ad8 Mon Sep 17 00:00:00 2001
+From 6315f15c7212c50a763b23a1b28ac784a7987dc3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 21 Jul 2018 08:25:40 -0400
 Subject: [PATCH] Add Debug Entities option to debug dupe uuid issues
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Debug Entities option to debug dupe uuid issues
 Add -Ddebug.entities=true to your JVM flags to gain more information
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 6ada92379..924187413 100644
+index 6ada923797..9241874139 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -75,6 +75,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -19,7 +19,7 @@ index 6ada92379..924187413 100644
          if (bukkitEntity == null) {
              bukkitEntity = CraftEntity.getEntity(world.getServer(), this);
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index e6c55d87b..6379d2d84 100644
+index e6c55d87b4..6379d2d84f 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1014,6 +1014,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -40,7 +40,7 @@ index e6c55d87b..6379d2d84 100644
  
      protected void g() {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index e780f7af4..627fec10a 100644
+index 6226a8c1a5..95c809ba95 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -68,6 +68,7 @@ public abstract class World implements IIBlockAccess, GeneratorAccess, AutoClose
@@ -52,7 +52,7 @@ index e780f7af4..627fec10a 100644
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index b00247fb4..c31fd30f9 100644
+index 3671b44feb..a5ba64a4c9 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -73,6 +73,9 @@ public class WorldServer extends World {
@@ -65,7 +65,7 @@ index b00247fb4..c31fd30f9 100644
  
      // Add env and gen to constructor
      public WorldServer(MinecraftServer minecraftserver, Executor executor, WorldNBTStorage worldnbtstorage, WorldData worlddata, DimensionManager dimensionmanager, GameProfilerFiller gameprofilerfiller, WorldLoadListener worldloadlistener, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
-@@ -972,8 +975,28 @@ public class WorldServer extends World {
+@@ -975,8 +978,28 @@ public class WorldServer extends World {
      // CraftBukkit start
      private boolean addEntity0(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
          org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot
@@ -95,7 +95,7 @@ index b00247fb4..c31fd30f9 100644
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getName(entity.getEntityType())); // CraftBukkit
              return false;
          } else if (this.isUUIDTaken(entity)) {
-@@ -1145,7 +1168,24 @@ public class WorldServer extends World {
+@@ -1148,7 +1171,24 @@ public class WorldServer extends World {
                  }
              }
  
@@ -122,5 +122,5 @@ index b00247fb4..c31fd30f9 100644
              // CraftBukkit start - SPIGOT-5278
              if (entity instanceof EntityDrowned) {
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0268-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0268-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -1,4 +1,4 @@
-From dd8e96e8cbe2211dc726c31d5bc0e86689214b04 Mon Sep 17 00:00:00 2001
+From a3d4cf323907ffaa92c7a1880fec59bbf2e7482a Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 28 Jul 2018 12:18:27 -0400
 Subject: [PATCH] Ignore Dead Entities in entityList iteration
@@ -11,7 +11,7 @@ This will ensure that dead entities are skipped from iteration since
 they shouldn't of been in the list in the first place.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index eecf27370..d704fc79c 100644
+index eecf27370b..d704fc79c0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -179,6 +179,7 @@ public class PaperCommand extends Command {
@@ -23,7 +23,7 @@ index eecf27370..d704fc79c 100644
                      MutablePair<Integer, Map<ChunkCoordIntPair, Integer>> info = list.computeIfAbsent(key, k -> MutablePair.of(0, Maps.newHashMap()));
                      ChunkCoordIntPair chunk = new ChunkCoordIntPair(e.getChunkX(), e.getChunkZ());
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index a74e389d1..09e010e67 100644
+index a74e389d14..09e010e670 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -678,6 +678,7 @@ public class Chunk implements IChunkAccess {
@@ -51,7 +51,7 @@ index a74e389d1..09e010e67 100644
                  if (oclass.isInstance(t0) && t0.getBoundingBox().c(axisalignedbb) && (predicate == null || predicate.test(t0))) { // Spigot - instance check
                      list.add(t0);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 701090c11..7d579c119 100644
+index 701090c11e..7d579c119b 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -126,6 +126,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -63,10 +63,10 @@ index 701090c11..7d579c119 100644
      private float av;
      private float aw;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 107a50011..9683b8708 100644
+index a5ba64a4c9..6c55ae1a9f 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -883,7 +883,7 @@ public class WorldServer extends World {
+@@ -886,7 +886,7 @@ public class WorldServer extends World {
  
          while (objectiterator.hasNext()) {
              Entity entity = (Entity) objectiterator.next();
@@ -75,7 +75,7 @@ index 107a50011..9683b8708 100644
              if (entity instanceof EntityInsentient) {
                  EntityInsentient entityinsentient = (EntityInsentient) entity;
  
-@@ -1202,6 +1202,7 @@ public class WorldServer extends World {
+@@ -1205,6 +1205,7 @@ public class WorldServer extends World {
                  entity.origin = entity.getBukkitEntity().getLocation();
              }
              // Paper end
@@ -83,7 +83,7 @@ index 107a50011..9683b8708 100644
              new com.destroystokyo.paper.event.entity.EntityAddToWorldEvent(entity.getBukkitEntity()).callEvent(); // Paper - fire while valid
          }
  
-@@ -1214,6 +1215,7 @@ public class WorldServer extends World {
+@@ -1217,6 +1218,7 @@ public class WorldServer extends World {
              this.removeEntityFromChunk(entity);
              this.entitiesById.remove(entity.getId());
              this.unregisterEntity(entity);
@@ -92,7 +92,7 @@ index 107a50011..9683b8708 100644
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 67137d69c..01b869a06 100644
+index 67137d69c1..01b869a06f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -965,6 +965,7 @@ public class CraftWorld implements World {
@@ -128,5 +128,5 @@ index 67137d69c..01b869a06 100644
  
                  if (bukkitEntity == null) {
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0286-Send-nearby-packets-from-world-player-list-not-serve.patch
+++ b/Spigot-Server-Patches/0286-Send-nearby-packets-from-world-player-list-not-serve.patch
@@ -1,11 +1,11 @@
-From 7249b87fe4fdebfdcb3baaa2013a514b8ca09e5b Mon Sep 17 00:00:00 2001
+From ca03c7262701704ccf28cc21a909c752ca1b9c19 Mon Sep 17 00:00:00 2001
 From: Mystiflow <mystiflow@gmail.com>
 Date: Fri, 6 Jul 2018 13:21:30 +0100
 Subject: [PATCH] Send nearby packets from world player list not server list
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 9e5cd22d7..049d702cb 100644
+index 9e5cd22d7d..049d702cb9 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -922,8 +922,25 @@ public abstract class PlayerList {
@@ -46,10 +46,10 @@ index 9e5cd22d7..049d702cb 100644
                  double d5 = d1 - entityplayer.locY;
                  double d6 = d2 - entityplayer.locZ;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 9683b8708..21d2965a1 100644
+index 6c55ae1a9f..8b55879c64 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1248,7 +1248,7 @@ public class WorldServer extends World {
+@@ -1251,7 +1251,7 @@ public class WorldServer extends World {
          }
          // CraftBukkit end
          this.globalEntityList.add(entitylightning);
@@ -58,7 +58,7 @@ index 9683b8708..21d2965a1 100644
      }
  
      @Override
-@@ -1380,7 +1380,7 @@ public class WorldServer extends World {
+@@ -1383,7 +1383,7 @@ public class WorldServer extends World {
              BlockActionData blockactiondata = (BlockActionData) this.I.removeFirst();
  
              if (this.a(blockactiondata)) {
@@ -68,7 +68,7 @@ index 9683b8708..21d2965a1 100644
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 01b869a06..f57023529 100644
+index 01b869a06f..f57023529d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2034,7 +2034,7 @@ public class CraftWorld implements World {
@@ -81,5 +81,5 @@ index 01b869a06..f57023529 100644
  
      private static Map<String, GameRules.GameRuleKey<?>> gamerules;
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0322-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0322-Limit-lightning-strike-effect-distance.patch
@@ -1,11 +1,11 @@
-From 6ad660099cf2b56fd5e6f98ba2146563f0fa8d5c Mon Sep 17 00:00:00 2001
+From 290df5e30a0c066bc69fabaa9b202e1ab2352b4a Mon Sep 17 00:00:00 2001
 From: Trigary <trigary0@gmail.com>
 Date: Fri, 14 Sep 2018 17:42:08 +0200
 Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7e031d18e..63f313a92 100644
+index 7e031d18e0..63f313a92d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -234,6 +234,28 @@ public class PaperWorldConfig {
@@ -38,7 +38,7 @@ index 7e031d18e..63f313a92 100644
      public int fixedInhabitedTime;
      private void fixedInhabitedTime() {
 diff --git a/src/main/java/net/minecraft/server/EntityLightning.java b/src/main/java/net/minecraft/server/EntityLightning.java
-index 2ceee79cf..27bf271bb 100644
+index 2ceee79cf2..27bf271bb5 100644
 --- a/src/main/java/net/minecraft/server/EntityLightning.java
 +++ b/src/main/java/net/minecraft/server/EntityLightning.java
 @@ -64,6 +64,17 @@ public class EntityLightning extends Entity {
@@ -69,10 +69,10 @@ index 2ceee79cf..27bf271bb 100644
  
          --this.lifeTicks;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 21d2965a1..c9fe8074e 100644
+index 8b55879c64..dbd357f1a3 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1248,7 +1248,7 @@ public class WorldServer extends World {
+@@ -1251,7 +1251,7 @@ public class WorldServer extends World {
          }
          // CraftBukkit end
          this.globalEntityList.add(entitylightning);
@@ -82,5 +82,5 @@ index 21d2965a1..c9fe8074e 100644
  
      @Override
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0344-Prevent-rayTrace-from-loading-chunks.patch
+++ b/Spigot-Server-Patches/0344-Prevent-rayTrace-from-loading-chunks.patch
@@ -1,4 +1,4 @@
-From cb816e21011991926e56dea616532d8df8f10a92 Mon Sep 17 00:00:00 2001
+From ff3dab598aaddf30e1de92362c108cefd4556caf Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 26 Nov 2018 19:21:58 -0500
 Subject: [PATCH] Prevent rayTrace from loading chunks
@@ -7,16 +7,16 @@ ray tracing into an unloaded chunk should be treated as a miss
 this saves a ton of lag for when AI tries to raytrace near unloaded chunks.
 
 diff --git a/src/main/java/net/minecraft/server/IBlockAccess.java b/src/main/java/net/minecraft/server/IBlockAccess.java
-index 577b227758..c5586e44d4 100644
+index 0dff023529..29cdc00875 100644
 --- a/src/main/java/net/minecraft/server/IBlockAccess.java
 +++ b/src/main/java/net/minecraft/server/IBlockAccess.java
 @@ -41,7 +41,15 @@ public interface IBlockAccess {
  
-     default MovingObjectPositionBlock rayTrace(RayTrace raytrace) {
-         return (MovingObjectPositionBlock) a(raytrace, (raytrace1, blockposition) -> {
+     // CraftBukkit start - moved block handling into separate method for use by Block#rayTrace
+     default MovingObjectPositionBlock rayTraceBlock(RayTrace raytrace1, BlockPosition blockposition) {
 -            IBlockData iblockdata = this.getType(blockposition);
 +            // Paper start - Prevent raytrace from loading chunks
-+            IBlockData iblockdata = ((World)this).getTypeIfLoaded(blockposition);
++            IBlockData iblockdata = this.getTypeIfLoaded(blockposition);
 +            if (iblockdata == null) {
 +                // copied the last function parameter (listed below)
 +                Vec3D vec3d = raytrace1.b().d(raytrace1.a());
@@ -28,5 +28,5 @@ index 577b227758..c5586e44d4 100644
              Vec3D vec3d = raytrace1.b();
              Vec3D vec3d1 = raytrace1.a();
 -- 
-2.22.0
+2.22.1
 

--- a/Spigot-Server-Patches/0366-Entity-getEntitySpawnReason.patch
+++ b/Spigot-Server-Patches/0366-Entity-getEntitySpawnReason.patch
@@ -1,4 +1,4 @@
-From fa41eb7ea98ff18dbe84236565c9bcb99a1201d5 Mon Sep 17 00:00:00 2001
+From 0231190c616327c55a18f288e22e0a0f383c5073 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 24 Mar 2019 00:24:52 -0400
 Subject: [PATCH] Entity#getEntitySpawnReason
@@ -10,7 +10,7 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 046e7e031..f87514a20 100644
+index 046e7e031c..f87514a200 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -68,6 +68,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -59,7 +59,7 @@ index 046e7e031..f87514a20 100644
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 65df0e7c8..abddc8895 100644
+index 65df0e7c8c..abddc8895e 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -250,7 +250,7 @@ public abstract class PlayerList {
@@ -72,10 +72,10 @@ index 65df0e7c8..abddc8895 100644
              });
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 82e6defdd..408bde5ca 100644
+index dbd357f1a3..628ad8b839 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -975,6 +975,7 @@ public class WorldServer extends World {
+@@ -978,6 +978,7 @@ public class WorldServer extends World {
      // CraftBukkit start
      private boolean addEntity0(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
          org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot
@@ -84,7 +84,7 @@ index 82e6defdd..408bde5ca 100644
          if (entity.valid) {
              MinecraftServer.LOGGER.error("Attempted Double World add on " + entity, new Throwable());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 517e42218..31db42e9f 100644
+index 517e422180..31db42e9fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1054,5 +1054,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -99,5 +99,5 @@ index 517e42218..31db42e9f 100644
      // Paper end
  }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0382-Fix-issues-with-entity-loss-due-to-unloaded-chunks.patch
+++ b/Spigot-Server-Patches/0382-Fix-issues-with-entity-loss-due-to-unloaded-chunks.patch
@@ -1,4 +1,4 @@
-From 62b6f06b1b5058350a704386051fe072e97a5b52 Mon Sep 17 00:00:00 2001
+From 42147b7cc99cfae2e2f4ba937be928a59b63f0b5 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 28 Sep 2018 21:49:53 -0400
 Subject: [PATCH] Fix issues with entity loss due to unloaded chunks
@@ -19,10 +19,10 @@ This change ensures the chunks are always loaded when entities are
 added to the world, or a valid entity moves between chunks.
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 408bde5ca..c31a212b4 100644
+index 628ad8b839..cc2c139904 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -672,7 +672,7 @@ public class WorldServer extends World {
+@@ -675,7 +675,7 @@ public class WorldServer extends World {
                  this.getChunkAt(entity.chunkX, entity.chunkZ).a(entity, entity.chunkY);
              }
  
@@ -31,7 +31,7 @@ index 408bde5ca..c31a212b4 100644
                  entity.inChunk = false;
              } else {
                  this.getChunkAt(i, k).a(entity);
-@@ -1007,7 +1007,7 @@ public class WorldServer extends World {
+@@ -1010,7 +1010,7 @@ public class WorldServer extends World {
                  return false;
              }
              // CraftBukkit end
@@ -41,5 +41,5 @@ index 408bde5ca..c31a212b4 100644
              if (!(ichunkaccess instanceof Chunk)) {
                  return false;
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0383-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0383-Duplicate-UUID-Resolve-Option.patch
@@ -1,4 +1,4 @@
-From bb045e1938c68fd56fb190ee740958d5d51a87a6 Mon Sep 17 00:00:00 2001
+From eb815c41725bd643d265dc37cece57e817062735 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 21 Jul 2018 14:27:34 -0400
 Subject: [PATCH] Duplicate UUID Resolve Option
@@ -33,7 +33,7 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 91c809b7c..d8bb13693 100644
+index 91c809b7ce..d8bb13693d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -444,4 +444,43 @@ public class PaperWorldConfig {
@@ -81,7 +81,7 @@ index 91c809b7c..d8bb13693 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 09e010e67..ee8f80174 100644
+index 09e010e670..ee8f801745 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -397,6 +397,7 @@ public class Chunk implements IChunkAccess {
@@ -93,7 +93,7 @@ index 09e010e67..ee8f80174 100644
  
          int k = MathHelper.floor(entity.locY / 16.0D);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index f87514a20..55c73ffca 100644
+index f87514a200..55c73ffcaa 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2728,6 +2728,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -105,7 +105,7 @@ index f87514a20..55c73ffca 100644
          this.uniqueID = uuid;
          this.ap = this.uniqueID.toString();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 6379d2d84..67d011745 100644
+index 6379d2d84f..67d011745f 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,6 +1,7 @@
@@ -196,7 +196,7 @@ index 6379d2d84..67d011745 100644
  
                      if (list != null) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c31a212b4..3f853e987 100644
+index cc2c139904..29bb795f73 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -208,7 +208,7 @@ index c31a212b4..3f853e987 100644
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Queues;
-@@ -1034,8 +1036,23 @@ public class WorldServer extends World {
+@@ -1037,8 +1039,23 @@ public class WorldServer extends World {
          if (entity1 == null) {
              return false;
          } else {
@@ -234,7 +234,7 @@ index c31a212b4..3f853e987 100644
              return true;
          }
      }
-@@ -1174,7 +1191,7 @@ public class WorldServer extends World {
+@@ -1177,7 +1194,7 @@ public class WorldServer extends World {
              }
  
              Entity old = this.entitiesByUUID.put(entity.getUniqueID(), entity);
@@ -244,5 +244,5 @@ index c31a212b4..3f853e987 100644
                  logger.error("Overwrote an existing entity " + old + " with " + entity);
                  if (DEBUG_ENTITIES) {
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0385-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0385-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -1,4 +1,4 @@
-From 1cc52ceff74ca390385e08a4f78d0bba92cde07c Mon Sep 17 00:00:00 2001
+From a2f4e3de9bff7e6420d243a41c2ae929178636f3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 13 Sep 2014 23:14:43 -0400
 Subject: [PATCH] Configurable Keep Spawn Loaded range per world
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d8bb13693..de11a91af 100644
+index d8bb13693d..de11a91af6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -483,4 +483,10 @@ public class PaperWorldConfig {
@@ -21,7 +21,7 @@ index d8bb13693..de11a91af 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ee0200170..a6f112bd0 100644
+index ee02001700..a6f112bd0f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -577,6 +577,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -72,7 +72,7 @@ index ee0200170..a6f112bd0 100644
          // CraftBukkit start
          // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListener.java b/src/main/java/net/minecraft/server/WorldLoadListener.java
-index d6762d385..7b6f5b2da 100644
+index d6762d3853..7b6f5b2da0 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListener.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListener.java
 @@ -9,4 +9,6 @@ public interface WorldLoadListener {
@@ -83,7 +83,7 @@ index d6762d385..7b6f5b2da 100644
 +    void setChunkRadius(int radius); // Paper - allow changing chunk radius
  }
 diff --git a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
-index 3868572ae..ae77805f7 100644
+index 3868572aed..ae77805f71 100644
 --- a/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 +++ b/src/main/java/net/minecraft/server/WorldLoadListenerLogger.java
 @@ -7,16 +7,24 @@ import org.apache.logging.log4j.Logger;
@@ -114,10 +114,10 @@ index 3868572ae..ae77805f7 100644
      @Override
      public void a(ChunkCoordIntPair chunkcoordintpair) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 891b89883..c9e018ac5 100644
+index 29bb795f73..3acea575d0 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1556,13 +1556,85 @@ public class WorldServer extends World {
+@@ -1559,13 +1559,85 @@ public class WorldServer extends World {
          return ((PersistentIdCounts) this.getMinecraftServer().getWorldServer(DimensionManager.OVERWORLD).getWorldPersistentData().a(PersistentIdCounts::new, "idcounts")).a();
      }
  
@@ -207,7 +207,7 @@ index 891b89883..c9e018ac5 100644
  
      public LongSet getForceLoadedChunks() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f2a68ec36..e42bd2638 100644
+index f2a68ec360..e42bd26380 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1872,15 +1872,21 @@ public class CraftWorld implements World {
@@ -237,5 +237,5 @@ index f2a68ec36..e42bd2638 100644
  
      @Override
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0391-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0391-incremental-chunk-saving.patch
@@ -1,11 +1,11 @@
-From 2e504540b15e8158c1df8de80f69c85d3184d2b2 Mon Sep 17 00:00:00 2001
+From 129f226208f6d4a3ec6cc7ad2e07ae3614794467 Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 9 Jun 2019 03:53:22 +0100
 Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de11a91af..4d3c6c6b4 100644
+index de11a91af6..4d3c6c6b47 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -489,4 +489,19 @@ public class PaperWorldConfig {
@@ -29,7 +29,7 @@ index de11a91af..4d3c6c6b4 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index ee8f80174..2003522d9 100644
+index ee8f801745..2003522d96 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -42,7 +42,7 @@ public class Chunk implements IChunkAccess {
@@ -42,7 +42,7 @@ index ee8f80174..2003522d9 100644
      private long t;
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 02dfd91c5..8689e0f9f 100644
+index 02dfd91c5e..8689e0f9f0 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -335,6 +335,15 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -62,7 +62,7 @@ index 02dfd91c5..8689e0f9f 100644
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a6f112bd0..5238a1a7c 100644
+index a6f112bd0f..5238a1a7ca 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -165,6 +165,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -108,7 +108,7 @@ index a6f112bd0..5238a1a7c 100644
          this.methodProfiler.enter("snooper");
          if (((DedicatedServer) this).getDedicatedServerProperties().snooperEnabled && !this.snooper.d() && this.ticks > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 493770bf6..2be6fa0f0 100644
+index 493770bf68..2be6fa0f07 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -297,6 +297,36 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -149,10 +149,10 @@ index 493770bf6..2be6fa0f0 100644
          if (flag) {
              List<PlayerChunk> list = (List) this.visibleChunks.values().stream().filter(PlayerChunk::hasBeenLoaded).peek(PlayerChunk::m).collect(Collectors.toList());
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 4068b90a2..bfe058bff 100644
+index 3acea575d0..7c5349b172 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -788,11 +788,44 @@ public class WorldServer extends World {
+@@ -791,11 +791,44 @@ public class WorldServer extends World {
          return this.worldProvider.d();
      }
  
@@ -199,5 +199,5 @@ index 4068b90a2..bfe058bff 100644
              if (iprogressupdate != null) {
                  iprogressupdate.a(new ChatMessage("menu.savingLevel", new Object[0]));
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0398-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0398-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -1,4 +1,4 @@
-From 812bfbec15b8210acc94fcc6ae60d5403111d4e7 Mon Sep 17 00:00:00 2001
+From 7b2b782e1ca503f84d3fbc1df497fcaa2381f7b3 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 24 Mar 2019 01:01:32 -0400
 Subject: [PATCH] Only count Natural Spawned mobs towards natural spawn mob
@@ -17,7 +17,7 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 929f5c303..ff520d9e8 100644
+index 929f5c3031..ff520d9e86 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -509,6 +509,16 @@ public class PaperWorldConfig {
@@ -38,10 +38,10 @@ index 929f5c303..ff520d9e8 100644
      public boolean asynchronous;
      public EngineMode engineMode;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index bfe058bff..9c688d80f 100644
+index 7c5349b172..0761f705be 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -931,6 +931,13 @@ public class WorldServer extends World {
+@@ -934,6 +934,13 @@ public class WorldServer extends World {
              EnumCreatureType enumcreaturetype = entity.getEntityType().e();
  
              if (enumcreaturetype != EnumCreatureType.MISC && this.getChunkProvider().b(entity)) {
@@ -56,5 +56,5 @@ index bfe058bff..9c688d80f 100644
              }
          }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0401-Mark-entities-as-being-ticked-when-notifying-navigat.patch
+++ b/Spigot-Server-Patches/0401-Mark-entities-as-being-ticked-when-notifying-navigat.patch
@@ -1,14 +1,14 @@
-From 8fbef8cf5604a96d7211b7c5f76adc9f4f4bf782 Mon Sep 17 00:00:00 2001
+From b117edd7ceca8c12db41bab25d92b3f5ad64d3ec Mon Sep 17 00:00:00 2001
 From: Shane Freeder <theboyetronic@gmail.com>
 Date: Sun, 28 Jul 2019 00:51:11 +0100
 Subject: [PATCH] Mark entities as being ticked when notifying navigation
 
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 7a575bc06..887775c99 100644
+index 0761f705be..5df9b0ffda 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -1368,6 +1368,7 @@ public class WorldServer extends World {
+@@ -1371,6 +1371,7 @@ public class WorldServer extends World {
          VoxelShape voxelshape1 = iblockdata1.getCollisionShape(this, blockposition);
  
          if (VoxelShapes.c(voxelshape, voxelshape1, OperatorBoolean.NOT_SAME)) {
@@ -16,7 +16,7 @@ index 7a575bc06..887775c99 100644
              Iterator iterator = this.H.iterator();
  
              while (iterator.hasNext()) {
-@@ -1378,6 +1379,7 @@ public class WorldServer extends World {
+@@ -1381,6 +1382,7 @@ public class WorldServer extends World {
                  }
              }
  
@@ -25,5 +25,5 @@ index 7a575bc06..887775c99 100644
      }
  
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0407-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/Spigot-Server-Patches/0407-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -1,4 +1,4 @@
-From ebbe48d73d106bf26f949a035220a03a82e75bbb Mon Sep 17 00:00:00 2001
+From d4d1dd1858ad3f51cd07eaac1ff5d799d50b1b79 Mon Sep 17 00:00:00 2001
 From: Paul Sauve <paul@burngames.net>
 Date: Sun, 14 Jul 2019 21:05:03 -0500
 Subject: [PATCH] Do less work if we have a custom Bukkit generator
@@ -7,10 +7,10 @@ If the Bukkit generator already has a spawn, use it immediately instead
 of spending time generating one that we won't use
 
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 164fcdc46..94df88c74 100644
+index 5df9b0ffda..1330956655 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -695,12 +695,6 @@ public class WorldServer extends World {
+@@ -698,12 +698,6 @@ public class WorldServer extends World {
          } else if (this.worldData.getType() == WorldType.DEBUG_ALL_BLOCK_STATES) {
              this.worldData.setSpawn(BlockPosition.ZERO.up());
          } else {
@@ -23,7 +23,7 @@ index 164fcdc46..94df88c74 100644
              // CraftBukkit start
              if (this.generator != null) {
                  Random rand = new Random(this.getSeed());
-@@ -717,6 +711,14 @@ public class WorldServer extends World {
+@@ -720,6 +714,14 @@ public class WorldServer extends World {
              }
              // CraftBukkit end
  
@@ -39,5 +39,5 @@ index 164fcdc46..94df88c74 100644
                  WorldServer.LOGGER.warn("Unable to find spawn biome");
              }
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0411-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0411-implement-optional-per-player-mob-spawns.patch
@@ -1,11 +1,11 @@
-From 03973cef3b27bd5e65456b940907094ef961c360 Mon Sep 17 00:00:00 2001
+From cd3d2ecbf1ff7fc3629cc18b4cf2e21c9c2d49fa Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Mon, 19 Aug 2019 01:27:58 +0500
 Subject: [PATCH] implement optional per player mob spawns
 
 
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-index 8de6c4816..ddec62fbf 100644
+index 8de6c4816c..ddec62fbf5 100644
 --- a/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -74,6 +74,8 @@ public class WorldTimingsHandler {
@@ -27,7 +27,7 @@ index 8de6c4816..ddec62fbf 100644
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7bbeef74..246bb4b01 100644
+index e7bbeef74d..246bb4b014 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -615,4 +615,9 @@ public class PaperWorldConfig {
@@ -42,7 +42,7 @@ index e7bbeef74..246bb4b01 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java b/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java
 new file mode 100644
-index 000000000..9ebd7ecb7
+index 0000000000..9ebd7ecb7a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java
 @@ -0,0 +1,253 @@
@@ -301,7 +301,7 @@ index 000000000..9ebd7ecb7
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java b/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java
 new file mode 100644
-index 000000000..4f13d3ff8
+index 0000000000..4f13d3ff83
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java
 @@ -0,0 +1,241 @@
@@ -547,7 +547,7 @@ index 000000000..4f13d3ff8
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 8d7971ad8..e7539dd79 100644
+index 8d7971ad80..e7539dd791 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -555,7 +555,22 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -601,7 +601,7 @@ index 8d7971ad8..e7539dd79 100644
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 106b1ffe0..fa79d0bed 100644
+index 106b1ffe07..fa79d0bed6 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -80,6 +80,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -633,7 +633,7 @@ index 106b1ffe0..fa79d0bed 100644
          return this.cv;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index a7fc34f85..612b9b7e3 100644
+index a7fc34f850..612b9b7e33 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -253,6 +253,7 @@ public class EntityTypes<T extends Entity> {
@@ -645,7 +645,7 @@ index a7fc34f85..612b9b7e3 100644
          return this.ba;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 31d106f95..59e74900f 100644
+index 31d106f951..59e74900f8 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -77,7 +77,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -684,7 +684,7 @@ index 31d106f95..59e74900f 100644
  
      private static double a(ChunkCoordIntPair chunkcoordintpair, Entity entity) {
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index c6ea37ffb..9d4a96ae4 100644
+index c6ea37ffbd..9d4a96ae49 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
 @@ -3,6 +3,7 @@ package net.minecraft.server;
@@ -757,10 +757,10 @@ index c6ea37ffb..9d4a96ae4 100644
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index b7878201b..3b0fc41be 100644
+index 71939e8086..bd1e4dbaed 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -996,7 +996,20 @@ public class WorldServer extends World {
+@@ -999,7 +999,20 @@ public class WorldServer extends World {
      }
  
      public Object2IntMap<EnumCreatureType> l() {
@@ -782,7 +782,7 @@ index b7878201b..3b0fc41be 100644
          ObjectIterator objectiterator = this.entitiesById.values().iterator();
  
          while (objectiterator.hasNext()) {
-@@ -1021,11 +1034,16 @@ public class WorldServer extends World {
+@@ -1024,11 +1037,16 @@ public class WorldServer extends World {
                      continue;
                  }
                  // Paper end
@@ -802,5 +802,5 @@ index b7878201b..3b0fc41be 100644
  
      @Override
 -- 
-2.23.0
+2.22.1
 

--- a/Spigot-Server-Patches/0417-Fix-zero-tick-instant-grow-farms-MC-113809.patch
+++ b/Spigot-Server-Patches/0417-Fix-zero-tick-instant-grow-farms-MC-113809.patch
@@ -1,11 +1,11 @@
-From 7268f0ba68321a9c557432ee9c1735dd314830b9 Mon Sep 17 00:00:00 2001
+From 52a8681d94a5ea7b67abdc6ef1e890901a0c6632 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Sun, 15 Sep 2019 11:32:32 -0500
 Subject: [PATCH] Fix zero-tick instant grow farms MC-113809
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 29fd49968..7ddcaeaa7 100644
+index 29fd499683..7ddcaeaa75 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -568,6 +568,11 @@ public class PaperWorldConfig {
@@ -21,7 +21,7 @@ index 29fd49968..7ddcaeaa7 100644
      public Map<Material, Integer> altItemDespawnRateMap;
      private void altItemDespawnRate() {
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index e077359b0..619237d68 100644
+index e077359b02..619237d68d 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -44,6 +44,7 @@ public class Block implements IMaterial {
@@ -33,7 +33,7 @@ index e077359b0..619237d68 100644
      private final boolean g;
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/BlockBamboo.java b/src/main/java/net/minecraft/server/BlockBamboo.java
-index ffb65776c..3a9c3b54a 100644
+index ffb65776c5..3a9c3b54a9 100644
 --- a/src/main/java/net/minecraft/server/BlockBamboo.java
 +++ b/src/main/java/net/minecraft/server/BlockBamboo.java
 @@ -85,6 +85,7 @@ public class BlockBamboo extends Block implements IBlockFragilePlantElement {
@@ -45,7 +45,7 @@ index ffb65776c..3a9c3b54a 100644
                  int i = this.b((IBlockAccess) world, blockposition) + 1;
  
 diff --git a/src/main/java/net/minecraft/server/BlockCactus.java b/src/main/java/net/minecraft/server/BlockCactus.java
-index 29f9ff6c1..124b4b4b0 100644
+index 29f9ff6c18..124b4b4b00 100644
 --- a/src/main/java/net/minecraft/server/BlockCactus.java
 +++ b/src/main/java/net/minecraft/server/BlockCactus.java
 @@ -21,6 +21,7 @@ public class BlockCactus extends Block {
@@ -57,7 +57,7 @@ index 29f9ff6c1..124b4b4b0 100644
  
              if (world.isEmpty(blockposition1)) {
 diff --git a/src/main/java/net/minecraft/server/BlockChorusFlower.java b/src/main/java/net/minecraft/server/BlockChorusFlower.java
-index 74fa4889f..cde2524ca 100644
+index 74fa4889ff..cde2524ca9 100644
 --- a/src/main/java/net/minecraft/server/BlockChorusFlower.java
 +++ b/src/main/java/net/minecraft/server/BlockChorusFlower.java
 @@ -22,6 +22,7 @@ public class BlockChorusFlower extends Block {
@@ -69,7 +69,7 @@ index 74fa4889f..cde2524ca 100644
  
              if (world.isEmpty(blockposition1) && blockposition1.getY() < 256) {
 diff --git a/src/main/java/net/minecraft/server/BlockReed.java b/src/main/java/net/minecraft/server/BlockReed.java
-index ff674a9d5..a4850c070 100644
+index ff674a9d5b..a4850c0705 100644
 --- a/src/main/java/net/minecraft/server/BlockReed.java
 +++ b/src/main/java/net/minecraft/server/BlockReed.java
 @@ -23,6 +23,7 @@ public class BlockReed extends Block {
@@ -81,10 +81,10 @@ index ff674a9d5..a4850c070 100644
  
              for (i = 1; world.getType(blockposition.down(i)).getBlock() == this; ++i) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 3b0fc41be..6ade18914 100644
+index bd1e4dbaed..5b18f4bd52 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
-@@ -565,7 +565,9 @@ public class WorldServer extends World {
+@@ -568,7 +568,9 @@ public class WorldServer extends World {
                          IBlockData iblockdata = chunksection.getType(blockposition2.getX() - j, blockposition2.getY() - j1, blockposition2.getZ() - k);
  
                          if (iblockdata.q()) {
@@ -95,5 +95,5 @@ index 3b0fc41be..6ade18914 100644
  
                          Fluid fluid = iblockdata.p();
 -- 
-2.23.0
+2.22.1
 


### PR DESCRIPTION
Upstream has released updates that appears to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
7554e08e Add UUID support to CraftProfileBanList
3fe37460 SPIGOT-5378: Fix TileEntity fixer deadlock
12386dd4 SPIGOT-5375: Add spaces to coordinates from tile fixer
606c19e2 SPIGOT-5373: Simultaneous left+right click in creative mode does not work
13caf848 SPIGOT-5370: Fix Block#rayTrace considering other blocks.