### PR TITLE
Backport Do less work if we have a custom Bukkit generator

### DIFF
--- a/Spigot-Server-Patches/0448-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/Spigot-Server-Patches/0448-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -1,0 +1,42 @@
+From 367bda02eaf6224a01907134e04c87b4230aca33 Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Fri, 17 Jan 2020 18:25:17 -0600
+Subject: [PATCH] Do less work if we have a custom Bukkit generator
+
+Patch originally for Paper 1.14 from Paul Sauve <paul@burngames.net>
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index ee071ba2..8af54019 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -769,12 +769,6 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+         } else if (this.worldData.getType() == WorldType.DEBUG_ALL_BLOCK_STATES) {
+             this.worldData.setSpawn(BlockPosition.ZERO.up());
+         } else {
+-            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
+-            List<BiomeBase> list = worldchunkmanager.a();
+-            Random random = new Random(this.getSeed());
+-            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
+-            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
+-
+             // CraftBukkit start
+             if (this.generator != null) {
+                 Random rand = new Random(this.getSeed());
+@@ -791,6 +785,14 @@ public class WorldServer extends World implements IAsyncTaskHandler {
+             }
+             // CraftBukkit end
+ 
++            // Paper start - this is useless if craftbukkit returns early
++            WorldChunkManager worldchunkmanager = this.chunkProvider.getChunkGenerator().getWorldChunkManager();
++            List<BiomeBase> list = worldchunkmanager.a();
++            Random random = new Random(this.getSeed());
++            BlockPosition blockposition = worldchunkmanager.a(0, 0, 256, list, random);
++            ChunkCoordIntPair chunkcoordintpair = blockposition == null ? new ChunkCoordIntPair(0, 0) : new ChunkCoordIntPair(blockposition);
++            // Paper end
++
+             if (blockposition == null) {
+                 WorldServer.a.warn("Unable to find spawn biome");
+             }
+-- 
+2.17.1
+

--- a/Spigot-Server-Patches/0448-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/Spigot-Server-Patches/0448-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -1,6 +1,6 @@
 From 367bda02eaf6224a01907134e04c87b4230aca33 Mon Sep 17 00:00:00 2001
-From: AJMFactsheets <AJMFactsheets@gmail.com>
-Date: Fri, 17 Jan 2020 18:25:17 -0600
+From: Paul Sauve <paul@burngames.net>
+Date: Sun, 14 Jul 2019 21:05:03 -0500
 Subject: [PATCH] Do less work if we have a custom Bukkit generator
 
 Patch originally for Paper 1.14 from Paul Sauve <paul@burngames.net>


### PR DESCRIPTION
This patch was originally created for Paper 1.14 from Paul Sauve <paul@burngames.net> (Github user PaulBGD), but was never backported to 1.13.

This patch aims to fix #2813 before support for Paper 1.13.2 is dropped tomorrow :1st_place_medal: