### PR TITLE
Expose enchantment display name translatable component

### DIFF
--- a/Spigot-API-Patches/0218-Expose-enchantment-display-name-translatable-compone.patch
+++ b/Spigot-API-Patches/0218-Expose-enchantment-display-name-translatable-compone.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 5 Jul 2020 19:07:14 -0500
+Subject: [PATCH] Expose enchantment display name translatable component
+
+
+diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
+index b833ef63fbe01271ceb2bd83a9eb4a84c9912761..d1dc3088536316f68195053ab59d8655602b5d57 100644
+--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
++++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
+@@ -2,6 +2,8 @@ package org.bukkit.enchantments;
+ 
+ import java.util.HashMap;
+ import java.util.Map;
++
++import net.md_5.bungee.api.chat.BaseComponent;
+ import org.bukkit.Keyed;
+ import org.bukkit.NamespacedKey;
+ import org.bukkit.inventory.ItemStack;
+@@ -389,4 +391,15 @@ public abstract class Enchantment implements Keyed {
+     public static Enchantment[] values() {
+         return byName.values().toArray(new Enchantment[byName.size()]);
+     }
++
++    // Paper start
++    /**
++     * Get's the display name translatable component of this enchantment at specified level
++     * 
++     * @param level Level of enchantment
++     * @return display name translatable component
++     */
++    @NotNull
++    public abstract BaseComponent[] getDisplayName(int level);
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/enchantments/EnchantmentWrapper.java b/src/main/java/org/bukkit/enchantments/EnchantmentWrapper.java
+index 9566e4306ada5e82dede0f002aa06da12c44996b..235b86b9e2edbd6cd10fb56b8e1e20c1eef52856 100644
+--- a/src/main/java/org/bukkit/enchantments/EnchantmentWrapper.java
++++ b/src/main/java/org/bukkit/enchantments/EnchantmentWrapper.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.enchantments;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
+ import org.bukkit.NamespacedKey;
+ import org.bukkit.inventory.ItemStack;
+ import org.jetbrains.annotations.NotNull;
+@@ -63,4 +64,12 @@ public class EnchantmentWrapper extends Enchantment {
+     public boolean conflictsWith(@NotNull Enchantment other) {
+         return getEnchantment().conflictsWith(other);
+     }
++
++    // Paper start
++    @Override
++    @NotNull
++    public BaseComponent[] getDisplayName(int level) {
++        return getEnchantment().getDisplayName(level);
++    }
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0539-Expose-enchantment-display-name-translatable-compone.patch
+++ b/Spigot-Server-Patches/0539-Expose-enchantment-display-name-translatable-compone.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sun, 5 Jul 2020 19:07:22 -0500
+Subject: [PATCH] Expose enchantment display name translatable component
+
+
+diff --git a/src/main/java/net/minecraft/server/Enchantment.java b/src/main/java/net/minecraft/server/Enchantment.java
+index 7e2162fc78168adb96ed20651e1a3e061c29f96d..2355992b249b32cf671f57c47b8e1f2e483b913a 100644
+--- a/src/main/java/net/minecraft/server/Enchantment.java
++++ b/src/main/java/net/minecraft/server/Enchantment.java
+@@ -83,6 +83,7 @@ public abstract class Enchantment {
+         return this.f();
+     }
+ 
++    public IChatBaseComponent getDisplayName(int i) { return d(i); } // Paper - OBFHELPER
+     public IChatBaseComponent d(int i) {
+         ChatMessage chatmessage = new ChatMessage(this.g());
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
+index 34ceee4a81ef4ed05eb9007ca17c223f75f4ff50..58c3d553f3f77de899629f39a0dcf6e5714a43b4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
++++ b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
+@@ -1,7 +1,10 @@
+ package org.bukkit.craftbukkit.enchantments;
+ 
++import net.md_5.bungee.api.chat.BaseComponent;
++import net.md_5.bungee.chat.ComponentSerializer;
+ import net.minecraft.server.EnchantmentBinding;
+ import net.minecraft.server.EnchantmentVanishing;
++import net.minecraft.server.IChatBaseComponent;
+ import net.minecraft.server.IRegistry;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.util.CraftNamespacedKey;
+@@ -191,4 +194,11 @@ public class CraftEnchantment extends Enchantment {
+     public net.minecraft.server.Enchantment getHandle() {
+         return target;
+     }
++
++    // Paper start
++    @Override
++    public BaseComponent[] getDisplayName(int level) {
++        return ComponentSerializer.parse(IChatBaseComponent.ChatSerializer.componentToJson(getHandle().getDisplayName(level)));
++    }
++    // Paper end
+ }


### PR DESCRIPTION
This exposes the internal translatable component used for enchantment's display names

----

Example 1:
```java
BaseComponent[] component = Enchantment.FIRE_ASPECT.getDisplayName(2);
System.out.println(ComponentSerializer.toString(component));
System.out.println(TranslatableComponent.toLegacyText(component));
System.out.println(TranslatableComponent.toPlainText(component));
```
Output 1:
```
{"color":"gray","extra":[{"text":" "},{"translate":"enchantment.level.2"}],"translate":"enchantment.minecraft.fire_aspect"}
§7Fire Aspect§7 §7II
Fire Aspect II
```

----

Example 2:
```java
BaseComponent[] component = Enchantment.BINDING_CURSE.getDisplayName(1);
System.out.println(ComponentSerializer.toString(component));
System.out.println(TranslatableComponent.toLegacyText(component));
System.out.println(TranslatableComponent.toPlainText(component));
```
Output 2:
```
{"color":"red","translate":"enchantment.minecraft.binding_curse"}
§cCurse of Binding
Curse of Binding
```