### PR TITLE
Anti Xray: Obfuscate blocks touching lava feature

### DIFF
--- a/Spigot-Server-Patches/0364-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0364-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..28ee5c483c7e7987f12c0afd6df785fe583fcbf5 100644
+index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..75c30889ec186dbae35159d9a4a38494fad0f6df 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -37,7 +37,7 @@ index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..28ee5c483c7e7987f12c0afd6df785fe
 +        maxChunkSectionIndex = getInt("anti-xray.max-chunk-section-index", 3);
 +        maxChunkSectionIndex = maxChunkSectionIndex > 15 ? 15 : maxChunkSectionIndex;
 +        updateRadius = getInt("anti-xray.update-radius", 2);
-+        lavaObscures = getBoolean("anti-xray.lava-obscures", true);
++        lavaObscures = getBoolean("anti-xray.lava-obscures", false);
 +        hiddenBlocks = getList("anti-xray.hidden-blocks", Arrays.asList("gold_ore", "iron_ore", "coal_ore", "lapis_ore", "mossy_cobblestone", "obsidian", "chest", "diamond_ore", "redstone_ore", "clay", "emerald_ore", "ender_chest"));
 +        replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList("stone", "oak_planks"));
 +        if (PaperConfig.version < 19) {

--- a/Spigot-Server-Patches/0364-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0364-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..fd869c25b83670ded11678988288ab1322b9b001 100644
+index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..28ee5c483c7e7987f12c0afd6df785fe583fcbf5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..fd869c25b83670ded11678988288ab13
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -454,4 +456,31 @@ public class PaperWorldConfig {
+@@ -454,4 +456,33 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
@@ -27,6 +27,7 @@ index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..fd869c25b83670ded11678988288ab13
 +    public EngineMode engineMode;
 +    public int maxChunkSectionIndex;
 +    public int updateRadius;
++    public boolean lavaObscures;
 +    public List<String> hiddenBlocks;
 +    public List<String> replacementBlocks;
 +    private void antiXray() {
@@ -36,6 +37,7 @@ index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..fd869c25b83670ded11678988288ab13
 +        maxChunkSectionIndex = getInt("anti-xray.max-chunk-section-index", 3);
 +        maxChunkSectionIndex = maxChunkSectionIndex > 15 ? 15 : maxChunkSectionIndex;
 +        updateRadius = getInt("anti-xray.update-radius", 2);
++        lavaObscures = getBoolean("anti-xray.lava-obscures", true);
 +        hiddenBlocks = getList("anti-xray.hidden-blocks", Arrays.asList("gold_ore", "iron_ore", "coal_ore", "lapis_ore", "mossy_cobblestone", "obsidian", "chest", "diamond_ore", "redstone_ore", "clay", "emerald_ore", "ender_chest"));
 +        replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList("stone", "oak_planks"));
 +        if (PaperConfig.version < 19) {
@@ -98,10 +100,10 @@ index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..70b854c2619551df1f1984204010fa15b743234a
+index 0000000000000000000000000000000000000000..9e48bcfae4fd4d56d8740907b91f501f1b4e0686
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,604 @@
+@@ -0,0 +1,605 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
@@ -202,7 +204,8 @@ index 0000000000000000000000000000000000000000..70b854c2619551df1f1984204010fa15
 +
 +            if (blockData != null) {
 +                solidGlobal[i] = blockData.isOccluding(emptyChunk, zeroPos)
-+                    && blockData.getBlock() != Blocks.SPAWNER && blockData.getBlock() != Blocks.BARRIER && blockData.getBlock() != Blocks.SHULKER_BOX;
++                    && blockData.getBlock() != Blocks.SPAWNER && blockData.getBlock() != Blocks.BARRIER && blockData.getBlock() != Blocks.SHULKER_BOX || paperWorldConfig.lavaObscures && blockData == Blocks.LAVA.getBlockData();
++                // Comparing blockData == Blocks.LAVA.getBlockData() instead of blockData.getBlock() == Blocks.LAVA ensures that only "stationary lava" is used
 +                // shulker box checks TE.
 +            }
 +        }

--- a/Spigot-Server-Patches/0366-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0366-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bdfaaa535a9339a8f6fb51d5fb7892becf617097..b83abceb55fd6cc6bde3e34da098e9916e3a497b 100644
+index b8e322d8b0f26546d7e5b41d0c0fa538c5b31c49..602e8f575cbafc5dbebd4916f1e19581e661f0d1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -493,4 +493,9 @@ public class PaperWorldConfig {
+@@ -495,4 +495,9 @@ public class PaperWorldConfig {
          }
          log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }

--- a/Spigot-Server-Patches/0373-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0373-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b83abceb55fd6cc6bde3e34da098e9916e3a497b..8221a9f5af9207b0a984ba2555df0e7690ff50ad 100644
+index 602e8f575cbafc5dbebd4916f1e19581e661f0d1..c534762f45eb502ec721ae28e03e55b724904c52 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,10 +1,15 @@
@@ -24,7 +24,7 @@ index b83abceb55fd6cc6bde3e34da098e9916e3a497b..8221a9f5af9207b0a984ba2555df0e76
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -498,4 +503,52 @@ public class PaperWorldConfig {
+@@ -500,4 +505,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0376-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0376-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8221a9f5af9207b0a984ba2555df0e7690ff50ad..aaa7ff2c861005618f3b2ab8f960a5199fd678ce 100644
+index c534762f45eb502ec721ae28e03e55b724904c52..91e78bfedf3e4fa1ee39b8dc7f7c5af8492da160 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -551,4 +551,9 @@ public class PaperWorldConfig {
+@@ -553,4 +553,9 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/Spigot-Server-Patches/0379-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0379-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index aaa7ff2c861005618f3b2ab8f960a5199fd678ce..6a102f56316b50c1993890d225b0eb4d619452c1 100644
+index 91e78bfedf3e4fa1ee39b8dc7f7c5af8492da160..802102dc716e99eaa3cc061995498e7cbe4e4f89 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -556,4 +556,9 @@ public class PaperWorldConfig {
+@@ -558,4 +558,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0385-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0385-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6a102f56316b50c1993890d225b0eb4d619452c1..06ed45f35025a0ce16ff80fa4316d8da98ed3c6a 100644
+index 802102dc716e99eaa3cc061995498e7cbe4e4f89..e654d215722e795027dbc504ef3c45ae94341bd3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -561,4 +561,9 @@ public class PaperWorldConfig {
+@@ -563,4 +563,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0390-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0390-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 06ed45f35025a0ce16ff80fa4316d8da98ed3c6a..b94c8e33780e10e458951384ffc49bd7fb015a6b 100644
+index e654d215722e795027dbc504ef3c45ae94341bd3..b79cd5945504a13f64f91e617099dea6f6893966 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -566,4 +566,9 @@ public class PaperWorldConfig {
+@@ -568,4 +568,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0391-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0391-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b94c8e33780e10e458951384ffc49bd7fb015a6b..d846c55de176879e94f6c0e5bf8f58910657fc75 100644
+index b79cd5945504a13f64f91e617099dea6f6893966..05a6d3a63e7b52515f788dda3af86750eaadaa65 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -571,4 +571,13 @@ public class PaperWorldConfig {
+@@ -573,4 +573,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0411-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0411-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d846c55de176879e94f6c0e5bf8f58910657fc75..5517caf85740c7d8ac29dba74f5da1c026629f63 100644
+index 05a6d3a63e7b52515f788dda3af86750eaadaa65..3d3423d3ccf4c92145ae803254ff85b67e3f14bf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -580,4 +580,9 @@ public class PaperWorldConfig {
+@@ -582,4 +582,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/Spigot-Server-Patches/0417-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0417-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8ef1c03cde1cc882ae96d684b26cbba0f8f75f83..b633d74450c40bcc8831836f79a7a2daa43e3d35 100644
+index 2700c626cdb612eec7f570c595b6f08365dd89c9..d8369d936bb7c060de1950878922998fd6804aa9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -590,4 +590,9 @@ public class PaperWorldConfig {
+@@ -592,4 +592,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0420-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0420-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b633d74450c40bcc8831836f79a7a2daa43e3d35..6c80906d0cf3594a30aa201793a16a29ffeb1fcb 100644
+index d8369d936bb7c060de1950878922998fd6804aa9..cc9b7cda00cce146a033a55d1b34fe4184173103 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -568,10 +568,21 @@ public class PaperWorldConfig {
+@@ -570,10 +570,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0430-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0430-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6c80906d0cf3594a30aa201793a16a29ffeb1fcb..82ff9cc4ae84ca120f7b0c4bd14c55d1a4280358 100644
+index cc9b7cda00cce146a033a55d1b34fe4184173103..0a8d127460730e7817f0f64509b9a9732096550b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -606,4 +606,9 @@ public class PaperWorldConfig {
+@@ -608,4 +608,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0459-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0459-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 82ff9cc4ae84ca120f7b0c4bd14c55d1a4280358..c6843f37f89f0df8a021f6f4b3ed048e6d36549a 100644
+index 0a8d127460730e7817f0f64509b9a9732096550b..a6dcc3606dd1f8aa963d4f09cad93d918d555339 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -611,4 +611,11 @@ public class PaperWorldConfig {
+@@ -613,4 +613,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0471-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0471-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c6843f37f89f0df8a021f6f4b3ed048e6d36549a..6a62f2000a58312773a8cb57c546d65df980b844 100644
+index a6dcc3606dd1f8aa963d4f09cad93d918d555339..ab9170c8440dbd30639c2d451b58583fef13220e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -618,4 +618,9 @@ public class PaperWorldConfig {
+@@ -620,4 +620,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/Spigot-Server-Patches/0496-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0496-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6a62f2000a58312773a8cb57c546d65df980b844..e1f943507de05f9f9559b8625342a02d9b8a51d6 100644
+index ab9170c8440dbd30639c2d451b58583fef13220e..af34b3430d74a8a7e86b7c9ebcd3f734a168da9c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -623,4 +623,13 @@ public class PaperWorldConfig {
+@@ -625,4 +625,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0508-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0508-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e1f943507de05f9f9559b8625342a02d9b8a51d6..d5a1ade21749bba420257f3ece7878f32148d6ff 100644
+index af34b3430d74a8a7e86b7c9ebcd3f734a168da9c..54e23de4a5058d6327bd2fdc7016e2ac3b287af1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -632,4 +632,26 @@ public class PaperWorldConfig {
+@@ -634,4 +634,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/Spigot-Server-Patches/0562-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0562-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d5a1ade21749bba420257f3ece7878f32148d6ff..b286928cca6effb7adf07bfd2882cb6c5bbffcf2 100644
+index 54e23de4a5058d6327bd2fdc7016e2ac3b287af1..11460f83fa2f4b075a4d37c0ff94ace960a89b60 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -654,4 +654,9 @@ public class PaperWorldConfig {
+@@ -656,4 +656,9 @@ public class PaperWorldConfig {
              maxLightningFlashDistance = 512; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0564-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0564-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b286928cca6effb7adf07bfd2882cb6c5bbffcf2..fbfea9e981bdc90d679d315b5e75ba01d3d396a0 100644
+index 11460f83fa2f4b075a4d37c0ff94ace960a89b60..81e75e1ad07a887de524f16c5bc1c44b6ae2eb9a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -659,4 +659,14 @@ public class PaperWorldConfig {
+@@ -661,4 +661,14 @@ public class PaperWorldConfig {
      private void zombiesTargetTurtleEggs() {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }


### PR DESCRIPTION
Resolves #2940.
Obfuscating blocks touching lava can be disabled by setting the new config
option anti-xray.lava-obscures in the paper world config to false.
Clearing lava with a bucket or replacing it by a transparent block already
triggers block updates for nearby blocks.