### PR TITLE
Added more Options and Operator API to Paper 

### DIFF
--- a/Spigot-API-Patches/0219-Quick-Commit.patch
+++ b/Spigot-API-Patches/0219-Quick-Commit.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BuildTools <unconfigured@null.spigotmc.org>
+Date: Thu, 6 Aug 2020 14:34:56 +0800
+Subject: [PATCH] Quick-Commit
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index b584f8b15f7ee36b42bba0e0bae721aae8f6f14b..a1f5a06b6b983f243b02e4b64e2544a067bbbb45 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1772,6 +1772,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     void resetCooldown();
+ 
++    /**
++     * Sets the OP Level for the Player, between 1 to 4
++     */
++    public void setOpLevel(int level);
++
++    /**
++     * Gets the Player's OP Level
++     */
++    public int getOpLevel();
++
+     /**
+      * @return the client option value of the player
+      */

--- a/Spigot-Server-Patches/0551-Quick-Commit.patch
+++ b/Spigot-Server-Patches/0551-Quick-Commit.patch
@@ -1,0 +1,144 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BuildTools <unconfigured@null.spigotmc.org>
+Date: Thu, 6 Aug 2020 14:34:39 +0800
+Subject: [PATCH] Quick-Commit
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index e471e764935e2a89560de56959a782b02e5e8fe1..41f3d3d4d0fdc3e783325138bdc1a6f7cba4faf8 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -72,6 +72,13 @@ public class PaperWorldConfig {
+         return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
+     }
+ 
++    public boolean disableWitchConversions;
++    public boolean removeAttackCooldown;
++    private void advancedSurvivalSettings() {
++    	disableWitchConversions = getBoolean("no-witch-transformations", true);
++    	removeAttackCooldown = getBoolean("no-attack-cooldown", true);
++    }
++    
+     public int cactusMaxHeight;
+     public int reedMaxHeight;
+     private void blockGrowthHeight() {
+@@ -578,14 +585,12 @@ public class PaperWorldConfig {
+         generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
+     }
+ 
+-    public boolean disablePillagerPatrols = false;
+     public double patrolSpawnChance = 0.2;
+     public boolean patrolPerPlayerDelay = false;
+     public int patrolDelay = 12000;
+     public boolean patrolPerPlayerStart = false;
+     public int patrolStartDay = 5;
+     private void pillagerSettings() {
+-        disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
+         patrolSpawnChance = getDouble("game-mechanics.pillager-patrols.spawn-chance", patrolSpawnChance);
+         patrolPerPlayerDelay = getBoolean("game-mechanics.pillager-patrols.spawn-delay.per-player", patrolPerPlayerDelay);
+         patrolDelay = getInt("game-mechanics.pillager-patrols.spawn-delay.ticks", patrolDelay);
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index e5a81f831813209d224ffedbc03f6d8243721a25..8e9b9acbb0c79f9957cb1dadf8a43885204a88c8 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -120,9 +120,9 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> cachedSingleHashSet; // Paper
+ 
+     double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
+-
++    private AttributeModifier disableAttackCooldown = new AttributeModifier("DisableCooldown", 7200, AttributeModifier.Operation.ADDITION);
+     boolean needsChunkCenterUpdate; // Paper - no-tick view distance
+-
++    
+     public EntityPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
+         super(worldserver, worldserver.getSpawn(), gameprofile);
+         this.spawnDimension = World.OVERWORLD;
+@@ -563,6 +563,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+                 this.lastSentExp = this.expTotal;
+                 this.playerConnection.sendPacket(new PacketPlayOutExperience(this.exp, this.expTotal, this.expLevel));
+             }
++            
++            if(this.world.paperConfig.removeAttackCooldown && !this.getAttributeInstance(GenericAttributes.ATTACK_SPEED).getModifiers().contains(disableAttackCooldown)) {
++            	this.getAttributeInstance(GenericAttributes.ATTACK_SPEED).addModifier(disableAttackCooldown);
++            }
+ 
+             if (this.ticksLived % 20 == 0) {
+                 CriterionTriggers.p.a(this);
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index bf019043a9338aca8d91da809f1d5520531386e7..820d3213ca9e8b68b62a6ba5a35080f96e08d72e 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -722,6 +722,10 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+ 
+     @Override
+     public void onLightningStrike(EntityLightning entitylightning) {
++    	if(this.world.paperConfig.disableWitchConversions) {
++    		super.onLightningStrike(entitylightning);
++    		return;
++    	}
+         if (this.world.getDifficulty() != EnumDifficulty.PEACEFUL) {
+             EntityVillager.LOGGER.info("Villager {} was struck by lightning {}.", this, entitylightning);
+             EntityWitch entitywitch = (EntityWitch) EntityTypes.WITCH.a(this.world);
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+index 776e54ff472a67f535dfb409e753325a1105bcce..c0c94b5bfffba092010bae66a99685943bedd47d 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+@@ -10,10 +10,8 @@ public class MobSpawnerPatrol implements MobSpawner {
+ 
+     @Override
+     public int a(WorldServer worldserver, boolean flag, boolean flag1) {
+-        if (worldserver.paperConfig.disablePillagerPatrols || worldserver.paperConfig.patrolSpawnChance == 0) return 0; // Paper
+-        if (!flag) {
+-            return 0;
+-        } else if (!worldserver.getGameRules().getBoolean(GameRules.DO_PATROL_SPAWNING)) {
++        if (worldserver.paperConfig.patrolSpawnChance == 0) return 0; // Paper
++        if (!worldserver.getGameRules().getBoolean(GameRules.DO_PATROL_SPAWNING)) {
+             return 0;
+         } else {
+             Random random = worldserver.random;
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 9382e8f79e8edec8885c629a36e230fbec50e1fb..080f2c2e2de11c1e2f15a53e83c7e2e8db952b74 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -1010,6 +1010,20 @@ public abstract class PlayerList {
+     public IpBanList getIPBans() {
+         return this.l;
+     }
++    
++    public void setOpLevel(GameProfile profile, int level) {
++    	if(level > 4) level = 4;
++    	if(level <= 0) {
++    		this.removeOp(profile);
++    		return;
++    	}
++    	this.operators.add(new OpListEntry(profile, level, this.operators.b(profile)));
++        EntityPlayer entityplayer = this.getPlayer(profile.getId());
++
++        if (entityplayer != null) {
++            this.d(entityplayer);
++        }
++    }
+ 
+     public void addOp(GameProfile gameprofile) {
+         this.operators.add(new OpListEntry(gameprofile, this.server.g(), this.operators.b(gameprofile)));
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index adf918fd757fe3147f897de3ade64a9adf1d3203..2c6af6ac865d6c8ece4f5166324e96646ec0bcde 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -161,6 +161,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return getHandle().getProfile();
+     }
+ 
++    @Override
++    public void setOpLevel(int level) {
++    	server.getHandle().setOpLevel(getProfile(), level);
++    }
++
++    @Override
++    public int getOpLevel() {
++    	return server.getServer().b(getProfile());
++    }
++
+     @Override
+     public boolean isOp() {
+         return server.getHandle().isOp(getProfile());

--- a/Spigot-Server-Patches/0552-Trader-Spawning-Patch.patch
+++ b/Spigot-Server-Patches/0552-Trader-Spawning-Patch.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BuildTools <unconfigured@null.spigotmc.org>
+Date: Thu, 6 Aug 2020 14:39:50 +0800
+Subject: [PATCH] Trader-Spawning-Patch
+
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerTrader.java b/src/main/java/net/minecraft/server/MobSpawnerTrader.java
+index 736b794f8268858e2e63a3aafef328b443386989..06599af6fe874efe934996e21ce9d52c98b0d970 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerTrader.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerTrader.java
+@@ -41,21 +41,17 @@ public class MobSpawnerTrader implements MobSpawner {
+                 return 0;
+             } else {
+                 this.d = 24000;
+-                if (!worldserver.getGameRules().getBoolean(GameRules.DO_MOB_SPAWNING)) {
++                int i = this.e;
++
++                this.e = MathHelper.clamp(this.e + 25, 25, 75);
++                this.b.h(this.e);
++                if (this.a.nextInt(100) > i) {
+                     return 0;
++                } else if (this.a(worldserver)) {
++                    this.e = 25;
++                    return 1;
+                 } else {
+-                    int i = this.e;
+-
+-                    this.e = MathHelper.clamp(this.e + 25, 25, 75);
+-                    this.b.h(this.e);
+-                    if (this.a.nextInt(100) > i) {
+-                        return 0;
+-                    } else if (this.a(worldserver)) {
+-                        this.e = 25;
+-                        return 1;
+-                    } else {
+-                        return 0;
+-                    }
++                    return 0;
+                 }
+             }
+         }

--- a/Spigot-Server-Patches/0553-Gamemode-Command-Alias.patch
+++ b/Spigot-Server-Patches/0553-Gamemode-Command-Alias.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BuildTools <unconfigured@null.spigotmc.org>
+Date: Thu, 6 Aug 2020 20:03:37 +0800
+Subject: [PATCH] Gamemode-Command-Alias
+
+
+diff --git a/src/main/java/net/minecraft/server/CommandGamemode.java b/src/main/java/net/minecraft/server/CommandGamemode.java
+index 8400fa356dd2c5a76ac7741d114bf066af8043c5..01f6433f2e889e352cb8ac73fa28f0672140a72f 100644
+--- a/src/main/java/net/minecraft/server/CommandGamemode.java
++++ b/src/main/java/net/minecraft/server/CommandGamemode.java
+@@ -25,6 +25,11 @@ public class CommandGamemode {
+                 })).then(CommandDispatcher.a("target", (ArgumentType) ArgumentEntity.d()).executes((commandcontext) -> {
+                     return a(commandcontext, ArgumentEntity.f(commandcontext, "target"), enumgamemode);
+                 })));
++                literalargumentbuilder.then(((LiteralArgumentBuilder) CommandDispatcher.a(String.valueOf(enumgamemode.getId())).executes((commandcontext) -> {
++                    return a(commandcontext, (Collection) Collections.singleton(((CommandListenerWrapper) commandcontext.getSource()).h()), enumgamemode);
++                })).then(CommandDispatcher.a("target", (ArgumentType) ArgumentEntity.d()).executes((commandcontext) -> {
++                    return a(commandcontext, ArgumentEntity.f(commandcontext, "target"), enumgamemode);
++                })));
+             }
+         }
+ 


### PR DESCRIPTION
List of changes:
-Tidied up my Patch, this time it's much cleaner than before

-Removed redundant option from Paper Config that disables Patrol Spawning
-Fixed Patrol and Wandering Trader Spawning to only be affected by their respective gamerules as they are unique events and not regular mob spawning, previously they would be affected by the doMobSpawning gamerule as well (And in the case of Patrols the option to disable normally spawning monsters)
-Added Operator API to Paper that allows Plugins to set the OP Level of Players ranging from 1-4, useful for rank and permission systems
-Added Option to disable the annoying event of Villagers turning into Witches when struck by Lightning in the Paper Config
-Added Option to completely disable the 1.9 Combat Attack Cooldown for PVP Players, while keeping the more interesting combat mechanics of 1.9 intact (This mechanic is completely seamless and does not interfere with the displayed attack speed on Weapons, allowing for an even better 1.9 PVP experience while retaining no cooldown)



I'm planning on adding more mechanics and events once 1.16.2 Full Release drops



P.S. I am aware that it's better practice to have each change as an individual commit but I was sort of in a rush