### PR TITLE
[1.16] Fix MobGoals#getAllGoals not actually returning all goals

### DIFF
--- a/Spigot-API-Patches/0202-Add-Mob-Goal-API.patch
+++ b/Spigot-API-Patches/0202-Add-Mob-Goal-API.patch
@@ -148,10 +148,10 @@ index 0000000000000000000000000000000000000000..9cd98c6fcfa3eb439d9013ef76ef4661
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/GoalType.java b/src/main/java/com/destroystokyo/paper/entity/ai/GoalType.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2b44aff21e6818512a81f03a3bff913abf61f9f
+index 0000000000000000000000000000000000000000..7024c8f484d2460abf3abfe65a29771d814105ec
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/GoalType.java
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,17 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +/**
@@ -162,7 +162,11 @@ index 0000000000000000000000000000000000000000..e2b44aff21e6818512a81f03a3bff913
 +    MOVE,
 +    LOOK,
 +    JUMP,
-+    TARGET
++    TARGET,
++    /**
++     * Used to map vanilla goals, that are a behavior goal but don't have a type set...
++     */
++    UNKNOWN_BEHAVIOR,
 +
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoals.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoals.java

--- a/Spigot-Server-Patches/0477-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0477-Implement-Mob-Goal-API.patch
@@ -24,10 +24,10 @@ index 6cde6f7dcbb3ff2fda0189a06573640777548d27..ef8ee637a8a0e5e703922b2991c58f4f
      <repositories>
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4ec476669d98ab2f03859e763cfe55904563238f
+index 0000000000000000000000000000000000000000..7b12014db0abd9c4b89f58ceaaa7d9dd032b027a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/MobGoalHelper.java
-@@ -0,0 +1,349 @@
+@@ -0,0 +1,353 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import com.google.common.collect.BiMap;
@@ -312,6 +312,8 @@ index 0000000000000000000000000000000000000000..4ec476669d98ab2f03859e763cfe5590
 +                return GoalType.LOOK;
 +            case JUMP:
 +                return GoalType.JUMP;
++            case UNKNOWN_BEHAVIOR:
++                return GoalType.UNKNOWN_BEHAVIOR;
 +            case TARGET:
 +                return GoalType.TARGET;
 +            default:
@@ -335,6 +337,8 @@ index 0000000000000000000000000000000000000000..4ec476669d98ab2f03859e763cfe5590
 +                return PathfinderGoal.Type.LOOK;
 +            case JUMP:
 +                return PathfinderGoal.Type.JUMP;
++            case UNKNOWN_BEHAVIOR:
++                return PathfinderGoal.Type.UNKNOWN_BEHAVIOR;
 +            case TARGET:
 +                return PathfinderGoal.Type.TARGET;
 +            default:
@@ -379,10 +383,10 @@ index 0000000000000000000000000000000000000000..4ec476669d98ab2f03859e763cfe5590
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/entity/ai/PaperCustomGoal.java b/src/main/java/com/destroystokyo/paper/entity/ai/PaperCustomGoal.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..8e4dc2708d71edcb8f32bb72a64f3c493052c2a8
+index 0000000000000000000000000000000000000000..5720feaaf92fc8b6a70e7f6e2d25163c42d231c1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/ai/PaperCustomGoal.java
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,55 @@
 +package com.destroystokyo.paper.entity.ai;
 +
 +import net.minecraft.server.PathfinderGoal;
@@ -400,6 +404,9 @@ index 0000000000000000000000000000000000000000..8e4dc2708d71edcb8f32bb72a64f3c49
 +        this.handle = handle;
 +
 +        this.setTypes(MobGoalHelper.paperToVanilla(handle.getTypes()));
++        if (this.getGoalTypes().size() == 0) {
++            this.getGoalTypes().addUnchecked(Type.UNKNOWN_BEHAVIOR);
++        }
 +    }
 +
 +    @Override
@@ -748,12 +755,21 @@ index 9df0006c1a283f77c4d01d9fce9062fc1c9bbb1f..b3329c6fcd6758a781a51f5ba8f5052a
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoal.java b/src/main/java/net/minecraft/server/PathfinderGoal.java
-index a85d81186ae92dec72f2cc3a1dcd8c4b7e7ede62..d2aa9a854ea013f24f585c194bd1ddfd8d5410a5 100644
+index a85d81186ae92dec72f2cc3a1dcd8c4b7e7ede62..8f26cb20b8c63f2809838c97528cef62ec39bcdb 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoal.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoal.java
-@@ -10,9 +10,9 @@ public abstract class PathfinderGoal {
+@@ -8,11 +8,17 @@ public abstract class PathfinderGoal {
+     private final EnumSet<PathfinderGoal.Type> a = EnumSet.noneOf(PathfinderGoal.Type.class); // Paper unused, but dummy to prevent plugins from crashing as hard. Theyll need to support paper in a special case if this is super important, but really doesn't seem like it would be.
+     private final OptimizedSmallEnumSet<Type> goalTypes = new OptimizedSmallEnumSet<>(PathfinderGoal.Type.class); // Paper - remove streams from pathfindergoalselector
  
-     public PathfinderGoal() {}
+-    public PathfinderGoal() {}
++    // Paper start make sure goaltypes is never empty
++    public PathfinderGoal() {
++        if (this.goalTypes.size() == 0) {
++            this.goalTypes.addUnchecked(Type.UNKNOWN_BEHAVIOR);
++        }
++    }
++    // paper end
  
 -    public abstract boolean a();
 +    public boolean a() { return this.shouldActivate(); } public boolean shouldActivate() { return false;} public boolean shouldActivate2() { return a(); } // Paper - OBFHELPER, for both directions...
@@ -763,7 +779,7 @@ index a85d81186ae92dec72f2cc3a1dcd8c4b7e7ede62..d2aa9a854ea013f24f585c194bd1ddfd
          return this.a();
      }
  
-@@ -20,16 +20,16 @@ public abstract class PathfinderGoal {
+@@ -20,19 +26,23 @@ public abstract class PathfinderGoal {
          return true;
      }
  
@@ -783,6 +799,22 @@ index a85d81186ae92dec72f2cc3a1dcd8c4b7e7ede62..d2aa9a854ea013f24f585c194bd1ddfd
          // Paper start - remove streams from pathfindergoalselector
          this.goalTypes.clear();
          this.goalTypes.addAllUnchecked(enumset);
++        // make sure its never empty
++        if (this.goalTypes.size() == 0) {
++            this.goalTypes.addUnchecked(Type.UNKNOWN_BEHAVIOR);
++        }
+         // Paper end - remove streams from pathfindergoalselector
+     }
+ 
+@@ -48,7 +58,7 @@ public abstract class PathfinderGoal {
+ 
+     public static enum Type {
+ 
+-        MOVE, LOOK, JUMP, TARGET;
++        MOVE, LOOK, JUMP, TARGET, UNKNOWN_BEHAVIOR; // Paper - add unknown
+ 
+         private Type() {}
+     }
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalSelector.java b/src/main/java/net/minecraft/server/PathfinderGoalSelector.java
 index 22f4fec58fbaab24673dd418700c51671248c510..d3f0327a2a7cdedf3fe8d10df981a9f1cb378d26 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalSelector.java


### PR DESCRIPTION
Basically, there are goals, that don't have a goal type, so the api wouldn't return those goals, nor remove them.
Examples are enderman pickup and placement of blocks.
This PR fixes that, by making sure all goals have a type