### PR TITLE
Add more material tags for 1.16

### DIFF
--- a/Spigot-API-Patches/0154-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0154-Add-Material-Tags.patch
@@ -204,10 +204,10 @@ index 0000000000000000000000000000000000000000..c91ea2a0679a7f3a5627b5a008e0b39d
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialTags.java b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e340830c34310
+index 0000000000000000000000000000000000000000..e72fc52240015051fe58b246fcf5c014f3330f0a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialTags.java
-@@ -0,0 +1,374 @@
+@@ -0,0 +1,410 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -253,7 +253,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("ARROWS", 3);
 +
 +    /**
-+     * Cover all 16 colors of beds.
++     * Covers all colors of beds.
 +     */
 +    public static final MaterialSetTag BEDS = new MaterialSetTag(keyFor("beds"))
 +        .endsWith("_BED")
@@ -286,14 +286,14 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .add(Material.COBBLESTONE, Material.MOSSY_COBBLESTONE);
 +
 +    /**
-+     * Covers all 16 colors of concrete.
++     * Covers all colors of concrete.
 +     */
 +    public static final MaterialSetTag CONCRETES = new MaterialSetTag(keyFor("concretes"))
 +        .endsWith("_CONCRETE")
 +        .ensureSize("CONCRETES", 16);
 +
 +    /**
-+     * Covers all 16 colors of concrete powder.
++     * Covers all colors of concrete powder.
 +     */
 +    public static final MaterialSetTag CONCRETE_POWDER = new MaterialSetTag(keyFor("concrete_powder"))
 +        .endsWith("_CONCRETE_POWDER")
@@ -306,7 +306,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .add(Material.COOKED_COD, Material.COOKED_SALMON);
 +
 +    /**
-+     * Covers all 16 dyes.
++     * Covers all dyes.
 +     */
 +    public static final MaterialSetTag DYES = new MaterialSetTag(keyFor("dyes"))
 +        .endsWith("_DYE")
@@ -327,7 +327,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("FENCES", 9);
 +
 +    /**
-+     * Covers all 4 variants of fish buckets.
++     * Covers all variants of fish buckets.
 +     */
 +    public static final MaterialSetTag FISH_BUCKETS = new MaterialSetTag(keyFor("fish_buckets"))
 +        .add(Material.COD_BUCKET, Material.PUFFERFISH_BUCKET, Material.SALMON_BUCKET, Material.TROPICAL_FISH_BUCKET);
@@ -341,21 +341,21 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("GLASS", 17);
 +
 +    /**
-+     * Covers the non-colored glass panes and 16 stained glass panes (panes only).
++     * Covers the non-colored glass panes and stained glass panes (panes only).
 +     */
 +    public static final MaterialSetTag GLASS_PANES = new MaterialSetTag(keyFor("glass_panes"))
 +        .endsWith("GLASS_PANE")
 +        .ensureSize("GLASS_PANES", 17);
 +
 +    /**
-+     * Covers all 16 glazed terracotta blocks.
++     * Covers all glazed terracotta blocks.
 +     */
 +    public static final MaterialSetTag GLAZED_TERRACOTTA = new MaterialSetTag(keyFor("glazed_terracotta"))
 +        .endsWith("GLAZED_TERRACOTTA")
 +        .ensureSize("GLAZED_TERRACOTTA", 16);
 +
 +    /**
-+     * Covers the 16 colors of stained terracotta.
++     * Covers the colors of stained terracotta.
 +     */
 +    public static final MaterialSetTag STAINED_TERRACOTTA = new MaterialSetTag(keyFor("stained_terracotta"))
 +        .endsWith("TERRACOTTA")
@@ -364,7 +364,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("STAINED_TERRACOTTA", 16);
 +
 +    /**
-+     * Covers terracotta along with the 16 stained variants.
++     * Covers terracotta along with the stained variants.
 +     */
 +    public static final MaterialSetTag TERRACOTTA = new MaterialSetTag(keyFor("terracotta"))
 +        .endsWith("TERRACOTTA")
