### PR TITLE
Fix #2906 - Bees get gravity in void - Fixes MC-167279

### DIFF
--- a/Spigot-Server-Patches/0435-Bees-get-gravity-in-void.-Fixes-MC-167279.patch
+++ b/Spigot-Server-Patches/0435-Bees-get-gravity-in-void.-Fixes-MC-167279.patch
@@ -1,0 +1,32 @@
+From 2489a23bdb7592b3f834adf5944598e3f507e6bb Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 26 Jan 2020 16:30:19 -0600
+Subject: [PATCH] Bees get gravity in void. Fixes MC-167279
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityBee.java b/src/main/java/net/minecraft/server/EntityBee.java
+index f67d66b9a..5f652fbbb 100644
+--- a/src/main/java/net/minecraft/server/EntityBee.java
++++ b/src/main/java/net/minecraft/server/EntityBee.java
+@@ -36,7 +36,17 @@ public class EntityBee extends EntityAnimal implements EntityBird {
+ 
+     public EntityBee(EntityTypes<? extends EntityBee> entitytypes, World world) {
+         super(entitytypes, world);
+-        this.moveController = new ControllerMoveFlying(this, 20, true);
++        // Paper start - apply gravity to bees when they get stuck in the void, fixes MC-167279
++        this.moveController = new ControllerMoveFlying(this, 20, true) {
++            @Override
++            public void a() {
++                if (a.locY() <= 0) {
++                    a.setNoGravity(false);
++                }
++                super.a();
++            }
++        };
++        // Paper end
+         this.lookController = new EntityBee.j(this);
+         this.a(PathType.WATER, -1.0F);
+         this.a(PathType.COCOA, -1.0F);
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0435-Bees-get-gravity-in-void.-Fixes-MC-167279.patch
+++ b/Spigot-Server-Patches/0435-Bees-get-gravity-in-void.-Fixes-MC-167279.patch
@@ -1,11 +1,37 @@
-From 2489a23bdb7592b3f834adf5944598e3f507e6bb Mon Sep 17 00:00:00 2001
+From 1d2909cc9f91cdc5dc23e61bfcd2c1583ab8ea65 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 26 Jan 2020 16:30:19 -0600
 Subject: [PATCH] Bees get gravity in void. Fixes MC-167279
 
 
+diff --git a/src/main/java/net/minecraft/server/ControllerMove.java b/src/main/java/net/minecraft/server/ControllerMove.java
+index 7e3671dae..a5c4cbb67 100644
+--- a/src/main/java/net/minecraft/server/ControllerMove.java
++++ b/src/main/java/net/minecraft/server/ControllerMove.java
+@@ -2,7 +2,7 @@ package net.minecraft.server;
+ 
+ public class ControllerMove {
+ 
+-    protected final EntityInsentient a;
++    protected final EntityInsentient a; public EntityInsentient getEntity() { return a; } // Paper - OBFHELPER
+     protected double b;
+     protected double c;
+     protected double d;
+diff --git a/src/main/java/net/minecraft/server/ControllerMoveFlying.java b/src/main/java/net/minecraft/server/ControllerMoveFlying.java
+index 2b6ac2eeb..0496c0c5d 100644
+--- a/src/main/java/net/minecraft/server/ControllerMoveFlying.java
++++ b/src/main/java/net/minecraft/server/ControllerMoveFlying.java
+@@ -12,7 +12,7 @@ public class ControllerMoveFlying extends ControllerMove {
+     }
+ 
+     @Override
+-    public void a() {
++    public void a() { tick(); } public void tick() { // Paper - OBFHELPER
+         if (this.h == ControllerMove.Operation.MOVE_TO) {
+             this.h = ControllerMove.Operation.WAIT;
+             this.a.setNoGravity(true);
 diff --git a/src/main/java/net/minecraft/server/EntityBee.java b/src/main/java/net/minecraft/server/EntityBee.java
-index f67d66b9a..5f652fbbb 100644
+index f67d66b9a..6154c4470 100644
 --- a/src/main/java/net/minecraft/server/EntityBee.java
 +++ b/src/main/java/net/minecraft/server/EntityBee.java
 @@ -36,7 +36,17 @@ public class EntityBee extends EntityAnimal implements EntityBird {
@@ -16,11 +42,11 @@ index f67d66b9a..5f652fbbb 100644
 +        // Paper start - apply gravity to bees when they get stuck in the void, fixes MC-167279
 +        this.moveController = new ControllerMoveFlying(this, 20, true) {
 +            @Override
-+            public void a() {
-+                if (a.locY() <= 0) {
-+                    a.setNoGravity(false);
++            public void tick() {
++                if (getEntity().locY() <= 0) {
++                    getEntity().setNoGravity(false);
 +                }
-+                super.a();
++                super.tick();
 +            }
 +        };
 +        // Paper end


### PR DESCRIPTION
This PR simply applies gravity to bees after they stop navigating in the void (below Y 0).