### PR TITLE
Use title packet for actionbar methods

### DIFF
--- a/Spigot-API-Patches/0041-Add-String-based-Action-Bar-API.patch
+++ b/Spigot-API-Patches/0041-Add-String-based-Action-Bar-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index bc9ff9b4a475d8b108b54f2d4a99199379b1c63d..3166d4809f12e55f53670a84e69f420ee3ee792b 100644
+index bc9ff9b4a475d8b108b54f2d4a99199379b1c63d..7ac87a8d177f7715204ed4ebbc9a1ef3cffe07df 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -483,6 +483,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -483,6 +483,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -32,10 +32,17 @@ index bc9ff9b4a475d8b108b54f2d4a99199379b1c63d..3166d4809f12e55f53670a84e69f420e
 +     */
 +    public void sendActionBar(char alternateChar, @NotNull String message);
 +
++    /**
++     * Sends an Action Bar message to the client.
++     *
++     * @param message The components to send
++     */
++    public void sendActionBar(@NotNull net.md_5.bungee.api.chat.BaseComponent... message);
++
      /**
       * Sends the component to the player
       *
-@@ -506,9 +526,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -506,9 +533,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *
@@ -47,7 +54,7 @@ index bc9ff9b4a475d8b108b54f2d4a99199379b1c63d..3166d4809f12e55f53670a84e69f420e
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1584,9 +1606,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1584,9 +1613,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -59,7 +66,7 @@ index bc9ff9b4a475d8b108b54f2d4a99199379b1c63d..3166d4809f12e55f53670a84e69f420e
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1594,9 +1618,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1594,9 +1625,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/Spigot-API-Patches/0050-Fix-upstream-javadoc-warnings-and-errors.patch
+++ b/Spigot-API-Patches/0050-Fix-upstream-javadoc-warnings-and-errors.patch
@@ -86,7 +86,7 @@ index c2096b5344d48d855d031538ec32e0154bd9054d..bca9d3659f6fceeca4b7fecbc7034d6f
      <T> void setParticle(@NotNull Particle particle, @Nullable T data);
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc0f080b23 100644
+index 7ac87a8d177f7715204ed4ebbc9a1ef3cffe07df..d3347e073cdc481f90de8076c5ee3986a4ae77aa 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -498,7 +498,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -98,7 +98,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       * @param message The message to send
       */
      public void sendActionBar(char alternateChar, @NotNull String message);
-@@ -565,6 +565,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -572,6 +572,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Update the subtitle of titles displayed to the player
       *
@@ -106,7 +106,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       * @deprecated Use {@link #updateTitle(Title)}
       */
      @Deprecated
-@@ -573,6 +574,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -580,6 +581,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Update the subtitle of titles displayed to the player
       *
@@ -114,7 +114,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       * @deprecated Use {@link #updateTitle(Title)}
       */
      @Deprecated
-@@ -581,6 +583,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -588,6 +590,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Show the given title to the player, along with the last subtitle set, using the last set times
       *
@@ -122,7 +122,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       * @deprecated Use {@link #sendTitle(Title)} or {@link #updateTitle(Title)}
       */
      @Deprecated
-@@ -589,6 +592,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -596,6 +599,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Show the given title to the player, along with the last subtitle set, using the last set times
       *
@@ -130,7 +130,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       * @deprecated Use {@link #sendTitle(Title)} or {@link #updateTitle(Title)}
       */
      @Deprecated
-@@ -1238,6 +1242,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1245,6 +1249,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param count the number of particles
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -138,7 +138,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, @Nullable T data);
  
-@@ -1254,6 +1259,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1261,6 +1266,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param count the number of particles
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -146,7 +146,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       */
      public <T> void spawnParticle(@NotNull Particle particle, double x, double y, double z, int count, @Nullable T data);
  
-@@ -1304,6 +1310,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1311,6 +1317,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param offsetZ the maximum random offset on the Z axis
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -154,7 +154,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, double offsetX, double offsetY, double offsetZ, @Nullable T data);
  
-@@ -1324,6 +1331,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1331,6 +1338,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param offsetZ the maximum random offset on the Z axis
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -162,7 +162,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       */
      public <T> void spawnParticle(@NotNull Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, @Nullable T data);
  
-@@ -1380,6 +1388,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1387,6 +1395,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *              particle used (normally speed)
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -170,7 +170,7 @@ index 3166d4809f12e55f53670a84e69f420ee3ee792b..4f419c7b07d771019ab2906d609772cc
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, double offsetX, double offsetY, double offsetZ, double extra, @Nullable T data);
  
-@@ -1402,6 +1411,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1409,6 +1418,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *              particle used (normally speed)
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}

