### PR TITLE
Reduce entity tracker updates on move

### DIFF
--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,11 +1,25 @@
-From 54dec4818215012d9751cf58e49eeb54b343a69f Mon Sep 17 00:00:00 2001
+From 707b7c13c57aa697b3d87c7b13aafdc907b85ac5 Mon Sep 17 00:00:00 2001
 From: froobynooby <froobynooby@froobworld.com>
-Date: Sat, 15 Feb 2020 22:58:58 +0930
+Date: Sun, 16 Feb 2020 19:50:10 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
 
 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index bce502181..e101c1156 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -653,4 +653,9 @@ public class PaperWorldConfig {
+         disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
+         log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
+     }
++
++    public double trackerUpdateDistance = 1;
++    private void trackeruUpdateDistance() {
++        trackerUpdateDistance = getDouble("tracker-update-distance", trackerUpdateDistance);
++    }
+ }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 15230a83..4bf6db8c 100644
+index 15230a834..4bf6db8c2 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -85,6 +85,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -20,28 +34,132 @@ index 15230a83..4bf6db8c 100644
      // CraftBukkit start
      public String displayName;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 46d20538..c13452cc 100644
+index 46d205380..34f6aa749 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1337,8 +1337,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-     public void movePlayer(EntityPlayer entityplayer) {
-         ObjectIterator objectiterator = this.trackedEntities.values().iterator();
+@@ -80,6 +80,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     private final Queue<Runnable> z;
+     int viewDistance; // Paper - private -> package private
+     public final com.destroystokyo.paper.util.PlayerMobDistanceMap playerMobDistanceMap; // Paper
++    // Paper start - Reduce entity tracker updates on move
++    private double trackerUpdateDistanceSquared;
++    private final Int2ObjectMap<Int2ObjectMap<PlayerChunkMap.EntityTracker>> playerTrackedEntities = new Int2ObjectOpenHashMap();
++    private final Int2ObjectMap<Queue<Integer>> playerTrackedEntitiesRemoveQueue = new Int2ObjectOpenHashMap();
++    // Paper end
  
+     // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
+     public final CallbackExecutor callbackExecutor = new CallbackExecutor();
+@@ -167,6 +172,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+         this.m = new VillagePlace(new File(this.w, "poi"), datafixer, this.world); // Paper
+         this.setViewDistance(i);
+         this.playerMobDistanceMap = this.world.paperConfig.perPlayerMobSpawns ? new com.destroystokyo.paper.util.PlayerMobDistanceMap() : null; // Paper
++        this.trackerUpdateDistanceSquared = Math.pow(this.world.paperConfig.trackerUpdateDistance, 2); // Paper - Reduce entity tracker updates on move
+     }
+ 
+     public void updatePlayerMobTypeMap(Entity entity) {
+@@ -1335,8 +1341,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     }
+ 
+     public void movePlayer(EntityPlayer entityplayer) {
+-        ObjectIterator objectiterator = this.trackedEntities.values().iterator();
 +        // Paper start - Reduce entity tracker updates on move
-+        boolean fullUpdate = false;
++        ObjectIterator objectiterator;
+ 
 +        if (MinecraftServer.currentTick - entityplayer.lastTrackedTick >= 20
-+            || entityplayer.lastTrackedPosition.distanceSquared(entityplayer.getPositionVector()) >= 1) {
-+            fullUpdate = true;
++            || entityplayer.lastTrackedPosition.distanceSquared(entityplayer.getPositionVector()) >= trackerUpdateDistanceSquared) {
 +            entityplayer.lastTrackedPosition = entityplayer.getPositionVector();
 +            entityplayer.lastTrackedTick = MinecraftServer.currentTick;
++            objectiterator = this.trackedEntities.values().iterator();
++        } else {
++            objectiterator = this.playerTrackedEntities.get(entityplayer.getId()).values().iterator();
 +        }
 +        // Paper end
          while (objectiterator.hasNext()) {
              PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
-+            if (!fullUpdate && (playerchunkmap_entitytracker.trackedPlayers.isEmpty() || !playerchunkmap_entitytracker.trackedPlayers.contains(entityplayer))) continue; // Paper - Reduce entity tracker updates on move
  
-             if (playerchunkmap_entitytracker.tracker == entityplayer) {
-                 playerchunkmap_entitytracker.track(this.world.getPlayers());
+@@ -1346,6 +1362,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                 playerchunkmap_entitytracker.updatePlayer(entityplayer);
+             }
+         }
++        // Paper start - Reduce entity tracker updates on move
++        Queue<Integer> removeQueue = playerTrackedEntitiesRemoveQueue.get(entityplayer.getId());
++        Int2ObjectMap entityMap = playerTrackedEntities.get(entityplayer.getId());
++        for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
++            entityMap.remove(id);
++        }
++        // Paper end
+ 
+         int i = MathHelper.floor(entityplayer.locX()) >> 4;
+         int j = MathHelper.floor(entityplayer.locZ()) >> 4;
+@@ -1456,6 +1479,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                     playerchunkmap_entitytracker.track(this.world.getPlayers());
+                     if (entity instanceof EntityPlayer) {
+                         EntityPlayer entityplayer = (EntityPlayer) entity;
++                        // Paper start - Reduce entity tracker updates on move
++                        playerTrackedEntities.put(entityplayer.getId(), new Int2ObjectOpenHashMap());
++                        playerTrackedEntitiesRemoveQueue.put(entityplayer.getId(), new java.util.ArrayDeque<>());
++                        // Paper end
+ 
+                         this.a(entityplayer, true);
+                         ObjectIterator objectiterator = this.trackedEntities.values().iterator();
+@@ -1487,12 +1514,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+ 
+                 playerchunkmap_entitytracker.clear(entityplayer);
+             }
++            // Paper start - Reduce entity tracker updates on move
++            playerTrackedEntities.remove(entityplayer.getId());
++            playerTrackedEntitiesRemoveQueue.remove(entityplayer.getId());
++            // Paper end
+         }
+ 
+         PlayerChunkMap.EntityTracker playerchunkmap_entitytracker1 = (PlayerChunkMap.EntityTracker) this.trackedEntities.remove(entity.getId());
+ 
+         if (playerchunkmap_entitytracker1 != null) {
+             playerchunkmap_entitytracker1.a();
++            // Paper start - Reduce entity tracker updates on move
++            for (EntityPlayer player : playerchunkmap_entitytracker1.trackedPlayers) {
++                playerTrackedEntities.get(player.getId()).remove(playerchunkmap_entitytracker1.tracker.getId());
++            }
++            // Paper end
+         }
+         entity.tracker = null; // Paper - We're no longer tracked
+     }
+@@ -1533,6 +1569,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             }
+             world.timings.tracker2.stopTiming(); // Paper
+         }
++        // Paper start - Reduce entity tracker updates on move
++        for (Int2ObjectMap.Entry<Queue<Integer>> entry : playerTrackedEntitiesRemoveQueue.int2ObjectEntrySet()) {
++            Int2ObjectMap entityMap = playerTrackedEntities.get(entry.getKey());
++            Queue<Integer> removeQueue = entry.getValue();
++            for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
++                entityMap.remove(id);
++            }
++        }
++        // Paper end
+ 
+ 
+     }
+@@ -1678,6 +1723,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
+             if (this.trackedPlayers.remove(entityplayer)) {
+                 this.trackerEntry.a(entityplayer);
++                playerTrackedEntities.get(entityplayer.getId()).remove(this.tracker.getId()); // Paper - Reduce entity tracker updates on move
+             }
+ 
+         }
+@@ -1714,9 +1760,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+ 
+                     if (flag1 && this.trackedPlayerMap.putIfAbsent(entityplayer, true) == null) { // Paper
+                         this.trackerEntry.b(entityplayer);
++                        playerTrackedEntities.get(entityplayer.getId()).put(this.tracker.getId(), this); // Paper - Reduce entity tracker updates on move
+                     }
+                 } else if (this.trackedPlayers.remove(entityplayer)) {
+                     this.trackerEntry.a(entityplayer);
++                    playerTrackedEntitiesRemoveQueue.get(entityplayer.getId()).add(this.tracker.getId()); // Paper - Reduce entity tracker updates on move
+                 }
+ 
+             }
 -- 
 2.24.1
 

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,6 +1,6 @@
-From 70ac522cf2c350d348e70f6fc87c5837230e84ab Mon Sep 17 00:00:00 2001
+From a612c4d69016aeb65306571e6068c665c6883817 Mon Sep 17 00:00:00 2001
 From: froobynooby <froobynooby@froobworld.com>
