### PR TITLE
Implement tick times API

### DIFF
--- a/Spigot-API-Patches/0190-Implement-tick-times-API.patch
+++ b/Spigot-API-Patches/0190-Implement-tick-times-API.patch
@@ -1,11 +1,11 @@
-From 5589e305be48fb4a5cd6dbe650acba709f24a6cd Mon Sep 17 00:00:00 2001
+From 08e9770903dc7026a0c1cb1ec9df1a180d37e244 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 2 Feb 2020 03:28:56 -0600
 Subject: [PATCH] Implement tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 388c2bbf..687be230 100644
+index 388c2bbf..ec59e4c0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1603,6 +1603,25 @@ public final class Bukkit {
@@ -14,12 +14,12 @@ index 388c2bbf..687be230 100644
      }
 +
 +    /**
-+     * Get the last 100 tick times (in nanos)
++     * Get a sample of the servers last tick times (in nanos)
 +     *
-+     * @return Last 100 tick times (in nanos)
++     * @return A sample of the servers last tick times (in nanos)
 +     */
 +    @NotNull
-+    public static long[] getTickTimes() {
++    public static long @NotNull[] getTickTimes() {
 +        return server.getTickTimes();
 +    }
 +
@@ -35,7 +35,7 @@ index 388c2bbf..687be230 100644
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a1371730..38395816 100644
+index a1371730..1d8f1d19 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1403,5 +1403,20 @@ public interface Server extends PluginMessageRecipient {
@@ -44,12 +44,12 @@ index a1371730..38395816 100644
      int getCurrentTick();
 +
 +    /**
-+     * Get the last 100 tick times (in nanos)
++     * Get a sample of the servers last tick times (in nanos)
 +     *
-+     * @return Last 100 tick times (in nanos)
++     * @return A sample of the servers last tick times (in nanos)
 +     */
 +    @NotNull
-+    long[] getTickTimes();
++    long @NotNull[] getTickTimes();
 +
 +    /**
 +     * Get the average tick time (in millis) of the last 100 ticks

--- a/Spigot-API-Patches/0190-Implement-tick-times-API.patch
+++ b/Spigot-API-Patches/0190-Implement-tick-times-API.patch
@@ -1,11 +1,11 @@
-From 08e9770903dc7026a0c1cb1ec9df1a180d37e244 Mon Sep 17 00:00:00 2001
+From 5cb96d110ea03a493f1878d211f9623e6e9b74b7 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 2 Feb 2020 03:28:56 -0600
 Subject: [PATCH] Implement tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 388c2bbf..ec59e4c0 100644
+index 388c2bbf..eb25ab0e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1603,6 +1603,25 @@ public final class Bukkit {
@@ -24,7 +24,7 @@ index 388c2bbf..ec59e4c0 100644
 +    }
 +
 +    /**
-+     * Get the average tick time (in millis) of the last 100 ticks
++     * Get the average tick time (in millis)
 +     *
 +     * @return Average tick time (in millis)
 +     */
@@ -35,7 +35,7 @@ index 388c2bbf..ec59e4c0 100644
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a1371730..1d8f1d19 100644
+index a1371730..9b77ffe7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1403,5 +1403,20 @@ public interface Server extends PluginMessageRecipient {
@@ -52,7 +52,7 @@ index a1371730..1d8f1d19 100644
 +    long @NotNull[] getTickTimes();
 +
 +    /**
-+     * Get the average tick time (in millis) of the last 100 ticks
++     * Get the average tick time (in millis)
 +     *
 +     * @return Average tick time (in millis)
 +     */

--- a/Spigot-API-Patches/0190-Implement-tick-times-API.patch
+++ b/Spigot-API-Patches/0190-Implement-tick-times-API.patch
@@ -1,0 +1,64 @@
+From 5589e305be48fb4a5cd6dbe650acba709f24a6cd Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 2 Feb 2020 03:28:56 -0600
+Subject: [PATCH] Implement tick times API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 388c2bbf..687be230 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1603,6 +1603,25 @@ public final class Bukkit {
+     public static int getCurrentTick() {
+         return server.getCurrentTick();
+     }
++
++    /**
++     * Get the last 100 tick times (in nanos)
++     *
++     * @return Last 100 tick times (in nanos)
++     */
++    @NotNull
++    public static long[] getTickTimes() {
++        return server.getTickTimes();
++    }
++
++    /**
++     * Get the average tick time (in millis) of the last 100 ticks
++     *
++     * @return Average tick time (in millis)
++     */
++    public static double getAverageTickTime() {
++        return server.getAverageTickTime();
++    }
+     // Paper end
+ 
+     @NotNull
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index a1371730..38395816 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1403,5 +1403,20 @@ public interface Server extends PluginMessageRecipient {
+      * @return Current tick
+      */
+     int getCurrentTick();
++
++    /**
++     * Get the last 100 tick times (in nanos)
++     *
++     * @return Last 100 tick times (in nanos)
++     */
++    @NotNull
++    long[] getTickTimes();
++
++    /**
++     * Get the average tick time (in millis) of the last 100 ticks
++     *
++     * @return Average tick time (in millis)
++     */
++    double getAverageTickTime();
+     // Paper end
+ }
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0435-Implement-tick-times-API.patch
+++ b/Spigot-Server-Patches/0435-Implement-tick-times-API.patch
@@ -1,0 +1,80 @@
+From 9fc9999bb60c4cbc243c2f1e12f762b08303d3c5 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 2 Feb 2020 03:29:04 -0600
+Subject: [PATCH] Implement tick times API
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 346664cee..c9deaffc4 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -105,7 +105,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+     private String motd;
+     private int G;
+     private int H;
+-    public final long[] f = new long[100];
++    public final long[] f = new long[100]; public long[] getTickTimes() { return f; } // Paper - OBFHELPER
+     @Nullable
+     private KeyPair I;
+     @Nullable
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index ee5c57ca2..a3dc3d59f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2169,5 +2169,20 @@ public final class CraftServer implements Server {
+     public int getCurrentTick() {
+         return net.minecraft.server.MinecraftServer.currentTick;
+     }
++
++    @Override
++    public long[] getTickTimes() {
++        return getServer().getTickTimes();
++    }
++
++    @Override
++    public double getAverageTickTime() {
++        long total = 0L;
++        long[] tickTimes = getTickTimes();
++        for (long value : tickTimes) {
++            total += value;
++        }
++        return ((double) total / (double) tickTimes.length) * 1.0E-6D;
++    }
+     // Paper end
+ }
+diff --git a/src/main/java/org/spigotmc/TicksPerSecondCommand.java b/src/main/java/org/spigotmc/TicksPerSecondCommand.java
+index 6d21c3269..7ca605f81 100644
+--- a/src/main/java/org/spigotmc/TicksPerSecondCommand.java
++++ b/src/main/java/org/spigotmc/TicksPerSecondCommand.java
+@@ -6,6 +6,7 @@ import org.bukkit.command.CommandSender;
+ 
+ public class TicksPerSecondCommand extends Command
+ {
++    private static final java.text.DecimalFormat DF = new java.text.DecimalFormat("########0.000"); // Paper
+ 
+     public TicksPerSecondCommand(String name)
+     {
+@@ -30,12 +31,20 @@ public class TicksPerSecondCommand extends Command
+         for ( int i = 0; i < tps.length; i++) {
+             tpsAvg[i] = format( tps[i] );
+         }
++        double avg = org.bukkit.Bukkit.getAverageTickTime();
+         sender.sendMessage( ChatColor.GOLD + "TPS from last 1m, 5m, 15m: " + org.apache.commons.lang.StringUtils.join(tpsAvg, ", "));
++        sender.sendMessage( ChatColor.GOLD + "Average tick time: " + getColor(avg) + DF.format(avg) + " ms");
+         // Paper end
+ 
+         return true;
+     }
+ 
++    // Paper start
++    private static String getColor(double avg) {
++        return (avg >= 50 ? ChatColor.RED : avg >= 40 ? ChatColor.YELLOW : ChatColor.GREEN).toString();
++    }
++    // Paper end
++
+     private static String format(double tps) // Paper - Made static
+     {
+         return ( ( tps > 18.0 ) ? ChatColor.GREEN : ( tps > 16.0 ) ? ChatColor.YELLOW : ChatColor.RED ).toString()
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0435-Implement-tick-times-API.patch
+++ b/Spigot-Server-Patches/0435-Implement-tick-times-API.patch
@@ -1,4 +1,4 @@
-From 9fc9999bb60c4cbc243c2f1e12f762b08303d3c5 Mon Sep 17 00:00:00 2001
+From 00e0b9c64ff7d2ba6649dd82817ec2a0dd203c2a Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 2 Feb 2020 03:29:04 -0600
 Subject: [PATCH] Implement tick times API
@@ -18,7 +18,7 @@ index 346664cee..c9deaffc4 100644
      private KeyPair I;
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ee5c57ca2..a3dc3d59f 100644
+index ee5c57ca2..88e9aa183 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2169,5 +2169,20 @@ public final class CraftServer implements Server {
@@ -28,7 +28,7 @@ index ee5c57ca2..a3dc3d59f 100644
 +
 +    @Override
 +    public long[] getTickTimes() {
-+        return getServer().getTickTimes();
++        return getServer().getTickTimes().clone();
 +    }
 +
 +    @Override


### PR DESCRIPTION
Adds tick times and tick average API.

Also adds average tick to `/tps` command output.

![Output of /tps](https://i.imgur.com/uIMN07T.png)