--- a/Spigot-API-Patches/0076-Ability-to-apply-mending-to-XP-API.patch
+++ b/Spigot-API-Patches/0076-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2079395c29854ec7e751d210a05f329f31ebb8ad..444a495e53d1be036f7a1bda89bedf438be913c1 100644
+index 54a8965dd4b986657a57c7d150c4314a4acee68e..dbe0ccfe2f00bc7b430c63f6384e4569b1fede2f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -730,12 +730,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -737,12 +737,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/Spigot-API-Patches/0087-Player.setPlayerProfile-API.patch
+++ b/Spigot-API-Patches/0087-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 444a495e53d1be036f7a1bda89bedf438be913c1..505078ce7fa5fce981d26d07e61fc1e12fbed67a 100644
+index dbe0ccfe2f00bc7b430c63f6384e4569b1fede2f..b7abe54c824662ff6f7e3928850e4c43d9edfafc 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -17,7 +17,7 @@ index 444a495e53d1be036f7a1bda89bedf438be913c1..505078ce7fa5fce981d26d07e61fc1e1
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1568,6 +1569,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1575,6 +1576,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/Spigot-API-Patches/0146-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-API-Patches/0146-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2441b714d343b963c43c9f8827550e683be4a93d..dec87413b5c22c95524a1b1f70fdd1ef016a6791 100644
+index d15d659ad9c721137e8692ac6c5981dd9ddb1e70..47556ebc99c552ac9508a37474f37fdda7185d56 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1743,6 +1743,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1750,6 +1750,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/Spigot-API-Patches/0196-Add-Player-Client-Options-API.patch
+++ b/Spigot-API-Patches/0196-Add-Player-Client-Options-API.patch
@@ -176,7 +176,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index dec87413b5c22c95524a1b1f70fdd1ef016a6791..2eb3121386e3bc5ccdd74726a7c4b5f832ec5aea 100644
+index 47556ebc99c552ac9508a37474f37fdda7185d56..b584f8b15f7ee36b42bba0e0bae721aae8f6f14b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1,6 +1,7 @@
@@ -187,7 +187,7 @@ index dec87413b5c22c95524a1b1f70fdd1ef016a6791..2eb3121386e3bc5ccdd74726a7c4b5f8
  import com.destroystokyo.paper.Title; // Paper
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
  import java.util.Date; // Paper
-@@ -1763,6 +1764,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1770,6 +1771,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/Spigot-Server-Patches/0131-String-based-Action-Bar-API.patch
+++ b/Spigot-Server-Patches/0131-String-based-Action-Bar-API.patch
@@ -18,17 +18,23 @@ index 275c1d2d1eb2649de9a9b5aece6e88c21362efba..d72ba7f76c42fd525a5b59a999a0c08e
  
      public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> a() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e9d054ed9d345eb7ab76ad9c3526889aeb220e3..e7c42fb4fd1235a934c16f4cccc1b1a66b3672a0 100644
+index 9e9d054ed9d345eb7ab76ad9c3526889aeb220e3..b03d7747ca582c212534b061369564daa74f5022 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -221,6 +221,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -221,6 +221,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start
 +    @Override
++    public void sendActionBar(BaseComponent[] message) {
++        if (getHandle().playerConnection == null) return;
++        getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.ACTIONBAR, message, -1, -1, -1));
++    }
++
++    @Override
 +    public void sendActionBar(String message) {
 +        if (getHandle().playerConnection == null || message == null || message.isEmpty()) return;
-+        getHandle().playerConnection.sendPacket(new PacketPlayOutChat(new net.minecraft.server.ChatComponentText(message), net.minecraft.server.ChatMessageType.GAME_INFO, SystemUtils.getNullUUID()));
++        getHandle().playerConnection.sendPacket(new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.ACTIONBAR, CraftChatMessage.fromStringOrNull(message)));
 +    }
 +
 +    @Override

--- a/Spigot-Server-Patches/0185-Ability-to-apply-mending-to-XP-API.patch
+++ b/Spigot-Server-Patches/0185-Ability-to-apply-mending-to-XP-API.patch
@@ -43,10 +43,10 @@ index e7fb982913f391bafd608c4626086cd9cab7fad7..7f2d8de12473c5413bbfc10ea0947d6a
          return i * 2;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 758981757996a8c9aa5066640e5b6c293bb7fc64..e2f707e461e2e13f240a30a94c9acf191828219b 100644
