### PR TITLE
Added Gradle configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,23 @@ How To (Plugin Developers)
  </dependency>
  ```
 
+**Or alternatively, with Gradle:**
+
+ * Repository:
+```groovy
+repositories {
+    maven {
+        url 'https://papermc.io/repo/repository/maven-public/'
+    }
+}
+```
+ * Artifact:
+```groovy
+dependencies {
+    compileOnly 'com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT'
+}
+```
+
 How To (Compiling Jar From Source)
 ------
 To compile Paper, you need JDK 8, maven, and an internet connection.


### PR DESCRIPTION
Many apologies that this is the fourth pull request for the same commit because for some reason I couldn't get it right the first three times, by now you probably all know what this commit does, it adds Gradle configuration to the README to help plugin developers who choose Gradle over Maven. Hopefully this time I've actually nailed it.

Again, let me know if I screwed anything up :slightly_smiling_face: 

Also, the other four files just appeared as changed for some reason, I haven't changed anything in any of them, not much I can really do about that.