@@ -379,21 +379,21 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("GOLDEN_APPLES", 2);
 +
 +    /**
-+     * Covers the 3 variants of horse armor.
++     * Covers the variants of horse armor.
 +     */
 +    public static final MaterialSetTag HORSE_ARMORS = new MaterialSetTag(keyFor("horse_armors"))
 +        .endsWith("_HORSE_ARMOR")
 +        .ensureSize("HORSE_ARMORS", 4);
 +
 +    /**
-+     * Covers the 6 variants of infested blocks.
++     * Covers the variants of infested blocks.
 +     */
 +    public static final MaterialSetTag INFESTED_BLOCKS = new MaterialSetTag(keyFor("infested_blocks"))
 +        .startsWith("INFESTED_")
 +        .ensureSize("INFESTED_BLOCKS", 6);
 +
 +    /**
-+     * Covers the 3 variants of mushroom blocks.
++     * Covers the variants of mushroom blocks.
 +     */
 +    public static final MaterialSetTag MUSHROOM_BLOCKS = new MaterialSetTag(keyFor("mushroom_blocks"))
 +        .endsWith("MUSHROOM_BLOCK")
@@ -401,7 +401,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("MUSHROOM_BLOCKS", 3);
 +
 +    /**
-+     * Covers both mushrooms.
++     * Covers all mushrooms.
 +     */
 +    public static final MaterialSetTag MUSHROOMS = new MaterialSetTag(keyFor("mushrooms"))
 +        .add(Material.BROWN_MUSHROOM, Material.RED_MUSHROOM);
@@ -435,38 +435,38 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("POTATOES", 3);
 +
 +    /**
-+     * Covers all wooden pressure plates and the weighted pressure plates and 1 stone pressure plate.
++     * Covers all wooden pressure plates and the weighted pressure plates and the stone pressure plate.
 +     */
 +    public static final MaterialSetTag PRESSURE_PLATES = new MaterialSetTag(keyFor("pressure_plates"))
 +        .endsWith("_PRESSURE_PLATE")
 +        .ensureSize("PRESSURE_PLATES", 12);
 +
 +    /**
-+     * Covers the 3 variants of prismarine blocks.
++     * Covers the variants of prismarine blocks.
 +     */
 +    public static final MaterialSetTag PRISMARINE = new MaterialSetTag(keyFor("prismarine"))
 +        .add(Material.PRISMARINE, Material.PRISMARINE_BRICKS, Material.DARK_PRISMARINE);
 +
 +    /**
-+     * Covers the 3 variants of prismarine slabs.
++     * Covers the variants of prismarine slabs.
 +     */
 +    public static final MaterialSetTag PRISMARINE_SLABS = new MaterialSetTag(keyFor("prismarine_slabs"))
 +        .add(Material.PRISMARINE_SLAB, Material.PRISMARINE_BRICK_SLAB, Material.DARK_PRISMARINE_SLAB);
 +
 +    /**
-+     * Covers the 3 variants of prismarine stairs.
++     * Covers the variants of prismarine stairs.
 +     */
 +    public static final MaterialSetTag PRISMARINE_STAIRS = new MaterialSetTag(keyFor("prismarine_stairs"))
 +        .add(Material.PRISMARINE_STAIRS, Material.PRISMARINE_BRICK_STAIRS, Material.DARK_PRISMARINE_STAIRS);
 +
 +    /**
-+     * Covers the 3 variants of pumpkins.
++     * Covers the variants of pumpkins.
 +     */
 +    public static final MaterialSetTag PUMPKINS = new MaterialSetTag(keyFor("pumpkins"))
 +        .add(Material.CARVED_PUMPKIN, Material.JACK_O_LANTERN, Material.PUMPKIN);
 +
 +    /**
-+     * Covers the 4 variants of quartz blocks.
++     * Covers the variants of quartz blocks.
 +     */
 +    public static final MaterialSetTag QUARTZ_BLOCKS = new MaterialSetTag(keyFor("quartz_blocks"))
 +        .add(Material.QUARTZ_BLOCK, Material.QUARTZ_PILLAR, Material.CHISELED_QUARTZ_BLOCK, Material.SMOOTH_QUARTZ);
@@ -478,14 +478,14 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .add(Material.COD, Material.PUFFERFISH, Material.SALMON, Material.TROPICAL_FISH);
 +
 +    /**
-+     * Covers the 4 variants of red sandstone blocks.
++     * Covers the variants of red sandstone blocks.
 +     */
 +    public static final MaterialSetTag RED_SANDSTONES = new MaterialSetTag(keyFor("red_sandstones"))
 +        .endsWith("RED_SANDSTONE")
 +        .ensureSize("RED_SANDSTONES", 4);
 +
 +    /**
-+     * Covers the 4 variants of sandstone blocks.
++     * Covers the variants of sandstone blocks.
 +     */
 +    public static final MaterialSetTag SANDSTONES = new MaterialSetTag(keyFor("sandstones"))
 +        .add(Material.SANDSTONE, Material.CHISELED_SANDSTONE, Material.CUT_SANDSTONE, Material.SMOOTH_SANDSTONE);
