### PR TITLE
Allow using signs inside of spawn protection

### DIFF
--- a/Spigot-Server-Patches/0692-Allow-using-signs-inside-spawn-protection.patch
+++ b/Spigot-Server-Patches/0692-Allow-using-signs-inside-spawn-protection.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anton Lindroth <ntoonio@gmail.com>
+Date: Wed, 15 Apr 2020 01:54:02 +0200
+Subject: [PATCH] Allow using signs inside spawn protection
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index b473709774fbbd502d5e04c98041ae7c829b4083..fd675585c61387156892b179af593ad640873d45 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -810,4 +810,9 @@ public class PaperWorldConfig {
+         fixWitherTargetingBug = getBoolean("fix-wither-targeting-bug", false);
+         log("Withers properly target players: " + fixWitherTargetingBug);
+     }
++
++    public boolean allowUsingSignsInsideSpawnProtection = false;
++    private void allowUsingSignsInsideSpawnProtection() {
++        allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index f3679a3ad2d51612381bc47bb23eeffec924d478..3db6a4903c77729145a797b747d992abaf6e6b5d 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1545,7 +1545,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+
+         this.player.resetIdleTimer();
+         if (blockposition.getY() < this.minecraftServer.getMaxBuildHeight()) {
+-            if (this.teleportPos == null && this.player.h((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.a((EntityHuman) this.player, blockposition)) {
++            if (this.teleportPos == null && this.player.h((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && (worldserver.a((EntityHuman) this.player, blockposition) || (worldserver.getType(blockposition).getBlock() instanceof net.minecraft.server.BlockSign && worldserver.paperConfig.allowUsingSignsInsideSpawnProtection))) { // Paper
+                 // CraftBukkit start - Check if we can actually do something over this large a distance
+                 // Paper - move check up
+                 this.player.clearActiveItem(); // SPIGOT-4706


### PR DESCRIPTION
Signs have the ability to have a `run_command` tag that allows the player to execute a command by right clicking the sign. However the game sees this as "using a sign" in the same way as "using a chest" so it doesn't allow it.

I propose we do allow signs to be right clicked inside of the spawn protection. I think this will be beneficial for most servers, for example choosing team in spawn. In case some server would like only op to use the signs that can be done in other ways using scoreboards.