### PR TITLE
Add PlayerSendPacketEvent

### DIFF
--- a/Spigot-API-Patches/0197-Add-PlayerSendPacketEvent.patch
+++ b/Spigot-API-Patches/0197-Add-PlayerSendPacketEvent.patch
@@ -1,0 +1,73 @@
+From 5521b9ed316a72f85178cbd4495c64b7504b04be Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Thu, 16 Apr 2020 20:43:29 +0200
+Subject: [PATCH] Add PlayerSendPacketEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerSendPacketEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerSendPacketEvent.java
+new file mode 100644
+index 00000000..1f2a8734
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerSendPacketEvent.java
+@@ -0,0 +1,58 @@
++package com.destroystokyo.paper.event.player;
++
++import org.jetbrains.annotations.NotNull;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++
++/**
++ * Called when the player send a packet while in protocol phase play.<br>
++ * If cancelled, the server ignores the packet.<br>
++ * This event is always called on the main thread, right before the packet gets processed.<br>
++ * Its only called for packets that get processed on the main thread.
++ */
++public class PlayerSendPacketEvent extends PlayerEvent implements Cancellable {
++
++    private int id;
++    private Object packet;
++    private boolean cancelled;
++
++    public PlayerSendPacketEvent(@NotNull Player who, int id, @NotNull Object packet) {
++        super(who);
++        this.id = id;
++        this.packet = packet;
++    }
++
++    public int getId() {
++        return id;
++    }
++
++    @NotNull
++    public Object getPacket() {
++        return packet;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    private static final HandlerList handlers = new HandlerList();
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.17.1
+

--- a/Spigot-Server-Patches/0480-Implement-PlayerSendPacketEvent.patch
+++ b/Spigot-Server-Patches/0480-Implement-PlayerSendPacketEvent.patch
@@ -1,0 +1,40 @@
+From 1eeb8f60ab8a35fe9552fc2d227b651238eab157 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Thu, 16 Apr 2020 20:43:46 +0200
+Subject: [PATCH] Implement PlayerSendPacketEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
+index eb3269e0e..bfd258909 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
++++ b/src/main/java/net/minecraft/server/PlayerConnectionUtils.java
+@@ -20,6 +20,7 @@ public class PlayerConnectionUtils {
+                 if (MinecraftServer.getServer().hasStopped() || (t0 instanceof PlayerConnection && ((PlayerConnection) t0).processedDisconnect)) return; // CraftBukkit, MC-142590
+                 if (t0.a().isConnected()) {
+                     try (Timing ignored = timing.startTiming()) { // Paper - timings
++                    if (!handleEvent(packet, t0)) return; // Paper - packet event
+                     packet.a(t0);
+                     } // Paper - timings
+                 } else {
+@@ -34,5 +35,18 @@ public class PlayerConnectionUtils {
+             throw CancelledPacketHandleException.INSTANCE;
+         }
+         // CraftBukkit end
++        if (!handleEvent(packet, t0)) throw CancelledPacketHandleException.INSTANCE; // Paper - packet event
+     }
++
++    // Paper start - packet event
++    private static <T extends PacketListener> boolean handleEvent(Packet<T> packet, T listener) {
++        if (listener instanceof PlayerConnection) {
++            Integer id = EnumProtocol.PLAY.a(EnumProtocolDirection.SERVERBOUND, packet);
++            if(id == null) return false;
++            PlayerConnection connection = (PlayerConnection) listener;
++            return new com.destroystokyo.paper.event.player.PlayerSendPacketEvent(connection.getPlayer(), id, packet).callEvent();
++        }
++        return true;
++    }
++    // Paper end
+ }
+-- 
+2.17.1
+


### PR DESCRIPTION
Before ppl yell at me: this isn't a packet api.
This is not exposing packets to the api.
This event aims to provide to fill a gap that plugins like protocollib can't fill right now: Listening to incoming packets on the main thread, so that you can validate them against world state.
This event allows you to get the packet as an object, a plugin may interact with it directly by using NMS, via reflection or via 3rd party apis such as protocollib.
This event also allows you to cancel further processing of the packet. At that time in the pipeline the server already "wasted" time decoding the packet, but it didnt do any gameplay logic, so its a nice interaction point for anti cheat plugins as you need to access the world in a savely manner to be able to validate the packet.