### PR TITLE
Huge Anti-Xray cleanup

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -1,4 +1,4 @@
-From e84c20166fcaa037639b0f5205807b1af111257f Mon Sep 17 00:00:00 2001
+From f36561fd1ff52fcd5c3c9d9b328a99ea5b607bfd Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Mon, 28 Mar 2016 20:55:47 -0400
 Subject: [PATCH] MC Utils
@@ -6,7 +6,7 @@ Subject: [PATCH] MC Utils
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/concurrent/WeakSeqLock.java b/src/main/java/com/destroystokyo/paper/util/concurrent/WeakSeqLock.java
 new file mode 100644
-index 0000000000..4029dc68cf
+index 00000000000..4029dc68cf3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/concurrent/WeakSeqLock.java
 @@ -0,0 +1,68 @@
@@ -80,7 +80,7 @@ index 0000000000..4029dc68cf
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Int.java b/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Int.java
 new file mode 100644
-index 0000000000..59868f37d1
+index 00000000000..59868f37d14
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Int.java
 @@ -0,0 +1,162 @@
@@ -248,7 +248,7 @@ index 0000000000..59868f37d1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Object.java b/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Object.java
 new file mode 100644
-index 0000000000..7bab31a312
+index 00000000000..7bab31a3124
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/map/QueuedChangesMapLong2Object.java
 @@ -0,0 +1,202 @@
@@ -456,7 +456,7 @@ index 0000000000..7bab31a312
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/maplist/ChunkList.java b/src/main/java/com/destroystokyo/paper/util/maplist/ChunkList.java
 new file mode 100644
-index 0000000000..4eac057786
+index 00000000000..4eac0577862
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/maplist/ChunkList.java
 @@ -0,0 +1,129 @@
@@ -591,7 +591,7 @@ index 0000000000..4eac057786
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/maplist/EntityList.java b/src/main/java/com/destroystokyo/paper/util/maplist/EntityList.java
 new file mode 100644
-index 0000000000..cdda74564c
+index 00000000000..cdda74564ce
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/maplist/EntityList.java
 @@ -0,0 +1,128 @@
@@ -725,7 +725,7 @@ index 0000000000..cdda74564c
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/maplist/IBlockDataList.java b/src/main/java/com/destroystokyo/paper/util/maplist/IBlockDataList.java
 new file mode 100644
-index 0000000000..84ef8d9eca
+index 00000000000..84ef8d9ecab
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/maplist/IBlockDataList.java
 @@ -0,0 +1,128 @@
@@ -859,7 +859,7 @@ index 0000000000..84ef8d9eca
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/math/IntegerUtil.java b/src/main/java/com/destroystokyo/paper/util/math/IntegerUtil.java
 new file mode 100644
-index 0000000000..c3b936f54b
+index 00000000000..c3b936f54b3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/math/IntegerUtil.java
 @@ -0,0 +1,230 @@
@@ -1095,7 +1095,7 @@ index 0000000000..c3b936f54b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 new file mode 100644
-index 0000000000..c71ed11834
+index 00000000000..c71ed118345
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
 @@ -0,0 +1,439 @@
@@ -1540,7 +1540,7 @@ index 0000000000..c71ed11834
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java
 new file mode 100644
-index 0000000000..3f86c1ad43
+index 00000000000..3f86c1ad437
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java
 @@ -0,0 +1,175 @@
@@ -1721,7 +1721,7 @@ index 0000000000..3f86c1ad43
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/PlayerAreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/PlayerAreaMap.java
 new file mode 100644
-index 0000000000..8a552a87ab
+index 00000000000..8a552a87abf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/PlayerAreaMap.java
 @@ -0,0 +1,27 @@
@@ -1754,7 +1754,7 @@ index 0000000000..8a552a87ab
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/PlayerDistanceTrackingAreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/PlayerDistanceTrackingAreaMap.java
 new file mode 100644
-index 0000000000..0292afc522
+index 00000000000..0292afc5224
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/PlayerDistanceTrackingAreaMap.java
 @@ -0,0 +1,24 @@
@@ -1784,7 +1784,7 @@ index 0000000000..0292afc522
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/misc/PooledLinkedHashSets.java b/src/main/java/com/destroystokyo/paper/util/misc/PooledLinkedHashSets.java
 new file mode 100644
-index 0000000000..e51104e65a
+index 00000000000..e51104e65a0
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/misc/PooledLinkedHashSets.java
 @@ -0,0 +1,287 @@
@@ -2077,7 +2077,7 @@ index 0000000000..e51104e65a
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/pooled/PooledObjects.java b/src/main/java/com/destroystokyo/paper/util/pooled/PooledObjects.java
 new file mode 100644
-index 0000000000..d4325f1f11
+index 00000000000..d4325f1f115
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/pooled/PooledObjects.java
 @@ -0,0 +1,185 @@
@@ -2268,7 +2268,7 @@ index 0000000000..d4325f1f11
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/set/OptimizedSmallEnumSet.java b/src/main/java/com/destroystokyo/paper/util/set/OptimizedSmallEnumSet.java
 new file mode 100644
-index 0000000000..9df0006c1a
+index 00000000000..9df0006c1a2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/set/OptimizedSmallEnumSet.java
 @@ -0,0 +1,67 @@
@@ -2340,7 +2340,7 @@ index 0000000000..9df0006c1a
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/AxisAlignedBB.java b/src/main/java/net/minecraft/server/AxisAlignedBB.java
-index 4f60b931a1..f427953a83 100644
+index 4f60b931a14..f427953a83c 100644
 --- a/src/main/java/net/minecraft/server/AxisAlignedBB.java
 +++ b/src/main/java/net/minecraft/server/AxisAlignedBB.java
 @@ -186,6 +186,7 @@ public class AxisAlignedBB {
@@ -2352,7 +2352,7 @@ index 4f60b931a1..f427953a83 100644
          return this.a(axisalignedbb.minX, axisalignedbb.minY, axisalignedbb.minZ, axisalignedbb.maxX, axisalignedbb.maxY, axisalignedbb.maxZ);
      }
 diff --git a/src/main/java/net/minecraft/server/BlockAccessAir.java b/src/main/java/net/minecraft/server/BlockAccessAir.java
