### PR TITLE
fixes #3757 (Lore on itemmeta)

### DIFF
--- a/Spigot-Server-Patches/0526-Improve-Legacy-Component-serialization-size.patch
+++ b/Spigot-Server-Patches/0526-Improve-Legacy-Component-serialization-size.patch
@@ -7,14 +7,14 @@ Don't constantly send format: false for all formatting options when parent alrea
 has it false
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-index a423e3bf3906d3114af885c48d0b45d88d7e7d8b..3b79ae44c5ef790998915148db92c7161ae36ab6 100644
+index a423e3bf3906d3114af885c48d0b45d88d7e7d8b..54f6f7d86741c3f318fa76bafe04b55cf420c35b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 @@ -45,6 +45,7 @@ public final class CraftChatMessage {
          // Separate pattern with no group 3, new lines are part of previous string
          private static final Pattern INCREMENTAL_PATTERN_KEEP_NEWLINES = Pattern.compile("(" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + "[0-9a-fk-orx])|((?:(?:https?):\\/\\/)?(?:[-\\w_\\.]{2,}\\.[a-z]{2,4}.*?(?=[\\.\\?!,;:]?(?:[" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + " ]|$))))", Pattern.CASE_INSENSITIVE);
          // ChatColor.b does not explicitly reset, its more of empty
-+        private static final ChatModifier EMPTY = ChatModifier.b; // Paper - OBFHELPER
++        private static final ChatModifier EMPTY = ChatModifier.b.setItalic(false); // Paper - OBFHELPER
          private static final ChatModifier RESET = ChatModifier.b.setBold(false).setItalic(false).setUnderline(false).setStrikethrough(false).setRandom(false);
  
          private final List<IChatBaseComponent> list = new ArrayList<IChatBaseComponent>();


### PR DESCRIPTION
Off the top of my head, I don't know where text that defaults to Bold, underlined, strikethrough, or obfuscated comes into play. Only that lore of items defaults to italics.