### PR TITLE
Report proxy onlinde mode to bstats as online

### DIFF
--- a/Spigot-Server-Patches/0005-Paper-Metrics.patch
+++ b/Spigot-Server-Patches/0005-Paper-Metrics.patch
@@ -15,7 +15,7 @@ decisions on behalf of the project.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e257d6b36e0e78dac5b8320017d92776171e1bb0
+index 0000000000000000000000000000000000000000..f2a0a9f5d86820ce8098301256d2faf3d1a7c697
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
 @@ -0,0 +1,627 @@
@@ -608,7 +608,7 @@ index 0000000000000000000000000000000000000000..e257d6b36e0e78dac5b8320017d92776
 +                }));
 +
 +                metrics.addCustomChart(new Metrics.SingleLineChart("players", () -> Bukkit.getOnlinePlayers().size()));
-+                metrics.addCustomChart(new Metrics.SimplePie("online_mode", () -> Bukkit.getOnlineMode() ? "online" : "offline"));
++                metrics.addCustomChart(new Metrics.SimplePie("online_mode", () -> Bukkit.getOnlineMode() || PaperConfig.isProxyOnlineMode() ? "online" : "offline"));
 +                metrics.addCustomChart(new Metrics.SimplePie("paper_version", () -> (Metrics.class.getPackage().getImplementationVersion() != null) ? Metrics.class.getPackage().getImplementationVersion() : "unknown"));
 +
 +                metrics.addCustomChart(new Metrics.DrilldownPie("java_version", () -> {


### PR DESCRIPTION
This adds "bungee" to the online mode pie chart on bStats. It uses the same checks that Aikar's timings uses for this.

![image](https://user-images.githubusercontent.com/332527/78420701-24167b80-7617-11ea-9663-96006a149c2a.png)

No more wondering if all those offline mode servers really are pirates, or if they are just behind a bungee proxy ^_^