### PR TITLE
Held Item Change Event

### DIFF
--- a/Spigot-API-Patches/0209-Add-PlayerHeldItemChangeEvent.patch
+++ b/Spigot-API-Patches/0209-Add-PlayerHeldItemChangeEvent.patch
@@ -3,6 +3,7 @@ From: Nesaak <52047222+Nesaak@users.noreply.github.com>
 Date: Sun, 17 May 2020 18:38:36 -0400
 Subject: [PATCH] Add PlayerHeldItemChangeEvent
 
+Adds PlayerHeldItemEvent which fires when the item in the player's hand changes.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHeldItemChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHeldItemChangeEvent.java
 new file mode 100644

--- a/Spigot-API-Patches/0209-Add-PlayerHeldItemChangeEvent.patch
+++ b/Spigot-API-Patches/0209-Add-PlayerHeldItemChangeEvent.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nesaak <52047222+Nesaak@users.noreply.github.com>
+Date: Sun, 17 May 2020 18:38:36 -0400
+Subject: [PATCH] Add PlayerHeldItemChangeEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHeldItemChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHeldItemChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..87782c775e3d2ae956bf3ecfcfec2af194a0e4b5
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerHeldItemChangeEvent.java
+@@ -0,0 +1,74 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.ItemStack;
++
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when the item in a player's hand changes.
++ */
++public class PlayerHeldItemChangeEvent extends PlayerEvent {
++    private static final HandlerList HANDLERS = new HandlerList();
++
++    @NotNull private final boolean isMainHand;
++    @Nullable private final ItemStack oldItem;
++    @Nullable private final ItemStack newItem;
++
++    public PlayerHeldItemChangeEvent(@NotNull Player player, @NotNull boolean isMainHand, @Nullable ItemStack oldItem, @Nullable ItemStack newItem) {
++        super(player);
++        this.isMainHand = isMainHand;
++        this.oldItem = oldItem;
++        this.newItem = newItem;
++    }
++
++    /**
++     * Get's whether the item changed is in the player's main hand
++     *
++     * @return true if the item changed is in the player's main hand, false otherwise
++     */
++    @NotNull
++    public boolean isMainHand() {
++        return this.isMainHand;
++    }
++
++    /**
++     * Gets the existing item that's being replaced
++     *
++     * @return old item
++     */
++    @Nullable
++    public ItemStack getOldItem() {
++        return this.oldItem;
++    }
++
++    /**
++     * Gets the new item that's replacing the old
++     *
++     * @return new item
++     */
++    @Nullable
++    public ItemStack getNewItem() {
++        return this.newItem;
++    }
++
++    @Override
++    public String toString() {
++        return "PlayerHeldItemChangedEvent{" + "isMainHand=" + isMainHand + ", oldItem=" + oldItem + ", newItem=" + newItem + ", player=" + player + '}';
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLERS;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLERS;
++    }
++
++}

--- a/Spigot-Server-Patches/0530-Add-PlayerHeldItemChangeEvent.patch
+++ b/Spigot-Server-Patches/0530-Add-PlayerHeldItemChangeEvent.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nesaak <52047222+Nesaak@users.noreply.github.com>
+Date: Sun, 17 May 2020 18:39:01 -0400
+Subject: [PATCH] Add PlayerHeldItemChangeEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 3fc2360a103a5399f2878eccb0c13eb6e41e824d..6eb4ba6c938ab4b33abfe8571ed653a551bbe76f 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.server;
+ 
+ import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
++import com.destroystokyo.paper.event.player.PlayerHeldItemChangeEvent;
+ import com.google.common.base.Objects;
+ import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.ImmutableSet;
+@@ -2497,11 +2498,17 @@ public abstract class EntityLiving extends Entity {
+             ItemStack itemstack1 = this.getEquipment(enumitemslot);
+ 
+             if (!ItemStack.matches(itemstack1, itemstack)) {
+-                // Paper start - PlayerArmorChangeEvent
+-                if (this instanceof EntityPlayer && enumitemslot.getType() == EnumItemSlot.Function.ARMOR) {
+-                    final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
+-                    final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
+-                    new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
++                // Paper start - PlayerArmorChangeEvent, PlayerHeldItemChangeEvent
++                if (this instanceof EntityPlayer) {
++                    if (enumitemslot.getType() == EnumItemSlot.Function.ARMOR) {
++                        final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
++                        final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
++                        new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
++                    } else if (enumitemslot.getType() == EnumItemSlot.Function.HAND) {
++                        final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
++                        final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
++                        new PlayerHeldItemChangeEvent((Player) this.getBukkitEntity(), enumitemslot == EnumItemSlot.MAINHAND, oldItem, newItem).callEvent();
++                    }
+                 }
+                 // Paper end
+                 ((WorldServer) this.world).getChunkProvider().broadcast(this, new PacketPlayOutEntityEquipment(this.getId(), enumitemslot, itemstack1));

--- a/Spigot-Server-Patches/0530-Add-PlayerHeldItemChangeEvent.patch
+++ b/Spigot-Server-Patches/0530-Add-PlayerHeldItemChangeEvent.patch
@@ -3,6 +3,7 @@ From: Nesaak <52047222+Nesaak@users.noreply.github.com>
 Date: Sun, 17 May 2020 18:39:01 -0400
 Subject: [PATCH] Add PlayerHeldItemChangeEvent
 
+Implements the trigger for PlayerHeldItemChangeEvent, using the code used for PlayerArmorChangeEvent and expanding on it.
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
 index 3fc2360a103a5399f2878eccb0c13eb6e41e824d..6eb4ba6c938ab4b33abfe8571ed653a551bbe76f 100644


### PR DESCRIPTION
The current "PlayerItemHeldEvent" is misleading, it states "Fired when a player changes their currently held item" but in reality just fires whenever a player changes slots. While this is useful for its own purposes, not for what you would originally assume. The functionality I am trying to add is whenever an item in the player's hand changes, it fires this event which has been working perfectly in my testing. 

The naming needs reworking but the perfect name is already taken by PlayerItemHeldEvent. We could either come up with a better name for this event or add this functionality to PlayerArmorChangeEvent and refactor it be something like PlayerEquipmentChangeEvent.