### PR TITLE
Fix data version check for ItemStack serialization

### DIFF
--- a/Spigot-Server-Patches/0529-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/Spigot-Server-Patches/0529-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -50,7 +50,7 @@ index 2322c0c8c5aacebb6317eab8ce4245554f6d9d55..3e6f878cdbbf5ebfa7fb390745ead135
          DataOutputStream dataoutputstream = new DataOutputStream(new BufferedOutputStream(new GZIPOutputStream(outputstream)));
          Throwable throwable = null;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 770375ed4207920e71d2d0799c611c4b3cdbe6f7..aa8f135250338452c6143d41cca9aaea886ba31f 100644
+index 770375ed4207920e71d2d0799c611c4b3cdbe6f7..549ba4d8068763f41c2307a9c88f0b3f304b17e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -313,6 +313,46 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -89,7 +89,7 @@ index 770375ed4207920e71d2d0799c611c4b3cdbe6f7..aa8f135250338452c6143d41cca9aaea
 +            );
 +            int dataVersion = compound.getInt("DataVersion");
 +
-+            Preconditions.checkArgument(dataVersion < getDataVersion(), "Newer version! Server downgrades are not supported!");
++            Preconditions.checkArgument(dataVersion <= getDataVersion(), "Newer version! Server downgrades are not supported!");
 +            Dynamic<NBTBase> converted = DataConverterRegistry.getDataFixer().update(DataConverterTypes.ITEM_STACK, new Dynamic<NBTBase>(DynamicOpsNBT.a, compound), -1, getDataVersion());
 +            return CraftItemStack.asCraftMirror(net.minecraft.server.ItemStack.fromCompound((NBTTagCompound) converted.getValue()));
 +        } catch (IOException ex) {


### PR DESCRIPTION
The expected version should be equal to or newer than the one stored.