### PR TITLE
Make the hopper occluding block skip for inventory entities configurable

### DIFF
--- a/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
@@ -9,25 +9,28 @@ Subject: [PATCH] Optimize Hoppers
   However, pushes do not exhibit the same behavior, so this is not something plugins could of been relying on.
 * Add option (Default on) to cooldown hoppers when they fail to move an item due to full inventory
 * Skip subsequent InventoryMoveItemEvents if a plugin does not use the item after first event fire for an iteration
-* Don't check for Entities with Inventories if the block above us is also occluding (not just Inventoried)
+* Add option (Default on) to skip checking for Entities with Inventories in above occluding blocks
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0a28d787e06ceae71034f757637b4c90b6f3c04..9bd64034587217743157a81c04fc20751474e21d 100644
+index f0a28d787e06ceae71034f757637b4c90b6f3c04..d449d802d7695de3375bbca48e25d69c5f329a78 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -582,4 +582,13 @@ public class PaperWorldConfig {
+@@ -582,4 +582,16 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
 +
 +    public boolean cooldownHopperWhenFull = true;
 +    public boolean disableHopperMoveEvents = false;
++    public boolean hoppersIgnoreOccludingBlocks = true;
 +    private void hopperOptimizations() {
 +        cooldownHopperWhenFull = getBoolean("hopper.cooldown-when-full", cooldownHopperWhenFull);
 +        log("Cooldown Hoppers when Full: " + (cooldownHopperWhenFull ? "enabled" : "disabled"));
 +        disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
 +        log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
++        hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
++        log("Hoppers Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/IHopper.java b/src/main/java/net/minecraft/server/IHopper.java
@@ -105,7 +108,7 @@ index 2b06c95b4fac97513e706ef073fdd7418e1f092c..67fda8bd5a0ad6fea2df0066c61e006c
              this.world.b(this.position, this);
              if (!this.c.isAir()) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityHopper.java b/src/main/java/net/minecraft/server/TileEntityHopper.java
-index a0a3adac3e2bc939b1809c5587929f674f4318a5..20df9bd21d0e4d2579d05d79672da2eb26478044 100644
+index a0a3adac3e2bc939b1809c5587929f674f4318a5..afba2230013db938bbaae23ef95c483b2af4c33f 100644
 --- a/src/main/java/net/minecraft/server/TileEntityHopper.java
 +++ b/src/main/java/net/minecraft/server/TileEntityHopper.java
 @@ -168,6 +168,160 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
@@ -454,7 +457,7 @@ index a0a3adac3e2bc939b1809c5587929f674f4318a5..20df9bd21d0e4d2579d05d79672da2eb
          }
  
 -        if (object == null) {
-+        if (object == null && (!optimizeEntities || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding())) { // Paper
++        if (object == null && (!optimizeEntities || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding()) || !world.paperConfig.hoppersIgnoreOccludingBlocks) { // Paper
              List<Entity> list = world.getEntities((Entity) null, new AxisAlignedBB(d0 - 0.5D, d1 - 0.5D, d2 - 0.5D, d0 + 0.5D, d1 + 0.5D, d2 + 0.5D), IEntitySelector.d);
  
              if (!list.isEmpty()) {

--- a/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
@@ -457,7 +457,7 @@ index a0a3adac3e2bc939b1809c5587929f674f4318a5..afba2230013db938bbaae23ef95c483b
          }
  
 -        if (object == null) {
-+        if (object == null && (!optimizeEntities || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding() || !world.paperConfig.hoppersIgnoreOccludingBlocks)) { // Paper
++        if (object == null && (!optimizeEntities || !world.paperConfig.hoppersIgnoreOccludingBlocks || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding())) { // Paper
              List<Entity> list = world.getEntities((Entity) null, new AxisAlignedBB(d0 - 0.5D, d1 - 0.5D, d2 - 0.5D, d0 + 0.5D, d1 + 0.5D, d2 + 0.5D), IEntitySelector.d);
  
              if (!list.isEmpty()) {

--- a/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0399-Optimize-Hoppers.patch
@@ -457,7 +457,7 @@ index a0a3adac3e2bc939b1809c5587929f674f4318a5..afba2230013db938bbaae23ef95c483b
          }
  
 -        if (object == null) {
-+        if (object == null && (!optimizeEntities || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding()) || !world.paperConfig.hoppersIgnoreOccludingBlocks) { // Paper
++        if (object == null && (!optimizeEntities || !org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(block).isOccluding() || !world.paperConfig.hoppersIgnoreOccludingBlocks)) { // Paper
              List<Entity> list = world.getEntities((Entity) null, new AxisAlignedBB(d0 - 0.5D, d1 - 0.5D, d2 - 0.5D, d0 + 0.5D, d1 + 0.5D, d2 + 0.5D), IEntitySelector.d);
  
              if (!list.isEmpty()) {

--- a/Spigot-Server-Patches/0419-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0419-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9bd64034587217743157a81c04fc20751474e21d..796c5a0b110009b479f5c9eef17e2605b564ce09 100644
+index d449d802d7695de3375bbca48e25d69c5f329a78..8d41126fcd6203f11dd111f5d2e85e04dc7aa705 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -591,4 +591,9 @@ public class PaperWorldConfig {
-         disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
-         log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
+@@ -594,4 +594,9 @@ public class PaperWorldConfig {
+         hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
+         log("Hoppers Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
 +
 +    public boolean nerfNetherPortalPigmen = false;
@@ -32,7 +32,7 @@ index e5b8d45ed9f62c28b0429859593d881546ccead2..77f8d5e6662fa75e622f07b3e6efae04
              }
          }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 39a7b8743a0612f818cda3796b5f6ae1137a7eee..c49d157b8ca25f9811bf64396c207b1c1d6e085d 100644
+index 73e02dfdb96104805df298e45c22983682b4216f..7f21d1a888a371468da5d318153e22a0baf0b64c 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -194,6 +194,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0425-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0425-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b2256144f7f968667570e5a9838a77173d515c5..f888fc1c5ef4212f81ed936da6485abadc336407 100644
+index fe5304c3f1fcda43fc3e9d0924405aa623d2912d..3dae4d8adbfc1cc7fad8febd84e897f1f4e59baf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -601,4 +601,9 @@ public class PaperWorldConfig {
+@@ -604,4 +604,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0438-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0438-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b987399ca3786a30f87c98658e8bf04d4aa2e2da..08949526752e4d66e4c0df11f76f6500846e1fe4 100644
+index f16b6d84c6e71965b8f006adc2fd79cc8730b05f..60ee5dde6264a270ce5baaca204e9edaccebf246 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -617,4 +617,9 @@ public class PaperWorldConfig {
+@@ -620,4 +620,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
@@ -28,7 +28,7 @@ index b987399ca3786a30f87c98658e8bf04d4aa2e2da..08949526752e4d66e4c0df11f76f6500
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 99b6a4d277816699a5abd9ec889535c064758e97..0d91765cb6386c9483a6b5494e37bd7806638928 100644
+index 28c7599a97942c14fe44c25807681973c9858c16..dd41f70db6aa50e7e79351d2a3bb321f284dc56e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -662,7 +662,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/Spigot-Server-Patches/0468-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0468-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 08949526752e4d66e4c0df11f76f6500846e1fe4..13b89276feb76fcecaeefc166a1bc161d5931d9d 100644
+index 60ee5dde6264a270ce5baaca204e9edaccebf246..3c8edfc138f37537ecd20f21a5d3bcd9f78d0e23 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -622,4 +622,11 @@ public class PaperWorldConfig {
+@@ -625,4 +625,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0480-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0480-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 13b89276feb76fcecaeefc166a1bc161d5931d9d..5af7e5c815752f2fd2b13c02a905796971401813 100644
+index 3c8edfc138f37537ecd20f21a5d3bcd9f78d0e23..aa1e3bc7ab0f25c154c1a2a780e6fc79dc94a084 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -629,4 +629,9 @@ public class PaperWorldConfig {
+@@ -632,4 +632,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/Spigot-Server-Patches/0505-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0505-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5af7e5c815752f2fd2b13c02a905796971401813..6e6534ab25dbebbad5d2ee848edb88ebcae86d03 100644
+index aa1e3bc7ab0f25c154c1a2a780e6fc79dc94a084..30556c35d06b344c150443a897d87d19132a51b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -634,4 +634,13 @@ public class PaperWorldConfig {
+@@ -637,4 +637,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0517-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0517-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6e6534ab25dbebbad5d2ee848edb88ebcae86d03..e471e764935e2a89560de56959a782b02e5e8fe1 100644
+index 30556c35d06b344c150443a897d87d19132a51b4..905405d97d0235e4266107c51b69e00cd90b17ea 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -643,4 +643,26 @@ public class PaperWorldConfig {
+@@ -646,4 +646,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }


### PR DESCRIPTION
f275e9cb9cd28eb560eab3cb444dd3393f0aa583 brought some nice optimizations but always skipping fetching inventory entities when the block above a hopper is occluding breaks a number of redstone creations. This PR makes that behavior configurable instead, with the default being that the optimization is enabled.

Resolves #3616 

(Fixed the Git tree from #4080... No clue what happened there, sorry)