### PR TITLE
Async command map building

### DIFF
--- a/Spigot-Server-Patches/0468-Async-command-map-building.patch
+++ b/Spigot-Server-Patches/0468-Async-command-map-building.patch
@@ -1,0 +1,43 @@
+From cfe71cd50f913752bbd30d929ebdbe357d56e662 Mon Sep 17 00:00:00 2001
+From: Callahan <mr.callahhh@gmail.com>
+Date: Wed, 8 Apr 2020 02:42:14 -0500
+Subject: [PATCH] Async command map building
+
+
+diff --git a/src/main/java/net/minecraft/server/CommandDispatcher.java b/src/main/java/net/minecraft/server/CommandDispatcher.java
+index 37b1a7947..2414b0a55 100644
+--- a/src/main/java/net/minecraft/server/CommandDispatcher.java
++++ b/src/main/java/net/minecraft/server/CommandDispatcher.java
+@@ -241,6 +241,14 @@ public class CommandDispatcher {
+         if ( org.spigotmc.SpigotConfig.tabComplete < 0 ) return; // Spigot
+         // CraftBukkit start
+         // Register Vanilla commands into builtRoot as before
++        // Paper start - Async command map building
++        java.util.concurrent.ForkJoinPool.commonPool().execute(() -> {
++            sendAsync(entityplayer);
++        });
++    }
++
++    private void sendAsync(EntityPlayer entityplayer) {
++        // Paper end - Async command map building
+         Map<CommandNode<CommandListenerWrapper>, CommandNode<ICompletionProvider>> map = Maps.newIdentityHashMap(); // Use identity to prevent aliasing issues
+         RootCommandNode vanillaRoot = new RootCommandNode();
+ 
+@@ -258,7 +266,14 @@ public class CommandDispatcher {
+         for (CommandNode node : rootcommandnode.getChildren()) {
+             bukkit.add(node.getName());
+         }
++        // Paper start - Async command map building
++        MinecraftServer.getServer().execute(() -> {
++           runSync(entityplayer, bukkit, rootcommandnode);
++        });
++    }
+ 
++    private void runSync(EntityPlayer entityplayer, Collection<String> bukkit, RootCommandNode<ICompletionProvider> rootcommandnode) {
++        // Paper end - Async command map building
+         PlayerCommandSendEvent event = new PlayerCommandSendEvent(entityplayer.getBukkitEntity(), new LinkedHashSet<>(bukkit));
+         event.getPlayer().getServer().getPluginManager().callEvent(event);
+ 
+-- 
+2.25.1
+


### PR DESCRIPTION
Builds the command map async, focuses on fixing the root problem described in #2938 instead of just ignoring it. Leaf said he had a better idea but since I had this finished already.. thought might as well PR it. 

Needs testing from someone who suffers from lag spikes when players connect/change worlds.
Shows up as CommandDispatcher.a() in sampler reports. 