### PR TITLE
Ensure world spawn is loaded when an entity travels through an end portal

### DIFF
--- a/Spigot-Server-Patches/0425-Ensure-world-spawn-is-loaded-when-an-entity-travels-.patch
+++ b/Spigot-Server-Patches/0425-Ensure-world-spawn-is-loaded-when-an-entity-travels-.patch
@@ -1,0 +1,26 @@
+From 86d36e2e4169106adef556acf2e159c253605aa4 Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Mon, 2 Dec 2019 21:22:06 -0600
+Subject: [PATCH] Ensure world spawn is loaded when an entity travels through
+ an end portal - Fixes #2681
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index e8def7f8..acb29d81 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2657,6 +2657,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+                 entity.v(this);
+                 entity.setPositionRotation(blockposition, entity.yaw + f, entity.pitch);
+                 entity.setMot(vec3d);
++                // Paper start - Fix item deletion through exit end portal if world spawn is not loaded
++                if (!worldserver.keepSpawnInMemory) {
++                    worldserver.getChunkAt(blockposition.getX(), blockposition.getZ());
++                }
++                // Paper end
+                 worldserver1.addEntityTeleport(entity);
+                 // CraftBukkit start - Forward the CraftEntity to the new entity
+                 this.getBukkitEntity().setHandle(entity);
+-- 
+2.17.1
+


### PR DESCRIPTION
Fixes #2681

This issue does not exist in the 1.13 branch. Upon further investigation of this issue, I have found that the `entityJoinedWorld()` method in `WorldServer.java` is exactly what is missing between 1.13 and 1.14, however, I don't currently have the time to fully port it's functionality to 1.14.

This solution is simple and lightweight, but it has a few caveats:

1. Not sure if this works properly with async chunks enabled.
2. Not sure if I should instantly unload the chunk (potential memory leak?)
3. Is any important logic missing from the `entityJoinedWorld()` method?

I am unsure if I will be able to fix any issues quickly as I have been quite busy recently, so anyone else is free to build upon my findings or suggest better methods to call. I wanted to get a fix out quickly as this issue results in items being unexpectedly deleted from the world if the `keep-spawn-loaded` flag is set to `false`.