### PR TITLE
Added custom ranges to beacons

### DIFF
--- a/Spigot-API-Patches/0233-Beacon-API-custom-effect-ranges.patch
+++ b/Spigot-API-Patches/0233-Beacon-API-custom-effect-ranges.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 24 Jun 2020 12:38:15 -0600
+Subject: [PATCH] Beacon API - custom effect ranges
+
+
+diff --git a/src/main/java/org/bukkit/block/Beacon.java b/src/main/java/org/bukkit/block/Beacon.java
+index 6349fa9da3f96df3553fb9552c1cab95338cecb0..2c8fce5e1d6cf8dade37851f0bee4cff5d15ea78 100644
+--- a/src/main/java/org/bukkit/block/Beacon.java
++++ b/src/main/java/org/bukkit/block/Beacon.java
+@@ -64,4 +64,26 @@ public interface Beacon extends TileState, Lockable, Nameable {
+      * @param effect desired secondary effect
+      */
+     void setSecondaryEffect(@Nullable PotionEffectType effect);
++
++    // Paper start - Custom effect ranges
++    /**
++     * Gets the effect range of this beacon.
++     * A negative range value means the beacon is using its default range based on tier.
++     * @return Either the custom range set with {@link #setEffectRange(double) or the range based on the beacon tier.
++     */
++    double getEffectRange();
++
++    /**
++     * Sets the effect range of the beacon
++     * A negative range value means the beacon is using its default range based on tier.
++     * @param range Radius of effect range.
++     */
++    void setEffectRange(double range);
++
++    /**
++     * Resets the custom range from this beacon and falls back to the range based on the the beacon tier.
++     * Shortcut for setting the effect range to a negative number.
++     */
++    void resetEffectRange();
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0597-Beacon-API-custom-effect-ranges.patch
+++ b/Spigot-Server-Patches/0597-Beacon-API-custom-effect-ranges.patch
@@ -1,0 +1,90 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 24 Jun 2020 12:39:08 -0600
+Subject: [PATCH] Beacon API - custom effect ranges
+
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityBeacon.java b/src/main/java/net/minecraft/server/TileEntityBeacon.java
+index c6b7bc3dc1445269c1562c308b386ce480d70ef3..f97b27a4751d1fc3287de8dba384ab5639b832b8 100644
+--- a/src/main/java/net/minecraft/server/TileEntityBeacon.java
++++ b/src/main/java/net/minecraft/server/TileEntityBeacon.java
+@@ -45,6 +45,26 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+         return (hasSecondaryEffect()) ? CraftPotionUtil.toBukkit(new MobEffect(this.secondaryEffect, getLevel(), getAmplification(), true, true)) : null;
+     }
+     // CraftBukkit end
++    // Paper start - add field/methods for custom range
++    private final String PAPER_RANGE_TAG = "Paper.Range";
++    private double effectRange = -1;
++
++    public double getEffectRange() {
++        if (this.effectRange < 0) {
++            return this.levels * 10 + 10;
++        } else {
++            return effectRange;
++        }
++    }
++
++    public void setEffectRange(double range) {
++        this.effectRange = range;
++    }
++
++    public void resetEffectRange() {
++        this.effectRange = -1;
++    }
++    // Paper end
+ 
+     public TileEntityBeacon() {
+         super(TileEntityTypes.BEACON);
+@@ -235,7 +255,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+ 
+     public List getHumansInRange() {
+         {
+-            double d0 = (double) (this.levels * 10 + 10);
++            // Paper - custom beacon ranges
++            double d0 = this.getEffectRange();
+ 
+             AxisAlignedBB axisalignedbb = (new AxisAlignedBB(this.position)).g(d0).b(0.0D, (double) this.world.getBuildHeight(), 0.0D);
+             List<EntityHuman> list = this.world.a(EntityHuman.class, axisalignedbb);
+@@ -336,6 +357,9 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+         this.secondaryEffect = MobEffectList.fromId(nbttagcompound.getInt("Secondary"));
+         this.levels = nbttagcompound.getInt("Levels"); // SPIGOT-5053, use where available
+         // CraftBukkit end
++        // Paper
++        this.effectRange = nbttagcompound.hasKeyOfType(PAPER_RANGE_TAG, 6) ? nbttagcompound.getDouble(PAPER_RANGE_TAG) : -1;
++
+         if (nbttagcompound.hasKeyOfType("CustomName", 8)) {
+             this.customName = IChatBaseComponent.ChatSerializer.a(nbttagcompound.getString("CustomName"));
+         }
+@@ -352,6 +376,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+         if (this.customName != null) {
+             nbttagcompound.setString("CustomName", IChatBaseComponent.ChatSerializer.a(this.customName));
+         }
++        // Paper
++        nbttagcompound.setDouble(PAPER_RANGE_TAG, this.effectRange);
+ 
+         this.chestLock.a(nbttagcompound);
+         return nbttagcompound;
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
+index 21ebceafbf27125761aa08cfe0785f6f05c77592..51efea5262b80b7cee917b1bdaf22e4b741d5e03 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
+@@ -95,4 +95,19 @@ public class CraftBeacon extends CraftBlockEntityState<TileEntityBeacon> impleme
+     public void setLock(String key) {
+         this.getSnapshot().chestLock = (key == null) ? ChestLock.a : new ChestLock(key);
+     }
++
++    @Override
++    public double getEffectRange() {
++        return this.getSnapshot().getEffectRange();
++    }
++
++    @Override
++    public void setEffectRange(double range) {
++        this.getSnapshot().setEffectRange(range);
++    }
++
++    @Override
++    public void resetEffectRange() {
++        this.getSnapshot().resetEffectRange();
++    }
+ }


### PR DESCRIPTION
Adds 3 methods to the Beacon block state to set a custom range for the beacon. One to set the range, one to get the range, and one to reset the range (aka go back to using the default range-by-beacon-tier system).