-Date: Sun, 16 Feb 2020 22:03:33 +0930
+Date: Mon, 17 Feb 2020 12:48:46 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
 
 With this patch, for each player we keep track of a set of
@@ -69,7 +69,7 @@ index 15230a834..4bf6db8c2 100644
      // CraftBukkit start
      public String displayName;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 46d205380..2a26f8198 100644
+index 46d205380..517c515f9 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -133,6 +133,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -108,54 +108,55 @@ index 46d205380..2a26f8198 100644
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, this.world); // Paper
          this.setViewDistance(i);
          this.playerMobDistanceMap = this.world.paperConfig.perPlayerMobSpawns ? new com.destroystokyo.paper.util.PlayerMobDistanceMap() : null; // Paper
-+        this.trackerUpdateDistanceSquared = Math.pow(this.world.paperConfig.trackerUpdateDistance, 2); // Paper - Reduce entity tracker updates on move
++        this.trackerUpdateDistanceSquared = Math.pow(this.world.paperConfig.trackerUpdateDistance, 2); // Paper
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1335,8 +1361,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1335,8 +1361,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void movePlayer(EntityPlayer entityplayer) {
 -        ObjectIterator objectiterator = this.trackedEntities.values().iterator();
-+        // Paper start - Reduce entity tracker updates on move
++        // Paper start
++        // ObjectIterator objectiterator = this.trackedEntities.values().iterator();
 +        ObjectIterator objectiterator;
  
 +        if (MinecraftServer.currentTick - entityplayer.lastTrackedTick >= 20
 +            || entityplayer.lastTrackedPosition.distanceSquared(entityplayer.getPositionVector()) >= trackerUpdateDistanceSquared) {
 +            entityplayer.lastTrackedPosition = entityplayer.getPositionVector();
 +            entityplayer.lastTrackedTick = MinecraftServer.currentTick;
-+            objectiterator = this.trackedEntities.values().iterator();
++            objectiterator = this.trackedEntities.values().iterator(); // Update all entity trackers
 +        } else {
-+            objectiterator = this.playerTrackedEntities.get(entityplayer.getId()).values().iterator();
++            objectiterator = this.playerTrackedEntities.get(entityplayer.getId()).values().iterator(); // Only update entity trackers for already tracked entities
 +        }
 +        // Paper end
          while (objectiterator.hasNext()) {
              PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
  
-@@ -1346,6 +1382,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1346,6 +1383,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  playerchunkmap_entitytracker.updatePlayer(entityplayer);
              }
          }
