### PR TITLE
Remove plugin illegal access 'not a depend' warning

### DIFF
--- a/Spigot-API-Patches/0210-Remove-plugin-illegal-access-not-a-depend-warning.patch
+++ b/Spigot-API-Patches/0210-Remove-plugin-illegal-access-not-a-depend-warning.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Luck <git@lucko.me>
+Date: Fri, 5 Jun 2020 18:54:23 +0100
+Subject: [PATCH] Remove plugin illegal access 'not a depend' warning
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index 62f7a6817da079513f471e36cd79739d36a36d86..92392a26a05a6355a424eb0274c26dbd6449b5c3 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -110,6 +110,8 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+             if (checkGlobal) {
+                 result = loader.getClassByName(name, this); // Paper - prioritize self
+ 
++                // Paper start - comment out warning
++                /*
+                 if (result != null) {
+                     PluginDescriptionFile provider = ((PluginClassLoader) result.getClassLoader()).description;
+ 
+@@ -126,6 +128,8 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+                         }
+                     }
+                 }
++                */
++                // Paper end
+             }
+ 
+             if (result == null) {


### PR DESCRIPTION
The warning is pretty useless and serves a very limited purpose. I've tried to reason with md_5 on this topic and got absolutely nowhere.

https://hub.spigotmc.org/jira/browse/SPIGOT-5546

tl;dr: the warning basically makes the plugin.yml `load-before` property unusable - and the reason for adding it is "just trying to improve the server and API" 🤷 

Some other relevant discussion here: https://github.com/lucko/LuckPerms/issues/1959

The same issue is also ran into by PlaceholderAPI (which loads from separate plugin-like expansions), spark (which loads other plugin classes to inspect for profiling), etc etc. Just incredibly spammy and annoying.

There is no sensible workaround for me here, and the only thing the warning is doing is confusing users.

Until a means for plugin authors to specifically signal "yes this is not a mistake, stop warning me about it" is added, removing the message seems like a sensible option.

Thanks for your consideration :)