### PR TITLE
Fix pick item kicking players when valid

### DIFF
--- a/Spigot-API-Patches/0201-Expose-game-version.patch
+++ b/Spigot-API-Patches/0201-Expose-game-version.patch
@@ -1,11 +1,11 @@
-From 12be987716c0516e0300b7e3b79bfa064747d46c Mon Sep 17 00:00:00 2001
+From d033d0bee79beb3a685eecf752f02ac06a9c9100 Mon Sep 17 00:00:00 2001
 From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
 Date: Fri, 1 May 2020 17:39:02 +0300
 Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index b9973406..d4af3a1d 100644
+index ea3e5d6f..95ad0122 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -118,6 +118,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index b9973406..d4af3a1d 100644
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 80f9abdc..08817f02 100644
+index 9ceaac0e..c3fb1c27 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -97,6 +97,16 @@ public interface Server extends PluginMessageRecipient {
@@ -49,4 +49,5 @@ index 80f9abdc..08817f02 100644
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 -- 
-2.25.1
+2.26.2
+

--- a/Spigot-Server-Patches/0496-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/Spigot-Server-Patches/0496-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -1,11 +1,11 @@
-From 35b2b6df0265e4e0743a0456cfa2c3ec73bbe7da Mon Sep 17 00:00:00 2001
+From 59e17ffbd3bdcb6bdf5f61c03616c4a065c70f92 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 2 May 2020 03:09:46 -0400
 Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 38ec22f4c0..60c3af4d64 100644
+index 38ec22f4c03..f4168ca4c1f 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -683,7 +683,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -14,7 +14,7 @@ index 38ec22f4c0..60c3af4d64 100644
          PlayerConnectionUtils.ensureMainThread(packetplayinpickitem, this, this.player.getWorldServer());
 -        this.player.inventory.c(packetplayinpickitem.b());
 +        // Paper start - validate pick item position
-+        if (!(packetplayinpickitem.b() >= 0 && packetplayinpickitem.b() < PlayerInventory.getHotbarSize())) {
++        if (!(packetplayinpickitem.b() >= 0 && packetplayinpickitem.b() < 36)) {
 +            PlayerConnection.LOGGER.warn("{} tried to set an invalid carried item", this.player.getDisplayName().getString());
 +            this.disconnect("Invalid hotbar selection (Hacking?)");
 +            return;

--- a/Spigot-Server-Patches/0497-Expose-game-version.patch
+++ b/Spigot-Server-Patches/0497-Expose-game-version.patch
@@ -1,14 +1,14 @@
-From af32f51b7d7f78c747834086cecc8e87c6180a97 Mon Sep 17 00:00:00 2001
+From 577250c48fa0e6f8d4a99648d456d426b2257bb4 Mon Sep 17 00:00:00 2001
 From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
 Date: Fri, 1 May 2020 17:39:26 +0300
 Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b9a398bc5..5bd6f2a88 100644
+index f49193d9d7c..1647c09756e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -488,6 +488,13 @@ public final class CraftServer implements Server {
+@@ -489,6 +489,13 @@ public final class CraftServer implements Server {
          return bukkitVersion;
      }
  
@@ -23,4 +23,5 @@ index b9a398bc5..5bd6f2a88 100644
      public List<CraftPlayer> getOnlinePlayers() {
          return this.playerView;
 -- 
-2.25.1
+2.26.2
+


### PR DESCRIPTION
This is a hand-edited commit.

Tested in survival and creative for items in hotbar, inventory, and not in
inventory at all.

Fixes https://github.com/PaperMC/Paper/issues/3277