### PR TITLE
prevent path space splitting in testServer.sh

### DIFF
--- a/scripts/testServer.sh
+++ b/scripts/testServer.sh
@@ -10,7 +10,7 @@ gitcmd="git -c commit.gpgsign=false"
 #
 # FUNCTIONS
 #
-source $basedir/scripts/functions.sh
+source "$basedir"/scripts/functions.sh
 
 updateTest() {
     paperstash


### PR DESCRIPTION
This fixes a bug which prevents using `./paper t` if the project is stored in a path with a space in a folders name.