-+        flushRemoveQueues(); // Paper - Reduce entity tracker updates on move
++        flushRemoveQueues(); // Paper
  
          int i = MathHelper.floor(entityplayer.locX()) >> 4;
          int j = MathHelper.floor(entityplayer.locZ()) >> 4;
-@@ -1456,6 +1493,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1456,6 +1494,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      playerchunkmap_entitytracker.track(this.world.getPlayers());
                      if (entity instanceof EntityPlayer) {
                          EntityPlayer entityplayer = (EntityPlayer) entity;
-+                        // Paper start - Reduce entity tracker updates on move
++                        // Paper start
 +                        playerTrackedEntities.put(entityplayer.getId(), new Int2ObjectOpenHashMap());
 +                        playerTrackedEntitiesRemoveQueue.put(entityplayer.getId(), new java.util.ArrayDeque<>());
 +                        // Paper end
  
                          this.a(entityplayer, true);
                          ObjectIterator objectiterator = this.trackedEntities.values().iterator();
-@@ -1487,12 +1528,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1487,12 +1529,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  playerchunkmap_entitytracker.clear(entityplayer);
              }
-+            // Paper start - Reduce entity tracker updates on move
++            // Paper start
 +            playerTrackedEntities.remove(entityplayer.getId());
 +            playerTrackedEntitiesRemoveQueue.remove(entityplayer.getId());
 +            // Paper end