+index 6b6f7b47747e78f5c0b91bf25ca369e964440b49..d3db77324e06d7cd39f05b664e987cce7a5a06e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1073,8 +1073,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1079,8 +1079,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(getHandle().playerInteractManager.getGameMode().getId());
      }
  

--- a/Spigot-Server-Patches/0202-Player.setPlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0202-Player.setPlayerProfile-API.patch
@@ -48,7 +48,7 @@ index 80a21dbc05ed3007f2e827f7a320131244c3044b..e0f0a1e91a037f93b239e779aa8fd92b
                              uniqueId = i.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e2f707e461e2e13f240a30a94c9acf191828219b..13c19f2a779caa9ff27b135fdf4ad720e5c9cce7 100644
+index d3db77324e06d7cd39f05b664e987cce7a5a06e5..172b11fc8473ee8cc18c7638cfdaa193df0e2e5e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,6 +1,8 @@
@@ -68,7 +68,7 @@ index e2f707e461e2e13f240a30a94c9acf191828219b..13c19f2a779caa9ff27b135fdf4ad720
  import net.minecraft.server.MapIcon;
  import net.minecraft.server.MinecraftKey;
  import net.minecraft.server.NBTTagCompound;
-@@ -1231,8 +1234,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1237,8 +1240,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -83,7 +83,7 @@ index e2f707e461e2e13f240a30a94c9acf191828219b..13c19f2a779caa9ff27b135fdf4ad720
          PlayerChunkMap.EntityTracker entry = tracker.trackedEntities.get(other.getId());
          if (entry != null) {
              entry.clear(getHandle());
-@@ -1273,8 +1281,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1279,8 +1287,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          hiddenPlayers.remove(player.getUniqueId());
  
@@ -98,7 +98,7 @@ index e2f707e461e2e13f240a30a94c9acf191828219b..13c19f2a779caa9ff27b135fdf4ad720
  
          getHandle().playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, other));
  
-@@ -1283,6 +1296,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1289,6 +1302,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(getHandle());
          }
      }

--- a/Spigot-Server-Patches/0208-Flag-to-disable-the-channel-limit.patch
+++ b/Spigot-Server-Patches/0208-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 13c19f2a779caa9ff27b135fdf4ad720e5c9cce7..b19072c26a37d577888cfefce612487d61aadd61 100644
+index 172b11fc8473ee8cc18c7638cfdaa193df0e2e5e..13d03e8fa783ac38ea2dd60529f395a3fd3ed96d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -144,6 +144,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index 13c19f2a779caa9ff27b135fdf4ad720e5c9cce7..b19072c26a37d577888cfefce612487d
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1502,7 +1503,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1508,7 +1509,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/Spigot-Server-Patches/0237-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0237-InventoryCloseEvent-Reason-API.patch
@@ -34,7 +34,7 @@ index 08141147f9795546e9397abed95834ed5e69a126..d9e5d71a87140c90b79902887bd2f481
          this.activeContainer = this.defaultContainer;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 49c455ae3ee793523133f0dde8dc6037ca899691..79ae3e47bff8a4e910f4dacda8930619d015c5dc 100644
+index ef0f8a66eefefce5f78ff35833bfe45437885e0b..5053b1a09bd992b884a5871cb8f355ffbcb26260 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -408,7 +408,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -101,7 +101,7 @@ index 411e6ff17ac50a410da038ad538ad56ba3aef8a8..201b2b0dcbaf6765390c18052f3b3450
          this.player.o();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 9d05320b132679ccd511422c2c187b0d5fa89c2c..4c11aa13b725b2bb502701f2d5fb3878ff162f05 100644
