### PR TITLE
Resolve #2824 - Display Warning Message for Outdated Java Versions

### DIFF
--- a/Spigot-Server-Patches/0422-Add-warning-message.patch
+++ b/Spigot-Server-Patches/0422-Add-warning-message.patch
@@ -1,0 +1,36 @@
+From 738165c54130ebfe232d6460370c1d62429e9983 Mon Sep 17 00:00:00 2001
+From: Matthias Ngeo <matthiasngeo@gmail.com>
+Date: Sat, 11 Jan 2020 11:02:55 +0800
+Subject: [PATCH] Add warning message
+
+Adds a warning message for outdated Java versions that are below the latest LTS version (11). 
+This warning can be disabled via the new "IHateNewSoftware" property.
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 75d3cbc4..3afd9363 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -210,7 +210,18 @@ public class Main {
+                     useJline = false; // Paper
+                     System.setProperty(TerminalConsoleAppender.JLINE_OVERRIDE_PROPERTY, "false"); // Paper
+                 }
+-
++                
++                // Paper start
++                if (System.getProperty("IHateNewSoftware") == null && System.getProperty("java.version") != null) {
++                    String version = System.getProperty("java.version");
++                    version = version.split(".")[version.startsWith("1.") ? 1 : 0];
++                    if (Integer.parseInt(version) < 11) {
++                        System.err.println("*** Warning, this server is currently running on Java " + version + " which is outdated ***");
++                        System.err.println("*** Please consider updating to Java 11 from https://adoptopenjdk.net/releases.html?variant=openjdk11&jvmVariant=hotspot ***");
++                    }
++                }
++                // Paper end
++                
+                 if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
+                     Date buildDate = new SimpleDateFormat("yyyyMMdd-HHmm").parse(Main.class.getPackage().getImplementationVendor());
+ 
+-- 
+2.24.1.windows.2
+


### PR DESCRIPTION
This PR resolves #2824 and adds a warning message with **no delay** for outdated Java versions below the latest LTS version (11). 