@@ -165,7 +166,7 @@ index 46d205380..2a26f8198 100644
  
          if (playerchunkmap_entitytracker1 != null) {
              playerchunkmap_entitytracker1.a();
-+            // Paper start - Reduce entity tracker updates on move
++            // Paper start
 +            for (EntityPlayer player : playerchunkmap_entitytracker1.trackedPlayers) {
 +                playerTrackedEntities.get(player.getId()).remove(playerchunkmap_entitytracker1.tracker.getId());
 +            }
@@ -173,40 +174,40 @@ index 46d205380..2a26f8198 100644
          }
          entity.tracker = null; // Paper - We're no longer tracked
      }
-@@ -1533,7 +1583,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1533,7 +1584,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
              world.timings.tracker2.stopTiming(); // Paper
          }
 -
-+        flushRemoveQueues(); // Paper start - Reduce entity tracker updates on move
++        flushRemoveQueues(); // Paper
  
      }
  
-@@ -1582,6 +1632,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1582,6 +1633,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
              }
          }
-+        flushRemoveQueue(entityplayer); // Paper - Reduce entity tracker updates on move
++        flushRemoveQueue(entityplayer); // Paper
  
          Iterator iterator;
          Entity entity1;
-@@ -1678,6 +1729,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1678,6 +1730,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
              if (this.trackedPlayers.remove(entityplayer)) {
                  this.trackerEntry.a(entityplayer);
-+                playerTrackedEntities.get(entityplayer.getId()).remove(this.tracker.getId()); // Paper - Reduce entity tracker updates on move
++                playerTrackedEntities.get(entityplayer.getId()).remove(this.tracker.getId()); // Paper
              }
  
          }
-@@ -1714,9 +1766,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1714,9 +1767,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                      if (flag1 && this.trackedPlayerMap.putIfAbsent(entityplayer, true) == null) { // Paper
                          this.trackerEntry.b(entityplayer);
-+                        playerTrackedEntities.get(entityplayer.getId()).put(this.tracker.getId(), this); // Paper - Reduce entity tracker updates on move
++                        playerTrackedEntities.get(entityplayer.getId()).put(this.tracker.getId(), this); // Paper
                      }
                  } else if (this.trackedPlayers.remove(entityplayer)) {
                      this.trackerEntry.a(entityplayer);
-+                    playerTrackedEntitiesRemoveQueue.get(entityplayer.getId()).add(this.tracker.getId()); // Paper - Reduce entity tracker updates on move
++                    playerTrackedEntitiesRemoveQueue.get(entityplayer.getId()).add(this.tracker.getId()); // Paper
                  }
  
              }

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,6 +1,6 @@
-From a612c4d69016aeb65306571e6068c665c6883817 Mon Sep 17 00:00:00 2001
+From 7b0e6796908ee45037e383de30f7960f24d487e8 Mon Sep 17 00:00:00 2001
 From: froobynooby <froobynooby@froobworld.com>
-Date: Mon, 17 Feb 2020 12:48:46 +0930
+Date: Thu, 20 Feb 2020 15:50:49 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
 
 With this patch, for each player we keep track of a set of
@@ -69,10 +69,10 @@ index 15230a834..4bf6db8c2 100644
      // CraftBukkit start
      public String displayName;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 46d205380..517c515f9 100644
+index 46d205380..0b9d8a5b5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -133,6 +133,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -133,6 +133,39 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
  
@@ -84,8 +84,8 @@ index 46d205380..517c515f9 100644
 +    private final Int2ObjectMap<Queue<Integer>> playerTrackedEntitiesRemoveQueue = new Int2ObjectOpenHashMap();
 +
 +    void flushRemoveQueue(EntityPlayer entityplayer) {
-+        Queue<Integer> removeQueue = playerTrackedEntitiesRemoveQueue.get(entityplayer.getId());
-+        Int2ObjectMap<PlayerChunkMap.EntityTracker> entityMap = playerTrackedEntities.get(entityplayer.getId());
++        Queue<Integer> removeQueue = getPlayerTrackedEntityMapRemoveQueue(entityplayer.getId());
++        Int2ObjectMap<PlayerChunkMap.EntityTracker> entityMap = getPlayerTrackedEntityMap(entityplayer.getId());
 +        for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
 +            entityMap.remove(id);
 +        }
@@ -93,7 +93,7 @@ index 46d205380..517c515f9 100644
 +
 +    void flushRemoveQueues() {
 +        for (Int2ObjectMap.Entry<Queue<Integer>> entry : playerTrackedEntitiesRemoveQueue.int2ObjectEntrySet()) {
-+            Int2ObjectMap entityMap = playerTrackedEntities.get(entry.getKey());
++            Int2ObjectMap entityMap = getPlayerTrackedEntityMap(entry.getKey());
 +            Queue<Integer> removeQueue = entry.getValue();
 +            for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
 +                entityMap.remove(id);
@@ -101,10 +101,18 @@ index 46d205380..517c515f9 100644
 +        }
 +    }
 +
++    Int2ObjectMap getPlayerTrackedEntityMap(int id) {
++        return playerTrackedEntities.computeIfAbsent(id, i -> new Int2ObjectOpenHashMap());
++    }
++
++    Queue<Integer> getPlayerTrackedEntityMapRemoveQueue(int id) {
++        return playerTrackedEntitiesRemoveQueue.computeIfAbsent(id, i -> new java.util.ArrayDeque<>());
++    }
++
      // Paper end
  
      public PlayerChunkMap(WorldServer worldserver, File file, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator<?> chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i) {
-@@ -167,6 +192,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -167,6 +200,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, this.world); // Paper
          this.setViewDistance(i);
          this.playerMobDistanceMap = this.world.paperConfig.perPlayerMobSpawns ? new com.destroystokyo.paper.util.PlayerMobDistanceMap() : null; // Paper
@@ -112,7 +120,7 @@ index 46d205380..517c515f9 100644
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1335,8 +1361,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1335,8 +1369,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void movePlayer(EntityPlayer entityplayer) {
@@ -127,13 +135,13 @@ index 46d205380..517c515f9 100644
 +            entityplayer.lastTrackedTick = MinecraftServer.currentTick;
 +            objectiterator = this.trackedEntities.values().iterator(); // Update all entity trackers
 +        } else {
-+            objectiterator = this.playerTrackedEntities.get(entityplayer.getId()).values().iterator(); // Only update entity trackers for already tracked entities
++            objectiterator = getPlayerTrackedEntityMap(entityplayer.getId()).values().iterator(); // Only update entity trackers for already tracked entities
 +        }
 +        // Paper end
          while (objectiterator.hasNext()) {
              PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
  
-@@ -1346,6 +1383,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1346,6 +1391,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  playerchunkmap_entitytracker.updatePlayer(entityplayer);
              }
          }
@@ -141,18 +149,7 @@ index 46d205380..517c515f9 100644
  
          int i = MathHelper.floor(entityplayer.locX()) >> 4;
          int j = MathHelper.floor(entityplayer.locZ()) >> 4;
-@@ -1456,6 +1494,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-                     playerchunkmap_entitytracker.track(this.world.getPlayers());
-                     if (entity instanceof EntityPlayer) {
-                         EntityPlayer entityplayer = (EntityPlayer) entity;
-+                        // Paper start
-+                        playerTrackedEntities.put(entityplayer.getId(), new Int2ObjectOpenHashMap());
-+                        playerTrackedEntitiesRemoveQueue.put(entityplayer.getId(), new java.util.ArrayDeque<>());
-+                        // Paper end
- 
-                         this.a(entityplayer, true);
-                         ObjectIterator objectiterator = this.trackedEntities.values().iterator();
-@@ -1487,12 +1529,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1487,12 +1533,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  playerchunkmap_entitytracker.clear(entityplayer);
              }
@@ -168,13 +165,13 @@ index 46d205380..517c515f9 100644
              playerchunkmap_entitytracker1.a();
 +            // Paper start
 +            for (EntityPlayer player : playerchunkmap_entitytracker1.trackedPlayers) {
-+                playerTrackedEntities.get(player.getId()).remove(playerchunkmap_entitytracker1.tracker.getId());
++                getPlayerTrackedEntityMap(player.getId()).remove(playerchunkmap_entitytracker1.tracker.getId());
 +            }
 +            // Paper end
          }
          entity.tracker = null; // Paper - We're no longer tracked
      }
-@@ -1533,7 +1584,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1533,7 +1588,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
              world.timings.tracker2.stopTiming(); // Paper
          }
@@ -183,7 +180,7 @@ index 46d205380..517c515f9 100644
  
      }
  
-@@ -1582,6 +1633,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1582,6 +1637,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
              }
          }
@@ -191,23 +188,23 @@ index 46d205380..517c515f9 100644
  
          Iterator iterator;
          Entity entity1;
