### PR TITLE
Fix harming potion dupe

### DIFF
--- a/Spigot-Server-Patches/0627-Fix-harming-potion-dupe.patch
+++ b/Spigot-Server-Patches/0627-Fix-harming-potion-dupe.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: PepperCode1 <44146161+PepperCode1@users.noreply.github.com>
+Date: Thu, 23 Jul 2020 14:25:07 -0700
+Subject: [PATCH] Fix harming potion dupe
+
+EntityLiving#applyInstantEffect() immediately kills the player and drops their inventory.
+Before this patch, instant effects would be applied before the potion ItemStack is removed and replaced with a glass bottle. This caused the potion ItemStack to be dropped before it was supposed to be removed from the inventory. It also caused the glass bottle to be put into a dead player's inventory.
+This patch makes it so that instant effects are applied after the potion ItemStack is removed, and the glass bottle is only put into the player's inventory if the player is not dead. Otherwise, the glass bottle is dropped on the ground.
+
+diff --git a/src/main/java/net/minecraft/server/ItemPotion.java b/src/main/java/net/minecraft/server/ItemPotion.java
+index 7862b63a245222d9a3d0896bdb2741b0e5e7ac40..d4389768963f40cb7b4bca950631d9f50f634543 100644
+--- a/src/main/java/net/minecraft/server/ItemPotion.java
++++ b/src/main/java/net/minecraft/server/ItemPotion.java
+@@ -22,6 +22,7 @@ public class ItemPotion extends Item {
+             CriterionTriggers.z.a((EntityPlayer) entityhuman, itemstack);
+         }
+ 
++        List<MobEffect> instantLater = new java.util.ArrayList<>(); // Paper - Fix harming potion dupe
+         if (!world.isClientSide) {
+             List<MobEffect> list = PotionUtil.getEffects(itemstack);
+             Iterator iterator = list.iterator();
+@@ -30,7 +31,7 @@ public class ItemPotion extends Item {
+                 MobEffect mobeffect = (MobEffect) iterator.next();
+ 
+                 if (mobeffect.getMobEffect().isInstant()) {
+-                    mobeffect.getMobEffect().applyInstantEffect(entityhuman, entityhuman, entityliving, mobeffect.getAmplifier(), 1.0D);
++                    instantLater.add(mobeffect); // Paper - Fix harming potion dupe
+                 } else {
+                     entityliving.addEffect(new MobEffect(mobeffect), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.POTION_DRINK); // CraftBukkit
+                 }
+@@ -44,7 +45,20 @@ public class ItemPotion extends Item {
+             }
+         }
+ 
++        // Paper start - Fix harming potion dupe
++        for (MobEffect mobeffect : instantLater) {
++            mobeffect.getMobEffect().applyInstantEffect(entityhuman, entityhuman, entityliving, mobeffect.getAmplifier(), 1.0D);
++        }
++        // Paper end
++
+         if (entityhuman == null || !entityhuman.abilities.canInstantlyBuild) {
++            // Paper start - Fix harming potion dupe
++            if (entityliving.getHealth() <= 0 && !entityliving.world.getGameRules().getBoolean(GameRules.KEEP_INVENTORY)) {
++                entityliving.dropItem(new ItemStack(Items.GLASS_BOTTLE), 0);
++                return ItemStack.NULL_ITEM;
++            }
++            // Paper end
++
+             if (itemstack.isEmpty()) {
+                 return new ItemStack(Items.GLASS_BOTTLE);
+             }


### PR DESCRIPTION
Fixes #3871

EntityLiving#applyInstantEffect() immediately kills the player and drops their inventory.
Before this patch, instant effects would be applied before the potion ItemStack is removed and replaced with a glass bottle. This caused the potion ItemStack to be dropped before it was supposed to be removed from the inventory. It also caused the glass bottle to be put into a dead player's inventory.
This patch makes it so that instant effects are applied after the potion ItemStack is removed, and the glass bottle is only put into the player's inventory if the player is not dead. Otherwise, the glass bottle is dropped on the ground.