### PR TITLE
Add item slot helper methods for various inventories

### DIFF
--- a/Spigot-API-Patches/0202-Add-item-slot-convenience-methods.patch
+++ b/Spigot-API-Patches/0202-Add-item-slot-convenience-methods.patch
@@ -1,0 +1,237 @@
+From a5b8056b394f5316411507e4998dfb423e6dff11 Mon Sep 17 00:00:00 2001
+From: KennyTV <kennytv@t-online.de>
+Date: Sat, 25 Apr 2020 23:31:28 +0200
+Subject: [PATCH] Add item slot convenience methods
+
+
+diff --git a/src/main/java/org/bukkit/inventory/AnvilInventory.java b/src/main/java/org/bukkit/inventory/AnvilInventory.java
+index 4af56242..b95e563b 100644
+--- a/src/main/java/org/bukkit/inventory/AnvilInventory.java
++++ b/src/main/java/org/bukkit/inventory/AnvilInventory.java
+@@ -49,4 +49,64 @@ public interface AnvilInventory extends Inventory {
+      * @param levels the maximum experience cost
+      */
+     void setMaximumRepairCost(int levels);
++
++    // Paper start
++    /**
++     * Gets the item in the left input slot.
++     *
++     * @return item in the first slot
++     */
++    @Nullable
++    default ItemStack getFirstItem() {
++        return getItem(0);
++    }
++
++    /**
++     * Sets the item in the left input slot.
++     *
++     * @param firstItem item to set
++     */
++    default void setFirstItem(@Nullable ItemStack firstItem) {
++        setItem(0, firstItem);
++    }
++
++    /**
++     * Gets the item in the right input slot.
++     *
++     * @return item in the second slot
++     */
++    @Nullable
++    default ItemStack getSecondItem() {
++        return getItem(1);
++    }
++
++    /**
++     * Sets the item in the right input slot.
++     *
++     * @param secondItem item to set
++     */
++    default void setSecondItem(@Nullable ItemStack secondItem) {
++        setItem(1, secondItem);
++    }
++
++    /**
++     * Gets the item in the result slot.
++     *
++     * @return item in the result slot
++     */
++    @Nullable
++    default ItemStack getResult() {
++        return getItem(2);
++    }
++
++    /**
++     * Sets the item in the result slot.
++     * Note that the client might not be able to take out the item if it does not match the input items.
++     *
++     * @param result item to set
++     */
++    default void setResult(@Nullable ItemStack result) {
++        setItem(2, result);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/inventory/GrindstoneInventory.java b/src/main/java/org/bukkit/inventory/GrindstoneInventory.java
+index 9048892c..1c750108 100644
+--- a/src/main/java/org/bukkit/inventory/GrindstoneInventory.java
++++ b/src/main/java/org/bukkit/inventory/GrindstoneInventory.java
+@@ -1,6 +1,68 @@
+ package org.bukkit.inventory;
+ 
++import org.jetbrains.annotations.Nullable; // Paper
++
+ /**
+  * Interface to the inventory of a Grindstone.
+  */
+-public interface GrindstoneInventory extends Inventory { }
++public interface GrindstoneInventory extends Inventory {
++
++    // Paper start
++    /**
++     * Gets the upper input item.
++     *
++     * @return upper input item
++     */
++    @Nullable
++    default ItemStack getUpperItem() {
++        return getItem(0);
++    }
++
++    /**
++     * Sets the upper input item.
++     *
++     * @param upperItem item to set
++     */
++    default void setUpperItem(@Nullable ItemStack upperItem) {
++        setItem(0, upperItem);
++    }
++
++    /**
++     * Gets the lower input item.
++     *
++     * @return lower input item
++     */
++    @Nullable
++    default ItemStack getLowerItem() {
++        return getItem(1);
++    }
++
++    /**
++     * Sets the lower input item.
++     *
++     * @param lowerItem item to set
++     */
++    default void setLowerItem(@Nullable ItemStack lowerItem) {
++        setItem(1, lowerItem);
++    }
++
++    /**
++     * Gets the result.
++     *
++     * @return result
++     */
++    @Nullable
++    default ItemStack getResult() {
++        return getItem(2);
++    }
++
++    /**
++     * Sets the result.
++     *
++     * @param result item to set
++     */
++    default void setResult(@Nullable ItemStack result) {
++        setItem(2, result);
++    }
++    // Paper end
++}
+diff --git a/src/main/java/org/bukkit/inventory/LecternInventory.java b/src/main/java/org/bukkit/inventory/LecternInventory.java
+index 4a0c43ac..2ea7ea04 100644
+--- a/src/main/java/org/bukkit/inventory/LecternInventory.java
++++ b/src/main/java/org/bukkit/inventory/LecternInventory.java
+@@ -11,4 +11,25 @@ public interface LecternInventory extends Inventory {
+     @Nullable
+     @Override
+     public Lectern getHolder();
++
++    // Paper start
++    /**
++     * Gets the lectern's held book.
++     *
++     * @return book set in the lectern
++     */
++    @Nullable
++    default ItemStack getBook() {
++        return getItem(0);
++    }
++
++    /**
++     * Sets the lectern's held book.
++     *
++     * @param book the new book
++     */
++    default void setBook(@Nullable ItemStack book) {
++        setItem(0, book);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/inventory/StonecutterInventory.java b/src/main/java/org/bukkit/inventory/StonecutterInventory.java
+index dbb034fa..e7a8e718 100644
+--- a/src/main/java/org/bukkit/inventory/StonecutterInventory.java
++++ b/src/main/java/org/bukkit/inventory/StonecutterInventory.java
+@@ -1,6 +1,49 @@
+ package org.bukkit.inventory;
+ 
++import org.jetbrains.annotations.Nullable; // Paper
++
+ /**
+  * Interface to the inventory of a Stonecutter.
+  */
+-public interface StonecutterInventory extends Inventory { }
++public interface StonecutterInventory extends Inventory {
++
++    // Paper start
++    /**
++     * Gets the input item.
++     *
++     * @return input item
++     */
++    @Nullable
++    default ItemStack getInputItem() {
++        return getItem(0);
++    }
++
++    /**
++     * Sets the input item.
++     *
++     * @param itemStack item to set
++     */
++    default void setInputItem(@Nullable ItemStack itemStack) {
++        setItem(0, itemStack);
++    }
++
++    /**
++     * Gets the result item.
++     *
++     * @return result
++     */
++    @Nullable
++    default ItemStack getResult() {
++        return getItem(1);
++    }
++
++    /**
++     * Sets the result item.
++     *
++     * @param itemStack item to set
++     */
++    default void setResult(@Nullable ItemStack itemStack) {
++        setItem(1, itemStack);
++    }
++    // Paper end
++}
+-- 
+2.26.2.windows.1
+


### PR DESCRIPTION
Even though mostly obvious by counting from 0 upwards, I (and a number of other people, as sometimes popping up in the dev channels) have troubles finding methods to set specific slots in specific inventories; setting a book in the lectern, setting the lower input item of a grindstone, etc.

These few simple helper methods spare devs from guessing such magic numbers and give a bit more intuitive item setting