### PR TITLE
Add Player#teleportRelative and Player#teleportWithoutRotation

### DIFF
--- a/Spigot-API-Patches/0218-Add-Player-teleportRelative-and-Player-teleportWitho.patch
+++ b/Spigot-API-Patches/0218-Add-Player-teleportRelative-and-Player-teleportWitho.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anrza <andrzejrzeczycki314@gmail.com>
+Date: Wed, 15 Jul 2020 12:29:19 +0200
+Subject: [PATCH] Add Player#teleportRelative and
+ Player#teleportWithoutRotation
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 2eb3121386e3bc5ccdd74726a7c4b5f832ec5aea..e98b5c3e66eb175dc6bdbdbdb8e6f3d8ea194ead 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1770,6 +1770,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     @NotNull
+     <T> T getClientOption(@NotNull ClientOption<T> option);
++
++    /**
++     * Teleports the player without forcing rotation.
++     * @param location Destination location. Yaw and pitch will be ignored.
++     */
++    void teleportWithoutRotation(@NotNull Location location);
++
++
++    /**
++     * Teleports and rotates the player relatively to its current position and rotation.
++     */
++    void teleportRelative(double x, double y, double z, float yaw, float pitch);
++
+     // Paper end
+ 
+     // Spigot start

--- a/Spigot-Server-Patches/0544-Add-Player-teleportRelative-and-Player-teleportWitho.patch
+++ b/Spigot-Server-Patches/0544-Add-Player-teleportRelative-and-Player-teleportWitho.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Anrza <andrzejrzeczycki314@gmail.com>
+Date: Wed, 15 Jul 2020 12:28:43 +0200
+Subject: [PATCH] Add Player#teleportRelative and
+ Player#teleportWithoutRotation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b832ece4948323e60fabecdeee5c9051b65c5e8e..1839082cc5e56b201cec722ded7db83324dfcc4e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -18,6 +18,7 @@ import java.net.InetSocketAddress;
+ import java.net.SocketAddress;
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.EnumSet;
+ import java.util.HashMap;
+ import java.util.HashSet;
+ import java.util.LinkedHashMap;
+@@ -60,6 +61,7 @@ import net.minecraft.server.PacketPlayOutMap;
+ import net.minecraft.server.PacketPlayOutNamedSoundEffect;
+ import net.minecraft.server.PacketPlayOutPlayerInfo;
+ import net.minecraft.server.PacketPlayOutPlayerListHeaderFooter;
++import net.minecraft.server.PacketPlayOutPosition;
+ import net.minecraft.server.PacketPlayOutSpawnPosition;
+ import net.minecraft.server.PacketPlayOutStopSound;
+ import net.minecraft.server.PacketPlayOutTitle;
+@@ -2064,6 +2066,23 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+         throw new RuntimeException("Unknown settings type");
+     }
++
++    @Override
++    public void teleportWithoutRotation(Location location) {
++        Set<PacketPlayOutPosition.EnumPlayerTeleportFlags> set = EnumSet.noneOf(PacketPlayOutPosition.EnumPlayerTeleportFlags.class);
++        set.add(PacketPlayOutPosition.EnumPlayerTeleportFlags.X_ROT);
++        set.add(PacketPlayOutPosition.EnumPlayerTeleportFlags.Y_ROT);
++        //getLocation().getYaw() returns the player's head rotation , but playerConnection.internalTeleport compares with the body rotation
++        getHandle().playerConnection.a(location.getX(), location.getY(), location.getZ(), getHandle().yaw, location.getPitch(), set);
++    }
++
++    @Override
++    public void teleportRelative(double x, double y, double z, float yaw, float pitch) {
++        Location l = this.getLocation();
++        //getLocation().getYaw() returns the player's head rotation , but playerConnection.internalTeleport compares with the body rotation
++        getHandle().playerConnection.a(x + l.getX(), y + l.getY(), z + l.getZ(), getHandle().yaw + yaw, l.getPitch() + pitch, EnumSet.allOf(PacketPlayOutPosition.EnumPlayerTeleportFlags.class));
++
++    }
+     // Paper end
+ 
+     // Spigot start


### PR DESCRIPTION
This might seem like useless thing when you can just player.teleport(player.getLocation.add(...)). But if you've ever tried repeatedly updating a player's position relative to itself, you've noticed that the player loses control and just jitters a lot if it tries to move.

I was inspired by this feature request on Spigot: https://hub.spigotmc.org/jira/browse/SPIGOT-2429
The author there linked a video which demonstrates the difference very clearly: https://www.youtube.com/watch?v=Ofl48rBs9yU&feature=youtu.be

In MC, we have two types of teleportation:
a) Absolute - sends absolute coordinates for the player to teleport to. 
b) Relative - sends relative coordinates for the player to teleport

So if it's not obvious to you what's going on and why normal relative teleport doesn't do this properly, I give you this example:
Player is at (0, 0, 0). We want to teleport it (0, 0, 1) relative to its position. Meanwhile, the player is walking east with the velocity (1, 0, 0).
Teleportation a) does this:
1. The server measures the player's location (0, 0, 0), adds (0, 0, 1), and tells the client to move to the sum (0, 0, 1).
2. Before the data reaches the client, the player has time to move to (1, 0, 0)
3. The data reaches the client and the player is teleported to (0, 0, 1), ignoring the player's own movement.

Teleportation b) does this:
1. The server tells the client to move (0, 0, 1) relative to its own location
2. Before the data reaches the client, the player has time to move to (1, 0, 0)
3. The data reaches the client and the player is teleported to (1, 0, 1), respecting the player's own movement.

The same thing happens with the player's rotation.
There are plenty of videos demonstrating "seamless" teleportation in MC.
A few interesting uses I've found for this include:
1. Applying constant "drag" to a player in a direction. This is not possible to do cleanly by setting the player's velocity, due to velocity interfering with the player's ability to jump.
2. Elevators, as demonstrated in the video above.
3. Applying a force to the player's rotation, pushing their vision while still respecting their own movement.

I'm not entirely sure my implementation is the best possible;
1. The relative teleportation can be per-coordinate. So you can choose which coordinates are absolute and which are relative. Maybe a Player#teleportRelative(Location l, boolean xIsRelative, boolean yIsRelative, et c.) would be better. Or an API enum could be added to match NMS structure. I chose this approach because I think it covers most cases, but it definitely has its limitations.
2. The NMS EntityPlayer#internalTeleport is a bit uncomfortable to work with. We need to calculate the absolute "expected" position of the player and give it to internalTeleport with the relative flags for it to work. Ideally, there should be a method that we can just feed the relative teleportation, but I thought it was best to not touch any NMS code, as long as it works.
3. Due to LivingEntity#getLocation().getYaw() returning the head rotation of the Player and internalTeleport comparing with the body rotation of the player, I use getHandle().yaw in the CraftPlayer methods instead of getLocation().getYaw(). This is only necessary because of point 2.

I'm new to contributing to paper, so I don't know if my approach was the best. I tried adding useful and clean methods. Please tell me if I should change my approach.

As a side note, the /teleport command has the ability to be relative. You can try running "/tp ~0 ~0 ~0.1" every tick and compare it to p.teleport(p.getLocation.add(0, 0, 0.1)).

