### PR TITLE
Restrict gateway teleports like portal teleports

### DIFF
--- a/Spigot-Server-Patches/0496-Restrict-gateway-teleports-like-portal-teleports.patch
+++ b/Spigot-Server-Patches/0496-Restrict-gateway-teleports-like-portal-teleports.patch
@@ -1,0 +1,21 @@
+From 61e65c97ed854433883ab36f81ad9902a63800c3 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 16 May 2020 10:16:38 +0200
+Subject: [PATCH] Restrict gateway teleports like portal teleports
+
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityEndGateway.java b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
+index c71f76004ed..3b0b34ad81e 100644
+--- a/src/main/java/net/minecraft/server/TileEntityEndGateway.java
++++ b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
+@@ -117,6 +117,7 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
+     }
+ 
+     public void a(Entity entity) {
++        if (!entity.canPortal() || entity.isVehicle() || entity.isPassenger()) return; // Paper - restrict gateway teleports like portal teleports
+         if (this.world instanceof WorldServer && !this.f()) {
+             this.c = 100;
+             if (this.exitPortal == null && this.world.worldProvider instanceof WorldProviderTheEnd) {
+-- 
+2.26.2
+


### PR DESCRIPTION
This restricts end gateway teleportations like normal
portal teleportations are restricted.

Fixes #3297.