### PR TITLE
add EntityTargetLivingEntityEvent for new 1.16 mobs

### DIFF
--- a/Spigot-API-Patches/0215-added-2-new-TargetReasons-for-1.16-mob-behavior.patch
+++ b/Spigot-API-Patches/0215-added-2-new-TargetReasons-for-1.16-mob-behavior.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 3 Jul 2020 15:05:54 -0700
+Subject: [PATCH] added 2 new TargetReasons for 1.16 mob behavior
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+index dee186e99463a56394bbc2039d1e763d109125b9..601904150156d475c18286b485f3409307a75950 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityTargetEvent.java
+@@ -159,6 +159,14 @@ public class EntityTargetEvent extends EntityEvent implements Cancellable {
+          * as wheat in it's hand.
+          */
+         TEMPT,
++        /**
++         * When the target is in a different dimension
++         */
++        TARGET_OTHER_LEVEL, // Paper
++        /**
++         * When the target is in creative or spectator mode, or the gamemode is peaceful, or other reasons
++         */
++        TARGET_INVALID, // Paper
+         /**
+          * A currently unknown reason for the entity changing target.
+          */

--- a/Spigot-Server-Patches/0532-added-EntityTargetLivingEntityEvent-to-1.16-mobs.patch
+++ b/Spigot-Server-Patches/0532-added-EntityTargetLivingEntityEvent-to-1.16-mobs.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 3 Jul 2020 15:03:33 -0700
+Subject: [PATCH] added EntityTargetLivingEntityEvent to 1.16 mobs
+
+
+diff --git a/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java b/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
+index d5cceb0672c7724b9d53dd7bf2d323e667c8617c..2a0e951618e45c3e4e171cbb4d987004ae354803 100644
+--- a/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
++++ b/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
+@@ -21,15 +21,22 @@ public class BehaviorAttackTargetForget<E extends EntityInsentient> extends Beha
+ 
+     protected void a(WorldServer worldserver, E e0, long i) {
+         if (a((EntityLiving) e0)) {
+-            this.d(e0);
++            handleEvent(e0, org.bukkit.event.entity.EntityTargetEvent.TargetReason.FORGOT_TARGET); // Paper
+         } else if (this.c(e0)) {
+-            this.d(e0);
++            handleEvent(e0, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TARGET_DIED); // Paper
+         } else if (this.a(e0)) {
+-            this.d(e0);
++            handleEvent(e0, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TARGET_OTHER_LEVEL); // Paper
+         } else if (!IEntitySelector.f.test(this.b(e0))) {
+-            this.d(e0);
++            handleEvent(e0, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TARGET_INVALID); // Paper
+         } else if (this.b.test(this.b(e0))) {
+-            this.d(e0);
++            handleEvent(e0, org.bukkit.event.entity.EntityTargetEvent.TargetReason.TARGET_INVALID); // Paper
++        }
++    }
++    // Paper start
++    private void handleEvent(E entity, org.bukkit.event.entity.EntityTargetEvent.TargetReason reason) {
++        org.bukkit.event.entity.EntityTargetLivingEntityEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(entity, null, reason);
++        if (!event.isCancelled()) {
++            this.d(entity);
+         }
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java b/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
+index 65e746859bede33bc59fd17b4c3defe911df993f..1610817939a3af8efd44a77188bf8b45f43a360f 100644
+--- a/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
++++ b/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
+@@ -26,20 +26,30 @@ public class BehaviorAttackTargetSet<E extends EntityInsentient> extends Behavio
+         if (!this.b.test(e0)) {
+             return false;
+         } else {
+-            Optional<? extends EntityLiving> optional = (Optional) this.c.apply(e0);
++            Optional<? extends EntityLiving> optional = (Optional<? extends EntityLiving>) this.c.apply(e0); // Paper - decompile error
+ 
+             return optional.isPresent() && ((EntityLiving) optional.get()).isAlive();
+         }
+     }
+ 
+     protected void a(WorldServer worldserver, E e0, long i) {
+-        ((Optional) this.c.apply(e0)).ifPresent((entityliving) -> {
++        ((Optional<? extends EntityLiving>) this.c.apply(e0)).ifPresent((entityliving) -> { // Paper - decompile error
+             this.a(e0, entityliving);
+         });
+     }
+ 
+     private void a(E e0, EntityLiving entityliving) {
+-        e0.getBehaviorController().setMemory(MemoryModuleType.ATTACK_TARGET, (Object) entityliving);
+-        e0.getBehaviorController().removeMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
++        // Paper start
++        org.bukkit.event.entity.EntityTargetEvent.TargetReason reason = entityliving instanceof EntityHuman ? org.bukkit.event.entity.EntityTargetEvent.TargetReason.CLOSEST_PLAYER : org.bukkit.event.entity.EntityTargetEvent.TargetReason.CLOSEST_ENTITY;
++        org.bukkit.event.entity.EntityTargetLivingEntityEvent event =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(e0, entityliving, org.bukkit.event.entity.EntityTargetEvent.TargetReason.CLOSEST_ENTITY);
++        if (!event.isCancelled()) {
++            EntityLiving target = event.getTarget() != null ? ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle() : null;
++            if (e0.getBehaviorController().getMemory(MemoryModuleType.HURT_BY_ENTITY).isPresent()) {
++                System.out.println(e0.getBehaviorController().getMemory(MemoryModuleType.HURT_BY_ENTITY).get().getMinecraftKey().toString());
++            }
++            e0.getBehaviorController().setMemory(MemoryModuleType.ATTACK_TARGET, target); // Paper - decompile error
++            e0.getBehaviorController().removeMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
++        }
++        // Paper end
+     }
+ }

--- a/Spigot-Server-Patches/0532-added-EntityTargetLivingEntityEvent-to-1.16-mobs.patch
+++ b/Spigot-Server-Patches/0532-added-EntityTargetLivingEntityEvent-to-1.16-mobs.patch
@@ -3,6 +3,7 @@ From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Fri, 3 Jul 2020 15:03:33 -0700
 Subject: [PATCH] added EntityTargetLivingEntityEvent to 1.16 mobs
 
+1.16 added a different behavior system for the new mobs
 
 diff --git a/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java b/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
 index d5cceb0672c7724b9d53dd7bf2d323e667c8617c..2a0e951618e45c3e4e171cbb4d987004ae354803 100644
@@ -37,10 +38,10 @@ index d5cceb0672c7724b9d53dd7bf2d323e667c8617c..2a0e951618e45c3e4e171cbb4d987004
      }
  
 diff --git a/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java b/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
-index 65e746859bede33bc59fd17b4c3defe911df993f..1610817939a3af8efd44a77188bf8b45f43a360f 100644
+index 65e746859bede33bc59fd17b4c3defe911df993f..178da19fdc5df330d4128feb831e8fa6a9a5cdc1 100644
 --- a/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
 +++ b/src/main/java/net/minecraft/server/BehaviorAttackTargetSet.java
-@@ -26,20 +26,30 @@ public class BehaviorAttackTargetSet<E extends EntityInsentient> extends Behavio
+@@ -26,20 +26,27 @@ public class BehaviorAttackTargetSet<E extends EntityInsentient> extends Behavio
          if (!this.b.test(e0)) {
              return false;
          } else {
@@ -66,9 +67,6 @@ index 65e746859bede33bc59fd17b4c3defe911df993f..1610817939a3af8efd44a77188bf8b45
 +        org.bukkit.event.entity.EntityTargetLivingEntityEvent event =  org.bukkit.craftbukkit.event.CraftEventFactory.callEntityTargetLivingEvent(e0, entityliving, org.bukkit.event.entity.EntityTargetEvent.TargetReason.CLOSEST_ENTITY);
 +        if (!event.isCancelled()) {
 +            EntityLiving target = event.getTarget() != null ? ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle() : null;
-+            if (e0.getBehaviorController().getMemory(MemoryModuleType.HURT_BY_ENTITY).isPresent()) {
-+                System.out.println(e0.getBehaviorController().getMemory(MemoryModuleType.HURT_BY_ENTITY).get().getMinecraftKey().toString());
-+            }
 +            e0.getBehaviorController().setMemory(MemoryModuleType.ATTACK_TARGET, target); // Paper - decompile error
 +            e0.getBehaviorController().removeMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
 +        }


### PR DESCRIPTION
Fixes #3752 

This pr isn't totally complete, I am still looking for a way to set the reason for a piglin targeting something to TARGET_ATTACKED_ENTITY, right now its always CLOSEST_ENTITY even if you are wearing gold armor, and hit one. I'm unsure as to how to separate the two. 

Other than that, this covers Hoglins, and Zoglins. It looks like Zombified Piglins still use the old Zombie Pigmen system.