### PR TITLE
Flying should extend Monster

### DIFF
--- a/Spigot-API-Patches/0215-Flying-should-extend-Monster.patch
+++ b/Spigot-API-Patches/0215-Flying-should-extend-Monster.patch
@@ -1,0 +1,16 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Michael <mtemple12@gmail.com>
+Date: Sat, 4 Jul 2020 19:38:03 -0500
+Subject: [PATCH] Flying should extend Monster
+
+
+diff --git a/src/main/java/org/bukkit/entity/Flying.java b/src/main/java/org/bukkit/entity/Flying.java
+index 580ce18bf43c8be34c8fc726d0ee79e85361b516..4edcf71b05f13a2495555caad88e021c5d59d19e 100644
+--- a/src/main/java/org/bukkit/entity/Flying.java
++++ b/src/main/java/org/bukkit/entity/Flying.java
+@@ -3,4 +3,4 @@ package org.bukkit.entity;
+ /**
+  * Represents a Flying Entity.
+  */
+-public interface Flying extends Mob {}
++public interface Flying extends Monster {} // Paper - all subinterfaces should be considered Monsters


### PR DESCRIPTION
All current subinterfaces of "Flying" are things that should be considered "Monster", but aren't.