### PR TITLE
Get an ItemStack's Name as Translatable Component

### DIFF
--- a/Spigot-API-Patches/0224-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-API-Patches/0224-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Tue, 11 Aug 2020 19:17:46 +0200
+Subject: [PATCH] Add a way to get translation keys for blocks, entities and
+ materials
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index e203c5bfc1d1bf6b500ef8a4446d3aef182b8ecb..4ba991b79f13219182df35b4ce0c5cf57cbd208b 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -3580,6 +3580,16 @@ public enum Material implements Keyed {
+         }
+         return false;
+     }
++
++    /**
++     * Return the translation key for the Material, so the client can translate it into the active
++     * locale when using a TranslatableComponent.
++     * @return the translation key
++     */
++    @NotNull
++    public String getTranslationKey() {
++        return Bukkit.getUnsafe().getTranslationKey(this);
++    }
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index d3ec5084e33dff038d54cdd2aeb703a3eb25f7a7..ac43afbf6230a481ab8cffbb3bc91b716316c00d 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -94,5 +94,27 @@ public interface UnsafeValues {
+     byte[] serializeItem(ItemStack item);
+ 
+     ItemStack deserializeItem(byte[] data);
++
++    /**
++     * Return the translation key for the Material, so the client can translate it into the active
++     * locale when using a TranslatableComponent.
++     * @return the translation key
++     */
++    String getTranslationKey(Material mat);
++
++    /**
++     * Return the translation key for the Block, so the client can translate it into the active
++     * locale when using a TranslatableComponent.
++     * @return the translation key
++     */
++    String getTranslationKey(org.bukkit.block.Block block);
++
++    /**
++     * Return the translation key for the EntityType, so the client can translate it into the active
++     * locale when using a TranslatableComponent.<br>
++     * This is <code>null</code>, when the EntityType isn't known to NMS (custom entities)
++     * @return the translation key
++     */
++    String getTranslationKey(org.bukkit.entity.EntityType type);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index f8c599718143fe638de422fd4625f353ee6c54ae..7616c5601adee3cbe0e5f722646a2458b535ab77 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -573,5 +573,13 @@ public interface Block extends Metadatable {
+      */
+     @NotNull
+     com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();
++
++    /**
++     * Return the translation key for the Block, so the client can translate it into the active
++     * locale when using a TranslatableComponent.
++     * @return the translation key
++     */
++    @NotNull
++    String getTranslationKey();
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/entity/EntityType.java b/src/main/java/org/bukkit/entity/EntityType.java
+index 774363a8186b3861f10c0452ac63726cae365169..692b75eb78405874077c850bfc72e247ccc80860 100644
+--- a/src/main/java/org/bukkit/entity/EntityType.java
++++ b/src/main/java/org/bukkit/entity/EntityType.java
+@@ -414,4 +414,15 @@ public enum EntityType implements Keyed {
+     public boolean isAlive() {
+         return living;
+     }
++
++    /**
++     * Return the translation key for the EntityType, so the client can translate it into the active
++     * locale when using a TranslatableComponent.<br>
++     * This is <code>null</code>, when the EntityType isn't known to NMS (custom entities)
++     * @return the translation key
++     */
++    @Nullable
++    String getTranslationKey() {
++        return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
++    }
+ }

--- a/Spigot-Server-Patches/0574-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-Server-Patches/0574-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -1,0 +1,110 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Tue, 11 Aug 2020 19:16:09 +0200
+Subject: [PATCH] Add a way to get translation keys for blocks, entities and
+ materials
+
+
+diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
+index a45ceff9ff970b996b2767379a2ecd4693f52d3a..4b4f14711d483089a5d5478b57539911a9c7a2fc 100644
+--- a/src/main/java/net/minecraft/server/Block.java
++++ b/src/main/java/net/minecraft/server/Block.java
+@@ -279,6 +279,7 @@ public class Block extends BlockBase implements IMaterial {
+         return !this.material.isBuildable() && !this.material.isLiquid();
+     }
+ 
++    public String getDescriptionId() { return i(); } // Paper - OBFHELPER
+     public String i() {
+         if (this.name == null) {
+             this.name = SystemUtils.a("block", IRegistry.BLOCK.getKey(this));
+diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
+index 2767de830bdb9051ae6a6b7c30342175b117e7ed..e23247e0a8b923ff7805f9ec894584818a447827 100644
+--- a/src/main/java/net/minecraft/server/EntityTypes.java
++++ b/src/main/java/net/minecraft/server/EntityTypes.java
+@@ -147,6 +147,7 @@ public class EntityTypes<T extends Entity> {
+         return IRegistry.ENTITY_TYPE.getKey(entitytypes);
+     }
+ 
++    public static Optional<EntityTypes<?>> getByName(String name) { return a(name); } // Paper - OBFHELPER
+     public static Optional<EntityTypes<?>> a(String s) {
+         return IRegistry.ENTITY_TYPE.getOptional(MinecraftKey.a(s));
+     }
+@@ -275,6 +276,7 @@ public class EntityTypes<T extends Entity> {
+         return this.bg;
+     }
+ 
++    public String getDescriptionId() { return f(); } // Paper - OBFHELPER
+     public String f() {
+         if (this.bo == null) {
+             this.bo = SystemUtils.a("entity", IRegistry.ENTITY_TYPE.getKey(this));
+diff --git a/src/main/java/net/minecraft/server/Item.java b/src/main/java/net/minecraft/server/Item.java
+index 3d3445bc5cdd93d315caf62a95f8a88e353605a0..5e7c924a2798cd918832a34a649044956970ae53 100644
+--- a/src/main/java/net/minecraft/server/Item.java
++++ b/src/main/java/net/minecraft/server/Item.java
+@@ -26,7 +26,7 @@ public class Item implements IMaterial {
+     private final FoodInfo foodInfo;
+ 
+     public static int getId(Item item) {
+-        return item == null ? 0 : IRegistry.ITEM.a((Object) item);
++        return item == null ? 0 : IRegistry.ITEM.a(item);  // Paper - Fix Decompiler Issue
+     }
+ 
+     public static Item getById(int i) {
+@@ -122,6 +122,7 @@ public class Item implements IMaterial {
+         return IRegistry.ITEM.getKey(this).getKey();
+     }
+ 
++    public String getOrCreateDescriptionId() { return m(); } // Paper - OBFHELPER
+     protected String m() {
+         if (this.name == null) {
+             this.name = SystemUtils.a("item", IRegistry.ITEM.getKey(this));
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 9905478f08aee2ea2beb6a1bcd86c2ab05718cac..3584d20c7a9d28cc2f027092f76b96e46a3c59e4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -752,5 +752,10 @@ public class CraftBlock implements Block {
+     public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
+         return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMSBlock().getBlockData().getStepSound());
+     }
++
++    @Override
++    public String getTranslationKey() {
++        return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
++    }
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index c1efe830dd0807d5f7bda10cb582556af6d23383..a9728c6c538822b8c751b5d08f5fcd14031dbc77 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -42,6 +42,7 @@ import org.bukkit.NamespacedKey;
+ import org.bukkit.UnsafeValues;
+ import org.bukkit.advancement.Advancement;
+ import org.bukkit.block.data.BlockData;
++import org.bukkit.craftbukkit.block.CraftBlock;
+ import org.bukkit.craftbukkit.block.data.CraftBlockData;
+ import org.bukkit.craftbukkit.inventory.CraftItemStack;
+ import org.bukkit.craftbukkit.legacy.CraftLegacy;
+@@ -373,6 +374,22 @@ public final class CraftMagicNumbers implements UnsafeValues {
+             throw new RuntimeException();
+         }
+     }
++
++    @Override
++    public String getTranslationKey(Material mat) {
++        return getItem(mat).getOrCreateDescriptionId();
++    }
++
++    @Override
++    public String getTranslationKey(org.bukkit.block.Block block) {
++        return ((org.bukkit.craftbukkit.block.CraftBlock)block).getNMS().getBlock().getDescriptionId();
++    }
++
++    @Override
++    public String getTranslationKey(org.bukkit.entity.EntityType type) {
++        return net.minecraft.server.EntityTypes.getByName(type.getName()).map(net.minecraft.server.EntityTypes::getDescriptionId).orElse(null);
++    }
++
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
Opening this in draft state as there are a couple of ways to solve it [and I don't know if you want to have such API additions at all].
Currently there is no way to get the internal key used in the translation map, without using NMS.
This has lead to code like https://github.com/PikaMug/LocaleLib/blob/master/src/main/java/me/pikamug/localelib/LocaleKeys.java 
For NMS, it's however trivial to get that key and that's what this patch solves.

There's just a few points where I am uncertain:
 1. Returning a TranslatableComponent instead of the Translation Key. It's more convenient and I don't see use cases where the key would be required without a component. In this case there's still TC#getTranslate, however if someone would soley need the keys, that'd be useless allocations
  2. Usually such things would belong into the ItemMeta, but due to NMS, this is only available on `ItemStack`, not even Material or something else. I've added it to ItemStack as Metas aren't linked to Stacks and so I couldn't add it to the Meta.
  3. The Implementation in Bukkit: Typically Bukkit has interfaces but ItemStack is a class, so I put an exception into it in the body. Should I maybe just return null instead?
  4. The OBFHELPER and changing the protection level instead of directly calling getName(). My Intention was to make it more future proof in case getName starts to return something different.

Thanks for your time!