### PR TITLE
Add Anti-Xray bypass permission

### DIFF
--- a/Spigot-Server-Patches/0362-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0362-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d18c4a2c8 100644
+index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..46a726f46b4f2d884d6657ebb49061ff1ae77138 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -455,4 +457,33 @@ public class PaperWorldConfig {
+@@ -455,4 +457,38 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
@@ -28,6 +28,7 @@ index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d
 +    public int maxChunkSectionIndex;
 +    public int updateRadius;
 +    public boolean lavaObscures;
++    public boolean usePermission;
 +    public List<String> hiddenBlocks;
 +    public List<String> replacementBlocks;
 +    private void antiXray() {
@@ -38,6 +39,7 @@ index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d
 +        maxChunkSectionIndex = maxChunkSectionIndex > 15 ? 15 : maxChunkSectionIndex;
 +        updateRadius = getInt("anti-xray.update-radius", 2);
 +        lavaObscures = getBoolean("anti-xray.lava-obscures", false);
++        usePermission = getBoolean("anti-xray.use-permission", false);
 +        hiddenBlocks = getList("anti-xray.hidden-blocks", Arrays.asList("gold_ore", "iron_ore", "coal_ore", "lapis_ore", "mossy_cobblestone", "obsidian", "chest", "diamond_ore", "redstone_ore", "clay", "emerald_ore", "ender_chest"));
 +        replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList("stone", "oak_planks"));
 +        if (PaperConfig.version < 19) {
@@ -50,19 +52,23 @@ index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d
 +            set("anti-xray.replacement-blocks", replacementBlocks);
 +        }
 +        log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
++        if (antiXray && usePermission) {
++            Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
++        }
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90742ff43c
+index 0000000000000000000000000000000000000000..2bfab782472b0b4f3a9cbb2b51183f286c314dcf
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockController.java
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,45 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import net.minecraft.server.BlockPosition;
 +import net.minecraft.server.Chunk;
 +import net.minecraft.server.ChunkSection;
++import net.minecraft.server.EntityPlayer;
 +import net.minecraft.server.EnumDirection;
 +import net.minecraft.server.IBlockData;
 +import net.minecraft.server.IChunkAccess;
@@ -80,6 +86,10 @@ index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90
 +
 +    public IBlockData[] getPredefinedBlockData(World world, IChunkAccess chunk, ChunkSection chunkSection, boolean initializeBlocks) {
 +        return null;
++    }
++
++    public boolean shouldModify(EntityPlayer entityPlayer, Chunk chunk, int chunkSectionSelector) {
++        return false;
 +    }
 +
 +    public ChunkPacketInfo<IBlockData> getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk, int chunkSectionSelector) {
@@ -100,10 +110,10 @@ index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae73fb52fc
+index 0000000000000000000000000000000000000000..bba2dbaf9549690d929f546c2a4a845b03e86130
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,615 @@
+@@ -0,0 +1,627 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
@@ -127,6 +137,7 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +    private final EngineMode engineMode;
 +    private final int maxChunkSectionIndex;
 +    private final int updateRadius;
++    private final boolean usePermission;
 +    private final IBlockData[] predefinedBlockData;
 +    private final IBlockData[] predefinedBlockDataFull;
 +    private final IBlockData[] predefinedBlockDataStone;
@@ -146,6 +157,7 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +        engineMode = paperWorldConfig.engineMode;
 +        maxChunkSectionIndex = paperWorldConfig.maxChunkSectionIndex;
 +        updateRadius = paperWorldConfig.updateRadius;
++        usePermission = paperWorldConfig.usePermission;
 +
 +        this.executor = executor;
 +
@@ -248,6 +260,11 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +    }
 +
 +    @Override
