### PR TITLE
Call BlockRedstoneEvent for fence gates

### DIFF
--- a/Spigot-API-Patches/0045-Fireworks-API-s.patch
+++ b/Spigot-API-Patches/0045-Fireworks-API-s.patch
@@ -1,4 +1,4 @@
-From 0b298d491792d27eb44e0f47efa1bf643b5297fb Mon Sep 17 00:00:00 2001
+From 5350778e510bb69d70efd8d83fb58caf1cdf8fd9 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 28 Dec 2016 01:18:55 -0500
 Subject: [PATCH] Fireworks API's
@@ -37,5 +37,5 @@ index f844d5aa..e8c04c13 100644
 +    // Paper end
  }
 -- 
-2.25.0.windows.1
+2.14.1.windows.1
 

--- a/Spigot-Server-Patches/0449-Call-BlockRedstoneEvent-for-fence-gates.patch
+++ b/Spigot-Server-Patches/0449-Call-BlockRedstoneEvent-for-fence-gates.patch
@@ -1,0 +1,31 @@
+From 916bcb6ec2a4b12f0e11095eacd09a56aaa0dfe1 Mon Sep 17 00:00:00 2001
+From: Jan Boerman <Janboerman95@gmail.com>
+Date: Sat, 14 Mar 2020 14:17:35 +0100
+Subject: [PATCH] Call BlockRedstoneEvent for fence gates
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockFenceGate.java b/src/main/java/net/minecraft/server/BlockFenceGate.java
+index 432e47bb..583eb688 100644
+--- a/src/main/java/net/minecraft/server/BlockFenceGate.java
++++ b/src/main/java/net/minecraft/server/BlockFenceGate.java
+@@ -103,6 +103,17 @@ public class BlockFenceGate extends BlockFacingHorizontal {
+     public void doPhysics(IBlockData iblockdata, World world, BlockPosition blockposition, Block block, BlockPosition blockposition1, boolean flag) {
+         if (!world.isClientSide) {
+             boolean flag1 = world.isBlockIndirectlyPowered(blockposition);
++            // Paper start
++            boolean isOldPowered = iblockdata.get(BlockFenceGate.POWERED);
++            if (flag1 != isOldPowered) {
++                int newPower = flag1 ? 15 : 0;
++                int oldPower = isOldPowered ? 15 : 0;
++                org.bukkit.block.Block bukkitBlock = org.bukkit.craftbukkit.block.CraftBlock.at(world, blockposition);
++                org.bukkit.event.block.BlockRedstoneEvent eventRedstone = new org.bukkit.event.block.BlockRedstoneEvent(bukkitBlock, oldPower, newPower);
++                world.getServer().getPluginManager().callEvent(eventRedstone);
++                flag1 = eventRedstone.getNewCurrent() > 0;
++            }
++            // Paper end
+ 
+             if ((Boolean) iblockdata.get(BlockFenceGate.POWERED) != flag1) {
+                 world.setTypeAndData(blockposition, (IBlockData) ((IBlockData) iblockdata.set(BlockFenceGate.POWERED, flag1)).set(BlockFenceGate.OPEN, flag1), 2);
+-- 
+2.14.1.windows.1
+


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/3025

The code for this patch was heavily based on the patch for BlockDoor, but I don't think there's an elegant way to share code between the two patches.

I tested the patch using the example plugin described in the bugreport, everything seems to work fine. As with BlockDoor, the BlockRedstoneEvent is only called when the fence gate actually changes from an open state to a closed state or vice versa. More specifically; redstone power level changes where both the old and new power levels are above 0 are ignored for this event.