### PR TITLE
Fix interact event not being called in adventure

### DIFF
--- a/Spigot-Server-Patches/0633-Fix-interact-event-not-being-called-in-adventure.patch
+++ b/Spigot-Server-Patches/0633-Fix-interact-event-not-being-called-in-adventure.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheMolkaPL <themolkapl@gmail.com>
+Date: Sun, 21 Jun 2020 17:21:46 +0200
+Subject: [PATCH] Fix interact event not being called in adventure
+
+Call PlayerInteractEvent when left-clicking on a block in adventure mode
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 73241af66256ef386790027fd6c7e0ca984524b4..87b1ff21957d5d708209257e569785aeaf191181 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -2055,7 +2055,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         Vec3D vec3d1 = vec3d.add((double) f7 * d3, (double) f6 * d3, (double) f8 * d3);
+         MovingObjectPosition movingobjectposition = this.player.world.rayTrace(new RayTrace(vec3d, vec3d1, RayTrace.BlockCollisionOption.OUTLINE, RayTrace.FluidCollisionOption.NONE, player));
+ 
+-        if (movingobjectposition == null || movingobjectposition.getType() != MovingObjectPosition.EnumMovingObjectType.BLOCK) {
++        if (movingobjectposition == null || movingobjectposition.getType() != MovingObjectPosition.EnumMovingObjectType.BLOCK || this.player.playerInteractManager.getGameMode() == EnumGamemode.ADVENTURE) { // Paper - call PlayerInteractEvent when left-clicking on a block in adventure mode
+             CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_AIR, this.player.inventory.getItemInHand(), EnumHand.MAIN_HAND);
+         }
+ 


### PR DESCRIPTION
Previously, when players were left-clicking on blocks in adventure mode PlayerInteractEvent wasn't called. This has been caught using WorldEdit's wand and navigation tools in adventure mode.