### PR TITLE
Remove choice on zero-tick farms

### DIFF
--- a/Spigot-Server-Patches/0401-Fix-zero-tick-instant-grow-farms-MC-113809.patch
+++ b/Spigot-Server-Patches/0401-Fix-zero-tick-instant-grow-farms-MC-113809.patch
@@ -4,22 +4,6 @@ Date: Sun, 15 Sep 2019 11:32:32 -0500
 Subject: [PATCH] Fix zero-tick instant grow farms MC-113809
 
 
-diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62fe175dc4f00cc9cab6cbd828b57e25740b3793..f6f5f9dea6284582e9a175c0875273ee1db76076 100644
---- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-+++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -552,6 +552,11 @@ public class PaperWorldConfig {
-         disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
-     }
- 
-+    public boolean fixZeroTickInstantGrowFarms = true;
-+    private void fixZeroTickInstantGrowFarms() {
-+        fixZeroTickInstantGrowFarms = getBoolean("fix-zero-tick-instant-grow-farms", fixZeroTickInstantGrowFarms);
-+    }
-+
-     public boolean altItemDespawnRateEnabled;
-     public Map<Material, Integer> altItemDespawnRateMap;
-     private void altItemDespawnRate() {
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
 index 540fcce1dd4d64dee51e2594f2199fac5299c6a0..e29ec958b3519d92cda215a50e97e6852d71c684 100644
 --- a/src/main/java/net/minecraft/server/Block.java
@@ -33,50 +17,50 @@ index 540fcce1dd4d64dee51e2594f2199fac5299c6a0..e29ec958b3519d92cda215a50e97e685
      private final boolean i;
      private final boolean j;
 diff --git a/src/main/java/net/minecraft/server/BlockBamboo.java b/src/main/java/net/minecraft/server/BlockBamboo.java
-index c482aad3e3e255dfe13b622859ed61b780a9e08e..02c548dd9c9a97bfb55d39ba2f6d4ab85ada0573 100644
+index c482aad3e3e255dfe13b622859ed61b780a9e08e..4c50409ebc905d6c5ce15ec1986c0be567faa794 100644
 --- a/src/main/java/net/minecraft/server/BlockBamboo.java
 +++ b/src/main/java/net/minecraft/server/BlockBamboo.java
 @@ -85,6 +85,7 @@ public class BlockBamboo extends Block implements IBlockFragilePlantElement {
          if (!iblockdata.canPlace(worldserver, blockposition)) {
              worldserver.b(blockposition, true);
          } else if ((Integer) iblockdata.get(BlockBamboo.f) == 0) {
-+            if (worldserver.paperConfig.fixZeroTickInstantGrowFarms && !randomTick) return; // Paper - fix MC-113809
++            if (!randomTick) return; // Paper - fix MC-113809
              if (random.nextInt(Math.max(1, (int) (100.0F / worldserver.spigotConfig.bambooModifier) * 3)) == 0 && worldserver.isEmpty(blockposition.up()) && worldserver.getLightLevel(blockposition.up(), 0) >= 9) { // Spigot
                  int i = this.b(worldserver, blockposition) + 1;
  
 diff --git a/src/main/java/net/minecraft/server/BlockCactus.java b/src/main/java/net/minecraft/server/BlockCactus.java
-index e0974e256f0f10e047b9eb8e362982c6578d2d98..3524fcb927865d7b8754d9fbf85b853f09b94bb8 100644
+index e0974e256f0f10e047b9eb8e362982c6578d2d98..ee28e210412554e067da9bc5de24059cd905e2b3 100644
 --- a/src/main/java/net/minecraft/server/BlockCactus.java
 +++ b/src/main/java/net/minecraft/server/BlockCactus.java
 @@ -21,6 +21,7 @@ public class BlockCactus extends Block {
          if (!iblockdata.canPlace(worldserver, blockposition)) {
              worldserver.b(blockposition, true);
          } else {
-+            if (worldserver.paperConfig.fixZeroTickInstantGrowFarms && !randomTick) return; // Paper - fix MC-113809
++            if (!randomTick) return; // Paper - fix MC-113809
              BlockPosition blockposition1 = blockposition.up();
  
              if (worldserver.isEmpty(blockposition1)) {
 diff --git a/src/main/java/net/minecraft/server/BlockChorusFlower.java b/src/main/java/net/minecraft/server/BlockChorusFlower.java
-index d70b52cadf1b76eff7984127837b0a3aa36f6a0e..b624cf38047e242569d30ee4e3ad971455b5ff0a 100644
+index d70b52cadf1b76eff7984127837b0a3aa36f6a0e..265671d4d7a2456453f607d226f128c95ca5766e 100644
 --- a/src/main/java/net/minecraft/server/BlockChorusFlower.java
 +++ b/src/main/java/net/minecraft/server/BlockChorusFlower.java
 @@ -22,6 +22,7 @@ public class BlockChorusFlower extends Block {
          if (!iblockdata.canPlace(worldserver, blockposition)) {
              worldserver.b(blockposition, true);
          } else {
-+            if (worldserver.paperConfig.fixZeroTickInstantGrowFarms && !randomTick) return; // Paper - fix MC-113809
++            if (!randomTick) return; // Paper - fix MC-113809
              BlockPosition blockposition1 = blockposition.up();
  
              if (worldserver.isEmpty(blockposition1) && blockposition1.getY() < 256) {
 diff --git a/src/main/java/net/minecraft/server/BlockReed.java b/src/main/java/net/minecraft/server/BlockReed.java
-index 55b07444e1d769952f2a411b1b5d1032565af8a1..3bc3c5aa29f45cd2ee1c0401b1ee1b1d49e81926 100644
+index 55b07444e1d769952f2a411b1b5d1032565af8a1..94d60c747cf1fe0807c7272a77b2cf3f11e9f6c2 100644
 --- a/src/main/java/net/minecraft/server/BlockReed.java
 +++ b/src/main/java/net/minecraft/server/BlockReed.java
 @@ -23,6 +23,7 @@ public class BlockReed extends Block {
          if (!iblockdata.canPlace(worldserver, blockposition)) {
              worldserver.b(blockposition, true);
          } else if (worldserver.isEmpty(blockposition.up())) {
-+            if (worldserver.paperConfig.fixZeroTickInstantGrowFarms && !randomTick) return; // Paper - fix MC-113809
++            if (!randomTick) return; // Paper - fix MC-113809
              int i;
  
              for (i = 1; worldserver.getType(blockposition.down(i)).getBlock() == this; ++i) {

--- a/Spigot-Server-Patches/0407-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0407-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f6f5f9dea6284582e9a175c0875273ee1db76076..19f355d00ebe7065ae2d2df8156ea4b6459a6598 100644
+index 62fe175dc4f00cc9cab6cbd828b57e25740b3793..24b048a7412cc05998e2f5ebd38b8ebfbeed9987 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -614,4 +614,9 @@ public class PaperWorldConfig {
+@@ -609,4 +609,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0413-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0413-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 19f355d00ebe7065ae2d2df8156ea4b6459a6598..a26848df994ffb0dc02d6a6051971439613dd0ba 100644
+index 24b048a7412cc05998e2f5ebd38b8ebfbeed9987..56124c0509dae1da28c645f1b080ee7e08bbb7c3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -619,4 +619,9 @@ public class PaperWorldConfig {
+@@ -614,4 +614,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0414-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0414-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a26848df994ffb0dc02d6a6051971439613dd0ba..cab503bd5c34d12b38a2f5deed6d3feb9287b370 100644
+index 56124c0509dae1da28c645f1b080ee7e08bbb7c3..1e9e3525700446c3260a9e3cf2abb3afbee7c324 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -624,4 +624,13 @@ public class PaperWorldConfig {
+@@ -619,4 +619,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0437-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0437-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2ab810f71beaa608af2194165696817a2cde4b92..578d81337394e5279c99937890c3ce35bf58404c 100644
+index 1c8284948a2cc1330fceaeba91bd7f5b801f3e07..98d96628d85203a90e1120d0372ed00da2d5437d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -639,4 +639,9 @@ public class PaperWorldConfig {
+@@ -634,4 +634,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0444-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d39028c930cbd66c867649d5148be2fb96bc579..0ff4475625e93d6f7a41345149e7c1fed0220bbb 100644
+index 02c08a23661486250f8ca09a155a97c328775d06..51655411655e72bb0e1352ae3c17274f55d0db63 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -649,4 +649,9 @@ public class PaperWorldConfig {
+@@ -644,4 +644,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0447-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0447-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0ff4475625e93d6f7a41345149e7c1fed0220bbb..598f27bc1b95132ded224dd5c7a0e2639ab2bd12 100644
+index 51655411655e72bb0e1352ae3c17274f55d0db63..0e9ccdcfcf9bec5bae50fdbeaaacdc9c9694955a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -627,10 +627,21 @@ public class PaperWorldConfig {
+@@ -622,10 +622,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0458-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0458-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 598f27bc1b95132ded224dd5c7a0e2639ab2bd12..ea5f306ef57fe5958a554f4bdf866a36d2b185e0 100644
+index 0e9ccdcfcf9bec5bae50fdbeaaacdc9c9694955a..8f633b8403fc3a899093edaa8cc2b3333d1d9f90 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -665,4 +665,9 @@ public class PaperWorldConfig {
+@@ -660,4 +660,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0491-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0491-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ea5f306ef57fe5958a554f4bdf866a36d2b185e0..9db76eae1649fe2ce0856ff4bdcb15569bf58d93 100644
+index 8f633b8403fc3a899093edaa8cc2b3333d1d9f90..18544321ff54884d197dac7ea00d7ae5ec4940b9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -670,4 +670,11 @@ public class PaperWorldConfig {
+@@ -665,4 +665,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0504-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0504-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index d4ebcf8f66197299256bd6b65710a1488c90ea41..a3b41ce5fc70948d4804659a472cb622
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9db76eae1649fe2ce0856ff4bdcb15569bf58d93..c3f7717869c86d9ac6395615bceda324aea16b27 100644
+index 18544321ff54884d197dac7ea00d7ae5ec4940b9..ca6f5d8912e35c6192a621942562127f64ac090a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -677,4 +677,9 @@ public class PaperWorldConfig {
+@@ -672,4 +672,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/Spigot-Server-Patches/0538-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0538-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c3f7717869c86d9ac6395615bceda324aea16b27..ecacb72b922927f06883b75e7d2cc1f904eb9f03 100644
+index ca6f5d8912e35c6192a621942562127f64ac090a..ef09430c271ab17327a1c2664158e9f6bfd3d355 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -682,4 +682,13 @@ public class PaperWorldConfig {
+@@ -677,4 +677,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
@@ -35,7 +35,7 @@ index c3f7717869c86d9ac6395615bceda324aea16b27..ecacb72b922927f06883b75e7d2cc1f9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ChunkMapDistance.java b/src/main/java/net/minecraft/server/ChunkMapDistance.java
-index 3a33d625cac39036df67aac81599fa1db7f808d4..7eb14c2e3a13a9d2d6c5e699eca3ce60b50e9188 100644
+index 02d07d3ff5c3b824047402ff1f58aa338a46c254..ee76ba3a31da1146fb791cdcf88e8bca5d14d2e1 100644
 --- a/src/main/java/net/minecraft/server/ChunkMapDistance.java
 +++ b/src/main/java/net/minecraft/server/ChunkMapDistance.java
 @@ -176,6 +176,27 @@ public abstract class ChunkMapDistance {


### PR DESCRIPTION
Remove the choice from the zero-tick farm fix.

Unsure how seriously this will actually be considered, but I personally think it
would be completely fair, especially with regards to the outcome of the
argument in #3544 resulting in no choice for the bug fix.
