### PR TITLE
add PlayerTradeEvent

### DIFF
--- a/Spigot-API-Patches/0244-Added-PlayerTradeEvent.patch
+++ b/Spigot-API-Patches/0244-Added-PlayerTradeEvent.patch
@@ -1,0 +1,133 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 2 Jul 2020 16:10:10 -0700
+Subject: [PATCH] added PlayerTradeEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
+new file mode 100755
+index 0000000000000000000000000000000000000000..198e5464eae6b961c83148a57c18f91a4bb33cf6
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerTradeEvent.java
+@@ -0,0 +1,121 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.entity.AbstractVillager;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.MerchantRecipe;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when a player trades with a villager or wandering trader
++ */
++public class PlayerTradeEvent extends PlayerEvent implements Cancellable {
++
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++
++    private boolean increaseTradeUses;
++    private boolean rewardExp;
++    private final AbstractVillager villager;
++    private MerchantRecipe trade;
++
++    public PlayerTradeEvent(@NotNull Player player, @NotNull AbstractVillager villager, @NotNull MerchantRecipe trade, boolean rewardExp, boolean increaseTradeUses) {
++        super(player);
++        this.villager = villager;
++        this.trade = trade;
++        this.rewardExp = rewardExp;
++        this.increaseTradeUses = increaseTradeUses;
++    }
++
++    /**
++     * Gets the Villager or Wandering trader associated with this event
++     * @return the villager or wandering trader
++     */
++    @NotNull
++    public AbstractVillager getVillager() {
++        return villager;
++    }
++
++    /**
++     * Gets the associated trade with this event
++     * @return the trade
++     */
++    @NotNull
++    public MerchantRecipe getTrade() {
++        return trade;
++    }
++
++    /**
++     * Sets the trade. This is then used to determine the next prices
++     * @param trade the trade to use
++     */
++    public void setTrade(@Nullable MerchantRecipe trade) {
++        this.trade = trade;
++    }
++
++    /**
++     * @return will trade try to reward exp
++     */
++    public boolean isRewardingExp() {
++        return rewardExp;
++    }
++
++    /**
++     * Sets whether the trade will try to reward exp
++     * @param rewardExp try to reward exp
++     */
++    public void setRewardExp(boolean rewardExp) {
++        this.rewardExp = rewardExp;
++    }
++
++    /**
++     * @return whether or not the trade will count as a use of the trade
++     */
++    public boolean willIncreaseTradeUses() {
++        return increaseTradeUses;
++    }
++
++    /**
++     * Sets whether or not the trade will count as a use
++     * @param increaseTradeUses true to count/false to not count
++     */
++    public void setIncreaseTradeUses(boolean increaseTradeUses) {
++        this.increaseTradeUses = increaseTradeUses;
++    }
++
++    /**
++     * Gets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins
++     *
++     * @return true if this event is cancelled
++     */
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    /**
++     * Sets the cancellation state of this event. A cancelled event will not
++     * be executed in the server, but will still pass to other plugins.
++     *
++     * @param cancel true if you wish to cancel this event
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0623-Added-PlayerTradeEvent.patch
+++ b/Spigot-Server-Patches/0623-Added-PlayerTradeEvent.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 2 Jul 2020 16:12:10 -0700
+Subject: [PATCH] added PlayerTradeEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
+index dcc5b098bfe36ef7ee8536b3da65c4ce1748c9d8..6d716214e756fe1326cd3d2becea969076f6fd5b 100644
+--- a/src/main/java/net/minecraft/server/EntityInsentient.java
++++ b/src/main/java/net/minecraft/server/EntityInsentient.java
+@@ -25,7 +25,7 @@ import org.bukkit.event.entity.EntityUnleashEvent.UnleashReason;
+ public abstract class EntityInsentient extends EntityLiving {
+ 
+     private static final DataWatcherObject<Byte> b = DataWatcher.a(EntityInsentient.class, DataWatcherRegistry.a);
+-    public int e;
++    public int e;public void setAmbientSoundTime(int time) { this.e = time; } // Paper - OBFHELPER
+     protected int f;
+     protected ControllerLook lookController;
+     protected ControllerMove moveController;
+@@ -227,6 +227,7 @@ public abstract class EntityInsentient extends EntityLiving {
+         this.datawatcher.register(EntityInsentient.b, (byte) 0);
+     }
+ 
++    public int getAmbientSoundInterval() { return D(); } // Paper - OBFHELPER
+     public int D() {
+         return 80;
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+index 8971dd013498e70c4e7a6ac6a218f62e599c86b9..b2a76db173ae12bff2e8a7de411cb489fdb2e9c7 100644
+--- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+@@ -11,6 +11,9 @@ import org.bukkit.craftbukkit.inventory.CraftMerchantRecipe;
+ import org.bukkit.entity.AbstractVillager;
+ import org.bukkit.event.entity.VillagerAcquireTradeEvent;
+ // CraftBukkit end
++// Paper start
++import io.papermc.paper.event.player.PlayerTradeEvent;
++// Paper end
+ 
+ public abstract class EntityVillagerAbstract extends EntityAgeable implements NPC, IMerchant {
+ 
+@@ -107,16 +110,27 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+ 
+     @Override
+     public void a(MerchantRecipe merchantrecipe) {
+-        merchantrecipe.increaseUses();
+-        this.e = -this.D();
+-        this.b(merchantrecipe);
++        // Paper - moved down
++        // Paper start
+         if (this.tradingPlayer instanceof EntityPlayer) {
+-            CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, merchantrecipe.getSellingItem());
++            PlayerTradeEvent event = new PlayerTradeEvent(((EntityPlayer) this.tradingPlayer).getBukkitEntity(), (AbstractVillager) this.getBukkitEntity(), merchantrecipe.asBukkit(), true, true);
++            event.callEvent();
++            if (!event.isCancelled()) {
++                MerchantRecipe recipe = CraftMerchantRecipe.fromBukkit(event.getTrade()).toMinecraft();
++                if (event.willIncreaseTradeUses()) recipe.increaseUses();
++                this.setAmbientSoundTime(-getAmbientSoundInterval());
++                if (event.isRewardingExp()) this.rewardTradeXp(recipe);
++                CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, recipe.getSellingItem());
++            }
++        } else {
++            merchantrecipe.increaseUses();
++            this.setAmbientSoundTime(-getAmbientSoundInterval());
++            this.rewardTradeXp(merchantrecipe);
+         }
+-
++        // Paper end
+     }
+ 
+-    protected abstract void b(MerchantRecipe merchantrecipe);
++    protected abstract void b(MerchantRecipe merchantrecipe); public void rewardTradeXp(MerchantRecipe merchantrecipe) { this.b(merchantrecipe); } // Paper - OBFHELPER
+ 
+     @Override
+     public boolean isRegularVillager() {


### PR DESCRIPTION
Replacement for VillagerReplenishTradeEvent
Issues with above event
1. Doesn't include the player
2. Isn't called for Wandering Traders
3. The setRecipe() doesn't look to actually have any effect at all.

If this gets merged, the VillagerReplenishTradeEvent should probably get deprecated.