### PR TITLE
Move player to spawn point if spawn in unloaded world

### DIFF
--- a/Spigot-Server-Patches/0488-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/Spigot-Server-Patches/0488-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -1,0 +1,30 @@
+From 3d7bdaea0c45ee77416c305159643fc4b397dfee Mon Sep 17 00:00:00 2001
+From: 2277 <38501234+2277@users.noreply.github.com>
+Date: Tue, 31 Mar 2020 10:33:55 +0100
+Subject: [PATCH] Move player to spawn point if spawn in unloaded world
+
+The code following this has better support for null worlds to move
+them back to the world spawn.
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 96a47dd1c2..46e631d466 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -1790,9 +1790,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+                     bworld = server.getWorld(worldName);
+                 }
+ 
+-                if (bworld == null) {
+-                    bworld = ((org.bukkit.craftbukkit.CraftServer) server).getServer().getWorldServer(DimensionManager.OVERWORLD).getWorld();
+-                }
++                // Paper start - Move player to spawn point if spawn in unloaded world
++                // if (bworld == null) {
++                //    bworld = ((org.bukkit.craftbukkit.CraftServer) server).getServer().getWorldServer(DimensionManager.OVERWORLD).getWorld();
++                // }
++                // Paper end
+ 
+                 spawnIn(bworld == null ? null : ((CraftWorld) bworld).getHandle());
+             }
+-- 
+2.25.1
+


### PR DESCRIPTION
Move player to their spawn point if their previous world is unloaded on join. The current behaviour is to relocate them to the overworld at the same coordinates, which can cause them to spawn inside of blocks.