### PR TITLE
Scheduling an async task timer creates a non-repeating task

### DIFF
--- a/Spigot-Server-Patches/0540-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
+++ b/Spigot-Server-Patches/0540-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ossi <oser0002@gmail.com>
+Date: Fri, 12 Jun 2020 01:38:06 +0300
+Subject: [PATCH] Fix CraftScheduler#runTaskTimerAsynchronously(Plugin,
+ Consumer<BukkitTask>, long, long) scheduling a non-repeating task instead of
+ a repeating one.
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+index 99ea0aabadfac2a68ec67a7d49831025820de2c3..c5d9170a35f38ecdec85607de714b72ffebc88c6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+@@ -184,7 +184,7 @@ public class CraftScheduler implements BukkitScheduler {
+ 
+     @Override
+     public void runTaskTimerAsynchronously(Plugin plugin, Consumer<BukkitTask> task, long delay, long period) throws IllegalArgumentException {
+-        runTaskTimerAsynchronously(plugin, (Object) task, delay, CraftTask.NO_REPEATING);
++        runTaskTimerAsynchronously(plugin, (Object) task, delay, period);
+     }
+ 
+     @Override


### PR DESCRIPTION
Fix CraftScheduler#runTaskTimerAsynchronously(Plugin, Consumer<BukkitTask>, long, long) scheduling a non-repeating task instead of a repeating one.