-index eff6ebcd30..30cbfc8eac 100644
+index eff6ebcd30b..30cbfc8eac2 100644
 --- a/src/main/java/net/minecraft/server/BlockAccessAir.java
 +++ b/src/main/java/net/minecraft/server/BlockAccessAir.java
 @@ -14,6 +14,18 @@ public enum BlockAccessAir implements IBlockAccess {
@@ -2375,7 +2375,7 @@ index eff6ebcd30..30cbfc8eac 100644
      public IBlockData getType(BlockPosition blockposition) {
          return Blocks.AIR.getBlockData();
 diff --git a/src/main/java/net/minecraft/server/BlockDataAbstract.java b/src/main/java/net/minecraft/server/BlockDataAbstract.java
-index 1cf97cefc9..2040f18349 100644
+index 1cf97cefc9d..2040f183490 100644
 --- a/src/main/java/net/minecraft/server/BlockDataAbstract.java
 +++ b/src/main/java/net/minecraft/server/BlockDataAbstract.java
 @@ -78,6 +78,7 @@ public abstract class BlockDataAbstract<O, S> implements IBlockDataHolder<S> {
@@ -2387,7 +2387,7 @@ index 1cf97cefc9..2040f18349 100644
          return this.d.containsKey(iblockstate);
      }
 diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
-index c88a62f6b7..f8ac39e1b0 100644
+index c88a62f6b72..f8ac39e1b01 100644
 --- a/src/main/java/net/minecraft/server/BlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BlockPosition.java
 @@ -120,6 +120,7 @@ public class BlockPosition extends BaseBlockPosition implements MinecraftSeriali
@@ -2450,7 +2450,7 @@ index c88a62f6b7..f8ac39e1b0 100644
              this.d = i;
          }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 55373cae07..b39ce329aa 100644
+index 55373cae078..b39ce329aa0 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -25,7 +25,7 @@ import org.apache.logging.log4j.Logger;
@@ -2681,7 +2681,7 @@ index 55373cae07..b39ce329aa 100644
      // CraftBukkit end
  
 diff --git a/src/main/java/net/minecraft/server/ChunkCache.java b/src/main/java/net/minecraft/server/ChunkCache.java
-index 11c4d23ba9..53c15c1c0b 100644
+index 11c4d23ba98..53c15c1c0bf 100644
 --- a/src/main/java/net/minecraft/server/ChunkCache.java
 +++ b/src/main/java/net/minecraft/server/ChunkCache.java
 @@ -8,7 +8,7 @@ public class ChunkCache implements IBlockAccess, ICollisionAccess {
@@ -2715,7 +2715,7 @@ index 11c4d23ba9..53c15c1c0b 100644
      @Override
      public TileEntity getTileEntity(BlockPosition blockposition) {
 diff --git a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
-index 260644bf0b..f2a19acd84 100644
+index 260644bf0be..f2a19acd845 100644
 --- a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 +++ b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 @@ -31,7 +31,9 @@ public class ChunkCoordIntPair {
@@ -2730,7 +2730,7 @@ index 260644bf0b..f2a19acd84 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 32c496fa88..ba2af2abe2 100644
+index 32c496fa88e..ba2af2abe2d 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -23,7 +23,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -2962,8 +2962,20 @@ index 32c496fa88..ba2af2abe2 100644
      @Nullable
      @Override
      public IChunkAccess getChunkAt(int i, int j, ChunkStatus chunkstatus, boolean flag) {
+diff --git a/src/main/java/net/minecraft/server/ChunkSection.java b/src/main/java/net/minecraft/server/ChunkSection.java
+index 652067757a6..638b0e39798 100644
+--- a/src/main/java/net/minecraft/server/ChunkSection.java
++++ b/src/main/java/net/minecraft/server/ChunkSection.java
+@@ -132,6 +132,7 @@ public class ChunkSection {
+         return this.blockIds;
+     }
+ 
++    public void writeChunkSection(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // Paper - OBFHELPER
+     public void b(PacketDataSerializer packetdataserializer) {
+         packetdataserializer.writeShort(this.nonEmptyBlockCount);
+         this.blockIds.b(packetdataserializer);
 diff --git a/src/main/java/net/minecraft/server/DataBits.java b/src/main/java/net/minecraft/server/DataBits.java
-index 7ca3a1d0c5..2edd9b8714 100644
+index 7ca3a1d0c59..2edd9b87146 100644
 --- a/src/main/java/net/minecraft/server/DataBits.java
 +++ b/src/main/java/net/minecraft/server/DataBits.java
 @@ -83,6 +83,7 @@ public class DataBits {
@@ -2975,7 +2987,7 @@ index 7ca3a1d0c5..2edd9b8714 100644
          return this.a;
      }
 diff --git a/src/main/java/net/minecraft/server/DataPalette.java b/src/main/java/net/minecraft/server/DataPalette.java
-index 75ba698868..45403fbe30 100644
+index 75ba6988687..45403fbe308 100644
 --- a/src/main/java/net/minecraft/server/DataPalette.java
 +++ b/src/main/java/net/minecraft/server/DataPalette.java
 @@ -4,10 +4,12 @@ import javax.annotation.Nullable;
@@ -2992,7 +3004,7 @@ index 75ba698868..45403fbe30 100644
      T a(int i);
  
 diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-index 774a8f5434..d5f5a51872 100644
+index 774a8f54342..d5f5a51872d 100644
 --- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
 +++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
 @@ -11,7 +11,7 @@ import java.util.stream.Collectors;
@@ -3034,7 +3046,7 @@ index 774a8f5434..d5f5a51872 100644
          this.a();
          packetdataserializer.writeByte(this.i);
 diff --git a/src/main/java/net/minecraft/server/EntityCreature.java b/src/main/java/net/minecraft/server/EntityCreature.java
-index fe69161e5b..b40c8d2f83 100644
+index fe69161e5b9..b40c8d2f83a 100644
 --- a/src/main/java/net/minecraft/server/EntityCreature.java
 +++ b/src/main/java/net/minecraft/server/EntityCreature.java
 @@ -6,6 +6,8 @@ import org.bukkit.event.entity.EntityUnleashEvent;
@@ -3047,7 +3059,7 @@ index fe69161e5b..b40c8d2f83 100644
          super(entitytypes, world);
      }
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index bdfb173853..0b06fa2b66 100644
+index bdfb1738539..0b06fa2b664 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -146,6 +146,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -3059,7 +3071,7 @@ index bdfb173853..0b06fa2b66 100644
          // CraftBukkit start - fire event
          setGoalTarget(entityliving, EntityTargetEvent.TargetReason.UNKNOWN, true);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 9d1adaaa2c..3ace8ee854 100644
+index 9d1adaaa2c0..3ace8ee854c 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -129,6 +129,7 @@ public abstract class EntityLiving extends Entity {
@@ -3071,7 +3083,7 @@ index 9d1adaaa2c..3ace8ee854 100644
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/server/EntityMonster.java b/src/main/java/net/minecraft/server/EntityMonster.java
-index 00c3b666d7..e5322fbae5 100644
+index 00c3b666d7b..e5322fbae51 100644
 --- a/src/main/java/net/minecraft/server/EntityMonster.java
 +++ b/src/main/java/net/minecraft/server/EntityMonster.java
 @@ -5,6 +5,7 @@ import java.util.function.Predicate;
@@ -3083,7 +3095,7 @@ index 00c3b666d7..e5322fbae5 100644
          super(entitytypes, world);
          this.f = 5;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 541ddc928b..26e32aa1db 100644
+index 541ddc928b9..26e32aa1dbd 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -87,6 +87,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -3105,7 +3117,7 @@ index 541ddc928b..26e32aa1db 100644
          this.displayName = this.getName();
          this.canPickUpLoot = true;
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 29e776ca19..4328273b1f 100644
+index 29e776ca196..4328273b1fc 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -4,6 +4,7 @@ import com.mojang.datafixers.DataFixUtils;
@@ -3128,7 +3140,7 @@ index 29e776ca19..4328273b1f 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
-index 1890c760f9..7e5ece9d50 100644
+index 1890c760f9f..7e5ece9d50a 100644
 --- a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 +++ b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 @@ -68,6 +68,15 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
@@ -3148,7 +3160,7 @@ index 1890c760f9..7e5ece9d50 100644
          this.d.add(r0);
          LockSupport.unpark(this.getThread());
 diff --git a/src/main/java/net/minecraft/server/IBlockAccess.java b/src/main/java/net/minecraft/server/IBlockAccess.java
-index 3b08770801..0dff023529 100644
+index 3b08770801c..0dff023529b 100644
 --- a/src/main/java/net/minecraft/server/IBlockAccess.java
 +++ b/src/main/java/net/minecraft/server/IBlockAccess.java
 @@ -9,10 +9,24 @@ public interface IBlockAccess {
@@ -3177,7 +3189,7 @@ index 3b08770801..0dff023529 100644
          return this.getType(blockposition).h();
      }
 diff --git a/src/main/java/net/minecraft/server/IOWorker.java b/src/main/java/net/minecraft/server/IOWorker.java
-index c5658c0779..b90baef0f5 100644
+index c5658c0779b..b90baef0f54 100644
 --- a/src/main/java/net/minecraft/server/IOWorker.java
 +++ b/src/main/java/net/minecraft/server/IOWorker.java
 @@ -22,7 +22,7 @@ public class IOWorker implements AutoCloseable {
@@ -3190,7 +3202,7 @@ index c5658c0779..b90baef0f5 100644
      private boolean g = true;
      private CompletableFuture<Void> h = new CompletableFuture();
 diff --git a/src/main/java/net/minecraft/server/IWorldReader.java b/src/main/java/net/minecraft/server/IWorldReader.java
-index ba315131e1..cbe2aa4c0a 100644
+index ba315131e16..cbe2aa4c0ac 100644
 --- a/src/main/java/net/minecraft/server/IWorldReader.java
 +++ b/src/main/java/net/minecraft/server/IWorldReader.java
 @@ -4,6 +4,7 @@ import javax.annotation.Nullable;
@@ -3202,7 +3214,7 @@ index ba315131e1..cbe2aa4c0a 100644
      IChunkAccess getChunkAt(int i, int j, ChunkStatus chunkstatus, boolean flag);
  
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index 75308712d0..aa7501d366 100644
+index 75308712d06..aa7501d366b 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -37,10 +37,19 @@ import org.bukkit.event.world.StructureGrowEvent;
@@ -3262,7 +3274,7 @@ index 75308712d0..aa7501d366 100644
      // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
 new file mode 100644
-index 0000000000..9fb9a96ccb
+index 00000000000..9fb9a96ccb3
 --- /dev/null
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -0,0 +1,414 @@
@@ -3681,7 +3693,7 @@ index 0000000000..9fb9a96ccb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/NBTTagCompound.java b/src/main/java/net/minecraft/server/NBTTagCompound.java
-index e85b24a327..75604dbc69 100644
+index e85b24a327f..75604dbc69d 100644
 --- a/src/main/java/net/minecraft/server/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/server/NBTTagCompound.java
 @@ -60,7 +60,7 @@ public class NBTTagCompound implements NBTBase {
@@ -3710,7 +3722,7 @@ index e85b24a327..75604dbc69 100644
          return new UUID(this.getLong(s + "Most"), this.getLong(s + "Least"));
      }
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index 6700582e36..3ccf166366 100644
+index 6700582e362..3ccf1663669 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -159,6 +159,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
@@ -3742,7 +3754,7 @@ index 6700582e36..3ccf166366 100644
          public QueuedPacket(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> genericfuturelistener) {
              this.a = packet;
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 81b6f4581f..d9574a9ace 100644
+index 81b6f4581f8..d9574a9ace9 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
 @@ -33,6 +33,7 @@ public class PacketDataSerializer extends ByteBuf {
@@ -3754,7 +3766,7 @@ index 81b6f4581f..d9574a9ace 100644
          for (int j = 1; j < 5; ++j) {
              if ((i & -1 << j * 7) == 0) {
 diff --git a/src/main/java/net/minecraft/server/PacketEncoder.java b/src/main/java/net/minecraft/server/PacketEncoder.java
-index 90223deae3..63c4dbd327 100644
+index 90223deae33..63c4dbd327b 100644
 --- a/src/main/java/net/minecraft/server/PacketEncoder.java
 +++ b/src/main/java/net/minecraft/server/PacketEncoder.java
 @@ -42,6 +42,7 @@ public class PacketEncoder extends MessageToByteEncoder<Packet<?>> {
@@ -3766,7 +3778,7 @@ index 90223deae3..63c4dbd327 100644
                          throw new SkipEncodeException(throwable);
                      } else {
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
-index 677e3e5f68..3a1d0deb0d 100644
+index 677e3e5f687..3a1d0deb0de 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 @@ -17,7 +17,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
@@ -3787,7 +3799,7 @@ index 677e3e5f68..3a1d0deb0d 100644
          int j = 0;
          ChunkSection[] achunksection = chunk.getSections();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 5c5bf010d0..6e9f402fb0 100644
+index 5c5bf010d07..6e9f402fb0f 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -19,9 +19,9 @@ public class PlayerChunk {
@@ -3977,7 +3989,7 @@ index 5c5bf010d0..6e9f402fb0 100644
          }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 7ad30548e2..b505244516 100644
+index 7ad30548e2a..b5052445163 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -99,6 +99,28 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -4050,7 +4062,7 @@ index 7ad30548e2..b505244516 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 0c496ee0a0..6a681d694e 100644
+index 0c496ee0a04..6a681d694e7 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -67,9 +67,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -4067,7 +4079,7 @@ index 0c496ee0a0..6a681d694e 100644
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
 diff --git a/src/main/java/net/minecraft/server/PlayerInventory.java b/src/main/java/net/minecraft/server/PlayerInventory.java
-index 08768a3c87..d103cfaace 100644
+index 08768a3c877..d103cfaace4 100644
 --- a/src/main/java/net/minecraft/server/PlayerInventory.java
 +++ b/src/main/java/net/minecraft/server/PlayerInventory.java
 @@ -17,7 +17,7 @@ public class PlayerInventory implements IInventory, INamableTileEntity {
@@ -4080,7 +4092,7 @@ index 08768a3c87..d103cfaace 100644
      public final EntityHuman player;
      private ItemStack carried;
 diff --git a/src/main/java/net/minecraft/server/PotionUtil.java b/src/main/java/net/minecraft/server/PotionUtil.java
-index b3824898da..bf4172be52 100644
+index b3824898daa..bf4172be525 100644
 --- a/src/main/java/net/minecraft/server/PotionUtil.java
 +++ b/src/main/java/net/minecraft/server/PotionUtil.java
 @@ -110,6 +110,7 @@ public class PotionUtil {
@@ -4092,7 +4104,7 @@ index b3824898da..bf4172be52 100644
          MinecraftKey minecraftkey = IRegistry.POTION.getKey(potionregistry);
  
 diff --git a/src/main/java/net/minecraft/server/ProtoChunk.java b/src/main/java/net/minecraft/server/ProtoChunk.java
-index 6e65306a27..39339fa275 100644
+index 6e65306a275..39339fa2755 100644
 --- a/src/main/java/net/minecraft/server/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/server/ProtoChunk.java
 @@ -80,6 +80,18 @@ public class ProtoChunk implements IChunkAccess {
@@ -4115,7 +4127,7 @@ index 6e65306a27..39339fa275 100644
      public IBlockData getType(BlockPosition blockposition) {
          int i = blockposition.getY();
 diff --git a/src/main/java/net/minecraft/server/RegionFile.java b/src/main/java/net/minecraft/server/RegionFile.java
-index 7b6e0e86b0..187c4e0f58 100644
+index 7b6e0e86b00..187c4e0f58b 100644
 --- a/src/main/java/net/minecraft/server/RegionFile.java
 +++ b/src/main/java/net/minecraft/server/RegionFile.java
 @@ -88,6 +88,7 @@ public class RegionFile implements AutoCloseable {
@@ -4127,7 +4139,7 @@ index 7b6e0e86b0..187c4e0f58 100644
      public synchronized DataInputStream a(ChunkCoordIntPair chunkcoordintpair) throws IOException {
          int i = this.getOffset(chunkcoordintpair);
 diff --git a/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java b/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
-index 8c123f265e..9d0e8c2d43 100644
+index 8c123f265e6..9d0e8c2d43b 100644
 --- a/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
 +++ b/src/main/java/net/minecraft/server/RegionLimitedWorldAccess.java
 @@ -108,6 +108,26 @@ public class RegionLimitedWorldAccess implements GeneratorAccess {
@@ -4158,7 +4170,7 @@ index 8c123f265e..9d0e8c2d43 100644
      public IBlockData getType(BlockPosition blockposition) {
          return this.getChunkAt(blockposition.getX() >> 4, blockposition.getZ() >> 4).getType(blockposition);
 diff --git a/src/main/java/net/minecraft/server/RegistryBlockID.java b/src/main/java/net/minecraft/server/RegistryBlockID.java
-index 4efcb8b595..60948afa4e 100644
+index 4efcb8b5957..60948afa4ea 100644
 --- a/src/main/java/net/minecraft/server/RegistryBlockID.java
 +++ b/src/main/java/net/minecraft/server/RegistryBlockID.java
 @@ -57,6 +57,7 @@ public class RegistryBlockID<T> implements Registry<T> {
@@ -4170,7 +4182,7 @@ index 4efcb8b595..60948afa4e 100644
          return this.b.size();
      }
 diff --git a/src/main/java/net/minecraft/server/SystemUtils.java b/src/main/java/net/minecraft/server/SystemUtils.java
-index 7b92ecfff9..7e224ebeff 100644
+index 7b92ecfff94..7e224ebeff3 100644
 --- a/src/main/java/net/minecraft/server/SystemUtils.java
 +++ b/src/main/java/net/minecraft/server/SystemUtils.java
 @@ -58,7 +58,7 @@ public class SystemUtils {
@@ -4183,7 +4195,7 @@ index 7b92ecfff9..7e224ebeff 100644
  
      public static long getTimeMillis() {
 diff --git a/src/main/java/net/minecraft/server/TicketType.java b/src/main/java/net/minecraft/server/TicketType.java
-index f82db93f88..75ab9f185b 100644
+index f82db93f882..75ab9f185b3 100644
 --- a/src/main/java/net/minecraft/server/TicketType.java
 +++ b/src/main/java/net/minecraft/server/TicketType.java
 @@ -21,6 +21,7 @@ public class TicketType<T> {
@@ -4195,7 +4207,7 @@ index f82db93f88..75ab9f185b 100644
      public static <T> TicketType<T> a(String s, Comparator<T> comparator) {
          return new TicketType<>(s, comparator, 0L);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 2e1eabba14..2a4fa455ff 100644
+index 2e1eabba14a..2a4fa455ff3 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.SpigotTimings; // Spigot
@@ -4259,7 +4271,7 @@ index 2e1eabba14..2a4fa455ff 100644
  
          return this.setTypeAndData(blockposition, fluid.getBlockData(), 3 | (flag ? 64 : 0));
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index e181df6f4d..4a9132c701 100644
+index e181df6f4d0..4a9132c7016 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -85,6 +85,7 @@ public final class CraftItemStack extends ItemStack {
@@ -4271,7 +4283,7 @@ index e181df6f4d..4a9132c701 100644
      /**
       * Mirror
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java b/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
-index d8358a0f03..d0b813008c 100644
+index d8358a0f031..d0b813008ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/DummyGeneratorAccess.java
 @@ -196,4 +196,22 @@ public class DummyGeneratorAccess implements GeneratorAccess {
@@ -4298,7 +4310,7 @@ index d8358a0f03..d0b813008c 100644
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/UnsafeList.java b/src/main/java/org/bukkit/craftbukkit/util/UnsafeList.java
-index 1aec70a1f1..f72c13beda 100644
+index 1aec70a1f1a..f72c13bedaa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/UnsafeList.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/UnsafeList.java
 @@ -17,7 +17,7 @@ import java.util.RandomAccess;
@@ -4311,5 +4323,5 @@ index 1aec70a1f1..f72c13beda 100644
      private int initialCapacity;
  
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0384-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0384-Anti-Xray.patch
@@ -1,26 +1,24 @@
-From deb49130a0248ad17fd28a1963c89e984fcdb72a Mon Sep 17 00:00:00 2001
+From 5428b63f7eed04603e23443185f1593dff63141f Mon Sep 17 00:00:00 2001
 From: stonar96 <minecraft.stonar96@gmail.com>
 Date: Mon, 20 Aug 2018 03:03:58 +0200
 Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4867615215..df24e3297b 100644
+index 48676152152..ca2ac17747d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,7 +1,11 @@
+@@ -1,7 +1,9 @@
  package com.destroystokyo.paper;
  
 +import java.util.Arrays;
  import java.util.List;
  
-+import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.ChunkEdgeMode;
 +import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
-+import net.minecraft.server.MinecraftServer;
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -502,4 +506,43 @@ public class PaperWorldConfig {
+@@ -502,4 +504,33 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
@@ -28,7 +26,6 @@ index 4867615215..df24e3297b 100644
 +    public boolean antiXray;
 +    public boolean asynchronous;
 +    public EngineMode engineMode;
-+    public ChunkEdgeMode chunkEdgeMode;
 +    public int maxChunkSectionIndex;
 +    public int updateRadius;
 +    public List<String> hiddenBlocks;
@@ -38,15 +35,6 @@ index 4867615215..df24e3297b 100644
 +        asynchronous = true;
 +        engineMode = EngineMode.getById(getInt("anti-xray.engine-mode", EngineMode.HIDE.getId()));
 +        engineMode = engineMode == null ? EngineMode.HIDE : engineMode;
-+        chunkEdgeMode = ChunkEdgeMode.getById(getInt("anti-xray.chunk-edge-mode", ChunkEdgeMode.WAIT.getId()));
-+        chunkEdgeMode = chunkEdgeMode == null ? ChunkEdgeMode.DEFAULT : chunkEdgeMode;
-+
-+        if (chunkEdgeMode != ChunkEdgeMode.WAIT) {
-+            log("Migrating anti-xray chunk edge mode to " + ChunkEdgeMode.WAIT + " (" + ChunkEdgeMode.WAIT.getId() + ")");
-+            chunkEdgeMode = ChunkEdgeMode.WAIT;
-+            set("anti-xray.chunk-edge-mode", ChunkEdgeMode.WAIT.getId());
-+        }
-+
 +        maxChunkSectionIndex = getInt("anti-xray.max-chunk-section-index", 3);
 +        maxChunkSectionIndex = maxChunkSectionIndex > 15 ? 15 : maxChunkSectionIndex;
 +        updateRadius = getInt("anti-xray.update-radius", 2);
@@ -61,15 +49,15 @@ index 4867615215..df24e3297b 100644
 +            set("anti-xray.hidden-blocks", hiddenBlocks);
 +            set("anti-xray.replacement-blocks", replacementBlocks);
 +        }
-+        log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Chunk Edge Mode: " + chunkEdgeMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
++        log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java
 new file mode 100644
-index 0000000000..f7e376ce6a
+index 00000000000..df7e4183d88
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,40 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import net.minecraft.server.BlockPosition;
@@ -78,7 +66,6 @@ index 0000000000..f7e376ce6a
 +import net.minecraft.server.EnumDirection;
 +import net.minecraft.server.IBlockData;
 +import net.minecraft.server.IChunkAccess;
-+import net.minecraft.server.IWorldReader;
 +import net.minecraft.server.PacketPlayOutMapChunk;
 +import net.minecraft.server.PlayerInteractManager;
 +import net.minecraft.server.World;
@@ -91,20 +78,15 @@ index 0000000000..f7e376ce6a
 +
 +    }
 +
-+    public IBlockData[] getPredefinedBlockData(IWorldReader world, IChunkAccess chunk, ChunkSection chunkSection, boolean initializeBlocks) {
++    public IBlockData[] getPredefinedBlockData(World world, IChunkAccess chunk, ChunkSection chunkSection, boolean initializeBlocks) {
 +        return null;
 +    }
 +
-+    public boolean onChunkPacketCreate(Chunk chunk, int chunkSectionSelector, boolean force) {
-+        return true;
-+    }
-+
-+    public ChunkPacketInfo<IBlockData> getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk,
-+                                                          int chunkSectionSelector, boolean forceLoad) {
++    public ChunkPacketInfo<IBlockData> getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk, int chunkSectionSelector) {
 +        return null;
 +    }
 +
-+    public void modifyBlocks(PacketPlayOutMapChunk packetPlayOutMapChunk, ChunkPacketInfo<IBlockData> chunkPacketInfo, boolean loadChunks, Integer ticketHold) {
++    public void modifyBlocks(PacketPlayOutMapChunk packetPlayOutMapChunk, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
 +        packetPlayOutMapChunk.setReady(true);
 +    }
 +
@@ -118,10 +100,10 @@ index 0000000000..f7e376ce6a
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000..23626bef3a
+index 00000000000..9c017eb027c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,782 @@
+@@ -0,0 +1,628 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
@@ -130,8 +112,6 @@ index 0000000000..23626bef3a
 +import java.util.Set;
 +import java.util.concurrent.ExecutorService;
 +import java.util.concurrent.Executors;
-+import java.util.concurrent.atomic.AtomicInteger;
-+import java.util.function.Supplier;
 +
 +import net.minecraft.server.*;
 +import org.bukkit.Bukkit;
@@ -139,13 +119,12 @@ index 0000000000..23626bef3a
 +
 +import com.destroystokyo.paper.PaperWorldConfig;
 +
-+public class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockController {
++public final class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockController {
 +
 +    private static ExecutorService executorServiceInstance = null;
 +    private final ExecutorService executorService;
 +    private final boolean asynchronous;
 +    private final EngineMode engineMode;
-+    private final ChunkEdgeMode chunkEdgeMode;
 +    private final int maxChunkSectionIndex;
 +    private final int updateRadius;
 +    private final IBlockData[] predefinedBlockData;
@@ -164,7 +143,6 @@ index 0000000000..23626bef3a
 +    public ChunkPacketBlockControllerAntiXray(PaperWorldConfig paperWorldConfig) {
 +        asynchronous = paperWorldConfig.asynchronous;
 +        engineMode = paperWorldConfig.engineMode;
-+        chunkEdgeMode = paperWorldConfig.chunkEdgeMode;
 +        maxChunkSectionIndex = paperWorldConfig.maxChunkSectionIndex;
 +        updateRadius = paperWorldConfig.updateRadius;
 +
@@ -247,23 +225,19 @@ index 0000000000..23626bef3a
 +    }
 +
 +    @Override
-+    public IBlockData[] getPredefinedBlockData(IWorldReader world, IChunkAccess chunk, ChunkSection chunkSection, boolean initializeBlocks) {
-+        //Return the block data which should be added to the data palettes so that they can be used for the obfuscation
++    public IBlockData[] getPredefinedBlockData(World world, IChunkAccess chunk, ChunkSection chunkSection, boolean initializeBlocks) {
++        // Return the block data which should be added to the data palettes so that they can be used for the obfuscation
 +        if (chunkSection.getYPosition() >> 4 <= maxChunkSectionIndex) {
 +            switch (engineMode) {
 +                case HIDE:
-+                    if (world instanceof GeneratorAccess) {
-+                        switch (((GeneratorAccess) world).getMinecraftWorld().getWorld().getEnvironment()) {
-+                            case NETHER:
-+                                return predefinedBlockDataNetherrack;
-+                            case THE_END:
-+                                return predefinedBlockDataEndStone;
-+                            default:
-+                                return predefinedBlockDataStone;
-+                        }
++                    switch (world.getWorld().getEnvironment()) {
++                        case NETHER:
++                            return predefinedBlockDataNetherrack;
++                        case THE_END:
++                            return predefinedBlockDataEndStone;
++                        default:
++                            return predefinedBlockDataStone;
 +                    }
-+
-+                    return null;
 +                default:
 +                    return predefinedBlockData;
 +            }
@@ -272,128 +246,33 @@ index 0000000000..23626bef3a
 +        return null;
 +    }
 +
-+    private final AtomicInteger xrayRequests = new AtomicInteger();
-+
-+    private Integer addXrayTickets(final int x, final int z, final ChunkProviderServer chunkProvider) {
-+        final Integer hold = Integer.valueOf(this.xrayRequests.getAndIncrement());
-+
-+        // Add at ticket level 33, which is just enough to keep chunks loaded
-+        chunkProvider.addTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z), 0, hold);
-+        chunkProvider.addTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x - 1, z), 0, hold);
-+        chunkProvider.addTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x + 1, z), 0, hold);
-+        chunkProvider.addTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z - 1), 0, hold);
-+        chunkProvider.addTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z + 1), 0, hold);
-+
-+        return hold;
-+    }
-+
-+    private void removeXrayTickets(final int x, final int z, final ChunkProviderServer chunkProvider, final Integer hold) {
-+        // Remove at ticket level 33 (same one we added as), which is just enough to keep chunks loaded
-+        chunkProvider.removeTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z), 0, hold);
-+        chunkProvider.removeTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x - 1, z), 0, hold);
-+        chunkProvider.removeTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x + 1, z), 0, hold);
-+        chunkProvider.removeTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z - 1), 0, hold);
-+        chunkProvider.removeTicket(TicketType.ANTIXRAY, new ChunkCoordIntPair(x, z + 1), 0, hold);
-+    }
-+
-+    private void loadNeighbours(Chunk chunk) {
-+        int locX = chunk.getPos().x;
-+        int locZ = chunk.getPos().z;
-+        chunk.world.getChunkAt(locX - 1, locZ);
-+        chunk.world.getChunkAt(locX + 1, locZ);
-+        chunk.world.getChunkAt(locX, locZ - 1);
-+        chunk.world.getChunkAt(locX, locZ + 1);
-+    }
-+
 +    @Override
-+    public boolean onChunkPacketCreate(Chunk chunk, int chunkSectionSelector, boolean force) {
-+        int locX = chunk.getPos().x;
-+        int locZ = chunk.getPos().z;
-+        WorldServer world = (WorldServer)chunk.world;
-+        ChunkProviderServer chunkProvider = world.getChunkProvider();
-+
-+        //Load nearby chunks if necessary
-+        if (force || chunkEdgeMode == ChunkEdgeMode.LOAD) { // TODO temporary
-+            // if forced, load NOW;
-+            this.loadNeighbours(chunk);
-+        } else if (chunkEdgeMode == ChunkEdgeMode.WAIT) {
-+            if (chunkProvider.getChunkAtIfCachedImmediately(locX - 1, locZ) == null ||
-+                chunkProvider.getChunkAtIfCachedImmediately(locX + 1, locZ) == null ||
-+                chunkProvider.getChunkAtIfCachedImmediately(locX, locZ - 1) == null ||
-+                chunkProvider.getChunkAtIfCachedImmediately(locX, locZ + 1) == null) {
-+                //Don't create the chunk packet now, wait until nearby chunks are loaded and create it later
-+                return false;
-+            }
-+        } else if (false && chunkEdgeMode == ChunkEdgeMode.LOAD) {
-+            // TODO Note: These should be asynchronous loads; however we have no such thing in 1.14.
-+            boolean missingChunk = false;
-+            //noinspection ConstantConditions
-+            /*
-+            missingChunk |= ((WorldServer)chunk.world).getChunkProvider().getChunkAt(chunk.locX - 1, chunk.locZ, true, true, c -> {}) == null;
-+            missingChunk |= ((WorldServer)chunk.world).getChunkProvider().getChunkAt(chunk.locX + 1, chunk.locZ, true, true, c -> {}) == null;
-+            missingChunk |= ((WorldServer)chunk.world).getChunkProvider().getChunkAt(chunk.locX, chunk.locZ - 1, true, true, c -> {}) == null;
-+            missingChunk |= ((WorldServer)chunk.world).getChunkProvider().getChunkAt(chunk.locX, chunk.locZ + 1, true, true, c -> {}) == null;
-+             */
-+            if (missingChunk) {
-+                return false;
-+            }
-+        }
-+
-+        //Create the chunk packet now
-+        return true;
-+    }
-+
-+    @Override
-+    public ChunkPacketInfoAntiXray getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk,
-+                                                      int chunkSectionSelector, boolean forceLoad) {
++    public ChunkPacketInfoAntiXray getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk, int chunkSectionSelector) {
 +        // Return a new instance to collect data and objects in the right state while creating the chunk packet for thread safe access later
 +        // Note: As of 1.14 this has to be moved later due to the chunk system.
-+
 +        ChunkPacketInfoAntiXray chunkPacketInfoAntiXray = new ChunkPacketInfoAntiXray(packetPlayOutMapChunk, chunk, chunkSectionSelector, this);
 +        return chunkPacketInfoAntiXray;
 +    }
 +
 +    @Override
-+    public void modifyBlocks(PacketPlayOutMapChunk packetPlayOutMapChunk, ChunkPacketInfo<IBlockData> chunkPacketInfo, boolean loadChunks, Integer hold) {
++    public void modifyBlocks(PacketPlayOutMapChunk packetPlayOutMapChunk, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
 +        if (!Bukkit.isPrimaryThread()) {
 +            // plugins?
-+            final Integer finalHold = hold;
 +            MinecraftServer.getServer().scheduleOnMain(() -> {
-+                this.modifyBlocks(packetPlayOutMapChunk, chunkPacketInfo, loadChunks, finalHold);
++                this.modifyBlocks(packetPlayOutMapChunk, chunkPacketInfo);
 +            });
 +            return;
 +        }
++
 +        Chunk chunk = chunkPacketInfo.getChunk();
-+        int locX = chunk.getPos().x;
-+        int locZ = chunk.getPos().z;
++        int x = chunk.getPos().x;
++        int z = chunk.getPos().z;
 +        WorldServer world = (WorldServer)chunk.world;
-+
-+        Chunk[] chunks = new Chunk[] {
-+            (Chunk)world.getChunkIfLoadedImmediately(locX - 1, locZ),
-+            (Chunk)world.getChunkIfLoadedImmediately(locX + 1, locZ),
-+            (Chunk)world.getChunkIfLoadedImmediately(locX, locZ - 1),
-+            (Chunk)world.getChunkIfLoadedImmediately(locX, locZ + 1)
-+        };
-+
-+        if (loadChunks) {
-+            // Note: This ugly hack is to get us out of the general chunk load/unload queue to prevent deadlock
-+
-+            if (chunks[0] == null || chunks[1] == null || chunks[2] == null || chunks[3] == null) {
-+                // we need to load
-+                MinecraftServer.getServer().scheduleOnMain(() -> {
-+                    Integer ticketHold = this.addXrayTickets(locX, locZ, world.getChunkProvider());
-+                    this.loadNeighbours(chunk);
-+                    this.modifyBlocks(packetPlayOutMapChunk, chunkPacketInfo, false, ticketHold);
-+                });
-+                return;
-+            }
-+
-+            hold = this.addXrayTickets(locX, locZ, world.getChunkProvider());
-+            // fall through to normal behavior, our chunks are now loaded & have a ticket
-+        }
-+
-+        ((ChunkPacketInfoAntiXray)chunkPacketInfo).setNearbyChunks(chunks);
-+        ((ChunkPacketInfoAntiXray)chunkPacketInfo).ticketHold = hold;
++        ((ChunkPacketInfoAntiXray) chunkPacketInfo).setNearbyChunks(
++            (Chunk) world.getChunkIfLoadedImmediately(x - 1, z),
++            (Chunk) world.getChunkIfLoadedImmediately(x + 1, z),
++            (Chunk) world.getChunkIfLoadedImmediately(x, z - 1),
++            (Chunk) world.getChunkIfLoadedImmediately(x, z + 1));
 +
 +        if (asynchronous) {
 +            executorService.submit((ChunkPacketInfoAntiXray) chunkPacketInfo);
@@ -402,11 +281,11 @@ index 0000000000..23626bef3a
 +        }
 +    }
 +
-+    //Actually these fields should be variables inside the obfuscate method but in sync mode or with SingleThreadExecutor in async mode it's okay
++    // Actually these fields should be variables inside the obfuscate method but in sync mode or with SingleThreadExecutor in async mode it's okay
 +    private int[] predefinedBlockDataBits;
 +    private final boolean[] solid = new boolean[Block.REGISTRY_ID.size()];
 +    private final boolean[] obfuscate = new boolean[Block.REGISTRY_ID.size()];
-+    //These boolean arrays represent chunk layers, true means don't obfuscate, false means obfuscate
++    // These boolean arrays represent chunk layers, true means don't obfuscate, false means obfuscate
 +    private boolean[][] current = new boolean[16][16];
 +    private boolean[][] next = new boolean[16][16];
 +    private boolean[][] nextNext = new boolean[16][16];
@@ -415,130 +294,112 @@ index 0000000000..23626bef3a
 +    private final ChunkSection[] nearbyChunkSections = new ChunkSection[4];
 +
 +    public void obfuscate(ChunkPacketInfoAntiXray chunkPacketInfoAntiXray) {
-+        try {
-+            boolean[] solidTemp = null;
-+            boolean[] obfuscateTemp = null;
-+            dataBitsReader.setDataBits(chunkPacketInfoAntiXray.getData());
-+            dataBitsWriter.setDataBits(chunkPacketInfoAntiXray.getData());
-+            int counter = 0;
++        boolean[] solidTemp = null;
++        boolean[] obfuscateTemp = null;
++        dataBitsReader.setDataBits(chunkPacketInfoAntiXray.getData());
++        dataBitsWriter.setDataBits(chunkPacketInfoAntiXray.getData());
++        int counter = 0;
 +
-+            for (int chunkSectionIndex = 0; chunkSectionIndex <= maxChunkSectionIndex; chunkSectionIndex++) {
-+                if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex) && chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex) != null) {
-+                    int[] predefinedBlockDataBitsTemp;
++        for (int chunkSectionIndex = 0; chunkSectionIndex <= maxChunkSectionIndex; chunkSectionIndex++) {
++            if (chunkPacketInfoAntiXray.isWritten(chunkSectionIndex) && chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex) != null) {
++                int[] predefinedBlockDataBitsTemp;
 +
-+                    if (chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex) == ChunkSection.GLOBAL_PALETTE) {
-+                        predefinedBlockDataBitsTemp = engineMode == EngineMode.HIDE ? chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.NETHER ? predefinedBlockDataBitsNetherrackGlobal : chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.THE_END ? predefinedBlockDataBitsEndStoneGlobal : predefinedBlockDataBitsStoneGlobal : predefinedBlockDataBitsGlobal;
-+                    } else {
-+                        predefinedBlockDataBitsTemp = predefinedBlockDataBits == null ? predefinedBlockDataBits = engineMode == EngineMode.HIDE ? new int[1] : new int[predefinedBlockData.length] : predefinedBlockDataBits;
++                if (chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex) == ChunkSection.GLOBAL_PALETTE) {
++                    predefinedBlockDataBitsTemp = engineMode == EngineMode.HIDE ? chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.NETHER ? predefinedBlockDataBitsNetherrackGlobal : chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.THE_END ? predefinedBlockDataBitsEndStoneGlobal : predefinedBlockDataBitsStoneGlobal : predefinedBlockDataBitsGlobal;
++                } else {
++                    predefinedBlockDataBitsTemp = predefinedBlockDataBits == null ? predefinedBlockDataBits = engineMode == EngineMode.HIDE ? new int[1] : new int[predefinedBlockData.length] : predefinedBlockDataBits;
 +
-+                        for (int i = 0; i < predefinedBlockDataBitsTemp.length; i++) {
-+                            predefinedBlockDataBitsTemp[i] = chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex).getOrCreateIdFor(chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex)[i]);
++                    for (int i = 0; i < predefinedBlockDataBitsTemp.length; i++) {
++                        predefinedBlockDataBitsTemp[i] = chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex).getOrCreateIdFor(chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex)[i]);
++                    }
++                }
++
++                dataBitsWriter.setIndex(chunkPacketInfoAntiXray.getDataBitsIndex(chunkSectionIndex));
++
++                // Check if the chunk section below was not obfuscated
++                if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1) || chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex - 1) == null) {
++                    // If so, initialize some stuff
++                    dataBitsReader.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex));
++                    dataBitsReader.setIndex(chunkPacketInfoAntiXray.getDataBitsIndex(chunkSectionIndex));
++                    solidTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex), solid, solidGlobal);
++                    obfuscateTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex), obfuscate, obfuscateGlobal);
++                    // Read the blocks of the upper layer of the chunk section below if it exists
++                    ChunkSection belowChunkSection = null;
++                    boolean skipFirstLayer = chunkSectionIndex == 0 || (belowChunkSection = chunkPacketInfoAntiXray.getChunk().getSections()[chunkSectionIndex - 1]) == Chunk.EMPTY_CHUNK_SECTION;
++
++                    for (int z = 0; z < 16; z++) {
++                        for (int x = 0; x < 16; x++) {
++                            current[z][x] = true;
++                            next[z][x] = skipFirstLayer || !solidGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(belowChunkSection.getType(x, 15, z))];
 +                        }
 +                    }
 +
-+                    dataBitsWriter.setIndex(chunkPacketInfoAntiXray.getOrCreateIdForIndex(chunkSectionIndex));
++                    // Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
++                    dataBitsWriter.setBitsPerObject(0);
++                    obfuscateLayer(-1, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, emptyNearbyChunkSections, counter);
++                }
 +
-+                    //Check if the chunk section below was not obfuscated
-+                    if (chunkSectionIndex == 0 || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex - 1) || chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex - 1) == null) {
-+                        //If so, initialize some stuff
-+                        dataBitsReader.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex));
-+                        dataBitsReader.setIndex(chunkPacketInfoAntiXray.getOrCreateIdForIndex(chunkSectionIndex));
-+                        solidTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex), solid, solidGlobal);
-+                        obfuscateTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex), obfuscate, obfuscateGlobal);
-+                        //Read the blocks of the upper layer of the chunk section below if it exists
-+                        ChunkSection belowChunkSection = null;
-+                        boolean skipFirstLayer = chunkSectionIndex == 0 || (belowChunkSection = chunkPacketInfoAntiXray.getChunk().getSections()[chunkSectionIndex - 1]) == Chunk.EMPTY_CHUNK_SECTION;
++                dataBitsWriter.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex));
++                nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
++                nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
++                nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
++                nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
++
++                // Obfuscate all layers of the current chunk section except the upper one
++                for (int y = 0; y < 15; y++) {
++                    boolean[][] temp = current;
++                    current = next;
++                    next = nextNext;
++                    nextNext = temp;
++                    counter = obfuscateLayer(y, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
++                }
++
++                // Check if the chunk section above doesn't need obfuscation
++                if (chunkSectionIndex == maxChunkSectionIndex || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1) || chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex + 1) == null) {
++                    // If so, obfuscate the upper layer of the current chunk section by reading blocks of the first layer from the chunk section above if it exists
++                    ChunkSection aboveChunkSection;
++
++                    if (chunkSectionIndex != 15 && (aboveChunkSection = chunkPacketInfoAntiXray.getChunk().getSections()[chunkSectionIndex + 1]) != Chunk.EMPTY_CHUNK_SECTION) {
++                        boolean[][] temp = current;
++                        current = next;
++                        next = nextNext;
++                        nextNext = temp;
 +
 +                        for (int z = 0; z < 16; z++) {
 +                            for (int x = 0; x < 16; x++) {
-+                                current[z][x] = true;
-+                                next[z][x] = skipFirstLayer || !solidGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(belowChunkSection.getType(x, 15, z))];
-+                            }
-+                        }
-+
-+                        //Abuse the obfuscateLayer method to read the blocks of the first layer of the current chunk section
-+                        dataBitsWriter.setBitsPerObject(0);
-+                        obfuscateLayer(-1, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, emptyNearbyChunkSections, counter);
-+                    }
-+
-+                    dataBitsWriter.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex));
-+                    nearbyChunkSections[0] = chunkPacketInfoAntiXray.getNearbyChunks()[0] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[0].getSections()[chunkSectionIndex];
-+                    nearbyChunkSections[1] = chunkPacketInfoAntiXray.getNearbyChunks()[1] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[1].getSections()[chunkSectionIndex];
-+                    nearbyChunkSections[2] = chunkPacketInfoAntiXray.getNearbyChunks()[2] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[2].getSections()[chunkSectionIndex];
-+                    nearbyChunkSections[3] = chunkPacketInfoAntiXray.getNearbyChunks()[3] == null ? Chunk.EMPTY_CHUNK_SECTION : chunkPacketInfoAntiXray.getNearbyChunks()[3].getSections()[chunkSectionIndex];
-+
-+                    //Obfuscate all layers of the current chunk section except the upper one
-+                    for (int y = 0; y < 15; y++) {
-+                        boolean[][] temp = current;
-+                        current = next;
-+                        next = nextNext;
-+                        nextNext = temp;
-+                        counter = obfuscateLayer(y, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
-+                    }
-+
-+                    //Check if the chunk section above doesn't need obfuscation
-+                    if (chunkSectionIndex == maxChunkSectionIndex || !chunkPacketInfoAntiXray.isWritten(chunkSectionIndex + 1) || chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex + 1) == null) {
-+                        //If so, obfuscate the upper layer of the current chunk section by reading blocks of the first layer from the chunk section above if it exists
-+                        ChunkSection aboveChunkSection;
-+
-+                        if (chunkSectionIndex != 15 && (aboveChunkSection = chunkPacketInfoAntiXray.getChunk().getSections()[chunkSectionIndex + 1]) != Chunk.EMPTY_CHUNK_SECTION) {
-+                            boolean[][] temp = current;
-+                            current = next;
-+                            next = nextNext;
-+                            nextNext = temp;
-+
-+                            for (int z = 0; z < 16; z++) {
-+                                for (int x = 0; x < 16; x++) {
-+                                    if (!solidGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(aboveChunkSection.getType(x, 0, z))]) {
-+                                        current[z][x] = true;
-+                                    }
++                                if (!solidGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(aboveChunkSection.getType(x, 0, z))]) {
++                                    current[z][x] = true;
 +                                }
 +                            }
-+
-+                            //There is nothing to read anymore
-+                            dataBitsReader.setBitsPerObject(0);
-+                            solid[0] = true;
-+                            counter = obfuscateLayer(15, dataBitsReader, dataBitsWriter, solid, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
 +                        }
-+                    } else {
-+                        //If not, initialize the reader and other stuff for the chunk section above to obfuscate the upper layer of the current chunk section
-+                        dataBitsReader.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex + 1));
-+                        dataBitsReader.setIndex(chunkPacketInfoAntiXray.getOrCreateIdForIndex(chunkSectionIndex + 1));
-+                        solidTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex + 1), solid, solidGlobal);
-+                        obfuscateTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex + 1), obfuscate, obfuscateGlobal);
-+                        boolean[][] temp = current;
-+                        current = next;
-+                        next = nextNext;
-+                        nextNext = temp;
-+                        counter = obfuscateLayer(15, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
++
++                        // There is nothing to read anymore
++                        dataBitsReader.setBitsPerObject(0);
++                        solid[0] = true;
++                        counter = obfuscateLayer(15, dataBitsReader, dataBitsWriter, solid, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
 +                    }
-+
-+                    dataBitsWriter.finish();
-+                }
-+            }
-+
-+            chunkPacketInfoAntiXray.getPacketPlayOutMapChunk().setReady(true);
-+
-+        } finally {
-+            if (chunkPacketInfoAntiXray.ticketHold != null) {
-+                Runnable runnable = () -> {
-+                    Chunk chunk = chunkPacketInfoAntiXray.getChunk();
-+                    ChunkCoordIntPair chunkPos = chunk.getPos();
-+
-+                    ChunkPacketBlockControllerAntiXray.this.removeXrayTickets(chunkPos.x, chunkPos.z, (ChunkProviderServer) chunk.world.getChunkProvider(),
-+                        chunkPacketInfoAntiXray.ticketHold);
-+                };
-+                if (MinecraftServer.getServer().isMainThread()) {
-+                    runnable.run();
 +                } else {
-+                    MinecraftServer.getServer().scheduleOnMain(runnable);
++                    // If not, initialize the reader and other stuff for the chunk section above to obfuscate the upper layer of the current chunk section
++                    dataBitsReader.setBitsPerObject(chunkPacketInfoAntiXray.getBitsPerObject(chunkSectionIndex + 1));
++                    dataBitsReader.setIndex(chunkPacketInfoAntiXray.getDataBitsIndex(chunkSectionIndex + 1));
++                    solidTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex + 1), solid, solidGlobal);
++                    obfuscateTemp = readDataPalette(chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex + 1), obfuscate, obfuscateGlobal);
++                    boolean[][] temp = current;
++                    current = next;
++                    next = nextNext;
++                    nextNext = temp;
++                    counter = obfuscateLayer(15, dataBitsReader, dataBitsWriter, solidTemp, obfuscateTemp, predefinedBlockDataBitsTemp, current, next, nextNext, nearbyChunkSections, counter);
 +                }
