### PR TITLE
Fix #2681 - Items vanish through exit end portal

### DIFF
--- a/Spigot-Server-Patches/0412-Fix-2681-Items-vanish-through-exit-end-portal.patch
+++ b/Spigot-Server-Patches/0412-Fix-2681-Items-vanish-through-exit-end-portal.patch
@@ -1,0 +1,22 @@
+From 37d97c06625b94ceb6530b7962f4b5a0384c99fa Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Sat, 14 Dec 2019 23:50:11 -0600
+Subject: [PATCH] Fix #2681 - Items vanish through exit end portal
+
+
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 985f3037..ad9acef6 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -616,7 +616,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         int k;
+ 
+         if (i >= -30000000 && j >= -30000000 && i < 30000000 && j < 30000000) {
+-            if (this.isChunkLoaded(i >> 4, j >> 4)) {
++            if (this.isChunkLoaded(i >> 4, j >> 4) || !this.keepSpawnInMemory) { // Paper - Fix #2681 - Items vanish through exit end portal
+                 k = this.getChunkAt(i >> 4, j >> 4).a(heightmap_type, i & 15, j & 15) + 1;
+             } else {
+                 k = 0;
+-- 
+2.17.1
+


### PR DESCRIPTION
I discovered that items do not vanish, but rather are teleported to Y=0 if the chunk is not loaded.

This patch simply ensures that the chunk is loaded before finding the highest block to spawn the item at. 1.13.2's code was very hard to follow (spaghetti anyone?), so I'm not sure how it was done in prior versions.

If this solution is acceptable, I also have a backported version for 1.14.4 that I would like to get in before support is dropped. :)

Download a 1.15 jar [here](https://github.com/AJMFactsheets/Paper/releases/download/V2.0/paperclip-8-fix-2681.jar)
Or download a backported 1.14.4 jar [here](https://github.com/AJMFactsheets/Paper/releases/download/V2.0/paperclip-236-fix-2681.jar)