### PR TITLE
Only complete from cache if ID is given

### DIFF
--- a/Spigot-Server-Patches/0154-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0154-Basic-PlayerProfile-API.patch
@@ -7,7 +7,7 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5eee712e4c9230b10a969daee9fd8b4eec9bf6c9
+index 0000000000000000000000000000000000000000..f98f4d55b14a59e06fb17a7f7500a2f98cba58a5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 @@ -0,0 +1,285 @@
@@ -170,7 +170,7 @@ index 0000000000000000000000000000000000000000..5eee712e4c9230b10a969daee9fd8b4e
 +            }
 +        }
 +
-+        if (profile.getName() == null || !hasTextures()) {
++        if ((profile.getName() == null || !hasTextures()) && profile.getId() != null) {
 +            GameProfile profile = userCache.getProfile(this.profile.getId());
 +            if (profile != null) {
 +                // if old has it, assume its newer, so overwrite, else use cached if it was set and ours wasn't


### PR DESCRIPTION
As it stands, one can complete from the cache if no ID is given. If
there is no ID, it will throw an NPE, as ConcurrentHashMap (which is used
in UserCache) does not support null keys. This should fix any current
and future issues where exceptions are thrown just because a UUID is not
currently given on the profile due to a plugin or server bug/issue.

Fixes #3590.

Do not merge until @osum54 or @MrEAlderson can confirm
it is fixed as the issue arose with a premium plugin unavailable
to the public on "a plugin leaking site".

Paperclip with patch applied for testing:
https://owo.whats-th.is/93GyDwP.jar