### PR TITLE
Prevent blocking on adding a new network manager

### DIFF
--- a/Spigot-Server-Patches/0102-Avoid-blocking-on-Network-Manager-creation.patch
+++ b/Spigot-Server-Patches/0102-Avoid-blocking-on-Network-Manager-creation.patch
@@ -1,4 +1,4 @@
-From 7146abc3f83a14013dab8591ad749ffa34ea5077 Mon Sep 17 00:00:00 2001
+From 55ced1105b5d5fe2f705ff0fdeeaa7f00fe95294 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 16 May 2016 23:19:16 -0400
 Subject: [PATCH] Avoid blocking on Network Manager creation
@@ -6,7 +6,7 @@ Subject: [PATCH] Avoid blocking on Network Manager creation
 Per Paper issue 294
 
 diff --git a/src/main/java/net/minecraft/server/ServerConnection.java b/src/main/java/net/minecraft/server/ServerConnection.java
-index e7e216850..9cd7c9064 100644
+index e7e21685..404e7834 100644
 --- a/src/main/java/net/minecraft/server/ServerConnection.java
 +++ b/src/main/java/net/minecraft/server/ServerConnection.java
 @@ -39,6 +39,15 @@ public class ServerConnection {
@@ -14,11 +14,11 @@ index e7e216850..9cd7c9064 100644
      private final List<ChannelFuture> listeningChannels = Collections.synchronizedList(Lists.newArrayList());
      private final List<NetworkManager> connectedChannels = Collections.synchronizedList(Lists.newArrayList());
 +    // Paper start - prevent blocking on adding a new network manager while the server is ticking
-+    private final List<NetworkManager> pending = Collections.synchronizedList(Lists.<NetworkManager>newArrayList());
++    private final java.util.Queue<NetworkManager> pending = new java.util.concurrent.ConcurrentLinkedQueue<>();
 +    private void addPending() {
-+        synchronized (pending) {
-+            connectedChannels.addAll(pending);
-+            pending.clear();
++        NetworkManager manager = null;
++        while ((manager = pending.poll()) != null) {
++            connectedChannels.add(manager);
 +        }
 +    }
 +    // Paper end
@@ -43,5 +43,4 @@ index e7e216850..9cd7c9064 100644
              if ( org.spigotmc.SpigotConfig.playerShuffle > 0 && MinecraftServer.currentTick % org.spigotmc.SpigotConfig.playerShuffle == 0 )
              {
 -- 
-2.25.0.windows.1
-
+2.17.1


### PR DESCRIPTION
Previous solution could still block network thread (while addPending is executing). This window is small, but removing it completely is better. This should probably also speed up concurrent adds, because no locking will be performed anymore.
The only possible downside is that adding elements one by one to synchronized list might be slower (But it's done while already locked, so maybe jvm will avoid additional locking?),