### PR TITLE
Implemented BlockFailedDispenseEvent

### DIFF
--- a/Spigot-API-Patches/0199-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-API-Patches/0199-Implemented-BlockFailedDispenseEvent.patch
@@ -1,0 +1,41 @@
+From 74cde8a498b882475b236e27fc34adeee51c7973 Mon Sep 17 00:00:00 2001
+From: TheViperShow <29604693+TheViperShow@users.noreply.github.com>
+Date: Wed, 22 Apr 2020 09:40:23 +0200
+Subject: [PATCH] Implemented BlockFailedDispenseEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockFailedDispenseEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockFailedDispenseEvent.java
+new file mode 100644
+index 00000000..99ab7b65
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/block/BlockFailedDispenseEvent.java
+@@ -0,0 +1,26 @@
++package com.destroystokyo.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a block tries to dispense an item, but is empty.
++ */
++public class BlockFailedDispenseEvent extends BlockEvent {
++    private static final HandlerList handlers = new HandlerList();
++
++    public BlockFailedDispenseEvent(@NotNull Block theBlock) {
++        super(theBlock);
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.26.0.windows.1
+

--- a/Spigot-API-Patches/0199-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-API-Patches/0199-Implemented-BlockFailedDispenseEvent.patch
@@ -18,7 +18,7 @@ index 00000000..99ab7b65
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Called when a block tries to dispense an item, but is empty.
++ * Called when a block tries to dispense an item, but its inventory is empty.
 + */
 +public class BlockFailedDispenseEvent extends BlockEvent {
 +    private static final HandlerList handlers = new HandlerList();
@@ -38,4 +38,3 @@ index 00000000..99ab7b65
 +}
 -- 
 2.26.0.windows.1
-

--- a/Spigot-Server-Patches/0491-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-Server-Patches/0491-Implemented-BlockFailedDispenseEvent.patch
@@ -1,0 +1,56 @@
+From f29037a5d41b3054fd8acb5bb950ab1e801fbbdf Mon Sep 17 00:00:00 2001
+From: TheViperShow <29604693+TheViperShow@users.noreply.github.com>
+Date: Wed, 22 Apr 2020 09:40:38 +0200
+Subject: [PATCH] Implemented BlockFailedDispenseEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockDispenser.java b/src/main/java/net/minecraft/server/BlockDispenser.java
+index 91389911..9908c269 100644
+--- a/src/main/java/net/minecraft/server/BlockDispenser.java
++++ b/src/main/java/net/minecraft/server/BlockDispenser.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.event.block.BlockFailedDispenseEvent;
+ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
+ import java.util.Map;
+ import java.util.Random;
+@@ -54,6 +55,11 @@ public class BlockDispenser extends BlockTileEntity {
+ 
+         if (i < 0) {
+             world.triggerEffect(1001, blockposition, 0);
++            // Paper start - BlockFailedDispenseEvent is called here
++            org.bukkit.block.Block block = world.getWorld().getBlockAt(blockposition.x, blockposition.y, blockposition.z);
++            BlockFailedDispenseEvent blockFailedDispenseEvent = new BlockFailedDispenseEvent(block);
++            blockFailedDispenseEvent.callEvent();
++            // Paper end
+         } else {
+             ItemStack itemstack = tileentitydispenser.getItem(i);
+             IDispenseBehavior idispensebehavior = this.a(itemstack);
+diff --git a/src/main/java/net/minecraft/server/BlockDropper.java b/src/main/java/net/minecraft/server/BlockDropper.java
+index f244f2d5..fe5555e0 100644
+--- a/src/main/java/net/minecraft/server/BlockDropper.java
++++ b/src/main/java/net/minecraft/server/BlockDropper.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.server;
+ 
+ // CraftBukkit start
++import com.destroystokyo.paper.event.block.BlockFailedDispenseEvent;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.event.inventory.InventoryMoveItemEvent;
+ // CraftBukkit end
+@@ -31,6 +32,11 @@ public class BlockDropper extends BlockDispenser {
+ 
+         if (i < 0) {
+             world.triggerEffect(1001, blockposition, 0);
++            // Paper start - BlockFailedDispenseEvent is called here
++            org.bukkit.block.Block block = world.getWorld().getBlockAt(blockposition.x, blockposition.y, blockposition.z);
++            BlockFailedDispenseEvent blockFailedDispenseEvent = new BlockFailedDispenseEvent(block);
++            blockFailedDispenseEvent.callEvent();
++            // Paper end
+         } else {
+             ItemStack itemstack = tileentitydispenser.getItem(i);
+ 
+-- 
+2.26.0.windows.1
+


### PR DESCRIPTION
This event should be fired when a block such as a Dispenser or a Dropper tries to dispense an item but it was empty. As KennyTV told me before, and as it also seems a good idea, this event should not be cancellable. The only reason someone could want is as cancellable would be to 'cancel' the 'click' noise produced by the empty dispenser/dropper being triggered.