### PR TITLE
Mob spawners slowly tick when there are no players nearby

### DIFF
--- a/Spigot-API-Patches/0210-Monumenta-Add-events-for-loading-and-saving-advancem.patch
+++ b/Spigot-API-Patches/0210-Monumenta-Add-events-for-loading-and-saving-advancem.patch
@@ -1,0 +1,185 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 1 Apr 2020 14:07:13 -0700
+Subject: [PATCH] Monumenta - Add events for loading and saving advancement
+ data
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataLoadEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataLoadEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f3ec306ba8d663f376724f5860cc9b685109166b
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataLoadEvent.java
+@@ -0,0 +1,83 @@
++package com.destroystokyo.paper.event.player;
++
++import java.io.File;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when the server loads the advancement data for a player
++ */
++public class PlayerAdvancementDataLoadEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    @Nullable private String jsonData;
++    @NotNull private File path;
++
++    public PlayerAdvancementDataLoadEvent(@NotNull Player who, @NotNull File path) {
++        super(who);
++        this.jsonData = null;
++        this.path = path;
++    }
++
++    /**
++     * Get the file path where advancement data will be loaded from.
++     *
++     * Data will only be loaded from here if the data is not directly set by {@link #setJsonData}
++     *
++     * @return advancement data File to load from
++     */
++    @NotNull
++    public File getPath() {
++        return path;
++    }
++
++    /**
++     * Set the file path where advancement data will be loaded from.
++     *
++     * Data will only be loaded from here if the data is not directly set by {@link #setJsonData}
++     *
++     * @param path advancement data File to load from
++     */
++    public void setPath(@NotNull File path) {
++        this.path = path;
++    }
++
++    /**
++     * Get the JSON data supplied by an earlier call to {@link #setJsonData}.
++     *
++     * This data will be used instead of loading the player's advancement file. It is null unless
++     * supplied by a plugin.
++     *
++     * @return JSON data of the player's advancements as set by {@link #setJsonData}
++     */
++    @Nullable
++    public String getJsonData() {
++        return jsonData;
++    }
++
++    /**
++     * Set the JSON data to use for the player's advancements instead of loading it from a file.
++     *
++     * This data will be used instead of loading the player's advancement file. It is null unless
++     * supplied by a plugin.
++     *
++     * @param jsonData advancement data JSON string to load. If null, load from file
++     */
++    public void setJsonData(@Nullable String jsonData) {
++        this.jsonData = jsonData;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataSaveEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataSaveEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c2322470206e960c9ff12f723d8b568966426c84
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerAdvancementDataSaveEvent.java
+@@ -0,0 +1,82 @@
++package com.destroystokyo.paper.event.player;
++
++import java.io.File;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when the server saves the advancement data for a player
++ */
++public class PlayerAdvancementDataSaveEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    @NotNull private String jsonData;
++    @NotNull private File path;
++    private boolean cancel = false;
++
++    public PlayerAdvancementDataSaveEvent(@NotNull Player who, @NotNull File path, @NotNull String jsonData) {
++        super(who);
++        this.jsonData = jsonData;
++        this.path = path;
++    }
++
++    /**
++     * Get the file path where advancement data will be saved to.
++     *
++     * @return advancement data File to save to
++     */
++    @NotNull
++    public File getPath() {
++        return path;
++    }
++
++    /**
++     * Set the file path where advancement data will be saved to.
++     *
++     * @return advancement data File to save to
++     */
++    public void setPath(@NotNull File path) {
++        this.path = path;
++    }
++
++    /**
++     * Get the JSON advancements data that will be saved.
++     *
++     * @return JSON data of the player's advancements
++     */
++    @NotNull
++    public String getJsonData() {
++        return jsonData;
++    }
++
++    /**
++     * Set the JSON advancements data that will be saved.
++     *
++     * @param jsonData advancement data JSON string to save instead
++     */
++    public void setJsonData(@NotNull String jsonData) {
++        this.jsonData = jsonData;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-API-Patches/0211-Monumenta-Add-events-for-loading-and-saving-player-d.patch
+++ b/Spigot-API-Patches/0211-Monumenta-Add-events-for-loading-and-saving-player-d.patch
@@ -1,0 +1,175 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Fri, 3 Apr 2020 20:42:49 -0700
+Subject: [PATCH] Monumenta - Add events for loading and saving player data
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerDataLoadEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerDataLoadEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1faf07a59b67edfc58766e71d5e8b9ba29a9f0de
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerDataLoadEvent.java
+@@ -0,0 +1,83 @@
++package com.destroystokyo.paper.event.player;
++
++import java.io.File;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when the server loads the playerdata data for a player
++ */
++public class PlayerDataLoadEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    @Nullable private Object data;
++    @NotNull private File path;
++
++    public PlayerDataLoadEvent(@NotNull Player who, @NotNull File path) {
++        super(who);
++        this.data = null;
++        this.path = path;
++    }
++
++    /**
++     * Get the file path where data will be loaded from.
++     *
++     * Data will only be loaded from here if the data is not directly set by {@link #setData}
++     *
++     * @return data File to load from
++     */
++    @NotNull
++    public File getPath() {
++        return path;
++    }
++
++    /**
++     * Set the file path where data will be loaded from.
++     *
++     * Data will only be loaded from here if the data is not directly set by {@link #setData}
++     *
++     * @param path data File to load from
++     */
++    public void setPath(@NotNull File path) {
++        this.path = path;
++    }
++
++    /**
++     * Get the data supplied by an earlier call to {@link #setData}.
++     *
++     * This data will be used instead of loading the player's file. It is null unless
++     * supplied by a plugin.
++     *
++     * @return NBTTagCompound data of the player's .dat file as set by {@link #setData}
++     */
++    @Nullable
++    public Object getData() {
++        return data;
++    }
++
++    /**
++     * Set the data to use for the player's data instead of loading it from a file.
++     *
++     * This data will be used instead of loading the player's .dat file. It is null unless
++     * supplied by a plugin.
++     *
++     * @param NBTTagCompound data to load. If null, load from file
++     */
++    public void setData(@Nullable Object data) {
++        this.data = data;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerDataSaveEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerDataSaveEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ba7bcc4b063c3e2d1fac461950a4db2f7ba11682
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerDataSaveEvent.java
+@@ -0,0 +1,73 @@
++package com.destroystokyo.paper.event.player;
++
++import java.io.File;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when the server saves the primary .dat data for a player
++ */
++public class PlayerDataSaveEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    @NotNull private final Object data;
++    @NotNull private File path;
++    private boolean cancel = false;
++
++    public PlayerDataSaveEvent(@NotNull Player who, @NotNull File path, @NotNull Object data) {
++        super(who);
++        this.data = data;
++        this.path = path;
++    }
++
++    /**
++     * Get the file path where player data will be saved to.
++     *
++     * @return player data File to save to
++     */
++    @NotNull
++    public File getPath() {
++        return path;
++    }
++
++    /**
++     * Set the file path where player data will be saved to.
++     *
++     * @return player data File to save to
++     */
++    public void setPath(@NotNull File path) {
++        this.path = path;
++    }
++
++    /**
++     * Get the NBTTagCompound player data that will be saved.
++     *
++     * @return NBTTagCompound player data
++     */
++    @NotNull
++    public Object getData() {
++        return data;
++    }
++
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0510-Monumenta-Move-player-saving-to-before-disabling-plu.patch
+++ b/Spigot-Server-Patches/0510-Monumenta-Move-player-saving-to-before-disabling-plu.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Sat, 9 May 2020 01:54:16 +0000
+Subject: [PATCH] Monumenta - Move player saving to before disabling plugins
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 1a4bc90435d0a56ab7b607c72f28772fb92049bc..a514477fa1b695fa57f71eea26bdcb8857f48cd6 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -736,6 +736,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         // CraftBukkit end
+         MinecraftServer.LOGGER.info("Stopping server");
+         MinecraftTimings.stopServer(); // Paper
++
++        if (this.playerList != null) {
++            MinecraftServer.LOGGER.info("Saving players");
++            this.playerList.savePlayers();
++            this.playerList.shutdown(this.isRestarting); // Paper
++            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
++        }
++
+         // CraftBukkit start
+         if (this.server != null) {
+             this.server.disablePlugins();
+@@ -745,13 +753,6 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+             this.getServerConnection().b();
+         }
+ 
+-        if (this.playerList != null) {
+-            MinecraftServer.LOGGER.info("Saving players");
+-            this.playerList.savePlayers();
+-            this.playerList.shutdown(this.isRestarting); // Paper
+-            try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
+-        }
+-
+         MinecraftServer.LOGGER.info("Saving worlds");
+         Iterator iterator = this.getWorlds().iterator();
+ 

--- a/Spigot-Server-Patches/0540-Monumenta-Add-events-for-loading-and-saving-advancem.patch
+++ b/Spigot-Server-Patches/0540-Monumenta-Add-events-for-loading-and-saving-advancem.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Sat, 28 Mar 2020 03:35:42 -0400
+Subject: [PATCH] Monumenta - Add events for loading and saving advancement
+ data
+
+
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index c41e1384724ab150f43dc43fe2a453c9b1262e48..2d95a2ef2170de88d4d86f7b209dd042a056cb16 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -131,9 +131,18 @@ public class AdvancementDataPlayer {
+     }
+ 
+     private void g() {
+-        if (this.e.isFile()) {
++        // Paper Start
++        com.destroystokyo.paper.event.player.PlayerAdvancementDataLoadEvent event = new com.destroystokyo.paper.event.player.PlayerAdvancementDataLoadEvent(this.player.getBukkitEntity(), this.e);
++        event.callEvent();
++        if (event.getPath().isFile() || event.getJsonData() != null) {
+             try {
+-                JsonReader jsonreader = new JsonReader(new StringReader(Files.toString(this.e, StandardCharsets.UTF_8)));
++                final JsonReader jsonreader;
++                if (event.getJsonData() != null) {
++                    jsonreader = new JsonReader(new StringReader(event.getJsonData()));
++                } else {
++                    jsonreader = new JsonReader(new StringReader(Files.toString(event.getPath(), StandardCharsets.UTF_8)));
++                }
++                // Paper End
+                 Throwable throwable = null;
+ 
+                 try {
+@@ -162,7 +171,7 @@ public class AdvancementDataPlayer {
+                         if (advancement == null) {
+                             // CraftBukkit start
+                             if (entry.getKey().getNamespace().equals("minecraft")) {
+-                                AdvancementDataPlayer.LOGGER.warn("Ignored advancement '{}' in progress file {} - it doesn't exist anymore?", entry.getKey(), this.e);
++                                AdvancementDataPlayer.LOGGER.warn("Ignored advancement '{}' in progress file {} - it doesn't exist anymore?", entry.getKey(), event.getPath()); // Paper
+                             }
+                             // CraftBukkit end
+                         } else {
+@@ -187,9 +196,9 @@ public class AdvancementDataPlayer {
+ 
+                 }
+             } catch (JsonParseException jsonparseexception) {
+-                AdvancementDataPlayer.LOGGER.error("Couldn't parse player advancements in {}", this.e, jsonparseexception);
++                AdvancementDataPlayer.LOGGER.error("Couldn't parse player advancements in {}", event.getPath(), jsonparseexception); // Paper
+             } catch (IOException ioexception) {
+-                AdvancementDataPlayer.LOGGER.error("Couldn't access player advancements in {}", this.e, ioexception);
++                AdvancementDataPlayer.LOGGER.error("Couldn't access player advancements in {}", event.getPath(), ioexception); // Paper
+             }
+         }
+ 
+@@ -220,8 +229,18 @@ public class AdvancementDataPlayer {
+ 
+         jsonelement.getAsJsonObject().addProperty("DataVersion", SharedConstants.getGameVersion().getWorldVersion());
+ 
++        // Paper start
++        com.destroystokyo.paper.event.player.PlayerAdvancementDataSaveEvent event = new com.destroystokyo.paper.event.player.PlayerAdvancementDataSaveEvent(this.player.getBukkitEntity(), this.e, AdvancementDataPlayer.b.toJson(jsonelement));
++        if (!event.callEvent()) {
++            return;
++        }
++        if (event.getPath().getParentFile() != null) {
++            event.getPath().getParentFile().mkdirs();
++        }
++        // Paper end
++
+         try {
+-            FileOutputStream fileoutputstream = new FileOutputStream(this.e);
++            FileOutputStream fileoutputstream = new FileOutputStream(event.getPath()); // Paper
+             Throwable throwable = null;
+ 
+             try {
+@@ -229,7 +248,7 @@ public class AdvancementDataPlayer {
+                 Throwable throwable1 = null;
+ 
+                 try {
+-                    AdvancementDataPlayer.b.toJson(jsonelement, outputstreamwriter);
++                    outputstreamwriter.write(event.getJsonData()); // Paper
+                 } catch (Throwable throwable2) {
+                     throwable1 = throwable2;
+                     throw throwable2;

--- a/Spigot-Server-Patches/0541-Monumenta-Add-events-for-loading-and-saving-player-d.patch
+++ b/Spigot-Server-Patches/0541-Monumenta-Add-events-for-loading-and-saving-player-d.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Fri, 3 Apr 2020 21:20:03 -0700
+Subject: [PATCH] Monumenta - Add events for loading and saving player data
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/WorldNBTStorage.java b/src/main/java/net/minecraft/server/WorldNBTStorage.java
+index 350ac42d6b45a1023f6254de7706818775b7957b..03d3d7854eec58e69d50585d0c2ed95f621a8aa2 100644
+--- a/src/main/java/net/minecraft/server/WorldNBTStorage.java
++++ b/src/main/java/net/minecraft/server/WorldNBTStorage.java
+@@ -144,12 +144,19 @@ public class WorldNBTStorage implements IPlayerFileData {
+             File file = new File(this.playerDir, entityhuman.getUniqueIDString() + ".dat.tmp");
+             File file1 = new File(this.playerDir, entityhuman.getUniqueIDString() + ".dat");
+ 
+-            NBTCompressedStreamTools.a(nbttagcompound, (OutputStream) (new FileOutputStream(file)));
+-            if (file1.exists()) {
+-                file1.delete();
++            // Paper start
++            com.destroystokyo.paper.event.player.PlayerDataSaveEvent event = new com.destroystokyo.paper.event.player.PlayerDataSaveEvent(((EntityPlayer)entityhuman).getBukkitEntity(), file1, nbttagcompound);
++            if (!event.callEvent()) {
++                return;
++            }
++
++            NBTCompressedStreamTools.a((NBTTagCompound)event.getData(), (OutputStream) (new FileOutputStream(file)));
++            if (event.getPath().exists()) {
++                event.getPath().delete();
+             }
+ 
+-            file.renameTo(file1);
++            file.renameTo(event.getPath());
++            // Paper end
+         } catch (Exception exception) {
+             WorldNBTStorage.LOGGER.error("Failed to save player data for {}", entityhuman.getName(), exception); // Paper
+         }
+@@ -163,28 +170,16 @@ public class WorldNBTStorage implements IPlayerFileData {
+ 
+         try {
+             File file = new File(this.playerDir, entityhuman.getUniqueIDString() + ".dat");
+-            // Spigot Start
+-            boolean usingWrongFile = false;
+-            if ( org.bukkit.Bukkit.getOnlineMode() && !file.exists() ) // Paper - Check online mode first
+-            {
+-                file = new File( this.playerDir, UUID.nameUUIDFromBytes( ( "OfflinePlayer:" + entityhuman.getName() ).getBytes( "UTF-8" ) ).toString() + ".dat");
+-                if ( file.exists() )
+-                {
+-                    usingWrongFile = true;
+-                    org.bukkit.Bukkit.getServer().getLogger().warning( "Using offline mode UUID file for player " + entityhuman.getName() + " as it is the only copy we can find." );
+-                }
+-            }
+-            // Spigot End
+-
+-            if (file.exists() && file.isFile()) {
+-                nbttagcompound = NBTCompressedStreamTools.a((InputStream) (new FileInputStream(file)));
+-            }
+-            // Spigot Start
+-            if ( usingWrongFile )
+-            {
+-                file.renameTo( new File( file.getPath() + ".offline-read" ) );
++            // Paper Start
++            com.destroystokyo.paper.event.player.PlayerDataLoadEvent event = new com.destroystokyo.paper.event.player.PlayerDataLoadEvent(((EntityPlayer)entityhuman).getBukkitEntity(), file);
++            event.callEvent();
++
++            if (event.getData() != null) {
++                nbttagcompound = (NBTTagCompound) event.getData();
++            } else if (event.getPath().exists() && event.getPath().isFile()) {
++                nbttagcompound = NBTCompressedStreamTools.a((InputStream) (new FileInputStream(event.getPath())));
+             }
+-            // Spigot End
++            // Paper End
+         } catch (Exception exception) {
+             WorldNBTStorage.LOGGER.warn("Failed to load player data for {}", entityhuman.getDisplayName().getString());
+         }

--- a/Spigot-Server-Patches/0542-Monumenta-Move-player-saving-to-before-disabling-plu.patch
+++ b/Spigot-Server-Patches/0542-Monumenta-Move-player-saving-to-before-disabling-plu.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Monumenta - Move player saving to before disabling plugins
 Signed-off-by: Byron Marohn <combustible@live.com>
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1a4bc90435d0a56ab7b607c72f28772fb92049bc..a514477fa1b695fa57f71eea26bdcb8857f48cd6 100644
+index a03dc230521673a21872d70836903a2c2d15220e..6f6ed51b14c6d6a12b91fbd064b1bc61171ccc95 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -736,6 +736,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -743,6 +743,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // CraftBukkit end
-         MinecraftServer.LOGGER.info("Stopping server");
+         MinecraftServer.LOGGER.info("Stopping server (Ignore any thread death message you see! - DO NOT REPORT THREAD DEATH TO PAPER)"); // Paper
          MinecraftTimings.stopServer(); // Paper
 +
 +        if (this.playerList != null) {
@@ -24,7 +24,7 @@ index 1a4bc90435d0a56ab7b607c72f28772fb92049bc..a514477fa1b695fa57f71eea26bdcb88
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
-@@ -745,13 +753,6 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -753,13 +761,6 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getServerConnection().b();
          }
  

--- a/Spigot-Server-Patches/0543-Monumenta-Disable-potion-has-no-item-logspam.patch
+++ b/Spigot-Server-Patches/0543-Monumenta-Disable-potion-has-no-item-logspam.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 27 Sep 2017 18:46:14 -0700
+Subject: [PATCH] Monumenta - Disable potion has no item logspam
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPotion.java b/src/main/java/net/minecraft/server/EntityPotion.java
+index b56b021b4cb61bd69536f3aba50ab681dc2a4ea0..061e9d484d50c539d4eed1d3629a1163aaed5f7b 100644
+--- a/src/main/java/net/minecraft/server/EntityPotion.java
++++ b/src/main/java/net/minecraft/server/EntityPotion.java
+@@ -41,10 +41,6 @@ public class EntityPotion extends EntityProjectile {
+         ItemStack itemstack = (ItemStack) this.getDataWatcher().get(EntityPotion.f);
+ 
+         if (itemstack.getItem() != Items.SPLASH_POTION && itemstack.getItem() != Items.LINGERING_POTION) {
+-            if (this.world != null) {
+-                EntityPotion.LOGGER.error("ThrownPotion entity {} has no item?!", this.getId());
+-            }
+-
+             return new ItemStack(Items.SPLASH_POTION);
+         } else {
+             return itemstack;

--- a/Spigot-Server-Patches/0544-Monumenta-Removed-test-for-monsters-when-sleeping-in.patch
+++ b/Spigot-Server-Patches/0544-Monumenta-Removed-test-for-monsters-when-sleeping-in.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 5 Oct 2017 21:45:16 -0700
+Subject: [PATCH] Monumenta - Removed test for monsters when sleeping in beds
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
+index 7df24be46e4471ae0ddad5cded5eef4937fd37a3..fda891dc5449e3e0e3ed304fc9b1ace20e4a87fa 100644
+--- a/src/main/java/net/minecraft/server/EntityHuman.java
++++ b/src/main/java/net/minecraft/server/EntityHuman.java
+@@ -1327,16 +1327,6 @@ public abstract class EntityHuman extends EntityLiving {
+             }
+ 
+             if (!this.isCreative()) {
+-                double d0 = 8.0D;
+-                double d1 = 5.0D;
+-                Vec3D vec3d = new Vec3D((double) blockposition.getX() + 0.5D, (double) blockposition.getY(), (double) blockposition.getZ() + 0.5D);
+-                List<EntityMonster> list = this.world.a(EntityMonster.class, new AxisAlignedBB(vec3d.getX() - 8.0D, vec3d.getY() - 5.0D, vec3d.getZ() - 8.0D, vec3d.getX() + 8.0D, vec3d.getY() + 5.0D, vec3d.getZ() + 8.0D), (entitymonster) -> {
+-                    return entitymonster.e(this);
+-                });
+-
+-                if (!list.isEmpty()) {
+-                    return Either.left(EntityHuman.EnumBedResult.NOT_SAFE);
+-                }
+             }
+         }
+         return Either.right(Unit.INSTANCE);

--- a/Spigot-Server-Patches/0545-Monumenta-Prevent-ice-from-breaking-melting-into-wat.patch
+++ b/Spigot-Server-Patches/0545-Monumenta-Prevent-ice-from-breaking-melting-into-wat.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 26 Oct 2017 22:09:28 -0700
+Subject: [PATCH] Monumenta - Prevent ice from breaking/melting into water
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockIce.java b/src/main/java/net/minecraft/server/BlockIce.java
+index 81c7dc9a31e283bfcd6a470bd99d54dd345f2ebc..e52a9d56f6e0d4ad7c16e999a9f072f78fff0d32 100644
+--- a/src/main/java/net/minecraft/server/BlockIce.java
++++ b/src/main/java/net/minecraft/server/BlockIce.java
+@@ -13,16 +13,7 @@ public class BlockIce extends BlockHalfTransparent {
+     public void a(World world, EntityHuman entityhuman, BlockPosition blockposition, IBlockData iblockdata, @Nullable TileEntity tileentity, ItemStack itemstack) {
+         super.a(world, entityhuman, blockposition, iblockdata, tileentity, itemstack);
+         if (EnchantmentManager.getEnchantmentLevel(Enchantments.SILK_TOUCH, itemstack) == 0) {
+-            if (world.worldProvider.isNether()) {
+-                world.a(blockposition, false);
+-                return;
+-            }
+-
+-            Material material = world.getType(blockposition.down()).getMaterial();
+-
+-            if (material.isSolid() || material.isLiquid()) {
+-                world.setTypeUpdate(blockposition, Blocks.WATER.getBlockData());
+-            }
++            world.a(blockposition, false);
+         }
+ 
+     }
+@@ -36,17 +27,7 @@ public class BlockIce extends BlockHalfTransparent {
+     }
+ 
+     protected void melt(IBlockData iblockdata, World world, BlockPosition blockposition) {
+-        // CraftBukkit start
+-        if (org.bukkit.craftbukkit.event.CraftEventFactory.callBlockFadeEvent(world, blockposition, world.worldProvider.isNether() ? Blocks.AIR.getBlockData() : Blocks.WATER.getBlockData()).isCancelled()) {
+-            return;
+-        }
+-        // CraftBukkit end
+-        if (world.worldProvider.isNether()) {
+-            world.a(blockposition, false);
+-        } else {
+-            world.setTypeUpdate(blockposition, Blocks.WATER.getBlockData());
+-            world.a(blockposition, Blocks.WATER, blockposition);
+-        }
++        return;
+     }
+ 
+     @Override

--- a/Spigot-Server-Patches/0546-Monumenta-Charged-creepers-no-longer-cause-mob-head-.patch
+++ b/Spigot-Server-Patches/0546-Monumenta-Charged-creepers-no-longer-cause-mob-head-.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Tue, 31 Oct 2017 17:44:53 -0700
+Subject: [PATCH] Monumenta - Charged creepers no longer cause mob head drops
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
+index 45dfc8104a75f9893c6ee03d507cac80b893249c..481606feef87025e9b268db83225c1ee9d3ae5f6 100644
+--- a/src/main/java/net/minecraft/server/EntityCreeper.java
++++ b/src/main/java/net/minecraft/server/EntityCreeper.java
+@@ -271,7 +271,7 @@ public class EntityCreeper extends EntityMonster {
+     }
+ 
+     public boolean canCauseHeadDrop() {
+-        return this.isPowered() && this.bA < 1;
++        return false;
+     }
+ 
+     public void setCausedHeadDrop() {

--- a/Spigot-Server-Patches/0547-Monumenta-Spreadplayers-now-ignores-the-block-at-wor.patch
+++ b/Spigot-Server-Patches/0547-Monumenta-Spreadplayers-now-ignores-the-block-at-wor.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Monumenta <monumenta.mgmt@gmail.com>
+Date: Fri, 12 Jan 2018 19:54:34 -0500
+Subject: [PATCH] Monumenta - Spreadplayers now ignores the block at world
+ height
+
+Signed-off-by: Monumenta <monumenta.mgmt@gmail.com>
+
+diff --git a/src/main/java/net/minecraft/server/CommandSpreadPlayers.java b/src/main/java/net/minecraft/server/CommandSpreadPlayers.java
+index e7f230c7e5836dc95c7c0dc446bdfeeb5e30f402..c16454050cdd904ee6ada52bf4a1a30ce7122b1e 100644
+--- a/src/main/java/net/minecraft/server/CommandSpreadPlayers.java
++++ b/src/main/java/net/minecraft/server/CommandSpreadPlayers.java
+@@ -258,7 +258,7 @@ public class CommandSpreadPlayers {
+         }
+ 
+         public int a(IBlockAccess iblockaccess) {
+-            BlockPosition blockposition = new BlockPosition(this.a, 256.0D, this.b);
++            BlockPosition blockposition = new BlockPosition(this.a, 255.0D, this.b);
+ 
+             do {
+                 if (blockposition.getY() <= 0) {
+@@ -272,7 +272,7 @@ public class CommandSpreadPlayers {
+         }
+ 
+         public boolean b(IBlockAccess iblockaccess) {
+-            BlockPosition blockposition = new BlockPosition(this.a, 256.0D, this.b);
++            BlockPosition blockposition = new BlockPosition(this.a, 255.0D, this.b);
+ 
+             IBlockData iblockdata;
+ 

--- a/Spigot-Server-Patches/0548-Monumenta-Prevent-concrete-powder-from-solidifying.patch
+++ b/Spigot-Server-Patches/0548-Monumenta-Prevent-concrete-powder-from-solidifying.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 13 Sep 2018 17:26:47 -0400
+Subject: [PATCH] Monumenta - Prevent concrete powder from solidifying
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/BlockConcretePowder.java b/src/main/java/net/minecraft/server/BlockConcretePowder.java
+index e78cc8d1b0a46ea3ab79a68c1d727b527b3f7f09..2d96efb8cd95be81acf1837dfcddd12cf4719ec1 100644
+--- a/src/main/java/net/minecraft/server/BlockConcretePowder.java
++++ b/src/main/java/net/minecraft/server/BlockConcretePowder.java
+@@ -49,7 +49,7 @@ public class BlockConcretePowder extends BlockFalling {
+     }
+ 
+     private static boolean canHarden(IBlockAccess iblockaccess, BlockPosition blockposition, IBlockData iblockdata) {
+-        return r(iblockdata) || a(iblockaccess, blockposition);
++        return false;
+     }
+ 
+     private static boolean a(IBlockAccess iblockaccess, BlockPosition blockposition) {
+@@ -76,7 +76,7 @@ public class BlockConcretePowder extends BlockFalling {
+     }
+ 
+     private static boolean r(IBlockData iblockdata) {
+-        return iblockdata.getFluid().a(TagsFluid.WATER);
++        return false;
+     }
+ 
+     @Override

--- a/Spigot-Server-Patches/0549-Monumenta-Coral-is-always-waterlogged.patch
+++ b/Spigot-Server-Patches/0549-Monumenta-Coral-is-always-waterlogged.patch
@@ -1,0 +1,111 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Mon, 17 Sep 2018 22:03:48 -0400
+Subject: [PATCH] Monumenta - Coral is always waterlogged
+
+NOTE:
+This patch is annoying because Spigot hasn't made any modifications to
+BlockCoralBase. So if this patch breaks, the change to that file is the
+same as the change to BlockCoral.
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/BlockCoral.java b/src/main/java/net/minecraft/server/BlockCoral.java
+index 78a7c7377bddc9665be9c85b0da850eb16dbb435..e3b6ec5fdd9537714166bab086fd5fec1149ce50 100644
+--- a/src/main/java/net/minecraft/server/BlockCoral.java
++++ b/src/main/java/net/minecraft/server/BlockCoral.java
+@@ -35,19 +35,7 @@ public class BlockCoral extends Block {
+     }
+ 
+     protected boolean a(IBlockAccess iblockaccess, BlockPosition blockposition) {
+-        EnumDirection[] aenumdirection = EnumDirection.values();
+-        int i = aenumdirection.length;
+-
+-        for (int j = 0; j < i; ++j) {
+-            EnumDirection enumdirection = aenumdirection[j];
+-            Fluid fluid = iblockaccess.getFluid(blockposition.shift(enumdirection));
+-
+-            if (fluid.a(TagsFluid.WATER)) {
+-                return true;
+-            }
+-        }
+-
+-        return false;
++        return true;
+     }
+ 
+     @Nullable
+diff --git a/src/main/java/net/minecraft/server/BlockCoralBase.java b/src/main/java/net/minecraft/server/BlockCoralBase.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..fd059b4e7e5674d004bd0428a230b7bcb987753d
+--- /dev/null
++++ b/src/main/java/net/minecraft/server/BlockCoralBase.java
+@@ -0,0 +1,68 @@
++package net.minecraft.server;
++
++import javax.annotation.Nullable;
++
++public class BlockCoralBase extends Block implements IBlockWaterlogged {
++
++    public static final BlockStateBoolean b = BlockProperties.C;
++    private static final VoxelShape a = Block.a(2.0D, 0.0D, 2.0D, 14.0D, 4.0D, 14.0D);
++
++    protected BlockCoralBase(Block.Info block_info) {
++        super(block_info);
++        this.p((IBlockData) ((IBlockData) this.blockStateList.getBlockData()).set(BlockCoralBase.b, true));
++    }
++
++    protected void a(IBlockData iblockdata, GeneratorAccess generatoraccess, BlockPosition blockposition) {
++        if (!b_(iblockdata, generatoraccess, blockposition)) {
++            generatoraccess.getBlockTickList().a(blockposition, this, 60 + generatoraccess.getRandom().nextInt(40));
++        }
++
++    }
++
++    protected static boolean b_(IBlockData iblockdata, IBlockAccess iblockaccess, BlockPosition blockposition) {
++        if ((Boolean) iblockdata.get(BlockCoralBase.b)) {
++            return true;
++        } else {
++            return true;
++        }
++    }
++
++    @Nullable
++    @Override
++    public IBlockData getPlacedState(BlockActionContext blockactioncontext) {
++        Fluid fluid = blockactioncontext.getWorld().getFluid(blockactioncontext.getClickPosition());
++
++        return (IBlockData) this.getBlockData().set(BlockCoralBase.b, fluid.a(TagsFluid.WATER) && fluid.g() == 8);
++    }
++
++    @Override
++    public VoxelShape a(IBlockData iblockdata, IBlockAccess iblockaccess, BlockPosition blockposition, VoxelShapeCollision voxelshapecollision) {
++        return BlockCoralBase.a;
++    }
++
++    @Override
++    public IBlockData updateState(IBlockData iblockdata, EnumDirection enumdirection, IBlockData iblockdata1, GeneratorAccess generatoraccess, BlockPosition blockposition, BlockPosition blockposition1) {
++        if ((Boolean) iblockdata.get(BlockCoralBase.b)) {
++            generatoraccess.getFluidTickList().a(blockposition, FluidTypes.WATER, FluidTypes.WATER.a((IWorldReader) generatoraccess));
++        }
++
++        return enumdirection == EnumDirection.DOWN && !this.canPlace(iblockdata, generatoraccess, blockposition) ? Blocks.AIR.getBlockData() : super.updateState(iblockdata, enumdirection, iblockdata1, generatoraccess, blockposition, blockposition1);
++    }
++
++    @Override
++    public boolean canPlace(IBlockData iblockdata, IWorldReader iworldreader, BlockPosition blockposition) {
++        BlockPosition blockposition1 = blockposition.down();
++
++        return iworldreader.getType(blockposition1).d(iworldreader, blockposition1, EnumDirection.UP);
++    }
++
++    @Override
++    protected void a(BlockStateList.a<Block, IBlockData> blockstatelist_a) {
++        blockstatelist_a.a(BlockCoralBase.b);
++    }
++
++    @Override
++    public Fluid a_(IBlockData iblockdata) {
++        return (Boolean) iblockdata.get(BlockCoralBase.b) ? FluidTypes.WATER.a(false) : super.a_(iblockdata);
++    }
++}

--- a/Spigot-Server-Patches/0550-Monumenta-Drowned-no-longer-convert-naturally.patch
+++ b/Spigot-Server-Patches/0550-Monumenta-Drowned-no-longer-convert-naturally.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Fri, 28 Dec 2018 22:21:40 -0500
+Subject: [PATCH] Monumenta - Drowned no longer convert naturally
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
+index 07ebc1d81610bc506e51c7bbffefdcf676a2bb85..1dba2b5aff8a79d90b26c806f82fae1965639d81 100644
+--- a/src/main/java/net/minecraft/server/EntityZombie.java
++++ b/src/main/java/net/minecraft/server/EntityZombie.java
+@@ -168,8 +168,6 @@ public class EntityZombie extends EntityMonster {
+                 if (this.a(TagsFluid.WATER)) {
+                     ++this.bC;
+                     if (this.bC >= 600) {
+-                        this.startDrownedConversion(300);
+-                        this.lastTick = MinecraftServer.currentTick; // Paper - Make sure this is set at start of process - GH-1887
+                     }
+                 } else {
+                     this.bC = -1;

--- a/Spigot-Server-Patches/0551-Monumenta-Skeletons-attack-wolves-instead-of-running.patch
+++ b/Spigot-Server-Patches/0551-Monumenta-Skeletons-attack-wolves-instead-of-running.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 7 Feb 2019 22:23:02 -0500
+Subject: [PATCH] Monumenta - Skeletons attack wolves instead of running from
+ them
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java b/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
+index 3c95c0428b211b14db65be16a95446debda789e6..ebf7a35b694fadf1fbf26fb0ebcd21f1c1a6bebd 100644
+--- a/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
++++ b/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
+@@ -30,13 +30,13 @@ public abstract class EntitySkeletonAbstract extends EntityMonster implements IR
+     protected void initPathfinder() {
+         this.goalSelector.a(2, new PathfinderGoalRestrictSun(this));
+         this.goalSelector.a(3, new PathfinderGoalFleeSun(this, 1.0D));
+-        this.goalSelector.a(3, new PathfinderGoalAvoidTarget<>(this, EntityWolf.class, 6.0F, 1.0D, 1.2D));
+         this.goalSelector.a(5, new PathfinderGoalRandomStrollLand(this, 1.0D));
+         this.goalSelector.a(6, new PathfinderGoalLookAtPlayer(this, EntityHuman.class, 8.0F));
+         this.goalSelector.a(6, new PathfinderGoalRandomLookaround(this));
+         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, new Class[0]));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
++        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityWolf.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bw));
+     }
+ 

--- a/Spigot-Server-Patches/0552-Monumenta-Increase-kicked-for-flying-timer-from-4s-t.patch
+++ b/Spigot-Server-Patches/0552-Monumenta-Increase-kicked-for-flying-timer-from-4s-t.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 28 Feb 2019 23:37:12 -0500
+Subject: [PATCH] Monumenta - Increase kicked-for-flying timer from 4s to 6s
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index d52fbda79fe1c52d3ddb53c0f1c1f521d7620702..e6a12879ca3e1e795d42ba399d6c8ad0b80441ae 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -161,7 +161,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         ++this.e;
+         this.processedMovePackets = this.receivedMovePackets;
+         if (this.B && !this.player.isSleeping()) { // Paper - #3176 Allow sleeping players to float
+-            if (++this.C > 80) {
++            if (++this.C > 120) {
+                 PlayerConnection.LOGGER.warn("{} was kicked for floating too long!", this.player.getDisplayName().getString());
+                 this.disconnect(com.destroystokyo.paper.PaperConfig.flyingKickPlayerMessage); // Paper - use configurable kick message
+                 return;
+@@ -180,7 +180,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+             this.w = this.r.locY();
+             this.x = this.r.locZ();
+             if (this.D && this.player.getRootVehicle().getRidingPassenger() == this.player) {
+-                if (++this.E > 80) {
++                if (++this.E > 120) {
+                     PlayerConnection.LOGGER.warn("{} was kicked for floating a vehicle too long!", this.player.getDisplayName().getString());
+                     this.disconnect(com.destroystokyo.paper.PaperConfig.flyingKickVehicleMessage); // Paper - use configurable kick message
+                     return;

--- a/Spigot-Server-Patches/0553-Monumenta-Iron-golems-no-longer-automatically-attack.patch
+++ b/Spigot-Server-Patches/0553-Monumenta-Iron-golems-no-longer-automatically-attack.patch
@@ -1,0 +1,120 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 6 Mar 2019 16:35:05 -0500
+Subject: [PATCH] Monumenta - Iron golems no longer automatically attack
+ monsters
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityDrowned.java b/src/main/java/net/minecraft/server/EntityDrowned.java
+index 77885f67ffa907f7b6dced5d0040d9a9a73454f4..4bdd21047cd8f4a9590229c8d1c5d258c9aadb82 100644
+--- a/src/main/java/net/minecraft/server/EntityDrowned.java
++++ b/src/main/java/net/minecraft/server/EntityDrowned.java
+@@ -30,7 +30,6 @@ public class EntityDrowned extends EntityZombie implements IRangedEntity {
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityDrowned.class})).a(EntityPigZombie.class));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, 10, true, false, this::i));
+         if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false)); // Paper
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(5, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bw));
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/EntityIllagerIllusioner.java b/src/main/java/net/minecraft/server/EntityIllagerIllusioner.java
+index 81b7cd06f2e1f1f2ce75ba84d47cc18723c2bfb6..d29b4ae3d0e711e8c86c111b8bda815add12ea3c 100644
+--- a/src/main/java/net/minecraft/server/EntityIllagerIllusioner.java
++++ b/src/main/java/net/minecraft/server/EntityIllagerIllusioner.java
+@@ -33,7 +33,6 @@ public class EntityIllagerIllusioner extends EntityIllagerWizard implements IRan
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityRaider.class})).a(new Class[0])); // CraftBukkit - decompile error
+         this.targetSelector.a(2, (new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true)).a(300));
+         this.targetSelector.a(3, (new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false)).a(300));
+-        this.targetSelector.a(3, (new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, false)).a(300));
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityIronGolem.java b/src/main/java/net/minecraft/server/EntityIronGolem.java
+index 7f6a56776000643ecc42b0b917f6673b7b038d79..98cb50023be85c659a91c5ceb79f00e8b526e412 100644
+--- a/src/main/java/net/minecraft/server/EntityIronGolem.java
++++ b/src/main/java/net/minecraft/server/EntityIronGolem.java
+@@ -29,11 +29,7 @@ public class EntityIronGolem extends EntityGolem {
+         this.goalSelector.a(6, new PathfinderGoalRandomStrollLand(this, 0.6D));
+         this.goalSelector.a(7, new PathfinderGoalLookAtPlayer(this, EntityHuman.class, 6.0F));
+         this.goalSelector.a(8, new PathfinderGoalRandomLookaround(this));
+-        this.targetSelector.a(1, new PathfinderGoalDefendVillage(this));
+         this.targetSelector.a(2, new PathfinderGoalHurtByTarget(this, new Class[0]));
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityInsentient.class, 5, false, false, (entityliving) -> {
+-            return entityliving instanceof IMonster && !(entityliving instanceof EntityCreeper);
+-        }));
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityPillager.java b/src/main/java/net/minecraft/server/EntityPillager.java
+index 0357c9da93e377cf5e90f83511fba138a7735f13..7de0ba64d8a47653423e156063c44c2230a25942 100644
+--- a/src/main/java/net/minecraft/server/EntityPillager.java
++++ b/src/main/java/net/minecraft/server/EntityPillager.java
+@@ -25,7 +25,6 @@ public class EntityPillager extends EntityIllagerAbstract implements ICrossbow,
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityRaider.class})).a(new Class[0])); // CraftBukkit - decompile error
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false));
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityRavager.java b/src/main/java/net/minecraft/server/EntityRavager.java
+index fd25ce10263d2af876d9dc31c17b21e43beac1de..345615d9a1524a4aafe08cdb8563484d7f847c97 100644
+--- a/src/main/java/net/minecraft/server/EntityRavager.java
++++ b/src/main/java/net/minecraft/server/EntityRavager.java
+@@ -31,7 +31,6 @@ public class EntityRavager extends EntityRaider {
+         this.targetSelector.a(2, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityRaider.class})).a(new Class[0])); // CraftBukkit - decompile error
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+         this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, true));
+-        this.targetSelector.a(4, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java b/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
+index ebf7a35b694fadf1fbf26fb0ebcd21f1c1a6bebd..7608bf74f7adf295c6d5dd0f641fd30c90454264 100644
+--- a/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
++++ b/src/main/java/net/minecraft/server/EntitySkeletonAbstract.java
+@@ -35,7 +35,6 @@ public abstract class EntitySkeletonAbstract extends EntityMonster implements IR
+         this.goalSelector.a(6, new PathfinderGoalRandomLookaround(this));
+         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, new Class[0]));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityWolf.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bw));
+     }
+diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
+index 2efc18df945bcaa6eba59f561733b9fd6b217d6d..b183113c1d795efd6ba7d29c0a4af5857376946b 100644
+--- a/src/main/java/net/minecraft/server/EntitySlime.java
++++ b/src/main/java/net/minecraft/server/EntitySlime.java
+@@ -41,7 +41,6 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+         this.targetSelector.a(1, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, 10, true, false, (entityliving) -> {
+             return Math.abs(entityliving.locY() - this.locY()) <= 4.0D;
+         }));
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityVindicator.java b/src/main/java/net/minecraft/server/EntityVindicator.java
+index c974c02e92345fdc43f4acc9b02d40c735b677df..a6fef1697da719f5fdd3d109c235981824f1a5a8 100644
+--- a/src/main/java/net/minecraft/server/EntityVindicator.java
++++ b/src/main/java/net/minecraft/server/EntityVindicator.java
+@@ -28,7 +28,6 @@ public class EntityVindicator extends EntityIllagerAbstract {
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[]{EntityRaider.class})).a(new Class[0])); // Paper - decompile fix
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+         this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, true));
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(4, new EntityVindicator.b(this));
+         this.goalSelector.a(8, new PathfinderGoalRandomStroll(this, 0.6D));
+         this.goalSelector.a(9, new PathfinderGoalLookAtPlayer(this, EntityHuman.class, 3.0F, 1.0F));
+diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
+index 1dba2b5aff8a79d90b26c806f82fae1965639d81..c29f01782fe5274bb086513d56d3143206d31a60 100644
+--- a/src/main/java/net/minecraft/server/EntityZombie.java
++++ b/src/main/java/net/minecraft/server/EntityZombie.java
+@@ -59,7 +59,6 @@ public class EntityZombie extends EntityMonster {
+         this.targetSelector.a(1, (new PathfinderGoalHurtByTarget(this, new Class[0])).a(EntityPigZombie.class));
+         this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityHuman.class, true));
+         if ( world.spigotConfig.zombieAggressiveTowardsVillager ) this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityVillagerAbstract.class, false)); // Spigot
+-        this.targetSelector.a(3, new PathfinderGoalNearestAttackableTarget<>(this, EntityIronGolem.class, true));
+         this.targetSelector.a(5, new PathfinderGoalNearestAttackableTarget<>(this, EntityTurtle.class, 10, true, false, EntityTurtle.bw));
+     }
+ 