++
++                dataBitsWriter.finish();
 +            }
 +        }
++
++        chunkPacketInfoAntiXray.getPacketPlayOutMapChunk().setReady(true);
 +    }
 +
 +    private int obfuscateLayer(int y, DataBitsReader dataBitsReader, DataBitsWriter dataBitsWriter, boolean[] solid, boolean[] obfuscate, int[] predefinedBlockDataBits, boolean[][] current, boolean[][] next, boolean[][] nextNext, ChunkSection[] nearbyChunkSections, int counter) {
-+        //First block of first line
++        // First block of first line
 +        int dataBits = dataBitsReader.read();
 +
 +        if (nextNext[0][0] = !solid[dataBits]) {
@@ -561,7 +422,7 @@ index 0000000000..23626bef3a
 +            next[0][0] = true;
 +        }
 +
-+        //First line
++        // First line
 +        for (int x = 1; x < 15; x++) {
 +            dataBits = dataBitsReader.read();
 +
@@ -587,7 +448,7 @@ index 0000000000..23626bef3a
 +            }
 +        }
 +
-+        //Last block of first line
++        // Last block of first line
 +        dataBits = dataBitsReader.read();
 +
 +        if (nextNext[0][15] = !solid[dataBits]) {
@@ -610,9 +471,9 @@ index 0000000000..23626bef3a
 +            next[0][15] = true;
 +        }
 +
-+        //All inner lines
++        // All inner lines
 +        for (int z = 1; z < 15; z++) {
-+            //First block
++            // First block
 +            dataBits = dataBitsReader.read();
 +
 +            if (nextNext[z][0] = !solid[dataBits]) {
@@ -636,7 +497,7 @@ index 0000000000..23626bef3a
 +                next[z][0] = true;
 +            }
 +
-+            //All inner blocks
++            // All inner blocks
 +            for (int x = 1; x < 15; x++) {
 +                dataBits = dataBitsReader.read();
 +
@@ -663,7 +524,7 @@ index 0000000000..23626bef3a
 +                }
 +            }
 +
-+            //Last block
++            // Last block
 +            dataBits = dataBitsReader.read();
 +
 +            if (nextNext[z][15] = !solid[dataBits]) {
@@ -688,7 +549,7 @@ index 0000000000..23626bef3a
 +            }
 +        }
 +
-+        //First block of last line
++        // First block of last line
 +        dataBits = dataBitsReader.read();
 +
 +        if (nextNext[15][0] = !solid[dataBits]) {
@@ -711,7 +572,7 @@ index 0000000000..23626bef3a
 +            next[15][0] = true;
 +        }
 +
-+        //Last line
++        // Last line
 +        for (int x = 1; x < 15; x++) {
 +            dataBits = dataBitsReader.read();
 +
@@ -737,7 +598,7 @@ index 0000000000..23626bef3a
 +            }
 +        }
 +
-+        //Last block of last line
++        // Last block of last line
 +        dataBits = dataBitsReader.read();
 +
 +        if (nextNext[15][15] = !solid[dataBits]) {
@@ -826,7 +687,7 @@ index 0000000000..23626bef3a
 +            updateBlock(world, blockPosition.north());
 +            updateBlock(world, blockPosition.south());
 +        } else {
-+            //Do nothing if updateRadius <= 0 (test mode)
++            // Do nothing if updateRadius <= 0 (test mode)
 +        }
 +    }
 +
@@ -834,7 +695,7 @@ index 0000000000..23626bef3a
 +        IBlockData blockData = world.getTypeIfLoaded(blockPosition);
 +
 +        if (blockData != null && obfuscateGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(blockData)]) {
-+            //world.notify(blockPosition, blockData, blockData, 3);
++            // world.notify(blockPosition, blockData, blockData, 3);
 +            ((WorldServer)world).getChunkProvider().flagDirty(blockPosition); // We only need to re-send to client
 +        }
 +    }
@@ -870,43 +731,10 @@ index 0000000000..23626bef3a
 +            return description;
 +        }
 +    }
-+
-+    public enum ChunkEdgeMode {
-+
-+        DEFAULT(1, "default"),
-+        WAIT(2, "wait until nearby chunks are loaded"),
-+        LOAD(3, "load nearby chunks");
-+
-+        private final int id;
-+        private final String description;
-+
-+        ChunkEdgeMode(int id, String description) {
-+            this.id = id;
-+            this.description = description;
-+        }
-+
-+        public static ChunkEdgeMode getById(int id) {
-+            for (ChunkEdgeMode chunkEdgeMode : values()) {
-+                if (chunkEdgeMode.id == id) {
-+                    return chunkEdgeMode;
-+                }
-+            }
-+
-+            return null;
-+        }
-+
-+        public int getId() {
-+            return id;
-+        }
-+
-+        public String getDescription() {
-+            return description;
-+        }
-+    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfo.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfo.java
 new file mode 100644
-index 0000000000..a68bace353
+index 00000000000..41618994b46
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfo.java
 @@ -0,0 +1,81 @@
@@ -970,7 +798,7 @@ index 0000000000..a68bace353
 +        dataPalettes[chunkSectionIndex] = dataPalette;
 +    }
 +
