### PR TITLE
Add clear reputation API

### DIFF
--- a/Spigot-API-Patches/0204-Add-villager-reputation-API.patch
+++ b/Spigot-API-Patches/0204-Add-villager-reputation-API.patch
@@ -107,7 +107,7 @@ index 0000000000000000000000000000000000000000..5600fcdc9795a9f49091db48d73bbd49
 +    TRADING,
 +}
 diff --git a/src/main/java/org/bukkit/entity/Villager.java b/src/main/java/org/bukkit/entity/Villager.java
-index d1579153092c1b80350155110f1b9926b1a1ef57..e0a3285b8ca97f6d56e5548d1f95efc1cc7cbd3c 100644
+index d1579153092c1b80350155110f1b9926b1a1ef57..c8777a476e38ef5e72b6709761990a339eb43d2b 100644
 --- a/src/main/java/org/bukkit/entity/Villager.java
 +++ b/src/main/java/org/bukkit/entity/Villager.java
 @@ -1,10 +1,13 @@
@@ -124,7 +124,7 @@ index d1579153092c1b80350155110f1b9926b1a1ef57..e0a3285b8ca97f6d56e5548d1f95efc1
  
  /**
   * Represents a villager NPC
-@@ -224,4 +227,44 @@ public interface Villager extends AbstractVillager {
+@@ -224,4 +227,50 @@ public interface Villager extends AbstractVillager {
              return key;
          }
      }
@@ -167,5 +167,11 @@ index d1579153092c1b80350155110f1b9926b1a1ef57..e0a3285b8ca97f6d56e5548d1f95efc1
 +     * for all players mapped by their {@link UUID unique IDs}.
 +     */
 +    public void setReputations(@NotNull Map<UUID, com.destroystokyo.paper.entity.villager.Reputation> reputations);
++
++    /**
++     * Clear all reputations from this villager. This removes every single
++     * reputation regardless of its impact and the player associated.
++     */
++    public void clearReputations();
 +    // Paper end
  }

--- a/Spigot-Server-Patches/0505-Add-villager-reputation-API.patch
+++ b/Spigot-Server-Patches/0505-Add-villager-reputation-API.patch
@@ -87,7 +87,7 @@ index 0b6f91ac1206089654a6745bccb038fba8c13d98..4ae31599664ee8478ca1acf68f7253eb
  
      static class b {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index a8384081c03884c86578dca677914d77441c1863..19409c7a25c48f3f72f7e0b6306b81aa90b38f7c 100644
+index a8384081c03884c86578dca677914d77441c1863..d24a892c498d7ee58741c9358748a117f01d8a8d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 @@ -1,9 +1,13 @@
@@ -104,7 +104,7 @@ index a8384081c03884c86578dca677914d77441c1863..19409c7a25c48f3f72f7e0b6306b81aa
  import net.minecraft.server.EntityVillager;
  import net.minecraft.server.IBlockData;
  import net.minecraft.server.IRegistry;
-@@ -124,4 +128,40 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -124,4 +128,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
      public static VillagerProfession bukkitToNmsProfession(Profession bukkit) {
          return IRegistry.VILLAGER_PROFESSION.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
      }
@@ -142,6 +142,11 @@ index a8384081c03884c86578dca677914d77441c1863..19409c7a25c48f3f72f7e0b6306b81aa
 +        for (Map.Entry<UUID, Reputation> entry : reputations.entrySet()) {
 +            setReputation(entry.getKey(), entry.getValue());
 +        }
++    }
++
++    @Override
++    public void clearReputations() {
++        getHandle().getReputation().getReputations().clear();
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
This adds what I would deem a fairly dangerous API which lets you remove every
single reputation a villager stores.