-@@ -1678,6 +1730,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1678,6 +1734,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
              if (this.trackedPlayers.remove(entityplayer)) {
                  this.trackerEntry.a(entityplayer);
-+                playerTrackedEntities.get(entityplayer.getId()).remove(this.tracker.getId()); // Paper
++                getPlayerTrackedEntityMap(entityplayer.getId()).remove(this.tracker.getId()); // Paper
              }
  
          }
-@@ -1714,9 +1767,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1714,9 +1771,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                      if (flag1 && this.trackedPlayerMap.putIfAbsent(entityplayer, true) == null) { // Paper
                          this.trackerEntry.b(entityplayer);
-+                        playerTrackedEntities.get(entityplayer.getId()).put(this.tracker.getId(), this); // Paper
++                        getPlayerTrackedEntityMap(entityplayer.getId()).put(this.tracker.getId(), this); // Paper
                      }
                  } else if (this.trackedPlayers.remove(entityplayer)) {
                      this.trackerEntry.a(entityplayer);
-+                    playerTrackedEntitiesRemoveQueue.get(entityplayer.getId()).add(this.tracker.getId()); // Paper
++                    getPlayerTrackedEntityMapRemoveQueue(entityplayer.getId()).add(this.tracker.getId()); // Paper
                  }
  
              }

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,6 +1,6 @@
-From 707b7c13c57aa697b3d87c7b13aafdc907b85ac5 Mon Sep 17 00:00:00 2001
+From 70ac522cf2c350d348e70f6fc87c5837230e84ab Mon Sep 17 00:00:00 2001
 From: froobynooby <froobynooby@froobworld.com>
-Date: Sun, 16 Feb 2020 19:50:10 +0930
+Date: Sun, 16 Feb 2020 22:03:33 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
 
 
@@ -34,22 +34,42 @@ index 15230a834..4bf6db8c2 100644
      // CraftBukkit start
      public String displayName;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 46d205380..34f6aa749 100644
+index 46d205380..2a26f8198 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -80,6 +80,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-     private final Queue<Runnable> z;
-     int viewDistance; // Paper - private -> package private
-     public final com.destroystokyo.paper.util.PlayerMobDistanceMap playerMobDistanceMap; // Paper
+@@ -133,6 +133,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     }
+ 
+ 
++    // Paper end
++
 +    // Paper start - Reduce entity tracker updates on move
 +    private double trackerUpdateDistanceSquared;
 +    private final Int2ObjectMap<Int2ObjectMap<PlayerChunkMap.EntityTracker>> playerTrackedEntities = new Int2ObjectOpenHashMap();
 +    private final Int2ObjectMap<Queue<Integer>> playerTrackedEntitiesRemoveQueue = new Int2ObjectOpenHashMap();
-+    // Paper end
++
++    void flushRemoveQueue(EntityPlayer entityplayer) {
++        Queue<Integer> removeQueue = playerTrackedEntitiesRemoveQueue.get(entityplayer.getId());
++        Int2ObjectMap<PlayerChunkMap.EntityTracker> entityMap = playerTrackedEntities.get(entityplayer.getId());
++        for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
++            entityMap.remove(id);
++        }
++    }
++
++    void flushRemoveQueues() {
++        for (Int2ObjectMap.Entry<Queue<Integer>> entry : playerTrackedEntitiesRemoveQueue.int2ObjectEntrySet()) {
++            Int2ObjectMap entityMap = playerTrackedEntities.get(entry.getKey());
++            Queue<Integer> removeQueue = entry.getValue();
++            for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
++                entityMap.remove(id);
++            }
++        }
++    }
++
+     // Paper end
  
-     // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
-     public final CallbackExecutor callbackExecutor = new CallbackExecutor();
-@@ -167,6 +172,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     public PlayerChunkMap(WorldServer worldserver, File file, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator<?> chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i) {
+@@ -167,6 +192,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, this.world); // Paper
          this.setViewDistance(i);
          this.playerMobDistanceMap = this.world.paperConfig.perPlayerMobSpawns ? new com.destroystokyo.paper.util.PlayerMobDistanceMap() : null; // Paper
