### PR TITLE
Use block distance in portal search radius

### DIFF
--- a/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
@@ -5,23 +5,25 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62e793b71b313146b86b466421e7a5f894bef9df..cd47a4ca069df26969de3051c2aac80540093818 100644
+index 62e793b71b313146b86b466421e7a5f894bef9df..cec28bfaaa4498308ce6ac0a0ec0f711826b9457 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -191,4 +191,11 @@ public class PaperWorldConfig {
+@@ -191,4 +191,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
 +
 +    public int portalSearchRadius;
++    public boolean portalSearchRadiusExact;
 +    public int portalCreateRadius;
 +    private void portalSearchRadius() {
 +        portalSearchRadius = getInt("portal-search-radius", 128);
++        portalSearchRadiusExact = getBoolean("portal-search-radius-exact", false);
 +        portalCreateRadius = getInt("portal-create-radius", 16);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 9e132052e1a9b997300e3f5d88473fc5f9ebdd73..1a8fc714f6e4663fc02c1df6a67aaa37d48f743d 100644
+index d151340f346b1d34e0d7eed93fceebefbec6799c..4aee6e73017de0cd71b87f62eb3dc5bf7fa96ac5 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2508,7 +2508,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -48,7 +50,7 @@ index 5dce27334541d55c7a7d494cd92370570615dc05..2cdb999dd78611e6f72ef06d9128f21a
              if (event.isCancelled() || event.getTo() == null) {
                  return null;
 diff --git a/src/main/java/net/minecraft/server/PortalTravelAgent.java b/src/main/java/net/minecraft/server/PortalTravelAgent.java
-index 8eacfc66dc04bba89c8e1c03746c67068e07718b..f6ec165f9c7d83698100c85b1d4bf6b4cea0f458 100644
+index 8eacfc66dc04bba89c8e1c03746c67068e07718b..46bbf92f60e2a0198493d83577f44d89f77977c5 100644
 --- a/src/main/java/net/minecraft/server/PortalTravelAgent.java
 +++ b/src/main/java/net/minecraft/server/PortalTravelAgent.java
 @@ -45,7 +45,7 @@ public class PortalTravelAgent {
@@ -60,7 +62,7 @@ index 8eacfc66dc04bba89c8e1c03746c67068e07718b..f6ec165f9c7d83698100c85b1d4bf6b4
      }
  
      @Nullable
-@@ -53,7 +53,7 @@ public class PortalTravelAgent {
+@@ -53,15 +53,23 @@ public class PortalTravelAgent {
          // CraftBukkit end
          VillagePlace villageplace = this.world.x();
  
@@ -69,3 +71,24 @@ index 8eacfc66dc04bba89c8e1c03746c67068e07718b..f6ec165f9c7d83698100c85b1d4bf6b4
          List<VillagePlaceRecord> list = (List) villageplace.b((villageplacetype) -> {
              return villageplacetype == VillagePlaceType.v;
          }, blockposition, searchRadius, VillagePlace.Occupancy.ANY).collect(Collectors.toList()); // CraftBukkit - searchRadius
+-        Optional<VillagePlaceRecord> optional = list.stream().min(Comparator.<VillagePlaceRecord>comparingDouble((villageplacerecord) -> { // CraftBukkit - decompile error
+-            return villageplacerecord.f().j(blockposition);
+-        }).thenComparingInt((villageplacerecord) -> {
+-            return villageplacerecord.f().getY();
+-        }));
++        // Paper start - filter by searchRadius
++        if (world.paperConfig.portalSearchRadiusExact)
++            list.removeIf(villagePlaceRecord -> {
++                BlockPosition portalPosition = villagePlaceRecord.f();
++                return Math.abs(portalPosition.getX() - blockposition.getX()) > searchRadius || Math.abs(portalPosition.getZ() - blockposition.getZ()) > searchRadius;
++            });
++        Optional<VillagePlaceRecord> optional = list.size() == 0 ? Optional.empty() : Optional.of(
++            java.util.Collections.min(list, Comparator.<VillagePlaceRecord>comparingDouble((villageplacerecord) -> {
++                return villageplacerecord.f().j(blockposition);
++            }).thenComparingInt((villageplacerecord) -> {
++                return villageplacerecord.f().getY();
++            })));
++        // Paper end
+ 
+         return (ShapeDetector.Shape) optional.map((villageplacerecord) -> {
+             BlockPosition blockposition1 = villageplacerecord.f();

--- a/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,11 +16,11 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cd47a4ca069df26969de3051c2aac80540093818..abbf59bb91021821876a8960e8f77fac24457ec4 100644
+index cec28bfaaa4498308ce6ac0a0ec0f711826b9457..b3909b9de543069b3f4735bdbdcfa5e46c18fb06 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -198,4 +198,9 @@ public class PaperWorldConfig {
-         portalSearchRadius = getInt("portal-search-radius", 128);
+@@ -200,4 +200,9 @@ public class PaperWorldConfig {
+         portalSearchRadiusExact = getBoolean("portal-search-radius-exact", false);
          portalCreateRadius = getInt("portal-create-radius", 16);
      }
 +

--- a/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index abbf59bb91021821876a8960e8f77fac24457ec4..04430aae52205ee167662004e45c145b9d2e8bed 100644
+index b3909b9de543069b3f4735bdbdcfa5e46c18fb06..7382344e02ff3fcde62a82e8cf4c096e97bf535d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -203,4 +203,9 @@ public class PaperWorldConfig {
+@@ -205,4 +205,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }
@@ -25,7 +25,7 @@ index abbf59bb91021821876a8960e8f77fac24457ec4..04430aae52205ee167662004e45c145b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 1a8fc714f6e4663fc02c1df6a67aaa37d48f743d..1903635fd3416965adbbba5af38ff29dac0c6670 100644
+index 4aee6e73017de0cd71b87f62eb3dc5bf7fa96ac5..e080eac070d427e3bbd52c5bfe826102c73d93d9 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2201,6 +2201,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -37,7 +37,7 @@ index 1a8fc714f6e4663fc02c1df6a67aaa37d48f743d..1903635fd3416965adbbba5af38ff29d
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 8fc632b4b0d79efaced83ea9b39b5727f6f5ebef..d96f6736826896d2b7f482fba0c5125edf2ce3c0 100644
+index 8667a7a13008a8ddc4a9a337cf6c097c6affea35..ac608392ec480b927ce5047cc0519ea06a68e040 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -641,6 +641,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04430aae52205ee167662004e45c145b9d2e8bed..d8b9d87bca6eb95c2cea91e4d8466b9792582d52 100644
+index 7382344e02ff3fcde62a82e8cf4c096e97bf535d..fdb0608c9a9dd031a7c0ebcd2bdb89ef80e54399 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -208,4 +208,19 @@ public class PaperWorldConfig {
+@@ -210,4 +210,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/Spigot-Server-Patches/0070-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/Spigot-Server-Patches/0070-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d8b9d87bca6eb95c2cea91e4d8466b9792582d52..92d1dffbf436a21943b4a6aa0fabf54f064e6046 100644
+index fdb0608c9a9dd031a7c0ebcd2bdb89ef80e54399..e61878c830980f6a1c68556dc5cc753aff6f021b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -223,4 +223,12 @@ public class PaperWorldConfig {
+@@ -225,4 +225,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/Spigot-Server-Patches/0074-Configurable-Chunk-Inhabited-Time.patch
+++ b/Spigot-Server-Patches/0074-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 92d1dffbf436a21943b4a6aa0fabf54f064e6046..725958efab3dd05e04b7b18e169230762ef800d0 100644
+index e61878c830980f6a1c68556dc5cc753aff6f021b..cf343ed5aec7a6424286d39ace798a2d814439c5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -231,4 +231,14 @@ public class PaperWorldConfig {
+@@ -233,4 +233,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }
@@ -30,7 +30,7 @@ index 92d1dffbf436a21943b4a6aa0fabf54f064e6046..725958efab3dd05e04b7b18e16923076
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index dc65ad095f9ec281c13f04254311d9cea80f43f8..c0b5d25f63741947c0d8ee32f317eb7fd3db4b65 100644
+index 64a1c6f4672626818e28842bca7e8d78d013d14a..71c2588269bacc58526221061b5fe68f25ceaa63 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -977,7 +977,7 @@ public class Chunk implements IChunkAccess {

--- a/Spigot-Server-Patches/0080-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/Spigot-Server-Patches/0080-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 725958efab3dd05e04b7b18e169230762ef800d0..fe2c8001897dc6d66ce0d24ddb1a5d3b79810294 100644
+index cf343ed5aec7a6424286d39ace798a2d814439c5..73c043ede252966f0cb7ac9357b586447798ec23 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -241,4 +241,10 @@ public class PaperWorldConfig {
+@@ -243,4 +243,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fe2c8001897dc6d66ce0d24ddb1a5d3b79810294..538e6751f3bda77ba32256158d2a6a25025b360c 100644
+index 73c043ede252966f0cb7ac9357b586447798ec23..95f3c36d76440549f0213954e14c13ccf41d01b5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -247,4 +247,9 @@ public class PaperWorldConfig {
+@@ -249,4 +249,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/Spigot-Server-Patches/0093-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/Spigot-Server-Patches/0093-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 538e6751f3bda77ba32256158d2a6a25025b360c..fd3793c55b8021b9fc61ce6be585a8c9b477aba2 100644
+index 95f3c36d76440549f0213954e14c13ccf41d01b5..12e55f84cfaa8e5aa135513b50a3f487dfb98fb4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -252,4 +252,14 @@ public class PaperWorldConfig {
+@@ -254,4 +254,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd3793c55b8021b9fc61ce6be585a8c9b477aba2..05ea87a473228f5b386258fae3943f3f4561eaa6 100644
+index 12e55f84cfaa8e5aa135513b50a3f487dfb98fb4..6783d0a29919d3f3f10fd401e5b7c94d3423bb2c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -262,4 +262,26 @@ public class PaperWorldConfig {
+@@ -264,4 +264,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 05ea87a473228f5b386258fae3943f3f4561eaa6..ac76bdd7e1d91b0d242539c4495948cdfbb622e0 100644
+index 6783d0a29919d3f3f10fd401e5b7c94d3423bb2c..c664e96f8cca4cd8bf975a7907c8b82afd54c151 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,7 +2,6 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 05ea87a473228f5b386258fae3943f3f4561eaa6..ac76bdd7e1d91b0d242539c4495948cd
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -284,4 +283,14 @@ public class PaperWorldConfig {
+@@ -286,4 +285,14 @@ public class PaperWorldConfig {
              );
          }
      }
@@ -32,7 +32,7 @@ index 05ea87a473228f5b386258fae3943f3f4561eaa6..ac76bdd7e1d91b0d242539c4495948cd
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 562f2e3e639a07852951081ea0887a9c582be6c5..14351cc9e60a0b8d33d319da9d473e74072767d7 100644
+index 05a297534e1986226404f5fa27d817eb0fe87fec..62516bd33f52c01502157def48601f129e49b618 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2652,6 +2652,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0115-Option-to-remove-corrupt-tile-entities.patch
+++ b/Spigot-Server-Patches/0115-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ac76bdd7e1d91b0d242539c4495948cdfbb622e0..6cb717a63f52d757b0b323408d2fc0c3d7db77da 100644
+index c664e96f8cca4cd8bf975a7907c8b82afd54c151..c00e5f1833f745ac0806b5e54b2ab8e662d7bb20 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -293,4 +293,9 @@ public class PaperWorldConfig {
+@@ -295,4 +295,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }
@@ -19,7 +19,7 @@ index ac76bdd7e1d91b0d242539c4495948cdfbb622e0..6cb717a63f52d757b0b323408d2fc0c3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index c0b5d25f63741947c0d8ee32f317eb7fd3db4b65..fdc02b512f2d4bc968977564d520bc7ec7189c69 100644
+index 71c2588269bacc58526221061b5fe68f25ceaa63..4185c28a86f8cdbe18c913a30734b002b4b74cd5 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -637,6 +637,12 @@ public class Chunk implements IChunkAccess {

--- a/Spigot-Server-Patches/0117-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/Spigot-Server-Patches/0117-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6cb717a63f52d757b0b323408d2fc0c3d7db77da..e43aee3757b6765d898b50ebfff1a28071638558 100644
+index c00e5f1833f745ac0806b5e54b2ab8e662d7bb20..fd680b591e17d2f442e0ea1589ee5a18169d37b9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,6 +2,7 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 6cb717a63f52d757b0b323408d2fc0c3d7db77da..e43aee3757b6765d898b50ebfff1a280
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -298,4 +299,12 @@ public class PaperWorldConfig {
+@@ -300,4 +301,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e43aee3757b6765d898b50ebfff1a28071638558..255b4081314162cbe344b008158c6f4584795fb8 100644
+index fd680b591e17d2f442e0ea1589ee5a18169d37b9..abb2a97ebc52910adb4d26ce252d5c90e43d06e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -307,4 +307,14 @@ public class PaperWorldConfig {
+@@ -309,4 +309,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 255b4081314162cbe344b008158c6f4584795fb8..04ee0856a8c62e1afb438d4fddf40e605e82a074 100644
+index abb2a97ebc52910adb4d26ce252d5c90e43d06e3..0e464b92a4a792a41eaba786c5f090f292914f76 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -317,4 +317,10 @@ public class PaperWorldConfig {
+@@ -319,4 +319,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }
@@ -27,7 +27,7 @@ index 255b4081314162cbe344b008158c6f4584795fb8..04ee0856a8c62e1afb438d4fddf40e60
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index bd270ea92404c2055c09324988e1ec28109a8815..912f5be0264b604df175f5825765b03b319a841c 100644
+index b88cea66f69d5c20d40becba8b33ae0eabbed8e6..689385a3b077b49afb7ba4955153e4a6ab2572d2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -188,6 +188,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04ee0856a8c62e1afb438d4fddf40e605e82a074..0cc7ad571eba249199a2e5e8ec567a874241c903 100644
+index 0e464b92a4a792a41eaba786c5f090f292914f76..bfe103a70da38c452e5ecfe2eb8541cca0e708da 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -323,4 +323,10 @@ public class PaperWorldConfig {
+@@ -325,4 +325,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }
@@ -39,7 +39,7 @@ index d1cf7602a0c47723593be11c030d3c819426d4d4..0dc2ffcfceeffed2cb949d31c4f976bc
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index e04bb290a94f5cfc93b5bd2121e6b32610199237..f62357be4225fa48dd445f0843c99235276566c7 100644
+index 71e52d4a114bca5d3a2edea4988db7848c0c638f..d6d7157be629de98f7cdc93f2d689c9b1d1ad31d 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1818,6 +1818,13 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0cc7ad571eba249199a2e5e8ec567a874241c903..e30f48caf2ce4f48f371b2594b765c27bc9e9778 100644
+index bfe103a70da38c452e5ecfe2eb8541cca0e708da..38baa02a19412377f251fa775126438775a71fc8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -329,4 +329,10 @@ public class PaperWorldConfig {
+@@ -331,4 +331,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/Spigot-Server-Patches/0176-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0176-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e30f48caf2ce4f48f371b2594b765c27bc9e9778..2d8b354d707e8b5b0e7cd644fb93bc8f1c4009f1 100644
+index 38baa02a19412377f251fa775126438775a71fc8..2caeb2fc456b8b3e5e7fdda8e16fa5f4961c5e6f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -335,4 +335,10 @@ public class PaperWorldConfig {
+@@ -337,4 +337,10 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/Spigot-Server-Patches/0186-Make-max-squid-spawn-height-configurable.patch
+++ b/Spigot-Server-Patches/0186-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2d8b354d707e8b5b0e7cd644fb93bc8f1c4009f1..48fa2483fc657b36b8f2fd7d8b35703cff2698a5 100644
+index 2caeb2fc456b8b3e5e7fdda8e16fa5f4961c5e6f..1b228cc566b9c278e434b4fc41c56a2853075299 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -341,4 +341,9 @@ public class PaperWorldConfig {
+@@ -343,4 +343,9 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }

--- a/Spigot-Server-Patches/0210-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0210-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3804c7cf96087cdf94fd5fbdce4ebcdafa9e0019..873f81c74a94f6d76edd45e34ddc476dc525b47c 100644
+index f46145e7c1d93d95d1de08f9f929115f897e2a00..c25d7b2bd0209578544a84cddef2abde1a27a6b8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -351,4 +351,9 @@ public class PaperWorldConfig {
+@@ -353,4 +353,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }
@@ -20,7 +20,7 @@ index 3804c7cf96087cdf94fd5fbdce4ebcdafa9e0019..873f81c74a94f6d76edd45e34ddc476d
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 74950d74e6a11d5552369e830f9fdd63c4306221..e05e56f464c643925abfdf04bd745e3932ca001d 100644
+index 506830aba36dc990a0d04c894c2c59e63178f170..c9019ccee8942bf0aace0d7adb1157c4e0861cbf 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -1091,7 +1091,11 @@ public abstract class EntityHuman extends EntityLiving {

--- a/Spigot-Server-Patches/0214-Block-Enderpearl-Travel-Exploit.patch
+++ b/Spigot-Server-Patches/0214-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 873f81c74a94f6d76edd45e34ddc476dc525b47c..69009246f12cc3acb0055af746e01097fa668e1b 100644
+index c25d7b2bd0209578544a84cddef2abde1a27a6b8..c9bfc4d74a62288380e107d257ad592b38c0e9d8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -356,4 +356,10 @@ public class PaperWorldConfig {
+@@ -358,4 +358,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/Spigot-Server-Patches/0227-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0227-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 69009246f12cc3acb0055af746e01097fa668e1b..35075ffac394153e28039809e0ed48fe066a6223 100644
+index c9bfc4d74a62288380e107d257ad592b38c0e9d8..55f8b761d4e377c152ab6022d152591e7d1fc882 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -362,4 +362,9 @@ public class PaperWorldConfig {
+@@ -364,4 +364,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/Spigot-Server-Patches/0235-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/Spigot-Server-Patches/0235-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 35075ffac394153e28039809e0ed48fe066a6223..6352051ab937d4d365e823a7112e76dc3ec34225 100644
+index 55f8b761d4e377c152ab6022d152591e7d1fc882..d39c68786ec45df9549dc9e2cf143c3d3a3d997d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -367,4 +367,9 @@ public class PaperWorldConfig {
+@@ -369,4 +369,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/Spigot-Server-Patches/0238-Configurable-Bed-Search-Radius.patch
+++ b/Spigot-Server-Patches/0238-Configurable-Bed-Search-Radius.patch
@@ -10,10 +10,10 @@ player at their bed should it of became obstructed.
 Defaults to vanilla 1.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6352051ab937d4d365e823a7112e76dc3ec34225..d6a3d882e375ac5a2b6ec8920532db615f4fe4ef 100644
+index d39c68786ec45df9549dc9e2cf143c3d3a3d997d..50e9114288fe45a27b18495929d552d0757d97ed 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -372,4 +372,15 @@ public class PaperWorldConfig {
+@@ -374,4 +374,15 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/Spigot-Server-Patches/0251-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0251-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d6a3d882e375ac5a2b6ec8920532db615f4fe4ef..14bb9d843f05058cae5cc64de8149d2c97264f1a 100644
+index 50e9114288fe45a27b18495929d552d0757d97ed..49c8a1f534957f2875a751f600c0890b5e3bb41b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -383,4 +383,9 @@ public class PaperWorldConfig {
+@@ -385,4 +385,9 @@ public class PaperWorldConfig {
              log("Bed Search Radius: " + bedSearchRadius);
          }
      }

--- a/Spigot-Server-Patches/0272-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0272-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 14bb9d843f05058cae5cc64de8149d2c97264f1a..661694da6cfbed5e3e26de2355e67a5a6d17a3fc 100644
+index 49c8a1f534957f2875a751f600c0890b5e3bb41b..118418331b8ef8fba23fc5c5fe80f32e6c86de6c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -388,4 +388,10 @@ public class PaperWorldConfig {
+@@ -390,4 +390,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }
@@ -20,7 +20,7 @@ index 14bb9d843f05058cae5cc64de8149d2c97264f1a..661694da6cfbed5e3e26de2355e67a5a
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index a70b1a17fe884980ef7c3c0a36e567a0e69ef7f0..d5c09152acc93b25d626284071599afdbd76b709 100644
+index 8beb3cb9efbb8953dd24390fe58240f3b9841e79..c3dcccd7ae8267e5db942b46d48ee8b71a680960 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -44,6 +44,12 @@ public class EntityArmorStand extends EntityLiving {

--- a/Spigot-Server-Patches/0277-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/Spigot-Server-Patches/0277-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 661694da6cfbed5e3e26de2355e67a5a6d17a3fc..37bd28f18d3f48767d8141bde3395b8443d5650a 100644
+index 118418331b8ef8fba23fc5c5fe80f32e6c86de6c..6646c237c919182043aaa2e81bc1f34bd661bda8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -394,4 +394,10 @@ public class PaperWorldConfig {
+@@ -396,4 +396,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/Spigot-Server-Patches/0309-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0309-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 37bd28f18d3f48767d8141bde3395b8443d5650a..a73b88d51608ce94f6e4c9013c8c4de97523fe42 100644
+index 6646c237c919182043aaa2e81bc1f34bd661bda8..b03a46c05bc5b2b6d8951d51f94bf826106d1634 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -400,4 +400,9 @@ public class PaperWorldConfig {
+@@ -402,4 +402,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }
@@ -20,7 +20,7 @@ index 37bd28f18d3f48767d8141bde3395b8443d5650a..a73b88d51608ce94f6e4c9013c8c4de9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index d33657d94a4e9c6563fbc7826e18624528c498f5..b1bad421650a8c93cdc38d1f4f83ab1c39e2f624 100644
+index b9da13a60662d8197290382725e4069f4617a5ad..3d673e6a2d40f21e2ecc3de6409e9ecf34df5a80 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -350,6 +350,13 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0359-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0359-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a73b88d51608ce94f6e4c9013c8c4de97523fe42..6e29e3294d0661cc35d53b4201d980a2db4f5c93 100644
+index b03a46c05bc5b2b6d8951d51f94bf826106d1634..93fb17176822f1581dd7c8fe37e50ad888798ad6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -405,4 +405,43 @@ public class PaperWorldConfig {
+@@ -407,4 +407,43 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/Spigot-Server-Patches/0361-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0361-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6e29e3294d0661cc35d53b4201d980a2db4f5c93..6e1756eb90b6237100612527f69c995246d53ed1 100644
+index 93fb17176822f1581dd7c8fe37e50ad888798ad6..8745d5094f84416a8bd47fac2fed33544054f88f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -444,4 +444,10 @@ public class PaperWorldConfig {
+@@ -446,4 +446,10 @@ public class PaperWorldConfig {
                  break;
          }
      }
@@ -21,7 +21,7 @@ index 6e29e3294d0661cc35d53b4201d980a2db4f5c93..6e1756eb90b6237100612527f69c9952
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b9e047643e1c3f84f26d936fcb067f607018ef34..d6a3c51826ac82fd46b8f6c98be7bf405ffa3f38 100644
+index 3cef06734e2c6d9b49dd6307f285d00127b66233..0b3db615eb9b25968644326f06c2f9c8550a0798 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -607,6 +607,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -198,7 +198,7 @@ index 41c68de8119dc53a033ac005d69cd57d38b4f719..7b4182a0dc9aaa76f0a4a3b09cc497bc
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 48805c32aabe453e0a860168b79ea9026fa848b1..b5621b8456fbd3c5e94a9b9ec9b4be0068962674 100644
+index 17e181068794b07e5d7bddb21d865ef9ba05be6c..c99932bc38ac2bb0bd82c694a76b844efcdbdd52 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1949,15 +1949,21 @@ public class CraftWorld implements World {

--- a/Spigot-Server-Patches/0370-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0370-incremental-chunk-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6e1756eb90b6237100612527f69c995246d53ed1..5f3c8f74a60f9446623b863f9297402be1cd2f88 100644
+index 8745d5094f84416a8bd47fac2fed33544054f88f..128b0cdee5d37f4e360f97aec6b85afb47833a49 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -450,4 +450,19 @@ public class PaperWorldConfig {
+@@ -452,4 +452,19 @@ public class PaperWorldConfig {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }
@@ -29,7 +29,7 @@ index 6e1756eb90b6237100612527f69c995246d53ed1..5f3c8f74a60f9446623b863f9297402b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 141f2e8975b01fc2a5e7743955894f100c3062a2..8a316f732644886c476921c69838e9cb8b93a5b5 100644
+index 81b7b6c110dfce7185ab59d41d7ef7d648522787..0073f8abe4001a4ea0fda97a1607d6317cbd3485 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -43,7 +43,7 @@ public class Chunk implements IChunkAccess {
@@ -62,7 +62,7 @@ index 726926f19c6725c1d935beec2f0f766d7466835e..f2ff1aa915c218bb1fc72467ccbd73cc
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d6a3c51826ac82fd46b8f6c98be7bf405ffa3f38..4ffd9c1d7b4fc2f42fa157b2235365cab41e295f 100644
+index 0b3db615eb9b25968644326f06c2f9c8550a0798..7291946fdd283685b5eedf3503fb4c52544acc7b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -152,6 +152,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -171,7 +171,7 @@ index 3b0d13d319fe1d274ab657c7c87e5a2db5c02c4f..3e1c1253ad5e2fa68fd8a0bac100c2e7
      public void a(ProtoChunkExtension protochunkextension) {
          for (int i = 0; i < this.statusFutures.length(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 6dda11ffc022aa9bc7481506811a710a184f5e78..39d89d6209123ae2146ae292009cad44c25f490a 100644
+index dbfd1f4d2156a99ff11bc295d3751eadc87fd40c..17c656a6cbbefea211414e8685d0f6b6aacb61c2 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -333,6 +333,64 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {

--- a/Spigot-Server-Patches/0371-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0371-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5f3c8f74a60f9446623b863f9297402be1cd2f88..c2cc7b8ebb1b15cf2c080ef5f78c5215d7c20828 100644
+index 128b0cdee5d37f4e360f97aec6b85afb47833a49..4507ccdc459e41339707c883b10db8d7dd709f12 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index 5f3c8f74a60f9446623b863f9297402be1cd2f88..c2cc7b8ebb1b15cf2c080ef5f78c5215
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -465,4 +467,31 @@ public class PaperWorldConfig {
+@@ -467,4 +469,31 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }

--- a/Spigot-Server-Patches/0372-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0372-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c2cc7b8ebb1b15cf2c080ef5f78c5215d7c20828..bccc2cb3e76aa3ffe1c4200f1b7380d136cb2f96 100644
+index 4507ccdc459e41339707c883b10db8d7dd709f12..e585e26bfe6c4c3b322dd3c06b9091c32f63698d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -468,6 +468,16 @@ public class PaperWorldConfig {
+@@ -470,6 +470,16 @@ public class PaperWorldConfig {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
  

--- a/Spigot-Server-Patches/0373-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0373-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bccc2cb3e76aa3ffe1c4200f1b7380d136cb2f96..822b738f48578b39f81bb8e38208dc3d26c2a221 100644
+index e585e26bfe6c4c3b322dd3c06b9091c32f63698d..a49b0beb4789c0e63899d9a316a901c68bc5264c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -504,4 +504,9 @@ public class PaperWorldConfig {
+@@ -506,4 +506,9 @@ public class PaperWorldConfig {
          }
          log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }

--- a/Spigot-Server-Patches/0380-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0380-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 822b738f48578b39f81bb8e38208dc3d26c2a221..ce0db77ccd24c3543c7894db4044bed03ea776d8 100644
+index a49b0beb4789c0e63899d9a316a901c68bc5264c..6e40ce2ad44953b54b5020f67932d28820a99bd5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,10 +1,15 @@
@@ -24,7 +24,7 @@ index 822b738f48578b39f81bb8e38208dc3d26c2a221..ce0db77ccd24c3543c7894db4044bed0
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -509,4 +514,52 @@ public class PaperWorldConfig {
+@@ -511,4 +516,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0383-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0383-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ce0db77ccd24c3543c7894db4044bed03ea776d8..edf4fa474d32ac20ff85cecfa9f03464a7ecf6ec 100644
+index 6e40ce2ad44953b54b5020f67932d28820a99bd5..043a2ca983ee5a7e90ff51f368efc7a982d5a464 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -562,4 +562,9 @@ public class PaperWorldConfig {
+@@ -564,4 +564,9 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -617,7 +617,7 @@ index b9fe08301409bc1f0d61a7566c26e720ff720d80..18a806ebbf092b904983691529ce5edf
          return this.bf;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index cacf60563826da0219754a67500fdc239b13f0cd..f06c41d06f853b625dbd46822126810da3c3264a 100644
+index 33becdbf730151e386f1d9aa727a8060b42e7abc..7268f63e733547cf0fbe54193ccd7bcb90ec8edd 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -80,7 +80,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {

--- a/Spigot-Server-Patches/0387-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0387-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index edf4fa474d32ac20ff85cecfa9f03464a7ecf6ec..fde31f324b3578c65a7d064c466b80ee46b65e03 100644
+index 043a2ca983ee5a7e90ff51f368efc7a982d5a464..627b9f69202d70dcd8b8ea6875936631281fda45 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -567,4 +567,9 @@ public class PaperWorldConfig {
+@@ -569,4 +569,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0393-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0393-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fde31f324b3578c65a7d064c466b80ee46b65e03..c51a149fd9cd7f2d250f07a4ca0e7ce8c9b91383 100644
+index 627b9f69202d70dcd8b8ea6875936631281fda45..86d768c2ba8369d717b5b074c88610e206e94018 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -572,4 +572,9 @@ public class PaperWorldConfig {
+@@ -574,4 +574,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0398-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0398-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c51a149fd9cd7f2d250f07a4ca0e7ce8c9b91383..f0a28d787e06ceae71034f757637b4c90b6f3c04 100644
+index 86d768c2ba8369d717b5b074c88610e206e94018..7b968f6820a561bdc8473e8f59214e47b2c9f208 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -577,4 +577,9 @@ public class PaperWorldConfig {
+@@ -579,4 +579,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0a28d787e06ceae71034f757637b4c90b6f3c04..9bd64034587217743157a81c04fc20751474e21d 100644
+index 7b968f6820a561bdc8473e8f59214e47b2c9f208..448051ba30444a2265b1eec92f396bfb48cbb7fb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -582,4 +582,13 @@ public class PaperWorldConfig {
+@@ -584,4 +584,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0419-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0419-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9bd64034587217743157a81c04fc20751474e21d..796c5a0b110009b479f5c9eef17e2605b564ce09 100644
+index 448051ba30444a2265b1eec92f396bfb48cbb7fb..55370bfd1eee907e0181f4bfd3d920e7dbafff09 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -591,4 +591,9 @@ public class PaperWorldConfig {
+@@ -593,4 +593,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
@@ -32,7 +32,7 @@ index e5b8d45ed9f62c28b0429859593d881546ccead2..77f8d5e6662fa75e622f07b3e6efae04
              }
          }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 39a7b8743a0612f818cda3796b5f6ae1137a7eee..c49d157b8ca25f9811bf64396c207b1c1d6e085d 100644
+index 73e02dfdb96104805df298e45c22983682b4216f..7f21d1a888a371468da5d318153e22a0baf0b64c 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -194,6 +194,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0424-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/Spigot-Server-Patches/0424-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 796c5a0b110009b479f5c9eef17e2605b564ce09..1b2256144f7f968667570e5a9838a77173d515c5 100644
+index 55370bfd1eee907e0181f4bfd3d920e7dbafff09..091e30163a11d6e987154aeedf0ca47d352c7a96 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -380,6 +380,11 @@ public class PaperWorldConfig {
+@@ -382,6 +382,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/Spigot-Server-Patches/0425-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0425-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b2256144f7f968667570e5a9838a77173d515c5..f888fc1c5ef4212f81ed936da6485abadc336407 100644
+index 091e30163a11d6e987154aeedf0ca47d352c7a96..b23879ece0026d6d862ecc8bfd3e5fbe9439e877 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -601,4 +601,9 @@ public class PaperWorldConfig {
+@@ -603,4 +603,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0428-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0428-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f888fc1c5ef4212f81ed936da6485abadc336407..b987399ca3786a30f87c98658e8bf04d4aa2e2da 100644
+index b23879ece0026d6d862ecc8bfd3e5fbe9439e877..2f9ea69a43c9e77fb55c33ecdf4cadfc395d267d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -579,10 +579,21 @@ public class PaperWorldConfig {
+@@ -581,10 +581,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0438-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0438-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b987399ca3786a30f87c98658e8bf04d4aa2e2da..08949526752e4d66e4c0df11f76f6500846e1fe4 100644
+index 2f9ea69a43c9e77fb55c33ecdf4cadfc395d267d..271a73f0a7f77fafe49c409e428cece7899d09f1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -617,4 +617,9 @@ public class PaperWorldConfig {
+@@ -619,4 +619,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
@@ -28,7 +28,7 @@ index b987399ca3786a30f87c98658e8bf04d4aa2e2da..08949526752e4d66e4c0df11f76f6500
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 99b6a4d277816699a5abd9ec889535c064758e97..0d91765cb6386c9483a6b5494e37bd7806638928 100644
+index 28c7599a97942c14fe44c25807681973c9858c16..dd41f70db6aa50e7e79351d2a3bb321f284dc56e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -662,7 +662,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/Spigot-Server-Patches/0468-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0468-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 08949526752e4d66e4c0df11f76f6500846e1fe4..13b89276feb76fcecaeefc166a1bc161d5931d9d 100644
+index 271a73f0a7f77fafe49c409e428cece7899d09f1..6057f9fc3c4302d67752272065bda23a1cbc41f2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -622,4 +622,11 @@ public class PaperWorldConfig {
+@@ -624,4 +624,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0480-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0480-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 13b89276feb76fcecaeefc166a1bc161d5931d9d..5af7e5c815752f2fd2b13c02a905796971401813 100644
+index 6057f9fc3c4302d67752272065bda23a1cbc41f2..479e359869c9e11a875a7413b7c0137a9aac17d2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -629,4 +629,9 @@ public class PaperWorldConfig {
+@@ -631,4 +631,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/Spigot-Server-Patches/0505-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0505-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5af7e5c815752f2fd2b13c02a905796971401813..6e6534ab25dbebbad5d2ee848edb88ebcae86d03 100644
+index 479e359869c9e11a875a7413b7c0137a9aac17d2..4051b5e29f017d0bda2ec962c7b04b9991265dbf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -634,4 +634,13 @@ public class PaperWorldConfig {
+@@ -636,4 +636,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0517-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0517-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6e6534ab25dbebbad5d2ee848edb88ebcae86d03..e471e764935e2a89560de56959a782b02e5e8fe1 100644
+index 4051b5e29f017d0bda2ec962c7b04b9991265dbf..19ac896f244953cda9189b777639a7fa48b4e705 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -643,4 +643,26 @@ public class PaperWorldConfig {
+@@ -645,4 +645,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }


### PR DESCRIPTION
Previously when searching for a portal, the server would use the search radius to determine which chunks it needs to search, and then would consider any portal within those chunks as a match, even if it is outside the search radius.
This changes it so that the portal list is filtered to only include portals within the configured search radius (ignoring the Y coordinate).

fixes #3583 
