### PR TITLE
Added Gradle configuration to README, updated dependency version to 1.16.1-R0.1-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,27 @@ How To (Plugin Developers)
 <dependency>
     <groupId>com.destroystokyo.paper</groupId>
     <artifactId>paper-api</artifactId>
-    <version>1.15.2-R0.1-SNAPSHOT</version>
+    <version>1.16.1-R0.1-SNAPSHOT</version>
     <scope>provided</scope>
  </dependency>
  ```
+#####Or alternatively, with Gradle:
 
+ * Repository:
+```groovy
+repositories {
+    maven {
+        url('https://papermc.io/repo/repository/maven-public/')
+    }
+}
+```
+
+ * Artifact:
+```groovy
+dependencies {
+    compileOnly('com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT')
+}
+```
 How To (Compiling Jar From Source)
 ------
 To compile Paper, you need JDK 8, maven, and an internet connection.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ How To (Plugin Developers)
     <scope>provided</scope>
  </dependency>
  ```
-#####Or alternatively, with Gradle:
+##### Or alternatively, with Gradle:
 
  * Repository:
 ```groovy


### PR DESCRIPTION
I've added an example configuration for Gradle to the README, to help plugin developers who choose to use Gradle rather than Maven. I've also changed the `<version>` tag in the Maven dependency to 1.16.1-R0.1-SNAPSHOT rather than what it was before (still 1.15.2-R0.1-SNAPSHOT).

Let me know if you think I should change anything else about this :slightly_smiling_face: