### PR TITLE
Add API MinecraftServer#isStopping

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -40,4 +40,5 @@ MicleBrick <miclebrick@outlook.com>
 Trigary <trigary0@gmail.com>
 rickyboy320 <rickw320@hotmail.com>
 DoNotSpamPls <7570108+DoNotSpamPls@users.noreply.github.com>
+JRoy <joshroy126@gmail.com>
 ```

--- a/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From 0f38ed2b2376a7728b1251f5ef0fd80bde967e70 Mon Sep 17 00:00:00 2001
+From 0803b121eb03e81e5d6c200240b953db89ca13b7 Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:35 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b9973406..791ce81a 100644
+index b9973406..eca8a43b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1661,6 +1661,15 @@ public final class Bukkit {
@@ -20,13 +20,13 @@ index b9973406..791ce81a 100644
 +     * @return true if server is not in the process of being shutdown
 +     */
 +    public static boolean isServerRunning() {
-+        return server.isServerRunning();
++        return server.isRunning();
 +    }
      // Paper end
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 80f9abdc..14c266fa 100644
+index 80f9abdc..3d0e3095 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1455,5 +1455,12 @@ public interface Server extends PluginMessageRecipient {
@@ -39,7 +39,7 @@ index 80f9abdc..14c266fa 100644
 +     *
 +     * @return true if server is not in the process of being shutdown
 +     */
-+    boolean isServerRunning();
++    boolean isRunning();
      // Paper end
  }
 -- 

--- a/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
@@ -1,0 +1,47 @@
+From 0f38ed2b2376a7728b1251f5ef0fd80bde967e70 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Fri, 10 Apr 2020 21:24:35 -0400
+Subject: [PATCH] Expose MinecraftServer#isRunning
+
+This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index b9973406..791ce81a 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1661,6 +1661,15 @@ public final class Bukkit {
+     public static int getCurrentTick() {
+         return server.getCurrentTick();
+     }
++
++    /**
++     * Checks if the server is still running (not being shutdown).
++     *
++     * @return true if server is not in the process of being shutdown
++     */
++    public static boolean isServerRunning() {
++        return server.isServerRunning();
++    }
+     // Paper end
+ 
+     @NotNull
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 80f9abdc..14c266fa 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1455,5 +1455,12 @@ public interface Server extends PluginMessageRecipient {
+      * @return Current tick
+      */
+     int getCurrentTick();
++
++    /**
++     * Checks if the server is still running (not being shutdown).
++     *
++     * @return true if server is not in the process of being shutdown
++     */
++    boolean isServerRunning();
+     // Paper end
+ }
+-- 
+2.17.1
+

--- a/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From 0803b121eb03e81e5d6c200240b953db89ca13b7 Mon Sep 17 00:00:00 2001
+From 0f38ed2b2376a7728b1251f5ef0fd80bde967e70 Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:35 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b9973406..eca8a43b 100644
+index b9973406..791ce81a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1661,6 +1661,15 @@ public final class Bukkit {
@@ -20,13 +20,13 @@ index b9973406..eca8a43b 100644
 +     * @return true if server is not in the process of being shutdown
 +     */
 +    public static boolean isServerRunning() {
-+        return server.isRunning();
++        return server.isServerRunning();
 +    }
      // Paper end
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 80f9abdc..3d0e3095 100644
+index 80f9abdc..14c266fa 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1455,5 +1455,12 @@ public interface Server extends PluginMessageRecipient {
@@ -39,7 +39,7 @@ index 80f9abdc..3d0e3095 100644
 +     *
 +     * @return true if server is not in the process of being shutdown
 +     */
-+    boolean isRunning();
++    boolean isServerRunning();
      // Paper end
  }
 -- 

--- a/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-API-Patches/0193-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From 0f38ed2b2376a7728b1251f5ef0fd80bde967e70 Mon Sep 17 00:00:00 2001
+From 4cafe0ab6318dce5b1775e57728b433bf581267d Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:35 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b9973406..791ce81a 100644
+index b9973406..dda12412 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1661,6 +1661,15 @@ public final class Bukkit {
@@ -15,18 +15,18 @@ index b9973406..791ce81a 100644
      }
 +
 +    /**
-+     * Checks if the server is still running (not being shutdown).
++     * Checks if the server is in the process of being shutdown.
 +     *
-+     * @return true if server is not in the process of being shutdown
++     * @return true if server is in the process of being shutdown
 +     */
-+    public static boolean isServerRunning() {
-+        return server.isServerRunning();
++    public static boolean isStopping() {
++        return server.isStopping();
 +    }
      // Paper end
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 80f9abdc..14c266fa 100644
+index 80f9abdc..5758ae79 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1455,5 +1455,12 @@ public interface Server extends PluginMessageRecipient {
@@ -35,11 +35,11 @@ index 80f9abdc..14c266fa 100644
      int getCurrentTick();
 +
 +    /**
-+     * Checks if the server is still running (not being shutdown).
++     * Checks if the server is in the process of being shutdown.
 +     *
-+     * @return true if server is not in the process of being shutdown
++     * @return true if server is in the process of being shutdown
 +     */
-+    boolean isServerRunning();
++    boolean isStopping();
      // Paper end
  }
 -- 

--- a/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
@@ -1,0 +1,25 @@
+From ed0c15a5b1253ae74a1c1c7c21c8e54da6ae4e63 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Fri, 10 Apr 2020 21:24:12 -0400
+Subject: [PATCH] Expose MinecraftServer#isRunning
+
+This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index b9a398bc..45c83b1a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2207,5 +2207,10 @@ public final class CraftServer implements Server {
+     public int getCurrentTick() {
+         return net.minecraft.server.MinecraftServer.currentTick;
+     }
++
++    @Override
++    public boolean isServerRunning() {
++        return net.minecraft.server.MinecraftServer.getServer().isRunning();
++    }
+     // Paper end
+ }
+-- 
+2.17.1
+

--- a/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From ed0c15a5b1253ae74a1c1c7c21c8e54da6ae4e63 Mon Sep 17 00:00:00 2001
+From 1e40778f000b2b4575a84ddf567f815b32d3d380 Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:12 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b9a398bc..45c83b1a 100644
+index b9a398bc5..331dba90f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2207,5 +2207,10 @@ public final class CraftServer implements Server {
@@ -15,7 +15,7 @@ index b9a398bc..45c83b1a 100644
      }
 +
 +    @Override
-+    public boolean isServerRunning() {
++    public boolean isRunning() {
 +        return net.minecraft.server.MinecraftServer.getServer().isRunning();
 +    }
      // Paper end

--- a/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From 1e40778f000b2b4575a84ddf567f815b32d3d380 Mon Sep 17 00:00:00 2001
+From ed0c15a5b1253ae74a1c1c7c21c8e54da6ae4e63 Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:12 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b9a398bc5..331dba90f 100644
+index b9a398bc..45c83b1a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2207,5 +2207,10 @@ public final class CraftServer implements Server {
@@ -15,7 +15,7 @@ index b9a398bc5..331dba90f 100644
      }
 +
 +    @Override
-+    public boolean isRunning() {
++    public boolean isServerRunning() {
 +        return net.minecraft.server.MinecraftServer.getServer().isRunning();
 +    }
      // Paper end

--- a/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0464-Expose-MinecraftServer-isRunning.patch
@@ -1,4 +1,4 @@
-From ed0c15a5b1253ae74a1c1c7c21c8e54da6ae4e63 Mon Sep 17 00:00:00 2001
+From b8b834494e5bc24038c34e2ad59a46b38a1330fd Mon Sep 17 00:00:00 2001
 From: JRoy <joshroy126@gmail.com>
 Date: Fri, 10 Apr 2020 21:24:12 -0400
 Subject: [PATCH] Expose MinecraftServer#isRunning
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b9a398bc..45c83b1a 100644
+index b9a398bc5..32121e87b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2207,5 +2207,10 @@ public final class CraftServer implements Server {
@@ -15,8 +15,8 @@ index b9a398bc..45c83b1a 100644
      }
 +
 +    @Override
-+    public boolean isServerRunning() {
-+        return net.minecraft.server.MinecraftServer.getServer().isRunning();
++    public boolean isStopping() {
++        return !net.minecraft.server.MinecraftServer.getServer().isRunning();
 +    }
      // Paper end
  }


### PR DESCRIPTION
Exposes `MinecraftServer#isRunning` in order to allow for plugins to discern if the server is shutting down or reloading the plugins in the `onDisable` method.