### PR TITLE
Optimize brigadier child sorting performance

### DIFF
--- a/Spigot-Server-Patches/0509-Optimize-brigadier-child-sorting-performance.patch
+++ b/Spigot-Server-Patches/0509-Optimize-brigadier-child-sorting-performance.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: virustotalop <virustotalop@gmail.com>
+Date: Thu, 16 Apr 2020 20:51:32 -0700
+Subject: [PATCH] Optimize brigadier child sorting performance
+
+
+diff --git a/src/main/java/com/mojang/brigadier/tree/CommandNode.java b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+index 98592a3e63591b54f895e5fa6d8761ca7c4d9de4..bd2802d362cbf40ea0603162b66f4bcefe7944df 100644
+--- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
++++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
+@@ -26,7 +26,7 @@ import java.util.stream.Collectors;
+ import net.minecraft.server.CommandListenerWrapper; // CraftBukkit
+ 
+ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
+-    private Map<String, CommandNode<S>> children = Maps.newLinkedHashMap();
++    private Map<String, CommandNode<S>> children = Maps.newTreeMap(); //Paper - Switch to tree map for automatic sorting
+     private Map<String, LiteralCommandNode<S>> literals = Maps.newLinkedHashMap();
+     private Map<String, ArgumentCommandNode<S, ?>> arguments = Maps.newLinkedHashMap();
+     private final Predicate<S> requirement;
+@@ -106,8 +106,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
+                 arguments.put(node.getName(), (ArgumentCommandNode<S, ?>) node);
+             }
+         }
+-
+-        children = children.entrySet().stream().sorted(Map.Entry.comparingByValue()).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, LinkedHashMap::new));
++        //Paper - Remove manual sorting, it is no longer needed
+     }
+ 
+     public void findAmbiguities(final AmbiguityConsumer<S> consumer) {


### PR DESCRIPTION
Use a TreeMap instead of a LinkedHashMap and then manually sorting. Performance was discussed in #3154 