### PR TITLE
Add tick times API and /mspt command

### DIFF
--- a/Spigot-API-Patches/0193-Add-tick-times-API.patch
+++ b/Spigot-API-Patches/0193-Add-tick-times-API.patch
@@ -1,0 +1,65 @@
+From 1fe29f877ba04e8bed08b47c185ddb9244705507 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 5 Apr 2020 22:22:58 -0500
+Subject: [PATCH] Add tick times API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index b9973406..c3c2d9c6 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1412,6 +1412,25 @@ public final class Bukkit {
+     public static double[] getTPS() {
+         return server.getTPS();
+     }
++
++    /**
++     * Get a sample of the servers last tick times (in nanos)
++     *
++     * @return A sample of the servers last tick times (in nanos)
++     */
++    @NotNull
++    public static long[] getTickTimes() {
++        return server.getTickTimes();
++    }
++
++    /**
++     * Get the average tick time (in millis)
++     *
++     * @return Average tick time (in millis)
++     */
++    public static double getAverageTickTime() {
++        return server == null ? 0D : server.getAverageTickTime();
++    }
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 80f9abdc..bfa83c9b 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1188,6 +1188,21 @@ public interface Server extends PluginMessageRecipient {
+      */
+     @NotNull
+     public double[] getTPS();
++
++    /**
++     * Get a sample of the servers last tick times (in nanos)
++     *
++     * @return A sample of the servers last tick times (in nanos)
++     */
++    @NotNull
++    long[] getTickTimes();
++
++    /**
++     * Get the average tick time (in millis)
++     *
++     * @return Average tick time (in millis)
++     */
++    double getAverageTickTime();
+     // Paper end
+ 
+     // Paper start
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
@@ -1,0 +1,172 @@
+From e4eddb2d1948d258e270cad611bbedbdde692f2f Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 5 Apr 2020 22:23:14 -0500
+Subject: [PATCH] Add tick times API and /mspt command
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/MSPTCommand.java b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
+new file mode 100644
+index 000000000..d0211d4f3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
+@@ -0,0 +1,64 @@
++package com.destroystokyo.paper;
++
++import net.minecraft.server.MinecraftServer;
++import org.bukkit.ChatColor;
++import org.bukkit.Location;
++import org.bukkit.command.Command;
++import org.bukkit.command.CommandSender;
++
++import java.text.DecimalFormat;
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collections;
++import java.util.List;
++
++public class MSPTCommand extends Command {
++    private static final DecimalFormat DF = new DecimalFormat("########0.0");
++
++    public MSPTCommand(String name) {
++        super(name);
++        this.description = "View server tick times";
++        this.usageMessage = "/mspt";
++        this.setPermission("bukkit.command.mspt");
++    }
++
++    @Override
++    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
++        return Collections.emptyList();
++    }
++
++    @Override
++    public boolean execute(CommandSender sender, String commandLabel, String[] args) {
++        if (!testPermission(sender)) return true;
++
++        MinecraftServer server = MinecraftServer.getServer();
++
++        List<String> times = new ArrayList<>();
++        times.addAll(eval(server.tickTimes5s.getTimes()));
++        times.addAll(eval(server.tickTimes10s.getTimes()));
++        times.addAll(eval(server.tickTimes60s.getTimes()));
++
++        sender.sendMessage("§6Server tick times §e(§7avg§e/§7min§e/§7max§e)§6 from last 5s§7,§6 10s§7,§6 1m§e:");
++        sender.sendMessage(String.format("§6◴ %s§7/%s§7/%s§e, %s§7/%s§7/%s§e, %s§7/%s§7/%s", times.toArray()));
++        return true;
++    }
++
++    private static List<String> eval(long[] times) {
++        long min = Integer.MAX_VALUE;
++        long max = 0L;
++        long total = 0L;
++        for (long value : times) {
++            if (value > 0L && value < min) min = value;
++            if (value > max) max = value;
++            total += value;
++        }
++        double avgD = ((double) total / (double) times.length) * 1.0E-6D;
++        double minD = ((double) min) * 1.0E-6D;
++        double maxD = ((double) max) * 1.0E-6D;
++        return Arrays.asList(getColor(avgD), getColor(minD), getColor(maxD));
++    }
++
++    private static String getColor(double avg) {
++        return ChatColor.COLOR_CHAR + (avg >= 50 ? "c" : avg >= 40 ? "e" : "a") + DF.format(avg);
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 6916ed30c..1c4cd3635 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -70,6 +70,7 @@ public class PaperConfig {
+ 
+         commands = new HashMap<String, Command>();
+         commands.put("paper", new PaperCommand("paper"));
++        commands.put("mspt", new MSPTCommand("mspt"));
+ 
+         version = getInt("config-version", 20);
+         set("config-version", 20);
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index c9deaffc4..9e5d569f7 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -106,6 +106,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+     private int G;
+     private int H;
+     public final long[] f = new long[100]; public long[] getTickTimes() { return f; } // Paper - OBFHELPER
++    // Paper start
++    public final TickTimes tickTimes5s = new TickTimes(100);
++    public final TickTimes tickTimes10s = new TickTimes(200);
++    public final TickTimes tickTimes60s = new TickTimes(1200);
++    // Paper end
+     @Nullable
+     private KeyPair I;
+     @Nullable
+@@ -1160,6 +1165,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         this.methodProfiler.enter("tallying");
+         long l = this.f[this.ticks % 100] = SystemUtils.getMonotonicNanos() - i;
+ 
++        // Paper start
++        tickTimes5s.add(this.ticks, l);
++        tickTimes10s.add(this.ticks, l);
++        tickTimes60s.add(this.ticks, l);
++        // Paper end
++
+         this.av = this.av * 0.8F + (float) l / 1000000.0F * 0.19999999F;
+         long i1 = SystemUtils.getMonotonicNanos();
+ 
+@@ -2254,4 +2265,30 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         return SERVER; // Paper
+     }
+     // CraftBukkit end
++
++    // Paper start
++    public static class TickTimes {
++        private final long[] times;
++
++        public TickTimes(int length) {
++            times = new long[length];
++        }
++
++        void add(int index, long time) {
++            times[index % times.length] = time;
++        }
++
++        public long[] getTimes() {
++            return times.clone();
++        }
++
++        public double getAverage() {
++            long total = 0L;
++            for (long value : times) {
++                total += value;
++            }
++            return ((double) total / (double) times.length) * 1.0E-6D;
++        }
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index b9a398bc5..53b71b791 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2052,6 +2052,16 @@ public final class CraftServer implements Server {
+                 net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
+         };
+     }
++
++    @Override
++    public long[] getTickTimes() {
++        return getServer().tickTimes5s.getTimes();
++    }
++
++    @Override
++    public double getAverageTickTime() {
++        return getServer().tickTimes5s.getAverage();
++    }
+     // Paper end
+ 
+     private final Spigot spigot = new Spigot()
+-- 
+2.24.0
+

--- a/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
@@ -1,4 +1,4 @@
-From e4eddb2d1948d258e270cad611bbedbdde692f2f Mon Sep 17 00:00:00 2001
+From d9363829a425ed107a3b90c6bb425df1c4b9ac36 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 5 Apr 2020 22:23:14 -0500
 Subject: [PATCH] Add tick times API and /mspt command
@@ -6,7 +6,7 @@ Subject: [PATCH] Add tick times API and /mspt command
 
 diff --git a/src/main/java/com/destroystokyo/paper/MSPTCommand.java b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
 new file mode 100644
-index 000000000..d0211d4f3
+index 000000000..7504879a4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
 @@ -0,0 +1,64 @@
@@ -50,8 +50,8 @@ index 000000000..d0211d4f3
 +        times.addAll(eval(server.tickTimes10s.getTimes()));
 +        times.addAll(eval(server.tickTimes60s.getTimes()));
 +
-+        sender.sendMessage("§6Server tick times §e(§7avg§e/§7min§e/§7max§e)§6 from last 5s§7,§6 10s§7,§6 1m§e:");
-+        sender.sendMessage(String.format("§6◴ %s§7/%s§7/%s§e, %s§7/%s§7/%s§e, %s§7/%s§7/%s", times.toArray()));
++        sender.sendMessage(PaperConfig.msptCommandHeaderMessage);
++        sender.sendMessage(String.format(PaperConfig.msptCommandTimesMessage, times.toArray()));
 +        return true;
 +    }
 +
@@ -75,7 +75,7 @@ index 000000000..d0211d4f3
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6916ed30c..1c4cd3635 100644
+index 6916ed30c..541942fcc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -70,6 +70,7 @@ public class PaperConfig {
@@ -86,6 +86,20 @@ index 6916ed30c..1c4cd3635 100644
  
          version = getInt("config-version", 20);
          set("config-version", 20);
+@@ -287,6 +288,13 @@ public class PaperConfig {
+         noPermissionMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.no-permission", noPermissionMessage));
+     }
+ 
++    public static String msptCommandHeaderMessage = "§6Server tick times §e(§7avg§e/§7min§e/§7max§e)§6 from last 5s§7,§6 10s§7,§6 1m§e:";
++    public static String msptCommandTimesMessage = "§6◴ %s§7/%s§7/%s§e, %s§7/%s§7/%s§e, %s§7/%s§7/%s";
++    private static void msptCommandMessages() {
++        msptCommandHeaderMessage = getString("messages.mspt-command.header", msptCommandHeaderMessage);
++        msptCommandTimesMessage = getString("messages.mspt-command.times", msptCommandTimesMessage);
++    }
++
+     public static boolean savePlayerData = true;
+     private static void savePlayerData() {
+         savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index c9deaffc4..9e5d569f7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
@@ -1,4 +1,4 @@
-From d9363829a425ed107a3b90c6bb425df1c4b9ac36 Mon Sep 17 00:00:00 2001
+From 8d00dcaeb1eab03b45794b3f0d92cd1529d315dc Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 5 Apr 2020 22:23:14 -0500
 Subject: [PATCH] Add tick times API and /mspt command
@@ -75,7 +75,7 @@ index 000000000..7504879a4
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6916ed30c..541942fcc 100644
+index 6916ed30c..32a992874 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -70,6 +70,7 @@ public class PaperConfig {
@@ -90,11 +90,11 @@ index 6916ed30c..541942fcc 100644
          noPermissionMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.no-permission", noPermissionMessage));
      }
  
-+    public static String msptCommandHeaderMessage = "§6Server tick times §e(§7avg§e/§7min§e/§7max§e)§6 from last 5s§7,§6 10s§7,§6 1m§e:";
-+    public static String msptCommandTimesMessage = "§6◴ %s§7/%s§7/%s§e, %s§7/%s§7/%s§e, %s§7/%s§7/%s";
++    public static String msptCommandHeaderMessage = "&6Server tick times &e(&7avg&e/&7min&e/&7max&e)&6 from last 5s&7,&6 10s&7,&6 1m&e:";
++    public static String msptCommandTimesMessage = "&6◴ %s&7/%s&7/%s&e, %s&7/%s&7/%s&e, %s&7/%s&7/%s";
 +    private static void msptCommandMessages() {
-+        msptCommandHeaderMessage = getString("messages.mspt-command.header", msptCommandHeaderMessage);
-+        msptCommandTimesMessage = getString("messages.mspt-command.times", msptCommandTimesMessage);
++        msptCommandHeaderMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.mspt-command.header", msptCommandHeaderMessage));
++        msptCommandTimesMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.mspt-command.times", msptCommandTimesMessage));
 +    }
 +
      public static boolean savePlayerData = true;

--- a/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0460-Add-tick-times-API-and-mspt-command.patch
@@ -1,4 +1,4 @@
-From 8d00dcaeb1eab03b45794b3f0d92cd1529d315dc Mon Sep 17 00:00:00 2001
+From b27e5e76fb9039e25e502f831badc083d73afbf7 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sun, 5 Apr 2020 22:23:14 -0500
 Subject: [PATCH] Add tick times API and /mspt command
@@ -6,7 +6,7 @@ Subject: [PATCH] Add tick times API and /mspt command
 
 diff --git a/src/main/java/com/destroystokyo/paper/MSPTCommand.java b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
 new file mode 100644
-index 000000000..7504879a4
+index 000000000..d0211d4f3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MSPTCommand.java
 @@ -0,0 +1,64 @@
@@ -50,8 +50,8 @@ index 000000000..7504879a4
 +        times.addAll(eval(server.tickTimes10s.getTimes()));
 +        times.addAll(eval(server.tickTimes60s.getTimes()));
 +
-+        sender.sendMessage(PaperConfig.msptCommandHeaderMessage);
-+        sender.sendMessage(String.format(PaperConfig.msptCommandTimesMessage, times.toArray()));
++        sender.sendMessage("§6Server tick times §e(§7avg§e/§7min§e/§7max§e)§6 from last 5s§7,§6 10s§7,§6 1m§e:");
++        sender.sendMessage(String.format("§6◴ %s§7/%s§7/%s§e, %s§7/%s§7/%s§e, %s§7/%s§7/%s", times.toArray()));
 +        return true;
 +    }
 +
@@ -75,7 +75,7 @@ index 000000000..7504879a4
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6916ed30c..32a992874 100644
+index 6916ed30c..1c4cd3635 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -70,6 +70,7 @@ public class PaperConfig {
@@ -86,20 +86,6 @@ index 6916ed30c..32a992874 100644
  
          version = getInt("config-version", 20);
          set("config-version", 20);
-@@ -287,6 +288,13 @@ public class PaperConfig {
-         noPermissionMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.no-permission", noPermissionMessage));
-     }
- 
-+    public static String msptCommandHeaderMessage = "&6Server tick times &e(&7avg&e/&7min&e/&7max&e)&6 from last 5s&7,&6 10s&7,&6 1m&e:";
-+    public static String msptCommandTimesMessage = "&6◴ %s&7/%s&7/%s&e, %s&7/%s&7/%s&e, %s&7/%s&7/%s";
-+    private static void msptCommandMessages() {
-+        msptCommandHeaderMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.mspt-command.header", msptCommandHeaderMessage));
-+        msptCommandTimesMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.mspt-command.times", msptCommandTimesMessage));
-+    }
-+
-     public static boolean savePlayerData = true;
-     private static void savePlayerData() {
-         savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index c9deaffc4..9e5d569f7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java


### PR DESCRIPTION
Exposes the server tick times and the last 5 second average to the API.

Also adds a new `/mspt` command for viewing this information, plus a bit extra.

![image](https://user-images.githubusercontent.com/332527/78520976-0d466500-778e-11ea-8620-f4bd7dce8c12.png)

This supersedes #2926