### PR TITLE
Add patch to fix spawn rates of ambient and water mobs

### DIFF
--- a/Spigot-Server-Patches/0446-Fix-ambient-and-water-mob-spawn-rates.patch
+++ b/Spigot-Server-Patches/0446-Fix-ambient-and-water-mob-spawn-rates.patch
@@ -1,0 +1,22 @@
+From 34274ab2f8e26321fe188735b91d90447714e262 Mon Sep 17 00:00:00 2001
+From: Rodney_Mc_Kay <herr-fant@web.de>
+Date: Fri, 25 Oct 2019 19:12:27 +0200
+Subject: [PATCH] Fix ambient and water mob spawn rates
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index ee071ba2..f3614fa1 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -271,7 +271,7 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         long time = this.worldData.getTime();
+         if (this.getGameRules().getBoolean("doMobSpawning") && this.worldData.getType() != WorldType.DEBUG_ALL_BLOCK_STATES && (this.allowMonsters || this.allowAnimals) && (this instanceof WorldServer && this.players.size() > 0)) {
+             timings.mobSpawn.startTiming(); // Spigot
+-            this.spawnerCreature.a(this, this.allowMonsters && (this.ticksPerMonsterSpawns != 0 && time % this.ticksPerMonsterSpawns == 0L), this.allowAnimals && (this.ticksPerAnimalSpawns != 0 && time % this.ticksPerAnimalSpawns == 0L), this.worldData.getTime() % 400L == 0L);
++            this.spawnerCreature.a(this, this.allowMonsters && (this.ticksPerMonsterSpawns != 0 && time % this.ticksPerMonsterSpawns == 0L), this.allowAnimals, (this.ticksPerAnimalSpawns != 0 && time % this.ticksPerAnimalSpawns == 0L)); // Paper - Only effect real animals with animal spawn limit - Fixes squid and ambient mob spawn rates broken by Bukkit
+             this.getChunkProvider().a(this, this.allowMonsters && (this.ticksPerMonsterSpawns != 0 && time % this.ticksPerMonsterSpawns == 0L), this.allowAnimals && (this.ticksPerAnimalSpawns != 0 && time % this.ticksPerAnimalSpawns == 0L));
+             timings.mobSpawn.stopTiming(); // Spigot
+             // CraftBukkit end
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
Bukkit applies it's animal spawn rates (declared in bukkit.yml) not only to animals, but to all peaceful mobs. That causes the spawn rates of water mobs and ambient mobs to be drastically lower than in vanilla. The added patch fixes the issue.