### PR TITLE
Add PlayerAttackEntityCooldownResetEvent

### DIFF
--- a/Spigot-API-Patches/0198-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/Spigot-API-Patches/0198-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -1,0 +1,91 @@
+From e38b34700c710bf372ce83acfb7a0aeaa54bc7d0 Mon Sep 17 00:00:00 2001
+From: nossr50 <nossr50@gmail.com>
+Date: Thu, 26 Mar 2020 19:30:58 -0700
+Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java
+new file mode 100644
+index 00000000..ebdebe7b
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAttackEntityCooldownResetEvent.java
+@@ -0,0 +1,76 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when processing a player's attack on an entity when the player's attack strength cooldown is reset
++ */
++public class PlayerAttackEntityCooldownResetEvent extends PlayerEvent implements Cancellable {
++
++    private final float cooledAttackStrength;
++    private boolean cancel = false;
++    private static final HandlerList handlers = new HandlerList();
++    @NotNull private final Entity attackedEntity;
++
++    public PlayerAttackEntityCooldownResetEvent(@NotNull Player who, @NotNull Entity attackedEntity, float cooledAttackStrength) {
++        super(who);
++        this.attackedEntity = attackedEntity;
++        this.cooledAttackStrength = cooledAttackStrength;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    /**
++     * Gets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     * <p>
++     * If an attack cooldown event is cancelled, the players attack strength will remain at the same value instead of being reset.
++     *
++     * @return true if this event is cancelled
++     */
++    @Override
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    /**
++     * Cancelling this event will prevent the target player from having their cooldown reset from attacking this entity
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    /**
++     * Get the value of the players cooldown attack strength when they initiated the attack
++     *
++     * @return returns the original player cooldown value
++     */
++    public float getCooledAttackStrength() {
++        return cooledAttackStrength;
++    }
++
++    /**
++     * Returns the entity attacked by the player
++     *
++     * @return the entity attacked by the player
++     */
++    @NotNull
++    public Entity getAttackedEntity() {
++        return attackedEntity;
++    }
++}
+-- 
+2.25.1
+

--- a/Spigot-Server-Patches/0490-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/Spigot-Server-Patches/0490-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -1,0 +1,26 @@
+From 21dfa9a7108ea72db2e34c0ad40cff723f7f792c Mon Sep 17 00:00:00 2001
+From: nossr50 <nossr50@gmail.com>
+Date: Thu, 26 Mar 2020 19:44:50 -0700
+Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 8a3f2b5e40..2e186134ea 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -1057,7 +1057,11 @@ public abstract class EntityHuman extends EntityLiving {
+ 
+                 f *= 0.2F + f2 * f2 * 0.8F;
+                 f1 *= f2;
+-                this.ey();
++                // Paper start - PlayerAttackEntityCooldownResetEvent
++                if (new com.destroystokyo.paper.event.player.PlayerAttackEntityCooldownResetEvent((Player) this.getBukkitEntity(), entity.getBukkitEntity(), this.getCooledAttackStrength(0F)).callEvent()) {
++                    this.resetCooldown(); // reset it like normal
++                }
++                // Paper end
+                 if (f > 0.0F || f1 > 0.0F) {
+                     boolean flag = f2 > 0.9F;
+                     boolean flag1 = false;
+-- 
+2.25.1
+


### PR DESCRIPTION
This event is called when processing a player's attack on an entity
right before their attack strength cooldown is reset, there are no existing
events that fire within this period of time so it was impossible to
capture the players attack strength via API prior to this commit.

The event is cancellable, which will just skip over the normal reset of
attack strength cooldown