### PR TITLE
Fix startup errors when double clicking jar

### DIFF
--- a/Spigot-Server-Patches/0150-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0150-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From aec337e66237495db8935baae5b323a74ffc44f5 Mon Sep 17 00:00:00 2001
+From 33ffa2db7d269531288bfa00c2cda19ae26060f4 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -579,10 +579,10 @@ index 000000000..0694b2146
 @@ -0,0 +1 @@
 +log4j.skipJansi=true
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 722ca8496..5a049e1b5 100644
+index 722ca8496..620b9490e 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
-@@ -1,17 +1,17 @@
+@@ -1,17 +1,14 @@
  <?xml version="1.0" encoding="UTF-8"?>
  <Configuration status="WARN" packages="com.mojang.util">
      <Appenders>
@@ -592,9 +592,9 @@ index 722ca8496..5a049e1b5 100644
          <Queue name="ServerGuiConsole">
              <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />
          </Queue>
-         <Queue name="TerminalConsole">
-             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
-         </Queue>
+-        <Queue name="TerminalConsole">
+-            <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+-        </Queue>
 +        <TerminalConsole name="TerminalConsole">
 +            <PatternLayout pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx}" />
 +        </TerminalConsole>
@@ -604,7 +604,7 @@ index 722ca8496..5a049e1b5 100644
              <Policies>
                  <TimeBasedTriggeringPolicy />
                  <OnStartupTriggeringPolicy />
-@@ -24,10 +24,9 @@
+@@ -24,10 +21,9 @@
              <filters>
                  <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
              </filters>
@@ -617,5 +617,5 @@ index 722ca8496..5a049e1b5 100644
      </Loggers>
  </Configuration>
 -- 
-2.25.0.windows.1
+2.24.0
 

--- a/Spigot-Server-Patches/0172-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/Spigot-Server-Patches/0172-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -1,4 +1,4 @@
-From 02defb30546e8f70326f06dc850b15c518b0ec92 Mon Sep 17 00:00:00 2001
+From c933a958f37c72234adcccd4f1d52e7f97dd3f49 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Thu, 21 Sep 2017 16:14:55 +0200
 Subject: [PATCH] Handle plugin prefixes using Log4J configuration
@@ -41,11 +41,11 @@ index fdca34346..6d77bbc5a 100644
  
      public static int playerShuffle;
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 5a049e1b5..4b3c0269e 100644
+index 620b9490e..a8bdaaeaa 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
-@@ -8,10 +8,22 @@
-             <PatternLayout pattern="[%d{HH:mm:ss}] [%t/%level]: %msg%n" />
+@@ -5,10 +5,22 @@
+             <PatternLayout pattern="[%d{HH:mm:ss} %level]: %msg%n" />
          </Queue>
          <TerminalConsole name="TerminalConsole">
 -            <PatternLayout pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx}" />
@@ -70,5 +70,5 @@ index 5a049e1b5..4b3c0269e 100644
                  <TimeBasedTriggeringPolicy />
                  <OnStartupTriggeringPolicy />
 -- 
-2.25.0.windows.1
+2.24.0
 

--- a/Spigot-Server-Patches/0174-Disable-logger-prefix-for-various-plugins-bypassing-.patch
+++ b/Spigot-Server-Patches/0174-Disable-logger-prefix-for-various-plugins-bypassing-.patch
@@ -1,4 +1,4 @@
-From e0d08cc7e4ca64bcb7afcc27cde365d838b6b155 Mon Sep 17 00:00:00 2001
+From fceb95f6c30cba36961d90cf4f666003509b54a3 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Sat, 23 Sep 2017 21:07:20 +0200
 Subject: [PATCH] Disable logger prefix for various plugins bypassing the
@@ -11,10 +11,10 @@ log. Disable the logger prefix for these plugins so the messages
 show up correctly.
 
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 4b3c0269e..869bff4af 100644
+index a8bdaaeaa..a9bb98765 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
-@@ -11,7 +11,8 @@
+@@ -8,7 +8,8 @@
              <PatternLayout>
                  <LoggerNamePatternSelector defaultPattern="%highlightError{[%d{HH:mm:ss} %level]: [%logger] %minecraftFormatting{%msg}%n%xEx}">
                      <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
@@ -24,7 +24,7 @@ index 4b3c0269e..869bff4af 100644
                                    pattern="%highlightError{[%d{HH:mm:ss} %level]: %minecraftFormatting{%msg}%n%xEx}" />
                  </LoggerNamePatternSelector>
              </PatternLayout>
-@@ -20,7 +21,8 @@
+@@ -17,7 +18,8 @@
              <PatternLayout>
                  <LoggerNamePatternSelector defaultPattern="[%d{HH:mm:ss}] [%t/%level]: [%logger] %minecraftFormatting{%msg}{strip}%n">
                      <!-- Log root, Minecraft, Mojang and Bukkit loggers without prefix -->
@@ -35,5 +35,5 @@ index 4b3c0269e..869bff4af 100644
                  </LoggerNamePatternSelector>
              </PatternLayout>
 -- 
-2.25.0.windows.1
+2.24.0
 


### PR DESCRIPTION
Ok, after further investigating this turns out to be the proper solution.

Cause: There is a duplicate `TerminalConsole` in the log4j2.xml file.

Fix: Remove the duplicate.

Solves: No more errors on startup when double clicking the jar, and without edge case side effects like MultiCrap not working.