### PR TITLE
Fix SkullMeta.setPlayerProfile()

### DIFF
--- a/Spigot-Server-Patches/0193-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/Spigot-Server-Patches/0193-Add-setPlayerProfile-API-for-Skulls.patch
@@ -1,4 +1,4 @@
-From 9027adb44adb78dd5a0b21f7a154b8c3e2063517 Mon Sep 17 00:00:00 2001
+From 5ff4a71c1c866f9e7e8d4e8426667cfb5f9b84d0 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Fri, 19 Jan 2018 00:36:25 -0500
 Subject: [PATCH] Add setPlayerProfile API for Skulls
@@ -48,7 +48,7 @@ index a4bc7f970..2dd2f476f 100644
      public BlockFace getRotation() {
          BlockData blockData = getBlockData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index 4fb27cc7e..18545e5ef 100644
+index 4fb27cc7e..96d62bbf8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -3,6 +3,8 @@ package org.bukkit.craftbukkit.inventory;
@@ -75,7 +75,7 @@ index 4fb27cc7e..18545e5ef 100644
 +    // Paper start
 +    @Override
 +    public void setPlayerProfile(@Nullable PlayerProfile profile) {
-+        this.profile = (profile == null) ? null : CraftPlayerProfile.asAuthlibCopy(profile);
++        setProfile((profile == null) ? null : CraftPlayerProfile.asAuthlibCopy(profile));
 +    }
 +
 +    @Nullable
@@ -89,5 +89,5 @@ index 4fb27cc7e..18545e5ef 100644
      public OfflinePlayer getOwningPlayer() {
          if (hasOwner()) {
 -- 
-2.24.1
+2.16.1.windows.1
 


### PR DESCRIPTION
Without this change skulls do not update correctly after calling setPlayerProfile, because of changes in spigot. Fixes #2830