### PR TITLE
Create Player#sendActionBar with components as parameters also pass t…

### DIFF
--- a/Spigot-API-Patches/0218-Create-Player-sendActionBar-with-component-support.patch
+++ b/Spigot-API-Patches/0218-Create-Player-sendActionBar-with-component-support.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Tuck <jan@tuck.dk>
+Date: Fri, 17 Jul 2020 01:54:22 +0200
+Subject: [PATCH] Create Player#sendActionBar with component support
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 2eb3121386e3bc5ccdd74726a7c4b5f832ec5aea..dfd04c341f6681e64cae21637395b59088b16d7a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -646,6 +646,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+         return banEntry;
+     }
+ 
++    // Paper - Start
++    /**
++     * Sends an Action Bar message to the client.
++     *
++     * Use Section symbols for legacy color codes to send formatting.
++     *
++     * @param components The message to send in components
++     */
++    public void sendActionBar(@NotNull net.md_5.bungee.api.chat.BaseComponent... components);
++    // Paper - End
++
+     /**
+      * Sends an Action Bar message to the client.
+      *

--- a/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
+++ b/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
@@ -14,7 +14,7 @@ index b832ece4948323e60fabecdeee5c9051b65c5e8e..4e05437d3ca725732a7d015f2a71db5a
      public void sendActionBar(String message) {
 -        if (getHandle().playerConnection == null || message == null || message.isEmpty()) return;
 -        getHandle().playerConnection.sendPacket(new PacketPlayOutChat(new net.minecraft.server.ChatComponentText(message), net.minecraft.server.ChatMessageType.GAME_INFO, SystemUtils.getNullUUID()));
-+        net.md_5.bungee.api.chat.TextComponent.fromLegacyText(message);
++        sendActionBar(net.md_5.bungee.api.chat.TextComponent.fromLegacyText(message));
      }
  
      @Override

--- a/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
+++ b/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Tuck <jan@tuck.dk>
+Date: Fri, 17 Jul 2020 01:54:20 +0200
+Subject: [PATCH] Create Player#sendActionBar with component support
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b832ece4948323e60fabecdeee5c9051b65c5e8e..4e05437d3ca725732a7d015f2a71db5a9d962439 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -245,8 +245,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     // Paper start
+     @Override
+     public void sendActionBar(String message) {
+-        if (getHandle().playerConnection == null || message == null || message.isEmpty()) return;
+-        getHandle().playerConnection.sendPacket(new PacketPlayOutChat(new net.minecraft.server.ChatComponentText(message), net.minecraft.server.ChatMessageType.GAME_INFO, SystemUtils.getNullUUID()));
++        net.md_5.bungee.api.chat.TextComponent.fromLegacyText(message);
+     }
+ 
+     @Override
+@@ -255,6 +254,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         sendActionBar(org.bukkit.ChatColor.translateAlternateColorCodes(alternateChar, message));
+     }
+ 
++    @Override
++    public void sendActionBar(BaseComponent... components) {
++        if (getHandle().playerConnection == null || components == null || components.length == 0) return;
++        PacketPlayOutChat packetPlayOutChat = new PacketPlayOutChat(null, net.minecraft.server.ChatMessageType.GAME_INFO, SystemUtils.getNullUUID());
++        getHandle().playerConnection.sendPacket(packetPlayOutChat);
++    }
++
+     @Override
+     public void setPlayerListHeaderFooter(BaseComponent[] header, BaseComponent[] footer) {
+          if (header != null) {

--- a/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
+++ b/Spigot-Server-Patches/0544-Create-Player-sendActionBar-with-component-support.patch
@@ -26,6 +26,7 @@ index b832ece4948323e60fabecdeee5c9051b65c5e8e..4e05437d3ca725732a7d015f2a71db5a
 +    public void sendActionBar(BaseComponent... components) {
 +        if (getHandle().playerConnection == null || components == null || components.length == 0) return;
 +        PacketPlayOutChat packetPlayOutChat = new PacketPlayOutChat(null, net.minecraft.server.ChatMessageType.GAME_INFO, SystemUtils.getNullUUID());
++        packetPlayOutChat.components = components;
 +        getHandle().playerConnection.sendPacket(packetPlayOutChat);
 +    }
 +


### PR DESCRIPTION
…hrough legacy sendActionBar(String) to fix some miscolouring


To see the issue try using Player#sendActionBar(ChatColor.of(Color.RED) + "Test")

This will horribly turn all black, this pr fixes that and also adds a method to use with components since the other one is deprecated for some reason.