### PR TITLE
Expose getItemStack() in Arrows

### DIFF
--- a/Spigot-API-Patches/0211-Expose-Arrow-getItemStack.patch
+++ b/Spigot-API-Patches/0211-Expose-Arrow-getItemStack.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nesaak <52047222+Nesaak@users.noreply.github.com>
+Date: Fri, 22 May 2020 13:35:21 -0400
+Subject: [PATCH] Expose Arrow getItemStack
+
+
+diff --git a/src/main/java/org/bukkit/entity/AbstractArrow.java b/src/main/java/org/bukkit/entity/AbstractArrow.java
+index b2bf62a50177e612369993f8ed340d456c3c2fc8..6cb38d412c89a85ef6c1d98f32338d22bd2c2795 100644
+--- a/src/main/java/org/bukkit/entity/AbstractArrow.java
++++ b/src/main/java/org/bukkit/entity/AbstractArrow.java
+@@ -129,6 +129,14 @@ public interface AbstractArrow extends Projectile {
+     }
+ 
+     // Paper start
++    /**
++     * Gets the ItemStack for this arrow.
++     *
++     * @return The ItemStack, as if a player picked up the arrow
++     */
++    @NotNull
++    org.bukkit.inventory.ItemStack getItemStack();
++
+     /**
+      * Gets the {@link PickupRule} for this arrow.
+      *

--- a/Spigot-Server-Patches/0547-Expose-Arrow-getItemStack.patch
+++ b/Spigot-Server-Patches/0547-Expose-Arrow-getItemStack.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nesaak <52047222+Nesaak@users.noreply.github.com>
+Date: Sat, 23 May 2020 10:31:11 -0400
+Subject: [PATCH] Expose Arrow getItemStack
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
+index 9c97edf9c9e9a8cdf029264f6b563090142c686b..e66f6b30069af5b9031c7c78a2bb3d3a645034c0 100644
+--- a/src/main/java/net/minecraft/server/EntityArrow.java
++++ b/src/main/java/net/minecraft/server/EntityArrow.java
+@@ -556,6 +556,8 @@ public abstract class EntityArrow extends Entity implements IProjectile {
+         }
+     }
+ 
++    public ItemStack getOriginalItemStack() { return getItemStack(); }  // Paper - OBFHelper
++
+     protected abstract ItemStack getItemStack();
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
+index 29d23db4121bf8cbd98b4d7acce90b13790df245..2e4765ba14c591f995f6ab0a6e3a16158c7ca308 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
+@@ -102,6 +102,13 @@ public class CraftArrow extends AbstractProjectile implements AbstractArrow {
+         getHandle().fromPlayer = EntityArrow.PickupStatus.a(status.ordinal());
+     }
+ 
++    // Paper start
++    @Override
++    public org.bukkit.craftbukkit.inventory.CraftItemStack getItemStack() {
++        return org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(getHandle().getOriginalItemStack());
++    }
++    //Paper end
++
+     @Override
+     public void setTicksLived(int value) {
+         super.setTicksLived(value);


### PR DESCRIPTION
This PR exposes getItemStack() in AbstractArrow which I have implemented CraftArrow to return the NMS method of getItemStack(). This is currently not possible in the API without some trickery and would involve little maintenance in future versions. The only NMS change I had to make was changing the visibility of getItemStack() in EntityArrow and subclasses from protected to public.