### PR TITLE
Add Switch.Face <-> FaceAttachable.AttachedFace converters

### DIFF
--- a/Spigot-API-Patches/0219-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
+++ b/Spigot-API-Patches/0219-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
@@ -1,0 +1,73 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 5 Aug 2020 00:10:45 +0200
+Subject: [PATCH] Add Switch.Face <-> FaceAttachable.AttachedFace converters
+
+
+diff --git a/src/main/java/org/bukkit/block/data/FaceAttachable.java b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+index 9599e1237b9717ddbf84c3738bf6c1293e8b3c54..8c2341b03dc9f5fe62ae67d5828ed51d698de73a 100644
+--- a/src/main/java/org/bukkit/block/data/FaceAttachable.java
++++ b/src/main/java/org/bukkit/block/data/FaceAttachable.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.block.data;
+ 
++import org.bukkit.block.data.type.Switch;
+ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+@@ -41,5 +42,25 @@ public interface FaceAttachable extends BlockData {
+          * The switch is mounted to the ceiling and pointing dowanrds.
+          */
+         CEILING;
++
++        // Paper start
++        /**
++         * @return The {@link Switch.Face} equivalent to this.
++         * @deprecated Prefer {@link AttachedFace} over {@link Switch.Face}.
++         */
++        @Deprecated
++        public Switch.Face toSwitchFace() {
++            switch (this) {
++                case FLOOR:
++                    return Switch.Face.FLOOR;
++                case WALL:
++                    return Switch.Face.WALL;
++                case CEILING:
++                    return Switch.Face.CEILING;
++            }
++
++            throw new IllegalStateException("Unknown face: " + this);
++        }
++        // Paper end
+     }
+ }
+diff --git a/src/main/java/org/bukkit/block/data/type/Switch.java b/src/main/java/org/bukkit/block/data/type/Switch.java
+index be06f8db02ca41d5cc3a5dc02951ad27e3cc8f9d..ddfa0edb8e5c8718b10d5040d5f619134d98e45a 100644
+--- a/src/main/java/org/bukkit/block/data/type/Switch.java
++++ b/src/main/java/org/bukkit/block/data/type/Switch.java
+@@ -45,5 +45,25 @@ public interface Switch extends Directional, FaceAttachable, Powerable {
+          * The switch is mounted to the ceiling and pointing dowanrds.
+          */
+         CEILING;
++
++        // Paper start
++        /**
++         * @return The {@link AttachedFace} equivalent to this.
++         * @deprecated Prefer {@link AttachedFace} over {@link Switch.Face}.
++         */
++        @Deprecated
++        public AttachedFace toAttachedFace() {
++            switch (this) {
++                case FLOOR:
++                    return AttachedFace.FLOOR;
++                case WALL:
++                    return AttachedFace.WALL;
++                case CEILING:
++                    return AttachedFace.CEILING;
++            }
++
++            throw new IllegalStateException("Unknown face: " + this);
++        }
++        // Paper end
+     }
+ }

--- a/Spigot-Server-Patches/0551-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
+++ b/Spigot-Server-Patches/0551-Add-Switch.Face-FaceAttachable.AttachedFace-converte.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Wed, 5 Aug 2020 00:10:50 +0200
+Subject: [PATCH] Add Switch.Face <-> FaceAttachable.AttachedFace converters
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
+index 2761b3710b00e317cf3ffc9ff8e1e04e48c26b79..69bbb760b93164cd764a6cc7799e586a5a010a6e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftSwitch.java
+@@ -9,11 +9,11 @@ public abstract class CraftSwitch extends CraftBlockData implements Switch {
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
+index c3713d1dcfdd416853d79c61b0549537304f1c37..e69f64ccf30f6aa61d16255203f9b9aabb49f9fa 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLever.java
+@@ -19,12 +19,12 @@ public final class CraftLever extends org.bukkit.craftbukkit.block.data.CraftBlo
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
+index ee3bef136414ccd71998522f0b2f62909b8d87b0..b32545279bade994df589bbf2d3f5ec041c80363 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftStoneButton.java
+@@ -19,12 +19,12 @@ public final class CraftStoneButton extends org.bukkit.craftbukkit.block.data.Cr
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
+index bbe76e7ddd8c6548a00730013e5a5b85724170f9..99099ef6bb753b0ef591a87c2a97c27b86ba6b9d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftWoodButton.java
+@@ -19,12 +19,12 @@ public final class CraftWoodButton extends org.bukkit.craftbukkit.block.data.Cra
+ 
+     @Override
+     public Face getFace() {
+-        return get(FACE, Face.class);
++        return get(FACE, AttachedFace.class).toSwitchFace(); // Paper
+     }
+ 
+     @Override
+     public void setFace(Face face) {
+-        set(FACE, face);
++        set(FACE, face.toAttachedFace()); // Paper
+     }
+ 
+     // org.bukkit.craftbukkit.block.data.CraftDirectional


### PR DESCRIPTION
This is required because the *same* enum is used for getting both on
blocks. If a `Switch.Face` is requested on a block first, then
`FaceAttachable.AttachedFace`, it will throw a `ClassCastException`.
This is because the converted class is cached as `Switch.Face` in an
internal map, while what we expect and cast to is
`FaceAttachable.AttachedFace`.

I'm fairly certain my approach is less than ideal, and would therefore
appreciate reviews and ideas on how to do it in a more idiomatic way.