@@ -57,7 +77,7 @@ index 46d205380..34f6aa749 100644
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1335,8 +1341,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1335,8 +1361,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void movePlayer(EntityPlayer entityplayer) {
@@ -77,21 +97,15 @@ index 46d205380..34f6aa749 100644
          while (objectiterator.hasNext()) {
              PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
  
-@@ -1346,6 +1362,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1346,6 +1382,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  playerchunkmap_entitytracker.updatePlayer(entityplayer);
              }
          }
-+        // Paper start - Reduce entity tracker updates on move
-+        Queue<Integer> removeQueue = playerTrackedEntitiesRemoveQueue.get(entityplayer.getId());
-+        Int2ObjectMap entityMap = playerTrackedEntities.get(entityplayer.getId());
-+        for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
-+            entityMap.remove(id);
-+        }
-+        // Paper end
++        flushRemoveQueues(); // Paper - Reduce entity tracker updates on move
  
          int i = MathHelper.floor(entityplayer.locX()) >> 4;
          int j = MathHelper.floor(entityplayer.locZ()) >> 4;
-@@ -1456,6 +1479,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1456,6 +1493,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      playerchunkmap_entitytracker.track(this.world.getPlayers());
                      if (entity instanceof EntityPlayer) {
                          EntityPlayer entityplayer = (EntityPlayer) entity;
@@ -102,7 +116,7 @@ index 46d205380..34f6aa749 100644
  
                          this.a(entityplayer, true);
                          ObjectIterator objectiterator = this.trackedEntities.values().iterator();
-@@ -1487,12 +1514,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1487,12 +1528,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  playerchunkmap_entitytracker.clear(entityplayer);
              }
@@ -124,23 +138,24 @@ index 46d205380..34f6aa749 100644
          }
          entity.tracker = null; // Paper - We're no longer tracked
      }
-@@ -1533,6 +1569,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1533,7 +1583,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
              world.timings.tracker2.stopTiming(); // Paper
          }
-+        // Paper start - Reduce entity tracker updates on move
-+        for (Int2ObjectMap.Entry<Queue<Integer>> entry : playerTrackedEntitiesRemoveQueue.int2ObjectEntrySet()) {
-+            Int2ObjectMap entityMap = playerTrackedEntities.get(entry.getKey());
-+            Queue<Integer> removeQueue = entry.getValue();
-+            for (Integer id = removeQueue.poll(); id != null; id = removeQueue.poll()) {
-+                entityMap.remove(id);
-+            }
-+        }
-+        // Paper end
- 
+-
++        flushRemoveQueues(); // Paper start - Reduce entity tracker updates on move
  
      }
-@@ -1678,6 +1723,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+ 
+@@ -1582,6 +1632,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                 }
+             }
+         }
++        flushRemoveQueue(entityplayer); // Paper - Reduce entity tracker updates on move
+ 
+         Iterator iterator;
+         Entity entity1;
+@@ -1678,6 +1729,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              org.spigotmc.AsyncCatcher.catchOp("player tracker clear"); // Spigot
              if (this.trackedPlayers.remove(entityplayer)) {
                  this.trackerEntry.a(entityplayer);
@@ -148,7 +163,7 @@ index 46d205380..34f6aa749 100644
              }
  
          }
