### PR TITLE
Add support for Brigadier commands

### DIFF
--- a/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
+++ b/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
@@ -1,4 +1,4 @@
-From 57404ce735d98267904acbff58e1060239b52e6d Mon Sep 17 00:00:00 2001
+From 9aea3df7c07b0a8742af7cd23265d8944d19603f Mon Sep 17 00:00:00 2001
 From: PixelLima <pixellima@outlook.com>
 Date: Mon, 13 Jan 2020 18:53:10 +0000
 Subject: [PATCH] Add support for brigadier commands
@@ -36,7 +36,7 @@ index 252ddd22..c01732a8 100644
      <build>
 diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 new file mode 100644
-index 00000000..2ba1956b
+index 00000000..c25a4ffa
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 @@ -0,0 +1,164 @@
@@ -199,7 +199,7 @@ index 00000000..2ba1956b
 +     */
 +    @Deprecated
 +    public void registerNode() {
-+        if (isRegistered() && getCommandDispatcher() != null && brigadierTabExecutor.getCommandDispatcher().getRoot().getChild(node.getName()) == null) {
++        if (isRegistered() && getCommandDispatcher() != null) {
 +            brigadierTabExecutor.getCommandDispatcher().getRoot().addChild(this.node);
 +        }
 +    }

--- a/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
+++ b/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
@@ -1,0 +1,288 @@
+From a4f4469b20ec2bea6eb21f2ef3e418d136f2ebb9 Mon Sep 17 00:00:00 2001
+From: PixelLima <pixellima@outlook.com>
+Date: Mon, 13 Jan 2020 18:53:10 +0000
+Subject: [PATCH] Add support for brigadier commands
+
+
+diff --git a/pom.xml b/pom.xml
+index 252ddd22..c01732a8 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -39,6 +39,12 @@
+             <id>sonatype</id>
+             <url>https://oss.sonatype.org/content/groups/public/</url>
+         </repository>
++        <!-- Paper - Add support for brigadier commands -->
++        <repository>
++            <id>minecraft-libraries</id>
++            <name>Minecraft Libraries</name>
++            <url>https://libraries.minecraft.net</url>
++        </repository>
+     </repositories>
+ 
+     <pluginRepositories>
+@@ -146,6 +152,12 @@
+             <artifactId>asm-commons</artifactId>
+             <version>7.1</version>
+         </dependency>
++        <!-- Paper - Add support for brigadier commands -->
++        <dependency>
++            <groupId>com.mojang</groupId>
++            <artifactId>brigadier</artifactId>
++            <version>1.0.17</version>
++        </dependency>
+     </dependencies>
+ 
+     <build>
+diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
+new file mode 100644
+index 00000000..d793e2b9
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
+@@ -0,0 +1,125 @@
++package com.destroystokyo.paper.command;
++
++import com.google.common.collect.ImmutableList;
++import com.mojang.brigadier.CommandDispatcher;
++import com.mojang.brigadier.tree.CommandNode;
++import com.mojang.brigadier.tree.LiteralCommandNode;
++import org.bukkit.command.Command;
++import org.bukkit.command.CommandSender;
++import org.bukkit.command.PluginIdentifiableCommand;
++import org.bukkit.plugin.Plugin;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.List;
++
++/**
++ * Represents a command that holds a {@link CommandNode}. Enables the full use of Minecraft's implementation of Brigadier.
++ */
++public class BrigadierCommand extends Command implements PluginIdentifiableCommand {
++
++    private static BrigadierTabExecutor brigadierTabExecutor;
++
++    private final Plugin plugin;
++    private final CommandNode<CommandSource> node;
++
++    public BrigadierCommand(@NotNull Plugin plugin, @NotNull CommandNode<CommandSource> node) {
++        super(node.getName());
++
++        if (!(node instanceof LiteralCommandNode))
++            throw new IllegalArgumentException("Node must be a LiteralCommandNode.");
++
++        this.plugin = plugin;
++        this.node = node;
++    }
++
++    public BrigadierCommand(@NotNull Plugin plugin, @NotNull CommandNode<CommandSource> node, @Nullable String description, @Nullable String usageMessage, @NotNull List<String> aliases) {
++        this(plugin, node);
++        this.description = (description == null) ? "" : description;
++        this.usageMessage = (usageMessage == null) ? "/" + node.getName() : usageMessage;
++        this.setAliases(aliases);
++    }
++
++    /**
++     * Gets the owner of this command.
++     *
++     * @return Plugin that owns this command.
++     */
++    @NotNull
++    @Override
++    public Plugin getPlugin() {
++        return plugin;
++    }
++
++    /**
++     * Gets the node held by this instance.
++     *
++     * @return The node held by this instance.
++     */
++    @NotNull
++    public CommandNode<CommandSource> getNode() {
++        return node;
++    }
++
++    /**
++     * Executes the command, returning its success
++     *
++     * @param sender Source object which is executing this command
++     * @param commandLabel The alias of the command used
++     * @param args All arguments passed to the command, split via ' '
++     * @return true if the command was successful, otherwise false
++     */
++    @Override
++    public boolean execute(@NotNull CommandSender sender, @NotNull String commandLabel, @NotNull String[] args) {
++        return brigadierTabExecutor != null && brigadierTabExecutor.onCommand(sender, this, commandLabel, args);
++    }
++
++    /**
++     * Executed on tab completion for this command, returning a list of
++     * options the player can tab through.
++     *
++     * @param sender Source object which is executing this command
++     * @param alias the alias being used
++     * @param args All arguments passed to the command, split via ' '
++     * @return a list of tab-completions for the specified arguments. This
++     *     will never be null. List may be immutable.
++     * @throws IllegalArgumentException if sender, alias, or args is null
++     */
++    @NotNull
++    @Override
++    public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
++        if (brigadierTabExecutor != null) {
++            List<String> result = brigadierTabExecutor.onTabComplete(sender, this, alias, args);
++            if (result != null)
++                return result;
++        }
++        return ImmutableList.of();
++    }
++
++    /**
++     * Attempts to set the {@link BrigadierTabExecutor} singleton.
++     * <p>
++     * This cannot be done if the BrigadierTabExecutor is already set.
++     *
++     * @param brigadierTabExecutor BrigadierTabExecutor instance
++     */
++    public static void setBrigadierTabExecutor(@NotNull BrigadierTabExecutor brigadierTabExecutor) {
++        if (BrigadierCommand.brigadierTabExecutor != null) {
++            throw new UnsupportedOperationException("Cannot redefine the tab executor for brigadier commands.");
++        }
++
++        BrigadierCommand.brigadierTabExecutor = brigadierTabExecutor;
++    }
++
++    /**
++     * Register the node to the {@link CommandDispatcher}
++     *
++     * @deprecated This method is not meant to be used by plugins.
++     */
++    @Deprecated
++    public void registerNode() {
++        if (brigadierTabExecutor.getCommandDispatcher() != null && isRegistered() && brigadierTabExecutor.getCommandDispatcher().getRoot().getChild(node.getName()) == null) {
++            brigadierTabExecutor.getCommandDispatcher().getRoot().addChild(this.node);
++        }
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierTabExecutor.java b/src/main/java/com/destroystokyo/paper/command/BrigadierTabExecutor.java
+new file mode 100644
+index 00000000..da5eded1
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/command/BrigadierTabExecutor.java
+@@ -0,0 +1,19 @@
++package com.destroystokyo.paper.command;
++
++import com.mojang.brigadier.CommandDispatcher;
++import org.bukkit.command.TabExecutor;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Represents a {@link TabExecutor} that is linked to a {@link CommandDispatcher}.
++ */
++public interface BrigadierTabExecutor extends TabExecutor {
++
++    /**
++     * Get the {@link CommandDispatcher} linked to this instance.
++     *
++     * @return The command dispatcher linked to this instance.
++     */
++    @Nullable
++    CommandDispatcher<CommandSource> getCommandDispatcher();
++}
+diff --git a/src/main/java/com/destroystokyo/paper/command/CommandSource.java b/src/main/java/com/destroystokyo/paper/command/CommandSource.java
+new file mode 100644
+index 00000000..403ff327
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/command/CommandSource.java
+@@ -0,0 +1,62 @@
++package com.destroystokyo.paper.command;
++
++import org.bukkit.Location;
++import org.bukkit.command.CommandSender;
++import org.bukkit.entity.Entity;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Represents the context of the execution of a {@link BrigadierCommand}.
++ */
++public interface CommandSource {
++
++    /**
++     * Get the sender of the command.
++     *
++     * @return The sender of the command.
++     */
++    @NotNull
++    CommandSender getSender();
++
++    /**
++     * Get the executing entity of the command.
++     * <p>
++     * This can be changed by running '/execute as <entity> run ...'
++     * or other commands that change the context's executing entity.
++     *
++     * @return The executing entity of the command.
++     */
++    @Nullable
++    Entity getExecutingEntity();
++
++    /**
++     * Get the location (world, x, y, z, pitch, yaw) of the command context.
++     * <p>
++     * This can be changed by running '/execute at <entity> run ...'
++     * or '/execute positioned <x> <y> <z> run ...' or '/execute in <world> run ...'
++     * or other commands that change the context's world, position or rotation.
++     *
++     * @return The location of the command context.
++     */
++    @NotNull
++    Location getLocation();
++
++    /**
++     * Get the {@link Anchor} of the command context.
++     * <p>
++     * This can be changed by running '/execute anchored <feet|eyes> run ...'
++     * or other commands that change the context's anchor.
++     *
++     * @return The anchor of the command context.
++     */
++    @NotNull
++    Anchor getAnchor();
++
++    /**
++     * Enumeration of the different anchor types that a command context can have.
++     */
++    public enum Anchor {
++        FEET, EYES;
++    }
++}
+diff --git a/src/main/java/org/bukkit/command/SimpleCommandMap.java b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+index 460fda05..45a81e2b 100644
+--- a/src/main/java/org/bukkit/command/SimpleCommandMap.java
++++ b/src/main/java/org/bukkit/command/SimpleCommandMap.java
+@@ -9,6 +9,7 @@ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Map;
+ 
++import com.destroystokyo.paper.command.BrigadierCommand;
+ import com.destroystokyo.paper.event.server.ServerExceptionEvent;
+ import com.destroystokyo.paper.exception.ServerCommandException;
+ import com.destroystokyo.paper.exception.ServerTabCompleteException;
+@@ -90,6 +91,12 @@ public class SimpleCommandMap implements CommandMap {
+         // Register to us so further updates of the commands label and aliases are postponed until its reregistered
+         command.register(this);
+ 
++        // Paper start - Add support for brigadier commands
++        if(command instanceof BrigadierCommand) {
++            ((BrigadierCommand) command).registerNode();
++        }
++        // Paper end
++
+         return registered;
+     }
+ 
+-- 
+2.24.1.windows.2
+

--- a/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
+++ b/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
@@ -1,4 +1,4 @@
-From cdf1dbb90c2c214c01cc67659b696528c078555b Mon Sep 17 00:00:00 2001
+From 57404ce735d98267904acbff58e1060239b52e6d Mon Sep 17 00:00:00 2001
 From: PixelLima <pixellima@outlook.com>
 Date: Mon, 13 Jan 2020 18:53:10 +0000
 Subject: [PATCH] Add support for brigadier commands
@@ -36,10 +36,10 @@ index 252ddd22..c01732a8 100644
      <build>
 diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 new file mode 100644
-index 00000000..548d6f0a
+index 00000000..2ba1956b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
-@@ -0,0 +1,163 @@
+@@ -0,0 +1,164 @@
 +package com.destroystokyo.paper.command;
 +
 +import com.google.common.collect.ImmutableList;
@@ -172,6 +172,7 @@ index 00000000..548d6f0a
 +     * @param <T> type of object that is returned by the argument.
 +     * @return A RequiredArgumentBuilder for a command node with the given name and argument type.
 +     */
++    @NotNull
 +    public static <T> RequiredArgumentBuilder<CommandSource, T> argument(@NotNull String name, @NotNull ArgumentType<T> argumentType) {
 +        return RequiredArgumentBuilder.argument(name, argumentType);
 +    }

--- a/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
+++ b/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
@@ -1,4 +1,4 @@
-From a7c44328b3c96e8895b2e652129e4508f51f10d6 Mon Sep 17 00:00:00 2001
+From cdf1dbb90c2c214c01cc67659b696528c078555b Mon Sep 17 00:00:00 2001
 From: PixelLima <pixellima@outlook.com>
 Date: Mon, 13 Jan 2020 18:53:10 +0000
 Subject: [PATCH] Add support for brigadier commands
@@ -36,7 +36,7 @@ index 252ddd22..c01732a8 100644
      <build>
 diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 new file mode 100644
-index 00000000..eb7f7968
+index 00000000..548d6f0a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 @@ -0,0 +1,163 @@
@@ -198,7 +198,7 @@ index 00000000..eb7f7968
 +     */
 +    @Deprecated
 +    public void registerNode() {
-+        if (brigadierTabExecutor.getCommandDispatcher() != null && isRegistered() && brigadierTabExecutor.getCommandDispatcher().getRoot().getChild(node.getName()) == null) {
++        if (isRegistered() && getCommandDispatcher() != null && brigadierTabExecutor.getCommandDispatcher().getRoot().getChild(node.getName()) == null) {
 +            brigadierTabExecutor.getCommandDispatcher().getRoot().addChild(this.node);
 +        }
 +    }

--- a/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
+++ b/Spigot-API-Patches/0189-Add-support-for-brigadier-commands.patch
@@ -1,4 +1,4 @@
-From a4f4469b20ec2bea6eb21f2ef3e418d136f2ebb9 Mon Sep 17 00:00:00 2001
+From a7c44328b3c96e8895b2e652129e4508f51f10d6 Mon Sep 17 00:00:00 2001
 From: PixelLima <pixellima@outlook.com>
 Date: Mon, 13 Jan 2020 18:53:10 +0000
 Subject: [PATCH] Add support for brigadier commands
@@ -36,14 +36,17 @@ index 252ddd22..c01732a8 100644
      <build>
 diff --git a/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
 new file mode 100644
-index 00000000..d793e2b9
+index 00000000..eb7f7968
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/command/BrigadierCommand.java
-@@ -0,0 +1,125 @@
+@@ -0,0 +1,163 @@
 +package com.destroystokyo.paper.command;
 +
 +import com.google.common.collect.ImmutableList;
 +import com.mojang.brigadier.CommandDispatcher;
++import com.mojang.brigadier.arguments.ArgumentType;
++import com.mojang.brigadier.builder.LiteralArgumentBuilder;
++import com.mojang.brigadier.builder.RequiredArgumentBuilder;
 +import com.mojang.brigadier.tree.CommandNode;
 +import com.mojang.brigadier.tree.LiteralCommandNode;
 +import org.bukkit.command.Command;
@@ -136,6 +139,41 @@ index 00000000..d793e2b9
 +                return result;
 +        }
 +        return ImmutableList.of();
++    }
++
++    /**
++     * Get the {@link CommandDispatcher} currently in use by the server.
++     *
++     * @return the CommandDispatcher in use by the server, or null, if there is none.
++     */
++    @Nullable
++    public static CommandDispatcher<CommandSource> getCommandDispatcher() {
++        if (brigadierTabExecutor != null)
++            return brigadierTabExecutor.getCommandDispatcher();
++        return null;
++    }
++
++    /**
++     * Get a {@link LiteralArgumentBuilder} for a command node with a given name.
++     *
++     * @param name name of the node
++     * @return A LiteralArgumentBuilder for a command node with the given name.
++     */
++    @NotNull
++    public static LiteralArgumentBuilder<CommandSource> literal(@NotNull String name) {
++        return LiteralArgumentBuilder.literal(name);
++    }
++
++    /**
++     * Get a {@link RequiredArgumentBuilder} for a command node with a given name and argument type.
++     *
++     * @param name name of the node
++     * @param argumentType argument type of the node
++     * @param <T> type of object that is returned by the argument.
++     * @return A RequiredArgumentBuilder for a command node with the given name and argument type.
++     */
++    public static <T> RequiredArgumentBuilder<CommandSource, T> argument(@NotNull String name, @NotNull ArgumentType<T> argumentType) {
++        return RequiredArgumentBuilder.argument(name, argumentType);
 +    }
 +
 +    /**

--- a/Spigot-Server-Patches/0424-Add-support-for-brigadier-commands.patch
+++ b/Spigot-Server-Patches/0424-Add-support-for-brigadier-commands.patch
@@ -1,0 +1,230 @@
+From c1c989d63974c8d869fe99c33bdcd41c57e250ae Mon Sep 17 00:00:00 2001
+From: PixelLima <pixellima@outlook.com>
+Date: Wed, 15 Jan 2020 17:51:48 +0000
+Subject: [PATCH] Add support for brigadier commands
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/command/PaperBrigadierTabExecutor.java b/src/main/java/com/destroystokyo/paper/command/PaperBrigadierTabExecutor.java
+new file mode 100644
+index 000000000..0ab2b1714
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/command/PaperBrigadierTabExecutor.java
+@@ -0,0 +1,64 @@
++package com.destroystokyo.paper.command;
++
++import com.mojang.brigadier.ParseResults;
++import net.minecraft.server.CommandDispatcher;
++import net.minecraft.server.CommandListenerWrapper;
++import org.apache.commons.lang.Validate;
++import org.bukkit.command.Command;
++import org.bukkit.command.CommandSender;
++import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
++
++import java.util.ArrayList;
++import java.util.List;
++
++public class PaperBrigadierTabExecutor implements BrigadierTabExecutor {
++
++    private CommandDispatcher dispatcher;
++
++    public PaperBrigadierTabExecutor(CommandDispatcher dispatcher) {
++        this.dispatcher = dispatcher;
++    }
++
++    @Override
++    public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
++        if (!(command instanceof BrigadierCommand))
++            return true;
++        
++        if (!command.testPermission(sender)) 
++            return true;
++
++        CommandListenerWrapper icommandlistener = VanillaCommandWrapper.getListener(sender);
++        dispatcher.a(icommandlistener, VanillaCommandWrapper.toDispatcher(args, command.getName()), VanillaCommandWrapper.toDispatcher(args, label));
++        return true;
++    }
++
++    @Override
++    public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
++        Validate.notNull(sender, "Sender cannot be null");
++        Validate.notNull(args, "Arguments cannot be null");
++        Validate.notNull(alias, "Alias cannot be null");
++        
++        if (!(command instanceof BrigadierCommand))
++            return null;
++
++        CommandListenerWrapper icommandlistener = VanillaCommandWrapper.getListener(sender);
++        ParseResults<CommandListenerWrapper> parsed = dispatcher.a().parse(VanillaCommandWrapper.toDispatcher(args, command.getName()), icommandlistener);
++
++        List<String> results = new ArrayList<>();
++        dispatcher.a().getCompletionSuggestions(parsed).thenAccept((suggestions) -> {
++            suggestions.getList().forEach((s) -> results.add(s.getText()));
++        });
++        
++        return results;
++    }
++
++    public void setDispatcher(CommandDispatcher dispatcher) {
++        if (dispatcher != null)
++            this.dispatcher = dispatcher;
++    }
++
++    @Override
++    public com.mojang.brigadier.CommandDispatcher<CommandSource> getCommandDispatcher() {
++        return (com.mojang.brigadier.CommandDispatcher) this.dispatcher.a();
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/CommandListenerWrapper.java b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
+index 0b23a0548..b870fbd89 100644
+--- a/src/main/java/net/minecraft/server/CommandListenerWrapper.java
++++ b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.command.CommandSource;
+ import com.google.common.collect.Lists;
+ import com.mojang.brigadier.ResultConsumer;
+ import com.mojang.brigadier.context.CommandContext;
+@@ -8,6 +9,9 @@ import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+ import com.mojang.brigadier.suggestion.Suggestions;
+ import com.mojang.brigadier.suggestion.SuggestionsBuilder;
+ import com.mojang.brigadier.tree.CommandNode;
++import org.bukkit.Location;
++import org.bukkit.command.CommandSender;
++
+ import java.util.Collection;
+ import java.util.Iterator;
+ import java.util.concurrent.CompletableFuture;
+@@ -15,7 +19,7 @@ import java.util.function.BinaryOperator;
+ import java.util.stream.Stream;
+ import javax.annotation.Nullable;
+ 
+-public class CommandListenerWrapper implements ICompletionProvider {
++public class CommandListenerWrapper implements ICompletionProvider, CommandSource { // Paper - Implemented CommandSource in order to add support for brigadier commands
+ 
+     public static final SimpleCommandExceptionType a = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.player", new Object[0]));
+     public static final SimpleCommandExceptionType b = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.entity", new Object[0]));
+@@ -33,6 +37,7 @@ public class CommandListenerWrapper implements ICompletionProvider {
+     private final ArgumentAnchor.Anchor m;
+     private final Vec2F n;
+     public CommandNode currentCommand; // CraftBukkit
++    public Location location; // Paper - Add support for brigadier commands
+ 
+     public CommandListenerWrapper(ICommandListener icommandlistener, Vec3D vec3d, Vec2F vec2f, WorldServer worldserver, int i, String s, IChatBaseComponent ichatbasecomponent, MinecraftServer minecraftserver, @Nullable Entity entity) {
+         this(icommandlistener, vec3d, vec2f, worldserver, i, s, ichatbasecomponent, minecraftserver, entity, false, (commandcontext, flag, j) -> {
+@@ -52,6 +57,8 @@ public class CommandListenerWrapper implements ICompletionProvider {
+         this.l = resultconsumer;
+         this.m = argumentanchor_anchor;
+         this.n = vec2f;
++
++        this.location = new org.bukkit.Location(getWorld().getWorld(), getPosition().x, getPosition().y, getPosition().z, i().i, i().j);
+     }
+ 
+     public CommandListenerWrapper a(Entity entity) {
+@@ -255,4 +262,36 @@ public class CommandListenerWrapper implements ICompletionProvider {
+         return base.getBukkitSender(this);
+     }
+     // CraftBukkit end
++
++    // Paper start - Implement CommandSource in order to support brigadier command
++    @Override
++    public org.bukkit.entity.Entity getExecutingEntity() {
++        if (getEntity() == null)
++            return null;
++
++        return getEntity().getBukkitEntity();
++    }
++
++    @Override
++    public CommandSender getSender() {
++        return getBukkitSender();
++    }
++
++    @Override
++    public Location getLocation() {
++        return this.location;
++    }
++
++    @Override
++    public Anchor getAnchor() {
++        switch (k()) {
++            case EYES:
++                return Anchor.EYES;
++            case FEET:
++                return Anchor.FEET;
++        }
++        return null;
++    }
++
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index ee5c57ca2..60a7ccdd8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1,5 +1,7 @@
+ package org.bukkit.craftbukkit;
+ 
++import com.destroystokyo.paper.command.BrigadierCommand;
++import com.destroystokyo.paper.command.PaperBrigadierTabExecutor;
+ import com.google.common.base.Charsets;
+ import com.google.common.base.Function;
+ import com.google.common.base.Preconditions;
+@@ -237,6 +239,7 @@ public final class CraftServer implements Server {
+     private final List<CraftPlayer> playerView;
+     public int reloadCount;
+     public static Exception excessiveVelEx; // Paper - Velocity warnings
++    private final PaperBrigadierTabExecutor brigadierTabExecutor; // Paper - Add support for brigadier commands
+ 
+     static {
+         ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
+@@ -256,6 +259,8 @@ public final class CraftServer implements Server {
+ 
+         Bukkit.setServer(this);
+ 
++        BrigadierCommand.setBrigadierTabExecutor(brigadierTabExecutor = new PaperBrigadierTabExecutor(console.commandDispatcher)); // Paper - Add support for brigadier commands
++
+         // Register all the Enchantments and PotionTypes now so we can stop new registration immediately after
+         Enchantments.DAMAGE_ALL.getClass();
+         org.bukkit.enchantments.Enchantment.stopAcceptingRegistrations();
+@@ -424,13 +429,22 @@ public final class CraftServer implements Server {
+         // Clear existing commands
+         CommandDispatcher dispatcher = console.commandDispatcher = new CommandDispatcher();
+ 
++        brigadierTabExecutor.setDispatcher(dispatcher); // Paper - Add support for brigadier commands
++
+         // Register all commands, vanilla ones will be using the old dispatcher references
+         for (Map.Entry<String, Command> entry : commandMap.getKnownCommands().entrySet()) {
+             String label = entry.getKey();
+             Command command = entry.getValue();
+ 
+-            if (command instanceof VanillaCommandWrapper) {
+-                LiteralCommandNode<CommandListenerWrapper> node = (LiteralCommandNode<CommandListenerWrapper>) ((VanillaCommandWrapper) command).vanillaCommand;
++            // Paper start - Add support for brigadier commands
++            if (command instanceof VanillaCommandWrapper || command instanceof BrigadierCommand) {
++                LiteralCommandNode<CommandListenerWrapper> node;
++                if (command instanceof  VanillaCommandWrapper)
++                    node = (LiteralCommandNode<CommandListenerWrapper>) ((VanillaCommandWrapper) command).vanillaCommand;
++                else
++                    node = (LiteralCommandNode) ((BrigadierCommand) command).getNode();
++                // Paper end
++
+                 if (!node.getLiteral().equals(label)) {
+                     LiteralCommandNode<CommandListenerWrapper> clone = new LiteralCommandNode(label, node.getCommand(), node.getRequirement(), node.getRedirect(), node.getRedirectModifier(), node.isFork());
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+index a3ae4a9ff..d665e3c86 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+@@ -90,7 +90,7 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+         return "minecraft.command." + ((vanillaCommand.getRedirect() == null) ? vanillaCommand.getName() : vanillaCommand.getRedirect().getName());
+     }
+ 
+-    private String toDispatcher(String[] args, String name) {
++    public static String toDispatcher(String[] args, String name) { // Paper - Add support for brigadier commands
+         return "/" + name + ((args.length > 0) ? " " + Joiner.on(' ').join(args) : "");
+     }
+ }
+-- 
+2.24.1.windows.2
+


### PR DESCRIPTION
Hello! This is my first PR ever, so *please don't judge me* xD

This patch allows plugin developers to register commands that use [Mojang's Brigadier library](https://github.com/Mojang/brigadier) and all of its capabilities. This means that plugin developers will be able to specify the type of an argument (such as greedy strings, quoted strings, integers, booleans, etc.) and that the client is able to give real-time errors, regarding what the player has written in the input box. Also, colored syntax :)

This is achieved by, first of all, adding Brigadier as an API dependency and by creating a class (`BrigadierCommand`) that extends the normal `Command` class. Then, developers can create objects of that class and register them to the command map. By doing so, the server automatically registers the node to Brigadier's command dispatcher. After that, they need to call `Player#updateCommands`, in order to send the command node to the player's client.

Of course, we require a source for the commands, so a new interface has been created, which is 'CommandSource'. It provides basic command context information and is implemented in 'CommandListenerWrapper'. 

Currently, the API does not support any argument types, other than the ones provided by Brigadier.

Finally, I know that Paper already supports Brigadier commands, however, there is no support on the API side, which is what this patch aims to fix.