### PR TITLE
Fix ./paper edit continue for Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ bin/
 dist/
 manifest.mf
 
+/work/Temp/
 work/1.*
 work/Minecraft
 work/BuildData

--- a/paper
+++ b/paper
@@ -125,7 +125,8 @@ case "$1" in
     "e" | "edit")
         case "$2" in
             "s" | "server")
-            export PAPER_LAST_EDIT="$basedir/Paper-Server"
+            mkdir -p "$basedir/work/Temp"
+            echo "$basedir/Paper-Server" > "$basedir/work/Temp/PAPER_LAST_EDIT"
             cd "$basedir/Paper-Server"
             (
                 set -e
@@ -136,7 +137,8 @@ case "$1" in
             )
             ;;
             "a" | "api")
-            export PAPER_LAST_EDIT="$basedir/Paper-API"
+            mkdir -p "$basedir/work/Temp"
+            echo "$basedir/Paper-API" > "$basedir/work/Temp/PAPER_LAST_EDIT"
             cd "$basedir/Paper-API"
             (
                 set -e
@@ -147,8 +149,8 @@ case "$1" in
             )
             ;;
             "c" | "continue")
-            cd "$PAPER_LAST_EDIT"
-            unset PAPER_LAST_EDIT
+            cd "$( < "$basedir/work/Temp/PAPER_LAST_EDIT")"
+            rm -f "$basedir/work/Temp/PAPER_LAST_EDIT"
             (
                 set -e
 


### PR DESCRIPTION
Resolves #3405.
Tested on Windows, probably works on Linux as well but needs testing!
There are probably better ways to fix this, I don't know. If you know one, just close this PR.
Note that I don't delete the created `work/Temp` directory because it might be also useful for other stuff in the future.
While fixing this, I have noticed that the `export` command is also used in other scripts for other things, so it might be a good idea to check their functionallity on Windows as well.