### PR TITLE
Add getDestroySpeed to Block API

### DIFF
--- a/Spigot-API-Patches/0237-Add-Destroy-Speed-API.patch
+++ b/Spigot-API-Patches/0237-Add-Destroy-Speed-API.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ineusia <ineusia@yahoo.com>
+Date: Mon, 26 Oct 2020 11:37:48 -0500
+Subject: [PATCH] Add Destroy Speed API
+
+
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 7616c5601adee3cbe0e5f722646a2458b535ab77..6933fd6ad353a2d008c4a64c52a64bf36bd8035c 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -581,5 +581,16 @@ public interface Block extends Metadatable {
+      */
+     @NotNull
+     String getTranslationKey();
++
++    /**
++     * Gets the speed at which this block will be destroyed by a given {@link ItemStack}
++     *
++     * <p>Default value is 1.0</p>
++     *
++     * @param itemStack {@link ItemStack} used to mine this Block
++     * @return the speed that this Block will be mined by the given {@link ItemStack}
++     */
++    @NotNull
++    float getDestroySpeed(@NotNull ItemStack itemStack);
+     // Paper end
+ }

--- a/Spigot-Server-Patches/0603-Add-Destroy-Speed-API.patch
+++ b/Spigot-Server-Patches/0603-Add-Destroy-Speed-API.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ineusia <ineusia@yahoo.com>
+Date: Mon, 26 Oct 2020 11:48:06 -0500
+Subject: [PATCH] Add Destroy Speed API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 3baf7b75c65c9beba40945ba904315251b5b7a64..6fde449aca446001145e49b5859725f840cc317c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -757,5 +757,16 @@ public class CraftBlock implements Block {
+     public String getTranslationKey() {
+         return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
+     }
++
++    @Override
++    public float getDestroySpeed(ItemStack itemStack) {
++        net.minecraft.server.ItemStack nmsItemStack;
++        if (itemStack instanceof CraftItemStack) {
++            nmsItemStack = ((CraftItemStack) itemStack).getHandle();
++        } else {
++            nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
++        }
++        return nmsItemStack.getItem().getDestroySpeed(nmsItemStack, this.getNMSBlock().getBlockData());
++    }
+     // Paper end
+ }


### PR DESCRIPTION
Allows plugins to get the base speed at which an ItemStack destroys a Block, useful for determining if an ItemStack is a "proper" tool to mine a Block.