### PR TITLE
Add unsupported-settings section to config (piston tnt dupe config option)

### DIFF
--- a/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -25,8 +25,21 @@ unaffected.
 
 This patch fixes https://bugs.mojang.com/browse/MC-188840
 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index f0284e81db3ab7c45018de2b446f2d8296df15c3..863bec74a6a0ee916b7db05687e588ae52eed4cd 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -442,4 +442,8 @@ public class PaperConfig {
+         consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
+     }
+ 
++    public static boolean allowTntDuplication = false;
++    private static void allowTntDuplication() {
++        allowTntDuplication = getBoolean("settings.unsupported-settings.allow-tnt-duplication", allowTntDuplication);
++    }
+ }
 diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
-index b29525c40dc8e3ae747b8ddf5a3bd79b7cc0b792..880aa8c86d1724cd9ef68e0abfff8bb38f389462 100644
+index b29525c40dc8e3ae747b8ddf5a3bd79b7cc0b792..32ff3f65cf9c2f9f4be1c1e78f5df555efe67b07 100644
 --- a/src/main/java/net/minecraft/server/BlockPiston.java
 +++ b/src/main/java/net/minecraft/server/BlockPiston.java
 @@ -364,11 +364,11 @@ public class BlockPiston extends BlockDirectional {
@@ -34,17 +47,17 @@ index b29525c40dc8e3ae747b8ddf5a3bd79b7cc0b792..880aa8c86d1724cd9ef68e0abfff8bb3
              for (k = list.size() - 1; k >= 0; --k) {
                  blockposition3 = (BlockPosition) list.get(k);
 -                iblockdata1 = world.getType(blockposition3);
-+                iblockdata1 = world.getType(blockposition3); map.replace(blockposition3, iblockdata1); // Paper - fix piston physics inconsistency
++                iblockdata1 = world.getType(blockposition3); if (!com.destroystokyo.paper.PaperConfig.allowTntDuplication) map.replace(blockposition3, iblockdata1); // Paper start - fix piston physics inconsistency
                  blockposition3 = blockposition3.shift(enumdirection1);
                  map.remove(blockposition3);
                  world.setTypeAndData(blockposition3, (IBlockData) Blocks.MOVING_PISTON.getBlockData().set(BlockPiston.FACING, enumdirection), 68);
 -                world.setTileEntity(blockposition3, BlockPistonMoving.a((IBlockData) list1.get(k), enumdirection, flag, false));
-+                world.setTileEntity(blockposition3, BlockPistonMoving.a(iblockdata1, enumdirection, flag, false)); // Paper - fix piston physics inconsistency
++                world.setTileEntity(blockposition3, BlockPistonMoving.a(com.destroystokyo.paper.PaperConfig.allowTntDuplication ? list1.get(k) : iblockdata1, enumdirection, flag, false)); // Paper - fix piston physics inconsistency
                  --j;
                  aiblockdata[j] = iblockdata1;
              }
 diff --git a/src/main/java/net/minecraft/server/TileEntityPiston.java b/src/main/java/net/minecraft/server/TileEntityPiston.java
-index 489175abd8e582a3c082364fec357c4f061a22d7..946522f6362638f518fba15172fb7f676d46b67c 100644
+index 489175abd8e582a3c082364fec357c4f061a22d7..634e37843097cdb08bab3a800565b42a58dce1d8 100644
 --- a/src/main/java/net/minecraft/server/TileEntityPiston.java
 +++ b/src/main/java/net/minecraft/server/TileEntityPiston.java
 @@ -275,7 +275,7 @@ public class TileEntityPiston extends TileEntity implements ITickable {
@@ -52,7 +65,7 @@ index 489175abd8e582a3c082364fec357c4f061a22d7..946522f6362638f518fba15172fb7f67
  
                  if (iblockdata.isAir()) {
 -                    this.world.setTypeAndData(this.position, this.a, 84);
-+                    this.world.setTypeAndData(this.position, this.a, 84 | 2); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
++                    this.world.setTypeAndData(this.position, this.a, 84 | (com.destroystokyo.paper.PaperConfig.allowTntDuplication ? 0 : 2)); // Paper - force notify (flag 2), it's possible the set type by the piston block (which doesn't notify) set this block to air
                      Block.a(this.a, iblockdata, this.world, this.position, 3);
                  } else {
                      if (iblockdata.b((IBlockState) BlockProperties.C) && (Boolean) iblockdata.get(BlockProperties.C)) {


### PR DESCRIPTION
This adds a configuration option to allow tnt duplication which was recently fixed. While I wouldn't personally use it, the config option should be here for users who want to use it.

The config option adds a new `unsupported-settings` which can be used for future controversial patches like the last one. By changing anything in this section, users should expect to not receive support unless they reproduce their issues by setting options in the `unsupported-settings` section to their default values. 

With that being said, there's no reason this shouldn't be added. Having multiple different forks/local forks of Paper will just cause further fragmentation and hurt Paper's market share. If you don't like this, don't use the option. 

To all those that I've been disrespectful to in the issue tracker, I'm sorry as I was under the impression that Mojang had fixed this in 1.16 and that you could suck it up for the remaining 1.15 lifecycle.