### PR TITLE
Add option for console having all permissions

### DIFF
--- a/Spigot-Server-Patches/0527-Add-option-for-console-having-all-permissions.patch
+++ b/Spigot-Server-Patches/0527-Add-option-for-console-having-all-permissions.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 16 May 2020 10:12:15 +0200
+Subject: [PATCH] Add option for console having all permissions
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 699727a79c1733092d010c2d0039fd93455ebc0a..2acfb4052c21bb944785b888511185a2f8aba486 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -433,4 +433,9 @@ public class PaperConfig {
+         allowBlockPermanentBreakingExploits = getBoolean("allow-perm-block-break-exploits", allowBlockPermanentBreakingExploits);
+     }
+ 
++    public static boolean consoleHasAllPermissions = false;
++    private static void consoleHasAllPermissions() {
++        consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
++    }
++
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+index bfd21a07280a79d279388c785c78fb8fe731102a..e67da10f9bfbb8125d8fbf34695997ecfebcc484 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+@@ -74,4 +74,16 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
+     public boolean isConversing() {
+         return conversationTracker.isConversing();
+     }
++
++    // Paper start
++    @Override
++    public boolean hasPermission(String name) {
++        return com.destroystokyo.paper.PaperConfig.consoleHasAllPermissions || super.hasPermission(name);
++    }
++
++    @Override
++    public boolean hasPermission(org.bukkit.permissions.Permission perm) {
++        return com.destroystokyo.paper.PaperConfig.consoleHasAllPermissions || super.hasPermission(perm);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
+index 228e88a6e2b93ef2c4a5774cc8663b64467fb9eb..4024408815205c12eac9fdb246497ba713295f4b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
+@@ -38,4 +38,16 @@ public class CraftRemoteConsoleCommandSender extends ServerCommandSender impleme
+     public void setOp(boolean value) {
+         throw new UnsupportedOperationException("Cannot change operator status of remote controller.");
+     }
++
++    // Paper start
++    @Override
++    public boolean hasPermission(String name) {
++        return com.destroystokyo.paper.PaperConfig.consoleHasAllPermissions || super.hasPermission(name);
++    }
++
++    @Override
++    public boolean hasPermission(org.bukkit.permissions.Permission perm) {
++        return com.destroystokyo.paper.PaperConfig.consoleHasAllPermissions || super.hasPermission(perm);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
This adds a configuration option for console always having
all permissions. This applies to the "terminal console" as well
as remote console (RCON) connections.