### PR TITLE
Add Inventory getHolder methods without creating new block snapshots

### DIFF
--- a/Spigot-API-Patches/0210-Inventory-getHolder-method-without-block-snapshot.patch
+++ b/Spigot-API-Patches/0210-Inventory-getHolder-method-without-block-snapshot.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Wed, 10 Jun 2020 23:55:16 +0100
+Subject: [PATCH] Inventory getHolder method without block snapshot
+
+
+diff --git a/src/main/java/org/bukkit/block/DoubleChest.java b/src/main/java/org/bukkit/block/DoubleChest.java
+index 83a4642119c3f33749e04c774cf2b39839f797e2..a39d2f1acbbd84ae0e2cf29f85594e09e55e9355 100644
+--- a/src/main/java/org/bukkit/block/DoubleChest.java
++++ b/src/main/java/org/bukkit/block/DoubleChest.java
+@@ -34,6 +34,18 @@ public class DoubleChest implements InventoryHolder {
+         return inventory.getRightSide().getHolder();
+     }
+ 
++    // Paper start - getHolder without snapshot
++    @Nullable
++    public InventoryHolder getLeftSide(boolean useSnapshot) {
++        return inventory.getLeftSide().getHolder(useSnapshot);
++    }
++
++    @Nullable
++    public InventoryHolder getRightSide(boolean useSnapshot) {
++        return inventory.getRightSide().getHolder(useSnapshot);
++    }
++    // Paper end
++
+     @NotNull
+     public Location getLocation() {
+         return getInventory().getLocation();
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index 01fe217dfa93c20bdec53eb981bd6e885a9f7a25..753c052291afb0455df8298ea3a8209778ba400f 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -376,6 +376,17 @@ public interface Inventory extends Iterable<ItemStack> {
+     @Nullable
+     public InventoryHolder getHolder();
+ 
++    // Paper start - getHolder without snapshot
++    /**
++     * Gets the block or entity belonging to the open inventory
++     *
++     * @param useSnapshot Create a snapshot if the holder is a tile entity
++     * @return The holder of the inventory; null if it has no holder.
++     */
++    @Nullable
++    public InventoryHolder getHolder(boolean useSnapshot);
++    // Paper end
++
+     @NotNull
+     @Override
+     public ListIterator<ItemStack> iterator();

--- a/Spigot-Server-Patches/0540-Inventory-getHolder-method-without-block-snapshot.patch
+++ b/Spigot-Server-Patches/0540-Inventory-getHolder-method-without-block-snapshot.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <mail@moep.tv>
+Date: Wed, 10 Jun 2020 23:55:15 +0100
+Subject: [PATCH] Inventory getHolder method without block snapshot
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+index 47827fbf1b80f88ffff8a252df10d70758c68703..57858327a4909fe536724371ac25f1cdede8c885 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventory.java
+@@ -519,6 +519,13 @@ public class CraftInventory implements Inventory {
+         return inventory.getOwner();
+     }
+ 
++    // Paper start - getHolder without snapshot
++    @Override
++    public InventoryHolder getHolder(boolean useSnapshot) {
++        return inventory instanceof net.minecraft.server.TileEntity ? ((net.minecraft.server.TileEntity) inventory).getOwner(useSnapshot) : getHolder();
++    }
++    // Paper end
++
+     @Override
+     public int getMaxStackSize() {
+         return inventory.getMaxStackSize();
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryDoubleChest.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryDoubleChest.java
+index e917db0b01c2fef46a1ea873bee9aa25044de036..ad425d89bcae3045d0e35ecfb70a233895f88cc8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryDoubleChest.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryDoubleChest.java
+@@ -64,6 +64,13 @@ public class CraftInventoryDoubleChest extends CraftInventory implements DoubleC
+         return new DoubleChest(this);
+     }
+ 
++    // Paper start - getHolder without snapshot
++    @Override
++    public DoubleChest getHolder(boolean useSnapshot) {
++        return getHolder();
++    }
++    // Paper end
++
+     @Override
+     public Location getLocation() {
+         return getLeftSide().getLocation().add(getRightSide().getLocation()).multiply(0.5);


### PR DESCRIPTION
This adds a getHolder method to the Inventory interface which allows getting a the BlockState holder of it without creating a snapshot of it. This (when used) can massively improve the performance of plugins that need to often check the type or some other properties of the container an inventory belongs to e.g. in the InventoryMoveItemEvent.

DoubleChests need to be handled a bit different as they aren't directly baked directly by a tile entity so there are two new snapshot methods for the left and right side of the chest.