### PR TITLE
Add missing mob goals

### DIFF
--- a/Spigot-API-Patches/0202-Add-Mob-Goal-API.patch
+++ b/Spigot-API-Patches/0202-Add-Mob-Goal-API.patch
@@ -223,10 +223,10 @@ index 0000000000000000000000000000000000000000..e21f7574763dd4f13794f91bbef192ef
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5afd2ea41d4
+index 0000000000000000000000000000000000000000..d23ad96ee436ae57231bbf88eed19487dec06780
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/VanillaGoal.java
-@@ -0,0 +1,182 @@
+@@ -0,0 +1,198 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import com.destroystokyo.paper.entity.RangedEntity;
@@ -242,7 +242,13 @@ index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5af
 +
 +    GoalKey<Bee> BEE_ATTACK = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_attack"));
 +    GoalKey<Bee> BEE_BECOME_ANGRY = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_become_angry"));
++    GoalKey<Bee> BEE_ENTER_HIVE = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_enter_hive"));
++    GoalKey<Bee> BEE_GO_TO_HIVE = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_go_to_hive"));
++    GoalKey<Bee> BEE_GO_TO_KNOWN_FLOWER = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_go_to_known_flower"));
++    GoalKey<Bee> BEE_GROW_CROP = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_grow_crop"));
 +    GoalKey<Bee> BEE_HURT_BY_OTHER = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_hurt_by_other"));
++    GoalKey<Bee> BEE_LOCATE_HIVE = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_locate_hive"));
++    GoalKey<Bee> BEE_POLLINATE = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_pollinate"));
 +    GoalKey<Bee> BEE_WANDER = GoalKey.of(Bee.class, NamespacedKey.minecraft("bee_wander"));
 +    GoalKey<Blaze> BLAZE_FIREBALL = GoalKey.of(Blaze.class, NamespacedKey.minecraft("blaze_fireball"));
 +    GoalKey<Cat> TEMPT_CHANCE = GoalKey.of(Cat.class, NamespacedKey.minecraft("tempt_chance"));
@@ -260,6 +266,10 @@ index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5af
 +    GoalKey<Enderman> ENDERMAN_PLACE_BLOCK = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_place_block"));
 +    GoalKey<Enderman> PLAYER_WHO_LOOKED_AT_TARGET = GoalKey.of(Enderman.class, NamespacedKey.minecraft("player_who_looked_at_target"));
 +    GoalKey<Enderman> ENDERMAN_FREEZE_WHEN_LOOKED_AT = GoalKey.of(Enderman.class, NamespacedKey.minecraft("enderman_freeze_when_looked_at"));
++    GoalKey<Evoker> EVOKER_ATTACK_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_attack_spell"));
++    GoalKey<Evoker> EVOKER_CAST_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_cast_spell"));
++    GoalKey<Evoker> EVOKER_SUMMON_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_summon_spell"));
++    GoalKey<Evoker> EVOKER_WOLOLO_SPELL = GoalKey.of(Evoker.class, NamespacedKey.minecraft("evoker_wololo_spell"));
 +    GoalKey<Fish> FISH_SWIM = GoalKey.of(Fish.class, NamespacedKey.minecraft("fish_swim"));
 +    GoalKey<Fox> FOX_DEFEND_TRUSTED = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_defend_trusted"));
 +    GoalKey<Fox> FOX_FACEPLANT = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_faceplant"));
@@ -270,8 +280,10 @@ index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5af
 +    GoalKey<Fox> FOX_LOOK_AT_PLAYER = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_look_at_player"));
 +    GoalKey<Fox> FOX_MELEE_ATTACK = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_melee_attack"));
 +    GoalKey<Fox> FOX_PANIC = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_panic"));
++    GoalKey<Fox> FOX_PERCH_AND_SEARCH = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_perch_and_search"));
 +    GoalKey<Fox> FOX_POUNCE = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_pounce"));
 +    GoalKey<Fox> FOX_SEARCH_FOR_ITEMS = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_search_for_items"));
++    GoalKey<Fox> FOX_SLEEP = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_sleep"));
 +    GoalKey<Fox> FOX_STROLL_THROUGH_VILLAGE = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_stroll_through_village"));
 +    GoalKey<Fox> FOX_SEEK_SHELTER = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_seek_shelter"));
 +    GoalKey<Fox> FOX_STALK_PREY = GoalKey.of(Fox.class, NamespacedKey.minecraft("fox_stalk_prey"));
@@ -280,6 +292,8 @@ index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5af
 +    GoalKey<Ghast> GHAST_MOVE_TOWARDS_TARGET = GoalKey.of(Ghast.class, NamespacedKey.minecraft("ghast_move_towards_target"));
 +    GoalKey<Guardian> GUARDIAN_ATTACK = GoalKey.of(Guardian.class, NamespacedKey.minecraft("guardian_attack"));
 +    GoalKey<Illager> RAIDER_OPEN_DOOR = GoalKey.of(Illager.class, NamespacedKey.minecraft("raider_open_door"));
