### PR TITLE
Fix enchantment costs

### DIFF
--- a/Spigot-Server-Patches/0535-Fixed-enchantment-costs.patch
+++ b/Spigot-Server-Patches/0535-Fixed-enchantment-costs.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander <protonull@protonmail.com>
+Date: Sun, 7 Jun 2020 22:37:24 +0100
+Subject: [PATCH] Fixed enchantment costs.
+
+As of now, the cost of enchantments are based on which button is pressed. The first, second, and third tier of enchantments will cost 1, 2, and 3 levels respectively. Plugins that listen for the `EnchantItemEvent` event can call `setExpLevelCost(20)` for example to, as the documentation states, set the cost of the enchantment, however that value will only be used as a threshold to enchantment; that a tier 3 enchantment that costs 30 levels will mean that you cannot enchant until you have 30 levels, but will in fact only cost you 3 levels.
+
+This bug, for a lack of a better word, was introduced in 1.13 and has persisted, though the exact version where this was introduced remains unknown, as is the reason for the change.
+
+diff --git a/src/main/java/net/minecraft/server/ContainerEnchantTable.java b/src/main/java/net/minecraft/server/ContainerEnchantTable.java
+index b8c5af8bee0dcb2ab25c03dabb7dbe20561da065..b3c0e251b58b088a43b104562b566191991152f2 100644
+--- a/src/main/java/net/minecraft/server/ContainerEnchantTable.java
++++ b/src/main/java/net/minecraft/server/ContainerEnchantTable.java
+@@ -274,7 +274,7 @@ public class ContainerEnchantTable extends Container {
+                         }
+                     }
+ 
+-                    entityhuman.enchantDone(itemstack, j);
++                    entityhuman.enchantDone(itemstack, level); // Paper - Make enchantments cost set levels
+                     // CraftBukkit end
+ 
+                     // CraftBukkit - TODO: let plugins change this


### PR DESCRIPTION
As of now, the cost of enchantments are based on which button is pressed. The first, second, and third tier of enchantments will cost 1, 2, and 3 levels respectively. Plugins that listen for the `EnchantItemEvent` event can call `setExpLevelCost(20)` for example to, as the documentation states, set the cost of the enchantment, however that value will only be used as a threshold to enchantment; that a tier 3 enchantment that costs 30 levels will mean that you cannot enchant until you have 30 levels, but will in fact only cost you 3 levels.

This bug, for a lack of a better word, was introduced in 1.13 and has persisted, though the exact version where this was introduced remains unknown, as is the reason for the change.