--- a/Spigot-Server-Patches/0554-Monumenta-drowned-no-longer-have-biome-restrictions.patch
+++ b/Spigot-Server-Patches/0554-Monumenta-drowned-no-longer-have-biome-restrictions.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Sat, 23 Mar 2019 01:51:24 -0400
+Subject: [PATCH] Monumenta - drowned no longer have biome restrictions
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityDrowned.java b/src/main/java/net/minecraft/server/EntityDrowned.java
+index 4bdd21047cd8f4a9590229c8d1c5d258c9aadb82..dbf5a989376233f61cf8811341484a8ce0af0a72 100644
+--- a/src/main/java/net/minecraft/server/EntityDrowned.java
++++ b/src/main/java/net/minecraft/server/EntityDrowned.java
+@@ -48,7 +48,7 @@ public class EntityDrowned extends EntityZombie implements IRangedEntity {
+         BiomeBase biomebase = generatoraccess.getBiome(blockposition);
+         boolean flag = generatoraccess.getDifficulty() != EnumDifficulty.PEACEFUL && a(generatoraccess, blockposition, random) && (enummobspawn == EnumMobSpawn.SPAWNER || generatoraccess.getFluid(blockposition).a(TagsFluid.WATER));
+ 
+-        return biomebase != Biomes.RIVER && biomebase != Biomes.FROZEN_RIVER ? random.nextInt(40) == 0 && a(generatoraccess, blockposition) && flag : random.nextInt(15) == 0 && flag;
++        return random.nextInt(15) == 0 && flag;
+     }
+ 
+     private static boolean a(GeneratorAccess generatoraccess, BlockPosition blockposition) {

--- a/Spigot-Server-Patches/0555-Monumenta-Make-NBT-List-comparisons-ignore-order.patch
+++ b/Spigot-Server-Patches/0555-Monumenta-Make-NBT-List-comparisons-ignore-order.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hazerdous <dransom96@gmail.com>
+Date: Wed, 22 May 2019 12:07:20 -0400
+Subject: [PATCH] Monumenta - Make NBT List comparisons ignore order
+
+
+diff --git a/src/main/java/net/minecraft/server/NBTTagList.java b/src/main/java/net/minecraft/server/NBTTagList.java
+index d778eac45de775cf4058621fadb55b1b4e1f3457..afb627b8780519baa8766bbf1c718b9f44d528e6 100644
+--- a/src/main/java/net/minecraft/server/NBTTagList.java
++++ b/src/main/java/net/minecraft/server/NBTTagList.java
+@@ -289,7 +289,7 @@ public class NBTTagList extends NBTList<NBTBase> {
+     }
+ 
+     public boolean equals(Object object) {
+-        return this == object ? true : object instanceof NBTTagList && Objects.equals(this.list, ((NBTTagList) object).list);
++        return this == object ? true : object instanceof NBTTagList && this.list.size() == ((NBTTagList) object).list.size() && this.list.containsAll(((NBTTagList) object).list);
+     }
+ 
+     public int hashCode() {

--- a/Spigot-Server-Patches/0556-Monumenta-Fix-shield-banners-shulkers-id-missing-min.patch
+++ b/Spigot-Server-Patches/0556-Monumenta-Fix-shield-banners-shulkers-id-missing-min.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 30 May 2019 18:33:51 -0400
+Subject: [PATCH] Monumenta - Fix shield banners & shulkers id missing
+ 'minecraft' namespace
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index 7d47e2615cbf49b2fba9b7f9e98a1ecb0ac080ee..7ed10469b87a432ffe9c2f8d79477ace1eac613a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -265,9 +265,6 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+     public BlockState getBlockState() {
+         if (blockEntityTag != null) {
+             switch (material) {
+-                case SHIELD:
+-                    blockEntityTag.setString("id", "banner");
+-                    break;
+                 case SHULKER_BOX:
+                 case WHITE_SHULKER_BOX:
+                 case ORANGE_SHULKER_BOX:
+@@ -285,7 +282,7 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+                 case GREEN_SHULKER_BOX:
+                 case RED_SHULKER_BOX:
+                 case BLACK_SHULKER_BOX:
+-                    blockEntityTag.setString("id", "shulker_box");
++                    blockEntityTag.setString("id", "minecraft:shulker_box");
+                     break;
+                 case BEE_NEST:
+                 case BEEHIVE:

--- a/Spigot-Server-Patches/0557-Monumenta-Clear-crafting-slots-when-clearing-player-.patch
+++ b/Spigot-Server-Patches/0557-Monumenta-Clear-crafting-slots-when-clearing-player-.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hazerdous <dransom96@gmail.com>
+Date: Wed, 12 Jun 2019 01:24:34 -0400
+Subject: [PATCH] Monumenta - Clear crafting slots when clearing player
+ inventory
+
+
+diff --git a/src/main/java/net/minecraft/server/ContainerPlayer.java b/src/main/java/net/minecraft/server/ContainerPlayer.java
+index a26ee8e37e84b6a309a05b4cba8c089a3f6c5cce..1710d4dc12d6b413f2dabf2067e8cd7ea388c3e4 100644
+--- a/src/main/java/net/minecraft/server/ContainerPlayer.java
++++ b/src/main/java/net/minecraft/server/ContainerPlayer.java
+@@ -16,7 +16,7 @@ public class ContainerPlayer extends ContainerRecipeBook<InventoryCrafting> {
+     private static final MinecraftKey[] j = new MinecraftKey[]{ContainerPlayer.g, ContainerPlayer.f, ContainerPlayer.e, ContainerPlayer.d};
+     private static final EnumItemSlot[] k = new EnumItemSlot[]{EnumItemSlot.HEAD, EnumItemSlot.CHEST, EnumItemSlot.LEGS, EnumItemSlot.FEET};
+     // CraftBukkit start
+-    private final InventoryCrafting craftInventory;
++    public final InventoryCrafting craftInventory;
+     private final InventoryCraftResult resultInventory;
+     // CraftBukkit end
+     public final boolean i;
+diff --git a/src/main/java/net/minecraft/server/ContainerWorkbench.java b/src/main/java/net/minecraft/server/ContainerWorkbench.java
+index 8ffaba58fb13a33c023d71fdb88a29f98b0d1cea..1ba4f4dc29cc263cca8dccc5dedfb2560d5455fa 100644
+--- a/src/main/java/net/minecraft/server/ContainerWorkbench.java
++++ b/src/main/java/net/minecraft/server/ContainerWorkbench.java
+@@ -8,7 +8,7 @@ import org.bukkit.craftbukkit.inventory.CraftInventoryView;
+ 
+ public class ContainerWorkbench extends ContainerRecipeBook<InventoryCrafting> {
+ 
+-    private final InventoryCrafting craftInventory;
++    public final InventoryCrafting craftInventory;
+     private final InventoryCraftResult resultInventory;
+     public final ContainerAccess containerAccess;
+     private final EntityHuman f;
+diff --git a/src/main/java/net/minecraft/server/PlayerInventory.java b/src/main/java/net/minecraft/server/PlayerInventory.java
+index d103cfaace4f42aaad677103f4eef578490699da..17b9e08e3cfd18f6a2047842950c357f3fc84288 100644
+--- a/src/main/java/net/minecraft/server/PlayerInventory.java
++++ b/src/main/java/net/minecraft/server/PlayerInventory.java
+@@ -213,6 +213,31 @@ public class PlayerInventory implements IInventory, INamableTileEntity {
+             }
+         }
+ 
++        InventoryCrafting craftInventory =
++            this.player.activeContainer instanceof ContainerPlayer ? ((ContainerPlayer) this.player.activeContainer).craftInventory :
++            this.player.activeContainer instanceof ContainerWorkbench ? ((ContainerWorkbench) this.player.activeContainer).craftInventory : null;
++        if (craftInventory != null) {
++            for (k = 0; k < craftInventory.getSize(); ++k) {
++                ItemStack itemstack = craftInventory.getItem(k);
++
++                if (!itemstack.isEmpty() && predicate.test(itemstack)) {
++                    int l = i <= 0 ? itemstack.getCount() : Math.min(i - j, itemstack.getCount());
++
++                    j += l;
++                    if (i != 0) {
++                        itemstack.subtract(l);
++                        if (itemstack.isEmpty()) {
++                            craftInventory.setItem(k, ItemStack.a);
++                        }
++
++                        if (i > 0 && j >= i) {
++                            return j;
++                        }
++                    }
++                }
++            }
++        }
++
+         return j;
+     }
+ 

--- a/Spigot-Server-Patches/0558-Monumenta-DamageCause.CUSTOM-support-for-class-abili.patch
+++ b/Spigot-Server-Patches/0558-Monumenta-DamageCause.CUSTOM-support-for-class-abili.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Fri, 6 Sep 2019 20:36:55 -0400
+Subject: [PATCH] Monumenta - DamageCause.CUSTOM support for class abilities
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index ce8d7877adcc4635ebf2f5743c8b02aa95691102..47b633772c212006286bc5a6345394919d4e8597 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -888,6 +888,8 @@ public class CraftEventFactory {
+                 } else if (damager.getBukkitEntity() instanceof Projectile) {
+                     cause = DamageCause.PROJECTILE;
+                 }
++            } else if ("custom".equals(source.translationIndex)) {
++                cause = DamageCause.CUSTOM;
+             } else if ("thorns".equals(source.translationIndex)) {
+                 cause = DamageCause.THORNS;
+             }

--- a/Spigot-Server-Patches/0559-Monumenta-Ocelots-spawn-on-any-block.patch
+++ b/Spigot-Server-Patches/0559-Monumenta-Ocelots-spawn-on-any-block.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 20 Nov 2019 01:20:13 -0500
+Subject: [PATCH] Monumenta - Ocelots spawn on any block
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityOcelot.java b/src/main/java/net/minecraft/server/EntityOcelot.java
+index d9a7b8ac1eac58e02607f4df0c9413239fcec3a4..694ef67aac007d5dbfa11234ec219b244110ee7a 100644
+--- a/src/main/java/net/minecraft/server/EntityOcelot.java
++++ b/src/main/java/net/minecraft/server/EntityOcelot.java
+@@ -204,14 +204,10 @@ public class EntityOcelot extends EntityAnimal {
+         if (iworldreader.i(this) && !iworldreader.containsLiquid(this.getBoundingBox())) {
+             BlockPosition blockposition = new BlockPosition(this);
+ 
+-            if (blockposition.getY() < iworldreader.getSeaLevel()) {
+-                return false;
+-            }
+-
+             IBlockData iblockdata = iworldreader.getType(blockposition.down());
+             Block block = iblockdata.getBlock();
+ 
+-            if (block == Blocks.GRASS_BLOCK || iblockdata.a(TagsBlock.LEAVES)) {
++            if (block != Blocks.AIR) {
+                 return true;
+             }
+         }

--- a/Spigot-Server-Patches/0560-Monumenta-Ocelots-golems-wolves-phantoms-no-longer-s.patch
+++ b/Spigot-Server-Patches/0560-Monumenta-Ocelots-golems-wolves-phantoms-no-longer-s.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 20 Nov 2019 01:20:13 -0500
+Subject: [PATCH] Monumenta - Ocelots, golems, wolves, phantoms no longer spawn
+ in peaceful from spawners
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityGolem.java b/src/main/java/net/minecraft/server/EntityGolem.java
+index c5c30b16043cb9c474a2f5a07954f98f263d1316..4933e5e4e49d4782769315985ce05acb4bf8d00c 100644
+--- a/src/main/java/net/minecraft/server/EntityGolem.java
++++ b/src/main/java/net/minecraft/server/EntityGolem.java
+@@ -8,6 +8,11 @@ public abstract class EntityGolem extends EntityCreature {
+         super(entitytypes, world);
+     }
+ 
++    @Override
++    public boolean a(GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn) {
++        return super.a(generatoraccess, enummobspawn) && (generatoraccess.getDifficulty() != EnumDifficulty.PEACEFUL || enummobspawn != EnumMobSpawn.SPAWNER);
++    }
++
+     @Override
+     public boolean b(float f, float f1) {
+         return false;
+diff --git a/src/main/java/net/minecraft/server/EntityOcelot.java b/src/main/java/net/minecraft/server/EntityOcelot.java
+index 694ef67aac007d5dbfa11234ec219b244110ee7a..fc7ec866b2d419f036233a4661d6f519dcf6501c 100644
+--- a/src/main/java/net/minecraft/server/EntityOcelot.java
++++ b/src/main/java/net/minecraft/server/EntityOcelot.java
+@@ -195,8 +195,13 @@ public class EntityOcelot extends EntityAnimal {
+         return EntityOcelot.bw.test(itemstack);
+     }
+ 
++    @Override
++    public boolean a(GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn) {
++        return super.a(generatoraccess, enummobspawn) && (generatoraccess.getDifficulty() != EnumDifficulty.PEACEFUL || enummobspawn != EnumMobSpawn.SPAWNER);
++    }
++
+     public static boolean c(EntityTypes<EntityOcelot> entitytypes, GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn, BlockPosition blockposition, Random random) {
+-        return random.nextInt(3) != 0;
++        return generatoraccess.getDifficulty() != net.minecraft.server.EnumDifficulty.PEACEFUL;
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityPhantom.java b/src/main/java/net/minecraft/server/EntityPhantom.java
+index 96b4912c4832bee0337d35cb23e574cd02f64c3b..e63382a1fc42052c2ef450f0e8e05b62be02b371 100644
+--- a/src/main/java/net/minecraft/server/EntityPhantom.java
++++ b/src/main/java/net/minecraft/server/EntityPhantom.java
+@@ -115,6 +115,11 @@ public class EntityPhantom extends EntityFlying implements IMonster {
+         super.mobTick();
+     }
+ 
++    @Override
++    public boolean a(GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn) {
++        return super.a(generatoraccess, enummobspawn) && (generatoraccess.getDifficulty() != EnumDifficulty.PEACEFUL || enummobspawn != EnumMobSpawn.SPAWNER);
++    }
++
+     @Override
+     public GroupDataEntity prepare(GeneratorAccess generatoraccess, DifficultyDamageScaler difficultydamagescaler, EnumMobSpawn enummobspawn, @Nullable GroupDataEntity groupdataentity, @Nullable NBTTagCompound nbttagcompound) {
+         this.d = (new BlockPosition(this)).up(5);
+diff --git a/src/main/java/net/minecraft/server/EntityWolf.java b/src/main/java/net/minecraft/server/EntityWolf.java
+index eec1e26b6eba07c31d251ecf69dc36199688110e..731a64595ac210dbc45714bff0892a5a927ba955 100644
+--- a/src/main/java/net/minecraft/server/EntityWolf.java
++++ b/src/main/java/net/minecraft/server/EntityWolf.java
+@@ -30,6 +30,11 @@ public class EntityWolf extends EntityTameableAnimal {
+         this.setTamed(false);
+     }
+ 
++    @Override
++    public boolean a(GeneratorAccess generatoraccess, EnumMobSpawn enummobspawn) {
++        return super.a(generatoraccess, enummobspawn) && (generatoraccess.getDifficulty() != EnumDifficulty.PEACEFUL || enummobspawn != EnumMobSpawn.SPAWNER);
++    }
++
+     @Override
+     protected void initPathfinder() {
+         this.goalSit = new PathfinderGoalSit(this);

--- a/Spigot-Server-Patches/0561-Monumenta-Refuse-to-start-shard-if-scoreboard-fails-.patch
+++ b/Spigot-Server-Patches/0561-Monumenta-Refuse-to-start-shard-if-scoreboard-fails-.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 6 Feb 2020 01:34:38 -0500
+Subject: [PATCH] Monumenta - Refuse to start shard if scoreboard fails to load
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/WorldPersistentData.java b/src/main/java/net/minecraft/server/WorldPersistentData.java
+index a2a25cf6a43a1f59a80c997e2980f2bb8e6b3817..9bfbe6c75c2bcedfbbc8609aa3ff7f1285291fae 100644
+--- a/src/main/java/net/minecraft/server/WorldPersistentData.java
++++ b/src/main/java/net/minecraft/server/WorldPersistentData.java
+@@ -70,6 +70,7 @@ public class WorldPersistentData {
+             }
+         } catch (Exception exception) {
+             WorldPersistentData.LOGGER.error("Error loading saved data: {}", s, exception);
++            System.exit(-9001);
+         }
+ 
+         return null;

--- a/Spigot-Server-Patches/0562-Monumenta-Make-armor-unbreaking-work-the-same-as-too.patch
+++ b/Spigot-Server-Patches/0562-Monumenta-Make-armor-unbreaking-work-the-same-as-too.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Fri, 13 Mar 2020 17:33:42 -0400
+Subject: [PATCH] Monumenta - Make armor unbreaking work the same as tools
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EnchantmentDurability.java b/src/main/java/net/minecraft/server/EnchantmentDurability.java
+index c946326fbc436a9c825625e6f58b8771a05832af..73054160f0f897914e403791227546e04e155915 100644
+--- a/src/main/java/net/minecraft/server/EnchantmentDurability.java
++++ b/src/main/java/net/minecraft/server/EnchantmentDurability.java
+@@ -29,6 +29,7 @@ public class EnchantmentDurability extends Enchantment {
+     }
+ 
+     public static boolean a(ItemStack itemstack, int i, Random random) {
+-        return itemstack.getItem() instanceof ItemArmor && random.nextFloat() < 0.6F ? false : random.nextInt(i + 1) > 0;
++        /* MONUMENTA: All items work like tools for unbreaking */
++        return random.nextInt(i + 1) > 0;
+     }
+ }
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index ea60880c6f15b1a39579896d78cf641563621aa4..71420d7d30b6e986db469948b3baae9c3516802c 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -396,6 +396,12 @@ public final class ItemStack {
+                 j = EnchantmentManager.getEnchantmentLevel(Enchantments.DURABILITY, this);
+                 int k = 0;
+ 
++                /* MONUMENTA:
++                 * Reduce giant spikes of gear damage to make high-damage mobs less destructive to gear
++                 * https://www.wolframalpha.com/input/?i=plot+min%28x%2F8%2B2%2Cx%2F4%29+and+min%28sqrt%28x%29%2Cx%2F4%29+and+x%2F4%2C+x%3D1..40
++                 */
++                i = (int)Math.min(i, Math.sqrt(i * 4));
++
+                 for (int l = 0; j > 0 && l < i; ++l) {
+                     if (EnchantmentDurability.a(this, j, random)) {
+                         ++k;

--- a/Spigot-Server-Patches/0563-Monumenta-Max-level-for-curse-of-vanishing-is-2.patch
+++ b/Spigot-Server-Patches/0563-Monumenta-Max-level-for-curse-of-vanishing-is-2.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Thu, 16 Apr 2020 19:50:43 -0400
+Subject: [PATCH] Monumenta - Max level for curse of vanishing is 2
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EnchantmentVanishing.java b/src/main/java/net/minecraft/server/EnchantmentVanishing.java
+index 4ef59d7f171d183a35c0975a82e041457903fe10..07f6d5ada98f6af59c6ae62f06bb6b8c83a73559 100644
+--- a/src/main/java/net/minecraft/server/EnchantmentVanishing.java
++++ b/src/main/java/net/minecraft/server/EnchantmentVanishing.java
+@@ -18,7 +18,7 @@ public class EnchantmentVanishing extends Enchantment {
+ 
+     @Override
+     public int getMaxLevel() {
+-        return 1;
++        return 2;
+     }
+ 
+     @Override

--- a/Spigot-Server-Patches/0564-Monumenta-Selectors-require-targets-to-be-alive.patch
+++ b/Spigot-Server-Patches/0564-Monumenta-Selectors-require-targets-to-be-alive.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Southwick <NickNackGus@gmail.com>
+Date: Sun, 19 Apr 2020 19:34:47 -0400
+Subject: [PATCH] Monumenta - Selectors require targets to be alive
+
+
+diff --git a/src/main/java/net/minecraft/server/ArgumentParserSelector.java b/src/main/java/net/minecraft/server/ArgumentParserSelector.java
+index 75db3678a610bd3c420ba1b3fa5242761692fc75..b104fca3d1572061c03db132e10fbef92ff0338f 100644
+--- a/src/main/java/net/minecraft/server/ArgumentParserSelector.java
++++ b/src/main/java/net/minecraft/server/ArgumentParserSelector.java
+@@ -103,9 +103,7 @@ public class ArgumentParserSelector {
+         this.r = CriterionConditionValue.IntegerRange.e;
+         this.y = CriterionConditionRange.a;
+         this.z = CriterionConditionRange.a;
+-        this.A = (entity) -> {
+-            return true;
+-        };
++        this.A = Entity::isAlive;
+         this.B = ArgumentParserSelector.g;
+         this.G = ArgumentParserSelector.k;
+         this.l = stringreader;

--- a/Spigot-Server-Patches/0565-Monumenta-Reset-last-player-hurt-time-on-taking-any-.patch
+++ b/Spigot-Server-Patches/0565-Monumenta-Reset-last-player-hurt-time-on-taking-any-.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Wed, 29 Apr 2020 21:17:15 +0000
+Subject: [PATCH] Monumenta - Reset last player hurt time on taking any damage
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index 3fc2360a103a5399f2878eccb0c13eb6e41e824d..0d5344cee792e8abbb88d0dea626e06677b81fd3 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -1069,6 +1069,10 @@ public abstract class EntityLiving extends Entity {
+             this.ax = 0.0F;
+             Entity entity1 = damagesource.getEntity();
+ 
++            if (this.killer != null) {
++                this.lastDamageByPlayerTime = 100;
++            }
++
+             if (entity1 != null) {
+                 if (entity1 instanceof EntityLiving) {
+                     this.setLastDamager((EntityLiving) entity1);

--- a/Spigot-Server-Patches/0566-Monumenta-Villager-trades-match-durability-0-with-du.patch
+++ b/Spigot-Server-Patches/0566-Monumenta-Villager-trades-match-durability-0-with-du.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hazerd <dransom96@gmail.com>
+Date: Sun, 10 May 2020 18:42:57 -0400
+Subject: [PATCH] Monumenta - Villager trades match durability=0 with
+ durability=null
+
+
+diff --git a/src/main/java/net/minecraft/server/MerchantRecipe.java b/src/main/java/net/minecraft/server/MerchantRecipe.java
+index 7c4dc1143696320c8b8dc21ea4ae0600d5686d62..5053b677b07a812b07096ab0aa034e036a28c778 100644
+--- a/src/main/java/net/minecraft/server/MerchantRecipe.java
++++ b/src/main/java/net/minecraft/server/MerchantRecipe.java
+@@ -196,12 +196,14 @@ public class MerchantRecipe {
+             return true;
+         } else {
+             ItemStack itemstack2 = itemstack.cloneItemStack();
++            ItemStack itemstack3 = itemstack1.cloneItemStack();
+ 
+-            if (itemstack2.getItem().usesDurability()) {
++            if (itemstack2.getItem().usesDurability() && itemstack3.getItem().usesDurability()) {
+                 itemstack2.setDamage(itemstack2.getDamage());
++				itemstack3.setDamage(itemstack3.getDamage());
+             }
+ 
+-            return ItemStack.c(itemstack2, itemstack1) && (!itemstack1.hasTag() || itemstack2.hasTag() && GameProfileSerializer.a(itemstack1.getTag(), itemstack2.getTag(), false));
++            return ItemStack.c(itemstack2, itemstack3) && (!itemstack3.hasTag() || itemstack2.hasTag() && GameProfileSerializer.a(itemstack3.getTag(), itemstack2.getTag(), false));
+         }
+     }
+ 

--- a/Spigot-Server-Patches/0567-Monumenta-Fix-generating-loot-table-contents.patch
+++ b/Spigot-Server-Patches/0567-Monumenta-Fix-generating-loot-table-contents.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Byron Marohn <combustible@live.com>
+Date: Tue, 9 Jun 2020 21:19:52 -0400
+Subject: [PATCH] Monumenta - Fix generating loot table contents
+
+Signed-off-by: Byron Marohn <combustible@live.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java b/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+index 260d54b30499c45167e4274ef0932167b6509ba4..ad218c826c63fcf93efcbf499ea7d0aeb1b25414 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftLootTable.java
+@@ -101,9 +101,6 @@ public class CraftLootTable implements org.bukkit.loot.LootTable {
+ 
+         // SPIGOT-5603 - Avoid IllegalArgumentException in LootTableInfo#build()
+         LootContextParameterSet.a nmsBuilder = new LootContextParameterSet.a(); // PAIL rename Builder
+-        for (LootContextParameter<?> param : getHandle().getLootContextParameterSet().a()) { // PAIL rename required
+-            nmsBuilder.a(param); // PAIL rename addRequired
+-        }
+         for (LootContextParameter<?> param : getHandle().getLootContextParameterSet().b()) { // PAIL rename optional
+             if (!getHandle().getLootContextParameterSet().a().contains(param)) { // PAIL rename required
+                 nmsBuilder.b(param); // PAIL rename addOptional

--- a/Spigot-Server-Patches/0568-Monumenta-Mob-spawners-slowly-tick-with-no-nearby-pl.patch
+++ b/Spigot-Server-Patches/0568-Monumenta-Mob-spawners-slowly-tick-with-no-nearby-pl.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hazerd <dransom96@gmail.com>
+Date: Fri, 26 Jun 2020 21:02:03 -0400
+Subject: [PATCH] Monumenta - Mob spawners slowly tick with no nearby players
+
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+index df494d37be687860878c2709ae7996510118a559..36e490013a05fc1e37c561b3dcd60c0be974b92b 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
+@@ -59,6 +59,12 @@ public abstract class MobSpawnerAbstract {
+         if (spawnDelay > 0 && --tickDelay > 0) return;
+         tickDelay = this.a().paperConfig.mobSpawnerTickRate;
+         // Paper end
++		// Monumenta start - Mob spawners slowly tick with no nearby players
++		int adjustedTickDelay = tickDelay - 1;
++		if (spawnDelay > 0) {
++			spawnDelay -= 1;
++		}
++		// Monumenta end
+         if (!this.h()) {
+             this.f = this.e;
+         } else {
+@@ -73,18 +79,18 @@ public abstract class MobSpawnerAbstract {
+                 world.addParticle(Particles.SMOKE, d0, d1, d2, 0.0D, 0.0D, 0.0D);
+                 world.addParticle(Particles.FLAME, d0, d1, d2, 0.0D, 0.0D, 0.0D);
+                 if (this.spawnDelay > 0) {
+-                    this.spawnDelay -= tickDelay; // Paper
++                    this.spawnDelay -= adjustedTickDelay; // Paper // Monumenta
+                 }
+ 
+                 this.f = this.e;
+                 this.e = (this.e + (double) (1000.0F / ((float) this.spawnDelay + 200.0F))) % 360.0D;
+             } else {
+-                if (this.spawnDelay < -tickDelay) { // Paper
++                if (this.spawnDelay < -adjustedTickDelay) { // Paper // Monumenta
+                     this.i();
+                 }
+ 
+                 if (this.spawnDelay > 0) {
+-                    this.spawnDelay -= tickDelay; // Paper
++                    this.spawnDelay -= adjustedTickDelay; // Paper // Monumenta
+                     return;
+                 }
+ 


### PR DESCRIPTION
This allows spawners to "reprime" themselves after being left alone for a while.
The speed is based on the paper mob-spawner-tick-rate setting.
If the setting is N, spawners with no nearby players tick at 1/N speed.