### PR TITLE
Optimize the advancement data player iteration to be O(N) rather than O(N^2)

### DIFF
--- a/Spigot-Server-Patches/0533-Optimize-the-advancement-data-player-iteration-to-be.patch
+++ b/Spigot-Server-Patches/0533-Optimize-the-advancement-data-player-iteration-to-be.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Wyatt Childers <wchilders@nearce.com>
+Date: Sat, 4 Jul 2020 23:07:43 -0400
+Subject: [PATCH] Optimize the advancement data player iteration to be O(N)
+ rather than O(N^2)
+
+
+diff --git a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+index 57b9d13447a4f7804827c1bd41121c3069c696bd..d2ee4660effe75e8cdb4f23f3a853cdb4e4e26e1 100644
+--- a/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
++++ b/src/main/java/net/minecraft/server/AdvancementDataPlayer.java
+@@ -438,7 +438,17 @@ public class AdvancementDataPlayer {
+         this.data.put(advancement, advancementprogress);
+     }
+ 
++    private enum IterationEntryPoint {
++        ROOT,
++        ITERATOR,
++        PARENT_OF_ITERATOR
++    }
++
+     private void e(Advancement advancement) {
++        e(advancement, IterationEntryPoint.ROOT);
++    }
++
++    private void e(Advancement advancement, IterationEntryPoint entryPoint) {
+         boolean flag = this.f(advancement);
+         boolean flag1 = this.h.contains(advancement);
+ 
+@@ -453,8 +463,19 @@ public class AdvancementDataPlayer {
+             this.i.add(advancement);
+         }
+ 
++
+         if (flag != flag1 && advancement.b() != null) {
+-            this.e(advancement.b());
++            // If we're not coming from an iterator consider this to be a root entry, otherwise
++            // market that we're entering from the parent of an iterator.
++            e(advancement.b(),
++                entryPoint == IterationEntryPoint.ITERATOR ?
++                    IterationEntryPoint.PARENT_OF_ITERATOR : IterationEntryPoint.ROOT);
++        }
++
++        // Paper - If this is true, we've went through a child iteration, entered the parent, processed the parent
++        // and are about to reprocess the children. Stop processing here to prevent O(N^2) processing.
++        if (entryPoint == IterationEntryPoint.PARENT_OF_ITERATOR) {
++            return;
+         }
+ 
+         Iterator iterator = advancement.e().iterator();
+@@ -462,7 +483,7 @@ public class AdvancementDataPlayer {
+         while (iterator.hasNext()) {
+             Advancement advancement1 = (Advancement) iterator.next();
+ 
+-            this.e(advancement1);
++            e(advancement1, IterationEntryPoint.ITERATOR);
+         }
+ 
+     }


### PR DESCRIPTION
Fixes https://github.com/PaperMC/Paper/issues/3796

I'm not 100% sure this is the correct logic for handling this, and as such I wouldn't recommend pulling it without further testing.

In particular, I haven't figured out exactly what the flag logic is doing:
```
        boolean flag = this.f(advancement);
        boolean flag1 = this.h.contains(advancement);

        if (flag && !flag1) {
            this.h.add(advancement);
            this.i.add(advancement);
            if (this.data.containsKey(advancement)) {
                this.j.add(advancement);
            }
        } else if (!flag && flag1) {
            this.h.remove(advancement);
            this.i.add(advancement);
        }
```

However, this patch captures the essence of the problem, which may be useful to someone more familiar with this system. 

This code as it stands is iterating over the children, then, each child iteration can iterate back over the parent. This causes the algorithm to `O(N^2)` as each child spawns a new iteration over the parent.

In this patch, I add 3 states, root, iterator, and parent of iterator. Iterators are allowed to iterate their children, but if they access their parent, the parent is blocked from reiterating its children, though it is allowed to reprocess the flag logic (I'm assuming this reprocessing has some value).

----

I also have a branch with my diagnostic patch that prints the traversal: https://github.com/DarkArc/Paper/tree/hotfix/login-perf-diag

The new traversal looks something like the following:
```
 R-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/jungle_slab
   P-minecraft:recipes/root
  I-minecraft:recipes/misc/quartz_from_blasting
   P-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/polished_granite_slab
   P-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/acacia_planks
   P-minecraft:recipes/root
  I-minecraft:recipes/redstone/repeater
   P-minecraft:recipes/root
  I-minecraft:recipes/tools/compass
   P-minecraft:recipes/root
  I-minecraft:recipes/redstone/oak_button
   P-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/quartz_block
   P-minecraft:recipes/root
  I-minecraft:recipes/redstone/dark_oak_pressure_plate
   P-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/mossy_stone_brick_slab_from_mossy_stone_brick_stonecutting
   P-minecraft:recipes/root
  I-minecraft:recipes/food/cooked_beef
   P-minecraft:recipes/root
  I-minecraft:recipes/building_blocks/smooth_quartz_stairs_from_smooth_quartz_stonecutting
   P-minecraft:recipes/root
  I-minecraft:recipes/redstone/iron_door
   P-minecraft:recipes/root
  I-minecraft:recipes/decorations/nether_brick_fence
   P-minecraft:recipes/root
```
