### PR TITLE
Fix piston dupe patch creating ghost blocks

### DIFF
--- a/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/Spigot-Server-Patches/0542-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -46,7 +46,7 @@ index f0284e81db3ab7c45018de2b446f2d8296df15c3..8444819f071b13e98ba07032520016a6
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockPiston.java b/src/main/java/net/minecraft/server/BlockPiston.java
-index 39cd8ab5925ceb9494e0ac910c73338c24ecda2c..f90ac88d33fb6e83eb7bf1e1432df14e452387ec 100644
+index 39cd8ab5925ceb9494e0ac910c73338c24ecda2c..73ac83832121e0390b7c4649681fc247e3d8c30b 100644
 --- a/src/main/java/net/minecraft/server/BlockPiston.java
 +++ b/src/main/java/net/minecraft/server/BlockPiston.java
 @@ -376,12 +376,24 @@ public class BlockPiston extends BlockDirectional {
@@ -71,7 +71,7 @@ index 39cd8ab5925ceb9494e0ac910c73338c24ecda2c..f90ac88d33fb6e83eb7bf1e1432df14e
 +                }
 +                world.setTileEntity(blockposition3, BlockPistonMoving.a(allowDesync ? list1.get(k) : iblockdata1, enumdirection, flag, false));
 +                if (!allowDesync) {
-+                    world.setTypeAndData(oldPos, Blocks.AIR.getBlockData(), 4 | 16 | 1024); // set air to prevent later physics updates from seeing this block
++                    world.setTypeAndData(oldPos, Blocks.AIR.getBlockData(), 2 | 4 | 16 | 1024); // set air to prevent later physics updates from seeing this block
 +                }
 +                // Paper end - fix a variety of piston desync dupes
                  --j;


### PR DESCRIPTION
The notify flag (bitwise OR 2) must always be set. If it is only set
when the `map.replace` call before it does something, as was suggested
on Discord, the issue will not change whatsoever.

Fixes #3593.