### PR TITLE
Fix missing chunks due to integer overflow

### DIFF
--- a/Spigot-Server-Patches/0539-Fix-missing-chunks-due-to-integer-overflow.patch
+++ b/Spigot-Server-Patches/0539-Fix-missing-chunks-due-to-integer-overflow.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: David Slovikosky <davidslovikosky@gmail.com>
+Date: Tue, 9 Jun 2020 00:10:03 -0700
+Subject: [PATCH] Fix missing chunks due to integer overflow
+
+This patch fixes a bug in the WorldChunkManagerTheEnd class where the distance
+from 0,0 squared overflows the maximum size of an integer. The overflow leads
+to hard chunk borders around 370,000 blocks from 0,0. After this cutoff there
+is a few hundred thousand block gap before end land resuming to generate at
+530,000 blocks from spawn. This is due to the integer flipping back and forth.
+
+The fix for the issue is quite simple, casting chunk coordinates to longs
+allows the distance calculation to avoid overflow and work as intended.
+
+diff --git a/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java b/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
+index 985f54067073909f413a0c9bb574017bf6d177f3..1ba0f43702b6c576fa9251bef574b7d52406f2f1 100644
+--- a/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
++++ b/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
+@@ -36,7 +36,9 @@ public class WorldChunkManagerTheEnd extends WorldChunkManager {
+         int l = j / 2;
+         int i1 = i % 2;
+         int j1 = j % 2;
+-        float f = 100.0F - MathHelper.c((float) (i * i + j * j)) * 8.0F;
++        // Paper start - cast ints to long to avoid integer overflow
++        float f = 100.0F - MathHelper.sqrt((long) i * (long) i + (long) j * (long) j) * 8.0F;
++        // Paper end
+ 
+         f = MathHelper.a(f, -100.0F, 80.0F);
+ 


### PR DESCRIPTION
This patch fixes a bug in the WorldChunkManagerTheEnd class where the distance
from 0,0 squared overflows the maximum size of an integer. The overflow leads
to hard chunk borders around 370,000 blocks away from 0,0. After this cutoff there
is a few hundred thousand block gap of void until end cities resume to generating around
530,000 blocks from spawn. This is due to the integer flipping back and forth as it overflows.

The fix for the issue is quite simple, casting chunk coordinates to longs
allows the distance calculation to avoid overflow and work as intended.

The issue is described on this Reddit post which also mentions an official Mojang issue: https://old.reddit.com/r/admincraft/comments/gyvlbt/end_islands_disappearstop_generating_after_about/

Mojang fixed the bug in MC 1.12.2 but appears to have re-introduced it in 1.14+.

The bug looks like this:
![](https://i.imgur.com/BItnmwN.png)