### PR TITLE
Fix items not falling correctly (Resolves #2835)

### DIFF
--- a/Spigot-Server-Patches/0425-Fix-items-not-falling-correctly.patch
+++ b/Spigot-Server-Patches/0425-Fix-items-not-falling-correctly.patch
@@ -1,20 +1,18 @@
-From 201ec8e75c7efc888441abf20efc2077f4fb3f7b Mon Sep 17 00:00:00 2001
+From e748f07aa4a2d6c1e2b85f64bc9505f8a0163bb8 Mon Sep 17 00:00:00 2001
 From: AJMFactsheets <AJMFactsheets@gmail.com>
 Date: Fri, 17 Jan 2020 17:17:54 -0600
 Subject: [PATCH] Fix items not falling correctly
 
-Since 1.14, Mojang has added an optimization which checks if items
-should fall on every fourth tick.
+Since 1.14, Mojang has added an optimization which skips checking if 
+an item should fall every fourth tick.
 
 However, Spigot's entity activation range class also has an
-optimization which ticks active entities every fourth tick.
+optimization which skips ticking active entities every fourth tick.
 This can result in a state where an item will never properly fall
 due to its move method never being called.
 
-This patch resolves the conflict by ticking items every other tick,
-since excluding item entities from Spigot's entity activation range
-would offer worse performance overall.
-
+This patch resolves the conflict by offsetting checking an item's
+move method from Spigot's entity activation range check.
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
 index e61af3f5..30a7843b 100644
@@ -25,7 +23,7 @@ index e61af3f5..30a7843b 100644
              }
  
 -            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || (this.ticksLived + this.getId()) % 4 == 0) {
-+            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || (this.ticksLived + this.getId()) % 2 == 0) { // Paper - Check for item movement twice as often to not conflict with Spigot's Entity Activation Range
++            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || this.ticksLived % 4 == 3) { // Paper - Ensure checking item movement is always offset from Spigot's entity activation range check
                  this.move(EnumMoveType.SELF, this.getMot());
                  float f = 0.98F;
  

--- a/Spigot-Server-Patches/0425-Fix-items-not-falling-correctly.patch
+++ b/Spigot-Server-Patches/0425-Fix-items-not-falling-correctly.patch
@@ -1,0 +1,34 @@
+From 201ec8e75c7efc888441abf20efc2077f4fb3f7b Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Fri, 17 Jan 2020 17:17:54 -0600
+Subject: [PATCH] Fix items not falling correctly
+
+Since 1.14, Mojang has added an optimization which checks if items
+should fall on every fourth tick.
+
+However, Spigot's entity activation range class also has an
+optimization which ticks active entities every fourth tick.
+This can result in a state where an item will never properly fall
+due to its move method never being called.
+
+This patch resolves the conflict by ticking items every other tick,
+since excluding item entities from Spigot's entity activation range
+would offer worse performance overall.
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index e61af3f5..30a7843b 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -86,7 +86,7 @@ public class EntityItem extends Entity {
+                 }
+             }
+ 
+-            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || (this.ticksLived + this.getId()) % 4 == 0) {
++            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || (this.ticksLived + this.getId()) % 2 == 0) { // Paper - Check for item movement twice as often to not conflict with Spigot's Entity Activation Range
+                 this.move(EnumMoveType.SELF, this.getMot());
+                 float f = 0.98F;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
Since 1.14, Mojang has added an optimization which checks if items should fall on every fourth tick.

However, Spigot's entity activation range class also has an optimization which ticks active entities every fourth tick. This can result in a state where an item will never properly fall due to its move method never being called.

I have found 3 simple solutions that all work:
1. Change item entity tick frequency
2. Change activation range tick frequency
3. Exclude item entities from entity activation range checks

I went with solution 1, because in versions 1.13 and below, items checked if they needed to be moved every tick.

I will also backport this solution to 1.14.4 if it is deemed sufficient.