### PR TITLE
added gradle configuration to README, updated README dependency version to 1.16.1-R0.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,27 @@ How To (Plugin Developers)
 <dependency>
     <groupId>com.destroystokyo.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>1.15.2-R0.1-SNAPSHOT</version>
+    <version>1.16.1-R0.1-SNAPSHOT</version>
     <scope>provided</scope>
  </dependency>
  ```
+
+##### Or alternatively, with Gradle:
+
+* Repository:
+```groovy
+repositories {
+    maven { 
+        url "https://papermc.io/repo/repository/maven-public/" 
+    }
+}
+```
+ * Artifact:
+```groovy
+dependencies {
+    compileOnly "com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT"
+}
+```
 
 How To (Compiling Jar From Source)
 ------


### PR DESCRIPTION
I thought I'd add an example Gradle implementation for the Paper API, just to help with people who choose to use Gradle over Maven. Also, I've updated the Maven dependency version in the README to 1.16.1-R0.1-SNAPSHOT as it says in the title.