### PR TITLE
Fix zero reputation deleting villagers

### DIFF
--- a/Spigot-Server-Patches/0482-Add-villager-reputation-API.patch
+++ b/Spigot-Server-Patches/0482-Add-villager-reputation-API.patch
@@ -32,7 +32,7 @@ index 9f28c7e4bd70abc280a8cf3cbf5ccc84246aff12..bf019043a9338aca8d91da809f1d5520
          return this.bF;
      }
 diff --git a/src/main/java/net/minecraft/server/Reputation.java b/src/main/java/net/minecraft/server/Reputation.java
-index 3c6d6be4485cad4f2e9a395425b5837590853eee..28c9f9ed2d532a1eb14b74c2e9723a2cf1b3c6fa 100644
+index 3c6d6be4485cad4f2e9a395425b5837590853eee..09d2fc5769089f6d29971d10de5b8209829baae8 100644
 --- a/src/main/java/net/minecraft/server/Reputation.java
 +++ b/src/main/java/net/minecraft/server/Reputation.java
 @@ -25,7 +25,7 @@ import java.util.stream.Stream;
@@ -58,7 +58,7 @@ index 3c6d6be4485cad4f2e9a395425b5837590853eee..28c9f9ed2d532a1eb14b74c2e9723a2c
              this.a = new Object2IntOpenHashMap();
          }
  
-@@ -198,6 +198,27 @@ public class Reputation {
+@@ -198,6 +198,28 @@ public class Reputation {
          public void b(ReputationType reputationtype) {
              this.a.removeInt(reputationtype);
          }
@@ -76,11 +76,12 @@ index 3c6d6be4485cad4f2e9a395425b5837590853eee..28c9f9ed2d532a1eb14b74c2e9723a2c
 +        }
 +
 +        public void assignFromPaperReputation(com.destroystokyo.paper.entity.villager.Reputation rep) {
-+            this.a.put(net.minecraft.server.ReputationType.MAJOR_NEGATIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_NEGATIVE));
-+            this.a.put(net.minecraft.server.ReputationType.MAJOR_POSITIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_POSITIVE));
-+            this.a.put(net.minecraft.server.ReputationType.MINOR_NEGATIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_NEGATIVE));
-+            this.a.put(net.minecraft.server.ReputationType.MINOR_POSITIVE, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_POSITIVE));
-+            this.a.put(net.minecraft.server.ReputationType.TRADING, rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.TRADING));
++            int val;
++            if ((val = rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_NEGATIVE)) != 0) this.a.put(ReputationType.MAJOR_NEGATIVE, val);
++            if ((val = rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MAJOR_POSITIVE)) != 0) this.a.put(ReputationType.MAJOR_POSITIVE, val);
++            if ((val = rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_NEGATIVE)) != 0) this.a.put(ReputationType.MINOR_NEGATIVE, val);
++            if ((val = rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.MINOR_POSITIVE)) != 0) this.a.put(ReputationType.MINOR_POSITIVE, val);
++            if ((val = rep.getReputation(com.destroystokyo.paper.entity.villager.ReputationType.TRADING)) != 0) this.a.put(ReputationType.TRADING, val);
 +        }
 +        // Paper end
      }

--- a/Spigot-Server-Patches/0530-Remove-streams-from-classes-related-villager-gossip.patch
+++ b/Spigot-Server-Patches/0530-Remove-streams-from-classes-related-villager-gossip.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove streams from classes related villager gossip
 
 
 diff --git a/src/main/java/net/minecraft/server/Reputation.java b/src/main/java/net/minecraft/server/Reputation.java
-index 28c9f9ed2d532a1eb14b74c2e9723a2cf1b3c6fa..b3a4ec25446878fce5961e9014d24a3009571438 100644
+index 09d2fc5769089f6d29971d10de5b8209829baae8..dffac0dc85fe7d093c58663f91ad687a6be50ad5 100644
 --- a/src/main/java/net/minecraft/server/Reputation.java
 +++ b/src/main/java/net/minecraft/server/Reputation.java
-@@ -49,8 +49,20 @@ public class Reputation {
+@@ -49,8 +49,21 @@ public class Reputation {
          });
      }
  
@@ -17,7 +17,8 @@ index 28c9f9ed2d532a1eb14b74c2e9723a2cf1b3c6fa..b3a4ec25446878fce5961e9014d24a30
 +        List<Reputation.b> list = new it.unimi.dsi.fastutil.objects.ObjectArrayList<>();
 +        for (Map.Entry<UUID, Reputation.a> entry : getReputations().entrySet()) {
 +            for (Reputation.b cur : entry.getValue().decompress(entry.getKey())) {
-+                list.add(cur);
++                if (cur.a() != 0)
++                    list.add(cur);
 +            }
 +        }
 +        return list;
@@ -30,7 +31,7 @@ index 28c9f9ed2d532a1eb14b74c2e9723a2cf1b3c6fa..b3a4ec25446878fce5961e9014d24a30
  
          if (list.isEmpty()) {
              return Collections.emptyList();
-@@ -117,7 +129,7 @@ public class Reputation {
+@@ -117,7 +130,7 @@ public class Reputation {
      }
  
      public <T> Dynamic<T> a(DynamicOps<T> dynamicops) {
@@ -39,7 +40,7 @@ index 28c9f9ed2d532a1eb14b74c2e9723a2cf1b3c6fa..b3a4ec25446878fce5961e9014d24a30
              return reputation_b.a(dynamicops);
          }).map(Dynamic::getValue)));
      }
-@@ -142,18 +154,30 @@ public class Reputation {
+@@ -142,18 +155,30 @@ public class Reputation {
  
      public static class a { // Paper - make public
  


### PR DESCRIPTION
Upon a reputation of zero (or in an absolute edge case which should not
occur, negative), the villager sharing its gossip will delete itself
because a Random expects a bound N where N > 0.

If the bound N does not fulfill this expectation, return an empty list
of gossip to share.

I am not certain this should copy the list or return an empty one,
so feedback around that would be appreciated.