### PR TITLE
Fix villager trading demand MC-163962

### DIFF
--- a/Spigot-Server-Patches/0534-Fix-villager-trading-demand-MC-163962.patch
+++ b/Spigot-Server-Patches/0534-Fix-villager-trading-demand-MC-163962.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
+Date: Fri, 5 Jun 2020 20:02:04 -0500
+Subject: [PATCH] Fix villager trading demand - MC-163962
+
+Prevent demand from going negative and tending to negative infinity
+
+diff --git a/src/main/java/net/minecraft/server/MerchantRecipe.java b/src/main/java/net/minecraft/server/MerchantRecipe.java
+index f1f49c2ebff93ce3537bd4a58916d4c624a3fe82..7c4dc1143696320c8b8dc21ea4ae0600d5686d62 100644
+--- a/src/main/java/net/minecraft/server/MerchantRecipe.java
++++ b/src/main/java/net/minecraft/server/MerchantRecipe.java
+@@ -104,7 +104,7 @@ public class MerchantRecipe {
+     }
+ 
+     public void e() {
+-        this.demand = this.demand + this.uses - (this.maxUses - this.uses);
++        this.demand = Math.max(0, this.demand + this.uses - (this.maxUses - this.uses)); // Paper
+     }
+ 
+     public ItemStack f() {


### PR DESCRIPTION
Prevent demand from becoming negative and creating an indefinite demand deficit
This fixes https://bugs.mojang.com/browse/MC-163962
There is nothing preventing the demand from decreasing forever. This causes the demand value to never be used. But when demand eventually negative overflows, will jump to the max value causing all prices to jump to their maximum value.