### PR TITLE
fix for nerfed slime mobs splitting (#3930)

### DIFF
--- a/Spigot-Server-Patches/0635-Fix-nerfed-slime-when-splitting.patch
+++ b/Spigot-Server-Patches/0635-Fix-nerfed-slime-when-splitting.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 24 Aug 2020 08:39:06 -0700
+Subject: [PATCH] Fix nerfed slime when splitting
+
+
+diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
+index e99fd88118a75f36cb93d02aa7c6029bcffd5f10..8a1ff579ddf2fef191bc370dc51dd2e6404d9a22 100644
+--- a/src/main/java/net/minecraft/server/EntitySlime.java
++++ b/src/main/java/net/minecraft/server/EntitySlime.java
+@@ -206,6 +206,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+                     entityslime.setPersistent();
+                 }
+ 
++                entityslime.aware = this.aware; // Paper
+                 entityslime.setCustomName(ichatbasecomponent);
+                 entityslime.setNoAI(flag);
+                 entityslime.setInvulnerable(this.isInvulnerable());


### PR DESCRIPTION
Fixes #3930 
Slimes/Magma cubes did not pass on their Bukkit.Aware status to their "children" when they split.