++    GoalKey<Illusioner> ILLUSIONER_BLINDNESS_SPELL = GoalKey.of(Illusioner.class, NamespacedKey.minecraft("illusioner_blindness_spell"));
++    GoalKey<Illusioner> ILLUSIONER_MIRROR_SPELL = GoalKey.of(Illusioner.class, NamespacedKey.minecraft("illusioner_mirror_spell"));
 +    GoalKey<Spellcaster> SPELLCASTER_CAST_SPELL = GoalKey.of(Spellcaster.class, NamespacedKey.minecraft("spellcaster_cast_spell"));
 +    GoalKey<Llama> LLAMA_ATTACK_WOLF = GoalKey.of(Llama.class, NamespacedKey.minecraft("llama_attack_wolf"));
 +    GoalKey<Llama> LLAMA_HURT_BY = GoalKey.of(Llama.class, NamespacedKey.minecraft("llama_hurt_by"));
@@ -299,6 +313,8 @@ index 0000000000000000000000000000000000000000..dc60d9450b80785034a3cfcdeb4cd5af
 +    GoalKey<Panda> PANDA_SNEEZE = GoalKey.of(Panda.class, NamespacedKey.minecraft("panda_sneeze"));
 +    GoalKey<Phantom> PHANTOM_ATTACK_PLAYER = GoalKey.of(Phantom.class, NamespacedKey.minecraft("phantom_attack_player"));
 +    GoalKey<Phantom> PHANTOM_ATTACK_STRATEGY = GoalKey.of(Phantom.class, NamespacedKey.minecraft("phantom_attack_strategy"));
++    GoalKey<Phantom> PHANTOM_CIRCLE_AROUND_ANCHOR = GoalKey.of(Phantom.class, NamespacedKey.minecraft("phantom_circle_around_anchor"));
++    GoalKey<Phantom> PHANTOM_SWEEP_ATTACK = GoalKey.of(Phantom.class, NamespacedKey.minecraft("phantom_sweep_attack"));
 +    GoalKey<PigZombie> ANGER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger"));
 +    GoalKey<PigZombie> ANGER_OTHER = GoalKey.of(PigZombie.class, NamespacedKey.minecraft("anger_other"));
 +    GoalKey<PolarBear> POLARBEAR_ATTACK_PLAYERS = GoalKey.of(PolarBear.class, NamespacedKey.minecraft("polarbear_attack_players"));

--- a/Spigot-Server-Patches/0501-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0501-Implement-Mob-Goal-API.patch
@@ -24,10 +24,10 @@ index bc8438ae1ae939be4d2257d37df9a843a13ac301..0c0051f7f2a58d63b851e80b442acbb4
      <repositories>
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d6ee9410786006be0ffe137c7c0aa4a34e0a3025
+index 0000000000000000000000000000000000000000..9ee1a8d5f494680ac9d4c45d7b1255e28a77c566
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
-@@ -0,0 +1,329 @@
+@@ -0,0 +1,345 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import com.google.common.collect.BiMap;
@@ -62,7 +62,13 @@ index 0000000000000000000000000000000000000000..d6ee9410786006be0ffe137c7c0aa4a3
 +        // TODO these kinda should be checked on each release, in case obfuscation changes
 +        deobfuscationMap.put("bee_b", "bee_attack");
 +        deobfuscationMap.put("bee_c", "bee_become_angry");
++        deobfuscationMap.put("bee_d", "bee_enter_hive");
++        deobfuscationMap.put("bee_e", "bee_go_to_hive");
++        deobfuscationMap.put("bee_f", "bee_go_to_known_flower");
++        deobfuscationMap.put("bee_g", "bee_grow_crop");
 +        deobfuscationMap.put("bee_h", "bee_hurt_by_other");
++        deobfuscationMap.put("bee_i", "bee_locate_hive");
++        deobfuscationMap.put("bee_k", "bee_pollinate");
 +        deobfuscationMap.put("bee_l", "bee_wander");
 +        deobfuscationMap.put("cat_a", "cat_avoid_entity");
 +        deobfuscationMap.put("cat_b", "cat_relax_on_owner");
@@ -75,6 +81,10 @@ index 0000000000000000000000000000000000000000..d6ee9410786006be0ffe137c7c0aa4a3
 +        deobfuscationMap.put("drowned_e", "drowned_swim_up");
 +        deobfuscationMap.put("drowned_f", "drowned_trident_attack");
 +        deobfuscationMap.put("enderman_a", "enderman_freeze_when_looked_at");
