### PR TITLE
Add LivingEntity#clearActiveItem

### DIFF
--- a/Spigot-API-Patches/0237-Add-LivingEntity-clearActiveItem.patch
+++ b/Spigot-API-Patches/0237-Add-LivingEntity-clearActiveItem.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anrza <andrzejrzeczycki314@gmail.com>
+Date: Wed, 15 Jul 2020 12:07:58 +0200
+Subject: [PATCH] Add LivingEntity#clearActiveItem
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index 9bf525b795ff1d88d2596b1f2bc787ce0df047bb..e535750d01a6c1bf4b1fe94df518166213da9b08 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -766,6 +766,13 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+     @Nullable
+     ItemStack getActiveItem();
+ 
++    // Paper start
++    /**
++     * Interrupts any ongoing active "usage" or consumption or an item.
++     */
++    void clearActiveItem();
++    // Paper end
++
+     /**
+      * Get's remaining time a player needs to keep hands raised with an item to finish using it.
+      * @return Remaining ticks to use the item

--- a/Spigot-Server-Patches/0605-Add-LivingEntity-clearActiveItem.patch
+++ b/Spigot-Server-Patches/0605-Add-LivingEntity-clearActiveItem.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anrza <andrzejrzeczycki314@gmail.com>
+Date: Wed, 15 Jul 2020 12:08:49 +0200
+Subject: [PATCH] Add LivingEntity#clearActiveItem
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 9e9bdf9bc2e5c4d72d811fcb439628d946741324..1fc356d0b74c1cbb19bf7527088f1f61b6da5422 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -775,6 +775,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+         return getHandle().activeItem.asBukkitMirror();
+     }
+ 
++    // Paper start
++    @Override
++    public void clearActiveItem() {
++        getHandle().clearActiveItem();
++    }
++    // Paper end
++
+     @Override
+     public int getItemUseRemainingTime() {
+         return getHandle().getItemUseRemainingTime();


### PR DESCRIPTION
Prior to 1.16, you could clear a Player's activeItem by calling Player#updateInventory. That method no longer clears the activeItem.

This new method LivingEntity#clearActiveItem can be used to interrupt shield blocking, bow drawing, eating and drinking, and possibly other things that I haven't thought about. It calls EntityLiving#clearActiveItem, which is the method used by the server when a player's shield is disabled by being hit with an axe.

This is a copy of a previous PR I did, which I chose to discard due to poor branch management by me: https://github.com/PaperMC/Paper/pull/3895