### PR TITLE
Tweaked Patrol Spawning

### DIFF
--- a/Spigot-Server-Patches/0551-Tweaked-Patrol-Spawning.patch
+++ b/Spigot-Server-Patches/0551-Tweaked-Patrol-Spawning.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheShermanTanker <tanksherman27@gmail.com>
+Date: Sat, 8 Aug 2020 02:14:48 +0800
+Subject: [PATCH] Tweaked-Patrol-Spawning
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index e471e764935e2a89560de56959a782b02e5e8fe1..84d6dee81610a727a52026b80a5757ae1ab2ba23 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -578,14 +578,12 @@ public class PaperWorldConfig {
+         generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
+     }
+ 
+-    public boolean disablePillagerPatrols = false;
+     public double patrolSpawnChance = 0.2;
+     public boolean patrolPerPlayerDelay = false;
+     public int patrolDelay = 12000;
+     public boolean patrolPerPlayerStart = false;
+     public int patrolStartDay = 5;
+     private void pillagerSettings() {
+-        disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
+         patrolSpawnChance = getDouble("game-mechanics.pillager-patrols.spawn-chance", patrolSpawnChance);
+         patrolPerPlayerDelay = getBoolean("game-mechanics.pillager-patrols.spawn-delay.per-player", patrolPerPlayerDelay);
+         patrolDelay = getInt("game-mechanics.pillager-patrols.spawn-delay.ticks", patrolDelay);
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+index 776e54ff472a67f535dfb409e753325a1105bcce..af6828809dad5c16f0910678c6ef399893a5233c 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerPatrol.java
+@@ -10,10 +10,8 @@ public class MobSpawnerPatrol implements MobSpawner {
+ 
+     @Override
+     public int a(WorldServer worldserver, boolean flag, boolean flag1) {
+-        if (worldserver.paperConfig.disablePillagerPatrols || worldserver.paperConfig.patrolSpawnChance == 0) return 0; // Paper
+-        if (!flag) {
+-            return 0;
+-        } else if (!worldserver.getGameRules().getBoolean(GameRules.DO_PATROL_SPAWNING)) {
++        if (worldserver.paperConfig.patrolSpawnChance == 0) return 0; // Paper
++        if (!worldserver.getGameRules().getBoolean(GameRules.DO_PATROL_SPAWNING)) { //Paper - Made Patrols a fully unique event unaffected by natural mob spawn rules
+             return 0;
+         } else {
+             Random random = worldserver.random;


### PR DESCRIPTION
Tweaked Patrol Spawning to make it a truly unique event rather than obey Natural Mob Spawning laws to fit other event based spawns (Also removed redundant option to disable said Patrols)