### PR TITLE
Implement Brigadier Mojang API

### DIFF
--- a/Paper-MojangAPI/pom.xml
+++ b/Paper-MojangAPI/pom.xml
@@ -1,0 +1,204 @@
+
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.destroystokyo.paper</groupId>
+        <artifactId>paper-parent</artifactId>
+        <version>dev-SNAPSHOT</version>
+    </parent>
+
+    <groupId>com.destroystokyo.paper</groupId>
+    <artifactId>paper-mojangapi</artifactId>
+    <version>1.15.2-R0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Paper-MojangAPI</name>
+    <url>https://github.com/PaperMC/Paper</url>
+    <description>API additions that utilize Mojang Specific API's</description>
+
+    <properties>
+        <!-- <skipTests>true</skipTests> Paper - This [was] not going to end well -->
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <repositories>
+        <repository>
+            <id>spigotmc-public</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>sonatype</id>
+            <url>https://oss.sonatype.org/content/groups/public/</url>
+        </repository>
+        <repository>
+            <id>minecraft-libraries</id>
+            <name>Minecraft Libraries</name>
+            <url>https://libraries.minecraft.net</url>
+        </repository>
+    </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>spigotmc-public</id>
+            <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.destroystokyo.paper</groupId>
+            <artifactId>paper-api</artifactId>
+            <version>${project.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- mojang api -->
+        <dependency>
+            <groupId>com.mojang</groupId>
+            <artifactId>brigadier</artifactId>
+            <version>1.0.17</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- utils -->
+        <dependency>
+            <groupId>it.unimi.dsi</groupId>
+            <artifactId>fastutil</artifactId>
+            <version>8.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- annotations -->
+        <dependency>
+            <groupId>org.jetbrains</groupId>
+            <artifactId>annotations</artifactId>
+            <version>18.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <!-- testing -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm-tree</artifactId>
+            <version>7.3.1</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <defaultGoal>clean install</defaultGoal>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.8.1</version>
+                <dependencies>
+                    <!-- we need our custom version as it fixes some bugs on case sensitive file systems -->
+                    <dependency>
+                        <groupId>org.codehaus.plexus</groupId>
+                        <artifactId>plexus-compiler-eclipse</artifactId>
+                        <version>2.8.5-spigotmc</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <configuration>
+                    <archive>
+                        <manifestEntries>
+                            <Automatic-Module-Name>org.bukkit</Automatic-Module-Name>
+                        </manifestEntries>
+                    </archive>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
+                    <!-- when downloading via Maven we can pull depends individually -->
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>development</id>
+            <properties>
+                <skipTests>false</skipTests>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-checkstyle-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <configLocation>checkstyle.xml</configLocation>
+                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>com.puppycrawl.tools</groupId>
+                                <artifactId>checkstyle</artifactId>
+                                <version>8.29</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>animal-sniffer-maven-plugin</artifactId>
+                        <version>1.18</version>
+                        <executions>
+                            <execution>
+                                <phase>process-classes</phase>
+                                <goals>
+                                    <goal>check</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <signature>
+                                <groupId>org.codehaus.mojo.signature</groupId>
+                                <artifactId>java18</artifactId>
+                                <version>1.0</version>
+                            </signature>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
+</project>

--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/brigadier/BukkitBrigadierCommand.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/brigadier/BukkitBrigadierCommand.java
@@ -1,0 +1,9 @@
+package com.destroystokyo.paper.brigadier;
+
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+
+import java.util.function.Predicate;
+
+public interface BukkitBrigadierCommand <S extends BukkitBrigadierCommandSource> extends Command<S>, Predicate<S>, SuggestionProvider<S> {
+}

--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/brigadier/BukkitBrigadierCommandSource.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/brigadier/BukkitBrigadierCommandSource.java
@@ -1,0 +1,21 @@
+package com.destroystokyo.paper.brigadier;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Entity;
+import org.jetbrains.annotations.Nullable;
+
+public interface BukkitBrigadierCommandSource {
+
+    @Nullable
+    Entity getBukkitEntity();
+
+    @Nullable
+    World getBukkitWorld();
+
+    @Nullable
+    Location getBukkitLocation();
+
+    CommandSender getBukkitSender();
+}

--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/AsyncPlayerSendCommandsEvent.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/AsyncPlayerSendCommandsEvent.java
@@ -1,0 +1,65 @@
+package com.destroystokyo.paper.event.brigadier;
+
+import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
+import com.mojang.brigadier.tree.RootCommandNode;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fired any time a Brigadier RootCommandNode is generated for a player to inform the client of commands.
+ * You may manipulate this CommandNode to change what the client sees.
+ *
+ * This event may fire on login, world change, and permission rebuilds, by plugin request, and potentially future means.
+ *
+ * This event will fire before {@link org.bukkit.event.player.PlayerCommandSendEvent}, so no filtering has been done by
+ * other plugins yet.
+ *
+ * WARNING: This event will potentially (and most likely) fire twice! Once for Async, and once again for Sync.
+ * It is important that you check event.isAsynchronous() and event.hasFiredAsync() to ensure you only act once.
+ * If for some reason we are unable to send this asynchronously in the future, only the sync method will fire.
+ *
+ * Your logic should look like this:
+ * if (event.isAsynchronous() || !event.hasFiredAsync()) { do stuff }
+ *
+ * If your logic is not safe to run asynchronously, only react to the synchronous version.
+ * @deprecated Draft API - Subject to change until confirmed solves desired use cases
+ */
+public class AsyncPlayerSendCommandsEvent <S extends BukkitBrigadierCommandSource> extends PlayerEvent {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final RootCommandNode<S> node;
+    private final boolean hasFiredAsync;
+
+    public AsyncPlayerSendCommandsEvent(Player player, RootCommandNode<S> node, boolean hasFiredAsync) {
+        super(player, !Bukkit.isPrimaryThread());
+        this.node = node;
+        this.hasFiredAsync = hasFiredAsync;
+    }
+
+    /**
+     * @return The full Root Command Node being sent to the client, which is mutable.
+     */
+    public RootCommandNode<S> getCommandNode() {
+        return node;
+    }
+
+    /**
+     * @return If this event has already fired asynchronously.
+     */
+    public boolean hasFiredAsync() {
+        return hasFiredAsync;
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
@@ -1,0 +1,122 @@
+package com.destroystokyo.paper.event.brigadier;
+
+import com.destroystokyo.paper.brigadier.BukkitBrigadierCommand;
+import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
+import com.mojang.brigadier.tree.ArgumentCommandNode;
+import com.mojang.brigadier.tree.LiteralCommandNode;
+import com.mojang.brigadier.tree.RootCommandNode;
+import org.bukkit.command.Command;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.server.ServerEvent;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Fired anytime the server synchronizes Bukkit CommandMap to Brigadier.
+ *
+ * Allows a plugin to control the Literal and Argument nodes for this command to be
+ * sent to the client.
+ * This is done at Plugin Enable time after commands have been registered, but some
+ * plugins may use reflection to retrigger this rebuild during runtime.
+ *
+ * @deprecated Draft API - Subject to change until confirmed solves desired use cases
+ */
+public class CommandRegisteredEvent <S extends BukkitBrigadierCommandSource> extends ServerEvent implements Cancellable {
+
+    private static final HandlerList handlers = new HandlerList();
+    private final String commandLabel;
+    private final Command command;
+    private final BukkitBrigadierCommand<S> brigadierCommand;
+    private final RootCommandNode<S> root;
+    private final ArgumentCommandNode<S, String> defaultArgs;
+    private LiteralCommandNode<S> literal;
+    private boolean cancelled = false;
+
+    public CommandRegisteredEvent(String commandLabel, BukkitBrigadierCommand<S> brigadierCommand, Command command, RootCommandNode<S> root, LiteralCommandNode<S> literal, ArgumentCommandNode<S, String> defaultArgs) {
+        this.commandLabel = commandLabel;
+        this.brigadierCommand = brigadierCommand;
+        this.command = command;
+        this.root = root;
+        this.literal = literal;
+        this.defaultArgs = defaultArgs;
+    }
+
+    /**
+     * @return The command name being registered
+     */
+    public String getCommandLabel() {
+        return commandLabel;
+    }
+
+    /**
+     * @return The Bukkit API Brigadier Wrapped Command Object to handle executions and suggestions
+     */
+    public BukkitBrigadierCommand<S> getBrigadierCommand() {
+        return brigadierCommand;
+    }
+
+    public Command getCommand() {
+        return command;
+    }
+
+    /**
+     * @return Gets the root command node being used to register a command to.
+     */
+    public RootCommandNode<S> getRoot() {
+        return root;
+    }
+
+    /**
+     * Returns the Bukkit API's default handling of Arguments, if you wish to reuse it.
+     * @return
+     */
+    public ArgumentCommandNode<S, String> getDefaultArgs() {
+        return defaultArgs;
+    }
+
+    /**
+     * Returns the Bukkit API's default literal for this command, including the {@link #getDefaultArgs()} as a child already.
+     * @return
+     */
+    public LiteralCommandNode<S> getLiteral() {
+        return literal;
+    }
+
+    /**
+     * Changes the literal used to register this command. The previous literable is mutable, so this is primarily if
+     * you want to completely replace the object.
+     * @param literal
+     */
+    public void setLiteral(LiteralCommandNode<S> literal) {
+        this.literal = literal;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isCancelled() {
+        return this.cancelled;
+    }
+
+    /**
+     * Cancels registering this command to Brigadier, but will remain in Bukkit Command Map. Can be used to hide a
+     * command from all players.
+     *
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+
+    @NotNull
+    public HandlerList getHandlers() {
+        return handlers;
+    }
+
+    @NotNull
+    public static HandlerList getHandlerList() {
+        return handlers;
+    }
+}

--- a/Spigot-API-Patches/0001-POM-changes.patch
+++ b/Spigot-API-Patches/0001-POM-changes.patch
@@ -1,11 +1,11 @@
-From 755a3e8943286365b0f518c5423687872c8181ae Mon Sep 17 00:00:00 2001
+From 72e2e4af618fca06282903aa0100a779f2945168 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 00:16:08 +0100
 Subject: [PATCH] POM changes
 
 
 diff --git a/pom.xml b/pom.xml
-index 8964b9e33..ce09baeab 100644
+index 8964b9e3..ce09baea 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -2,34 +2,28 @@
@@ -110,6 +110,19 @@ index 8964b9e33..ce09baeab 100644
                      <!-- when downloading via Maven we can pull depends individually -->
                      <shadedArtifactAttached>true</shadedArtifactAttached>
                  </configuration>
+diff --git a/src/main/java/org/bukkit/event/player/PlayerEvent.java b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+index 793b661b..b7c8f2c3 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerEvent.java
+@@ -14,7 +14,7 @@ public abstract class PlayerEvent extends Event {
+         player = who;
+     }
+ 
+-    PlayerEvent(@NotNull final Player who, boolean async) {
++    public PlayerEvent(@NotNull final Player who, boolean async) { // Paper - wtf?
+         super(async);
+         player = who;
+ 
 -- 
-2.25.1
+2.26.2
 

--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -1,11 +1,11 @@
-From c9716ffd01bb1c07e57fdb1e3f5da315ce435605 Mon Sep 17 00:00:00 2001
+From e5972e429a6ce140fcdca52e906abf72e8c20243 Mon Sep 17 00:00:00 2001
 From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Mon, 29 Feb 2016 20:40:33 -0600
 Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index def28b3bec..3dc6c2a3f5 100644
+index def28b3bec..23f33d0477 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,15 +1,14 @@
@@ -28,7 +28,7 @@ index def28b3bec..3dc6c2a3f5 100644
          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
          <api.version>unknown</api.version>
          <minecraft.version>1.15.2</minecraft.version>
-@@ -22,16 +21,16 @@
+@@ -22,16 +21,22 @@
      </properties>
  
      <parent>
@@ -46,10 +46,16 @@ index def28b3bec..3dc6c2a3f5 100644
 -            <artifactId>spigot-api</artifactId>
 +            <groupId>com.destroystokyo.paper</groupId>
 +            <artifactId>paper-api</artifactId>
++            <version>${project.version}</version>
++            <scope>compile</scope>
++        </dependency>
++        <dependency>
++            <groupId>com.destroystokyo.paper</groupId>
++            <artifactId>paper-mojangapi</artifactId>
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
-@@ -109,34 +108,22 @@
+@@ -109,34 +114,22 @@
  
      <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
      <build>
@@ -95,7 +101,7 @@ index def28b3bec..3dc6c2a3f5 100644
                          </goals>
                      </execution>
                  </executions>
-@@ -146,11 +133,13 @@
+@@ -146,11 +139,13 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>2.4</version>
                  <configuration>
@@ -110,7 +116,7 @@ index def28b3bec..3dc6c2a3f5 100644
                              <Implementation-Vendor>${maven.build.timestamp}</Implementation-Vendor>
                              <Specification-Title>Bukkit</Specification-Title>
                              <Specification-Version>${api.version}</Specification-Version>
-@@ -190,6 +179,7 @@
+@@ -190,6 +185,7 @@
                              <goal>shade</goal>
                          </goals>
                          <configuration>
@@ -118,7 +124,7 @@ index def28b3bec..3dc6c2a3f5 100644
                              <createSourcesJar>${shadeSourcesJar}</createSourcesJar>
                              <relocations>
                                  <!-- Cannot be relocated as it breaks translation property keys -->
-@@ -203,10 +193,11 @@
+@@ -203,10 +199,11 @@
                                      <pattern>jline</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.jline</shadedPattern>
                                  </relocation>
@@ -134,7 +140,7 @@ index def28b3bec..3dc6c2a3f5 100644
                                  <relocation>
                                      <pattern>org.apache.commons.codec</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.apache.commons.codec</shadedPattern>
-@@ -248,10 +239,6 @@
+@@ -248,10 +245,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>
@@ -159,5 +165,5 @@ index 93046379d0..674096cab1 100644
  
          if (stream != null) {
 -- 
-2.25.1
+2.26.2
 

--- a/Spigot-Server-Patches/0149-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0149-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -1,4 +1,4 @@
-From bd039fe4f27ea8f45a60714fb121a7e639eb0b94 Mon Sep 17 00:00:00 2001
+From 1c57cf609900d050035f40a897d442f171803efa Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Fri, 9 Jun 2017 19:03:43 +0200
 Subject: [PATCH] Use TerminalConsoleAppender for console improvements
@@ -19,10 +19,10 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 3dc6c2a3f5..b1f008738b 100644
+index 23f33d0477..dea7bc2619 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -41,10 +41,27 @@
+@@ -47,10 +47,27 @@
              <scope>compile</scope>
          </dependency>
          <dependency>
@@ -54,7 +54,7 @@ index 3dc6c2a3f5..b1f008738b 100644
          </dependency>
          <dependency>
              <groupId>org.ow2.asm</groupId>
-@@ -230,10 +247,18 @@
+@@ -236,10 +253,18 @@
                                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                      <resource>META-INF/services/java.sql.Driver</resource>
                                  </transformer>

--- a/Spigot-Server-Patches/0170-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
+++ b/Spigot-Server-Patches/0170-Use-Log4j-IOStreams-to-redirect-System.out-err-to-lo.patch
@@ -1,4 +1,4 @@
-From cc7eb34ab0d7d3ed2ac9c1133b0867d3f46c0227 Mon Sep 17 00:00:00 2001
+From 5f12e07474ebfc007a3a8fddca90e4e076127efa Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Mon, 18 Sep 2017 12:00:03 +0200
 Subject: [PATCH] Use Log4j IOStreams to redirect System.out/err to logger
@@ -12,10 +12,10 @@ results in a separate line, even though it should not result in
 a line break. Log4j's implementation handles it correctly.
 
 diff --git a/pom.xml b/pom.xml
-index b1f00873..14c4ec25 100644
+index dea7bc2619..24cdeb6ff4 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -63,6 +63,11 @@
+@@ -69,6 +69,11 @@
              <version>2.8.1</version>
              <scope>runtime</scope>
          </dependency>
@@ -28,7 +28,7 @@ index b1f00873..14c4ec25 100644
              <groupId>org.ow2.asm</groupId>
              <artifactId>asm</artifactId>
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index d34f772f..ec257ba3 100644
+index d34f772fae..ec257ba31f 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -155,8 +155,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -45,5 +45,5 @@ index d34f772f..ec257ba3 100644
  
          thread.setDaemon(true);
 -- 
-2.25.1.windows.1
+2.26.2
 

--- a/Spigot-Server-Patches/0171-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/Spigot-Server-Patches/0171-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -1,4 +1,4 @@
-From d1c079b07d209c70bf52c519ce4b2cfc5a2a9fe0 Mon Sep 17 00:00:00 2001
+From c564d96c0c02a902a986e9a512da7dc5a2b25628 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Thu, 21 Sep 2017 16:14:55 +0200
 Subject: [PATCH] Handle plugin prefixes using Log4J configuration
@@ -15,10 +15,10 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/pom.xml b/pom.xml
-index 14c4ec25..5a230592 100644
+index 24cdeb6ff4..ab8c61ab53 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -61,7 +61,7 @@
+@@ -67,7 +67,7 @@
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-core</artifactId>
              <version>2.8.1</version>
@@ -28,7 +28,7 @@ index 14c4ec25..5a230592 100644
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index fdca3434..6d77bbc5 100644
+index fdca34346a..6d77bbc5aa 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -286,7 +286,7 @@ public class SpigotConfig
@@ -41,7 +41,7 @@ index fdca3434..6d77bbc5 100644
  
      public static int playerShuffle;
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
-index 620b9490..a8bdaaea 100644
+index 620b9490e5..a8bdaaeaa1 100644
 --- a/src/main/resources/log4j2.xml
 +++ b/src/main/resources/log4j2.xml
 @@ -5,10 +5,22 @@
@@ -70,5 +70,5 @@ index 620b9490..a8bdaaea 100644
                  <TimeBasedTriggeringPolicy />
                  <OnStartupTriggeringPolicy />
 -- 
-2.25.1.windows.1
+2.26.2
 

--- a/Spigot-Server-Patches/0172-Include-Log4J2-SLF4J-implementation.patch
+++ b/Spigot-Server-Patches/0172-Include-Log4J2-SLF4J-implementation.patch
@@ -1,14 +1,14 @@
-From a40b48933c0e67d7f6146cf6a40d377a33b54857 Mon Sep 17 00:00:00 2001
+From 9e21ba071cd08c5232b4352237d05eec746746f8 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Thu, 21 Sep 2017 16:33:35 +0200
 Subject: [PATCH] Include Log4J2 SLF4J implementation
 
 
 diff --git a/pom.xml b/pom.xml
-index 5a230592..6f2fe9c2 100644
+index ab8c61ab53..76ce7f4486 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -63,6 +63,12 @@
+@@ -69,6 +69,12 @@
              <version>2.8.1</version>
              <scope>compile</scope>
          </dependency>
@@ -22,5 +22,5 @@ index 5a230592..6f2fe9c2 100644
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-iostreams</artifactId>
 -- 
-2.25.1.windows.1
+2.26.2
 

--- a/Spigot-Server-Patches/0247-Use-asynchronous-Log4j-2-loggers.patch
+++ b/Spigot-Server-Patches/0247-Use-asynchronous-Log4j-2-loggers.patch
@@ -1,14 +1,14 @@
-From 3d7f218a63941724b6e4fd12852b8e8a1f12df98 Mon Sep 17 00:00:00 2001
+From f52e7ce0fdce36da196c298d84ac8b5d778c4cb6 Mon Sep 17 00:00:00 2001
 From: Minecrell <minecrell@minecrell.net>
 Date: Tue, 17 Jul 2018 16:42:17 +0200
 Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/pom.xml b/pom.xml
-index 6f2fe9c2..55679af9 100644
+index 76ce7f4486..28ff064c19 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -74,6 +74,13 @@
+@@ -80,6 +80,13 @@
              <artifactId>log4j-iostreams</artifactId>
              <version>2.8.1</version>
          </dependency>
@@ -24,7 +24,7 @@ index 6f2fe9c2..55679af9 100644
              <artifactId>asm</artifactId>
 diff --git a/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java b/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java
 new file mode 100644
-index 00000000..db652a1f
+index 0000000000..db652a1f7a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/log/LogFullPolicy.java
 @@ -0,0 +1,17 @@
@@ -46,7 +46,7 @@ index 00000000..db652a1f
 +    }
 +}
 diff --git a/src/main/resources/log4j2.component.properties b/src/main/resources/log4j2.component.properties
-index 0694b214..30efeb5f 100644
+index 0694b21465..30efeb5faf 100644
 --- a/src/main/resources/log4j2.component.properties
 +++ b/src/main/resources/log4j2.component.properties
 @@ -1 +1,3 @@
@@ -54,5 +54,5 @@ index 0694b214..30efeb5f 100644
 +log4j2.AsyncQueueFullPolicy="com.destroystokyo.paper.log.LogFullPolicy"
  log4j.skipJansi=true
 -- 
-2.25.1.windows.1
+2.26.2
 

--- a/Spigot-Server-Patches/0494-Implement-Brigadier-Mojang-API.patch
+++ b/Spigot-Server-Patches/0494-Implement-Brigadier-Mojang-API.patch
@@ -1,0 +1,110 @@
+From bdb2c31298c1b905485d70aa0e4a09841fd38023 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Sun, 19 Apr 2020 18:15:29 -0400
+Subject: [PATCH] Implement Brigadier Mojang API
+
+Adds AsyncPlayerSendCommandsEvent
+  - Allows modifying on a per command basis what command data they see.
+
+Adds CommandRegisteredEvent
+  - Allows manipulating the CommandNode to add more children/metadata for the client
+
+diff --git a/src/main/java/net/minecraft/server/CommandDispatcher.java b/src/main/java/net/minecraft/server/CommandDispatcher.java
+index 2414b0a552..2d512aa4f9 100644
+--- a/src/main/java/net/minecraft/server/CommandDispatcher.java
++++ b/src/main/java/net/minecraft/server/CommandDispatcher.java
+@@ -267,6 +267,7 @@ public class CommandDispatcher {
+             bukkit.add(node.getName());
+         }
+         // Paper start - Async command map building
++        new com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent<CommandListenerWrapper>(entityplayer.getBukkitEntity(), (RootCommandNode) rootcommandnode, false).callEvent(); // Paper
+         MinecraftServer.getServer().execute(() -> {
+            runSync(entityplayer, bukkit, rootcommandnode);
+         });
+@@ -274,6 +275,7 @@ public class CommandDispatcher {
+ 
+     private void runSync(EntityPlayer entityplayer, Collection<String> bukkit, RootCommandNode<ICompletionProvider> rootcommandnode) {
+         // Paper end - Async command map building
++        new com.destroystokyo.paper.event.brigadier.AsyncPlayerSendCommandsEvent<CommandListenerWrapper>(entityplayer.getBukkitEntity(), (RootCommandNode) rootcommandnode, false).callEvent(); // Paper
+         PlayerCommandSendEvent event = new PlayerCommandSendEvent(entityplayer.getBukkitEntity(), new LinkedHashSet<>(bukkit));
+         event.getPlayer().getServer().getPluginManager().callEvent(event);
+ 
+diff --git a/src/main/java/net/minecraft/server/CommandListenerWrapper.java b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
+index 0b23a0548d..c988c929f1 100644
+--- a/src/main/java/net/minecraft/server/CommandListenerWrapper.java
++++ b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
+@@ -15,7 +15,7 @@ import java.util.function.BinaryOperator;
+ import java.util.stream.Stream;
+ import javax.annotation.Nullable;
+ 
+-public class CommandListenerWrapper implements ICompletionProvider {
++public class CommandListenerWrapper implements ICompletionProvider, com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource { // Paper
+ 
+     public static final SimpleCommandExceptionType a = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.player", new Object[0]));
+     public static final SimpleCommandExceptionType b = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.entity", new Object[0]));
+@@ -120,6 +120,25 @@ public class CommandListenerWrapper implements ICompletionProvider {
+         return this.g;
+     }
+ 
++    // Paper start
++    @Override
++    public org.bukkit.entity.Entity getBukkitEntity() {
++        return getEntity() != null ? getEntity().getBukkitEntity() : null;
++    }
++
++    @Override
++    public org.bukkit.World getBukkitWorld() {
++        return getWorld() != null ? getWorld().getWorld() : null;
++    }
++
++    @Override
++    public org.bukkit.Location getBukkitLocation() {
++        Vec3D pos = getPosition();
++        org.bukkit.World world = getBukkitWorld();
++        return world != null && pos != null ? new org.bukkit.Location(world, pos.x, pos.y, pos.z) : null;
++    }
++    // Paper end
++
+     @Override
+     public boolean hasPermission(int i) {
+         // CraftBukkit start
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/BukkitCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/BukkitCommandWrapper.java
+index 5f33c9e52a..e16ecdea7d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/BukkitCommandWrapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/BukkitCommandWrapper.java
+@@ -17,7 +17,7 @@ import net.minecraft.server.CommandListenerWrapper;
+ import org.bukkit.command.Command;
+ import org.bukkit.craftbukkit.CraftServer;
+ 
+-public class BukkitCommandWrapper implements com.mojang.brigadier.Command<CommandListenerWrapper>, Predicate<CommandListenerWrapper>, SuggestionProvider<CommandListenerWrapper> {
++public class BukkitCommandWrapper implements com.mojang.brigadier.Command<CommandListenerWrapper>, Predicate<CommandListenerWrapper>, SuggestionProvider<CommandListenerWrapper>, com.destroystokyo.paper.brigadier.BukkitBrigadierCommand<CommandListenerWrapper> { // Paper
+ 
+     private final CraftServer server;
+     private final Command command;
+@@ -28,10 +28,19 @@ public class BukkitCommandWrapper implements com.mojang.brigadier.Command<Comman
+     }
+ 
+     public LiteralCommandNode<CommandListenerWrapper> register(CommandDispatcher<CommandListenerWrapper> dispatcher, String label) {
+-        return dispatcher.register(
+-                LiteralArgumentBuilder.<CommandListenerWrapper>literal(label).requires(this).executes(this)
+-                .then(RequiredArgumentBuilder.<CommandListenerWrapper, String>argument("args", StringArgumentType.greedyString()).suggests(this).executes(this))
+-        );
++        // Paper start - Expose Brigadier to Paper-MojangAPI
++        com.mojang.brigadier.tree.RootCommandNode<CommandListenerWrapper> root = dispatcher.getRoot();
++        LiteralCommandNode<CommandListenerWrapper> literal = LiteralArgumentBuilder.<CommandListenerWrapper>literal(label).requires(this).executes(this).build();
++        com.mojang.brigadier.tree.ArgumentCommandNode<CommandListenerWrapper, String> defaultArgs = RequiredArgumentBuilder.<CommandListenerWrapper, String>argument("args", StringArgumentType.greedyString()).suggests(this).executes(this).build();
++        literal.addChild(defaultArgs);
++        com.destroystokyo.paper.event.brigadier.CommandRegisteredEvent<CommandListenerWrapper> event = new com.destroystokyo.paper.event.brigadier.CommandRegisteredEvent<>(label, this, this.command, root, literal, defaultArgs);
++        if (!event.callEvent()) {
++            return null;
++        }
++        literal = event.getLiteral();
++        root.addChild(literal);
++        return literal;
++        // Paper end
+     }
+ 
+     @Override
+-- 
+2.26.2
+

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,9 @@
     <url>https://github.com/PaperMC/Paper</url>
 
     <modules>
-        <module>Paper-Server</module>
         <module>Paper-API</module>
+        <module>Paper-MojangAPI</module>
+        <module>Paper-Server</module>
     </modules>
 
     <build>


### PR DESCRIPTION
This is the start of a new module for Paper to add support for API's
that interface Mojang API's directly.

This allows us to version properly by MC version incase Mojang makes any major breaking changes.

It also lets us separate Mojang API's from Paper-API so our downstream friends at Glowstone
will not have to worry about Mojang code.

Adds AsyncPlayerSendCommandsEvent
  - Allows modifying on a per command basis what command data they see.

Adds CommandRegisteredEvent
  - Allows manipulating the CommandNode to add more children/metadata for the client