### PR TITLE
Maps shouldn't load chunks

### DIFF
--- a/Spigot-Server-Patches/0535-Maps-shouldn-t-load-chunks.patch
+++ b/Spigot-Server-Patches/0535-Maps-shouldn-t-load-chunks.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Sun, 7 Jun 2020 21:43:42 +0100
+Subject: [PATCH] Maps shouldn't load chunks
+
+Previously maps would load all chunks in a certain radius depending on
+ their scale when trying to update their content. This would result in
+ main thread chunk loads when they weren't really necessary, especially
+ on low view distances or "slow" async chunk loads after teleports or
+ other prioritisation.
+
+ This changes it to only try to render already loaded chunks based on
+ the assumption that the chunks around the player will get loaded
+ eventually anyways and that maps will get checked for update every
+ five ticks that movement occur in anyways.
+
+diff --git a/src/main/java/net/minecraft/server/ItemWorldMap.java b/src/main/java/net/minecraft/server/ItemWorldMap.java
+index 189e6d753d43b145a5480b10db11bba54fe8fbf3..134468da1a8fad6fdd48f64bf9ea885794e86bdf 100644
+--- a/src/main/java/net/minecraft/server/ItemWorldMap.java
++++ b/src/main/java/net/minecraft/server/ItemWorldMap.java
+@@ -96,9 +96,9 @@ public class ItemWorldMap extends ItemWorldMapBase {
+                             int k2 = (j / i + k1 - 64) * i;
+                             int l2 = (k / i + l1 - 64) * i;
+                             Multiset<MaterialMapColor> multiset = LinkedHashMultiset.create();
+-                            Chunk chunk = world.getChunkAtWorldCoords(new BlockPosition(k2, 0, l2));
++                            Chunk chunk = world.getChunkIfLoaded(new BlockPosition(k2, 0, l2)); // Paper - Maps shouldn't load chunks
+ 
+-                            if (!chunk.isEmpty()) {
++                            if (chunk != null && !chunk.isEmpty()) { // Paper - Maps shouldn't load chunks
+                                 ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
+                                 int i3 = k2 & 15;
+                                 int j3 = l2 & 15;


### PR DESCRIPTION
Previously maps would load all chunks in a certain radius depending on their scale when trying to update their content. This would result in main thread chunk loads when they weren't really necessary, especially on low view distances or "slow" async chunk loads after teleports or other prioritisation.

This changes it to only try to render already loaded chunks based on the assumption that the chunks around the player will get loaded eventually and that maps will get checked for update every
 five ticks that movement occur in anyways.