### PR TITLE
Add lightning API to get/set flash count and life ticks

### DIFF
--- a/Spigot-API-Patches/0239-More-lightning-API.patch
+++ b/Spigot-API-Patches/0239-More-lightning-API.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KennyTV <jahnke.nassim@gmail.com>
+Date: Sun, 26 Jul 2020 14:44:16 +0200
+Subject: [PATCH] More lightning API
+
+
+diff --git a/src/main/java/org/bukkit/entity/LightningStrike.java b/src/main/java/org/bukkit/entity/LightningStrike.java
+index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..2c81a3f685588431a3c7675c84b35a28975232af 100644
+--- a/src/main/java/org/bukkit/entity/LightningStrike.java
++++ b/src/main/java/org/bukkit/entity/LightningStrike.java
+@@ -31,4 +31,38 @@ public interface LightningStrike extends Entity {
+     @Override
+     Spigot spigot();
+     // Spigot end
++
++    // Paper start
++    /**
++     * Returns the amount of flash iterations that will be done before the lightning dies.
++     *
++     * @see #getLifeTicks() for how long the current flash will last
++     * @return amount of flashes that will be shown before the lightning dies
++     */
++    int getFlashCount();
++
++    /**
++     * Sets the amount of life iterations that will be done before the lightning dies.
++     * Default number of flashes on creation is between 1-3.
++     *
++     * @param flashes amount of iterations that will be done before the lightning dies, must to be a positive number
++     */
++    void setFlashCount(int flashes);
++
++    /**
++     * Returns the amount of ticks the current flash will do damage for.
++     * Starts with 2 by default, will damage while it is equal to or above 0, with the next flash beginning somewhere between 0 and -9.
++     *
++     * @return ticks the current flash will do damage for
++     */
++    int getLifeTicks();
++
++    /**
++     * Sets the amount of ticks the current flash will do damage/fire for.
++     * Default is 2 for each flash, on which the sound and effect will also be played.
++     *
++     * @param lifeTicks ticks the current flash will do damage for
++     */
++    void setLifeTicks(int lifeTicks);
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0607-More-lightning-API.patch
+++ b/Spigot-Server-Patches/0607-More-lightning-API.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KennyTV <jahnke.nassim@gmail.com>
+Date: Sun, 26 Jul 2020 14:44:09 +0200
+Subject: [PATCH] More lightning API
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLightning.java b/src/main/java/net/minecraft/server/EntityLightning.java
+index 180bfd4a60e18723b5fbae96123001284658afcb..5200b0396ee41edb42ff727c78cf3b5fce091d6b 100644
+--- a/src/main/java/net/minecraft/server/EntityLightning.java
++++ b/src/main/java/net/minecraft/server/EntityLightning.java
+@@ -11,7 +11,7 @@ public class EntityLightning extends Entity {
+ 
+     private int lifeTicks;
+     public long b;
+-    private int d;
++    private int d; public int getFlashCount() { return d; } public void setFlashCount(int flashes) { this.d = flashes; } // Paper - OBFHELPER
+     public boolean isEffect;
+     @Nullable
+     private EntityPlayer f;
+@@ -29,6 +29,16 @@ public class EntityLightning extends Entity {
+         this.isEffect = flag;
+     }
+ 
++    // Paper start
++    public int getLifeTicks() {
++        return lifeTicks;
++    }
++
++    public void setLifeTicks(int lifeTicks) {
++        this.lifeTicks = lifeTicks;
++    }
++    // Paper end
++
+     @Override
+     public SoundCategory getSoundCategory() {
+         return SoundCategory.WEATHER;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
+index 988386a9a7fb23e24ab14254d53895f9606c94f3..8016f4c053cca2b015150b2fe735958bd7c7cf92 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
+@@ -45,4 +45,27 @@ public class CraftLightningStrike extends CraftEntity implements LightningStrike
+         return spigot;
+     }
+     // Spigot end
++
++    // Paper start
++    @Override
++    public int getFlashCount() {
++        return getHandle().getFlashCount();
++    }
++
++    @Override
++    public void setFlashCount(int flashes) {
++        com.google.common.base.Preconditions.checkArgument(flashes >= 0, "Flashes has to be a positive number!");
++        getHandle().setFlashCount(flashes);
++    }
++
++    @Override
++    public int getLifeTicks() {
++        return getHandle().getLifeTicks();
++    }
++
++    @Override
++    public void setLifeTicks(int lifeTicks) {
++        getHandle().setLifeTicks(lifeTicks);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Not the absolutely most useful things in the world, but it's nice to play around to have damage applied for a few more ticks (could also be used as a little force field to take damage in 👀),
or even more than one effect during its lifetime,
or or mimic real life visual vs. sound by only setting the first lifetime higher, so that visual comes first with the sound a bit delayed by setting the first life ticks higher

If setting those values is undesired for some reason, at least being able to get them would be nice