### PR TITLE
[CI-SKIP] enable Parallel builds

### DIFF
--- a/paper
+++ b/paper
@@ -24,6 +24,7 @@ done
 SOURCE=$([[ "$SOURCE" = /* ]] && echo "$SOURCE" || echo "$PWD/${SOURCE#./}")
 basedir=$(dirname "$SOURCE")
 gitcmd="git -c commit.gpgsign=false"
+mvncmd="mvn -T 1.5C"
 
 source "$basedir/scripts/functions.sh"
 
@@ -62,8 +63,8 @@ case "$1" in
         set -e
         cd "$basedir"
         scripts/build.sh "$basedir" || exit 1
-        (cd Paper-API ; mvn clean install) || exit 1
-        (cd Paper-Server ; mvn clean package) || exit 1
+        (cd Paper-API ; $mvncmd clean install) || exit 1
+        (cd Paper-Server ; $mvncmd clean package) || exit 1
         echo "Paper jar successfully built"
         ls -la Paper-Server/target/paper*.jar
     ) || failed=1

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,12 +4,13 @@
 set -e
 basedir="$(cd "$1" && pwd -P)"
 gitcmd="git -c commit.gpgsign=false"
+mvncmd="mvn -T 1.5C"
 
 ($gitcmd submodule update --init && ./scripts/remap.sh "$basedir" && ./scripts/decompile.sh "$basedir" && ./scripts/init.sh "$basedir" && ./scripts/applyPatches.sh "$basedir") || (
     echo "Failed to build Paper"
     exit 1
 ) || exit 1
 if [ "$2" == "--jar" ]; then
-    mvn clean install && ./scripts/paperclip.sh "$basedir"
+    $mvncmd clean install && ./scripts/paperclip.sh "$basedir"
 fi
 ) || exit 1

--- a/scripts/paperclip.sh
+++ b/scripts/paperclip.sh
@@ -7,10 +7,11 @@ workdir="$basedir/work"
 mcver=$(cat "$workdir/BuildData/info.json" | grep minecraftVersion | cut -d '"' -f 4)
 paperjar="$basedir/Paper-Server/target/paper-$mcver.jar"
 vanillajar="$workdir/Minecraft/$mcver/$mcver.jar"
+mvncmd="mvn -T 1.5C"
 
 (
     cd "$workdir/Paperclip"
-    mvn clean package "-Dmcver=$mcver" "-Dpaperjar=$paperjar" "-Dvanillajar=$vanillajar"
+    $mvncmd clean package "-Dmcver=$mcver" "-Dpaperjar=$paperjar" "-Dvanillajar=$vanillajar"
 )
 cp "$workdir/Paperclip/assembly/target/paperclip-${mcver}.jar" "$basedir/paperclip.jar"
 


### PR DESCRIPTION
The difference in compilation time is significant according to the test by @josephworks
https://discordapp.com/channels/457932577073004550/684852205379256397/705480143191146606
https://github.com/Akarin-project/Akarin/commit/14a36a6861c475204c0f1a1901a5dcb4fb459737
> Before (1.15.2 without multithread building): 5min39sec
> After (1.15.2 buildmultithread branch): 3min19sec

> Build speed hasnt changed on github ci as
> Using the MultiThreadedBuilder implementation with a thread count of 2
> but on the jenkins server which has 4 - 16 cores per build, the speed is much quicker.