++    public boolean shouldModify(EntityPlayer entityPlayer, Chunk chunk, int chunkSectionSelector) {
++        return !usePermission || !entityPlayer.getBukkitEntity().hasPermission("paper.antixray.bypass");
++    }
++
++    @Override
 +    public ChunkPacketInfoAntiXray getChunkPacketInfo(PacketPlayOutMapChunk packetPlayOutMapChunk, Chunk chunk, int chunkSectionSelector) {
 +        // Return a new instance to collect data and objects in the right state while creating the chunk packet for thread safe access later
 +        // Note: As of 1.14 this has to be moved later due to the chunk system.
@@ -257,6 +274,11 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +
 +    @Override
 +    public void modifyBlocks(PacketPlayOutMapChunk packetPlayOutMapChunk, ChunkPacketInfo<IBlockData> chunkPacketInfo) {
++        if (chunkPacketInfo == null) {
++            packetPlayOutMapChunk.setReady(true);
++            return;
++        }
++
 +        if (!Bukkit.isPrimaryThread()) {
 +            // plugins?
 +            MinecraftServer.getServer().scheduleOnMain(() -> {
@@ -1211,7 +1233,7 @@ index f4c1b8d32b239c44e70d3fa6d094b74955f75339..ed77117630d54b7ad81f633110c7d2a7
  
          if (this.h == this.b) {
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
-index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c047d9cfa 100644
+index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..b9276928a58d56ca9aac95d262d8555522946bd7 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutMapChunk.java
 @@ -1,5 +1,6 @@
@@ -1236,15 +1258,20 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c
      // Paper start
      private final java.util.List<Packet> extraPackets = new java.util.ArrayList<>();
      private static final int TE_LIMIT = Integer.getInteger("Paper.excessiveTELimit", 750);
-@@ -32,6 +39,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -31,7 +38,11 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+         return extraPackets;
      }
      // Paper end
-     public PacketPlayOutMapChunk(Chunk chunk, int i) {
-+        ChunkPacketInfo<IBlockData> chunkPacketInfo = chunk.world.chunkPacketBlockController.getChunkPacketInfo(this, chunk, i); // Paper - Anti-Xray - Add chunk packet info
+-    public PacketPlayOutMapChunk(Chunk chunk, int i) {
++    // Paper start - Anti-Xray - Add chunk packet info
++    @Deprecated public PacketPlayOutMapChunk(Chunk chunk, int i) { this(chunk, i, true); } // Notice for updates: Please make sure this constructor isn't used anywhere
++    public PacketPlayOutMapChunk(Chunk chunk, int i, boolean modifyBlocks) {
++        ChunkPacketInfo<IBlockData> chunkPacketInfo = modifyBlocks ? chunk.world.chunkPacketBlockController.getChunkPacketInfo(this, chunk, i) : null;
++        // Paper end
          ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
  
          this.a = chunkcoordintpair.x;
-@@ -54,7 +62,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -54,7 +65,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
          }
  
          this.f = new byte[this.a(chunk, i)];
@@ -1258,7 +1285,7 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c
          this.g = Lists.newArrayList();
          iterator = chunk.getTileEntities().entrySet().iterator();
          int totalTileEntities = 0; // Paper
-@@ -81,8 +94,19 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -81,8 +97,19 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
                  this.g.add(nbttagcompound);
              }
          }
@@ -1278,7 +1305,7 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c
  
      @Override
      public void a(PacketDataSerializer packetdataserializer) throws IOException {
-@@ -148,8 +172,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -148,8 +175,12 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
          return bytebuf;
      }
  
@@ -1293,7 +1320,7 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c
          int j = 0;
          ChunkSection[] achunksection = chunk.getSections();
          int k = 0;
-@@ -159,7 +187,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
+@@ -159,7 +190,7 @@ public class PacketPlayOutMapChunk implements Packet<PacketListenerPlayOut> {
  
              if (chunksection != Chunk.a && (!this.f() || !chunksection.c()) && (i & 1 << k) != 0) {
                  j |= 1 << k;
@@ -1303,7 +1330,7 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..5094a5d6fb3c1a84d6e8f6abe79e894c
          }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index c4ed4d58f7b344626acb13baeb14288970a7bb90..8e79200b23f2dee612b0cbdcd6359a25dc2323cb 100644
+index c4ed4d58f7b344626acb13baeb14288970a7bb90..325532e1585beefe1cb341580e0bb3e95020b6fe 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -609,7 +609,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -1314,6 +1341,18 @@ index c4ed4d58f7b344626acb13baeb14288970a7bb90..8e79200b23f2dee612b0cbdcd6359a25
 +            return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray - Add parameter
          }, this.executor);
      }
+ 
+@@ -1349,9 +1349,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+ 
+     }
+ 
++    private final void sendChunk(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) { this.a(entityplayer, apacket, chunk); } // Paper - OBFHELPER
+     private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
+         if (apacket[0] == null) {
+-            apacket[0] = new PacketPlayOutMapChunk(chunk, 65535);
++            apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
+             apacket[1] = new PacketPlayOutLightUpdate(chunk.getPos(), this.lightEngine, true);
+         }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 index 3056468a7e70238228b91be0f103cfbe111fedb5..cdaeeb8b01f084ae7a91f9681850a737af8a74be 100644

--- a/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
@@ -25,12 +25,12 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 90e8defde0ef84f3146c8664805d6f11b84c593d..36eff622d5638f1bd11b7b4ebe97036205ccf88b 100644
+index f2a5426934e712c828cf0369058ff2fb5353075e..ab2ddb39b0d15a5c40101f957fcd4c8d7a588c87 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -496,4 +496,9 @@ public class PaperWorldConfig {
+@@ -501,4 +501,9 @@ public class PaperWorldConfig {
+             Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
-         log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }
 +
 +    public boolean disableRelativeProjectileVelocity;

--- a/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
@@ -3055,7 +3055,7 @@ index 10dfdecba53cf16f9fae8a2be1144ef8cda1006d..301836c7d465afe82737b0aa5ad68bf5
                  completablefuture = (CompletableFuture) this.statusFutures.get(i);
                  if (completablefuture != null) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 8e79200b23f2dee612b0cbdcd6359a25dc2323cb..e7d9674e25c06090d57bba6c8229bc3b75cb67e6 100644
+index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d43769215303d1f139e 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -65,7 +65,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -3496,7 +3496,7 @@ index 8e79200b23f2dee612b0cbdcd6359a25dc2323cb..e7d9674e25c06090d57bba6c8229bc3b
      boolean isOutsideOfRange(ChunkCoordIntPair chunkcoordintpair) {
          // Spigot start
          return isOutsideOfRange(chunkcoordintpair, false);
-@@ -1400,6 +1592,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1401,6 +1593,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  

--- a/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 36eff622d5638f1bd11b7b4ebe97036205ccf88b..fb84e7ca2873bcb5fed80b7ce58cf38a376289ed 100644
+index ab2ddb39b0d15a5c40101f957fcd4c8d7a588c87..95fd136e0ff9ebfa9e61fac5297c049f6db4ce1a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,10 +1,15 @@
@@ -24,7 +24,7 @@ index 36eff622d5638f1bd11b7b4ebe97036205ccf88b..fb84e7ca2873bcb5fed80b7ce58cf38a
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -501,4 +506,52 @@ public class PaperWorldConfig {
+@@ -506,4 +511,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fb84e7ca2873bcb5fed80b7ce58cf38a376289ed..617a8af814dc224762dc21669392960cc1702693 100644
+index 95fd136e0ff9ebfa9e61fac5297c049f6db4ce1a..eb3f939cf7c3f22b16bd5200a09c4b0925998bad 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -554,4 +554,9 @@ public class PaperWorldConfig {
+@@ -559,4 +559,9 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -617,7 +617,7 @@ index b1fe488e41a2c9f77df091e1d14ed5c87a4358c8..788540ab2b090e9625d35e20d495733a
          return this.bg;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index e7d9674e25c06090d57bba6c8229bc3b75cb67e6..70a291090f022ff7d79a75b94ac54b94ff6db751 100644
+index 7f72d13bb39182666a741d43769215303d1f139e..a167696d2fc3cb69b9eaa720c5904762e073008b 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -81,7 +81,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {

--- a/Spigot-Server-Patches/0377-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0377-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 617a8af814dc224762dc21669392960cc1702693..505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3 100644
+index eb3f939cf7c3f22b16bd5200a09c4b0925998bad..f72c22601db157d047bf8ea4aba44b29ef56b615 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -559,4 +559,9 @@ public class PaperWorldConfig {
+@@ -564,4 +564,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3..45191d101b38953a53ef6a21c0c1592cac42b2aa 100644
+index f72c22601db157d047bf8ea4aba44b29ef56b615..8e055213c12aff1d964c962d9d33a165b4f75b3f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -564,4 +564,9 @@ public class PaperWorldConfig {
+@@ -569,4 +569,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 45191d101b38953a53ef6a21c0c1592cac42b2aa..7453becf8c56bd41a7e532c08c4f274026eadefb 100644
+index 8e055213c12aff1d964c962d9d33a165b4f75b3f..09d5d799bdb215d5a0b4fb7d4d46b6266a79a0a6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -569,4 +569,9 @@ public class PaperWorldConfig {
+@@ -574,4 +574,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7453becf8c56bd41a7e532c08c4f274026eadefb..4438d567dd779650533c7128ae8b25b8fd369836 100644
+index 09d5d799bdb215d5a0b4fb7d4d46b6266a79a0a6..561f50debcc5fe7cbff46aa1bfc7f3b4241ee77a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -574,4 +574,13 @@ public class PaperWorldConfig {
+@@ -579,4 +579,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0400-Tracking-Range-Improvements.patch
+++ b/Spigot-Server-Patches/0400-Tracking-Range-Improvements.patch
@@ -8,10 +8,10 @@ Sets tracking range of watermobs to animals instead of misc and simplifies code
 Also ignores Enderdragon, defaulting it to Mojang's setting
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 70a291090f022ff7d79a75b94ac54b94ff6db751..512940ef8608d28c83a4a8d0777a99ebf25b4e8b 100644
+index a167696d2fc3cb69b9eaa720c5904762e073008b..74df45e6c3f86736f7d136cf6fd911d5b574221d 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1739,6 +1739,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1740,6 +1740,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              while (iterator.hasNext()) {
                  Entity entity = (Entity) iterator.next();
                  int j = entity.getEntityType().getChunkRange() * 16;

--- a/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4438d567dd779650533c7128ae8b25b8fd369836..89f6de173225315783a09aae2fe77a3ede2b78d5 100644
+index 561f50debcc5fe7cbff46aa1bfc7f3b4241ee77a..ea05b427fdf7489af7a0e96da9291e2e0a9cf49b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -583,4 +583,9 @@ public class PaperWorldConfig {
+@@ -588,4 +588,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd0e58574f4f07913161be489d031a011f059f8e..f0f94ac2432ad79d2957b7f723fe7eb9cbd36507 100644
+index 7ef3de74d52fc7c1499c1247a612cb6dddcbb587..71daef97e99642776a9507409f26eb035544fd81 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -593,4 +593,9 @@ public class PaperWorldConfig {
+@@ -598,4 +598,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0f94ac2432ad79d2957b7f723fe7eb9cbd36507..1b49c214998a5a9b424472df040d634d9fcc0c4a 100644
+index 71daef97e99642776a9507409f26eb035544fd81..729b58e94a4c71472710873f24cac2be779e9ce0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -571,10 +571,21 @@ public class PaperWorldConfig {
+@@ -576,10 +576,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b49c214998a5a9b424472df040d634d9fcc0c4a..d7e22e1bf886800adbe8ed7baa3349e5d2ee1818 100644
+index 729b58e94a4c71472710873f24cac2be779e9ce0..16c00efb81d961b0b2aaaddfeee1f7aeba25d675 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -609,4 +609,9 @@ public class PaperWorldConfig {
+@@ -614,4 +614,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d7e22e1bf886800adbe8ed7baa3349e5d2ee1818..de95bd406173c38fa8a745c201b5cd5fbec91702 100644
+index 16c00efb81d961b0b2aaaddfeee1f7aeba25d675..ecd248254923c24022d33aeb10bb0c84a887e5e8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -614,4 +614,11 @@ public class PaperWorldConfig {
+@@ -619,4 +619,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
@@ -56,7 +56,7 @@ index fe88179037f1a56cec3543910cfab67b0e2ebbe4..a91a581b25b19d62949f641847b63320
          return i;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index b6f7fd501432560d4ed557371bc770724ce032ce..21a9a0364ec6cfd28fcfc0a62d3465993dac1a1c 100644
+index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a620237a724168 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -146,21 +146,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -228,7 +228,7 @@ index b6f7fd501432560d4ed557371bc770724ce032ce..21a9a0364ec6cfd28fcfc0a62d346599
          List<EntityPlayer> list = Lists.newArrayList();
          List<EntityPlayer> list1 = this.world.getPlayers();
  
-@@ -1672,23 +1765,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1673,23 +1766,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          PacketDebug.a(this.world, chunk.getPos());
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
@@ -272,7 +272,7 @@ index b6f7fd501432560d4ed557371bc770724ce032ce..21a9a0364ec6cfd28fcfc0a62d346599
  
          Iterator iterator;
          Entity entity1;
-@@ -1726,7 +1827,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1727,7 +1828,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      public class EntityTracker {
  
@@ -281,7 +281,7 @@ index b6f7fd501432560d4ed557371bc770724ce032ce..21a9a0364ec6cfd28fcfc0a62d346599
          private final Entity tracker;
          private final int trackingDistance;
          private SectionPosition e;
-@@ -1743,6 +1844,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1744,6 +1845,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.e = SectionPosition.a(entity);
          }
  
@@ -324,7 +324,7 @@ index b6f7fd501432560d4ed557371bc770724ce032ce..21a9a0364ec6cfd28fcfc0a62d346599
          public boolean equals(Object object) {
              return object instanceof PlayerChunkMap.EntityTracker ? ((PlayerChunkMap.EntityTracker) object).tracker.getId() == this.tracker.getId() : false;
          }
-@@ -1843,7 +1980,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1844,7 +1981,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  int j = entity.getEntityType().getChunkRange() * 16;
                  j = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, j); // Paper
  

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de95bd406173c38fa8a745c201b5cd5fbec91702..9e55c800eb8b4dd4930dbf730bb6d106a2029036 100644
+index ecd248254923c24022d33aeb10bb0c84a887e5e8..768440a20977556e0fb7f61ce4d0ddd82c76da4e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -621,4 +621,9 @@ public class PaperWorldConfig {
+@@ -626,4 +626,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
@@ -244,7 +244,7 @@ index 69c7bbf6a83b07a3af62b8fabaa851c7f7dc9a98..bd5643cae88b0c510a630b6166d95368
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index b4067657eefe6a418b76b599b4c8ffb8359c3f89..3e73ef8059139b09518075bb6dc89a67f46be51a 100644
+index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908bc909266 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -96,7 +96,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -558,15 +558,16 @@ index b4067657eefe6a418b76b599b4c8ffb8359c3f89..3e73ef8059139b09518075bb6dc89a67
      }
  
      protected void addEntity(Entity entity) {
-@@ -1833,6 +1952,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1833,7 +1952,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
+-    private final void sendChunk(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) { this.a(entityplayer, apacket, chunk); } // Paper - OBFHELPER
 +    final void sendChunk(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) { this.a(entityplayer, apacket, chunk); } // Paper - OBFHELPER
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {
-             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535);
-@@ -2018,7 +2138,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
+@@ -2019,7 +2138,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
  

--- a/Spigot-Server-Patches/0484-Workaround-for-Client-Lag-Spikes-MC-162253.patch
+++ b/Spigot-Server-Patches/0484-Workaround-for-Client-Lag-Spikes-MC-162253.patch
@@ -37,7 +37,7 @@ index 39572cdce691a459cb9df0cc064fbf7bde83a99e..e52df8096e399c84ff8a2637fdd65ea5
          return chunksection == Chunk.a || chunksection.c();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 21aba92fe1b5036a4df3add7688019446a1d5fe5..fba7c9b5724114eab35a3d24febdee3cd3e30aa0 100644
+index 1685d6f9f497455636dbcef057db48f9d4039be4..e38c9a8f4bf017db9f296bffcd029f9603ee82f6 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1959,12 +1959,112 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -93,7 +93,7 @@ index 21aba92fe1b5036a4df3add7688019446a1d5fe5..fba7c9b5724114eab35a3d24febdee3c
 +                apacket = new Packet[10];
 +            }
 +            // Paper end
-             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535);
+             apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
              apacket[1] = new PacketPlayOutLightUpdate(chunk.getPos(), this.lightEngine, true);
 +
 +            // Paper start - Fix MC-162253

--- a/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9e55c800eb8b4dd4930dbf730bb6d106a2029036..62e25da19c7ffc13ef1f7dcc375585afd79bb59f 100644
+index 768440a20977556e0fb7f61ce4d0ddd82c76da4e..bdd5532e0d331941be6b65a11362c637a9a75889 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -626,4 +626,13 @@ public class PaperWorldConfig {
+@@ -631,4 +631,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62e25da19c7ffc13ef1f7dcc375585afd79bb59f..dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43 100644
+index bdd5532e0d331941be6b65a11362c637a9a75889..03779bdd0436dd4b6fa388eabb37bebc57a62890 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -635,4 +635,26 @@ public class PaperWorldConfig {
+@@ -640,4 +640,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43..5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8 100644
+index 03779bdd0436dd4b6fa388eabb37bebc57a62890..ae4b413075fadbb2701963df50a9d671e1f1fd50 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -657,4 +657,9 @@ public class PaperWorldConfig {
+@@ -662,4 +662,9 @@ public class PaperWorldConfig {
              maxLightningFlashDistance = 512; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8..8923314d731dea5c2707dbb271b8b0819d826a2e 100644
+index ae4b413075fadbb2701963df50a9d671e1f1fd50..4008fa73ede97e8efeca81dcdd846ab3a8e9bebf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -662,4 +662,14 @@ public class PaperWorldConfig {
+@@ -667,4 +667,14 @@ public class PaperWorldConfig {
      private void zombiesTargetTurtleEggs() {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }

--- a/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
+++ b/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8923314d731dea5c2707dbb271b8b0819d826a2e..9a0ade5875c34487a65f82f9380f9d25b4432586 100644
+index 4008fa73ede97e8efeca81dcdd846ab3a8e9bebf..66e4f23ab19fe162bbbee4d7ea6563e609179d04 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -672,4 +672,12 @@ public class PaperWorldConfig {
+@@ -677,4 +677,12 @@ public class PaperWorldConfig {
              log("Using vanilla redstone algorithm.");
          }
      }

--- a/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ff0e4447b6574e91bf8815de4e04ce881ed7026d..80b0c08cef9a5326492b1faec020929fca59ff77 100644
+index e4181ce15f26482205f81dbdf79f452b77942a3d..f6ad4aa50677f2c41be8b1930ef3ddd66bd653bf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -686,4 +686,17 @@ public class PaperWorldConfig {
+@@ -691,4 +691,17 @@ public class PaperWorldConfig {
              log("The Ender Dragon will be removed if she already exists without a portal.");
          }
      }

--- a/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 80b0c08cef9a5326492b1faec020929fca59ff77..5596d9f42523dbcbad47d21a4b2fdba39e3c5590 100644
+index f6ad4aa50677f2c41be8b1930ef3ddd66bd653bf..54236cad3f36503929426ecd2a918006d7730a28 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -699,4 +699,9 @@ public class PaperWorldConfig {
+@@ -704,4 +704,9 @@ public class PaperWorldConfig {
          wanderingTraderSpawnChanceMin = getInt("wandering-trader.spawn-chance-min", wanderingTraderSpawnChanceMin);
          wanderingTraderSpawnChanceMax = getInt("wandering-trader.spawn-chance-max", wanderingTraderSpawnChanceMax);
      }
@@ -19,7 +19,7 @@ index 80b0c08cef9a5326492b1faec020929fca59ff77..5596d9f42523dbcbad47d21a4b2fdba3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 0c952fea30aa6890809d728420e4710d95e10c19..e44e5652c12fbee51acedc1f911181b8443fae93 100644
+index 3309a3ea9dc895bc910238e10d993ff5f66d4240..d9021fde3d0908dc89384617055874ac356a8fcf 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1483,6 +1483,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -88,7 +88,7 @@ index 8af1fe5d820f3bcb5e02dd2300e8e9cbd7e4e201..fcb31147622b4b81934be05ffc8de5e8
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 6b3e521dac8823ac8103f5aa2b1ea62edb260a72..dd3287f953a1a24d2406816b3c0ae176476b6452 100644
+index 943cbd0a9ac449117812cad968bffcbc68cc2cf7..5f5cea628c7f4c10670524f5fd7d9328f9a685a0 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -43,7 +43,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;

--- a/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
@@ -8,10 +8,10 @@ and curing a villager on repeat by simply resetting the reputation when it
 is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5596d9f42523dbcbad47d21a4b2fdba39e3c5590..ae5ed3bd0b663092a4658b24cbd69d37b4e141cb 100644
+index 54236cad3f36503929426ecd2a918006d7730a28..2f94f274addee9f768913eb9bcd694e01a3dcf49 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -704,4 +704,9 @@ public class PaperWorldConfig {
+@@ -709,4 +709,9 @@ public class PaperWorldConfig {
      private void fixClimbingBypassingCrammingRule() {
          fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
      }

--- a/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ae5ed3bd0b663092a4658b24cbd69d37b4e141cb..3542746c427192ef836675af1acd002b20fd0649 100644
+index 2f94f274addee9f768913eb9bcd694e01a3dcf49..42eff22126dacdb4a9841ff521dce0b7ae60b227 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -709,4 +709,9 @@ public class PaperWorldConfig {
+@@ -714,4 +714,9 @@ public class PaperWorldConfig {
      private void fixCuringExploit() {
          fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
      }


### PR DESCRIPTION
This is a frequently requested feature. <strike>In rare cases two chunk packets
must be created.</strike> The permission is 'paper.antixray.bypass'. <strike>I have added
all the required OBFHELPERs to 0004-MC-Utils.patch.</strike>