### PR TITLE
Add hover event joiner for items

### DIFF
--- a/Spigot-API-Patches/0201-Add-hover-event-joiner-for-items.patch
+++ b/Spigot-API-Patches/0201-Add-hover-event-joiner-for-items.patch
@@ -1,0 +1,84 @@
+From 491755c15ddc6af88fb00225467a4350c25ca6ab Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Thu, 30 Apr 2020 17:09:16 +0200
+Subject: [PATCH] Add hover event joiner for items
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/ItemStackHoverJoiner.java b/src/main/java/com/destroystokyo/paper/ItemStackHoverJoiner.java
+new file mode 100644
+index 00000000..33ca1563
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/ItemStackHoverJoiner.java
+@@ -0,0 +1,69 @@
++package com.destroystokyo.paper;
++
++import com.google.common.base.Preconditions;
++import java.util.function.Function;
++import net.md_5.bungee.api.chat.ComponentBuilder;
++import net.md_5.bungee.api.chat.ComponentBuilder.FormatRetention;
++import net.md_5.bungee.api.chat.ComponentBuilder.Joiner;
++import net.md_5.bungee.api.chat.HoverEvent;
++import org.bukkit.Material;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * A {@link Joiner} for applying a {@link HoverEvent} for an {@link ItemStack} to text.
++ * <p>
++ * This is a no-op on {@link Material#AIR}, {@link Material#VOID_AIR}, and {@link Material#CAVE_AIR}.
++ * </p>
++ */
++public class ItemStackHoverJoiner implements Joiner {
++    // This is package-level to abuse Java mechanics where a custom interface would be unnecessary.
++    static Function<ItemStack, HoverEvent> converter = null;
++
++    @NotNull
++    private final ItemStack itemStack;
++
++    public ItemStackHoverJoiner(@NotNull ItemStack itemStack) {
++        Preconditions.checkNotNull(itemStack, "itemStack cannot be null");
++
++        this.itemStack = itemStack;
++    }
++
++    @Override
++    @NotNull
++    public ComponentBuilder join(@NotNull ComponentBuilder componentBuilder,
++        @Nullable FormatRetention formatRetention) {
++        HoverEvent event = createEvent();
++        if (event == null) {
++            return componentBuilder;
++        }
++        return componentBuilder.event(event);
++    }
++
++    /**
++     * Return the {@link ItemStack} this applies a {@link HoverEvent} for.
++     *
++     * @return the {@link ItemStack} this makes a {@link HoverEvent} for.
++     */
++    @NotNull
++    public ItemStack getItemStack() {
++        return itemStack;
++    }
++
++    /**
++     * Creates a {@link HoverEvent} for the {@link ItemStack} this is for.
++     *
++     * @return a new {@link HoverEvent} for this item or null if not applicable.
++     */
++    @Nullable
++    public HoverEvent createEvent() {
++        if (itemStack.getType() == Material.AIR
++            || itemStack.getType() == Material.CAVE_AIR
++            || itemStack.getType() == Material.VOID_AIR) {
++            return null;
++        }
++
++        return converter.apply(itemStack);
++    }
++}
+-- 
+2.26.2
+

--- a/Spigot-Server-Patches/0496-Add-hover-events-joiner-for-items.patch
+++ b/Spigot-Server-Patches/0496-Add-hover-events-joiner-for-items.patch
@@ -1,0 +1,62 @@
+From acd45a0492e8507ae0e9b2dc5c634ec37ea21980 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Thu, 30 Apr 2020 17:09:23 +0200
+Subject: [PATCH] Add hover events joiner for items
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/ItemStackHoverConstructor.java b/src/main/java/com/destroystokyo/paper/ItemStackHoverConstructor.java
+new file mode 100644
+index 00000000000..d4efe68451d
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/ItemStackHoverConstructor.java
+@@ -0,0 +1,35 @@
++package com.destroystokyo.paper;
++
++import java.util.function.Function;
++import net.md_5.bungee.api.chat.BaseComponent;
++import net.md_5.bungee.api.chat.HoverEvent;
++import net.md_5.bungee.api.chat.TextComponent;
++import net.minecraft.server.NBTTagCompound;
++import org.bukkit.craftbukkit.inventory.CraftItemStack;
++import org.bukkit.inventory.ItemStack;
++
++public class ItemStackHoverConstructor implements Function<ItemStack, HoverEvent> {
++    public static final ItemStackHoverConstructor INSTANCE = new ItemStackHoverConstructor();
++
++    private ItemStackHoverConstructor() {
++    }
++
++    /**
++     * This <b>must</b> be called at least once during setup of the server.
++     */
++    public static void setup() {
++        ItemStackHoverJoiner.converter = INSTANCE;
++    }
++
++    @Override
++    public HoverEvent apply(ItemStack itemStack) {
++        return new HoverEvent(
++            HoverEvent.Action.SHOW_ITEM,
++            new BaseComponent[]{
++                new TextComponent(
++                    CraftItemStack.asNMSCopy(itemStack).save(new NBTTagCompound()).toString()
++                )
++            }
++        );
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index e62ca0543f1..057052768b2 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -229,6 +229,8 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+             return false;
+         }
+ 
++        com.destroystokyo.paper.ItemStackHoverConstructor.setup(); // Paper
++
+         // CraftBukkit start
+         // this.a((PlayerList) (new DedicatedPlayerList(this))); // Spigot - moved up
+         server.loadPlugins();
+2.26.2
+


### PR DESCRIPTION
Adds an unsafe API to create `HoverEvent`s for `ItemStack`s with their internal data.

Please see this conversation for why this is on `UnsafeValues`: https://canary.discordapp.com/channels/289587909051416579/555462289851940864/701751987464568973 (or search `in:#paper-dev from: marï diamandis#0001 during: 2020-04-20 hover`)