### PR TITLE
Fix NPE on GUI during Windows Lock Screen

### DIFF
--- a/Spigot-Server-Patches/0442-Make-the-GUI-graph-fancier.patch
+++ b/Spigot-Server-Patches/0442-Make-the-GUI-graph-fancier.patch
@@ -1,4 +1,4 @@
-From 82753021f3070245c7b53ac48e1f806d5ea4cb59 Mon Sep 17 00:00:00 2001
+From 6b75fff901ccd8a8126a98f8a7fc6fd98f57edee Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 2 Feb 2020 04:00:40 -0600
 Subject: [PATCH] Make the GUI graph fancier
@@ -236,10 +236,10 @@ index 000000000..e463a86a6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java b/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java
 new file mode 100644
-index 000000000..5892c4dc1
+index 000000000..c3e54da4a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/gui/RAMGraph.java
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,144 @@
 +package com.destroystokyo.paper.gui;
 +
 +import javax.swing.JComponent;
@@ -251,6 +251,7 @@ index 000000000..5892c4dc1
 +import java.awt.Graphics;
 +import java.awt.MouseInfo;
 +import java.awt.Point;
++import java.awt.PointerInfo;
 +import java.awt.event.MouseAdapter;
 +import java.awt.event.MouseEvent;
 +import java.text.SimpleDateFormat;
@@ -312,13 +313,18 @@ index 000000000..5892c4dc1
 +        Runtime jvm = Runtime.getRuntime();
 +        DATA.add(new GraphData(jvm.totalMemory(), jvm.freeMemory(), jvm.maxMemory()));
 +
-+        Point scr = MouseInfo.getPointerInfo().getLocation();
-+        Point loc = new Point(scr);
-+        SwingUtilities.convertPointFromScreen(loc, this);
-+        if (this.contains(loc)) {
-+            ToolTipManager.sharedInstance().mouseMoved(
-+                new MouseEvent(this, -1, System.currentTimeMillis(), 0, loc.x, loc.y,
-+                    scr.x, scr.y, 0, false, 0));
++        PointerInfo pointerInfo = MouseInfo.getPointerInfo();
++        if (pointerInfo != null) {
++            Point point = pointerInfo.getLocation();
++            if (point != null) {
++                Point loc = new Point(point);
++                SwingUtilities.convertPointFromScreen(loc, this);
++                if (this.contains(loc)) {
++                    ToolTipManager.sharedInstance().mouseMoved(
++                        new MouseEvent(this, -1, System.currentTimeMillis(), 0, loc.x, loc.y,
++                            point.x, point.y, 0, false, 0));
++                }
++            }
 +        }
 +
 +        currentTick++;
@@ -418,5 +424,5 @@ index 95561d9db..470009fe4 100644
          this.e.add(guistatscomponent::a);
          jpanel.add(guistatscomponent, "North");
 -- 
-2.25.0
+2.24.0
 


### PR DESCRIPTION
This fixes an issues where an NPE is thrown when the mouse information is unavailable to the GUI, like when Windows Lock Screen is enabled.