### PR TITLE
Fix errors on startup when double clicking jar

### DIFF
--- a/Spigot-Server-Patches/0150-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0150-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From aec337e66237495db8935baae5b323a74ffc44f5 Mon Sep 17 00:00:00 2001
+From 322bdbdbd5693d6f216dc292396c192f3b4ded33 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -143,20 +143,22 @@ index 000000000..685deaa0e
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index a78896dc8..886900006 100644
+index a78896dc8..999361e34 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -86,6 +86,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -86,6 +86,11 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
                  if (!org.bukkit.craftbukkit.Main.useConsole) {
                      return;
                  }
 +                // Paper start - Use TerminalConsoleAppender
-+                new com.destroystokyo.paper.console.PaperConsole(DedicatedServer.this).start();
++                if (System.console() != null) {
++                    new com.destroystokyo.paper.console.PaperConsole(DedicatedServer.this).start();
++                }
 +                /*
                  jline.console.ConsoleReader bufferedreader = reader;
                  // CraftBukkit end
  
-@@ -118,6 +121,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -118,6 +123,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
                      DedicatedServer.LOGGER.error("Exception handling console input", ioexception);
                  }
  
@@ -165,7 +167,7 @@ index a78896dc8..886900006 100644
              }
          };
  
-@@ -129,6 +134,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -129,6 +136,9 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
          global.addHandler(new org.bukkit.craftbukkit.util.ForwardLogHandler());
  
@@ -175,7 +177,7 @@ index a78896dc8..886900006 100644
          final org.apache.logging.log4j.core.Logger logger = ((org.apache.logging.log4j.core.Logger) LogManager.getRootLogger());
          for (org.apache.logging.log4j.core.Appender appender : logger.getAppenders().values()) {
              if (appender instanceof org.apache.logging.log4j.core.appender.ConsoleAppender) {
-@@ -137,6 +145,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -137,6 +147,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
          new org.bukkit.craftbukkit.util.TerminalConsoleWriterThread(System.out, this.reader).start();
@@ -617,5 +619,5 @@ index 722ca8496..5a049e1b5 100644
      </Loggers>
  </Configuration>
 -- 
-2.25.0.windows.1
+2.24.0
 

--- a/Spigot-Server-Patches/0171-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
+++ b/Spigot-Server-Patches/0171-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
@@ -1,4 +1,4 @@
-From 8e4e7526d65ab60ec0c5b51524448837abe6249d Mon Sep 17 00:00:00 2001
+From 2d630b43625d43754349a02130be17f59eddeac6 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Mon, 18 Sep 2017 12:00:03 +0200
 Subject: [PATCH] Use Log4j IOStreams to redirect System.out/err to logger
@@ -28,10 +28,10 @@ index 93c1a04bc..663eacfe2 100644
              <groupId>org.ow2.asm</groupId>
              <artifactId>asm</artifactId>
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 886900006..0411fb3ee 100644
+index 999361e34..5fee3f9a9 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -148,8 +148,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -150,8 +150,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          */
          // Paper end
  
@@ -45,5 +45,5 @@ index 886900006..0411fb3ee 100644
  
          thread.setDaemon(true);
 -- 
-2.25.0.windows.1
+2.24.0
 

--- a/Spigot-Server-Patches/0276-Use-a-Queue-for-Queueing-Commands.patch
+++ b/Spigot-Server-Patches/0276-Use-a-Queue-for-Queueing-Commands.patch
@@ -1,4 +1,4 @@
-From 5632d26dd961b00051930945ccc100df3d16b34f Mon Sep 17 00:00:00 2001
+From 8f4d4336da37df3266a1faa8b6179c89999e3206 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 12 Aug 2018 02:33:39 -0400
 Subject: [PATCH] Use a Queue for Queueing Commands
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Queue for Queueing Commands
 Lists are bad as Queues mmmkay.
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 0411fb3ee..a74fae9ed 100644
+index 5fee3f9a9..d9dee47f8 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -44,7 +44,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -18,7 +18,7 @@ index 0411fb3ee..a74fae9ed 100644
      private RemoteStatusListener remoteStatusListener;
      public final RemoteControlCommandListener remoteControlCommandListener;
      private RemoteControlListener remoteControlListener;
-@@ -447,8 +447,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -449,8 +449,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
  
      public void handleCommandQueue() {
          MinecraftTimings.serverCommandTimer.startTiming(); // Spigot
@@ -32,5 +32,5 @@ index 0411fb3ee..a74fae9ed 100644
              // CraftBukkit start - ServerCommand for preprocessing
              ServerCommandEvent event = new ServerCommandEvent(console, servercommand.command);
 -- 
-2.25.0.windows.1
+2.24.0
 


### PR DESCRIPTION
This fixes [the IOException](https://pastebin.com/XMBM5MuP) when starting the server without a console (aka, double clicking the jar in a graphical environment).