### PR TITLE
Fix empty CanPlaceOn tags causing errors

### DIFF
--- a/Spigot-Server-Patches/0304-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/Spigot-Server-Patches/0304-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -378,7 +378,7 @@ index 6a6b80b5bd..dbb4e5258c 100644
 +    }
 +
 +    private @Nullable Namespaced deserializeNamespaced(String raw) {
-+        boolean isTag = raw.codePointAt(0) == '#';
++        boolean isTag = raw.length() > 0 && raw.codePointAt(0) == '#';
 +        net.minecraft.server.ArgumentBlock blockParser = new net.minecraft.server.ArgumentBlock(new com.mojang.brigadier.StringReader(raw), true);
 +        try {
 +            blockParser = blockParser.parse(false);


### PR DESCRIPTION
As mentioned by someone in the Paper discord guild an empty CanPlaceOn tag causes an error to be thrown. When such an item is placed in the player's inventory, the player will be disconnected. Players who already have that item in their inventory when joining the server will be kicked upon doing so. Replicating this behaviour should be possible with executing the following command as a player `/give @s oak_leaves{CanPlaceOn:[""]}`. This change should address this issue.

I am completely new to working with this codebase and this is the fifth attempt at actually not destroying either all files or overriding previous commits - I didn't even manage to get through the steps as specified in the CONTRIBUTING.md file without messing up, so I have no idea if I'm doing this right. Please let me know if I messed anything up regarding the changes I made to the file or this pull request in general, cause then I'll try to fix them.