### PR TITLE
Add effect to block break naturally

### DIFF
--- a/Spigot-API-Patches/0189-Add-effect-to-block-break-naturally.patch
+++ b/Spigot-API-Patches/0189-Add-effect-to-block-break-naturally.patch
@@ -1,0 +1,32 @@
+From a6f3309992513df27d95f5585c39e143371fcf53 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Thu, 2 Jan 2020 12:25:16 -0600
+Subject: [PATCH] Add effect to block break naturally
+
+
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 038de5a6..a14a7583 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -467,6 +467,18 @@ public interface Block extends Metadatable {
+      */
+     boolean breakNaturally(@NotNull ItemStack tool);
+
++    // Paper start
++    /**
++     * Breaks the block and spawns items as if a player had digged it with a
++     * specific tool
++     *
++     * @param tool The tool or item in hand used for digging
++     * @param triggerEffect Play the block break particle effect and sound
++     * @return true if the block was destroyed
++     */
++    boolean breakNaturally(@NotNull ItemStack tool, boolean triggerEffect);
++    // Paper end
++
+     /**
+      * Returns a list of items which would drop by destroying this block
+      *
+-- 
+2.24.0
+

--- a/Spigot-API-Patches/0189-Add-effect-to-block-break-naturally.patch
+++ b/Spigot-API-Patches/0189-Add-effect-to-block-break-naturally.patch
@@ -1,4 +1,4 @@
-From a6f3309992513df27d95f5585c39e143371fcf53 Mon Sep 17 00:00:00 2001
+From 26ab8a84de63cd94f51c9edbe7f9f4070b4e4dbe Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Thu, 2 Jan 2020 12:25:16 -0600
 Subject: [PATCH] Add effect to block break naturally
@@ -11,7 +11,7 @@ index 038de5a6..a14a7583 100644
 @@ -467,6 +467,18 @@ public interface Block extends Metadatable {
       */
      boolean breakNaturally(@NotNull ItemStack tool);
-
+ 
 +    // Paper start
 +    /**
 +     * Breaks the block and spawns items as if a player had digged it with a

--- a/Spigot-Server-Patches/0420-Add-effect-to-block-break-naturally.patch
+++ b/Spigot-Server-Patches/0420-Add-effect-to-block-break-naturally.patch
@@ -1,0 +1,34 @@
+From f59a300db3dba8d827fe78eb0207fb7a32cbf612 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Thu, 2 Jan 2020 12:25:07 -0600
+Subject: [PATCH] Add effect to block break naturally
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index a667e58ed..f6aa78e9e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -607,12 +607,20 @@ public class CraftBlock implements Block {
+ 
+     @Override
+     public boolean breakNaturally(ItemStack item) {
++        // Paper start
++        return breakNaturally(item, false);
++    }
++
++    @Override
++    public boolean breakNaturally(ItemStack item, boolean triggerEffect) {
++        // Paper end
+         // Order matters here, need to drop before setting to air so skulls can get their data
+         net.minecraft.server.Block block = this.getNMSBlock();
+         boolean result = false;
+ 
+         if (block != null && block != Blocks.AIR) {
+             net.minecraft.server.Block.dropItems(getNMS(), world.getMinecraftWorld(), position, world.getTileEntity(position), null, CraftItemStack.asNMSCopy(item));
++            if (triggerEffect) world.triggerEffect(2001, position, net.minecraft.server.Block.getCombinedId(block.getBlockData())); // Paper
+             result = true;
+         }
+ 
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0427-Add-effect-to-block-break-naturally.patch
+++ b/Spigot-Server-Patches/0427-Add-effect-to-block-break-naturally.patch
@@ -1,11 +1,11 @@
-From f59a300db3dba8d827fe78eb0207fb7a32cbf612 Mon Sep 17 00:00:00 2001
+From 7843c52321c07cb7998260731313b3f582b3699b Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Thu, 2 Jan 2020 12:25:07 -0600
 Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index a667e58ed..f6aa78e9e 100644
+index a667e58ed..78e84c3d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 @@ -607,12 +607,20 @@ public class CraftBlock implements Block {
@@ -25,10 +25,10 @@ index a667e58ed..f6aa78e9e 100644
  
          if (block != null && block != Blocks.AIR) {
              net.minecraft.server.Block.dropItems(getNMS(), world.getMinecraftWorld(), position, world.getTileEntity(position), null, CraftItemStack.asNMSCopy(item));
-+            if (triggerEffect) world.triggerEffect(2001, position, net.minecraft.server.Block.getCombinedId(block.getBlockData())); // Paper
++            if (triggerEffect) world.triggerEffect(org.bukkit.Effect.STEP_SOUND.getId(), position, net.minecraft.server.Block.getCombinedId(block.getBlockData())); // Paper
              result = true;
          }
  
 -- 
-2.24.0
+2.25.0
 


### PR DESCRIPTION
Adds another break naturally method that enables the plugin dev to easily trigger the block break particle animation effect and sound when breaking a block.