### PR TITLE
Backport Fix items not falling correctly (Resolves #2835)

### DIFF
--- a/Spigot-Server-Patches/0428-Fix-items-not-falling-correctly.patch
+++ b/Spigot-Server-Patches/0428-Fix-items-not-falling-correctly.patch
@@ -1,0 +1,32 @@
+From 208d64fae2cd3292ad4e8f7e8ca00ada20ff5b9a Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Mon, 20 Jan 2020 17:05:05 -0600
+Subject: [PATCH] Fix items not falling correctly
+
+Since 1.14, Mojang has added an optimization which skips checking if
+an item should fall every fourth tick.
+
+However, Spigot's entity activation range class also has an
+optimization which skips ticking active entities every fourth tick.
+This can result in a state where an item will never properly fall
+due to its move method never being called.
+
+This patch resolves the conflict by offsetting checking an item's
+move method from Spigot's entity activation range check.
+
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index df26cef6..4fe33aad 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -85,7 +85,7 @@ public class EntityItem extends Entity {
+                 }
+             }
+ 
+-            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || (this.ticksLived + this.getId()) % 4 == 0) {
++            if (!this.onGround || b(this.getMot()) > 9.999999747378752E-6D || this.ticksLived % 4 == 3) { // Paper - Ensure checking item movement is always offset from Spigot's entity activation range check
+                 this.move(EnumMoveType.SELF, this.getMot());
+                 float f = 0.98F;
+ 
+-- 
+2.17.1
+


### PR DESCRIPTION
The same fix from PR #2872 can also be applied to 1.14 too. Resolves issue #2835 for 1.14.4 players ;)

Since 1.14, Mojang has added an optimization which skips checking if an item should fall every fourth tick.

However, Spigot's entity activation range class also has an optimization which skips ticking active entities every fourth tick. This can result in a state where an item will never properly fall due to its move method never being called.

This patch resolves the conflict by offsetting checking an item's move method from Spigot's entity activation range check.