### PR TITLE
Skip distance map update when world spawning is disabled

### DIFF
--- a/Spigot-Server-Patches/0664-Skip-distance-map-update-when-spawning-disabled.patch
+++ b/Spigot-Server-Patches/0664-Skip-distance-map-update-when-spawning-disabled.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Beech Horn <beechhorn@gmail.com>
+Date: Fri, 14 Feb 2020 19:39:59 +0000
+Subject: [PATCH] Skip distance map update when spawning disabled.
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index 75d25576d68ec95a14372f8530f4916f2bd7c3c5..96a6f4675dc10a0047b7d2ee4164d0376de36c27 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -792,7 +792,7 @@ public class ChunkProviderServer extends IChunkProvider {
+             int l = this.chunkMapDistance.b();
+             // Paper start - per player mob spawning
+             SpawnerCreature.d spawnercreature_d; // moved down
+-            if (this.playerChunkMap.playerMobDistanceMap != null) {
++            if ((this.allowAnimals || this.allowMonsters) && this.playerChunkMap.playerMobDistanceMap != null) { // don't update when animals and monsters are disabled
+                 // update distance map
+                 this.world.timings.playerMobDistanceMapUpdate.startTiming();
+                 this.playerChunkMap.playerMobDistanceMap.update(this.world.players, this.playerChunkMap.viewDistance);


### PR DESCRIPTION
Kept receiving timings reports with the distance map being updated in worlds where mob and animal spawning had been disabled. This patch fixes that. Have looked at what work this skips and cannot see any harm/potential for harm. Where the work skipped is used here the check is similar.