### PR TITLE
Add villager reputation API

### DIFF
--- a/Spigot-API-Patches/0205-Add-villager-reputation-API.patch
+++ b/Spigot-API-Patches/0205-Add-villager-reputation-API.patch
@@ -1,0 +1,171 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 22 Apr 2020 23:13:49 +0200
+Subject: [PATCH] Add villager reputation API
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/villager/Reputation.java b/src/main/java/com/destroystokyo/paper/entity/villager/Reputation.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1cc9ef255df888cb7dd7f7f2c5014e818d1be613
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/entity/villager/Reputation.java
+@@ -0,0 +1,54 @@
++package com.destroystokyo.paper.entity.villager;
++
++import com.google.common.base.Preconditions;
++import java.util.Map;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * A reputation score for a player on a villager.
++ */
++public final class Reputation {
++    private static final ReputationType[] REPUTATION_TYPES = ReputationType.values(); // Avoid allocation
++    @NotNull
++    private final int[] reputation;
++
++    public Reputation() {
++        this(new int[REPUTATION_TYPES.length]);
++    }
++
++    // Package level to avoid plugins creating reputations with "magic values".
++    Reputation(@NotNull int[] reputation) {
++        this.reputation = reputation;
++    }
++
++    public Reputation(@NotNull final Map<ReputationType, Integer> reputation) {
++        this();
++        Preconditions.checkNotNull(reputation, "reputation cannot be null");
++
++        for (Map.Entry<ReputationType, Integer> entry : reputation.entrySet()) {
++            setReputation(entry.getKey(), entry.getValue());
++        }
++    }
++
++    /**
++     * Gets the reputation value for a specific {@link ReputationType}.
++     *
++     * @param type The {@link ReputationType type} of reputation to get.
++     * @return The value of the {@link ReputationType type}.
++     */
++    public int getReputation(@NotNull ReputationType type) {
++        Preconditions.checkNotNull(type, "the reputation type cannot be null");
++        return reputation[type.ordinal()];
++    }
++
++    /**
++     * Sets the reputation value for a specific {@link ReputationType}.
++     *
++     * @param type The {@link ReputationType type} of reputation to set.
++     * @param value The value of the {@link ReputationType type}.
++     */
++    public void setReputation(@NotNull ReputationType type, int value) {
++        Preconditions.checkNotNull(type, "the reputation type cannot be null");
++        reputation[type.ordinal()] = value;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/entity/villager/ReputationType.java b/src/main/java/com/destroystokyo/paper/entity/villager/ReputationType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5600fcdc9795a9f49091db48d73bbd4964b8b737
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/entity/villager/ReputationType.java
+@@ -0,0 +1,36 @@
++package com.destroystokyo.paper.entity.villager;
++
++/**
++ * A type of reputation gained with a {@link org.bukkit.entity.Villager Villager}.
++ * <p>
++ * All types but {@link #MAJOR_POSITIVE} are shared to other villagers.
++ */
++public enum ReputationType {
++    /**
++     * A gossip with a majorly negative effect. This is only gained through killing a nearby
++     * villager.
++     */
++    MAJOR_NEGATIVE,
++
++    /**
++     * A gossip with a minor negative effect. This is only gained through damaging a villager.
++     */
++    MINOR_NEGATIVE,
++
++    /**
++     * A gossip with a minor positive effect. This is only gained through curing a zombie
++     * villager.
++     */
++    MINOR_POSITIVE,
++
++    /**
++     * A gossip with a major positive effect. This is only gained through curing a zombie
++     * villager.
++     */
++    MAJOR_POSITIVE,
++
++    /**
++     * A gossip with a minor positive effect. This is only gained through trading with a villager.
++     */
++    TRADING,
++}
+diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
+index d1579153092c1b80350155110f1b9926b1a1ef57..e0a3285b8ca97f6d56e5548d1f95efc1cc7cbd3c 100644
+--- a/src/main/java/org/bukkit/entity/Villager.java
++++ b/src/main/java/org/bukkit/entity/Villager.java
+@@ -1,10 +1,13 @@
+ package org.bukkit.entity;
+ 
+ import java.util.Locale;
++import java.util.Map; // Paper
++import java.util.UUID; // Paper
+ import org.bukkit.Keyed;
+ import org.bukkit.Location;
+ import org.bukkit.NamespacedKey;
+ import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable; // Paper
+ 
+ /**
+  * Represents a villager NPC
+@@ -224,4 +227,44 @@ public interface Villager extends AbstractVillager {
+             return key;
+         }
+     }
++
++    // Paper start - Add villager reputation API
++    /**
++     * Get the {@link com.destroystokyo.paper.entity.villager.Reputation reputation}
++     * for a specific player by {@link UUID}.
++     *
++     * @param uniqueId The {@link UUID} of the player to get the reputation of.
++     * @return The player's copied reputation with this villager.
++     */
++    @Nullable
++    public com.destroystokyo.paper.entity.villager.Reputation getReputation(@NotNull UUID uniqueId);
++
++    /**
++     * Get all {@link com.destroystokyo.paper.entity.villager.Reputation reputations}
++     * for all players mapped by their {@link UUID unique IDs}.
++     *
++     * @return All {@link com.destroystokyo.paper.entity.villager.Reputation reputations} for all players
++     * in a copied map.
++     */
++    @NotNull
++    public Map<UUID, com.destroystokyo.paper.entity.villager.Reputation> getReputations();
++
++    /**
++     * Set the {@link com.destroystokyo.paper.entity.villager.Reputation reputation}
++     * for a specific player by {@link UUID}.
++     *
++     * @param uniqueId The {@link UUID} of the player to set the reputation of.
++     * @param reputation The {@link com.destroystokyo.paper.entity.villager.Reputation reputation} to set.
++     */
++    public void setReputation(@NotNull UUID uniqueId, @NotNull com.destroystokyo.paper.entity.villager.Reputation reputation);
++
++    /**
++     * Set all {@link com.destroystokyo.paper.entity.villager.Reputation reputations}
++     * for all players mapped by their {@link UUID unique IDs}.
++     *
++     * @param reputations All {@link com.destroystokyo.paper.entity.villager.Reputation reputations}
++     * for all players mapped by their {@link UUID unique IDs}.
++     */
++    public void setReputations(@NotNull Map<UUID, com.destroystokyo.paper.entity.villager.Reputation> reputations);
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0508-Add-villager-reputation-API.patch
+++ b/Spigot-Server-Patches/0508-Add-villager-reputation-API.patch
@@ -1,0 +1,147 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 22 Apr 2020 23:29:20 +0200
+Subject: [PATCH] Add villager reputation API
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/entity/villager/ReputationConstructor.java b/src/main/java/com/destroystokyo/paper/entity/villager/ReputationConstructor.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0f10c333d88f2e1c56a6c7f22d421084adfd3789
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/entity/villager/ReputationConstructor.java
+@@ -0,0 +1,9 @@
++package com.destroystokyo.paper.entity.villager;
++// Must have own package due to package-level constructor.
++
++public final class ReputationConstructor {
++    // Abuse the package-level constructor.
++    public static Reputation construct(int[] values) {
++        return new Reputation(values);
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index ef2ee68cd6774d4ed51e78c4cc4a4d46a1911bfc..1094324d004a1841a3b67cf9de07ec1795524607 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -945,6 +945,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+         this.bL = 0;
+     }
+ 
++    public Reputation getReputation() { return this.eN(); } // Paper - OBFHELPER
+     public Reputation eN() {
+         return this.bG;
+     }
+diff --git a/src/main/java/net/minecraft/server/Reputation.java b/src/main/java/net/minecraft/server/Reputation.java
+index 0b6f91ac1206089654a6745bccb038fba8c13d98..4ae31599664ee8478ca1acf68f7253eb02eb45ed 100644
+--- a/src/main/java/net/minecraft/server/Reputation.java
++++ b/src/main/java/net/minecraft/server/Reputation.java
+@@ -25,7 +25,7 @@ import java.util.stream.Stream;
+ 
+ public class Reputation {
+ 
+-    private final Map<UUID, Reputation.a> a = Maps.newHashMap();
++    private final Map<UUID, Reputation.a> a = Maps.newHashMap(); public Map<UUID, Reputation.a> getReputations() { return this.a; } // Paper - add getter for reputations
+ 
+     public Reputation() {}
+ 
+@@ -138,11 +138,11 @@ public class Reputation {
+         return k > reputationtype.h ? Math.max(reputationtype.h, i) : k;
+     }
+ 
+-    static class a {
++    public static class a { // Paper - make public
+ 
+         private final Object2IntMap<ReputationType> a;
+ 
+-        private a() {
++        public a() { // Paper - make public - update CraftVillager setReputation on change
+             this.a = new Object2IntOpenHashMap();
+         }
+ 
+@@ -196,6 +196,27 @@ public class Reputation {
+         public void b(ReputationType reputationtype) {
+             this.a.removeInt(reputationtype);
+         }
++
++        // Paper start - Add villager reputation API
++        private static final com.destroystokyo.paper.entity.villager.ReputationType[] REPUTATION_TYPES = com.destroystokyo.paper.entity.villager.ReputationType.values();
++        public com.destroystokyo.paper.entity.villager.Reputation getPaperReputation() {
++            int[] reputation = new int[REPUTATION_TYPES.length];
++            reputation[com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_NEGATIVE.ordinal()] = a.getOrDefault(ReputationType.MAJOR_NEGATIVE, 0);
++            reputation[com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_POSITIVE.ordinal()] = a.getOrDefault(ReputationType.MAJOR_POSITIVE, 0);
++            reputation[com.destroystokyo.paper.entity.villager.ReputationType.MINOR_NEGATIVE.ordinal()] = a.getOrDefault(ReputationType.MINOR_NEGATIVE, 0);
++            reputation[com.destroystokyo.paper.entity.villager.ReputationType.MINOR_POSITIVE.ordinal()] = a.getOrDefault(ReputationType.MINOR_POSITIVE, 0);
++            reputation[com.destroystokyo.paper.entity.villager.ReputationType.TRADING.ordinal()] = a.getOrDefault(ReputationType.TRADING, 0);
++            return com.destroystokyo.paper.entity.villager.ReputationConstructor.construct(reputation);
++        }
++
++        public void assignFromPaperReputation(com.destroystokyo.paper.entity.villager.Reputation rep) {
++            this.a.put(net.minecraft.server.ReputationType.MAJOR_NEGATIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_NEGATIVE));
++            this.a.put(net.minecraft.server.ReputationType.MAJOR_POSITIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_POSITIVE));
++            this.a.put(net.minecraft.server.ReputationType.MINOR_NEGATIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_NEGATIVE));
++            this.a.put(net.minecraft.server.ReputationType.MINOR_POSITIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_POSITIVE));
++            this.a.put(net.minecraft.server.ReputationType.TRADING, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.TRADING));
++        }
++        // Paper end
+     }
+ 
+     static class b {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+index a8384081c03884c86578dca677914d77441c1863..19409c7a25c48f3f72f7e0b6306b81aa90b38f7c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
+@@ -1,9 +1,13 @@
+ package org.bukkit.craftbukkit.entity;
+ 
++import com.destroystokyo.paper.entity.villager.Reputation; // Paper
+ import com.google.common.base.Preconditions;
++import com.google.common.collect.Maps; // Paper
+ import java.util.Locale;
+ import net.minecraft.server.BlockBed;
+ import net.minecraft.server.BlockPosition;
++import java.util.Map; // Paper
++import java.util.UUID; // Paper
+ import net.minecraft.server.EntityVillager;
+ import net.minecraft.server.IBlockData;
+ import net.minecraft.server.IRegistry;
+@@ -124,4 +128,40 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+     public static VillagerProfession bukkitToNmsProfession(Profession bukkit) {
+         return IRegistry.VILLAGER_PROFESSION.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
+     }
++
++    // Paper start - Add villager reputation API
++    @Override
++    public Reputation getReputation(UUID uniqueId) {
++        net.minecraft.server.Reputation.a rep = getHandle().getReputation().getReputations().get(uniqueId);
++        if (rep == null) {
++            return new Reputation(Maps.newHashMap());
++        }
++
++        return rep.getPaperReputation();
++    }
++
++    @Override
++    public Map<UUID, Reputation> getReputations() {
++        return getHandle().getReputation().getReputations().entrySet()
++            .stream()
++            .collect(java.util.stream.Collectors.toMap(Map.Entry::getKey, entry -> entry.getValue().getPaperReputation()));
++    }
++
++    @Override
++    public void setReputation(UUID uniqueId, Reputation reputation) {
++        net.minecraft.server.Reputation.a nmsReputation =
++            getHandle().getReputation().getReputations().computeIfAbsent(
++                uniqueId,
++                key -> new net.minecraft.server.Reputation.a()
++            );
++        nmsReputation.assignFromPaperReputation(reputation);
++    }
++
++    @Override
++    public void setReputations(Map<UUID, Reputation> reputations) {
++        for (Map.Entry<UUID, Reputation> entry : reputations.entrySet()) {
++            setReputation(entry.getKey(), entry.getValue());
++        }
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Adds new API for managing the reputation of players with villagers.

Note for anyone who might be a little confused as to why I chose to do it this way: This is the same approach as with getting trades (constructing & converting `MerchantRecipe`s). I don't want to change all instances of `ReputationType` in NMS to the Paper one, thus I have no way of exposing the map directly. An `int[]` could be used instead, but that would be such marginal gains I'm unsure if it's worth doing.