### PR TITLE
Add original source block data to BlockPhysicsEvent

### DIFF
--- a/Spigot-API-Patches/0206-Add-original-source-block-data-to-BlockPhysicsEvent.patch
+++ b/Spigot-API-Patches/0206-Add-original-source-block-data-to-BlockPhysicsEvent.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Sun, 10 May 2020 09:26:14 -0500
+Subject: [PATCH] Add original source block data to BlockPhysicsEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java b/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
+index c382f9fc2b8c5b959df7071007110dab737e400e..b7ffc22aeec457276c3d3cd215c96791533395b9 100644
+--- a/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockPhysicsEvent.java
+@@ -29,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
+ public class BlockPhysicsEvent extends BlockEvent implements Cancellable {
+     private static final HandlerList handlers = new HandlerList();
+     private final BlockData changed;
++    private final BlockData originalSourceData; // Paper
+     private final Block sourceBlock;
+     private boolean cancel = false;
+ 
+@@ -47,11 +48,35 @@ public class BlockPhysicsEvent extends BlockEvent implements Cancellable {
+         super(block);
+         this.changed = changed;
+         this.sourceBlock = sourceBlock;
++        this.originalSourceData = sourceBlock.getBlockData(); // Paper
++    }
++
++    // Paper start
++    public BlockPhysicsEvent(@NotNull final Block block, @NotNull final BlockData changed, @NotNull final BlockData originalSourceData) {
++        this(block, changed, block, originalSourceData);
++    }
++
++    public BlockPhysicsEvent(@NotNull final Block block, @NotNull final BlockData changed, @NotNull final Block sourceBlock, @NotNull final BlockData originalSourceData) {
++        super(block);
++        this.changed = changed;
++        this.sourceBlock = sourceBlock;
++        this.originalSourceData = originalSourceData;
+     }
+ 
+     /**
+-     * Gets the source block that triggered this event.
++     * Gets the Original BlockData of the block that triggered this event which may not be the same as the sourceBlock.
+      *
++     * @return The source block data
++     */
++    @NotNull
++    public BlockData getOriginalSourceData() {
++        return originalSourceData;
++    }
++    // Paper end
++
++    /**
++     * Gets the source block that triggered this event.
++     * <p>
+      * Note: This will default to block if not set.
+      *
+      * @return The source block

--- a/Spigot-Server-Patches/0514-Add-original-source-block-data-to-BlockPhysicsEvent.patch
+++ b/Spigot-Server-Patches/0514-Add-original-source-block-data-to-BlockPhysicsEvent.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Sun, 10 May 2020 09:26:14 -0500
+Subject: [PATCH] Add original source block data to BlockPhysicsEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 0e6368d0fb3beccb492ae3867fb4e22825f928a2..4039d407f60308acc34dfa8ef326ebfa339c22fe 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -466,7 +466,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                 iblockdata1.b(this, blockposition, j); // Don't call an event for the old block to limit event spam
+                 CraftWorld world = ((WorldServer) this).getWorld();
+                 if (world != null && ((WorldServer)this).hasPhysicsEvent) { // Paper
+-                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata));
++                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata), CraftBlockData.fromData(iblockdata1));
+                     this.getServer().getPluginManager().callEvent(event);
+ 
+                     if (event.isCancelled()) {
+@@ -592,7 +592,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                 // CraftBukkit start
+                 CraftWorld world = ((WorldServer) this).getWorld();
+                 if (world != null && ((WorldServer)this).hasPhysicsEvent) { // Paper
+-                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata), world.getBlockAt(blockposition1.getX(), blockposition1.getY(), blockposition1.getZ()));
++                    BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata), world.getBlockAt(blockposition1.getX(), blockposition1.getY(), blockposition1.getZ()), CraftBlockData.fromData(block.getBlockData())); // Paper
+                     this.getServer().getPluginManager().callEvent(event);
+ 
+                     if (event.isCancelled()) {


### PR DESCRIPTION
BlockPhysicsEvent did not provide sufficient data in all cases. The best use-case example for this PR is block-break chain reactions. For example, breaking a dirt block with a torch attached to it would provide a PhysicsEvent that indicated an AIR source block caused the Torch to break. What isn't known from the event is that the Source block used to be a dirt block. Another example is that some Redstone Torch behaviors like burnout would only tell you "AIR is affecting this RS Torch", but that wasn't causing it to break, merely flicker. Hopefully this grants some more control over what to do with this event.

Ultimately, this allows more information for players to be able to determine a Physics "Block Break" in the absence of a perhaps more useful "BlockBrokenByBlockEvent" or something.