### PR TITLE
Fix more exploits (carpet dupe, rail dupe, bedrock destroying, falling block (sand/dragon egg/etc) duping, dragon exp dupe) and properly prevent tnt duplication

### DIFF
--- a/Spigot-Server-Patches/0520-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/Spigot-Server-Patches/0520-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -28,10 +28,10 @@ index 3ee7e5671dd2519cec72b81211f1f39176a228ba..cf9b9de8688e3f655631451409096d7e
 +
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index e40375b67a4a321048c87002a07fde5c5d2395db..d051a54aa04326f84e211cd68ddd2bb209230770 100644
+index e40375b67a4a321048c87002a07fde5c5d2395db..d2207a2c95690de586ab2d181b64955a6d2ea70d 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
-@@ -32,6 +32,13 @@ public class Block implements IMaterial {
+@@ -32,6 +32,14 @@ public class Block implements IMaterial {
      protected final SoundEffectType stepSound;
      protected final Material material;
      // Paper start
@@ -40,12 +40,13 @@ index e40375b67a4a321048c87002a07fde5c5d2395db..d051a54aa04326f84e211cd68ddd2bb2
 +            this != Blocks.BEDROCK &&
 +            this != Blocks.END_PORTAL_FRAME &&
 +            this != Blocks.END_PORTAL &&
-+            this != Blocks.END_GATEWAY;
++            this != Blocks.END_GATEWAY &&
++            this != Blocks.MOVING_PISTON; // try to prevent creation of headless pistons
 +    }
      public co.aikar.timings.Timing timing;
      public co.aikar.timings.Timing getTiming() {
          if (timing == null) {
-@@ -276,7 +283,7 @@ public class Block implements IMaterial {
+@@ -276,7 +284,7 @@ public class Block implements IMaterial {
  
      @Deprecated
      public boolean a(IBlockData iblockdata, BlockActionContext blockactioncontext) {
@@ -54,7 +55,7 @@ index e40375b67a4a321048c87002a07fde5c5d2395db..d051a54aa04326f84e211cd68ddd2bb2
      }
  
      @Deprecated
-@@ -596,7 +603,7 @@ public class Block implements IMaterial {
+@@ -596,7 +604,7 @@ public class Block implements IMaterial {
  
      @Deprecated
      public EnumPistonReaction getPushReaction(IBlockData iblockdata) {
@@ -63,6 +64,48 @@ index e40375b67a4a321048c87002a07fde5c5d2395db..d051a54aa04326f84e211cd68ddd2bb2
      }
  
      public void fallOn(World world, BlockPosition blockposition, Entity entity, float f) {
+diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
+index b29525c40dc8e3ae747b8ddf5a3bd79b7cc0b792..39cd8ab5925ceb9494e0ac910c73338c24ecda2c 100644
+--- a/src/main/java/net/minecraft/server/BlockPiston.java
++++ b/src/main/java/net/minecraft/server/BlockPiston.java
+@@ -175,6 +175,12 @@ public class BlockPiston extends BlockDirectional {
+     @Override
+     public boolean a(IBlockData iblockdata, World world, BlockPosition blockposition, int i, int j) {
+         EnumDirection enumdirection = (EnumDirection) iblockdata.get(BlockPiston.FACING);
++        // Paper start - prevent retracting when we're facing the wrong way (we were replaced before retraction could occur)
++        EnumDirection directionQueuedAs = EnumDirection.fromType1(j & 7); // Paper - copied from below
++        if (!com.destroystokyo.paper.PaperConfig.allowBlockPermanentBreakingExploits && enumdirection != directionQueuedAs) {
++            return false;
++        }
++        // Paper end - prevent retracting when we're facing the wrong way
+ 
+         if (!world.isClientSide) {
+             boolean flag = this.a(world, blockposition, enumdirection);
+@@ -204,7 +210,7 @@ public class BlockPiston extends BlockDirectional {
+             }
+ 
+             world.setTypeAndData(blockposition, (IBlockData) ((IBlockData) Blocks.MOVING_PISTON.getBlockData().set(BlockPistonMoving.a, enumdirection)).set(BlockPistonMoving.b, this.sticky ? BlockPropertyPistonType.STICKY : BlockPropertyPistonType.DEFAULT), 3);
+-            world.setTileEntity(blockposition, BlockPistonMoving.a((IBlockData) this.getBlockData().set(BlockPiston.FACING, EnumDirection.fromType1(j & 7)), enumdirection, false, true));
++            world.setTileEntity(blockposition, BlockPistonMoving.a((IBlockData) this.getBlockData().set(BlockPiston.FACING, EnumDirection.fromType1(j & 7)), enumdirection, false, true)); // Paper - diff on change, j is facing direction
+             if (this.sticky) {
+                 BlockPosition blockposition1 = blockposition.b(enumdirection.getAdjacentX() * 2, enumdirection.getAdjacentY() * 2, enumdirection.getAdjacentZ() * 2);
+                 IBlockData iblockdata1 = world.getType(blockposition1);
+@@ -232,7 +238,14 @@ public class BlockPiston extends BlockDirectional {
+                     }
+                 }
+             } else {
+-                world.a(blockposition.shift(enumdirection), false);
++                // Paper start - fix headless pistons breaking blocks
++                BlockPosition headPos = blockposition.shift(enumdirection);
++                if (com.destroystokyo.paper.PaperConfig.allowBlockPermanentBreakingExploits || world.getType(headPos) == Blocks.PISTON_HEAD.getBlockData().set(FACING, enumdirection)) { // double check to make sure we're not a headless piston.
++                    world.setAir(headPos, false);
++                } else {
++                    ((WorldServer)world).getChunkProvider().flagDirty(headPos); // ... fix client desync
++                }
++                // Paper end - fix headless pistons breaking blocks
+             }
+ 
+             world.playSound((EntityHuman) null, blockposition, SoundEffects.BLOCK_PISTON_CONTRACT, SoundCategory.BLOCKS, 0.5F, world.random.nextFloat() * 0.15F + 0.6F);
 diff --git a/src/main/java/net/minecraft/server/Explosion.java b/src/main/java/net/minecraft/server/Explosion.java
 index a353f3d5fa5a5f54335f73584589de3f5cb20d3e..2552f860ff7a25f74e9a0600e58cefe064fac484 100644
 --- a/src/main/java/net/minecraft/server/Explosion.java

--- a/Spigot-Server-Patches/0537-Optimize-Light-Engine.patch
+++ b/Spigot-Server-Patches/0537-Optimize-Light-Engine.patch
@@ -25,10 +25,10 @@ Massive update to light to improve performance and chunk loading/generation.
 8) Fix NPE risk that crashes server in getting nibble data
 
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index d051a54aa04326f84e211cd68ddd2bb209230770..bd7a92599b4182739aafef9eeaaf8665d2f9f954 100644
+index d2207a2c95690de586ab2d181b64955a6d2ea70d..66244a9d0e253b3709df4ae2adcd21e44ebbfc90 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
-@@ -309,7 +309,7 @@ public class Block implements IMaterial {
+@@ -310,7 +310,7 @@ public class Block implements IMaterial {
          return false;
      }
  

--- a/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -12,6 +12,10 @@ that can duplicate tnt, called "world eaters".
 This patch makes the piston logic retrieve the block state from the world
 prevent this from occuring.
 
+This patch also sets the moved pos to air immediately after creating
+the moving piston TE. This prevents the block from being updated from
+other physics calls by the piston.
+
 Tested against the following tnt duper design:
 https://www.youtube.com/watch?v=mS7xxNGhjxs
 
@@ -25,39 +29,56 @@ unaffected.
 
 This patch fixes https://bugs.mojang.com/browse/MC-188840
 
+This patch also fixes rail duping and carpet duping.
+
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f0284e81db3ab7c45018de2b446f2d8296df15c3..863bec74a6a0ee916b7db05687e588ae52eed4cd 100644
+index f0284e81db3ab7c45018de2b446f2d8296df15c3..8444819f071b13e98ba07032520016a664b7b9bc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -442,4 +442,8 @@ public class PaperConfig {
+@@ -442,4 +442,9 @@ public class PaperConfig {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }
  
-+    public static boolean allowTntDuplication = false;
-+    private static void allowTntDuplication() {
-+        allowTntDuplication = getBoolean("settings.unsupported-settings.allow-tnt-duplication", allowTntDuplication);
++    public static boolean allowPistonDuplication;
++    private static void allowPistonDuplication() {
++        allowPistonDuplication = getBoolean("settings.unsupported-settings.allow-piston-duplication", config.getBoolean("settings.unsupported-settings.allow-tnt-duplication", false));
++        set("settings.unsupported-settings.allow-tnt-duplication", null);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
-index b29525c40dc8e3ae747b8ddf5a3bd79b7cc0b792..32ff3f65cf9c2f9f4be1c1e78f5df555efe67b07 100644
+index 39cd8ab5925ceb9494e0ac910c73338c24ecda2c..f90ac88d33fb6e83eb7bf1e1432df14e452387ec 100644
 --- a/src/main/java/net/minecraft/server/BlockPiston.java
 +++ b/src/main/java/net/minecraft/server/BlockPiston.java
-@@ -364,11 +364,11 @@ public class BlockPiston extends BlockDirectional {
+@@ -376,12 +376,24 @@ public class BlockPiston extends BlockDirectional {
+             }
  
              for (k = list.size() - 1; k >= 0; --k) {
-                 blockposition3 = (BlockPosition) list.get(k);
+-                blockposition3 = (BlockPosition) list.get(k);
 -                iblockdata1 = world.getType(blockposition3);
-+                iblockdata1 = world.getType(blockposition3); if (!com.destroystokyo.paper.PaperConfig.allowTntDuplication) map.replace(blockposition3, iblockdata1); // Paper start - fix piston physics inconsistency
++                // Paper start - fix a variety of piston desync dupes
++                boolean allowDesync = com.destroystokyo.paper.PaperConfig.allowPistonDuplication;
++                BlockPosition oldPos = blockposition3 = (BlockPosition) list.get(k);
++                iblockdata1 = allowDesync ? world.getType(oldPos) : null;
++                // Paper end - fix a variety of piston desync dupes
                  blockposition3 = blockposition3.shift(enumdirection1);
                  map.remove(blockposition3);
                  world.setTypeAndData(blockposition3, (IBlockData) Blocks.MOVING_PISTON.getBlockData().set(BlockPiston.FACING, enumdirection), 68);
 -                world.setTileEntity(blockposition3, BlockPistonMoving.a((IBlockData) list1.get(k), enumdirection, flag, false));
-+                world.setTileEntity(blockposition3, BlockPistonMoving.a(com.destroystokyo.paper.PaperConfig.allowTntDuplication ? list1.get(k) : iblockdata1, enumdirection, flag, false)); // Paper - fix piston physics inconsistency
++                // Paper start - fix a variety of piston desync dupes
++                if (!allowDesync) {
++                    iblockdata1 = world.getType(oldPos);
++                    map.replace(oldPos, iblockdata1);
++                }
++                world.setTileEntity(blockposition3, BlockPistonMoving.a(allowDesync ? list1.get(k) : iblockdata1, enumdirection, flag, false));
++                if (!allowDesync) {
++                    world.setTypeAndData(oldPos, Blocks.AIR.getBlockData(), 4 | 16 | 1024); // set air to prevent later physics updates from seeing this block
++                }
++                // Paper end - fix a variety of piston desync dupes
                  --j;
                  aiblockdata[j] = iblockdata1;
              }
 diff --git a/src/main/java/net/minecraft/server/TileEntityPiston.java b/src/main/java/net/minecraft/server/TileEntityPiston.java
-index 489175abd8e582a3c082364fec357c4f061a22d7..634e37843097cdb08bab3a800565b42a58dce1d8 100644
+index 489175abd8e582a3c082364fec357c4f061a22d7..d700e8281fe50b1c4131ac260ff6c0d0dd8412f0 100644
 --- a/src/main/java/net/minecraft/server/TileEntityPiston.java
 +++ b/src/main/java/net/minecraft/server/TileEntityPiston.java
 @@ -275,7 +275,7 @@ public class TileEntityPiston extends TileEntity implements ITickable {
@@ -65,7 +86,7 @@ index 489175abd8e582a3c082364fec357c4f061a22d7..634e37843097cdb08bab3a800565b42a
  
                  if (iblockdata.isAir()) {
 -                    this.world.setTypeAndData(this.position, this.a, 84);
-+                    this.world.setTypeAndData(this.position, this.a, 84 | (com.destroystokyo.paper.PaperConfig.allowTntDuplication ? 0 : 2)); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
++                    this.world.setTypeAndData(this.position, this.a, com.destroystokyo.paper.PaperConfig.allowPistonDuplication ? 84 : (84 | 2)); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
                      Block.a(this.a, iblockdata, this.world, this.position, 3);
                  } else {
                      if (iblockdata.b((IBlockState) BlockProperties.C) && (Boolean) iblockdata.get(BlockProperties.C)) {

--- a/Spigot-Server-Patches/0543-Fix-sand-duping.patch
+++ b/Spigot-Server-Patches/0543-Fix-sand-duping.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Fri, 12 Jun 2020 13:33:19 -0700
+Subject: [PATCH] Fix sand duping
+
+If the falling block dies during teleportation (entity#move), then we need
+to detect that by placing a check after the move.
+
+diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+index 6683f7c5f31b88187961335c5f708b8a4f77b5af..243a8c570dd7cc5b1b622ff130c7339f9bcfc79a 100644
+--- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
++++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
+@@ -64,6 +64,11 @@ public class EntityFallingBlock extends Entity {
+ 
+     @Override
+     public void tick() {
++        // Paper start - fix sand duping
++        if (this.dead) {
++            return;
++        }
++        // Paper end - fix sand duping
+         if (this.block.isAir()) {
+             this.die();
+         } else {
+@@ -86,6 +91,12 @@ public class EntityFallingBlock extends Entity {
+ 
+             this.move(EnumMoveType.SELF, this.getMot());
+ 
++            // Paper start - fix sand duping
++            if (this.dead) {
++                return;
++            }
++            // Paper end - fix sand duping
++
+             // Paper start - Configurable EntityFallingBlock height nerf
+             if (this.world.paperConfig.fallingBlockHeightNerf != 0 && this.locY() > this.world.paperConfig.fallingBlockHeightNerf) {
+                 if (this.dropItem && this.world.getGameRules().getBoolean(GameRules.DO_ENTITY_DROPS)) {

--- a/Spigot-Server-Patches/0544-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/Spigot-Server-Patches/0544-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Fri, 12 Jun 2020 16:51:39 -0700
+Subject: [PATCH] Prevent position desync in playerconnection causing tp
+ exploit
+
+Caused the server to revert to the player's overworld coordinates
+after teleporting into the end.
+
+Sidenote: The underlying issue is that the move call can teleport
+entities and do other things like kill the entity. In the future,
+to fix all exploits derieved from this usually unexpected
+behaviour, we need to move all of this dangerous logic outside
+of the move call and into an appropriate place in the tick method.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 7123e197c7ed01afd4fbf7aa0760611373039a13..3e5dea60fd043010506436e700601c0e8ffd8f17 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1080,6 +1080,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+                             }
+ 
+                             this.player.move(EnumMoveType.PLAYER, new Vec3D(d7, d8, d9));
++                            // Paper start - prevent position desync
++                            if (this.teleportPos != null) {
++                                return; // ... thanks Mojang for letting move calls teleport across dimensions.
++                            }
++                            // Paper end - prevent position desync
+                             this.player.onGround = packetplayinflying.b();
+                             double d12 = d8;
+ 

--- a/Spigot-Server-Patches/0545-Fix-enderdragon-exp-dupe.patch
+++ b/Spigot-Server-Patches/0545-Fix-enderdragon-exp-dupe.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Fri, 12 Jun 2020 22:25:11 -0700
+Subject: [PATCH] Fix enderdragon exp dupe
+
+Properly track death stage when unloading/loading in the
+dragon
+
+diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+index aecdaacfc7da560759bc513680d76f55820d5046..7daebfdab5c6e258d3e426643c0dbd374774ff5d 100644
+--- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
++++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
+@@ -33,7 +33,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
+     public float bx;
+     public float by;
+     public boolean bz;
+-    public int bA;
++    public int bA; public final int getDeathTicks() { return this.bA; } public final void setDeathTicks(final int value) { this.bA = value; } // Paper
+     public float bB;
+     @Nullable
+     public EntityEnderCrystal currentEnderCrystal;
+@@ -833,6 +833,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
+     public void b(NBTTagCompound nbttagcompound) {
+         super.b(nbttagcompound);
+         nbttagcompound.setInt("DragonPhase", this.bO.a().getControllerPhase().b());
++        nbttagcompound.setInt("Paper.DeathTick", this.getDeathTicks()); // Paper
+     }
+ 
+     @Override
+@@ -841,6 +842,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
+         if (nbttagcompound.hasKey("DragonPhase")) {
+             this.bO.setControllerPhase(DragonControllerPhase.getById(nbttagcompound.getInt("DragonPhase")));
+         }
++        this.setDeathTicks(nbttagcompound.getInt("Paper.DeathTick")); // Paper
+ 
+     }
+ 


### PR DESCRIPTION
Properly prevents physics desyncs by setting the old pos to air and by getting the old pos after the set type call