### PR TITLE
Fix SPIGOT-5989

### DIFF
--- a/Spigot-Server-Patches/0545-Fix-SPIGOT-5989.patch
+++ b/Spigot-Server-Patches/0545-Fix-SPIGOT-5989.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Wed, 15 Jul 2020 21:42:52 -0400
+Subject: [PATCH] Fix SPIGOT-5989
+
+Before this fix, if a player was respawning to a respawn anchor and
+the respawn location was modified away from the anchor with the
+PlayerRespawnEvent, the anchor would still lose some charge.
+This fixes that by checking if the modified spawn location is
+still at a respawn anchor.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 3c2f1f140c3991195bb8147bd65d9cd16a8fd3da..b8ec7941784885ace0c33fdf768ddcba284a12f9 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -766,6 +766,7 @@ public abstract class PlayerList {
+         // Paper start
+         boolean isBedSpawn = false;
+         boolean isRespawn = false;
++        boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
+         // Paper end
+ 
+         // CraftBukkit start - fire PlayerRespawnEvent
+@@ -776,7 +777,7 @@ public abstract class PlayerList {
+                 Optional optional;
+ 
+                 if (blockposition != null) {
+-                    optional = EntityHuman.getBed(worldserver1, blockposition, flag1, flag);
++                    optional = EntityHuman.getBed(worldserver1, blockposition, flag1, true); // Paper - Fix SPIGOT-5989
+                 } else {
+                     optional = Optional.empty();
+                 }
+@@ -809,7 +810,12 @@ public abstract class PlayerList {
+             }
+             // Spigot End
+ 
+-            location = respawnEvent.getRespawnLocation();
++            // Paper start - Fix SPIGOT-5989
++            if (!location.equals(respawnEvent.getRespawnLocation()) ) {
++                location = respawnEvent.getRespawnLocation();
++                isLocAltered = true;
++            }
++            // Paper end
+             if (!flag) entityplayer.reset(); // SPIGOT-4785
+             isRespawn = true; // Paper
+         } else {
+@@ -847,8 +853,12 @@ public abstract class PlayerList {
+         }
+         // entityplayer1.syncInventory();
+         entityplayer1.setHealth(entityplayer1.getHealth());
+-        if (flag2) {
+-            entityplayer1.playerConnection.sendPacket(new PacketPlayOutNamedSoundEffect(SoundEffects.BLOCK_RESPAWN_ANCHOR_DEPLETE, SoundCategory.BLOCKS, (double) blockposition.getX(), (double) blockposition.getY(), (double) blockposition.getZ(), 1.0F, 1.0F));
++        // Paper start - Fix SPIGOT-5989
++        IBlockData data = worldserver1.getType(blockposition);
++        if (flag2 && !isLocAltered) {
++            worldserver1.setTypeAndData(blockposition, data.set(BlockRespawnAnchor.a, data.get(BlockRespawnAnchor.a) - 1), 3);
++            entityplayer1.playerConnection.sendPacket(new PacketPlayOutNamedSoundEffect(SoundEffects.BLOCK_RESPAWN_ANCHOR_DEPLETE, SoundCategory.BLOCKS, (double) location.getX(), (double) location.getY(), (double) location.getZ(), 1.0F, 1.0F));
++        // Paper end
+         }
+         // Added from changeDimension
+         updateClient(entityplayer); // Update health, etc...


### PR DESCRIPTION
Before this fix, if a player was respawning to a respawn anchor and the respawn location was modified away from the anchor with the PlayerRespawnEvent, the anchor would still lose some charge. This fixes that by checking if the modified spawn location is still at a respawn anchor.

Anyone is free to port this to Spigot if they'd like, I've signed their CLA and this patch is released under MIT

Att https://github.com/EssentialsX/Essentials/pull/3498