### PR TITLE
Entity Tick Limiter

### DIFF
--- a/Spigot-Server-Patches/0468-Tick-Limiter.patch
+++ b/Spigot-Server-Patches/0468-Tick-Limiter.patch
@@ -1,0 +1,175 @@
+From 690077295417b1a0d01f4742a86a5055a0176d95 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Sun, 12 Apr 2020 11:34:50 +0200
+Subject: [PATCH] Tick Limiter
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+index dfe92780a..9877affa8 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
++++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+@@ -48,7 +48,7 @@ public class PaperCommand extends Command {
+         {
+             case "entity":
+                 if (args.length == 2)
+-                    return getListMatchingLast(args, "help", "list");
++                    return getListMatchingLast(args, "help", "list", "ticklimit");
+                 if (args.length == 3)
+                     return getListMatchingLast(args, EntityTypes.getEntityNameList().stream().map(MinecraftKey::toString).sorted().toArray(String[]::new));
+                 break;
+@@ -281,11 +281,12 @@ public class PaperCommand extends Command {
+     }
+ 
+     /*
+-     * Ported from MinecraftForge - author: LexManos <LexManos@gmail.com> - License: LGPLv2.1
++     * Ported from MinecraftForge (excluding ticklimit) - author: LexManos <LexManos@gmail.com> - License: LGPLv2.1
++     *
+      */
+     private void listEntities(CommandSender sender, String[] args) {
+         if (args.length < 2 || args[1].toLowerCase(Locale.ENGLISH).equals("help")) {
+-            sender.sendMessage(ChatColor.RED + "Use /paper entity [list] help for more information on a specific command.");
++            sender.sendMessage(ChatColor.RED + "Use /paper entity [list|ticklimit] help for more information on a specific command.");
+             return;
+         }
+ 
+@@ -379,6 +380,34 @@ public class PaperCommand extends Command {
+                     sender.sendMessage("* First number is ticking entities, second number is non-ticking entities");
+                 }
+                 break;
++            case "ticklimit":
++                if (args.length > 2) {
++                    if (args[2].toLowerCase(Locale.ENGLISH).equals("help")) {
++                        sender.sendMessage(ChatColor.RED + "Use /paper entity ticklimit [entity] [value] to set the entity tick limiter value (1 for default)");
++                        return;
++                    } else if(args.length != 4) {
++                        sender.sendMessage(ChatColor.RED + "Usage: /paper entity ticklimit [entity] [value]");
++                        return;
++                    }
++
++                    Optional<EntityTypes<?>> type = EntityTypes.a(args[2]);
++                    if (!type.isPresent()) {
++                        sender.sendMessage(ChatColor.RED + "Unknown entity type " + args[2]);
++                        return;
++                    }
++
++                    int value;
++                    try {
++                        value = Integer.parseInt(args[3]);
++                    } catch (NumberFormatException e){
++                        sender.sendMessage(ChatColor.RED + "Value must be an int, was " + args[3]);
++                        return;
++                    }
++
++                    type.get().setTickLimiter(value);
++                    sender.sendMessage(ChatColor.GREEN + "Value updated");
++                }
++                break;
+         }
+     }
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 1c4cd3635..a5d10b663 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -13,12 +13,16 @@ import java.nio.charset.StandardCharsets;
+ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
++import java.util.Optional;
+ import java.util.Set;
+ import java.util.concurrent.TimeUnit;
+ import java.util.logging.Level;
+ import java.util.regex.Pattern;
+ 
+ import com.google.common.collect.Lists;
++
++import net.minecraft.server.EntityTypes;
++import net.minecraft.server.MinecraftKey;
+ import net.minecraft.server.MinecraftServer;
+ import org.bukkit.Bukkit;
+ import org.bukkit.ChatColor;
+@@ -429,4 +433,22 @@ public class PaperConfig {
+             */
+         }
+     }
++
++    public static Map<EntityTypes<?>, Integer> tickLimiters = new HashMap<>();
++    public static int getTickLimiter(EntityTypes<?> type) {
++        return tickLimiters.getOrDefault(type, 1);
++    }
++    private static void tickLimiters() {
++        ConfigurationSection section = config.getConfigurationSection("settings.tickLimiters");
++        if (section == null) {
++            config.addDefault("settings.tickLimiters", new HashMap<>());
++            section = config.createSection("settings.tickLimiters");
++        }
++        for (MinecraftKey key : EntityTypes.getEntityNameList()) {
++            int limit = section.getInt(key.getKey());
++            if (limit != 0) {
++                EntityTypes.a(key.getKey()).ifPresent(entityTypes -> tickLimiters.put(entityTypes, limit));
++            }
++        }
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
+index 0f04bcc8b..18ce91c9a 100644
+--- a/src/main/java/net/minecraft/server/EntityTypes.java
++++ b/src/main/java/net/minecraft/server/EntityTypes.java
+@@ -1,5 +1,7 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.PaperConfig;
++import com.destroystokyo.paper.PaperWorldConfig;
+ import com.mojang.datafixers.DataFixUtils;
+ import java.util.Collections;
+ import java.util.Optional;
+@@ -131,6 +133,7 @@ public class EntityTypes<T extends Entity> {
+     @Nullable
+     private MinecraftKey bi;
+     private final EntitySize bj;
++    private int tickLimiter = -1;
+ 
+     private static <T extends Entity> EntityTypes<T> a(String s, EntityTypes.a entitytypes_a) { // CraftBukkit - decompile error
+         return (EntityTypes) IRegistry.a((IRegistry) IRegistry.ENTITY_TYPE, s, (Object) entitytypes_a.a(s));
+@@ -367,6 +370,18 @@ public class EntityTypes<T extends Entity> {
+         return tag.isTagged(this);
+     }
+ 
++    // Paper start - tick limiting api
++    public boolean shouldTick(int ticksLived) {
++        if (tickLimiter == -1) {
++            tickLimiter = PaperConfig.getTickLimiter(this);
++        }
++        return ticksLived % tickLimiter == 0;
++    }
++    public void setTickLimiter(int tickLimiter) {
++        this.tickLimiter = tickLimiter;
++    }
++    // Paper end
++
+     public interface b<T extends Entity> {
+ 
+         T create(EntityTypes<T> entitytypes, World world);
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 84a3367b8..5f3c4412a 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -468,6 +468,7 @@ public class WorldServer extends World {
+                 // CraftBukkit end
+                 this.a((entity1) -> {
+                     ++entity1.ticksLived;
++                    if (entity1.getEntityType().shouldTick(entity1.ticksLived)) // Paper - tick limiting api
+                     entity1.tick();
+                 }, entity);
+                 if (entity.dead) {
+@@ -791,6 +792,7 @@ public class WorldServer extends World {
+                     return IRegistry.ENTITY_TYPE.getKey(entity.getEntityType()).toString();
+                 });
+                 gameprofilerfiller.c("tickNonPassenger");
++                if (entity.getEntityType().shouldTick(entity.ticksLived)) // Paper - tick limiting api
+                 entity.tick();
+                 entity.postTick(); // CraftBukkit
+                 gameprofilerfiller.exit();
+-- 
+2.17.1
+


### PR DESCRIPTION
This is rather experimental, haven't properly tested it yet.

It basically allows you to skip some ticks of some entities, either via config, or on demand via a command.

The impact is quite noticeable, both on the performance side:
![https://i.imgur.com/QPzEh7N.png](https://i.imgur.com/QPzEh7N.png)
(ticklimit for villager 1/2/3/4)

but also on the gameplay side, you can see the entities lagging:
https://streamable.com/lc9hzh

But, at 2 it isn't that noticeable and it's still better than your whole server lagging, so server owners might take that tradeoff. 

At dyescape we had great experience with setting high values for ender pearls, we use those at nametags and it eliminated the lag coming from them.
That's just one example how different setups may take use of this.