### PR TITLE
Fix last firework in stack not having effects when dispensed - #2871

### DIFF
--- a/Spigot-Server-Patches/0425-Fix-last-firework-in-stack-not-having-effects-when-d.patch
+++ b/Spigot-Server-Patches/0425-Fix-last-firework-in-stack-not-having-effects-when-d.patch
@@ -1,0 +1,26 @@
+From 875fded55e5170ede0b2319cce255b07da30923a Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Fri, 17 Jan 2020 18:44:55 -0800
+Subject: [PATCH] Fix last firework in stack not having effects when dispensed
+ - #2871
+
+CB used the resulting item in the dispenser rather than the item
+dispensed. The resulting item would have size == 0 and therefore
+be convertered to air, hence why the effects disappeared.
+
+diff --git a/src/main/java/net/minecraft/server/IDispenseBehavior.java b/src/main/java/net/minecraft/server/IDispenseBehavior.java
+index 9a8be1474..02d2e9a84 100644
+--- a/src/main/java/net/minecraft/server/IDispenseBehavior.java
++++ b/src/main/java/net/minecraft/server/IDispenseBehavior.java
+@@ -265,7 +265,7 @@ public interface IDispenseBehavior {
+                 }
+ 
+                 itemstack1 = CraftItemStack.asNMSCopy(event.getItem());
+-                EntityFireworks entityfireworks = new EntityFireworks(isourceblock.getWorld(), itemstack, d3, d4, d5, true);
++                EntityFireworks entityfireworks = new EntityFireworks(isourceblock.getWorld(), itemstack1, d3, d4, d5, true); // Paper - GH-2871 - fix last firework in stack having no effects when dispensed
+ 
+                 entityfireworks.shoot(d0, d1, d2, 0.5F, 1.0F);
+                 isourceblock.getWorld().addEntity(entityfireworks);
+-- 
+2.25.0.windows.1
+


### PR DESCRIPTION
CB used the resulting item in the dispenser rather than the item
dispensed. The resulting item would have size == 0 and therefore
be convertered to air, hence why the effects disappeared.

Fixes #2871 