### PR TITLE
Fix items vanishing through end portal (Resolves #2681)

### DIFF
--- a/Spigot-Server-Patches/0429-Fix-items-vanishing-through-end-portal.patch
+++ b/Spigot-Server-Patches/0429-Fix-items-vanishing-through-end-portal.patch
@@ -1,0 +1,33 @@
+From e144e041f0047b0a0e867a0f793fe5ba8c8fd546 Mon Sep 17 00:00:00 2001
+From: AJMFactsheets <AJMFactsheets@gmail.com>
+Date: Wed, 22 Jan 2020 19:52:28 -0600
+Subject: [PATCH] Fix items vanishing through end portal
+
+If the Paper configuration option "keep-spawn-loaded" is set to false,
+items entering the overworld from the end will spawn at Y = 0.
+
+This is due to logic in the getHighestBlockYAt method in World.java
+only searching the heightmap if the chunk is loaded.
+
+Quickly loading the exact world spawn chunk before searching the
+heightmap resolves the issue without having to load all spawn chunks.
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index e8def7f8..f65db8e2 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2591,6 +2591,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+ 
+         if (blockposition == null) { // CraftBukkit
+             if (dimensionmanager1.getType() == DimensionManager.THE_END && dimensionmanager == DimensionManager.OVERWORLD) { // CraftBukkit
++                // Paper start - Ensure spawn chunk is always loaded before calculating Y coordinate
++                if (!worldserver1.isLoaded(worldserver1.getSpawn())) {
++                    worldserver1.getChunkAtWorldCoords(worldserver1.getSpawn());
++                }
++                // Paper end
+                 blockposition = worldserver1.getHighestBlockYAt(HeightMap.Type.MOTION_BLOCKING_NO_LEAVES, worldserver1.getSpawn());
+             } else if (dimensionmanager.getType() == DimensionManager.THE_END) { // CraftBukkit
+                 blockposition = worldserver1.getDimensionSpawn();
+-- 
+2.17.1
+


### PR DESCRIPTION
If the Paper configuration option "keep-spawn-loaded" is set to false, items entering the overworld from the end will spawn at Y = 0. This is due to logic in the getHighestBlockYAt method in World.java only searching the heightmap if the chunk is loaded. Items would often get stuck in a cave or burn in lava since they had to travel to the surface from the very bottom of the world.

Quickly loading the exact world spawn chunk before searching the heightmap resolves the issue without having to load all spawn chunks. The chunk is only loaded if an entity travels through the exit end portal and the spawn chunks aren't already loaded.

I prioritized 1.14.4 due to EOL concerns. If this is merged, I can easily port it to 1.15.2 (see issue #2753)