### PR TITLE
Fix random ticks (Fixes #2990)

### DIFF
--- a/Spigot-Server-Patches/0438-Optimise-random-block-ticking.patch
+++ b/Spigot-Server-Patches/0438-Optimise-random-block-ticking.patch
@@ -328,6 +328,19 @@ index 44aed67274..fa664897fb 100644
      @FunctionalInterface
      public interface a<T> {
  
+diff --git a/src/main/java/net/minecraft/server/EntityTurtle.java b/src/main/java/net/minecraft/server/EntityTurtle.java
+index dd02cb34..b24a5100 100644
+--- a/src/main/java/net/minecraft/server/EntityTurtle.java
++++ b/src/main/java/net/minecraft/server/EntityTurtle.java
+@@ -29,7 +29,7 @@ public class EntityTurtle extends EntityAnimal {
+ 
+     public final void setHome(BlockPosition pos) { g(pos); } // Paper - OBFHELPER
+     public void g(BlockPosition blockposition) {
+-        this.datawatcher.set(EntityTurtle.bx, blockposition);
++        this.datawatcher.set(EntityTurtle.bx, blockposition.immutableCopy()); // Paper - make sure home position can't change
+     }
+ 
+     public final BlockPosition getHome() { return this.es(); } // Paper - OBFHELPER
 diff --git a/src/main/java/net/minecraft/server/IBlockData.java b/src/main/java/net/minecraft/server/IBlockData.java
 index de43881653..e821c236b4 100644
 --- a/src/main/java/net/minecraft/server/IBlockData.java


### PR DESCRIPTION
Originally, when a block was being random ticked, it was giving a mutable block position object. Whenever the next random tick was called, that same mutable block position was updated to a new block position, creating synchronization issues if the block being ticked cared about the block coordinates, such as newly hatched turtles.

This change simply forces an immutable block position to be generated whenever a random tick is scheduled, ensuring the position will be valid throughout the duration of the random tick's logic.