### PR TITLE
Add per world spawn limits

### DIFF
--- a/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
+++ b/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
@@ -1,4 +1,4 @@
-From 7136ff814df7a69967d3957a4c613848752aa597 Mon Sep 17 00:00:00 2001
+From 7b57de33bae4563a8d746f3ffd169a2aba5afe0f Mon Sep 17 00:00:00 2001
 From: chase <chasewhip20@gmail.com>
 Date: Sun, 15 Mar 2020 18:32:22 -0600
 Subject: [PATCH] Per World Spawn limits
@@ -28,7 +28,7 @@ index 7ca67a4a..e3262642 100644
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1a5ee341..5851606f 100644
+index 1a5ee341..6bb78592 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -324,6 +324,12 @@ public class CraftWorld implements World {
@@ -40,7 +40,7 @@ index 1a5ee341..5851606f 100644
 +        animalSpawn = world.paperConfig.spawnLimitAnimals;
 +        waterAnimalSpawn = world.paperConfig.spawnLimitWaterAnimals;
 +        ambientSpawn = world.paperConfig.spawnLimitAmbient;
-+        //Paper end - per world spawn limits
++        //Paper end
      }
  
      @Override

--- a/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
+++ b/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
@@ -1,0 +1,57 @@
+From b26bc842dd25a014963fbad84705a2d09ae0b024 Mon Sep 17 00:00:00 2001
+From: chase <chasewhip20@gmail.com>
+Date: Sun, 15 Mar 2020 18:32:22 -0600
+Subject: [PATCH] Per World Spawn limits
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 7ca67a4a..8e59b36f 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -8,7 +8,6 @@ import java.util.Map;
+ 
+ import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.ChunkEdgeMode;
+ import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+-import net.minecraft.server.MinecraftServer;
+ import org.bukkit.Bukkit;
+ import org.bukkit.Material;
+ import org.bukkit.configuration.ConfigurationSection;
+@@ -668,4 +667,18 @@ public class PaperWorldConfig {
+     private void zombieVillagerInfectionChance() {
+         zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
+     }
++
++    public int spawnLimitMonsters;
++    public int spawnLimitAnimals;
++    public int spawnLimitWaterAnimals;
++    public int spawnLimitAmbient;
++
++    private void perWorldSpawnLimit(){
++        String path = "spawn-limits";
++
++        spawnLimitMonsters = getInt(path + ".monsters", -1);
++        spawnLimitAnimals = getInt(path + ".animals", -1);
++        spawnLimitWaterAnimals = getInt(path + ".water-animals", -1);
++        spawnLimitAmbient = getInt(path + ".ambient", -1);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 1a5ee341..5851606f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -324,6 +324,12 @@ public class CraftWorld implements World {
+         this.generator = gen;
+ 
+         environment = env;
++        //Paper start - per world spawn limits
++        monsterSpawn = world.paperConfig.spawnLimitMonsters;
++        animalSpawn = world.paperConfig.spawnLimitAnimals;
++        waterAnimalSpawn = world.paperConfig.spawnLimitWaterAnimals;
++        ambientSpawn = world.paperConfig.spawnLimitAmbient;
++        //Paper end - per world spawn limits
+     }
+ 
+     @Override
+-- 
+2.19.1.windows.1
+

--- a/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
+++ b/Spigot-Server-Patches/0449-Per-World-Spawn-limits.patch
@@ -1,22 +1,14 @@
-From b26bc842dd25a014963fbad84705a2d09ae0b024 Mon Sep 17 00:00:00 2001
+From 7136ff814df7a69967d3957a4c613848752aa597 Mon Sep 17 00:00:00 2001
 From: chase <chasewhip20@gmail.com>
 Date: Sun, 15 Mar 2020 18:32:22 -0600
 Subject: [PATCH] Per World Spawn limits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7ca67a4a..8e59b36f 100644
+index 7ca67a4a..e3262642 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -8,7 +8,6 @@ import java.util.Map;
- 
- import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.ChunkEdgeMode;
- import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
--import net.minecraft.server.MinecraftServer;
- import org.bukkit.Bukkit;
- import org.bukkit.Material;
- import org.bukkit.configuration.ConfigurationSection;
-@@ -668,4 +667,18 @@ public class PaperWorldConfig {
+@@ -668,4 +668,18 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }


### PR DESCRIPTION
This adds a config option to the Paper config that allows configuration of spawn limits per world. This can be helpful for servers that need to nerf or increase mob spawns in the end or nether for instance with gold farms or enderman farms causing lag or being too slow. The config option was placed outside of the traditional world settings as the default was unable to be placed in the config entry as the default is in Bukkit.yml like normal.