-@@ -1714,9 +1760,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1714,9 +1766,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                      if (flag1 && this.trackedPlayerMap.putIfAbsent(entityplayer, true) == null) { // Paper
                          this.trackerEntry.b(entityplayer);

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,4 +1,4 @@
-From 7b0e6796908ee45037e383de30f7960f24d487e8 Mon Sep 17 00:00:00 2001
+From 95080f3664ab22242d5468f3cb5b402ef97e29ea Mon Sep 17 00:00:00 2001
 From: froobynooby <froobynooby@froobworld.com>
 Date: Thu, 20 Feb 2020 15:50:49 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
@@ -40,12 +40,12 @@ packets often show up as a major contributor to TPS loss in
 servers with large player counts
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bce502181..e101c1156 100644
+index 7d408542e..2ae44b230 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -653,4 +653,9 @@ public class PaperWorldConfig {
-         disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
-         log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
+@@ -658,4 +658,9 @@ public class PaperWorldConfig {
+     private void nerfNetherPortalPigmen() {
+         nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
 +
 +    public double trackerUpdateDistance = 1;

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -1,0 +1,47 @@
+From 54dec4818215012d9751cf58e49eeb54b343a69f Mon Sep 17 00:00:00 2001
+From: froobynooby <froobynooby@froobworld.com>
+Date: Sat, 15 Feb 2020 22:58:58 +0930
+Subject: [PATCH] Reduce entity tracker updates on move
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 15230a83..4bf6db8c 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -85,6 +85,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public final int[] mobCounts = new int[ENUMCREATURETYPE_TOTAL_ENUMS]; // Paper
+     public final com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> cachedSingleMobDistanceMap;
+     // Paper end
++    // Paper start - Reduce entity tracker updates on move
++    public Vec3D lastTrackedPosition = new Vec3D(0, 0, 0);
++    public long lastTrackedTick;
++    // Paper end
+ 
+     // CraftBukkit start
+     public String displayName;
+diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+index 46d20538..c13452cc 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
++++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+@@ -1337,8 +1337,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+     public void movePlayer(EntityPlayer entityplayer) {
+         ObjectIterator objectiterator = this.trackedEntities.values().iterator();
+ 
++        // Paper start - Reduce entity tracker updates on move
++        boolean fullUpdate = false;
++        if (MinecraftServer.currentTick - entityplayer.lastTrackedTick >= 20
++            || entityplayer.lastTrackedPosition.distanceSquared(entityplayer.getPositionVector()) >= 1) {
++            fullUpdate = true;
++            entityplayer.lastTrackedPosition = entityplayer.getPositionVector();
++            entityplayer.lastTrackedTick = MinecraftServer.currentTick;
++        }
++        // Paper end
+         while (objectiterator.hasNext()) {
+             PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
++            if (!fullUpdate && (playerchunkmap_entitytracker.trackedPlayers.isEmpty() || !playerchunkmap_entitytracker.trackedPlayers.contains(entityplayer))) continue; // Paper - Reduce entity tracker updates on move
+ 
+             if (playerchunkmap_entitytracker.tracker == entityplayer) {
+                 playerchunkmap_entitytracker.track(this.world.getPlayers());
+-- 
+2.24.1
+

--- a/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
+++ b/Spigot-Server-Patches/0440-Reduce-entity-tracker-updates-on-move.patch
@@ -3,6 +3,41 @@ From: froobynooby <froobynooby@froobworld.com>
 Date: Sun, 16 Feb 2020 22:03:33 +0930
 Subject: [PATCH] Reduce entity tracker updates on move
 
+With this patch, for each player we keep track of a set of
+entities that the player is tracking. This is used to split
+the entity tracker update logic in the movePlayer method in
+PlayerChunkMap in to two parts:
+* Full update: Run through all entity trackers and update them
+* Partial update: Run through all entity trackers for entities
+the player is already tracking and update them
+
+Partial updates will always take less time than full updates,
+usually by a considerable amount if players and entities are
+spread out over the map. Assuming they are evenly spread,
+and given there are x many players, it would be expected to
+take 1/x the time of a full update.
+
+Full updates are only run if the following conditions are met:
+* It has been 20 ticks since the last full update
+* The player has moved over set distance since the last full
+update (distance is configurable)
+
+The motivation for the first condition is that the client
+sends the server its position once a second, which calls
+movePlayer, so at a minimum we want to be sending the player
+an updated set of entities it can see every second.
+
+The motivation for the second condition is that looping
+through every entity in world to check if it is now within
+the tracking range after the player has moved 0.1 blocks is
+largely unnecessary. Checking only after the player has moved
+1 or 2 blocks is far better for performance, and very unlikely
+to give any noticeable side effects.
+
+In testing, this has reduced the time taken for movement
+packet processing by up to 4x. Packet processing for movement
+packets often show up as a major contributor to TPS loss in
+servers with large player counts
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index bce502181..e101c1156 100644


### PR DESCRIPTION
**See patch notes for full description**

This patch reduces the number of unnecessary entity tracker updates that occur when movement packets are processed by the server. In testing, it has reduced the time taken to process such packets by up to 4x. Packet processing for movement packets often show high in timings reports and are usually the cause for oversleep

Although I have tested this on my own and on my small survival server (and noticed no issues), I haven't got the resources to test this on servers with any more than about 10 concurrent players. Although it _should_ scale well with player count, external testing would be appreciated

Paperclip (based on 112): https://drive.google.com/file/d/1j2hSTpOFbGo8ioeOM7vZal9wAgzUWWra/view