### PR TITLE
Pillager patrol spawn settings and per player options

### DIFF
--- a/Spigot-Server-Patches/0435-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0435-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -1,0 +1,144 @@
+From 81740bc0e805b9b73bba0d7d3694300e609a6cf1 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Sat, 1 Feb 2020 16:50:39 +0100
+Subject: [PATCH] Pillager patrol spawn settings and per player options
+
+This adds config options for defining the spawn chance, spawn delay and
+spawn start day as well as toggles for handling the spawn delay and
+start day per player. (Based on the time played statistic)
+When not per player it will use the Vanilla mechanic of one delay per
+world and the world age for the start day.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index bce502181..3f7841471 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -636,10 +636,21 @@ public class PaperWorldConfig {
+     }
+ 
+     public boolean disablePillagerPatrols = false;
++    public double patrolSpawnChance = 0.2;
++    public boolean patrolPerPlayerDelay = false;
++    public int patrolDelay = 12000;
++    public boolean patrolPerPlayerStart = false;
++    public int patrolStartDay = 5;
+     private void pillagerSettings() {
+         disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
++        patrolSpawnChance = getDouble("game-mechanics.pillager-patrols.spawn-chance", patrolSpawnChance);
++        patrolPerPlayerDelay = getBoolean("game-mechanics.pillager-patrols.spawn-delay.per-player", patrolPerPlayerDelay);
++        patrolDelay = getInt("game-mechanics.pillager-patrols.spawn-delay.ticks", patrolDelay);
++        patrolPerPlayerStart = getBoolean("game-mechanics.pillager-patrols.start.per-player", patrolPerPlayerStart);
++        patrolStartDay = getInt("game-mechanics.pillager-patrols.start.day", patrolStartDay);
+     }
+ 
++
+     public boolean entitiesTargetWithFollowRange = false;
+     private void entitiesTargetWithFollowRange() {
+         entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 15230a834..c49e48e57 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -76,6 +76,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public boolean viewingCredits;
+     private int containerUpdateDelay; // Paper
+     public long loginTime; // Paper
++    public int patrolSpawnDelay; // Paper - per player patrol spawns
+     // Paper start - cancellable death event
+     public boolean queueHealthUpdatePacket = false;
+     public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+index a0f582807..edca6d3ab 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+@@ -4,12 +4,14 @@ import java.util.Random;
+ 
+ public class MobSpawnerPatrol {
+ 
++    private int getSpawnDelay() { return a; } // Paper - OBFHELPER
++    private void setSpawnDelay(int spawnDelay) { this.a = spawnDelay; } // Paper - OBFHELPER
+     private int a;
+ 
+     public MobSpawnerPatrol() {}
+ 
+     public int a(WorldServer worldserver, boolean flag, boolean flag1) {
+-        if (worldserver.paperConfig.disablePillagerPatrols) return 0; // Paper
++        if (worldserver.paperConfig.disablePillagerPatrols || worldserver.paperConfig.patrolSpawnChance == 0) return 0; // Paper
+         if (!flag) {
+             return 0;
+         } else if (!worldserver.getGameRules().getBoolean(GameRules.DO_PATROL_SPAWNING)) {
+@@ -17,23 +19,51 @@ public class MobSpawnerPatrol {
+         } else {
+             Random random = worldserver.random;
+ 
+-            --this.a;
+-            if (this.a > 0) {
++            // Paper start - Patrol settings
++            // Random player selection moved up for per player spawning and configuration
++            int j = worldserver.getPlayers().size();
++            if (j < 1) {
+                 return 0;
++            }
++
++            EntityPlayer entityhuman = worldserver.getPlayers().get(random.nextInt(j));
++            if (entityhuman.isSpectator()) {
++                return 0;
++            }
++
++            int patrolSpawnDelay;
++            if (worldserver.paperConfig.patrolPerPlayerDelay) {
++                --entityhuman.patrolSpawnDelay;
++                patrolSpawnDelay = entityhuman.patrolSpawnDelay;
+             } else {
+-                this.a += 12000 + random.nextInt(1200);
+-                long i = worldserver.getDayTime() / 24000L;
++                setSpawnDelay(getSpawnDelay() - 1);
++                patrolSpawnDelay = getSpawnDelay();
++            }
++
++            if (patrolSpawnDelay > 0) {
++                return 0;
++            } else {
++                long days;
++                if (worldserver.paperConfig.patrolPerPlayerStart) {
++                    days = entityhuman.getStatisticManager().getStatisticValue(StatisticList.CUSTOM.get(StatisticList.PLAY_ONE_MINUTE)) / 24000L; // PLAY_ONE_MINUTE is actually counting in ticks, a misnomer by Mojang
++                } else {
++                    days = worldserver.getDayTime() / 24000L;
++                }
++                if (worldserver.paperConfig.patrolPerPlayerDelay) {
++                    entityhuman.patrolSpawnDelay += worldserver.paperConfig.patrolDelay + random.nextInt(1200);
++                } else {
++                    setSpawnDelay(getSpawnDelay() + worldserver.paperConfig.patrolDelay + random.nextInt(1200));
++                }
+ 
+-                if (i >= 5L && worldserver.isDay()) {
+-                    if (random.nextInt(5) != 0) {
++                if (days >= worldserver.paperConfig.patrolStartDay && worldserver.isDay()) {
++                    if (random.nextDouble() >= worldserver.paperConfig.patrolSpawnChance) {
++                        // Paper end
+                         return 0;
+                     } else {
+-                        int j = worldserver.getPlayers().size();
+ 
+                         if (j < 1) {
+                             return 0;
+                         } else {
+-                            EntityHuman entityhuman = (EntityHuman) worldserver.getPlayers().get(random.nextInt(j));
+ 
+                             if (entityhuman.isSpectator()) {
+                                 return 0;
+diff --git a/src/main/java/net/minecraft/server/StatisticWrapper.java b/src/main/java/net/minecraft/server/StatisticWrapper.java
+index 3b6034038..9c95c0ccf 100644
+--- a/src/main/java/net/minecraft/server/StatisticWrapper.java
++++ b/src/main/java/net/minecraft/server/StatisticWrapper.java
+@@ -27,6 +27,7 @@ public class StatisticWrapper<T> implements Iterable<Statistic<T>> {
+         return this.b.values().iterator();
+     }
+ 
++    public Statistic<T> get(T t) { return this.b(t); }; // Paper - OBFHELPER
+     public Statistic<T> b(T t0) {
+         return this.a(t0, Counter.DEFAULT);
+     }
+-- 
+2.18.0.windows.1
+


### PR DESCRIPTION
This adds config options for defining the spawn chance, spawn delay and spawn start day as well as toggles for handling the spawn delay and start day per player. (Based on the time played statistic)

When not per player it will use the Vanilla mechanic of one delay per world and the world age for the start day.