### PR TITLE
Add StructureGenerateEvent

### DIFF
--- a/Spigot-API-Patches/0200-Add-StructureGenerateEvent.patch
+++ b/Spigot-API-Patches/0200-Add-StructureGenerateEvent.patch
@@ -1,0 +1,114 @@
+From e6eab6cc582a0174494f8b5f214466459132ba0a Mon Sep 17 00:00:00 2001
+From: Nahuel <nahueldolores@hotmail.com>
+Date: Mon, 27 Apr 2020 14:38:26 -0300
+Subject: [PATCH] Add StructureGenerateEvent It's an async event that is called
+ when a is generated in a world returning useful StructureTypes. This is a
+ cancellable event which prevents structures from generating in the world if
+ desired.
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java b/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java
+new file mode 100644
+index 00000000..d71f534e
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/world/StructureGenerateEvent.java
+@@ -0,0 +1,96 @@
++package com.destroystokyo.paper.event.world;
++
++import com.google.common.base.Preconditions;
++import org.bukkit.StructureType;
++import org.bukkit.World;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.Event;
++import org.bukkit.event.HandlerList;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Async event called when a structure is generated in a world.
++ */
++public class StructureGenerateEvent extends Event implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++
++    private final World world;
++    private final StructureType structureType;
++    private final int chunkX;
++    private final int chunkZ;
++
++    private boolean cancel = false;
++
++    public StructureGenerateEvent(@NotNull World world, @NotNull StructureType structureType, int chunkX, int chunkZ) {
++        super(true);
++        this.world = Preconditions.checkNotNull(world, "world");
++        this.structureType = Preconditions.checkNotNull(structureType, "structureType");
++        this.chunkX = chunkX;
++        this.chunkZ = chunkZ;
++    }
++
++    /**
++     * Get the world the structure is being generated in.
++     *
++     * @return structure world.
++     */
++    @NotNull
++    public World getWorld() {
++        return world;
++    }
++
++    /**
++     * Get the type of structure that is being generated.
++     *
++     * @return The type of structure generated.
++     */
++    @NotNull
++    public StructureType getStructureType() {
++        return structureType;
++    }
++
++    /**
++     * Get the chunk's X coordinate.
++     *
++     * @return chunk X.
++     */
++    public int getChunkX() {
++        return chunkX;
++    }
++
++    /**
++     * Get the chunk's Z coordinate.
++     *
++     * @return chunk Z.
++     */
++    public int getChunkZ() {
++        return chunkZ;
++    }
++
++    /**
++     * {@inheritDoc}
++     */
++    @Override
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    /**
++     * {@inheritDoc}
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+-- 
+2.26.2
+

--- a/Spigot-Server-Patches/0494-Add-StructureGenerateEvent.patch
+++ b/Spigot-Server-Patches/0494-Add-StructureGenerateEvent.patch
@@ -1,0 +1,75 @@
+From 6edf1e87eb89df0621edce47b7d7d01b28868fc2 Mon Sep 17 00:00:00 2001
+From: Nahuel <nahueldolores@hotmail.com>
+Date: Mon, 27 Apr 2020 14:38:26 -0300
+Subject: [PATCH] Add StructureGenerateEvent  It's an async event that is
+ called when a is generated in a world returning useful StructureTypes.  This
+ is a cancellable event which prevents structures from generating in the world
+ if desired.
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkGenerator.java b/src/main/java/net/minecraft/server/ChunkGenerator.java
+index a87f4532..9262354e 100644
+--- a/src/main/java/net/minecraft/server/ChunkGenerator.java
++++ b/src/main/java/net/minecraft/server/ChunkGenerator.java
+@@ -1,5 +1,10 @@
+ package net.minecraft.server;
+ 
++// Paper start
++import com.destroystokyo.paper.event.world.StructureGenerateEvent;
++import org.bukkit.StructureType;
++// Paper end
++
+ import java.util.BitSet;
+ import java.util.Iterator;
+ import java.util.List;
+@@ -147,23 +152,40 @@ public abstract class ChunkGenerator<C extends GeneratorSettingsDefault> {
+                 StructureStart structurestart1 = StructureStart.a;
+                 BiomeBase biomebase = biomemanager.a(new BlockPosition(chunkcoordintpair.d() + 9, 0, chunkcoordintpair.e() + 9));
+ 
++                // Paper start - Initialize structure generate event
++                StructureGenerateEvent event = new StructureGenerateEvent(
++                    getWorld().getWorld(),
++                    StructureType.getStructureTypes().get(structuregenerator.b().toLowerCase()),
++                    chunkcoordintpair.x,
++                    chunkcoordintpair.z
++                );
++                // Paper end
++
+                 // CraftBukkit start
+                 if (structuregenerator == WorldGenerator.STRONGHOLD) {
+                     synchronized (structuregenerator) {
+                         if (structuregenerator.a(biomemanager, chunkgenerator, seededrandom, chunkcoordintpair.x, chunkcoordintpair.z, biomebase)) {
+-                            StructureStart structurestart2 = structuregenerator.a().create(structuregenerator, chunkcoordintpair.x, chunkcoordintpair.z, StructureBoundingBox.a(), i, chunkgenerator.getSeed());
+-
+-                            structurestart2.a(this, definedstructuremanager, chunkcoordintpair.x, chunkcoordintpair.z, biomebase);
+-                            structurestart1 = structurestart2.e() ? structurestart2 : StructureStart.a;
++                            // Paper start - Fire structure generate event
++                            if (event.callEvent()) {
++                                StructureStart structurestart2 = structuregenerator.a().create(structuregenerator, chunkcoordintpair.x, chunkcoordintpair.z, StructureBoundingBox.a(), i, chunkgenerator.getSeed());
++
++                                structurestart2.a(this, definedstructuremanager, chunkcoordintpair.x, chunkcoordintpair.z, biomebase);
++                                structurestart1 = structurestart2.e() ? structurestart2 : StructureStart.a;
++                            }
++                            // Paper end
+                         }
+                     }
+                 } else
+                 // CraftBukkit end
+                 if (structuregenerator.a(biomemanager, chunkgenerator, seededrandom, chunkcoordintpair.x, chunkcoordintpair.z, biomebase)) {
+-                    StructureStart structurestart2 = structuregenerator.a().create(structuregenerator, chunkcoordintpair.x, chunkcoordintpair.z, StructureBoundingBox.a(), i, chunkgenerator.getSeed());
++                    // Paper start - Fire structure generate event
++                    if (event.callEvent()) {
++                        StructureStart structurestart2 = structuregenerator.a().create(structuregenerator, chunkcoordintpair.x, chunkcoordintpair.z, StructureBoundingBox.a(), i, chunkgenerator.getSeed());
+ 
+-                    structurestart2.a(this, definedstructuremanager, chunkcoordintpair.x, chunkcoordintpair.z, biomebase);
+-                    structurestart1 = structurestart2.e() ? structurestart2 : StructureStart.a;
++                        structurestart2.a(this, definedstructuremanager, chunkcoordintpair.x, chunkcoordintpair.z, biomebase);
++                        structurestart1 = structurestart2.e() ? structurestart2 : StructureStart.a;
++                    }
++                    // Paper end
+                 }
+ 
+                 ichunkaccess.a(structuregenerator.b(), structurestart1);
+-- 
+2.26.2
+


### PR DESCRIPTION
It's an event that is called when a structure is generated in a world.
For anyone wondering why it doesn't extend a ChunkEvent or a WorldEvent it's because they are both sync (as well as this event being fired before the chunk generation).