### PR TITLE
Fix MC-125757

### DIFF
--- a/Spigot-Server-Patches/0542-Fix-arrows-never-despawning-MC-125757.patch
+++ b/Spigot-Server-Patches/0542-Fix-arrows-never-despawning-MC-125757.patch
@@ -4,7 +4,7 @@ Date: Wed, 8 Jul 2020 11:24:30 -0500
 Subject: [PATCH] Fix arrows never despawning MC-125757
 
 This forces the despawn counter to start ticking regardless of
-state after the arrow has been alive for 20 ticks (10 seconds)
+state after the arrow has been alive for 200 ticks (10 seconds)
 instead of getting stuck in a never despawn state (bubble columns,
 etc).
 

--- a/Spigot-Server-Patches/0542-Fix-arrows-never-despawning-MC-125757.patch
+++ b/Spigot-Server-Patches/0542-Fix-arrows-never-despawning-MC-125757.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Wed, 8 Jul 2020 11:24:30 -0500
+Subject: [PATCH] Fix arrows never despawning MC-125757
+
+This forces the despawn counter to start ticking regardless of
+state after the arrow has been alive for 20 ticks (10 seconds)
+instead of getting stuck in a never despawn state (bubble columns,
+etc).
+
+diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
+index 6195a45e30d9a9d76e24fbc2493020917a8b87b9..1865f7a62307eb89d702f4824b090e050aa7afe7 100644
+--- a/src/main/java/net/minecraft/server/EntityArrow.java
++++ b/src/main/java/net/minecraft/server/EntityArrow.java
+@@ -133,6 +133,7 @@ public abstract class EntityArrow extends IProjectile {
+ 
+             ++this.c;
+         } else {
++            if (ticksLived > 200) this.tickDespawnCounter(); // Paper - tick despawnCounter regardless after 10 seconds
+             this.c = 0;
+             Vec3D vec3d2 = this.getPositionVector();
+ 
+@@ -254,6 +255,7 @@ public abstract class EntityArrow extends IProjectile {
+ 
+     }
+ 
++    protected void tickDespawnCounter() { this.h(); } // Paper - OBFHELPER
+     protected void h() {
+         ++this.despawnCounter;
+         if (this.despawnCounter >= (fromPlayer == PickupStatus.CREATIVE_ONLY ? world.paperConfig.creativeArrowDespawnRate : (fromPlayer == PickupStatus.DISALLOWED ? world.paperConfig.nonPlayerArrowDespawnRate : ((this instanceof EntityThrownTrident) ? world.spigotConfig.tridentDespawnRate : world.spigotConfig.arrowDespawnRate)))) { // Spigot // Paper - TODO: Extract this to init?


### PR DESCRIPTION
This forces the despawn counter to start ticking regardless of
state after the arrow has been alive for 200 ticks (10 seconds)
instead of getting stuck in a never despawn state (bubble columns,
etc).

https://bugs.mojang.com/browse/MC-125757