### PR TITLE
No Config For New Piston Inconsistency Fix

### DIFF
--- a/PistonInconsistency
+++ b/PistonInconsistency
@@ -1,0 +1,1 @@
+Enable-PistonInconsistency-Fix = true


### PR DESCRIPTION
There is no config to enable or disable the new Piston Inconsistency Fix, the fix that disabled TNT dupers. This is a vanilla mechanic until fixed by Mojang and makes it hard for my players to feel immersed in their game play. Until there is a config I must make a choice to either not update, make my player base unhappy (which is an unlikely choice), or switch back to spigot.
This fix should default true and only be disabled if admins want it to happen like the 0 tick farms.

Not 100% sure how github works. This fork obviously doesn't actually implement a fix and should not be merged. 