### PR TITLE
Fix #3701 - Loottables erasing on viewing

### DIFF
--- a/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -532,7 +532,7 @@ index b5625318ca6bfeeada2d3fb009b711685265ebaa..562f2e3e639a07852951081ea0887a9c
  
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartContainer.java b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
-index 9a969d71b078ec67a442cc2df387ad633e0fb0f7..fca0fb871e276f3e571944e0354f3acd821e8e86 100644
+index 9a969d71b078ec67a442cc2df387ad633e0fb0f7..397fc1a9857cf91043ebd7982e16ea92d95b5cde 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 @@ -15,10 +15,11 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
@@ -577,7 +577,7 @@ index 9a969d71b078ec67a442cc2df387ad633e0fb0f7..fca0fb871e276f3e571944e0354f3acd
              ContainerUtil.b(nbttagcompound, this.items);
          }
  
-@@ -213,7 +216,7 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+@@ -213,14 +216,15 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
      }
  
      public void d(@Nullable EntityHuman entityhuman) {
@@ -586,16 +586,17 @@ index 9a969d71b078ec67a442cc2df387ad633e0fb0f7..fca0fb871e276f3e571944e0354f3acd
              LootTable loottable = this.world.getMinecraftServer().getLootTableRegistry().getLootTable(this.lootTable);
  
              if (entityhuman instanceof EntityPlayer) {
-@@ -221,6 +224,7 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+                 CriterionTriggers.N.a((EntityPlayer) entityhuman, this.lootTable);
              }
  
-             this.lootTable = null;
+-            this.lootTable = null;
++            //this.lootTable = null; // Paper
 +            this.lootableData.processRefill(entityhuman); // Paper
              LootTableInfo.Builder loottableinfo_builder = (new LootTableInfo.Builder((WorldServer) this.world)).set(LootContextParameters.POSITION, this.getChunkCoordinates()).a(this.lootTableSeed);
  
              if (entityhuman != null) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityLootable.java b/src/main/java/net/minecraft/server/TileEntityLootable.java
-index 1eb43345bda9fa96d4f3383afb2fed1e998c9da6..5ebba482a65cfe6079484a99f016f968c59df8ee 100644
+index 1eb43345bda9fa96d4f3383afb2fed1e998c9da6..e00ae999194f96fb4de556518abe495432a43a62 100644
 --- a/src/main/java/net/minecraft/server/TileEntityLootable.java
 +++ b/src/main/java/net/minecraft/server/TileEntityLootable.java
 @@ -6,8 +6,9 @@ import javax.annotation.Nullable;
@@ -630,7 +631,7 @@ index 1eb43345bda9fa96d4f3383afb2fed1e998c9da6..5ebba482a65cfe6079484a99f016f968
          if (this.lootTable == null) {
              return false;
          } else {
-@@ -41,12 +44,12 @@ public abstract class TileEntityLootable extends TileEntityContainer {
+@@ -41,19 +44,20 @@ public abstract class TileEntityLootable extends TileEntityContainer {
                  nbttagcompound.setLong("LootTableSeed", this.lootTableSeed);
              }
  
@@ -645,10 +646,11 @@ index 1eb43345bda9fa96d4f3383afb2fed1e998c9da6..5ebba482a65cfe6079484a99f016f968
              LootTable loottable = this.world.getMinecraftServer().getLootTableRegistry().getLootTable(this.lootTable);
  
              if (entityhuman instanceof EntityPlayer) {
-@@ -54,6 +57,7 @@ public abstract class TileEntityLootable extends TileEntityContainer {
+                 CriterionTriggers.N.a((EntityPlayer) entityhuman, this.lootTable);
              }
  
-             this.lootTable = null;
+-            this.lootTable = null;
++            //this.lootTable = null; // Paper
 +            this.lootableData.processRefill(entityhuman); // Paper
              LootTableInfo.Builder loottableinfo_builder = (new LootTableInfo.Builder((WorldServer) this.world)).set(LootContextParameters.POSITION, new BlockPosition(this.position)).a(this.lootTableSeed);
  


### PR DESCRIPTION
Seems simple enough. Mojang added these lines, which dont seem to be necessary with paper's `shouldReplenish` check a few lines up..