### PR TITLE
added PlayerTradeEvent

### DIFF
--- a/Spigot-API-Patches/0215-added-PlayerTradeEvent.patch
+++ b/Spigot-API-Patches/0215-added-PlayerTradeEvent.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 2 Jul 2020 16:10:10 -0700
+Subject: [PATCH] added PlayerTradeEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeEvent.java
+new file mode 100755
+index 0000000000000000000000000000000000000000..db1dd76e844367fa09f2d8e9236ee27df070e4d2
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeEvent.java
+@@ -0,0 +1,118 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.AbstractVillager;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.MerchantRecipe;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++public class PlayerTradeEvent extends PlayerEvent implements Cancellable {
++
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++
++    private boolean increaseTradeUses;
++    private boolean rewardExp;
++    private final AbstractVillager villager;
++    private MerchantRecipe trade;
++
++    public PlayerTradeEvent(@NotNull Player player, @NotNull AbstractVillager villager, @NotNull MerchantRecipe trade, boolean rewardExp, boolean increaseTradeUses) {
++        super(player);
++        this.villager = villager;
++        this.trade = trade;
++        this.rewardExp = rewardExp;
++        this.increaseTradeUses = increaseTradeUses;
++    }
++
++    /**
++     * Gets the Villager or Wandering trader associated with this event
++     * @return the villager or wandering trader
++     */
++    @NotNull
++    public AbstractVillager getVillager() {
++        return villager;
++    }
++
++    /**
++     * Gets the associated trade with this event
++     * @return the trade
++     */
++    @NotNull
++    public MerchantRecipe getTrade() {
++        return trade;
++    }
++
++    /**
++     * Sets the trade. This is then used to determine the next prices
++     * @param trade the trade to use
++     */
++    public void setTrade(@Nullable MerchantRecipe trade) {
++        this.trade = trade;
++    }
++
++    /**
++     * @return will trade try to reward exp
++     */
++    public boolean isRewardingExp() {
++        return rewardExp;
++    }
++
++    /**
++     * Sets whether the trade will try to reward exp
++     * @param rewardExp try to reward exp
++     */
++    public void setRewardExp(boolean rewardExp) {
++        this.rewardExp = rewardExp;
++    }
++
++    /**
++     * @return whether or not the trade will count as a use of the trade
++     */
++    public boolean willIncreaseTradeUses() {
++        return increaseTradeUses;
++    }
++
++    /**
++     * Sets whether or not the trade will count as a use
++     * @param increaseTradeUses true to count/false to not count
++     */
++    public void setIncreaseTradeUses(boolean increaseTradeUses) {
++        this.increaseTradeUses = increaseTradeUses;
++    }
++
++    /**
++     * Gets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     *
++     * @return true if this event is cancelled
++     */
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * Sets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins.
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0532-added-PlayerTradeEvent.patch
+++ b/Spigot-Server-Patches/0532-added-PlayerTradeEvent.patch
@@ -5,24 +5,10 @@ Subject: [PATCH] added PlayerTradeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-index 81823b5d5ef17479583fda0121c95091175fdf1e..6a309c9d3606186f35a9b3b4d873ca9542441617 100644
+index 81823b5d5ef17479583fda0121c95091175fdf1e..966d93b4594d11b8ef701b50a53647e9b35071f2 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-@@ -1,11 +1,13 @@
- package net.minecraft.server;
- 
-+import com.destroystokyo.paper.event.player.PlayerTradeEvent;
- import com.google.common.collect.Sets;
- import java.util.Iterator;
- import java.util.Set;
- import javax.annotation.Nullable;
- // CraftBukkit start
- import org.bukkit.Bukkit;
-+import org.bukkit.craftbukkit.entity.CraftHumanEntity;
- import org.bukkit.craftbukkit.inventory.CraftMerchant;
- import org.bukkit.craftbukkit.inventory.CraftMerchantRecipe;
- import org.bukkit.entity.AbstractVillager;
-@@ -101,13 +103,23 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -101,13 +101,23 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
  
      @Override
      public void a(MerchantRecipe merchantrecipe) {
@@ -32,7 +18,7 @@ index 81823b5d5ef17479583fda0121c95091175fdf1e..6a309c9d3606186f35a9b3b4d873ca95
 +        // Paper start
          if (this.tradingPlayer instanceof EntityPlayer) {
 -            CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, merchantrecipe.getSellingItem());
-+            PlayerTradeEvent event = new PlayerTradeEvent(((EntityPlayer) this.tradingPlayer).getBukkitEntity(), (AbstractVillager) this.getBukkitEntity(), merchantrecipe.asBukkit(), true, true);
++            com.destroystokyo.paper.event.player.PlayerTradeEvent event = new com.destroystokyo.paper.event.player.PlayerTradeEvent(((EntityPlayer) this.tradingPlayer).getBukkitEntity(), (AbstractVillager) this.getBukkitEntity(), merchantrecipe.asBukkit(), true, true);
 +            event.callEvent();
 +            if (!event.isCancelled()) {
 +                MerchantRecipe recipe = CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();

--- a/Spigot-Server-Patches/0532-added-PlayerTradeEvent.patch
+++ b/Spigot-Server-Patches/0532-added-PlayerTradeEvent.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 2 Jul 2020 16:12:10 -0700
+Subject: [PATCH] added PlayerTradeEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+index 81823b5d5ef17479583fda0121c95091175fdf1e..6a309c9d3606186f35a9b3b4d873ca9542441617 100644
+--- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+@@ -1,11 +1,13 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.event.player.PlayerTradeEvent;
+ import com.google.common.collect.Sets;
+ import java.util.Iterator;
+ import java.util.Set;
+ import javax.annotation.Nullable;
+ // CraftBukkit start
+ import org.bukkit.Bukkit;
++import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+ import org.bukkit.craftbukkit.inventory.CraftMerchant;
+ import org.bukkit.craftbukkit.inventory.CraftMerchantRecipe;
+ import org.bukkit.entity.AbstractVillager;
+@@ -101,13 +103,23 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+ 
+     @Override
+     public void a(MerchantRecipe merchantrecipe) {
+-        merchantrecipe.increaseUses();
+-        this.e = -this.D();
+-        this.b(merchantrecipe);
++        // Paper start
+         if (this.tradingPlayer instanceof EntityPlayer) {
+-            CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, merchantrecipe.getSellingItem());
++            PlayerTradeEvent event = new PlayerTradeEvent(((EntityPlayer) this.tradingPlayer).getBukkitEntity(), (AbstractVillager) this.getBukkitEntity(), merchantrecipe.asBukkit(), true, true);
++            event.callEvent();
++            if (!event.isCancelled()) {
++                MerchantRecipe recipe = CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();
++                if (event.willIncreaseTradeUses()) recipe.increaseUses();
++                this.e = -this.D();
++                if (event.isRewardingExp()) this.b(recipe);
++                CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, recipe.getSellingItem());
++            }
++        } else {
++            merchantrecipe.increaseUses();
++            this.e = -this.D();
++            this.b(merchantrecipe);
+         }
+-
++        // Paper end
+     }
+ 
+     protected abstract void b(MerchantRecipe merchantrecipe);


### PR DESCRIPTION
Replacement for VillagerReplenishTradeEvent
Issues with above event
1. Doesn't include the player
2. Isn't called for Wandering Traders
3. The setRecipe() doesn't look to actually have any effect at all.

If this gets merged, the VillagerReplenishTradeEvent should probably get deprecated.