### PR TITLE
Fix sound/particles not showing when listening on BlockDestroyEvent

### DIFF
--- a/Spigot-API-Patches/0169-BlockDestroyEvent.patch
+++ b/Spigot-API-Patches/0169-BlockDestroyEvent.patch
@@ -12,7 +12,7 @@ This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3aee12f1cb37b0672bdcdfac1e932bd4e3a184b0
+index 0000000000000000000000000000000000000000..28255dc39eab5faf324d1fe556ab12daed527ff6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/block/BlockDestroyEvent.java
 @@ -0,0 +1,92 @@
@@ -42,7 +42,7 @@ index 0000000000000000000000000000000000000000..3aee12f1cb37b0672bdcdfac1e932bd4
 +
 +    @NotNull private final BlockData newState;
 +    private final boolean willDrop;
-+    private boolean playEffect;
++    private boolean playEffect = true;
 +
 +    private boolean cancelled = false;
 +


### PR DESCRIPTION
This fixes a bug (ChestShop-authors/ChestShop-3#328) where blocks wouldn't show the effect nor play the sound in certain cases when a plugin listened on the `BlockDestroyEvent`. This was due to the `playEffect` field in the `BlockDestroyEvent` class not being set which meant it was returned as `false` while it [should've been defaulted to `true`](https://github.com/PaperMC/Paper/blob/master/Spigot-Server-Patches/0331-BlockDestroyEvent.patch#L24).