### PR TITLE
Prevent handleDisconnection called twice

### DIFF
--- a/Spigot-Server-Patches/0346-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/Spigot-Server-Patches/0346-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf
 
 diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
-index b1dededc15cce686ead74a99bee64c89ac1de22c..289b17addd71aeab8a392e8f6a53d4c6329cf562 100644
+index b1dededc15cce686ead74a99bee64c89ac1de22c..32886109d03f9991446381160d5406056d2bf860 100644
 --- a/src/main/java/net/minecraft/server/NetworkManager.java
 +++ b/src/main/java/net/minecraft/server/NetworkManager.java
 @@ -64,6 +64,10 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
@@ -287,6 +287,15 @@ index b1dededc15cce686ead74a99bee64c89ac1de22c..289b17addd71aeab8a392e8f6a53d4c6
          // Spigot End
          if (this.channel.isOpen()) {
              this.channel.close(); // We can't wait as this may be called from an event loop.
+@@ -327,7 +472,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+     public void handleDisconnection() {
+         if (this.channel != null && !this.channel.isOpen()) {
+             if (this.o) {
+-                NetworkManager.LOGGER.warn("handleDisconnection() called twice");
++                //NetworkManager.LOGGER.warn("handleDisconnection() called twice"); // Paper - Do not log useless message
+             } else {
+                 this.o = true;
+                 if (this.j() != null) {
 @@ -335,7 +480,7 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
                  } else if (this.i() != null) {
                      this.i().a(new ChatMessage("multiplayer.disconnect.generic", new Object[0]));


### PR DESCRIPTION
When PlayerConnection.disconnect(String) is called,
"handleDisconnection() called twice" warning is shown.
Caller of handleDisconnect is PlayerConnection.disconnect(String) and
ServerConnection.b(). In ServerConnection, all NetworkManager in
connectedChannels is checked and call handleDisconnect if NetworkManager
is closed. However, PlayerConnection.disconnect call handleDisconnect
but do not remove it from connectedChannels. Therefore, handleDisconnect is
called twice by PlayerConnection and ServerConnection.

Since ServerConnection check whether NetworkManager is closed for every
tick, just marking it close is enough for PlayerConnection. Therefore
simply remove call of handleDisconnection from PlayerConnection.