### PR TITLE
Fix harming potion dupe

### DIFF
--- a/Spigot-Server-Patches/0543-Fix-harming-potion-dupe.patch
+++ b/Spigot-Server-Patches/0543-Fix-harming-potion-dupe.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: PepperCode1 <44146161+PepperCode1@users.noreply.github.com>
+Date: Sat, 11 Jul 2020 01:53:48 -0700
+Subject: [PATCH] Fix-harming-potion-dupe
+
+
+diff --git a/src/main/java/net/minecraft/server/ItemPotion.java b/src/main/java/net/minecraft/server/ItemPotion.java
+index 0d204a46b8b23b6fb58acffc5de085e15f77767d..7dfd0691c89bdddcbccfe19911d91e9aaf0c64d1 100644
+--- a/src/main/java/net/minecraft/server/ItemPotion.java
++++ b/src/main/java/net/minecraft/server/ItemPotion.java
+@@ -2,6 +2,7 @@ package net.minecraft.server;
+ 
+ import java.util.Iterator;
+ import java.util.List;
++import java.util.ArrayList; // Paper - Fix harming potion dupe
+ 
+ public class ItemPotion extends Item {
+ 
+@@ -22,6 +23,7 @@ public class ItemPotion extends Item {
+             CriterionTriggers.z.a((EntityPlayer) entityhuman, itemstack);
+         }
+ 
++        List<MobEffect> instantLater = new ArrayList<>(); // Paper - Fix harming potion dupe
+         if (!world.isClientSide) {
+             List<MobEffect> list = PotionUtil.getEffects(itemstack);
+             Iterator iterator = list.iterator();
+@@ -30,7 +32,7 @@ public class ItemPotion extends Item {
+                 MobEffect mobeffect = (MobEffect) iterator.next();
+ 
+                 if (mobeffect.getMobEffect().isInstant()) {
+-                    mobeffect.getMobEffect().applyInstantEffect(entityhuman, entityhuman, entityliving, mobeffect.getAmplifier(), 1.0D);
++                    instantLater.add(mobeffect); // Paper - Fix harming potion dupe
+                 } else {
+                     entityliving.addEffect(new MobEffect(mobeffect), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.POTION_DRINK); // CraftBukkit
+                 }
+@@ -44,7 +46,22 @@ public class ItemPotion extends Item {
+             }
+         }
+ 
++        // Paper start - Fix harming potion dupe
++        if (!world.isClientSide) {
++            for (MobEffect mobeffect : instantLater) {
++                mobeffect.getMobEffect().applyInstantEffect(entityhuman, entityhuman, entityliving, mobeffect.getAmplifier(), 1.0D);
++            }
++        }
++        // Paper end
++
+         if (entityhuman == null || !entityhuman.abilities.canInstantlyBuild) {
++            // Paper start - Fix harming potion dupe
++            if (entityliving.getHealth() <= 0 && !(entityhuman != null && entityliving.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY))) {
++                entityliving.dropItem(new ItemStack(Items.GLASS_BOTTLE), 0);
++                return ItemStack.NULL_ITEM;
++            }
++            // Paper end
++
+             if (itemstack.isEmpty()) {
+                 return new ItemStack(Items.GLASS_BOTTLE);
+             }


### PR DESCRIPTION
Fixes #3871

EntityLiving#applyInstantEffect() immediately kills the player and drops their inventory.
Before this patch, instant effects would be applied before the potion ItemStack is removed and replaced with a glass bottle. This caused the potion ItemStack to be dropped before it was supposed to be removed from the inventory. It also caused the glass bottle to be put into a dead player's inventory.
This patch makes it so that instant effects are applied after the potion ItemStack is removed, and the glass bottle is only put into the player's inventory if the player is not dead. Otherwise, the glass bottle is dropped on the ground.