### PR TITLE
Make `enableTreasureMaps` apply to shipwreck loot generation

### DIFF
--- a/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
+++ b/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
@@ -428,6 +428,19 @@ index ef315377579ca425ecb8d41aaf59eb1dd5b39e12..8776799de033f02b0f87e9ea7e4a4ce9
                  this.b();
                  this.g.set(false);
              }));
+diff --git a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
+index fa11b2fc6364dc6fb6a951e092ea01f5e74c2c1d..5fe0da76bd172c2c552b2dd210e89be214c4385c 100644
+--- a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
++++ b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
+@@ -69,7 +69,7 @@ public class LootItemFunctionExplorationMap extends LootItemFunctionConditional
+         }
+ 
+         public void a(JsonObject jsonobject, LootItemFunctionExplorationMap lootitemfunctionexplorationmap, JsonSerializationContext jsonserializationcontext) {
+-            super.a(jsonobject, (LootItemFunctionConditional) lootitemfunctionexplorationmap, jsonserializationcontext);
++            super.a(jsonobject, lootitemfunctionexplorationmap, jsonserializationcontext); // Paper - decompile fix
+             if (!lootitemfunctionexplorationmap.d.equals("Buried_Treasure")) {
+                 jsonobject.add("destination", jsonserializationcontext.serialize(lootitemfunctionexplorationmap.d));
+             }
 diff --git a/src/main/java/net/minecraft/server/LootSelectorEntry.java b/src/main/java/net/minecraft/server/LootSelectorEntry.java
 index 59bb53543113660cd2514350a24a4908a8464f24..3ed6a1e785f68c4bb6c5afe024c43150915968a3 100644
 --- a/src/main/java/net/minecraft/server/LootSelectorEntry.java

--- a/Spigot-Server-Patches/0129-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0129-Configurable-Cartographer-Treasure-Maps.patch
@@ -27,6 +27,26 @@ index bff2e9d26dc8057c3950d1b57ee2e7469e7f943c..f164844f339793860e773c499443ce16
 +        }
 +    }
  }
+diff --git a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
+index 5fe0da76bd172c2c552b2dd210e89be214c4385c..f7220f057e313ad137fe01397e43c4a42afbccc1 100644
+--- a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
++++ b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
+@@ -42,6 +42,15 @@ public class LootItemFunctionExplorationMap extends LootItemFunctionConditional
+ 
+             if (blockposition != null) {
+                 WorldServer worldserver = loottableinfo.c();
++                // Paper start
++                if (!worldserver.paperConfig.enableTreasureMaps) {
++                    /*
++                     * NOTE: I fear users will just get a plain map as their "treasure"
++                     * This is preferable to disrespecting the config.
++                     */
++                    return itemstack;
++                }
++                // Paper end
+                 BlockPosition blockposition1 = worldserver.a(this.d, blockposition, this.g, this.h);
+ 
+                 if (blockposition1 != null) {
 diff --git a/src/main/java/net/minecraft/server/VillagerTrades.java b/src/main/java/net/minecraft/server/VillagerTrades.java
 index 3bcf0b385d1f707176dae9c3ee49370e2e6dd481..4764ffef77bf0a73018017a07103186a9ce55b8f 100644
 --- a/src/main/java/net/minecraft/server/VillagerTrades.java


### PR DESCRIPTION
Fixes #3480
Previously it only controlled whether villagers could trade treasure maps.
Now it should apply to loot generated in treasure maps.

We don't unregister treasure maps from the loot table,
since this option is per-world and the table is global.
Instead I just replaced the implementation with a NOP.