-+    public int getOrCreateIdForIndex(int chunkSectionIndex) {
++    public int getDataBitsIndex(int chunkSectionIndex) {
 +        return dataBitsIndexes[chunkSectionIndex];
 +    }
 +
@@ -993,21 +821,20 @@ index 0000000000..a68bace353
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfoAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfoAntiXray.java
 new file mode 100644
-index 0000000000..067dfb2f14
+index 00000000000..e61421d87a1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketInfoAntiXray.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,30 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import net.minecraft.server.Chunk;
 +import net.minecraft.server.IBlockData;
 +import net.minecraft.server.PacketPlayOutMapChunk;
 +
-+public class ChunkPacketInfoAntiXray extends ChunkPacketInfo<IBlockData> implements Runnable {
++public final class ChunkPacketInfoAntiXray extends ChunkPacketInfo<IBlockData> implements Runnable {
 +
 +    private Chunk[] nearbyChunks;
 +    private final ChunkPacketBlockControllerAntiXray chunkPacketBlockControllerAntiXray;
-+    public Integer ticketHold;
 +
 +    public ChunkPacketInfoAntiXray(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk, int chunkSectionSelector,
 +                                   ChunkPacketBlockControllerAntiXray chunkPacketBlockControllerAntiXray) {
@@ -1030,13 +857,13 @@ index 0000000000..067dfb2f14
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/DataBitsReader.java b/src/main/java/com/destroystokyo/paper/antixray/DataBitsReader.java
 new file mode 100644
-index 0000000000..cc586827aa
+index 00000000000..c5a7b186e96
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/DataBitsReader.java
 @@ -0,0 +1,56 @@
 +package com.destroystokyo.paper.antixray;
 +
-+public class DataBitsReader {
++public final class DataBitsReader {
 +
 +    private byte[] dataBits;
 +    private int bitsPerObject;
@@ -1092,13 +919,13 @@ index 0000000000..cc586827aa
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/DataBitsWriter.java b/src/main/java/com/destroystokyo/paper/antixray/DataBitsWriter.java
 new file mode 100644
-index 0000000000..37093419cf
+index 00000000000..2eff19f6aaa
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/DataBitsWriter.java
 @@ -0,0 +1,84 @@
 +package com.destroystokyo.paper.antixray;
 +
-+public class DataBitsWriter {
++public final class DataBitsWriter {
 +
 +    private byte[] dataBits;
 +    private int bitsPerObject;
@@ -1181,7 +1008,7 @@ index 0000000000..37093419cf
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index af0d6aff4d..472d3a4c03 100644
+index af0d6aff4de..2604fe9756e 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -416,7 +416,7 @@ public class Chunk implements IChunkAccess {
@@ -1189,12 +1016,12 @@ index af0d6aff4d..472d3a4c03 100644
              }
  
 -            chunksection = new ChunkSection(j >> 4 << 4);
-+            chunksection = new ChunkSection(j >> 4 << 4, this, this.world, true); // Paper - Anti-Xray
++            chunksection = new ChunkSection(j >> 4 << 4, this, this.world, true); // Paper - Anti-Xray - Add parameters
              this.sections[j >> 4] = chunksection;
          }
  
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 8e4b3e52cb..79e85520f3 100644
+index 8e4b3e52cbc..d287ea55c55 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -57,7 +57,7 @@ public class ChunkRegionLoader {
@@ -1202,7 +1029,7 @@ index 8e4b3e52cb..79e85520f3 100644
  
              if (nbttagcompound2.hasKeyOfType("Palette", 9) && nbttagcompound2.hasKeyOfType("BlockStates", 12)) {
 -                ChunkSection chunksection = new ChunkSection(b0 << 4);
-+                ChunkSection chunksection = new ChunkSection(b0 << 4, null, worldserver, false); // Paper - Anti-Xray
++                ChunkSection chunksection = new ChunkSection(b0 << 4, null, worldserver, false); // Paper - Anti-Xray - Add parameters
  
                  chunksection.getBlocks().a(nbttagcompound2.getList("Palette", 10), nbttagcompound2.getLongArray("BlockStates"));
                  chunksection.recalcBlockCounts();
@@ -1211,58 +1038,75 @@ index 8e4b3e52cb..79e85520f3 100644
              });
          } else {
 -            ProtoChunk protochunk = new ProtoChunk(chunkcoordintpair, chunkconverter, achunksection, protochunkticklist, protochunkticklist1);
-+            ProtoChunk protochunk = new ProtoChunk(chunkcoordintpair, chunkconverter, achunksection, protochunkticklist, protochunkticklist1, worldserver); // Paper - Anti-Xray
++            ProtoChunk protochunk = new ProtoChunk(chunkcoordintpair, chunkconverter, achunksection, protochunkticklist, protochunkticklist1, worldserver); // Paper - Anti-Xray - Add parameter
  
              protochunk.a(biomestorage);
              object = protochunk;
 diff --git a/src/main/java/net/minecraft/server/ChunkSection.java b/src/main/java/net/minecraft/server/ChunkSection.java
-index 0d5deee365..4526527aca 100644
+index e056fbcb216..eeb7eee925d 100644
 --- a/src/main/java/net/minecraft/server/ChunkSection.java
 +++ b/src/main/java/net/minecraft/server/ChunkSection.java
-@@ -6,21 +6,31 @@ public class ChunkSection {
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
  
-     public static final DataPalette<IBlockData> GLOBAL_PALETTE = new DataPaletteGlobal<>(Block.REGISTRY_ID, Blocks.AIR.getBlockData());
-     private final int yPos;
--    private short nonEmptyBlockCount;
-+    short nonEmptyBlockCount; // Paper - private -> package-private
-     private short tickingBlockCount;
++import com.destroystokyo.paper.antixray.ChunkPacketInfo; // Paper - Anti-Xray - Add chunk packet info
+ import javax.annotation.Nullable;
+ 
+ public class ChunkSection {
+@@ -11,16 +12,22 @@ public class ChunkSection {
      private short e;
      final DataPaletteBlock<IBlockData> blockIds;
  
-     public ChunkSection(int i) {
+-    public ChunkSection(int i) {
 -        this(i, (short) 0, (short) 0, (short) 0);
-+        // Paper start - add parameters
-+        this(i, (IChunkAccess)null, (IWorldReader)null, true);
-+    }
-+    public ChunkSection(int i, IChunkAccess chunk, IWorldReader world, boolean initializeBlocks) {
++    // Paper start - Anti-Xray - Add parameters
++    @Deprecated public ChunkSection(int i) { this(i, null, null, true); } // Notice for updates: Please make sure this constructor isn't used anywhere
++    public ChunkSection(int i, IChunkAccess chunk, World world, boolean initializeBlocks) {
 +        this(i, (short) 0, (short) 0, (short) 0, chunk, world, initializeBlocks);
 +        // Paper end
      }
  
-     public ChunkSection(int i, short short0, short short1, short short2) {
-+        // Paper start - add parameters
-+        this(i, short0, short1, short2, (IChunkAccess)null, (IWorldReader)null, true);
-+    }
-+    public ChunkSection(int i, short short0, short short1, short short2, IChunkAccess chunk, IWorldReader world, boolean initializeBlocks) {
+-    public ChunkSection(int i, short short0, short short1, short short2) {
++    // Paper start - Anti-Xray - Add parameters
++    @Deprecated public ChunkSection(int i, short short0, short short1, short short2) { this(i, short0, short1, short2, null, null, true); } // Notice for updates: Please make sure this constructor isn't used anywhere
++    public ChunkSection(int i, short short0, short short1, short short2, IChunkAccess chunk, World world, boolean initializeBlocks) {
 +        // Paper end
          this.yPos = i;
          this.nonEmptyBlockCount = short0;
          this.tickingBlockCount = short1;
          this.e = short2;
 -        this.blockIds = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData());
-+        this.blockIds = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData(), world instanceof GeneratorAccess ? ((GeneratorAccess) world).getMinecraftWorld().chunkPacketBlockController.getPredefinedBlockData(world, chunk, this, initializeBlocks) : null, initializeBlocks); // Paper - Anti-Xray - Add predefined block data
++        this.blockIds = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData(), world == null ? null : world.chunkPacketBlockController.getPredefinedBlockData(world, chunk, this, initializeBlocks), initializeBlocks); // Paper - Anti-Xray - Add predefined block data
      }
  
      public IBlockData getType(int i, int j, int k) {
+@@ -132,10 +139,14 @@ public class ChunkSection {
+         return this.blockIds;
+     }
+ 
+-    public void writeChunkSection(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // Paper - OBFHELPER
+-    public void b(PacketDataSerializer packetdataserializer) {
++    // Paper start - Anti-Xray - Add chunk packet info
++    @Deprecated public void writeChunkSection(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // OBFHELPER // Notice for updates: Please make sure this method isn't used anywhere
++    @Deprecated public void b(PacketDataSerializer packetdataserializer) { this.writeChunkSection(packetdataserializer, null); } // Notice for updates: Please make sure this method isn't used anywhere
++    public void writeChunkSection(PacketDataSerializer packetDataSerializer, ChunkPacketInfo<IBlockData> chunkPacketInfo) { this.b(packetDataSerializer, chunkPacketInfo); } // OBFHELPER
++    public void b(PacketDataSerializer packetdataserializer, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
++        // Paper end
+         packetdataserializer.writeShort(this.nonEmptyBlockCount);
+-        this.blockIds.b(packetdataserializer);
++        this.blockIds.writeDataPaletteBlock(packetdataserializer, chunkPacketInfo, this.yPos >> 4); // Paper - Anti-Xray - Add chunk packet info
+     }
+ 
+     public int j() {
 diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-index 2c1d1b1a55..44aed67274 100644
+index 2c1d1b1a556..2c7872bd051 100644
 --- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
 +++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
 @@ -3,6 +3,7 @@ package net.minecraft.server;
  import it.unimi.dsi.fastutil.ints.Int2IntMap;
  import it.unimi.dsi.fastutil.ints.Int2IntOpenHashMap;
  import it.unimi.dsi.fastutil.ints.Int2IntMap.Entry;
-+import com.destroystokyo.paper.antixray.ChunkPacketInfo; // Paper - Anti-Xray
++import com.destroystokyo.paper.antixray.ChunkPacketInfo; // Paper - Anti-Xray - Add chunk packet info
  import java.util.Arrays;
  import java.util.Objects;
  import java.util.concurrent.locks.ReentrantLock;
@@ -1274,16 +1118,15 @@ index 2c1d1b1a55..44aed67274 100644
      protected DataBits a; protected DataBits getDataBits() { return this.a; } // Paper - OBFHELPER
      private DataPalette<T> h; private DataPalette<T> getDataPalette() { return this.h; } // Paper - OBFHELPER
      private int i; private int getBitsPerObject() { return this.i; } // Paper - OBFHELPER
-@@ -47,14 +49,50 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+@@ -46,14 +48,47 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+         this.j.unlock();
      }
  
-     public DataPaletteBlock(DataPalette<T> datapalette, RegistryBlockID<T> registryblockid, Function<NBTTagCompound, T> function, Function<T, NBTTagCompound> function1, T t0) {
-+        // Paper start - Anti-Xray - Support default constructor
-+        this(datapalette, registryblockid, function, function1, t0, null, true);
-+    }
-+
+-    public DataPaletteBlock(DataPalette<T> datapalette, RegistryBlockID<T> registryblockid, Function<NBTTagCompound, T> function, Function<T, NBTTagCompound> function1, T t0) {
++    // Paper start - Anti-Xray - Add predefined objects
++    @Deprecated public DataPaletteBlock(DataPalette<T> datapalette, RegistryBlockID<T> registryblockid, Function<NBTTagCompound, T> function, Function<T, NBTTagCompound> function1, T t0) { this(datapalette, registryblockid, function, function1, t0, null, true); } // Notice for updates: Please make sure this constructor isn't used anywhere
 +    public DataPaletteBlock(DataPalette<T> datapalette, RegistryBlockID<T> registryblockid, Function<NBTTagCompound, T> function, Function<T, NBTTagCompound> function1, T t0, T[] predefinedObjects, boolean initialize) {
-+        // Paper end - Anti-Xray - Add predefined objects
++        // Paper end
          this.b = datapalette;
          this.d = registryblockid;
          this.e = function;
@@ -1311,8 +1154,8 @@ index 2c1d1b1a55..44aed67274 100644
 +            }
 +        }
 +        // Paper end
-     }
- 
++    }
++
 +    // Paper start - Anti-Xray - Add predefined objects
 +    private void addPredefinedObjects() {
 +        if (this.predefinedObjects != null && this.getDataPalette() != this.getDataPaletteGlobal()) {
@@ -1320,13 +1163,12 @@ index 2c1d1b1a55..44aed67274 100644
 +                this.getDataPalette().getOrCreateIdFor(this.predefinedObjects[i]);
 +            }
 +        }
-+    }
+     }
 +    // Paper end
-+
+ 
      private static int b(int i, int j, int k) {
          return j << 8 | k << 4 | i;
-     }
-@@ -88,6 +126,7 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+@@ -88,6 +123,7 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
  
          int j;
  
@@ -1334,19 +1176,21 @@ index 2c1d1b1a55..44aed67274 100644
          for (j = 0; j < databits.b(); ++j) {
              T t1 = datapalette.a(databits.a(j));
  
-@@ -139,22 +178,39 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+@@ -137,24 +173,38 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+         return t0 == null ? this.g : t0;
+     }
  
-     public void writeDataPaletteBlock(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // Paper - OBFHELPER
-     public void b(PacketDataSerializer packetdataserializer) {
-+        // Paper start - add parameters
-+        this.writeDataPaletteBlock(packetdataserializer, null, 0);
-+    }
-+    public void writeDataPaletteBlock(PacketDataSerializer packetdataserializer, ChunkPacketInfo<T> chunkPacketInfo, int chunkSectionIndex) {
+-    public void writeDataPaletteBlock(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // Paper - OBFHELPER
+-    public void b(PacketDataSerializer packetdataserializer) {
++    // Paper start - Anti-Xray - Add chunk packet info
++    @Deprecated public void writeDataPaletteBlock(PacketDataSerializer packetDataSerializer) { this.b(packetDataSerializer); } // OBFHELPER // Notice for updates: Please make sure this method isn't used anywhere
++    @Deprecated public void b(PacketDataSerializer packetdataserializer) { this.writeDataPaletteBlock(packetdataserializer, null, 0); } // Notice for updates: Please make sure this method isn't used anywhere
++    public void writeDataPaletteBlock(PacketDataSerializer packetDataSerializer, ChunkPacketInfo<T> chunkPacketInfo, int chunkSectionIndex) { this.b(packetDataSerializer, chunkPacketInfo, chunkSectionIndex); } // OBFHELPER
++    public void b(PacketDataSerializer packetdataserializer, ChunkPacketInfo<T> chunkPacketInfo, int chunkSectionIndex) {
 +        // Paper end
          this.a();
          packetdataserializer.writeByte(this.i);
          this.h.b(packetdataserializer);
-+
 +        // Paper start - Anti-Xray - Add chunk packet info
 +        if (chunkPacketInfo != null) {
 +            chunkPacketInfo.setBitsPerObject(chunkSectionIndex, this.getBitsPerObject());
@@ -1355,7 +1199,6 @@ index 2c1d1b1a55..44aed67274 100644
 +            chunkPacketInfo.setPredefinedObjects(chunkSectionIndex, this.predefinedObjects);
 +        }
 +        // Paper end
-+
          packetdataserializer.a(this.a.a());
          this.b();
      }
@@ -1377,7 +1220,7 @@ index 2c1d1b1a55..44aed67274 100644
  
          if (this.h == this.b) {
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index 02a9f3d5fa..55441e1002 100644
+index 02a9f3d5fa4..55441e10023 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -188,6 +188,11 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
@@ -1432,43 +1275,40 @@ index 02a9f3d5fa..55441e1002 100644
      public void a() {
          this.o();
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
-index 23223f3f45..e54663c214 100644
+index 23223f3f452..0d485064cac 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 @@ -1,5 +1,6 @@
  package net.minecraft.server;
  
-+import com.destroystokyo.paper.antixray.ChunkPacketInfo; // Paper - Anti-Xray
++import com.destroystokyo.paper.antixray.ChunkPacketInfo; // Paper - Anti-Xray - Add chunk packet info
  import com.google.common.collect.Lists;
  import io.netty.buffer.ByteBuf;
  import io.netty.buffer.Unpooled;
-@@ -20,8 +21,11 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -20,8 +21,13 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
      private byte[] f; private byte[] getData() { return this.f; } // Paper - OBFHELPER
      private List<NBTTagCompound> g;
      private boolean h;
 +    private volatile boolean ready; // Paper - Async-Anti-Xray - Ready flag for the network manager
  
 -    public PacketPlayOutMapChunk() {}
++    // Paper start - Async-Anti-Xray - Set the ready flag to true
 +    public PacketPlayOutMapChunk() {
-+        this.ready = true; // Paper - Async-Anti-Xray - Set the ready flag to true
++        this.ready = true;
 +    }
++    // Paper end
  
      // Paper start
      private final java.util.List<Packet> extraPackets = new java.util.ArrayList<>();
-@@ -33,6 +37,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -33,6 +39,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
      }
      // Paper end
      public PacketPlayOutMapChunk(Chunk chunk, int i) {
-+        // Paper start - add forceLoad param
-+        this(chunk, i, false);
-+    }
-+    public PacketPlayOutMapChunk(Chunk chunk, int i, boolean forceLoad) {
-+        // Paper end
-+        ChunkPacketInfo<IBlockData> chunkPacketInfo = chunk.world.chunkPacketBlockController.getChunkPacketInfo(this, chunk, i, forceLoad); // Paper - Anti-Xray - Add chunk packet info
++        ChunkPacketInfo<IBlockData> chunkPacketInfo = chunk.world.chunkPacketBlockController.getChunkPacketInfo(this, chunk, i); // Paper - Anti-Xray - Add chunk packet info
          ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
  
          this.a = chunkcoordintpair.x;
-@@ -55,7 +65,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -55,7 +62,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
          }
  
          this.f = new byte[this.a(chunk, i)];
@@ -1477,16 +1317,16 @@ index 23223f3f45..e54663c214 100644
 +        if (chunkPacketInfo != null) {
 +            chunkPacketInfo.setData(this.getData());
 +        }
++        this.c = this.writeChunk(new PacketDataSerializer(this.j()), chunk, i, chunkPacketInfo);
 +        // Paper end
-+        this.c = this.writeChunk(new PacketDataSerializer(this.j()), chunk, i, chunkPacketInfo); // Paper - Anti-Xray - Add chunk packet info
          this.g = Lists.newArrayList();
          iterator = chunk.getTileEntities().entrySet().iterator();
          int totalTileEntities = 0; // Paper
-@@ -82,9 +97,19 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -82,9 +94,19 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
                  this.g.add(nbttagcompound);
              }
          }
-+        chunk.world.chunkPacketBlockController.modifyBlocks(this, chunkPacketInfo, forceLoad, null); // Paper - Anti-Xray - Modify blocks
++        chunk.world.chunkPacketBlockController.modifyBlocks(this, chunkPacketInfo); // Paper - Anti-Xray - Modify blocks
 +    }
  
 +    // Paper start - Async-Anti-Xray - Getter and Setter for the ready flag
@@ -1502,55 +1342,32 @@ index 23223f3f45..e54663c214 100644
      @Override
      public void a(PacketDataSerializer packetdataserializer) throws IOException {
          this.a = packetdataserializer.readInt();
-@@ -151,6 +176,11 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -149,8 +171,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+         return bytebuf;
+     }
  
-     public int writeChunk(PacketDataSerializer packetDataSerializer, Chunk chunk, int chunkSectionSelector) { return this.a(packetDataSerializer, chunk, chunkSectionSelector); } // Paper - OBFHELPER
-     public int a(PacketDataSerializer packetdataserializer, Chunk chunk, int i) {
-+        // Paper start - Add parameter
-+        return this.writeChunk(packetdataserializer, chunk, i, null);
-+    }
-+    public int writeChunk(PacketDataSerializer packetdataserializer, Chunk chunk, int i, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
+-    public int writeChunk(PacketDataSerializer packetDataSerializer, Chunk chunk, int chunkSectionSelector) { return this.a(packetDataSerializer, chunk, chunkSectionSelector); } // Paper - OBFHELPER
+-    public int a(PacketDataSerializer packetdataserializer, Chunk chunk, int i) {
++    // Paper start - Anti-Xray - Add chunk packet info
++    @Deprecated public int writeChunk(PacketDataSerializer packetDataSerializer, Chunk chunk, int chunkSectionSelector) { return this.a(packetDataSerializer, chunk, chunkSectionSelector); } // OBFHELPER // Notice for updates: Please make sure this method isn't used anywhere
++    @Deprecated public int a(PacketDataSerializer packetdataserializer, Chunk chunk, int i) { return this.writeChunk(packetdataserializer, chunk, i, null); } // Notice for updates: Please make sure this method isn't used anywhere
++    public int writeChunk(PacketDataSerializer packetDataSerializer, Chunk chunk, int chunkSectionSelector, ChunkPacketInfo<IBlockData> chunkPacketInfo) { return this.a(packetDataSerializer, chunk, chunkSectionSelector, chunkPacketInfo); } // OBFHELPER
++    public int a(PacketDataSerializer packetdataserializer, Chunk chunk, int i, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
 +        // Paper end
          int j = 0;
          ChunkSection[] achunksection = chunk.getSections();
          int k = 0;
-@@ -160,7 +190,8 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -160,7 +186,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
  
              if (chunksection != Chunk.a && (!this.f() || !chunksection.c()) && (i & 1 << k) != 0) {
                  j |= 1 << k;
 -                chunksection.b(packetdataserializer);
-+                packetdataserializer.writeShort(chunksection.nonEmptyBlockCount); // Paper - Anti-Xray - Add chunk packet info
-+                chunksection.getBlocks().writeDataPaletteBlock(packetdataserializer, chunkPacketInfo, k); // Paper - Anti-Xray - Add chunk packet info
++                chunksection.writeChunkSection(packetdataserializer, chunkPacketInfo); // Paper - Anti-Xray - Add chunk packet info
              }
          }
  
-diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 040d4b41ea..f1620ba80e 100644
---- a/src/main/java/net/minecraft/server/PlayerChunk.java
-+++ b/src/main/java/net/minecraft/server/PlayerChunk.java
-@@ -223,6 +223,11 @@ public class PlayerChunk {
-             World world = chunk.getWorld();
- 
-             if (this.dirtyCount == 64) {
-+                // Paper start - Anti-Xray - Load nearby chunks if necessary
-+                if (!chunk.world.chunkPacketBlockController.onChunkPacketCreate(chunk, '\uffff', false)) {
-+                    return;
-+                }
-+                // Paper end
-                 this.s = -1;
-             }
- 
-@@ -255,7 +260,7 @@ public class PlayerChunk {
-                     this.a(world, blockposition);
-                 }
-             } else if (this.dirtyCount == 64) {
--                this.a(new PacketPlayOutMapChunk(chunk, this.r), false);
-+                this.a(new PacketPlayOutMapChunk(chunk, this.r, true), false); // Paper - Anti-Xray
-             } else if (this.dirtyCount != 0) {
-                 this.a(new PacketPlayOutMultiBlockChange(this.dirtyCount, this.dirtyBlocks, chunk), false);
- 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 9171785ad5..eb29d0e956 100644
+index 9171785ad54..94b0c54d9d4 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -604,7 +604,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -1558,21 +1375,12 @@ index 9171785ad5..eb29d0e956 100644
              }
  
 -            return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a));
-+            return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray
++            return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray - Add parameter
          }, this.executor);
      }
  
-@@ -1325,7 +1325,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
- 
-     private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
-         if (apacket[0] == null) {
--            apacket[0] = new PacketPlayOutMapChunk(chunk, 65535);
-+            apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, true); // Paper - Anti-Xray
-             apacket[1] = new PacketPlayOutLightUpdate(chunk.getPos(), this.lightEngine);
-         }
- 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 17b7eddac4..ce66090b8d 100644
+index 17b7eddac4f..ce66090b8dc 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -266,6 +266,8 @@ public class PlayerInteractManager {
@@ -1585,62 +1393,61 @@ index 17b7eddac4..ce66090b8d 100644
  
      public void a(BlockPosition blockposition, PacketPlayInBlockDig.EnumPlayerDigType packetplayinblockdig_enumplayerdigtype, String s) {
 diff --git a/src/main/java/net/minecraft/server/ProtoChunk.java b/src/main/java/net/minecraft/server/ProtoChunk.java
-index 39339fa275..f376e21068 100644
+index 39339fa2755..deb7fb09019 100644
 --- a/src/main/java/net/minecraft/server/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/server/ProtoChunk.java
-@@ -45,16 +45,28 @@ public class ProtoChunk implements IChunkAccess {
+@@ -45,16 +45,24 @@ public class ProtoChunk implements IChunkAccess {
      private long s;
      private final Map<WorldGenStage.Features, BitSet> t;
      private volatile boolean u;
-+    private final GeneratorAccess world; // Paper - Anti-Xray
++    private final World world; // Paper - Anti-Xray - Add world
  
-     public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter) {
-+        // Paper start - add world parameter
-+        this(chunkcoordintpair, chunkconverter, (GeneratorAccess)null);
-+    }
-+    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, GeneratorAccess world) {
+-    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter) {
++    // Paper start - Anti-Xray - Add world
++    @Deprecated public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter) { this(chunkcoordintpair, chunkconverter, null); } // Notice for updates: Please make sure this constructor isn't used anywhere
++    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, World world) {
 +        // Paper end
          this(chunkcoordintpair, chunkconverter, (ChunkSection[]) null, new ProtoChunkTickList<>((block) -> {
              return block == null || block.getBlockData().isAir();
          }, chunkcoordintpair), new ProtoChunkTickList<>((fluidtype) -> {
              return fluidtype == null || fluidtype == FluidTypes.EMPTY;
 -        }, chunkcoordintpair));
-+        }, chunkcoordintpair), world); // Paper - add world parameter
++        }, chunkcoordintpair), world); // Paper - Anti-Xray - Add world
      }
  
-     public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, @Nullable ChunkSection[] achunksection, ProtoChunkTickList<Block> protochunkticklist, ProtoChunkTickList<FluidType> protochunkticklist1) {
-+        // Paper start - add world parameter
-+        this(chunkcoordintpair, chunkconverter, achunksection, protochunkticklist, protochunkticklist1, (GeneratorAccess)null);
-+    }
-+    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, @Nullable ChunkSection[] achunksection, ProtoChunkTickList<Block> protochunkticklist, ProtoChunkTickList<FluidType> protochunkticklist1, GeneratorAccess world) {
+-    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, @Nullable ChunkSection[] achunksection, ProtoChunkTickList<Block> protochunkticklist, ProtoChunkTickList<FluidType> protochunkticklist1) {
++    // Paper start - Anti-Xray - Add world
++    @Deprecated public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, @Nullable ChunkSection[] achunksection, ProtoChunkTickList<Block> protochunkticklist, ProtoChunkTickList<FluidType> protochunkticklist1) { this(chunkcoordintpair, chunkconverter, achunksection, protochunkticklist, protochunkticklist1, null); } // Notice for updates: Please make sure this constructor isn't used anywhere
++    public ProtoChunk(ChunkCoordIntPair chunkcoordintpair, ChunkConverter chunkconverter, @Nullable ChunkSection[] achunksection, ProtoChunkTickList<Block> protochunkticklist, ProtoChunkTickList<FluidType> protochunkticklist1, World world) {
 +        this.world = world;
 +        // Paper end
          this.f = Maps.newEnumMap(HeightMap.Type.class);
          this.g = ChunkStatus.EMPTY;
          this.h = Maps.newHashMap();
-@@ -207,7 +219,7 @@ public class ProtoChunk implements IChunkAccess {
+@@ -207,7 +215,7 @@ public class ProtoChunk implements IChunkAccess {
  
      public ChunkSection a(int i) {
          if (this.j[i] == Chunk.a) {
 -            this.j[i] = new ChunkSection(i << 4);
-+            this.j[i] = new ChunkSection(i << 4, this, this.world, true); // Paper - Anti-Xray
++            this.j[i] = new ChunkSection(i << 4, this, this.world, true); // Paper - Anti-Xray - Add parameters
          }
  
          return this.j[i];
-diff --git a/src/main/java/net/minecraft/server/TicketType.java b/src/main/java/net/minecraft/server/TicketType.java
-index 75ab9f185b..4cf28bc2df 100644
---- a/src/main/java/net/minecraft/server/TicketType.java
-+++ b/src/main/java/net/minecraft/server/TicketType.java
-@@ -22,6 +22,7 @@ public class TicketType<T> {
-     public static final TicketType<Unit> PLUGIN = a("plugin", (a, b) -> 0); // CraftBukkit
-     public static final TicketType<org.bukkit.plugin.Plugin> PLUGIN_TICKET = a("plugin_ticket", (plugin1, plugin2) -> plugin1.getClass().getName().compareTo(plugin2.getClass().getName())); // CraftBukkit
-     public static final TicketType<Long> FUTURE_AWAIT = a("future_await", Long::compareTo); // Paper
-+    public static final TicketType<Integer> ANTIXRAY = a("antixray", Integer::compareTo); // Paper - Anti-Xray
+diff --git a/src/main/java/net/minecraft/server/ProtoChunkExtension.java b/src/main/java/net/minecraft/server/ProtoChunkExtension.java
+index 01bf28dc34d..caa18b046cd 100644
+--- a/src/main/java/net/minecraft/server/ProtoChunkExtension.java
++++ b/src/main/java/net/minecraft/server/ProtoChunkExtension.java
+@@ -11,7 +11,7 @@ public class ProtoChunkExtension extends ProtoChunk {
+     private final Chunk a;
  
-     public static <T> TicketType<T> a(String s, Comparator<T> comparator) {
-         return new TicketType<>(s, comparator, 0L);
+     public ProtoChunkExtension(Chunk chunk) {
+-        super(chunk.getPos(), ChunkConverter.a);
++        super(chunk.getPos(), ChunkConverter.a, chunk.world); // Paper - Anti-Xray - Add parameter
+         this.a = chunk;
+     }
+ 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8cf3c10274..0bde171743 100644
+index 8cf3c10274b..0bde1717431 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -1676,19 +1483,41 @@ index 8cf3c10274..0bde171743 100644
  
              if (iblockdata1 == null) {
                  // CraftBukkit start - remove blockstate if failed (or the same)
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+index a53bb7295c5..47f1b970b9b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+@@ -38,7 +38,7 @@ public class CraftChunk implements Chunk {
+     private final WorldServer worldServer;
+     private final int x;
+     private final int z;
+-    private static final DataPaletteBlock<IBlockData> emptyBlockIDs = new ChunkSection(0).getBlocks();
++    private static final DataPaletteBlock<IBlockData> emptyBlockIDs = new ChunkSection(0, null, null, true).getBlocks(); // Paper - Anti-Xray - Add parameters
+     private static final byte[] emptyLight = new byte[2048];
+ 
+     public CraftChunk(net.minecraft.server.Chunk chunk) {
+@@ -260,7 +260,7 @@ public class CraftChunk implements Chunk {
+                 NBTTagCompound data = new NBTTagCompound();
+                 cs[i].getBlocks().a(data, "Palette", "BlockStates");
+ 
+-                DataPaletteBlock blockids = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, net.minecraft.server.Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData()); // TODO: snapshot whole ChunkSection
++                DataPaletteBlock blockids = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, net.minecraft.server.Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData(), null, false); // TODO: snapshot whole ChunkSection // Paper - Anti-Xray - Add no predefined block data and don't initialize because it's done in the line below internally
+                 blockids.a(data.getList("Palette", CraftMagicNumbers.NBT.TAG_COMPOUND), data.getLongArray("BlockStates"));
+ 
+                 sectionBlockIDs[i] = blockids;
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-index 8191e7c348..969d548de2 100644
+index 8191e7c3489..bb18740ebdf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 @@ -21,9 +21,11 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
      private final int maxHeight;
      private final ChunkSection[] sections;
      private Set<BlockPosition> tiles;
-+    private World world; // Paper - Anti-Xray
++    private World world; // Paper - Anti-Xray - Add world
  
      public CraftChunkData(World world) {
          this(world.getMaxHeight());
-+        this.world = world; // Paper - Anti-Xray
++        this.world = world; // Paper - Anti-Xray - Add world
      }
  
      /* pp for tests */ CraftChunkData(int maxHeight) {
@@ -1697,10 +1526,10 @@ index 8191e7c348..969d548de2 100644
          ChunkSection section = sections[y >> 4];
          if (create && section == null) {
 -            sections[y >> 4] = section = new ChunkSection(y >> 4 << 4);
-+            sections[y >> 4] = section = new ChunkSection(y >> 4 << 4, null, world instanceof org.bukkit.craftbukkit.CraftWorld ? ((org.bukkit.craftbukkit.CraftWorld) world).getHandle() : null, true); // Paper - Anti-Xray
++            sections[y >> 4] = section = new ChunkSection(y >> 4 << 4, null, world instanceof org.bukkit.craftbukkit.CraftWorld ? ((org.bukkit.craftbukkit.CraftWorld) world).getHandle() : null, true); // Paper - Anti-Xray - Add parameters
          }
          return section;
      }
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0385-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0385-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -1,4 +1,4 @@
-From f77fcf79437fced19d5ccef532ec98b15c276de7 Mon Sep 17 00:00:00 2001
+From 2a775d142dadfb085d3d2cfa1d68d241266f561c Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 24 Mar 2019 01:01:32 -0400
 Subject: [PATCH] Only count Natural Spawned mobs towards natural spawn mob
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index df24e3297b..4c50109365 100644
+index ca2ac17747d..a3fc76b5122 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -507,6 +507,16 @@ public class PaperWorldConfig {
+@@ -505,6 +505,16 @@ public class PaperWorldConfig {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
  
@@ -38,7 +38,7 @@ index df24e3297b..4c50109365 100644
      public boolean asynchronous;
      public EngineMode engineMode;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 62c2275098..6654b91998 100644
+index ad5e538b249..5d1fa08f697 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -957,6 +957,13 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0386-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0386-Configurable-projectile-relative-velocity.patch
@@ -1,4 +1,4 @@
-From 0efdcafd549e5d42d9d5adb890fed341268ab025 Mon Sep 17 00:00:00 2001
+From 3e542a3222644e3e755f1eccaf1928aa032c811c Mon Sep 17 00:00:00 2001
 From: Lucavon <lucavonlp@gmail.com>
 Date: Tue, 23 Jul 2019 20:29:20 -0500
 Subject: [PATCH] Configurable projectile relative velocity
@@ -25,12 +25,12 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4c50109365..a09282e00e 100644
+index a3fc76b5122..90ba51e05bb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -555,4 +555,9 @@ public class PaperWorldConfig {
+@@ -543,4 +543,9 @@ public class PaperWorldConfig {
          }
-         log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Chunk Edge Mode: " + chunkEdgeMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
+         log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }
 +
 +    public boolean disableRelativeProjectileVelocity;
@@ -39,7 +39,7 @@ index 4c50109365..a09282e00e 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 634e2bd304..9c97edf9c9 100644
+index 634e2bd3049..9c97edf9c9e 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
 @@ -85,7 +85,7 @@ public abstract class EntityArrow extends Entity implements IProjectile {
@@ -52,7 +52,7 @@ index 634e2bd304..9c97edf9c9 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityProjectile.java b/src/main/java/net/minecraft/server/EntityProjectile.java
-index 6c091b6808..f5c8074dcf 100644
+index 6c091b68087..f5c8074dcf1 100644
 --- a/src/main/java/net/minecraft/server/EntityProjectile.java
 +++ b/src/main/java/net/minecraft/server/EntityProjectile.java
 @@ -43,7 +43,7 @@ public abstract class EntityProjectile extends Entity implements IProjectile {

--- a/Spigot-Server-Patches/0390-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0390-Asynchronous-chunk-IO-and-loading.patch
@@ -1,4 +1,4 @@
-From b7931612f141bfce24d6020ff0432b868b3e9852 Mon Sep 17 00:00:00 2001
+From 716ddcc84ced03f72de0bbb0f322f2abacec6431 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Sat, 13 Jul 2019 09:23:10 -0700
 Subject: [PATCH] Asynchronous chunk IO and loading
@@ -121,7 +121,7 @@ tasks required to be executed by the chunk load task (i.e lighting
 and some poi tasks).
 
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-index fa1c920ea6..98acbfa44d 100644
+index fa1c920ea60..98acbfa44dd 100644
 --- a/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -57,6 +57,17 @@ public class WorldTimingsHandler {
@@ -161,7 +161,7 @@ index fa1c920ea6..98acbfa44d 100644
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index dbd1439970..f4836e2da1 100644
+index dbd14399707..f4836e2da10 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -222,89 +222,9 @@ index dbd1439970..f4836e2da1 100644
 +        }
 +    }
  }
-diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-index 23626bef3a..1edcecd2ee 100644
---- a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-+++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -9,6 +9,7 @@ import java.util.concurrent.Executors;
- import java.util.concurrent.atomic.AtomicInteger;
- import java.util.function.Supplier;
- 
-+import com.destroystokyo.paper.io.PrioritizedTaskQueue;
- import net.minecraft.server.*;
- import org.bukkit.Bukkit;
- import org.bukkit.World.Environment;
-@@ -150,6 +151,12 @@ public class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockControll
- 
-     private final AtomicInteger xrayRequests = new AtomicInteger();
- 
-+    // Paper start - async chunk api
-+    private Integer nextTicketHold() {
-+        return Integer.valueOf(this.xrayRequests.getAndIncrement());
-+    }
-+    // Paper end
-+
-     private Integer addXrayTickets(final int x, final int z, final ChunkProviderServer chunkProvider) {
-         final Integer hold = Integer.valueOf(this.xrayRequests.getAndIncrement());
- 
-@@ -181,6 +188,35 @@ public class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockControll
-         chunk.world.getChunkAt(locX, locZ + 1);
-     }
- 
-+    // Paper start - async chunk api
-+    private void loadNeighbourAsync(ChunkProviderServer chunkProvider, WorldServer world, int chunkX, int chunkZ, int[] counter, java.util.function.Consumer<Chunk> onNeighourLoad, Runnable onAllNeighboursLoad) {
-+        chunkProvider.getChunkAtAsynchronously(chunkX, chunkZ, true, (Chunk neighbour) -> {
-+            onNeighourLoad.accept(neighbour);
-+            if (++counter[0] == 4) {
-+                onAllNeighboursLoad.run();
-+            }
-+        });
-+        world.asyncChunkTaskManager.raisePriority(chunkX, chunkZ, PrioritizedTaskQueue.HIGHER_PRIORITY);
-+    }
-+
-+    private void loadNeighboursAsync(Chunk chunk, java.util.function.Consumer<Chunk> onNeighourLoad, Runnable onAllNeighboursLoad) {
-+        int[] loaded = new int[1];
-+
-+        int locX = chunk.getPos().x;
-+        int locZ = chunk.getPos().z;
-+        WorldServer world = ((WorldServer)chunk.world);
-+
-+        onNeighourLoad.accept(chunk);
-+
-+        ChunkProviderServer chunkProvider = world.getChunkProvider();
-+
-+        this.loadNeighbourAsync(chunkProvider, world, locX - 1, locZ, loaded, onNeighourLoad, onAllNeighboursLoad);
-+        this.loadNeighbourAsync(chunkProvider, world, locX + 1, locZ, loaded, onNeighourLoad, onAllNeighboursLoad);
-+        this.loadNeighbourAsync(chunkProvider, world, locX, locZ - 1, loaded, onNeighourLoad, onAllNeighboursLoad);
-+        this.loadNeighbourAsync(chunkProvider, world, locX, locZ + 1, loaded, onNeighourLoad, onAllNeighboursLoad);
-+    }
-+    // Paper end
-+
-     @Override
-     public boolean onChunkPacketCreate(Chunk chunk, int chunkSectionSelector, boolean force) {
-         int locX = chunk.getPos().x;
-@@ -256,11 +292,15 @@ public class ChunkPacketBlockControllerAntiXray extends ChunkPacketBlockControll
- 
-             if (chunks[0] == null || chunks[1] == null || chunks[2] == null || chunks[3] == null) {
-                 // we need to load
--                MinecraftServer.getServer().scheduleOnMain(() -> {
--                    Integer ticketHold = this.addXrayTickets(locX, locZ, world.getChunkProvider());
--                    this.loadNeighbours(chunk);
-+                // Paper start - async chunk api
-+                Integer ticketHold = this.nextTicketHold();
-+                this.loadNeighboursAsync(chunk, (Chunk neighbour) -> { // when a neighbour is loaded
-+                        ((WorldServer)neighbour.world).getChunkProvider().addTicket(TicketType.ANTIXRAY, neighbour.getPos(), 0, ticketHold);
-+                },
-+                () -> { // once neighbours get loaded
-                     this.modifyBlocks(packetPlayOutMapChunk, chunkPacketInfo, false, ticketHold);
-                 });
-+                // Paper end
-                 return;
-             }
- 
 diff --git a/src/main/java/com/destroystokyo/paper/io/IOUtil.java b/src/main/java/com/destroystokyo/paper/io/IOUtil.java
 new file mode 100644
-index 0000000000..5af0ac3d9e
+index 00000000000..5af0ac3d9e8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/IOUtil.java
 @@ -0,0 +1,62 @@
@@ -372,7 +292,7 @@ index 0000000000..5af0ac3d9e
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/PaperFileIOThread.java b/src/main/java/com/destroystokyo/paper/io/PaperFileIOThread.java
 new file mode 100644
-index 0000000000..4f10a8311e
+index 00000000000..4f10a8311ea
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/PaperFileIOThread.java
 @@ -0,0 +1,661 @@
@@ -1039,7 +959,7 @@ index 0000000000..4f10a8311e
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/PrioritizedTaskQueue.java b/src/main/java/com/destroystokyo/paper/io/PrioritizedTaskQueue.java
 new file mode 100644
-index 0000000000..97f2e433c4
+index 00000000000..97f2e433c48
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/PrioritizedTaskQueue.java
 @@ -0,0 +1,277 @@
@@ -1322,7 +1242,7 @@ index 0000000000..97f2e433c4
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/QueueExecutorThread.java b/src/main/java/com/destroystokyo/paper/io/QueueExecutorThread.java
 new file mode 100644
-index 0000000000..ee906b594b
+index 00000000000..ee906b594b3
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/QueueExecutorThread.java
 @@ -0,0 +1,241 @@
@@ -1569,7 +1489,7 @@ index 0000000000..ee906b594b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java
 new file mode 100644
-index 0000000000..ac9bc3e231
+index 00000000000..ac9bc3e2316
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkLoadTask.java
 @@ -0,0 +1,149 @@
@@ -1724,7 +1644,7 @@ index 0000000000..ac9bc3e231
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/chunk/ChunkSaveTask.java b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkSaveTask.java
 new file mode 100644
-index 0000000000..60312b85f9
+index 00000000000..60312b85f9e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkSaveTask.java
 @@ -0,0 +1,112 @@
@@ -1842,7 +1762,7 @@ index 0000000000..60312b85f9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTask.java b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTask.java
 new file mode 100644
-index 0000000000..1dfa8abfd8
+index 00000000000..1dfa8abfd86
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTask.java
 @@ -0,0 +1,40 @@
@@ -1888,7 +1808,7 @@ index 0000000000..1dfa8abfd8
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTaskManager.java b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTaskManager.java
 new file mode 100644
-index 0000000000..2b20c159f6
+index 00000000000..2b20c159f6b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/io/chunk/ChunkTaskManager.java
 @@ -0,0 +1,492 @@
@@ -2385,7 +2305,7 @@ index 0000000000..2b20c159f6
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 4c9c8e4839..259af7095c 100644
+index 4c9c8e48397..259af7095c4 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -299,11 +299,137 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -2555,7 +2475,7 @@ index 4c9c8e4839..259af7095c 100644
          } finally {
              playerChunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 79e85520f3..7389aba1a4 100644
+index d287ea55c55..34cd09a503b 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
@@ -2820,7 +2740,7 @@ index 79e85520f3..7389aba1a4 100644
  
          nbttagcompound1.set("PostProcessing", a(ichunkaccess.l()));
 diff --git a/src/main/java/net/minecraft/server/ChunkStatus.java b/src/main/java/net/minecraft/server/ChunkStatus.java
-index 134a4f0b7d..40ce30cdc2 100644
+index 134a4f0b7d2..40ce30cdc2a 100644
 --- a/src/main/java/net/minecraft/server/ChunkStatus.java
 +++ b/src/main/java/net/minecraft/server/ChunkStatus.java
 @@ -153,6 +153,7 @@ public class ChunkStatus {
@@ -2856,7 +2776,7 @@ index 134a4f0b7d..40ce30cdc2 100644
          return this.c() >= chunkstatus.c();
      }
 diff --git a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
-index 7e5ece9d50..cfe43e882e 100644
+index 7e5ece9d50a..cfe43e882e5 100644
 --- a/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 +++ b/src/main/java/net/minecraft/server/IAsyncTaskHandler.java
 @@ -91,7 +91,7 @@ public abstract class IAsyncTaskHandler<R extends Runnable> implements Mailbox<R
@@ -2869,7 +2789,7 @@ index 7e5ece9d50..cfe43e882e 100644
              ;
          }
 diff --git a/src/main/java/net/minecraft/server/IChunkLoader.java b/src/main/java/net/minecraft/server/IChunkLoader.java
-index 2f95174fcc..134c76065b 100644
+index 2f95174fcc4..134c76065bf 100644
 --- a/src/main/java/net/minecraft/server/IChunkLoader.java
 +++ b/src/main/java/net/minecraft/server/IChunkLoader.java
 @@ -3,37 +3,49 @@ package net.minecraft.server;
@@ -2994,7 +2914,7 @@ index 2f95174fcc..134c76065b 100644
 +//    Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 2dcecc1bbd..d9941b38ca 100644
+index 2dcecc1bbd0..d9941b38ca0 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -627,4 +627,9 @@ public final class MCUtil {
@@ -3008,7 +2928,7 @@ index 2dcecc1bbd..d9941b38ca 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7ecf781263..26be349870 100644
+index 7ecf7812631..26be3498704 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -777,6 +777,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -3020,7 +2940,7 @@ index 7ecf781263..26be349870 100644
  
      public String getServerIp() {
 diff --git a/src/main/java/net/minecraft/server/NextTickListEntry.java b/src/main/java/net/minecraft/server/NextTickListEntry.java
-index e9c405fb53..33cfeabdee 100644
+index e9c405fb537..33cfeabdee0 100644
 --- a/src/main/java/net/minecraft/server/NextTickListEntry.java
 +++ b/src/main/java/net/minecraft/server/NextTickListEntry.java
 @@ -4,7 +4,7 @@ import java.util.Comparator;
@@ -3042,7 +2962,7 @@ index e9c405fb53..33cfeabdee 100644
          this.e = t0;
          this.b = i;
 diff --git a/src/main/java/net/minecraft/server/NibbleArray.java b/src/main/java/net/minecraft/server/NibbleArray.java
-index ed8c4a87b5..996c832638 100644
+index ed8c4a87b52..996c8326387 100644
 --- a/src/main/java/net/minecraft/server/NibbleArray.java
 +++ b/src/main/java/net/minecraft/server/NibbleArray.java
 @@ -71,6 +71,7 @@ public class NibbleArray {
@@ -3054,7 +2974,7 @@ index ed8c4a87b5..996c832638 100644
          return this.a == null ? new NibbleArray() : new NibbleArray((byte[]) this.a.clone());
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index f1620ba80e..74e6b8b973 100644
+index 040d4b41ea2..bf592125f4c 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -127,6 +127,18 @@ public class PlayerChunk {
@@ -3076,7 +2996,7 @@ index f1620ba80e..74e6b8b973 100644
      // Paper end
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
-@@ -357,7 +369,7 @@ public class PlayerChunk {
+@@ -352,7 +364,7 @@ public class PlayerChunk {
          ChunkStatus chunkstatus = getChunkStatus(this.oldTicketLevel);
          ChunkStatus chunkstatus1 = getChunkStatus(this.ticketLevel);
          boolean flag = this.oldTicketLevel <= PlayerChunkMap.GOLDEN_TICKET;
@@ -3085,7 +3005,7 @@ index f1620ba80e..74e6b8b973 100644
          PlayerChunk.State playerchunk_state = getChunkState(this.oldTicketLevel);
          PlayerChunk.State playerchunk_state1 = getChunkState(this.ticketLevel);
          // CraftBukkit start
-@@ -393,6 +405,12 @@ public class PlayerChunk {
+@@ -388,6 +400,12 @@ public class PlayerChunk {
                  }
              });
  
@@ -3099,7 +3019,7 @@ index f1620ba80e..74e6b8b973 100644
                  completablefuture = (CompletableFuture) this.statusFutures.get(i);
                  if (completablefuture != null) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index eb29d0e956..43abdb47fd 100644
+index 94b0c54d9d4..963ce3eeec6 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -63,7 +63,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -3308,7 +3228,7 @@ index eb29d0e956..43abdb47fd 100644
 @@ -605,7 +677,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
  
-             return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray
+             return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray - Add parameter
 -        }, this.executor);
 +            // Paper start - Async chunk io
 +        };
@@ -3588,7 +3508,7 @@ index eb29d0e956..43abdb47fd 100644
          return this.m;
      }
 diff --git a/src/main/java/net/minecraft/server/RegionFile.java b/src/main/java/net/minecraft/server/RegionFile.java
-index d37abf2cf3..df728e2c0a 100644
+index d37abf2cf30..df728e2c0a2 100644
 --- a/src/main/java/net/minecraft/server/RegionFile.java
 +++ b/src/main/java/net/minecraft/server/RegionFile.java
 @@ -36,6 +36,8 @@ public class RegionFile implements AutoCloseable {
@@ -3633,7 +3553,7 @@ index d37abf2cf3..df728e2c0a 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/RegionFileCache.java b/src/main/java/net/minecraft/server/RegionFileCache.java
-index 2f8af42e2a..2b9bf25fbb 100644
+index 2f8af42e2aa..2b9bf25fbb0 100644
 --- a/src/main/java/net/minecraft/server/RegionFileCache.java
 +++ b/src/main/java/net/minecraft/server/RegionFileCache.java
 @@ -9,7 +9,7 @@ import java.io.File;
@@ -3746,7 +3666,7 @@ index 2f8af42e2a..2b9bf25fbb 100644
 +    // CraftBukkit end
  }
 diff --git a/src/main/java/net/minecraft/server/RegionFileSection.java b/src/main/java/net/minecraft/server/RegionFileSection.java
-index db9f0196bd..a6d8ef5eb4 100644
+index db9f0196bda..a6d8ef5eb44 100644
 --- a/src/main/java/net/minecraft/server/RegionFileSection.java
 +++ b/src/main/java/net/minecraft/server/RegionFileSection.java
 @@ -20,28 +20,29 @@ import javax.annotation.Nullable;
@@ -3882,19 +3802,19 @@ index db9f0196bd..a6d8ef5eb4 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/TicketType.java b/src/main/java/net/minecraft/server/TicketType.java
-index 4cf28bc2df..6e0d0a54a2 100644
+index 75ab9f185b3..8055f599821 100644
 --- a/src/main/java/net/minecraft/server/TicketType.java
 +++ b/src/main/java/net/minecraft/server/TicketType.java
-@@ -23,6 +23,7 @@ public class TicketType<T> {
+@@ -22,6 +22,7 @@ public class TicketType<T> {
+     public static final TicketType<Unit> PLUGIN = a("plugin", (a, b) -> 0); // CraftBukkit
      public static final TicketType<org.bukkit.plugin.Plugin> PLUGIN_TICKET = a("plugin_ticket", (plugin1, plugin2) -> plugin1.getClass().getName().compareTo(plugin2.getClass().getName())); // CraftBukkit
      public static final TicketType<Long> FUTURE_AWAIT = a("future_await", Long::compareTo); // Paper
-     public static final TicketType<Integer> ANTIXRAY = a("antixray", Integer::compareTo); // Paper - Anti-Xray
 +    public static final TicketType<Long> ASYNC_LOAD = a("async_load", Long::compareTo); // Paper
  
      public static <T> TicketType<T> a(String s, Comparator<T> comparator) {
          return new TicketType<>(s, comparator, 0L);
 diff --git a/src/main/java/net/minecraft/server/VillagePlace.java b/src/main/java/net/minecraft/server/VillagePlace.java
-index c999f8c9bf..b59ef1a633 100644
+index c999f8c9bf8..b59ef1a6333 100644
 --- a/src/main/java/net/minecraft/server/VillagePlace.java
 +++ b/src/main/java/net/minecraft/server/VillagePlace.java
 @@ -24,8 +24,16 @@ public class VillagePlace extends RegionFileSection<VillagePlaceSection> {
@@ -3983,7 +3903,7 @@ index c999f8c9bf..b59ef1a633 100644
  
          HAS_SPACE(VillagePlaceRecord::d), IS_OCCUPIED(VillagePlaceRecord::e), ANY((villageplacerecord) -> {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 8561f96b9a..c0476f69e4 100644
+index 8561f96b9a1..c0476f69e4a 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -82,6 +82,79 @@ public class WorldServer extends World {
@@ -4089,7 +4009,7 @@ index 8561f96b9a..c0476f69e4 100644
      }
      public void removeTicketsForSpawn(int radiusInBlocks, BlockPosition spawn) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 50467656df..d3ac0ffe46 100644
+index 50467656df0..d3ac0ffe468 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -556,22 +556,23 @@ public class CraftWorld implements World {
@@ -4150,7 +4070,7 @@ index 50467656df..d3ac0ffe46 100644
      // Spigot start
      @Override
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index 07936eeba2..5bdcdcf9e8 100644
+index 07936eeba2a..5bdcdcf9e85 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -6,6 +6,7 @@ import java.lang.management.ThreadInfo;
@@ -4170,5 +4090,5 @@ index 07936eeba2..5bdcdcf9e8 100644
                  log.log( Level.SEVERE, "------------------------------" );
                  //
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0393-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0393-Implement-alternative-item-despawn-rate.patch
@@ -1,14 +1,14 @@
-From 13a14cbebd37e1738e91f4b7064ee6d6dcefdce8 Mon Sep 17 00:00:00 2001
+From 3791e9d22672ab8da1a91136665fa4789a604971 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Mon, 3 Jun 2019 02:02:39 -0400
 Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a09282e00e..9d9260ad07 100644
+index 90ba51e05bb..b1d09eb457c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,12 +1,17 @@
+@@ -1,10 +1,15 @@
  package com.destroystokyo.paper;
  
  import java.util.Arrays;
@@ -17,16 +17,14 @@ index a09282e00e..9d9260ad07 100644
  import java.util.List;
 +import java.util.Map;
  
- import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.ChunkEdgeMode;
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
- import net.minecraft.server.MinecraftServer;
  import org.bukkit.Bukkit;
 +import org.bukkit.Material;
 +import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -560,4 +565,52 @@ public class PaperWorldConfig {
+@@ -548,4 +553,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
@@ -80,7 +78,7 @@ index a09282e00e..9d9260ad07 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index ef2cf6565b..507627a29f 100644
+index ef2cf6565b5..507627a29f6 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
 @@ -6,6 +6,7 @@ import java.util.Objects;

--- a/Spigot-Server-Patches/0396-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0396-implement-optional-per-player-mob-spawns.patch
@@ -1,11 +1,11 @@
-From 8dae2149d4060a1a6797d7d6ce4971f97fa25612 Mon Sep 17 00:00:00 2001
+From c3eac674b85ef88b47b0906686409f976616c207 Mon Sep 17 00:00:00 2001
 From: kickash32 <kickash32@gmail.com>
 Date: Mon, 19 Aug 2019 01:27:58 +0500
 Subject: [PATCH] implement optional per player mob spawns
 
 
 diff --git a/src/main/java/co/aikar/timings/WorldTimingsHandler.java b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
-index 98acbfa44d..a94ebf7c76 100644
+index 98acbfa44dd..a94ebf7c76f 100644
 --- a/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 +++ b/src/main/java/co/aikar/timings/WorldTimingsHandler.java
 @@ -56,6 +56,7 @@ public class WorldTimingsHandler {
@@ -25,10 +25,10 @@ index 98acbfa44d..a94ebf7c76 100644
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9d9260ad07..fd3dbea628 100644
+index b1d09eb457c..515673e0fec 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -613,4 +613,9 @@ public class PaperWorldConfig {
+@@ -601,4 +601,9 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -40,7 +40,7 @@ index 9d9260ad07..fd3dbea628 100644
  }
 diff --git a/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java b/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java
 new file mode 100644
-index 0000000000..9ebd7ecb7a
+index 00000000000..9ebd7ecb7a0
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/PlayerMobDistanceMap.java
 @@ -0,0 +1,253 @@
@@ -299,7 +299,7 @@ index 0000000000..9ebd7ecb7a
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java b/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java
 new file mode 100644
-index 0000000000..4f13d3ff83
+index 00000000000..4f13d3ff839
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/PooledHashSets.java
 @@ -0,0 +1,241 @@
@@ -545,7 +545,7 @@ index 0000000000..4f13d3ff83
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index ea1117dc86..fe894a68bc 100644
+index ea1117dc86e..fe894a68bc2 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -741,7 +741,22 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -599,7 +599,7 @@ index ea1117dc86..fe894a68bc 100644
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index f375c9507c..fcd887ce30 100644
+index f375c9507c0..fcd887ce30d 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -81,6 +81,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -631,7 +631,7 @@ index f375c9507c..fcd887ce30 100644
          return this.cs;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 8427ee2ee8..0f04bcc8b7 100644
+index 8427ee2ee8b..0f04bcc8b7c 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -254,6 +254,7 @@ public class EntityTypes<T extends Entity> {
@@ -643,7 +643,7 @@ index 8427ee2ee8..0f04bcc8b7 100644
          return this.bb;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 43abdb47fd..0fd1d6b3e6 100644
+index 963ce3eeec6..692388821a7 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -78,7 +78,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -682,7 +682,7 @@ index 43abdb47fd..0fd1d6b3e6 100644
  
      private static double a(ChunkCoordIntPair chunkcoordintpair, Entity entity) {
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
-index fdac5bb3a2..58bbf2f9d2 100644
+index fdac5bb3a2d..58bbf2f9d2e 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java
 +++ b/src/main/java/net/minecraft/server/SpawnerCreature.java
 @@ -3,6 +3,7 @@ package net.minecraft.server;
@@ -755,7 +755,7 @@ index fdac5bb3a2..58bbf2f9d2 100644
  
      @Nullable
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 731f6a8320..38c5b721bf 100644
+index 731f6a83200..38c5b721bf1 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1028,7 +1028,20 @@ public class WorldServer extends World {
@@ -800,5 +800,5 @@ index 731f6a8320..38c5b721bf 100644
  
      @Override
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0400-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0400-Generator-Settings.patch
@@ -1,14 +1,14 @@
-From 290425bd369b23ac8a78758a5370a6025aa00252 Mon Sep 17 00:00:00 2001
+From 82d538f5599601f13e2c0537f26056d4ddf64b3f Mon Sep 17 00:00:00 2001
 From: Byteflux <byte@byteflux.net>
 Date: Wed, 2 Mar 2016 02:17:54 -0600
 Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd3dbea628..e790326c9c 100644
+index 515673e0fec..928fefb4195 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -618,4 +618,9 @@ public class PaperWorldConfig {
+@@ -606,4 +606,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }
@@ -19,7 +19,7 @@ index fd3dbea628..e790326c9c 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ChunkGeneratorAbstract.java b/src/main/java/net/minecraft/server/ChunkGeneratorAbstract.java
-index af81a84142..2268fbdd87 100644
+index af81a841428..2268fbdd871 100644
 --- a/src/main/java/net/minecraft/server/ChunkGeneratorAbstract.java
 +++ b/src/main/java/net/minecraft/server/ChunkGeneratorAbstract.java
 @@ -211,8 +211,8 @@ public abstract class ChunkGeneratorAbstract<T extends GeneratorSettingsDefault>

--- a/Spigot-Server-Patches/0401-Fix-zero-tick-instant-grow-farms-MC-113809.patch
+++ b/Spigot-Server-Patches/0401-Fix-zero-tick-instant-grow-farms-MC-113809.patch
@@ -1,14 +1,14 @@
-From 5fed7f9ec8c8aa7a94b1a4e595918b4f8013a071 Mon Sep 17 00:00:00 2001
+From 801216b8988793fedf4755e0731d1480eec6c88e Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Sun, 15 Sep 2019 11:32:32 -0500
 Subject: [PATCH] Fix zero-tick instant grow farms MC-113809
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e790326c9c..c37a0f035d 100644
+index 928fefb4195..44210855560 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -566,6 +566,11 @@ public class PaperWorldConfig {
+@@ -554,6 +554,11 @@ public class PaperWorldConfig {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
  
@@ -21,7 +21,7 @@ index e790326c9c..c37a0f035d 100644
      public Map<Material, Integer> altItemDespawnRateMap;
      private void altItemDespawnRate() {
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index 540fcce1dd..e29ec958b3 100644
+index 540fcce1dd4..e29ec958b35 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -46,6 +46,7 @@ public class Block implements IMaterial {
@@ -33,7 +33,7 @@ index 540fcce1dd..e29ec958b3 100644
      private final boolean i;
      private final boolean j;
 diff --git a/src/main/java/net/minecraft/server/BlockBamboo.java b/src/main/java/net/minecraft/server/BlockBamboo.java
-index c482aad3e3..02c548dd9c 100644
+index c482aad3e3e..02c548dd9c9 100644
 --- a/src/main/java/net/minecraft/server/BlockBamboo.java
 +++ b/src/main/java/net/minecraft/server/BlockBamboo.java
 @@ -85,6 +85,7 @@ public class BlockBamboo extends Block implements IBlockFragilePlantElement {
@@ -45,7 +45,7 @@ index c482aad3e3..02c548dd9c 100644
                  int i = this.b(worldserver, blockposition) + 1;
  
 diff --git a/src/main/java/net/minecraft/server/BlockCactus.java b/src/main/java/net/minecraft/server/BlockCactus.java
-index e0974e256f..3524fcb927 100644
+index e0974e256f0..3524fcb9278 100644
 --- a/src/main/java/net/minecraft/server/BlockCactus.java
 +++ b/src/main/java/net/minecraft/server/BlockCactus.java
 @@ -21,6 +21,7 @@ public class BlockCactus extends Block {
@@ -57,7 +57,7 @@ index e0974e256f..3524fcb927 100644
  
              if (worldserver.isEmpty(blockposition1)) {
 diff --git a/src/main/java/net/minecraft/server/BlockChorusFlower.java b/src/main/java/net/minecraft/server/BlockChorusFlower.java
-index d70b52cadf..b624cf3804 100644
+index d70b52cadf1..b624cf38047 100644
 --- a/src/main/java/net/minecraft/server/BlockChorusFlower.java
 +++ b/src/main/java/net/minecraft/server/BlockChorusFlower.java
 @@ -22,6 +22,7 @@ public class BlockChorusFlower extends Block {
@@ -69,7 +69,7 @@ index d70b52cadf..b624cf3804 100644
  
              if (worldserver.isEmpty(blockposition1) && blockposition1.getY() < 256) {
 diff --git a/src/main/java/net/minecraft/server/BlockReed.java b/src/main/java/net/minecraft/server/BlockReed.java
-index 55b07444e1..3bc3c5aa29 100644
+index 55b07444e1d..3bc3c5aa29f 100644
 --- a/src/main/java/net/minecraft/server/BlockReed.java
 +++ b/src/main/java/net/minecraft/server/BlockReed.java
 @@ -23,6 +23,7 @@ public class BlockReed extends Block {
@@ -81,7 +81,7 @@ index 55b07444e1..3bc3c5aa29 100644
  
              for (i = 1; worldserver.getType(blockposition.down(i)).getBlock() == this; ++i) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index fd8ca2a510..06d693ca2c 100644
+index 38c5b721bf1..17560a20fce 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -589,7 +589,9 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0407-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0407-Add-option-to-disable-pillager-patrols.patch
@@ -1,14 +1,14 @@
-From e83f3c71bce7c2e5d6532050e3760afa7a6a09a1 Mon Sep 17 00:00:00 2001
+From b9d5e577abc7ea9c81a07c063ab9a923115d29ee Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <blake.galbreath@gmail.com>
 Date: Wed, 9 Oct 2019 21:46:15 -0500
 Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c37a0f035d..3bbf77a8ec 100644
+index 44210855560..1c703e48e99 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -628,4 +628,9 @@ public class PaperWorldConfig {
+@@ -616,4 +616,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }
@@ -19,7 +19,7 @@ index c37a0f035d..3bbf77a8ec 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
-index 33488b37e4..a0f5828076 100644
+index 33488b37e4d..a0f58280760 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
 +++ b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
 @@ -9,6 +9,7 @@ public class MobSpawnerPatrol {

--- a/Spigot-Server-Patches/0413-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0413-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -1,14 +1,14 @@
-From 47791f6612fb0b2cef0f8ed0d8879f4c202628cf Mon Sep 17 00:00:00 2001
+From 9f361143cfd9838fb109508ae6b102b9102177b9 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Wed, 18 Dec 2019 22:21:35 -0600
 Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3bbf77a8ec..f8d8cb8655 100644
+index 1c703e48e99..e89ad807ed9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -633,4 +633,9 @@ public class PaperWorldConfig {
+@@ -621,4 +621,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }
@@ -19,7 +19,7 @@ index 3bbf77a8ec..f8d8cb8655 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java b/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
-index cd17bf2be5..b85e67a85d 100644
+index cd17bf2be53..b85e67a85d1 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalNearestAttackableTarget.java
 @@ -25,6 +25,7 @@ public class PathfinderGoalNearestAttackableTarget<T extends EntityLiving> exten
@@ -31,7 +31,7 @@ index cd17bf2be5..b85e67a85d 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/PathfinderTargetCondition.java b/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
-index c76a43837b..e35ec2db07 100644
+index c76a43837b4..e35ec2db078 100644
 --- a/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
 +++ b/src/main/java/net/minecraft/server/PathfinderTargetCondition.java
 @@ -80,7 +80,7 @@ public class PathfinderTargetCondition {

--- a/Spigot-Server-Patches/0414-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0414-Optimize-Hoppers.patch
@@ -1,4 +1,4 @@
-From dfaaff5f86e58598819bb62d004d6561ac6c58e9 Mon Sep 17 00:00:00 2001
+From a83dbbb1d5292071a139187a538339d01fb55545 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 27 Apr 2016 22:09:52 -0400
 Subject: [PATCH] Optimize Hoppers
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f8d8cb8655..3b8488d3ff 100644
+index e89ad807ed9..fca4b6e20ab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -638,4 +638,13 @@ public class PaperWorldConfig {
+@@ -626,4 +626,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
@@ -31,7 +31,7 @@ index f8d8cb8655..3b8488d3ff 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/IHopper.java b/src/main/java/net/minecraft/server/IHopper.java
-index e1aa272e52..4da26365ec 100644
+index e1aa272e526..4da26365ec5 100644
 --- a/src/main/java/net/minecraft/server/IHopper.java
 +++ b/src/main/java/net/minecraft/server/IHopper.java
 @@ -12,12 +12,13 @@ public interface IHopper extends IInventory {
@@ -53,7 +53,7 @@ index e1aa272e52..4da26365ec 100644
 +    double B();default double getZ() { return B(); } // Paper - OBFHELPER
  }
 diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
-index d953cdef14..d6e43313bf 100644
+index d953cdef14a..d6e43313bf0 100644
 --- a/src/main/java/net/minecraft/server/ItemStack.java
 +++ b/src/main/java/net/minecraft/server/ItemStack.java
 @@ -482,11 +482,12 @@ public final class ItemStack {
@@ -73,7 +73,7 @@ index d953cdef14..d6e43313bf 100644
              itemstack.d(this.C());
              if (this.tag != null) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 26be349870..63db74993c 100644
+index 26be3498704..63db74993c1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1219,6 +1219,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -85,7 +85,7 @@ index 26be349870..63db74993c 100644
                  this.methodProfiler.a(() -> {
                      return worldserver.getWorldData().getName() + " " + IRegistry.DIMENSION_TYPE.getKey(worldserver.worldProvider.getDimensionManager());
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 958279249f..a8e64dfdab 100644
+index 958279249fd..a8e64dfdab1 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -62,6 +62,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
@@ -105,7 +105,7 @@ index 958279249f..a8e64dfdab 100644
              this.world.b(this.position, this);
              if (!this.c.isAir()) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index 907d088c86..280c4e99e8 100644
+index 907d088c869..280c4e99e82 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -168,6 +168,160 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -370,7 +370,7 @@ index 907d088c86..280c4e99e8 100644
  
              if (!list.isEmpty()) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 568e04faa3..9e161746f2 100644
+index 568e04faa31..9e161746f2a 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1205,8 +1205,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0429-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0429-Seed-based-feature-search.patch
@@ -1,4 +1,4 @@
-From 0ff0fcc356722ec20778632a874e8ada0d934335 Mon Sep 17 00:00:00 2001
+From d792a6e7f49015ded97c2eb2d41c930cf246395a Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Mon, 13 Jan 2020 15:40:32 +0100
 Subject: [PATCH] Seed based feature search
@@ -15,10 +15,10 @@ changes but this should usually not happen. A config option to disable
 this improvement is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3b8488d3ff..bce502181f 100644
+index fca4b6e20ab..ade7af40eff 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -359,6 +359,12 @@ public class PaperWorldConfig {
+@@ -357,6 +357,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -32,7 +32,7 @@ index 3b8488d3ff..bce502181f 100644
      private void maxEntityCollision() {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
 diff --git a/src/main/java/net/minecraft/server/BiomeManager.java b/src/main/java/net/minecraft/server/BiomeManager.java
-index e96f544f12..68423645df 100644
+index e96f544f126..68423645df3 100644
 --- a/src/main/java/net/minecraft/server/BiomeManager.java
 +++ b/src/main/java/net/minecraft/server/BiomeManager.java
 @@ -12,10 +12,12 @@ public class BiomeManager {
@@ -49,7 +49,7 @@ index e96f544f12..68423645df 100644
          return this.c.a(this.b, blockposition.getX(), blockposition.getY(), blockposition.getZ(), this.a);
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
-index f2a19acd84..09f1308b0d 100644
+index f2a19acd845..09f1308b0d0 100644
 --- a/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 +++ b/src/main/java/net/minecraft/server/ChunkCoordIntPair.java
 @@ -64,10 +64,12 @@ public class ChunkCoordIntPair {
@@ -66,7 +66,7 @@ index f2a19acd84..09f1308b0d 100644
          return this.z << 4;
      }
 diff --git a/src/main/java/net/minecraft/server/StructureGenerator.java b/src/main/java/net/minecraft/server/StructureGenerator.java
-index e8ce2ecf23..acfe732af5 100644
+index e8ce2ecf23e..acfe732af5b 100644
 --- a/src/main/java/net/minecraft/server/StructureGenerator.java
 +++ b/src/main/java/net/minecraft/server/StructureGenerator.java
 @@ -109,6 +109,15 @@ public abstract class StructureGenerator<C extends WorldGenFeatureConfiguration>
@@ -94,7 +94,7 @@ index e8ce2ecf23..acfe732af5 100644
  
      public abstract StructureGenerator.a a();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 228e6e9ab9..f1d072a39c 100644
+index 228e6e9ab99..f1d072a39cc 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1569,8 +1569,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0435-Optimise-random-block-ticking.patch
+++ b/Spigot-Server-Patches/0435-Optimise-random-block-ticking.patch
@@ -1,4 +1,4 @@
-From caeded93e5038666588e0e7d377325a086b5ec11 Mon Sep 17 00:00:00 2001
+From 1ff4b88c8f2c5f43455442a2d76a0438c3d9c593 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Mon, 27 Jan 2020 21:28:00 -0800
 Subject: [PATCH] Optimise random block ticking
@@ -20,7 +20,7 @@ remains the same.
 
 diff --git a/src/main/java/com/destroystokyo/paper/util/math/ThreadUnsafeRandom.java b/src/main/java/com/destroystokyo/paper/util/math/ThreadUnsafeRandom.java
 new file mode 100644
-index 0000000000..3edc8e52e0
+index 00000000000..3edc8e52e06
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/math/ThreadUnsafeRandom.java
 @@ -0,0 +1,46 @@
@@ -71,7 +71,7 @@ index 0000000000..3edc8e52e0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index e29ec958b3..e40375b67a 100644
+index e29ec958b35..e40375b67a4 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -109,8 +109,8 @@ public class Block implements IMaterial {
@@ -86,7 +86,7 @@ index e29ec958b3..e40375b67a 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/BlockFluids.java b/src/main/java/net/minecraft/server/BlockFluids.java
-index 6d351f0979..a44f65f40d 100644
+index 6d351f0979e..a44f65f40d2 100644
 --- a/src/main/java/net/minecraft/server/BlockFluids.java
 +++ b/src/main/java/net/minecraft/server/BlockFluids.java
 @@ -27,7 +27,7 @@ public class BlockFluids extends Block implements IFluidSource {
@@ -99,7 +99,7 @@ index 6d351f0979..a44f65f40d 100644
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
-index db7ba12fd4..9010359fbd 100644
+index db7ba12fd4f..9010359fbdc 100644
 --- a/src/main/java/net/minecraft/server/BlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BlockPosition.java
 @@ -451,6 +451,7 @@ public class BlockPosition extends BaseBlockPosition implements MinecraftSeriali
@@ -111,7 +111,7 @@ index db7ba12fd4..9010359fbd 100644
              return this.d(baseblockposition.getX(), baseblockposition.getY(), baseblockposition.getZ());
          }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 42eede6781..65882f4632 100644
+index a2a0ca3394c..bb95fe20e8a 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -586,8 +586,8 @@ public class Chunk implements IChunkAccess {
@@ -126,40 +126,27 @@ index 42eede6781..65882f4632 100644
      }
  
 diff --git a/src/main/java/net/minecraft/server/ChunkSection.java b/src/main/java/net/minecraft/server/ChunkSection.java
-index 4526527aca..3eaf893cdf 100644
+index eeb7eee925d..64b625e988f 100644
 --- a/src/main/java/net/minecraft/server/ChunkSection.java
 +++ b/src/main/java/net/minecraft/server/ChunkSection.java
-@@ -5,12 +5,15 @@ import javax.annotation.Nullable;
+@@ -6,12 +6,14 @@ import javax.annotation.Nullable;
  public class ChunkSection {
  
      public static final DataPalette<IBlockData> GLOBAL_PALETTE = new DataPaletteGlobal<>(Block.REGISTRY_ID, Blocks.AIR.getBlockData());
 -    private final int yPos;
 +    final int yPos; // Paper - private -> package-private
-     short nonEmptyBlockCount; // Paper - private -> package-private
+     private short nonEmptyBlockCount;
 -    private short tickingBlockCount;
 +    short tickingBlockCount; // Paper - private -> package-private
      private short e;
      final DataPaletteBlock<IBlockData> blockIds;
  
-+    Chunk chunk; // Paper
 +    final com.destroystokyo.paper.util.maplist.IBlockDataList tickingList = new com.destroystokyo.paper.util.maplist.IBlockDataList(); // Paper
 +
-     public ChunkSection(int i) {
-         // Paper start - add parameters
-         this(i, (IChunkAccess)null, (IWorldReader)null, true);
-@@ -31,6 +34,11 @@ public class ChunkSection {
-         this.tickingBlockCount = short1;
-         this.e = short2;
-         this.blockIds = new DataPaletteBlock<>(ChunkSection.GLOBAL_PALETTE, Block.REGISTRY_ID, GameProfileSerializer::d, GameProfileSerializer::a, Blocks.AIR.getBlockData(), world instanceof GeneratorAccess ? ((GeneratorAccess) world).getMinecraftWorld().chunkPacketBlockController.getPredefinedBlockData(world, chunk, this, initializeBlocks) : null, initializeBlocks); // Paper - Anti-Xray - Add predefined block data
-+        // Paper start
-+        if (chunk instanceof Chunk) {
-+            this.chunk = (Chunk)chunk;
-+        }
-+        // Paper end
-     }
- 
-     public IBlockData getType(int i, int j, int k) {
-@@ -69,6 +77,9 @@ public class ChunkSection {
+     // Paper start - Anti-Xray - Add parameters
+     @Deprecated public ChunkSection(int i) { this(i, null, null, true); } // Notice for updates: Please make sure this constructor isn't used anywhere
+     public ChunkSection(int i, IChunkAccess chunk, World world, boolean initializeBlocks) {
+@@ -66,6 +68,9 @@ public class ChunkSection {
              --this.nonEmptyBlockCount;
              if (iblockdata1.q()) {
                  --this.tickingBlockCount;
@@ -169,7 +156,7 @@ index 4526527aca..3eaf893cdf 100644
              }
          }
  
-@@ -80,6 +91,9 @@ public class ChunkSection {
+@@ -77,6 +82,9 @@ public class ChunkSection {
              ++this.nonEmptyBlockCount;
              if (iblockdata.q()) {
                  ++this.tickingBlockCount;
@@ -179,7 +166,7 @@ index 4526527aca..3eaf893cdf 100644
              }
          }
  
-@@ -115,23 +129,29 @@ public class ChunkSection {
+@@ -112,23 +120,29 @@ public class ChunkSection {
      }
  
      public void recalcBlockCounts() {
@@ -215,7 +202,7 @@ index 4526527aca..3eaf893cdf 100644
              }
  
 diff --git a/src/main/java/net/minecraft/server/DataBits.java b/src/main/java/net/minecraft/server/DataBits.java
-index f9680b6830..a61cffa3f4 100644
+index f9680b6830c..a61cffa3f49 100644
 --- a/src/main/java/net/minecraft/server/DataBits.java
 +++ b/src/main/java/net/minecraft/server/DataBits.java
 @@ -127,4 +127,46 @@ public class DataBits {
@@ -266,10 +253,10 @@ index f9680b6830..a61cffa3f4 100644
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/DataPaletteBlock.java b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-index 44aed67274..fa664897fb 100644
+index 2c7872bd051..be5f98c3c36 100644
 --- a/src/main/java/net/minecraft/server/DataPaletteBlock.java
 +++ b/src/main/java/net/minecraft/server/DataPaletteBlock.java
-@@ -287,6 +287,14 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
+@@ -281,6 +281,14 @@ public class DataPaletteBlock<T> implements DataPaletteExpandable<T> {
          });
      }
  
@@ -285,7 +272,7 @@ index 44aed67274..fa664897fb 100644
      public interface a<T> {
  
 diff --git a/src/main/java/net/minecraft/server/EntityTurtle.java b/src/main/java/net/minecraft/server/EntityTurtle.java
-index dd02cb3485..b24a5100b4 100644
+index dd02cb34850..b24a5100b45 100644
 --- a/src/main/java/net/minecraft/server/EntityTurtle.java
 +++ b/src/main/java/net/minecraft/server/EntityTurtle.java
 @@ -29,7 +29,7 @@ public class EntityTurtle extends EntityAnimal {
@@ -298,7 +285,7 @@ index dd02cb3485..b24a5100b4 100644
  
      public final BlockPosition getHome() { return this.es(); } // Paper - OBFHELPER
 diff --git a/src/main/java/net/minecraft/server/IBlockData.java b/src/main/java/net/minecraft/server/IBlockData.java
-index de43881653..e821c236b4 100644
+index de43881653f..e821c236b45 100644
 --- a/src/main/java/net/minecraft/server/IBlockData.java
 +++ b/src/main/java/net/minecraft/server/IBlockData.java
 @@ -22,11 +22,15 @@ public class IBlockData extends BlockDataAbstract<Block, IBlockData> implements
@@ -351,7 +338,7 @@ index de43881653..e821c236b4 100644
  
      public final SoundEffectType getStepSound() { return this.r(); } // Paper - OBFHELPER
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 0c23fc89d7..de9f49b884 100644
+index 0c23fc89d7a..de9f49b8848 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1563,10 +1563,19 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -376,7 +363,7 @@ index 0c23fc89d7..de9f49b884 100644
  
      public boolean isSavingDisabled() {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index c348e3e500..fcbc9f2913 100644
+index c348e3e5008..fcbc9f29139 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -531,7 +531,12 @@ public class WorldServer extends World {
@@ -520,5 +507,5 @@ index c348e3e500..fcbc9f2913 100644
  
      protected BlockPosition a(BlockPosition blockposition) {
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0437-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0437-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -1,14 +1,14 @@
-From 1801e9752d6966f08a71b51e05ab6c491b48d82b Mon Sep 17 00:00:00 2001
+From 6653c1309749d5e38c16b384041f830ab03d8e1a Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Fri, 7 Feb 2020 14:36:56 -0600
 Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bce502181f..7d408542e7 100644
+index ade7af40eff..47c6d66b78e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -653,4 +653,9 @@ public class PaperWorldConfig {
+@@ -641,4 +641,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
@@ -19,7 +19,7 @@ index bce502181f..7d408542e7 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockPortal.java b/src/main/java/net/minecraft/server/BlockPortal.java
-index 2dc3ab4cfa..09c7c13183 100644
+index 2dc3ab4cfa3..09c7c131833 100644
 --- a/src/main/java/net/minecraft/server/BlockPortal.java
 +++ b/src/main/java/net/minecraft/server/BlockPortal.java
 @@ -45,6 +45,8 @@ public class BlockPortal extends Block {
@@ -32,7 +32,7 @@ index 2dc3ab4cfa..09c7c13183 100644
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 599bcabd14..00df89d650 100644
+index 599bcabd14a..00df89d6509 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -194,6 +194,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0443-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/Spigot-Server-Patches/0443-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -1,14 +1,14 @@
-From fd386fcfe4a32bb728ea791ccb60da1a057a9a32 Mon Sep 17 00:00:00 2001
+From 0ea5faac090c99ceedb906e1bc3b4eb4f2f398c7 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <blake.galbreath@gmail.com>
 Date: Sat, 13 Apr 2019 16:50:58 -0500
 Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d408542e7..c7cde1d0a0 100644
+index 47c6d66b78e..b773b750ae4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -415,6 +415,11 @@ public class PaperWorldConfig {
+@@ -413,6 +413,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  
@@ -21,7 +21,7 @@ index 7d408542e7..c7cde1d0a0 100644
      private void bedSearchRadius() {
          bedSearchRadius = getInt("bed-search-radius", 1);
 diff --git a/src/main/java/net/minecraft/server/EntityIronGolem.java b/src/main/java/net/minecraft/server/EntityIronGolem.java
-index 2f764776b2..7f6a567760 100644
+index 2f764776b2f..7f6a5677600 100644
 --- a/src/main/java/net/minecraft/server/EntityIronGolem.java
 +++ b/src/main/java/net/minecraft/server/EntityIronGolem.java
 @@ -221,7 +221,7 @@ public class EntityIronGolem extends EntityGolem {

--- a/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
@@ -1,4 +1,4 @@
-From 5dcb48861ffd63739b53bc714b86715494be1a79 Mon Sep 17 00:00:00 2001
+From 8231d190422655d01fdbdd3442ae00e1c9862a82 Mon Sep 17 00:00:00 2001
 From: Zero <zero@cock.li>
 Date: Sat, 22 Feb 2020 16:10:31 -0500
 Subject: [PATCH] Configurable chance of villager zombie infection
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c7cde1d0a0..7ca67a4aa5 100644
+index b773b750ae4..c3af4c9a9fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -663,4 +663,9 @@ public class PaperWorldConfig {
+@@ -651,4 +651,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
@@ -22,7 +22,7 @@ index c7cde1d0a0..7ca67a4aa5 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 8635d4f40c..07ebc1d816 100644
+index 8635d4f40ca..07ebc1d8161 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
 @@ -455,10 +455,14 @@ public class EntityZombie extends EntityMonster {

--- a/Spigot-Server-Patches/0445-Optimise-Chunk-getFluid.patch
+++ b/Spigot-Server-Patches/0445-Optimise-Chunk-getFluid.patch
@@ -1,4 +1,4 @@
-From 34b65530d5c531d836075966000e6c9dfafb2877 Mon Sep 17 00:00:00 2001
+From bb77add12b69b2a029463faaf86c67c643371777 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Tue, 14 Jan 2020 14:59:08 -0800
 Subject: [PATCH] Optimise Chunk#getFluid
@@ -8,7 +8,7 @@ faster on its own, however removing the try catch makes it
 easier to inline due to code size
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 65882f4632..696634ebf5 100644
+index bb95fe20e8a..33456b0bb42 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -379,17 +379,20 @@ public class Chunk implements IChunkAccess {
@@ -48,10 +48,10 @@ index 65882f4632..696634ebf5 100644
  
      // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/ChunkSection.java b/src/main/java/net/minecraft/server/ChunkSection.java
-index 3eaf893cdf..cda718bba0 100644
+index 64b625e988f..b7b06e082e5 100644
 --- a/src/main/java/net/minecraft/server/ChunkSection.java
 +++ b/src/main/java/net/minecraft/server/ChunkSection.java
-@@ -46,7 +46,7 @@ public class ChunkSection {
+@@ -37,7 +37,7 @@ public class ChunkSection {
      }
  
      public Fluid b(int i, int j, int k) {
@@ -61,5 +61,5 @@ index 3eaf893cdf..cda718bba0 100644
  
      public void a() {
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0446-Optimise-TickListServer-by-rewriting-it.patch
+++ b/Spigot-Server-Patches/0446-Optimise-TickListServer-by-rewriting-it.patch
@@ -1,4 +1,4 @@
-From fddb66ce22f3c1bbae3b98b54cfd7939fcfa9320 Mon Sep 17 00:00:00 2001
+From 356c51a88c4e469fe8d0627c3a8c713d4e15689a Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Fri, 14 Feb 2020 01:24:39 -0800
 Subject: [PATCH] Optimise TickListServer by rewriting it
@@ -42,7 +42,7 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f4836e2da1..647f6fc8ef 100644
+index f4836e2da10..647f6fc8efb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -369,6 +369,13 @@ public class PaperConfig {
@@ -61,7 +61,7 @@ index f4836e2da1..647f6fc8ef 100644
          ConfigurationSection section;
 diff --git a/src/main/java/com/destroystokyo/paper/server/ticklist/PaperTickList.java b/src/main/java/com/destroystokyo/paper/server/ticklist/PaperTickList.java
 new file mode 100644
-index 0000000000..ce653f6b4b
+index 00000000000..ce653f6b4be
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/server/ticklist/PaperTickList.java
 @@ -0,0 +1,622 @@
@@ -689,7 +689,7 @@ index 0000000000..ce653f6b4b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/server/ticklist/TickListServerInterval.java b/src/main/java/com/destroystokyo/paper/server/ticklist/TickListServerInterval.java
 new file mode 100644
-index 0000000000..13cf1a55a9
+index 00000000000..13cf1a55a9b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/server/ticklist/TickListServerInterval.java
 @@ -0,0 +1,41 @@
@@ -736,7 +736,7 @@ index 0000000000..13cf1a55a9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/util/set/LinkedSortedSet.java b/src/main/java/com/destroystokyo/paper/util/set/LinkedSortedSet.java
 new file mode 100644
-index 0000000000..118988c39e
+index 00000000000..118988c39e5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/util/set/LinkedSortedSet.java
 @@ -0,0 +1,142 @@
@@ -883,7 +883,7 @@ index 0000000000..118988c39e
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/BlockPosition.java b/src/main/java/net/minecraft/server/BlockPosition.java
-index e650a2e48d..2d07d350d2 100644
+index 9010359fbdc..07813c55cdc 100644
 --- a/src/main/java/net/minecraft/server/BlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BlockPosition.java
 @@ -125,6 +125,7 @@ public class BlockPosition extends BaseBlockPosition implements MinecraftSeriali
@@ -895,7 +895,7 @@ index e650a2e48d..2d07d350d2 100644
          return this.b(baseblockposition.getX(), baseblockposition.getY(), baseblockposition.getZ());
      }
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index e67e006535..ca1b5b3b09 100644
+index e67e0065357..ca1b5b3b094 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -200,6 +200,13 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -913,7 +913,7 @@ index e67e006535..ca1b5b3b09 100644
      public ChunkProviderServer(WorldServer worldserver, File file, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, ChunkGenerator<?> chunkgenerator, int i, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier) {
          this.world = worldserver;
 diff --git a/src/main/java/net/minecraft/server/NextTickListEntry.java b/src/main/java/net/minecraft/server/NextTickListEntry.java
-index 33cfeabdee..2287e47d1b 100644
+index 33cfeabdee0..2287e47d1b8 100644
 --- a/src/main/java/net/minecraft/server/NextTickListEntry.java
 +++ b/src/main/java/net/minecraft/server/NextTickListEntry.java
 @@ -5,11 +5,13 @@ import java.util.Comparator;
@@ -984,10 +984,10 @@ index 33cfeabdee..2287e47d1b 100644
      public String toString() {
          return this.e + ": " + this.a + ", " + this.b + ", " + this.c + ", " + this.f;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 74e6b8b973..04b97cec29 100644
+index bf592125f4c..3d610e41969 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
-@@ -477,7 +477,9 @@ public class PlayerChunk {
+@@ -472,7 +472,9 @@ public class PlayerChunk {
                      PlayerChunk.this.isTickingReady = true;
  
  
@@ -999,7 +999,7 @@ index 74e6b8b973..04b97cec29 100644
                  }
              });
 diff --git a/src/main/java/net/minecraft/server/StructureBoundingBox.java b/src/main/java/net/minecraft/server/StructureBoundingBox.java
-index dbb565e74d..185658e230 100644
+index dbb565e74d2..185658e2306 100644
 --- a/src/main/java/net/minecraft/server/StructureBoundingBox.java
 +++ b/src/main/java/net/minecraft/server/StructureBoundingBox.java
 @@ -4,12 +4,12 @@ import com.google.common.base.MoreObjects;
@@ -1038,7 +1038,7 @@ index dbb565e74d..185658e230 100644
          return baseblockposition.getX() >= this.a && baseblockposition.getX() <= this.d && baseblockposition.getZ() >= this.c && baseblockposition.getZ() <= this.f && baseblockposition.getY() >= this.b && baseblockposition.getY() <= this.e;
      }
 diff --git a/src/main/java/net/minecraft/server/TickListServer.java b/src/main/java/net/minecraft/server/TickListServer.java
-index f533860bbe..3f1aa5ced6 100644
+index f533860bbed..3f1aa5ced69 100644
 --- a/src/main/java/net/minecraft/server/TickListServer.java
 +++ b/src/main/java/net/minecraft/server/TickListServer.java
 @@ -42,6 +42,11 @@ public class TickListServer<T> implements TickList<T> {
@@ -1161,7 +1161,7 @@ index f533860bbe..3f1aa5ced6 100644
      }
  }
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 9a2b4fa7a2..9b9e242432 100644
+index fcbc9f29139..5173731dc55 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -170,6 +170,15 @@ public class WorldServer extends World {

--- a/Spigot-Server-Patches/0447-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0447-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -1,4 +1,4 @@
-From bdec2cdf5fdacc359764dd666f6e45ffe8056fd3 Mon Sep 17 00:00:00 2001
+From d636af4fc71167bc8dab4c302c7254a087cf6ef1 Mon Sep 17 00:00:00 2001
 From: Phoenix616 <mail@moep.tv>
 Date: Sat, 1 Feb 2020 16:50:39 +0100
 Subject: [PATCH] Pillager patrol spawn settings and per player options
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7ca67a4aa5..803be76772 100644
+index c3af4c9a9fe..3f44be577e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -641,10 +641,21 @@ public class PaperWorldConfig {
+@@ -629,10 +629,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;
@@ -36,7 +36,7 @@ index 7ca67a4aa5..803be76772 100644
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index cf837bdb3b..900631ebe0 100644
+index cf837bdb3b2..900631ebe05 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -77,6 +77,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -48,7 +48,7 @@ index cf837bdb3b..900631ebe0 100644
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
-index a0f5828076..edca6d3abd 100644
+index a0f58280760..edca6d3abdc 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
 +++ b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
 @@ -4,12 +4,14 @@ import java.util.Random;
@@ -128,7 +128,7 @@ index a0f5828076..edca6d3abd 100644
                              if (entityhuman.isSpectator()) {
                                  return 0;
 diff --git a/src/main/java/net/minecraft/server/StatisticWrapper.java b/src/main/java/net/minecraft/server/StatisticWrapper.java
-index 3b6034038a..9c95c0ccfc 100644
+index 3b6034038a4..9c95c0ccfcd 100644
 --- a/src/main/java/net/minecraft/server/StatisticWrapper.java
 +++ b/src/main/java/net/minecraft/server/StatisticWrapper.java
 @@ -27,6 +27,7 @@ public class StatisticWrapper<T> implements Iterable<Statistic<T>> {
@@ -140,5 +140,5 @@ index 3b6034038a..9c95c0ccfc 100644
          return this.a(t0, Counter.DEFAULT);
      }
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0458-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0458-Increase-Light-Queue-Size.patch
@@ -1,4 +1,4 @@
-From 996bb55a72ebbe9ee6543b1e56a721208fa7f7cf Mon Sep 17 00:00:00 2001
+From a6e7765b2ccf8621cbef028703c1a20ad6a03a0f Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Wed, 8 Apr 2020 21:24:05 -0400
 Subject: [PATCH] Increase Light Queue Size
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 803be76772..3c0468bc44 100644
+index 3f44be577e3..a4815f5e69c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -679,4 +679,9 @@ public class PaperWorldConfig {
+@@ -667,4 +667,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
@@ -28,7 +28,7 @@ index 803be76772..3c0468bc44 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d1f82eff21..77adc64e30 100644
+index d1f82eff218..77adc64e30c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -637,7 +637,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -41,5 +41,5 @@ index d1f82eff21..77adc64e30 100644
          // CraftBukkit start
          this.forceTicks = false;
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0463-Implement-Chunk-Priority-Urgency-System-for-World-Ge.patch
+++ b/Spigot-Server-Patches/0463-Implement-Chunk-Priority-Urgency-System-for-World-Ge.patch
@@ -1,4 +1,4 @@
-From 29c2fec0e51219fb6b6cf9ef100c18f6f4ca3d4b Mon Sep 17 00:00:00 2001
+From 58d879a91971e96b5d2d5190bf8ca139db82a522 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sat, 11 Apr 2020 03:56:07 -0400
 Subject: [PATCH] Implement Chunk Priority / Urgency System for World Gen
@@ -16,7 +16,7 @@ lots of chunks already.
 This massively reduces the lag spikes from sync chunk gens.
 
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index 747305619b..746b5b5589 100644
+index 747305619b5..746b5b55896 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -308,6 +308,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -59,7 +59,7 @@ index 747305619b..746b5b5589 100644
                  return ichunkaccess1;
              }, (playerchunk_failure) -> {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 04b97cec29..568fbbd5f2 100644
+index 3d610e41969..4b341c81fc9 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -43,6 +43,111 @@ public class PlayerChunk {
@@ -187,7 +187,7 @@ index 04b97cec29..568fbbd5f2 100644
      // Paper end
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
-@@ -354,7 +465,7 @@ public class PlayerChunk {
+@@ -349,7 +460,7 @@ public class PlayerChunk {
      }
  
      public int k() {
@@ -197,7 +197,7 @@ index 04b97cec29..568fbbd5f2 100644
  
      private void d(int i) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index db5a35598d..22550f74df 100644
+index 00f26ae23da..6c178492b75 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -291,6 +291,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -280,5 +280,5 @@ index db5a35598d..22550f74df 100644
              return either.flatMap((list) -> {
                  Chunk chunk = (Chunk) list.get(list.size() / 2);
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0491-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0491-Add-phantom-creative-and-insomniac-controls.patch
@@ -1,14 +1,14 @@
-From c123493ddbfdf4ed2cda2ce0d60c7fadd995a7db Mon Sep 17 00:00:00 2001
+From 677c2d8b9fdcace682753b32175bbc16a3df9c59 Mon Sep 17 00:00:00 2001
 From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Sat, 25 Apr 2020 15:13:41 -0500
 Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3c0468bc44..bfb52d75c7 100644
+index a4815f5e69c..4612697569f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -684,4 +684,11 @@ public class PaperWorldConfig {
+@@ -672,4 +672,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
@@ -21,7 +21,7 @@ index 3c0468bc44..bfb52d75c7 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPhantom.java b/src/main/java/net/minecraft/server/EntityPhantom.java
-index 90eeddb1af..96b4912c48 100644
+index 90eeddb1af5..96b4912c483 100644
 --- a/src/main/java/net/minecraft/server/EntityPhantom.java
 +++ b/src/main/java/net/minecraft/server/EntityPhantom.java
 @@ -232,6 +232,7 @@ public class EntityPhantom extends EntityFlying implements IMonster {
@@ -33,7 +33,7 @@ index 90eeddb1af..96b4912c48 100644
                              return true;
                          }
 diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
-index a2d1ef3602..1398c47a2f 100644
+index a2d1ef3602a..1398c47a2f8 100644
 --- a/src/main/java/net/minecraft/server/IEntitySelector.java
 +++ b/src/main/java/net/minecraft/server/IEntitySelector.java
 @@ -23,6 +23,7 @@ public final class IEntitySelector {
@@ -45,7 +45,7 @@ index a2d1ef3602..1398c47a2f 100644
      public static Predicate<Entity> a(double d0, double d1, double d2, double d3) {
          double d4 = d3 * d3;
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerPhantom.java b/src/main/java/net/minecraft/server/MobSpawnerPhantom.java
-index f488c22ed6..0db431cd6a 100644
+index f488c22ed64..0db431cd6ad 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerPhantom.java
 +++ b/src/main/java/net/minecraft/server/MobSpawnerPhantom.java
 @@ -31,7 +31,7 @@ public class MobSpawnerPhantom {
@@ -58,5 +58,5 @@ index f488c22ed6..0db431cd6a 100644
  
                              if (!worldserver.worldProvider.f() || blockposition.getY() >= worldserver.getSeaLevel() && worldserver.f(blockposition)) {
 -- 
-2.26.0
+2.26.2
 

--- a/Spigot-Server-Patches/0506-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0506-No-Tick-view-distance-implementation.patch
@@ -1,4 +1,4 @@
-From 8e744f5b5d46417c511bce46f59fc1c329d30394 Mon Sep 17 00:00:00 2001
+From bd2cf1b4ef75665ee95267f4e238ee92fb64dcb6 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Tue, 5 May 2020 21:23:34 -0700
 Subject: [PATCH] No-Tick view distance implementation
@@ -9,10 +9,10 @@ Per-Player is absent due to difficulty of maintaining
 the diff required to make it happen.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bfb52d75c7..57baf7092d 100644
+index 4612697569f..5c8a946d5c8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -691,4 +691,9 @@ public class PaperWorldConfig {
+@@ -679,4 +679,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
@@ -23,7 +23,7 @@ index bfb52d75c7..57baf7092d 100644
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 53d3acccd3..af8a3e186e 100644
+index 69bfece7d43..2332f126f73 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -245,7 +245,51 @@ public class Chunk implements IChunkAccess {
@@ -79,7 +79,7 @@ index 53d3acccd3..af8a3e186e 100644
  
      public final boolean areNeighboursLoaded(final int radius) {
 diff --git a/src/main/java/net/minecraft/server/ChunkMapDistance.java b/src/main/java/net/minecraft/server/ChunkMapDistance.java
-index 7cd4e29123..942efe62fe 100644
+index 7cd4e291235..942efe62fe5 100644
 --- a/src/main/java/net/minecraft/server/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/ChunkMapDistance.java
 @@ -252,7 +252,7 @@ public abstract class ChunkMapDistance {
@@ -101,7 +101,7 @@ index 7cd4e29123..942efe62fe 100644
                  if (flag1) {
                      ChunkMapDistance.this.j.a(ChunkTaskQueueSorter.a(() -> { // CraftBukkit - decompile error
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 6e8179b465..e32c458dfe 100644
+index 6e8179b4651..e32c458dfe5 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -111,6 +111,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -114,7 +114,7 @@ index 6e8179b465..e32c458dfe 100644
          super((World) worldserver, gameprofile);
          playerinteractmanager.player = this;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 8742d13499..72ce7bf0c3 100644
+index bae9371a1e2..9d71c4c455d 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -160,6 +160,18 @@ public class PlayerChunk {
@@ -154,7 +154,7 @@ index 8742d13499..72ce7bf0c3 100644
  
          if (chunk != null) {
              chunk.setNeedsSaving(true);
-@@ -431,9 +443,48 @@ public class PlayerChunk {
+@@ -426,9 +438,48 @@ public class PlayerChunk {
      }
  
      private void a(Packet<?> packet, boolean flag) {
@@ -207,7 +207,7 @@ index 8742d13499..72ce7bf0c3 100644
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 099e612171..345f2689c7 100644
+index 4317d9b98e4..a3abad95a11 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -71,7 +71,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -539,7 +539,7 @@ index 099e612171..345f2689c7 100644
 +    final void sendChunk(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) { this.a(entityplayer, apacket, chunk); } // Paper - OBFHELPER
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {
-             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, true); // Paper - Anti-Xray
+             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535);
 @@ -2014,7 +2145,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
@@ -550,7 +550,7 @@ index 099e612171..345f2689c7 100644
                          }
                      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index edf9df8c8a..ec95b63e51 100644
+index edf9df8c8ad..ec95b63e51a 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -150,7 +150,7 @@ public abstract class PlayerList {
@@ -581,7 +581,7 @@ index edf9df8c8a..ec95b63e51 100644
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 899c535c40..0e6368d0fb 100644
+index 899c535c405..0e6368d0fb3 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -443,8 +443,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -600,7 +600,7 @@ index 899c535c40..0e6368d0fb 100644
  
              if (!this.isClientSide && (i & 1) != 0) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 995f706678..ee7ae46389 100644
+index 995f706678f..ee7ae463898 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2483,10 +2483,39 @@ public class CraftWorld implements World {
@@ -645,7 +645,7 @@ index 995f706678..ee7ae46389 100644
      private final Spigot spigot = new Spigot()
      {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index d873b8cf3a..f735217e7a 100644
+index d873b8cf3ae..f735217e7a9 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -201,7 +201,7 @@ public class ActivationRange
@@ -658,5 +658,5 @@ index d873b8cf3a..f735217e7a 100644
          for ( EntityHuman player : world.getPlayers() )
          {
 -- 
-2.26.0
+2.26.2
 


### PR DESCRIPTION
**Undo the accidental renaming of a method in 0aad8bf**
Aikar wanted to rename DataPalette<T>#getDataBits(T object) to getOrCreateIdFor
in 0aad8bf but he also accidentally renamed
ChunkPacketInfo<T>#getDataBitsIndex(int chunkSectionIndex) to
getOrCreateIdForIndex.

**Remove chunk-edge-mode and chunk loading entirely from Anti-Xray**
The chunk-edge-mode is broken since several versions.
Loading chunk neighbors for chunk edge obfuscation isn't needed anymore.
Unlike in previous versions, these are under normal circumstances already loaded
at the time we need them (plugins for example can bypass this).

**Use the modified methods and constructors everywhere**
Anti-Xray provides support for the default nms methods and constructors,
which where modified by Anti-Xray to avoid breaking stuff (plugins)
which somehow uses these methods.
However, the modified versions of those methods and constructors should be used
where possible.

~~**Remove support for the default methods and constructors**
Actually, in all cases the modified methods and constructors should be used.
The idea behind it was, that I didn't want to break plugins for example,
which make use of that nms stuff.
On the other hand it is bad supporting the default methods and constructors
because this makes updating more error-prone.
In particular it's easy to miss a new method or constructor call in an update,
which should be changed to call the modified one.~~

**Improve some comments**