++        deobfuscationMap.put("evoker_a", "evoker_attack_spell");
++        deobfuscationMap.put("evoker_b", "evoker_cast_spell");
++        deobfuscationMap.put("evoker_c", "evoker_summon_spell");
++        deobfuscationMap.put("evoker_d", "evoker_wololo_spell");
 +        deobfuscationMap.put("fish_b", "fish_swim");
 +        deobfuscationMap.put("fox_a", "fox_defend_trusted");
 +        deobfuscationMap.put("fox_b", "fox_faceplant");
@@ -88,9 +98,13 @@ index 0000000000000000000000000000000000000000..d6ee9410786006be0ffe137c7c0aa4a3
 +        deobfuscationMap.put("fox_o", "fox_pounce");
 +        deobfuscationMap.put("fox_p", "fox_search_for_items");
 +        deobfuscationMap.put("fox_q", "fox_stroll_through_village");
++        deobfuscationMap.put("fox_r", "fox_perch_and_search");
 +        deobfuscationMap.put("fox_s", "fox_seek_shelter");
++        deobfuscationMap.put("fox_t", "fox_sleep");
 +        deobfuscationMap.put("fox_u", "fox_stalk_prey");
 +        deobfuscationMap.put("illager_abstract_b", "raider_open_door");
++        deobfuscationMap.put("illager_illusioner_a", "illusioner_blindness_spell");
++        deobfuscationMap.put("illager_illusioner_b", "illusioner_mirror_spell");
 +        deobfuscationMap.put("illager_wizard_b", "spellcaster_cast_spell");
 +        deobfuscationMap.put("llama_a", "llama_attack_wolf");
 +        deobfuscationMap.put("llama_c", "llama_hurt_by");
@@ -110,6 +124,8 @@ index 0000000000000000000000000000000000000000..d6ee9410786006be0ffe137c7c0aa4a3
 +        deobfuscationMap.put("panda_l", "panda_sneeze");
 +        deobfuscationMap.put("phantom_b", "phantom_attack_player");
 +        deobfuscationMap.put("phantom_c", "phantom_attack_strategy");
++        deobfuscationMap.put("phantom_e", "phantom_circle_around_anchor");
++        deobfuscationMap.put("phantom_i", "phantom_sweep_attack");
 +        deobfuscationMap.put("polar_bear_a", "polarbear_attack_players");
 +        deobfuscationMap.put("polar_bear_b", "polarbear_hurt_by");
 +        deobfuscationMap.put("polar_bear_c", "polarbear_melee");
@@ -847,10 +863,10 @@ index 1647c09756ed303a3f3e879e877b5b3de639f843..b89f99a66fe2ab9ad4c956c38c9e4b1d
  }
 diff --git a/src/test/java/com/destroystokyo/paper/entity/ai/VanillaMobGoalTest.java b/src/test/java/com/destroystokyo/paper/entity/ai/VanillaMobGoalTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..83d34761d9197fa21cabe6d5859f0123bdda20bb
+index 0000000000000000000000000000000000000000..bca3fa43562d21fc16f0c987b8f3a4abe56278a3
 --- /dev/null
 +++ b/src/test/java/com/destroystokyo/paper/entity/ai/VanillaMobGoalTest.java
-@@ -0,0 +1,92 @@
+@@ -0,0 +1,96 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import com.destroystokyo.paper.entity.ai.GoalKey;
@@ -895,7 +911,7 @@ index 0000000000000000000000000000000000000000..83d34761d9197fa21cabe6d5859f0123
 +        }
 +
 +        List<GoalKey<?>> vanillaNames = classes.stream()
-+            .filter(clazz -> clazz.getEnclosingClass() == null || clazz.getSuperclass().getEnclosingClass() == null)
++            .filter(VanillaMobGoalTest::hasNoEnclosingClass)
 +            .filter(clazz -> !Modifier.isAbstract(clazz.getModifiers()))
 +            .map(goalClass -> MobGoalHelper.getKey((Class<? extends PathfinderGoal>) goalClass))
 +            .collect(Collectors.toList());
@@ -922,6 +938,10 @@ index 0000000000000000000000000000000000000000..83d34761d9197fa21cabe6d5859f0123
 +        }
 +
 +        if (shouldFail) Assert.fail("See above");
++    }
++
++    private static boolean hasNoEnclosingClass(Class<?> clazz) {
++        return clazz.getEnclosingClass() == null || hasNoEnclosingClass(clazz.getSuperclass());
 +    }
 +
 +    @Test


### PR DESCRIPTION
This adds some goals (for bees, evokers, foxes, illusioners and phantoms) that were missing and not caught by the test due to it only checking the enclosing class of the direct super class and not the full inheritance. 