### PR TITLE
[PATCH] bounding box check for hanging entities

### DIFF
--- a/Spigot-Server-Patches/0420-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
+++ b/Spigot-Server-Patches/0420-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
@@ -1,0 +1,28 @@
+From c41ab1dad3a063b15b9ceb44645c0ef99ffbae24 Mon Sep 17 00:00:00 2001
+From: MisterErwin <git@askarian.net>
+Date: Wed, 30 Oct 2019 16:57:54 +0100
+Subject: [PATCH] Fix spawning of hanging entities that are not ItemFrames and
+ can not face UP or DOWN
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 243722b6..f33d9c8b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1784,7 +1784,12 @@ public class CraftWorld implements World {
+                 height = 9;
+             }
+ 
+-            BlockFace[] faces = new BlockFace[]{BlockFace.EAST, BlockFace.NORTH, BlockFace.WEST, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
++            // Paper start - In addition to d65a2576e40e58c8e446b330febe6799d13a604f do not check UP/DOWN for non item frames
++            // BlockFace[] faces = new BlockFace[]{BlockFace.EAST, BlockFace.NORTH, BlockFace.WEST, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN};
++            BlockFace[] faces = (ItemFrame.class.isAssignableFrom(clazz))
++                    ? new BlockFace[]{BlockFace.EAST, BlockFace.NORTH, BlockFace.WEST, BlockFace.SOUTH, BlockFace.UP, BlockFace.DOWN}
++                    : new BlockFace[]{BlockFace.EAST, BlockFace.NORTH, BlockFace.WEST, BlockFace.SOUTH};
++            // Paper end
+             final BlockPosition pos = new BlockPosition(x, y, z);
+             for (BlockFace dir : faces) {
+                 IBlockData nmsBlock = world.getType(pos.shift(CraftBlock.blockFaceToNotch(dir)));
+-- 
+2.17.1
+


### PR DESCRIPTION
This patch intends to fix an issue with LeashHitchs where an exception
was thrown due EntityHanging#calculateBoundingBox not being able to
accept EnumDirections UP and DOWN.

This issue was introduced in a fix for SPIGOT-4674
([d65a2576e40e58c8e446b330febe6799d13a604f](https://hub.spigotmc.org/stash/users/aquazus/repos/craftbukkit/commits/d65a2576e40e58c8e446b330febe6799d13a604f))

See issue #2663 