### PR TITLE
Seed based feature search (Fixes #2312)

### DIFF
--- a/Spigot-Server-Patches/0424-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0424-Seed-based-feature-search.patch
@@ -1,0 +1,110 @@
+From 55f062af7886e33bc8945d0b3c97ea7ebcf0f4cd Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Mon, 13 Jan 2020 15:40:32 +0100
+Subject: [PATCH] Seed based feature search
+
+This fixes the issue where the server will load surrounding chunks up to
+a radius of 100 chunks in order to search for features e.g. when running
+the /locate command or for treasure maps (issue #2312).
+This is done by using the same seed checking functionality that is used
+by the server when generating these features before actually attempting
+to load the chunk to check if a feature is available in it.
+
+The only downside of this is that it breaks once the seed or generator
+changes but this should usually not happen. A config option to disable
+this improvement is added though in case that should ever be necessary.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index b309fdaba..0b86502eb 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -357,6 +357,12 @@ public class PaperWorldConfig {
+         }
+     }
+ 
++    public boolean seedBasedFeatureSearch = true;
++    private void seedBasedFeatureSearch() {
++        seedBasedFeatureSearch = getBoolean("seed-based-feature-search", seedBasedFeatureSearch);
++        log("Feature search is based on seed: " + seedBasedFeatureSearch);
++    }
++
+     public int maxCollisionsPerEntity;
+     private void maxEntityCollision() {
+         maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
+diff --git a/src/main/java/net/minecraft/server/BiomeManager.java b/src/main/java/net/minecraft/server/BiomeManager.java
+index e96f544f1..68423645d 100644
+--- a/src/main/java/net/minecraft/server/BiomeManager.java
++++ b/src/main/java/net/minecraft/server/BiomeManager.java
+@@ -12,10 +12,12 @@ public class BiomeManager {
+         this.c = genlayerzoomer;
+     }
+ 
++    public BiomeManager withProvider(WorldChunkManager worldchunkmanager) { return a(worldchunkmanager); } // Paper - OBFHELPER
+     public BiomeManager a(WorldChunkManager worldchunkmanager) {
+         return new BiomeManager(worldchunkmanager, this.b, this.c);
+     }
+ 
++    public BiomeBase getBiome(BlockPosition blockposition) { return a(blockposition); } // Paper - OBFHELPER
+     public BiomeBase a(BlockPosition blockposition) {
+         return this.c.a(this.b, blockposition.getX(), blockposition.getY(), blockposition.getZ(), this.a);
+     }
+diff --git a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
+index f2a19acd8..09f1308b0 100644
+--- a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
++++ b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
+@@ -64,10 +64,12 @@ public class ChunkCoordIntPair {
+         }
+     }
+ 
++    public int getBlockX() { return d(); } // Paper - OBFHELPER
+     public int d() {
+         return this.x << 4;
+     }
+ 
++    public int getBlockZ() { return e(); } // Paper - OBFHELPER
+     public int e() {
+         return this.z << 4;
+     }
+diff --git a/src/main/java/net/minecraft/server/StructureGenerator.java b/src/main/java/net/minecraft/server/StructureGenerator.java
+index e8ce2ecf2..acfe732af 100644
+--- a/src/main/java/net/minecraft/server/StructureGenerator.java
++++ b/src/main/java/net/minecraft/server/StructureGenerator.java
+@@ -109,6 +109,15 @@ public abstract class StructureGenerator<C extends WorldGenFeatureConfiguration>
+                             if (flag1 || flag2) {
+                                 ChunkCoordIntPair chunkcoordintpair = this.a(chunkgenerator, seededrandom, j, k, i1, j1);
+                                 if (!world.getWorldBorder().isChunkInBounds(chunkcoordintpair.x, chunkcoordintpair.z)) { continue; } // Paper
++                                // Paper start - seed based feature search
++                                if (world.paperConfig.seedBasedFeatureSearch) {
++                                    BiomeManager biomeManager = world.getBiomeManager().withProvider(chunkgenerator.getWorldChunkManager());
++                                    BiomeBase biomeBase = biomeManager.getBiome(new BlockPosition(chunkcoordintpair.getBlockX() + 9, 0, chunkcoordintpair.getBlockZ() + 9));
++                                    if (!shouldGenerate(biomeManager, chunkgenerator, seededrandom, chunkcoordintpair.x, chunkcoordintpair.z, biomeBase)) {
++                                        continue;
++                                    }
++                                }
++                                // Paper end
+                                 StructureStart structurestart = world.getChunkAt(chunkcoordintpair.x, chunkcoordintpair.z, ChunkStatus.STRUCTURE_STARTS).a(this.b());
+ 
+                                 if (structurestart != null && structurestart.e()) {
+@@ -165,6 +174,7 @@ public abstract class StructureGenerator<C extends WorldGenFeatureConfiguration>
+         return new ChunkCoordIntPair(i + k, j + l);
+     }
+ 
++    public boolean shouldGenerate(BiomeManager biomemanager, ChunkGenerator<?> chunkgenerator, Random random, int chunkX, int chunkZ, BiomeBase biomebase) { return a(biomemanager, chunkgenerator, random, chunkX, chunkZ, biomebase); } // Paper - OBFHELPER
+     public abstract boolean a(BiomeManager biomemanager, ChunkGenerator<?> chunkgenerator, Random random, int i, int j, BiomeBase biomebase);
+ 
+     public abstract StructureGenerator.a a();
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 5460ace8f..999338cfc 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -1584,6 +1584,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         return this.methodProfiler;
+     }
+ 
++    public BiomeManager getBiomeManager() { return d(); } // Paper - OBFHELPER
+     @Override
+     public BiomeManager d() {
+         return this.biomeManager;
+-- 
+2.18.0.windows.1
+

--- a/Spigot-Server-Patches/0424-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0424-Seed-based-feature-search.patch
@@ -1,4 +1,4 @@
-From 55f062af7886e33bc8945d0b3c97ea7ebcf0f4cd Mon Sep 17 00:00:00 2001
+From 53a8c63edaf854bf9daad63d9d3426541e6069d8 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Mon, 13 Jan 2020 15:40:32 +0100
 Subject: [PATCH] Seed based feature search
@@ -94,17 +94,20 @@ index e8ce2ecf2..acfe732af 100644
  
      public abstract StructureGenerator.a a();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5460ace8f..999338cfc 100644
+index 5460ace8f..6db94f266 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1584,6 +1584,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1584,8 +1584,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return this.methodProfiler;
      }
  
+-    @Override
+-    public BiomeManager d() {
 +    public BiomeManager getBiomeManager() { return d(); } // Paper - OBFHELPER
-     @Override
-     public BiomeManager d() {
++    @Override public BiomeManager d() {
          return this.biomeManager;
+     }
+ }
 -- 
 2.18.0.windows.1
 

--- a/Spigot-Server-Patches/0434-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0434-Seed-based-feature-search.patch
@@ -1,4 +1,4 @@
-From 53a8c63edaf854bf9daad63d9d3426541e6069d8 Mon Sep 17 00:00:00 2001
+From f6980b7867cefdfbb83471c04034465e6e3f004e Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Mon, 13 Jan 2020 15:40:32 +0100
 Subject: [PATCH] Seed based feature search
@@ -15,10 +15,10 @@ changes but this should usually not happen. A config option to disable
 this improvement is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b309fdaba..0b86502eb 100644
+index 3b8488d3f..bce502181 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -357,6 +357,12 @@ public class PaperWorldConfig {
+@@ -359,6 +359,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -94,10 +94,10 @@ index e8ce2ecf2..acfe732af 100644
  
      public abstract StructureGenerator.a a();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5460ace8f..6db94f266 100644
+index 9df079d8a..8a2bb79ad 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1584,8 +1584,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1588,8 +1588,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return this.methodProfiler;
      }
  


### PR DESCRIPTION
This fixes the issue where the server will load surrounding chunks up to a radius of 100 chunks in order to search for features e.g. when running the /locate command or for treasure maps (issue #2312).
This is done by using the same seed checking functionality that is used by the server when generating these features before actually attempting to load the chunk to check if a feature is available in it.

While the chunk loading itself will still be done on the main thread it should ideally only ever load a single chunk so this will be more compatible with existing usages of the feature search both in the server and the API. Theoretically this could be amended to also provide API methods to toggle this or to use the async chunk loading API but async chunk loading would require larger changes that require more looking into how to integrate into the rest of the server without breaking existing mechanics.

The only downside of this is that it breaks once the seed or generator changes but this should usually not happen. A config option to disable this improvement is added though in case that should ever be necessary.