### PR TITLE
Use result of setItemStack in PlayerBucketEmptyEvent (#2651)

### DIFF
--- a/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
+++ b/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
@@ -1,0 +1,33 @@
+From c75146afc87f1c47c4ccab14de486163cf7385aa Mon Sep 17 00:00:00 2001
+From: Draycia <lonelyyordle@gmail.com>
+Date: Tue, 14 Jan 2020 05:37:05 -0800
+Subject: [PATCH] Use result of setItemStack in PlayerBucketEmptyEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 80219f2d..c8184f94 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1897,6 +1897,7 @@ public abstract class EntityLiving extends Entity {
+         }
+     }
+ 
++    public void setItemInHand(EnumHand enumhand, ItemStack itemstack) { this.a(enumhand, itemstack); } // Paper - OBFHELPER
+     public void a(EnumHand enumhand, ItemStack itemstack) {
+         if (enumhand == EnumHand.MAIN_HAND) {
+             this.setSlot(EnumItemSlot.MAINHAND, itemstack);
+diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
+index 0ff92aea..168b5e80 100644
+--- a/src/main/java/net/minecraft/server/ItemBucket.java
++++ b/src/main/java/net/minecraft/server/ItemBucket.java
+@@ -140,6 +140,7 @@ public class ItemBucket extends Item {
+                         ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                         return false;
+                     }
++                    entityhuman.setItemInHand(enumhand, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItemStack())); // Paper - 2651: set item in hand if event isn't cancelled
+                 }
+                 // CraftBukkit end
+                 if (world.worldProvider.isNether() && this.fluidType.a(TagsFluid.WATER)) {
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
+++ b/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
@@ -1,4 +1,4 @@
-From 48645338cba36baadd48871d52565dd0f6cebe8d Mon Sep 17 00:00:00 2001
+From dda1ff9c1f7f140334acb511538db216a17f3581 Mon Sep 17 00:00:00 2001
 From: Draycia <lonelyyordle@gmail.com>
 Date: Tue, 14 Jan 2020 05:37:05 -0800
 Subject: [PATCH] Use result of setItemStack in PlayerBucketEmptyEvent
@@ -8,8 +8,21 @@ setItemStack was not functional in the PlayerBucketEmptyEvent
 server was set to assume the result is always BUCKET when
 player is in survival
 
+diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
+index 0ff92aea5..8c02e64c1 100644
+--- a/src/main/java/net/minecraft/server/ItemBucket.java
++++ b/src/main/java/net/minecraft/server/ItemBucket.java
+@@ -134,7 +134,7 @@ public class ItemBucket extends Item {
+             } else {
+                 // CraftBukkit start
+                 if (entityhuman != null) {
+-                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, itemstack, enumhand);
++                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, itemstack, entityhuman.isCreative() ? itemstack : new ItemStack(Items.BUCKET), enumhand);
+                     if (event.isCancelled()) {
+                         ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, blockposition)); // SPIGOT-4238: needed when looking through entity
+                         ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c0fd2948e..355804b5b 100644
+index c0fd2948e..ef59616e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -376,8 +376,14 @@ public class CraftEventFactory {
@@ -28,15 +41,17 @@ index c0fd2948e..355804b5b 100644
      }
  
      public static PlayerBucketFillEvent callPlayerBucketFillEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemInHand, net.minecraft.server.Item bucket, EnumHand enumHand) {
-@@ -386,8 +392,13 @@ public class CraftEventFactory {
+@@ -385,9 +391,15 @@ public class CraftEventFactory {
+     }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, net.minecraft.server.Item item, EnumHand enumHand) {
-         // Paper end
++        // Paper end
 +        // Paper start - Add full ItemStack parameter so we can keep meta
 +        return getPlayerBucketEvent(isFilling, world, who, changed, clicked, clickedFace, itemstack, new ItemStack(item), enumHand);
 +    }
 +
 +    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, ItemStack newItem, EnumHand enumHand) {
+         // Paper end
          Player player = (Player) who.getBukkitEntity();
 -        CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
 +        CraftItemStack itemInHand = CraftItemStack.asCraftMirror(newItem.cloneItemStack()); // Paper - need to clone because prev. event item was NOT a mirror, so changes did NOT modify the item in the player's hand

--- a/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
+++ b/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
@@ -1,11 +1,11 @@
-From c75146afc87f1c47c4ccab14de486163cf7385aa Mon Sep 17 00:00:00 2001
+From 210cf7b13fab9c83e8f3b10b80a8aea5a4e0affd Mon Sep 17 00:00:00 2001
 From: Draycia <lonelyyordle@gmail.com>
 Date: Tue, 14 Jan 2020 05:37:05 -0800
 Subject: [PATCH] Use result of setItemStack in PlayerBucketEmptyEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 80219f2d..c8184f94 100644
+index 80219f2df..c8184f94e 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1897,6 +1897,7 @@ public abstract class EntityLiving extends Entity {
@@ -17,10 +17,17 @@ index 80219f2d..c8184f94 100644
          if (enumhand == EnumHand.MAIN_HAND) {
              this.setSlot(EnumItemSlot.MAINHAND, itemstack);
 diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
-index 0ff92aea..168b5e80 100644
+index 0ff92aea5..498cd4d24 100644
 --- a/src/main/java/net/minecraft/server/ItemBucket.java
 +++ b/src/main/java/net/minecraft/server/ItemBucket.java
-@@ -140,6 +140,7 @@ public class ItemBucket extends Item {
+@@ -134,12 +134,13 @@ public class ItemBucket extends Item {
+             } else {
+                 // CraftBukkit start
+                 if (entityhuman != null) {
+-                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, itemstack, enumhand);
++                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, entityhuman.isCreative() ? entityhuman.getItemInHand(enumhand) : itemstack, enumhand); // Paper - 2651: Prevents creative players from having their buckets modified
+                     if (event.isCancelled()) {
+                         ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, blockposition)); // SPIGOT-4238: needed when looking through entity
                          ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                          return false;
                      }
@@ -28,6 +35,19 @@ index 0ff92aea..168b5e80 100644
                  }
                  // CraftBukkit end
                  if (world.worldProvider.isNether() && this.fluidType.a(TagsFluid.WATER)) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index c0fd2948e..aed1cca44 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -377,7 +377,7 @@ public class CraftEventFactory {
+     }
+ 
+     public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, EnumHand enumHand) {
+-        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, Items.BUCKET, enumHand);
++        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, itemstack.getItem(), enumHand); // Paper - don't forcefully set to bucket
+     }
+ 
+     public static PlayerBucketFillEvent callPlayerBucketFillEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemInHand, net.minecraft.server.Item bucket, EnumHand enumHand) {
 -- 
 2.24.0
 

--- a/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
+++ b/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
@@ -1,46 +1,48 @@
-From 3540b3f5e56446d07bff84ed0f1f9a6434e32ff3 Mon Sep 17 00:00:00 2001
+From 48645338cba36baadd48871d52565dd0f6cebe8d Mon Sep 17 00:00:00 2001
 From: Draycia <lonelyyordle@gmail.com>
 Date: Tue, 14 Jan 2020 05:37:05 -0800
 Subject: [PATCH] Use result of setItemStack in PlayerBucketEmptyEvent
 
+setItemStack was not functional in the PlayerBucketEmptyEvent
 
-diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 80219f2df..c8184f94e 100644
---- a/src/main/java/net/minecraft/server/EntityLiving.java
-+++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -1897,6 +1897,7 @@ public abstract class EntityLiving extends Entity {
-         }
-     }
- 
-+    public void setItemInHand(EnumHand enumhand, ItemStack itemstack) { this.a(enumhand, itemstack); } // Paper - OBFHELPER
-     public void a(EnumHand enumhand, ItemStack itemstack) {
-         if (enumhand == EnumHand.MAIN_HAND) {
-             this.setSlot(EnumItemSlot.MAINHAND, itemstack);
-diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
-index 0ff92aea5..fe4a99917 100644
---- a/src/main/java/net/minecraft/server/ItemBucket.java
-+++ b/src/main/java/net/minecraft/server/ItemBucket.java
-@@ -140,6 +140,7 @@ public class ItemBucket extends Item {
-                         ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
-                         return false;
-                     }
-+                    itemstack = CraftItemStack.asNMSCopy(event.getItemStack()); // Paper - 2651: set item in hand if event isn't cancelled
-                 }
-                 // CraftBukkit end
-                 if (world.worldProvider.isNether() && this.fluidType.a(TagsFluid.WATER)) {
+server was set to assume the result is always BUCKET when
+player is in survival
+
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c0fd2948e..4d07d3e89 100644
+index c0fd2948e..355804b5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -377,7 +377,7 @@ public class CraftEventFactory {
+@@ -376,8 +376,14 @@ public class CraftEventFactory {
+         return getPlayerBucketEvent(isFilling, world, who, changed, clicked, clickedFace, itemstack, item, null);
      }
  
++    // Paper start - Add full ItemStack parameter so we can keep meta
++    public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemInHand, ItemStack bucket, EnumHand enumHand) {
++        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemInHand, bucket, enumHand);
++    }
++    // Paper end
++
      public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, EnumHand enumHand) {
 -        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, Items.BUCKET, enumHand);
 +        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, who.isCreative() ? itemstack.getItem() : Items.BUCKET, enumHand); // Paper - don't forcefully set to bucket
      }
  
      public static PlayerBucketFillEvent callPlayerBucketFillEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemInHand, net.minecraft.server.Item bucket, EnumHand enumHand) {
+@@ -386,8 +392,13 @@ public class CraftEventFactory {
+ 
+     private static PlayerEvent getPlayerBucketEvent(boolean isFilling, World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, net.minecraft.server.Item item, EnumHand enumHand) {
+         // Paper end
++        // Paper start - Add full ItemStack parameter so we can keep meta
++        return getPlayerBucketEvent(isFilling, world, who, changed, clicked, clickedFace, itemstack, new ItemStack(item), enumHand);
++    }
++
++    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, ItemStack newItem, EnumHand enumHand) {
+         Player player = (Player) who.getBukkitEntity();
+-        CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
++        CraftItemStack itemInHand = CraftItemStack.asCraftMirror(newItem.cloneItemStack()); // Paper - need to clone because prev. event item was NOT a mirror, so changes did NOT modify the item in the player's hand
+         Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
+ 
+         CraftServer craftServer = (CraftServer) player.getServer();
 -- 
 2.24.0
 

--- a/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
+++ b/Spigot-Server-Patches/0425-Use-result-of-setItemStack-in-PlayerBucketEmptyEvent.patch
@@ -1,4 +1,4 @@
-From 210cf7b13fab9c83e8f3b10b80a8aea5a4e0affd Mon Sep 17 00:00:00 2001
+From 3540b3f5e56446d07bff84ed0f1f9a6434e32ff3 Mon Sep 17 00:00:00 2001
 From: Draycia <lonelyyordle@gmail.com>
 Date: Tue, 14 Jan 2020 05:37:05 -0800
 Subject: [PATCH] Use result of setItemStack in PlayerBucketEmptyEvent
@@ -17,26 +17,19 @@ index 80219f2df..c8184f94e 100644
          if (enumhand == EnumHand.MAIN_HAND) {
              this.setSlot(EnumItemSlot.MAINHAND, itemstack);
 diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
-index 0ff92aea5..498cd4d24 100644
+index 0ff92aea5..fe4a99917 100644
 --- a/src/main/java/net/minecraft/server/ItemBucket.java
 +++ b/src/main/java/net/minecraft/server/ItemBucket.java
-@@ -134,12 +134,13 @@ public class ItemBucket extends Item {
-             } else {
-                 // CraftBukkit start
-                 if (entityhuman != null) {
--                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, itemstack, enumhand);
-+                    PlayerBucketEmptyEvent event = CraftEventFactory.callPlayerBucketEmptyEvent(world, entityhuman, blockposition, clicked, enumdirection, entityhuman.isCreative() ? entityhuman.getItemInHand(enumhand) : itemstack, enumhand); // Paper - 2651: Prevents creative players from having their buckets modified
-                     if (event.isCancelled()) {
-                         ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, blockposition)); // SPIGOT-4238: needed when looking through entity
+@@ -140,6 +140,7 @@ public class ItemBucket extends Item {
                          ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
                          return false;
                      }
-+                    entityhuman.setItemInHand(enumhand, org.bukkit.craftbukkit.inventory.CraftItemStack.asNMSCopy(event.getItemStack())); // Paper - 2651: set item in hand if event isn't cancelled
++                    itemstack = CraftItemStack.asNMSCopy(event.getItemStack()); // Paper - 2651: set item in hand if event isn't cancelled
                  }
                  // CraftBukkit end
                  if (world.worldProvider.isNether() && this.fluidType.a(TagsFluid.WATER)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c0fd2948e..aed1cca44 100644
+index c0fd2948e..4d07d3e89 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -377,7 +377,7 @@ public class CraftEventFactory {
@@ -44,7 +37,7 @@ index c0fd2948e..aed1cca44 100644
  
      public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, EnumHand enumHand) {
 -        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, Items.BUCKET, enumHand);
-+        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, itemstack.getItem(), enumHand); // Paper - don't forcefully set to bucket
++        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, who.isCreative() ? itemstack.getItem() : Items.BUCKET, enumHand); // Paper - don't forcefully set to bucket
      }
  
      public static PlayerBucketFillEvent callPlayerBucketFillEvent(World world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemInHand, net.minecraft.server.Item bucket, EnumHand enumHand) {

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -91,7 +91,7 @@ done
 # Temporarily add new NMS dev imports here before you run paper patch
 # but after you have paper rb'd your changes, remove the line from this file before committing.
 # we do not need any lines added to this file for NMS
-
+import Item
 # import FileName
 
 

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -91,7 +91,7 @@ done
 # Temporarily add new NMS dev imports here before you run paper patch
 # but after you have paper rb'd your changes, remove the line from this file before committing.
 # we do not need any lines added to this file for NMS
-import Item
+
 # import FileName
 
 


### PR DESCRIPTION
Resolves the weird behaviour where modifications to itemStack in PlayerBucketEmptyEvent (through setItemStack in PlayerBucketEvent) are ignored.

Tested with #2651's code snippet and it seems to be functional with this change, things seem fine with the plugin omitted as well. 