### PR TITLE
Disable EntityTrackerFixer

### DIFF
--- a/Spigot-API-Patches/0209-Disable-EntityTrackerFixer.patch
+++ b/Spigot-API-Patches/0209-Disable-EntityTrackerFixer.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Fri, 22 May 2020 13:10:40 +0200
+Subject: [PATCH] Disable EntityTrackerFixer
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 04fa3991f6ce4e9dad804f28fc6c947695857089..37fef5a8cb6cd28a6a085416f16da57b2b757baa 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -260,6 +260,12 @@ public abstract class JavaPlugin extends PluginBase {
+             isEnabled = enabled;
+ 
+             if (isEnabled) {
++                // Paper start
++                if ("net.minemora.entitytrackerfixer.EntityTrackerFixer".equals(getDescription().getMain())) {
++                    getServer().getLogger().warning("EntityTrackerFixer is not recommended on Paper servers and will not enable.");
++                    return;
++                }
++                // Paper end
+                 onEnable();
+             } else {
+                 onDisable();

--- a/Spigot-Server-Patches/0529-Disable-EntityTrackerFixer.patch
+++ b/Spigot-Server-Patches/0529-Disable-EntityTrackerFixer.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Fri, 22 May 2020 13:10:30 +0200
+Subject: [PATCH] Disable EntityTrackerFixer
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 894917c8891a951edb251f019529d0f7bec7037d..24f9738ec9d459a60f9200bb95bb07b82c949575 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -359,6 +359,13 @@ public final class CraftServer implements Server {
+         if (pluginFolder.exists()) {
+             Plugin[] plugins = pluginManager.loadPlugins(pluginFolder);
+             for (Plugin plugin : plugins) {
++                // Paper start
++                if ("net.minemora.entitytrackerfixer.EntityTrackerFixer".equals(plugin.getDescription().getMain())) {
++                    getLogger().warning("EntityTrackerFixer is not recommended on Paper servers and will not load.");
++                    continue;
++                }
++                // Paper end
++
+                 try {
+                     String message = String.format("Loading %s", plugin.getDescription().getFullName());
+                     plugin.getLogger().info(message);


### PR DESCRIPTION
A meme turned reality. I don't expect this to be merged, but it's pretty funny
regardless.

This simply disables `net.minemora.entitytrackerfixer.EntityTrackerFixer` from
loading and enabling. It disables just fine afterwards, but that could be
changed if wanted.