### PR TITLE
Allow delegation to vanilla chunk gen (implements #3250)

### DIFF
--- a/Spigot-API-Patches/0216-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-API-Patches/0216-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Wed, 29 Apr 2020 02:09:17 +0200
+Subject: [PATCH] Allow delegation to vanilla chunk gen
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 329e2dd1c057788d6bb5a1adc7ee9282820e927d..4e92ce18227c8f650fe5c6f4a670e6f56d629872 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -1344,6 +1344,22 @@ public final class Bukkit {
+         return server.createChunkData(world);
+     }
+ 
++    // Paper start
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    @NotNull
++    public static ChunkGenerator.ChunkData createVanillaChunkData(@NotNull World world, int x, int z) {
++        return server.createVanillaChunkData(world, x, z);
++    }
++    // Paper stop
++
+     /**
+      * Creates a boss bar instance to display to players. The progress
+      * defaults to 1.0
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index b464cc1a70aca3450a5de84a657a1e069a1a8ab6..0653e0ffe96748dc971ec7e8027f8159696adf62 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -1127,6 +1127,20 @@ public interface Server extends PluginMessageRecipient {
+     @NotNull
+     public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
+ 
++    // Paper start
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    @NotNull
++    ChunkGenerator.ChunkData createVanillaChunkData(@NotNull World world, int x, int z);
++    // Paper end
++
+     /**
+      * Creates a boss bar instance to display to players. The progress
+      * defaults to 1.0
+diff --git a/src/main/java/org/bukkit/generator/ChunkGenerator.java b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+index 7caef27682f22a77de283dd6f391ec8bc0b0312b..5ba77d40a38e5e592ee265e4fbd510043a0b4345 100644
+--- a/src/main/java/org/bukkit/generator/ChunkGenerator.java
++++ b/src/main/java/org/bukkit/generator/ChunkGenerator.java
+@@ -227,6 +227,22 @@ public abstract class ChunkGenerator {
+         return false;
+     }
+ 
++    // Paper start
++    /**
++     * Create a ChunkData for use in a generator, that is populated by the vanilla generator for that world
++     *
++     * @param world the world to create the ChunkData for
++     * @param x the x coordinate of the chunk
++     * @param z the z coordinate of the chunk
++     * @return a new ChunkData for the world
++     *
++     */
++    @NotNull
++    public ChunkData createVanillaChunkData(@NotNull World world, int x, int z) {
++        return Bukkit.getServer().createVanillaChunkData(world, x, z);
++    }
++    // Paper end
++
+     /**
+      * Data for a Chunk.
+      */

--- a/Spigot-Server-Patches/0536-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-Server-Patches/0536-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -1,0 +1,88 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MiniDigger <admin@minidigger.me>
+Date: Wed, 29 Apr 2020 02:10:32 +0200
+Subject: [PATCH] Allow delegation to vanilla chunk gen
+
+
+diff --git a/src/main/java/net/minecraft/server/ChunkConverter.java b/src/main/java/net/minecraft/server/ChunkConverter.java
+index b51613040e4583ff056060b47b1f97a86ebcde51..5366314e5f889b5b8d7740bbd0f024d9b7b9d643 100644
+--- a/src/main/java/net/minecraft/server/ChunkConverter.java
++++ b/src/main/java/net/minecraft/server/ChunkConverter.java
+@@ -17,7 +17,7 @@ import org.apache.logging.log4j.Logger;
+ public class ChunkConverter {
+ 
+     private static final Logger LOGGER = LogManager.getLogger();
+-    public static final ChunkConverter a = new ChunkConverter();
++    public static final ChunkConverter a = new ChunkConverter(); public static ChunkConverter getEmptyConverter() { return a; } // Paper - obfhelper
+     private static final EnumDirection8[] c = EnumDirection8.values();
+     private final EnumSet<EnumDirection8> d;
+     private final int[][] e;
+@@ -303,7 +303,7 @@ public class ChunkConverter {
+                         if ((Integer) iblockdata.get(BlockProperties.an) >= j) {
+                             generatoraccess.setTypeAndData(blockposition, (IBlockData) iblockdata.set(BlockProperties.an, j), 18);
+                             if (i != 7) {
+-                                EnumDirection[] aenumdirection = null.f;
++                                EnumDirection[] aenumdirection = f; // Paper - decomp fix
+                                 int k = aenumdirection.length;
+ 
+                                 for (int l = 0; l < k; ++l) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 56bf840e3d514153ed249093761ddcc04b282403..0d044ed6d7dd77e1dcc6c69a94afb74cb8b9971c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1972,6 +1972,29 @@ public final class CraftServer implements Server {
+         return new CraftChunkData(world);
+     }
+ 
++    // Paper start
++    @Override
++    public ChunkGenerator.ChunkData createVanillaChunkData(World world, int x, int z) {
++        // get empty object
++        CraftChunkData data = (CraftChunkData) createChunkData(world);
++        // do bunch of vanilla shit
++        net.minecraft.server.WorldServer nmsWorld = ((CraftWorld) world).getHandle();
++        net.minecraft.server.ProtoChunk protoChunk = new net.minecraft.server.ProtoChunk(new net.minecraft.server.ChunkCoordIntPair(x, z), net.minecraft.server.ChunkConverter.getEmptyConverter(), nmsWorld);
++        List<net.minecraft.server.IChunkAccess> list = new ArrayList<>();
++        list.add(protoChunk);
++        net.minecraft.server.RegionLimitedWorldAccess genRegion = new net.minecraft.server.RegionLimitedWorldAccess(nmsWorld, list);
++        // call vanilla generator, one feature after another. Order here is important!
++        net.minecraft.server.ChunkGenerator<?> chunkGenerator = ((CraftWorld) world).getHandle().worldProvider.getChunkGenerator();
++        chunkGenerator.createBiomes(protoChunk);
++        chunkGenerator.buildNoise(genRegion, protoChunk);
++        chunkGenerator.buildBase(genRegion, protoChunk);
++        // copy over generated sections
++        data.setRawChunkData(protoChunk.getSections());
++        // hooray!
++        return data;
++    }
++    // Paper end
++
+     @Override
+     public BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag... flags) {
+         return new CraftBossBar(title, color, style, flags);
+diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+index bb18740ebdf4a14ced9944efa82103b350b32ba5..948a59217cca0f8dfa9d3befb61e679a67bf29bc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
++++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
+@@ -19,7 +19,7 @@ import org.bukkit.material.MaterialData;
+  */
+ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+     private final int maxHeight;
+-    private final ChunkSection[] sections;
++    private ChunkSection[] sections; // Paper - remove final
+     private Set<BlockPosition> tiles;
+     private World world; // Paper - Anti-Xray - Add world
+ 
+@@ -168,6 +168,12 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+         return sections;
+     }
+ 
++    // Paper start
++    public void setRawChunkData(ChunkSection[] sections) {
++        this.sections = sections;
++    }
++    // Paper end
++
+     Set<BlockPosition> getTiles() {
+         return tiles;
+     }


### PR DESCRIPTION
This PR adds a createVanillaChunkData (next to the createChunkData) method, that allows you to generate a chunk by vanilla chunk gen.

This allows you to create stuff like this, a chunk gen that creates a vanilla world in a plus shape with a bedrock world border
![https://i.imgur.com/7KIfxj1.jpg](https://i.imgur.com/7KIfxj1.jpg)
https://github.com/MiniDigger/worldgentest/blob/master/src/main/java/me/minidigger/worldgentest/PlusGenerator.kt