+index 628a5f109d6c44ba97876c42aefb5570deef6eb3..c4b0394d07b2af2ca14a68a300668197143e8fcc 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -420,7 +420,7 @@ public abstract class PlayerList {
@@ -114,7 +114,7 @@ index 9d05320b132679ccd511422c2c187b0d5fa89c2c..4c11aa13b725b2bb502701f2d5fb3878
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
          cserver.getPluginManager().callEvent(playerQuitEvent);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 089e7c301d48a2d4302ca3d6bb1235e6207363b7..b7253c4201d601d1e2e354af5d2b17421629d48e 100644
+index 5ccd9457f81dab2b2cb821960c0557c925623b50..f8139831254e676c2142a39858e8c0629943badc 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -966,7 +966,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -155,10 +155,10 @@ index fe8a21202340c5892f5166ec294212c6e44ed3a5..00d67c9911c52ddcdf48fda7998bcd2a
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b19072c26a37d577888cfefce612487d61aadd61..c7e43f5015851d44870986c6cd6c43b3332cf9be 100644
+index 13d03e8fa783ac38ea2dd60529f395a3fd3ed96d..62e62226bc11df7de80cd1029c7d549596cd760d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -791,7 +791,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -797,7 +797,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (getHandle().activeContainer != getHandle().defaultContainer) {

--- a/Spigot-Server-Patches/0285-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-Server-Patches/0285-Expose-attack-cooldown-methods-for-Player.patch
@@ -27,10 +27,10 @@ index d9e5d71a87140c90b79902887bd2f481f02956dc..afc665bfe9d527ca8d19f3ab9df0900d
          this.aA = 0;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c7e43f5015851d44870986c6cd6c43b3332cf9be..21aa19081ca3d9c20ea8e401c2a4b830ba667a51 100644
+index 62e62226bc11df7de80cd1029c7d549596cd760d..41f0a9159f2e92d43fbca112050198bd7f5e0eb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1971,6 +1971,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1977,6 +1977,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  

--- a/Spigot-Server-Patches/0286-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0286-Improve-death-events.patch
@@ -279,7 +279,7 @@ index 4b249a644c680a7cc64b0d31cf453f94ff2b6a0c..d6a98bb7fc107649c179cded2d37c06a
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index dc8f88d102c06d8fb28ffd66de36f32efec54ff2..650579eb1bb73416b629229fce897d2941bd3b0d 100644
+index 5053b1a09bd992b884a5871cb8f355ffbcb26260..c272bab87f9248cc3e7afe3607522f0b5e9c48d1 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -80,6 +80,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -357,10 +357,10 @@ index 7b565ddfffd0b9c78392ee115ef9c20ab89a3380..d78b9fd608da691220f1edeff506b36e
          this.minecraftKey = minecraftKey;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 21aa19081ca3d9c20ea8e401c2a4b830ba667a51..1398d911456b6e685bf7292687c5f5a4dcea5b7e 100644
+index 41f0a9159f2e92d43fbca112050198bd7f5e0eb7..b7253ab42447faa36abdbe3190f82f8673cc8ce6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1762,7 +1762,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1768,7 +1768,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/Spigot-Server-Patches/0326-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/Spigot-Server-Patches/0326-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index fa975d4788281b66e63b4e8b9ad05c8a0f78c40a..b9125ca724c60026f0dcff40f570f6a5da8c993b 100644
+index 0a6367dc8b62049cb210d905394183d051a357c0..999f474ab2ac5a3189eab2755f3a1c9b6cf58011 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -80,6 +80,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -28,7 +28,7 @@ index fa975d4788281b66e63b4e8b9ad05c8a0f78c40a..b9125ca724c60026f0dcff40f570f6a5
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 50fbf3e3fb82c25ab5f3b258206f324c8616dae7..2b5dda81b467cf1d813359faaa5c81d4aeb6ee1c 100644
+index d4e1fd05cbff3e0c0973a6188ec0469cd53c63f7..bbace0cf80a7cc85a4e70a8cd760a932e33cc72c 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -97,6 +97,7 @@ public abstract class PlayerList {
@@ -106,7 +106,7 @@ index 00333548b470435aa89fb0f4b29047eb1461e992..5770d4183c1b9ab6119a25930283c023
      public Location getBedSpawnLocation() {
          NBTTagCompound data = getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1398d911456b6e685bf7292687c5f5a4dcea5b7e..305deccc0343563ba6080ad75d7397c7c8dd7435 100644
+index b7253ab42447faa36abdbe3190f82f8673cc8ce6..f28d6aa664e21a1b39adba16b2857981d4443ddb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -145,6 +145,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 1398d911456b6e685bf7292687c5f5a4dcea5b7e..305deccc0343563ba6080ad75d7397c7
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1406,6 +1407,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1412,6 +1413,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 1398d911456b6e685bf7292687c5f5a4dcea5b7e..305deccc0343563ba6080ad75d7397c7
      public void readExtraData(NBTTagCompound nbttagcompound) {
          hasPlayedBefore = true;
          if (nbttagcompound.hasKey("bukkit")) {
-@@ -1428,6 +1441,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1434,6 +1447,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(NBTTagCompound nbttagcompound) {
@@ -145,7 +145,7 @@ index 1398d911456b6e685bf7292687c5f5a4dcea5b7e..305deccc0343563ba6080ad75d7397c7
          if (!nbttagcompound.hasKey("bukkit")) {
              nbttagcompound.set("bukkit", new NBTTagCompound());
          }
-@@ -1442,6 +1457,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1448,6 +1463,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.setLong("firstPlayed", getFirstPlayed());
          data.setLong("lastPlayed", System.currentTimeMillis());
          data.setString("lastKnownName", handle.getName());

--- a/Spigot-Server-Patches/0330-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/Spigot-Server-Patches/0330-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 305deccc0343563ba6080ad75d7397c7c8dd7435..ea083f0987fb85afdf23d894bdd8980cc6707e51 100644
+index f28d6aa664e21a1b39adba16b2857981d4443ddb..1b596878942e3911be4e5c501d6f5d6c1a1707e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2016,6 +2016,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2022,6 +2022,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetCooldown();
      }

--- a/Spigot-Server-Patches/0354-Per-Player-View-Distance-API-placeholders.patch
+++ b/Spigot-Server-Patches/0354-Per-Player-View-Distance-API-placeholders.patch
@@ -40,10 +40,10 @@ index 9331f96f68f121b41ce74904d624520291b7c72e..1074995e8c8a83f6cdb94019123fbffa
                          double deltaZ = this.locZ() - player.locZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ea083f0987fb85afdf23d894bdd8980cc6707e51..93bf15984f541b4daf05e4c27f105f9787cb0347 100644
+index 1b596878942e3911be4e5c501d6f5d6c1a1707e8..3ed64e19b9e0287a7396b9b5a63641794fad583c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2025,6 +2025,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2031,6 +2031,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              super.remove();
          }
      }

--- a/Spigot-Server-Patches/0458-Implement-Player-Client-Options-API.patch
+++ b/Spigot-Server-Patches/0458-Implement-Player-Client-Options-API.patch
@@ -98,7 +98,7 @@ index 22acfe1350eb122b7eaa7209f519e4f4f1469b6c..2cada09ced1660526e9c112c2c8d92bb
      protected static final DataWatcherObject<NBTTagCompound> br = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
      protected static final DataWatcherObject<NBTTagCompound> bs = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 27926559a665a5af14f11b8b4331cdb5f120eb41..83a3c8d8d15f5792f5618ab301e3c9ed1c1162cd 100644
+index 99513a682c0b1bbe141098427883ee561a4d5e9d..d4d789e84a2b6a3ba108532630a89f51b3a23f54 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -2,6 +2,7 @@ package net.minecraft.server;
@@ -158,7 +158,7 @@ index dbc3552d50c4129e1844c8a379ab5ba396645f52..be97a0b01b3272e01ece90172f283e3f
          return this.e;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 93bf15984f541b4daf05e4c27f105f9787cb0347..e3ae90aa7c2c067741540995fbb1c694b663f624 100644
+index 3ed64e19b9e0287a7396b9b5a63641794fad583c..3a2d5ff06b4114502348aac48ebf3b251fec858b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,8 @@
@@ -170,7 +170,7 @@ index 93bf15984f541b4daf05e4c27f105f9787cb0347..e3ae90aa7c2c067741540995fbb1c694
  import com.destroystokyo.paper.Title;
  import com.destroystokyo.paper.profile.CraftPlayerProfile;
  import com.destroystokyo.paper.profile.PlayerProfile;
-@@ -2035,6 +2038,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2041,6 +2044,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/Spigot-Server-Patches/0497-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0497-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1223,10 +1223,10 @@ index b34269cd29fe15408e8811a8ab88b8d0fa43fcd3..4210aa793b497889ca732a51b2eadea0
              net.minecraft.server.Chunk chunk = (net.minecraft.server.Chunk) either.left().orElse(null);
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e3ae90aa7c2c067741540995fbb1c694b663f624..b832ece4948323e60fabecdeee5c9051b65c5e8e 100644
+index 3a2d5ff06b4114502348aac48ebf3b251fec858b..2cbf405470973323064c4205739d164f742c67a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -744,6 +744,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -750,6 +750,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  


### PR DESCRIPTION
This is quite the micro change, but this makes Paper's actionbar methods use the title packet instead of the chat packet to *ever so slightly* reduce encoded data (without the uuid, since that's always the system uuid anyways).
Also puts the title packet use for components to a method inside of the Player interface, as opposed to Spigot's sub class, so that using the stupid sub class isn't encouraged any more than it already is

Thought this might *just* be enough to be at least slightly better in cases of extremely frequent actionbar spam / using the 'more appropriate' packet, since what you send isn't  "Game Info", but a custom actionbar title, which also spares the client from 1-2 extra checks