### PR TITLE
Track EnderDragon in View Distance

### DIFF
--- a/Spigot-Server-Patches/0426-Tracking-Range-Improvements.patch
+++ b/Spigot-Server-Patches/0426-Tracking-Range-Improvements.patch
@@ -20,18 +20,19 @@ index c20acd86beb8f28345d1359d0a2b68b7d8e0e410..4ba661c5a89bebe29c8802387bc93c10
                  if (j > i) {
                      i = j;
 diff --git a/src/main/java/org/spigotmc/TrackingRange.java b/src/main/java/org/spigotmc/TrackingRange.java
-index 6f8e6c1d079f82d7706d0b4f710bfb9b50e209d9..765bdaf9b525a989ec8d37a2fe856dcfcbd06782 100644
+index 6f8e6c1d079f82d7706d0b4f710bfb9b50e209d9..03990231a8b6bc6925f054e9033825316abfafcc 100644
 --- a/src/main/java/org/spigotmc/TrackingRange.java
 +++ b/src/main/java/org/spigotmc/TrackingRange.java
-@@ -1,6 +1,7 @@
+@@ -1,6 +1,8 @@
  package org.spigotmc;
  
  import net.minecraft.server.Entity;
 +import net.minecraft.server.EntityEnderDragon; // Paper
++import net.minecraft.server.WorldServer; // Paper
  import net.minecraft.server.EntityExperienceOrb;
  import net.minecraft.server.EntityGhast;
  import net.minecraft.server.EntityItem;
-@@ -25,26 +26,26 @@ public class TrackingRange
+@@ -25,26 +27,26 @@ public class TrackingRange
          if ( entity instanceof EntityPlayer )
          {
              return config.playerTrackingRange;
@@ -69,7 +70,7 @@ index 6f8e6c1d079f82d7706d0b4f710bfb9b50e209d9..765bdaf9b525a989ec8d37a2fe856dcf
              return config.miscTrackingRange;
          } else
          {
-+            if (entity instanceof EntityEnderDragon) return defaultRange; // Paper - enderdragon is exempt
++            if (entity instanceof EntityEnderDragon) return ((WorldServer)(entity.getWorld())).getChunkProvider().playerChunkMap.getLoadViewDistance(); // Paper - enderdragon is exempt
              return config.otherTrackingRange;
          }
      }

--- a/Spigot-Server-Patches/0501-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0501-Use-distance-map-to-optimise-entity-tracker.patch
@@ -317,10 +317,10 @@ index 3f1a5e48676d1b4b01fbbc25fc9c9cf556cbf0eb..f09bb1329cf993034661fb8cfbf87571
                  }
              }
 diff --git a/src/main/java/org/spigotmc/TrackingRange.java b/src/main/java/org/spigotmc/TrackingRange.java
-index 765bdaf9b525a989ec8d37a2fe856dcfcbd06782..43b5ed8e396e5312f7de1f160f596f58baead28a 100644
+index 03990231a8b6bc6925f054e9033825316abfafcc..2ba1c1b9160e8d24cb338fa9b6b844423119dc73 100644
 --- a/src/main/java/org/spigotmc/TrackingRange.java
 +++ b/src/main/java/org/spigotmc/TrackingRange.java
-@@ -49,4 +49,43 @@ public class TrackingRange
+@@ -50,4 +50,43 @@ public class TrackingRange
              return config.otherTrackingRange;
          }
      }


### PR DESCRIPTION
In vanilla Enderdragon is tracked for 10 chunks, however if the view distance or no-tick view distance is set higher than 10, the enderdragon can be invisible even though the chunks it is in are visible.

Fixes #2616