@@ -498,7 +498,7 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("SPONGES", 2);
 +
 +    /**
-+     * Covers the non-colored and 16 colored shulker boxes.
++     * Covers the non-colored and colored shulker boxes.
 +     */
 +    public static final MaterialSetTag SHULKER_BOXES = new MaterialSetTag(keyFor("shulker_boxes"))
 +        .endsWith("SHULKER_BOX")
@@ -521,14 +521,14 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .ensureSize("SPAWN_EGGS", 63);
 +
 +    /**
-+     * Covers all 16 colors of stained glass.
++     * Covers all colors of stained glass.
 +     */
 +    public static final MaterialSetTag STAINED_GLASS = new MaterialSetTag(keyFor("stained_glass"))
 +        .endsWith("_STAINED_GLASS")
 +        .ensureSize("STAINED_GLASS", 16);
 +
 +    /**
-+     * Covers all 16 colors of stained glass panes.
++     * Covers all colors of stained glass panes.
 +     */
 +    public static final MaterialSetTag STAINED_GLASS_PANES = new MaterialSetTag(keyFor("stained_glass_panes"))
 +        .endsWith("STAINED_GLASS_PANE")
@@ -557,25 +557,61 @@ index 0000000000000000000000000000000000000000..5ed3c33b3f29255c538ad209574e3408
 +        .not(Material.IRON_TRAPDOOR)
 +        .ensureSize("WOODEN_TRAPDOORS", 8);
 +
++    /**
++     * Covers the wood variants of gates.
++     */
 +    public static final MaterialSetTag WOODEN_GATES = new MaterialSetTag(keyFor("wooden_gates"))
 +        .endsWith("_GATE")
 +        .ensureSize("WOODEN_GATES", 8);
 +
++    /**
++     * Covers the variants of purpur.
++     */
 +    public static final MaterialSetTag PURPUR = new MaterialSetTag(keyFor("purpur"))
 +        .startsWith("PURPUR_")
 +        .ensureSize("PURPUR", 4);
 +
++    /**
++     * Covers the variants of signs.
++     */
 +    public static final MaterialSetTag SIGNS = new MaterialSetTag(keyFor("signs"))
 +        .endsWith("_SIGN")
 +        .ensureSize("SIGNS", 16);
 +
++    /**
++     * Covers the variants of a regular torch.
++     */
 +    public static final MaterialSetTag TORCH = new MaterialSetTag(keyFor("torch"))
 +        .add(Material.TORCH, Material.WALL_TORCH)
 +        .ensureSize("TORCH", 2);
 +
++    /**
++     * Covers the variants of a redstone torch.
++     */
 +    public static final MaterialSetTag REDSTONE_TORCH = new MaterialSetTag(keyFor("restone_torch"))
 +        .add(Material.REDSTONE_TORCH, Material.REDSTONE_WALL_TORCH)
 +        .ensureSize("REDSTONE_TORCH", 2);
++
++    /**
++     * Covers the variants of a soul torch.
++     */
++    public static final MaterialSetTag SOUL_TORCH = new MaterialSetTag(keyFor("soul_torch"))
++        .add(Material.SOUL_TORCH, Material.SOUL_WALL_TORCH)
++        .ensureSize("SOUL_TORCH", 2);
++
++    /**
++     * Covers the variants of torches.
++     */
++    public static final MaterialSetTag TORCHES = new MaterialSetTag(keyFor("torches"))
++        .add(TORCH, REDSTONE_TORCH, SOUL_TORCH)
++        .ensureSize("TORCHES", 6);
++
++    /**
++     * Covers the variants of lanterns.
++     */
++    public static final MaterialSetTag LANTERNS = new MaterialSetTag(keyFor("lanterns"))
++        .add(Material.LANTERN, Material.SOUL_LANTERN)
++        .ensureSize("LANTERNS", 2);
 +
 +    @SuppressWarnings("unchecked")
 +    public static final MaterialSetTag COLORABLE = new MaterialSetTag(keyFor("colorable"))


### PR DESCRIPTION
Added material tags for soul torches, all torches, and lanterns.
Also remove the number of materials from the documentation. As it is definitely an implementation detail, but more practically is an extra step if an update changes that number...