### PR TITLE
PlayerArmorChangeEvent made cancellable and added missing materials

### DIFF
--- a/Spigot-API-Patches/0070-Add-PlayerArmorChangeEvent.patch
+++ b/Spigot-API-Patches/0070-Add-PlayerArmorChangeEvent.patch
@@ -3,17 +3,19 @@ From: pkt77 <parkerkt77@gmail.com>
 Date: Fri, 10 Nov 2017 23:45:59 -0500
 Subject: [PATCH] Add PlayerArmorChangeEvent
 
+Make Event cancellable, Added missing materials to PlayerArmorChangeEvent.SlotType
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2827a100275f8e1316b5d06c14662d41ca1bd5fa
+index 0000000000000000000000000000000000000000..8ab75aeacb54894addf31838d87f0bc4ba38a125
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,149 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Material;
 +import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.player.PlayerEvent;
 +import org.bukkit.inventory.ItemStack;
@@ -32,8 +34,9 @@ index 0000000000000000000000000000000000000000..2827a100275f8e1316b5d06c14662d41
 + * <p>
 + * Not currently called for environmental factors though it <strong>MAY BE IN THE FUTURE</strong>
 + */
-+public class PlayerArmorChangeEvent extends PlayerEvent {
++public class PlayerArmorChangeEvent extends PlayerEvent implements Cancellable {
 +    private static final HandlerList HANDLERS = new HandlerList();
++    private boolean cancelled = false;
 +
 +    @NotNull private final SlotType slotType;
 +    @Nullable private final ItemStack oldItem;
@@ -92,11 +95,21 @@ index 0000000000000000000000000000000000000000..2827a100275f8e1316b5d06c14662d41
 +        return HANDLERS;
 +    }
 +
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
 +    public enum SlotType {
-+        HEAD(DIAMOND_HELMET, GOLDEN_HELMET, IRON_HELMET, CHAINMAIL_HELMET, LEATHER_HELMET, PUMPKIN, JACK_O_LANTERN),
-+        CHEST(DIAMOND_CHESTPLATE, GOLDEN_CHESTPLATE, IRON_CHESTPLATE, CHAINMAIL_CHESTPLATE, LEATHER_CHESTPLATE, ELYTRA),
-+        LEGS(DIAMOND_LEGGINGS, GOLDEN_LEGGINGS, IRON_LEGGINGS, CHAINMAIL_LEGGINGS, LEATHER_LEGGINGS),
-+        FEET(DIAMOND_BOOTS, GOLDEN_BOOTS, IRON_BOOTS, CHAINMAIL_BOOTS, LEATHER_BOOTS);
++        HEAD(NETHERITE_HELMET, DIAMOND_HELMET, GOLDEN_HELMET, IRON_HELMET, CHAINMAIL_HELMET, LEATHER_HELMET, PUMPKIN, JACK_O_LANTERN, TURTLE_HELMET),
++        CHEST(NETHERITE_CHESTPLATE, DIAMOND_CHESTPLATE, GOLDEN_CHESTPLATE, IRON_CHESTPLATE, CHAINMAIL_CHESTPLATE, LEATHER_CHESTPLATE, ELYTRA),
++        LEGS(NETHERITE_LEGGINGS, DIAMOND_LEGGINGS, GOLDEN_LEGGINGS, IRON_LEGGINGS, CHAINMAIL_LEGGINGS, LEATHER_LEGGINGS),
++        FEET(NETHERITE_BOOTS, DIAMOND_BOOTS, GOLDEN_BOOTS, IRON_BOOTS, CHAINMAIL_BOOTS, LEATHER_BOOTS);
 +
 +        private final Set<Material> mutableTypes = new HashSet<>();
 +        private Set<Material> immutableTypes;

--- a/Spigot-Server-Patches/0177-Add-PlayerArmorChangeEvent.patch
+++ b/Spigot-Server-Patches/0177-Add-PlayerArmorChangeEvent.patch
@@ -3,9 +3,10 @@ From: pkt77 <parkerkt77@gmail.com>
 Date: Fri, 10 Nov 2017 23:46:34 -0500
 Subject: [PATCH] Add PlayerArmorChangeEvent
 
+Make Event cancellable, Added missing materials to PlayerArmorChangeEvent.SlotType
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index fc4c7dc452450b7a4253c344284a056425109cc8..35ec16b2bb0491e22ca834abc762f03fafdc764a 100644
+index fc4c7dc452450b7a4253c344284a056425109cc8..dad411e8f962b6fddd2e637b4831775f7c8f7b2a 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1,5 +1,6 @@
@@ -15,7 +16,7 @@ index fc4c7dc452450b7a4253c344284a056425109cc8..35ec16b2bb0491e22ca834abc762f03f
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
  import com.google.common.collect.ImmutableMap;
-@@ -2521,6 +2522,13 @@ public abstract class EntityLiving extends Entity {
+@@ -2521,6 +2522,17 @@ public abstract class EntityLiving extends Entity {
              ItemStack itemstack1 = this.getEquipment(enumitemslot);
  
              if (!ItemStack.matches(itemstack1, itemstack)) {
@@ -23,7 +24,11 @@ index fc4c7dc452450b7a4253c344284a056425109cc8..35ec16b2bb0491e22ca834abc762f03f
 +                if (this instanceof EntityPlayer && enumitemslot.getType() == EnumItemSlot.Function.ARMOR) {
 +                    final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
 +                    final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
-+                    new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();
++
++                    if(!new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent()){
++                        // Event got cancelled, return empty map to not change items
++                        return null;
++                    }
 +                }
 +                // Paper end
                  if (map == null) {

--- a/Spigot-Server-Patches/0227-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0227-Make-shield-blocking-delay-configurable.patch
@@ -19,10 +19,10 @@ index 69009246f12cc3acb0055af746e01097fa668e1b..35075ffac394153e28039809e0ed48fe
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 35ec16b2bb0491e22ca834abc762f03fafdc764a..2fcae52461794f51d1ec0e3ca4817da026d3ae24 100644
+index dad411e8f962b6fddd2e637b4831775f7c8f7b2a..671a1433c29ce6fe78bafc65686a11dbd38823fc 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -3169,7 +3169,7 @@ public abstract class EntityLiving extends Entity {
+@@ -3173,7 +3173,7 @@ public abstract class EntityLiving extends Entity {
          if (this.isHandRaised() && !this.activeItem.isEmpty()) {
              Item item = this.activeItem.getItem();
  
@@ -31,7 +31,7 @@ index 35ec16b2bb0491e22ca834abc762f03fafdc764a..2fcae52461794f51d1ec0e3ca4817da0
          } else {
              return false;
          }
-@@ -3421,4 +3421,15 @@ public abstract class EntityLiving extends Entity {
+@@ -3425,4 +3425,15 @@ public abstract class EntityLiving extends Entity {
      public void broadcastItemBreak(EnumHand enumhand) {
          this.broadcastItemBreak(enumhand == EnumHand.MAIN_HAND ? EnumItemSlot.MAINHAND : EnumItemSlot.OFFHAND);
      }

--- a/Spigot-Server-Patches/0233-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/Spigot-Server-Patches/0233-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] LivingEntity Hand Raised/Item Use API
 How long an entity has raised hands to charge an attack or use an item
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index c549eda057b58b985bef98fabeaa642280cff1c3..b7df37450c1fa4cdefa8267005d052180291d5ba 100644
+index 22d4ff8a5c83b5424f693539d56f43d808745024..f0f107c4cadd82b09d2e70cb7a7f49c7797ed487 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -118,7 +118,7 @@ public abstract class EntityLiving extends Entity {
@@ -18,7 +18,7 @@ index c549eda057b58b985bef98fabeaa642280cff1c3..b7df37450c1fa4cdefa8267005d05218
      protected int bk;
      protected int bl;
      private BlockPosition bE;
-@@ -3152,10 +3152,12 @@ public abstract class EntityLiving extends Entity {
+@@ -3156,10 +3156,12 @@ public abstract class EntityLiving extends Entity {
          return this.activeItem;
      }
  

--- a/Spigot-Server-Patches/0284-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/Spigot-Server-Patches/0284-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ray tracing methods to LivingEntity
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 1aa9e57daa84f54271781cadc9826f12dc80201b..ac5f11a2f5598584ff112a208bfd16aeb574e580 100644
+index 93cb411b8d1c3d91545365299655d40f1bf957cc..15f35766a4a4a9ae16afe65222c6ef73236ae8e2 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -3440,6 +3440,23 @@ public abstract class EntityLiving extends Entity {
+@@ -3444,6 +3444,23 @@ public abstract class EntityLiving extends Entity {
          this.broadcastItemBreak(enumhand == EnumHand.MAIN_HAND ? EnumItemSlot.MAINHAND : EnumItemSlot.OFFHAND);
      }
      // Paper start

--- a/Spigot-Server-Patches/0322-force-entity-dismount-during-teleportation.patch
+++ b/Spigot-Server-Patches/0322-force-entity-dismount-during-teleportation.patch
@@ -20,7 +20,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 1a677783baa0b9a3dcfcd84caccba61d76fad2fb..5c37d6f2523ead3eee082dc615d9b0c9fbd71443 100644
+index 3c2cfca679e88aa07be6c747822317ecb28f091d..1407a891fb2dad4e8c298b20fcbd749f89ba2d84 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1948,12 +1948,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -72,7 +72,7 @@ index 1a677783baa0b9a3dcfcd84caccba61d76fad2fb..5c37d6f2523ead3eee082dc615d9b0c9
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index afc665bfe9d527ca8d19f3ab9df0900d87f2d3f2..7916421fe1dd8eadfd1c9bd15c4bbbb7331faca6 100644
+index fa656a424cebe42f12c3f8ecf82204e9d837c868..904078d90170b4ab474ed24c3d161ddcd80df901 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -942,9 +942,11 @@ public abstract class EntityHuman extends EntityLiving {
@@ -91,10 +91,10 @@ index afc665bfe9d527ca8d19f3ab9df0900d87f2d3f2..7916421fe1dd8eadfd1c9bd15c4bbbb7
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index fb53d8e178b5a8e229036f90fafb48a8a142125e..2e298126405764fd342d05f8fb87ed60fb9a813d 100644
+index 08720c51136fe75bb11ade3da009b9c8f63d026f..23caefb5db36ff015a487d62b742db42a5fdef44 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -2889,11 +2889,13 @@ public abstract class EntityLiving extends Entity {
+@@ -2893,11 +2893,13 @@ public abstract class EntityLiving extends Entity {
          return ((Byte) this.datawatcher.get(EntityLiving.an) & 4) != 0;
      }
  

--- a/Spigot-Server-Patches/0342-Add-LivingEntity-getTargetEntity.patch
+++ b/Spigot-Server-Patches/0342-Add-LivingEntity-getTargetEntity.patch
@@ -46,7 +46,7 @@ index 02c09f39848399a86d46bd17569b4f01a7b5ab1f..ed9b2f9adfecdc6d1b9925579ec51065
          double[] adouble = new double[]{1.0D};
          double d0 = vec3d1.x - vec3d.x;
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 5c37d6f2523ead3eee082dc615d9b0c9fbd71443..c5abac3eb3f98a948ff7a3423cfcad70abae86ff 100644
+index 1407a891fb2dad4e8c298b20fcbd749f89ba2d84..677468a3dc649a97330a7a8d5736e57873d19d44 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1426,6 +1426,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -66,10 +66,10 @@ index 5c37d6f2523ead3eee082dc615d9b0c9fbd71443..c5abac3eb3f98a948ff7a3423cfcad70
          return 0.0F;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 2e298126405764fd342d05f8fb87ed60fb9a813d..a6f38a95b78ac43a2250f575a755e833d1baea33 100644
+index 23caefb5db36ff015a487d62b742db42a5fdef44..7998192871ef0f6df2606321478d6a9d75700ec5 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -3492,6 +3492,37 @@ public abstract class EntityLiving extends Entity {
+@@ -3496,6 +3496,37 @@ public abstract class EntityLiving extends Entity {
          return world.rayTrace(raytrace);
      }
  

--- a/Spigot-Server-Patches/0384-Prevent-consuming-the-wrong-itemstack.patch
+++ b/Spigot-Server-Patches/0384-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index a6f38a95b78ac43a2250f575a755e833d1baea33..0515587559a75e4afddbcac90f65d5d60156a527 100644
+index 7998192871ef0f6df2606321478d6a9d75700ec5..c06d88975767199f227b196589b6920482b6241f 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -3065,10 +3065,13 @@ public abstract class EntityLiving extends Entity {
+@@ -3069,10 +3069,13 @@ public abstract class EntityLiving extends Entity {
          this.datawatcher.set(EntityLiving.an, (byte) j);
      }
  
@@ -24,7 +24,7 @@ index a6f38a95b78ac43a2250f575a755e833d1baea33..0515587559a75e4afddbcac90f65d5d6
              this.activeItem = itemstack;
              this.bk = itemstack.k();
              if (!this.world.isClientSide) {
-@@ -3144,6 +3147,7 @@ public abstract class EntityLiving extends Entity {
+@@ -3148,6 +3151,7 @@ public abstract class EntityLiving extends Entity {
              this.releaseActiveItem();
          } else {
              if (!this.activeItem.isEmpty() && this.isHandRaised()) {
@@ -32,7 +32,7 @@ index a6f38a95b78ac43a2250f575a755e833d1baea33..0515587559a75e4afddbcac90f65d5d6
                  this.b(this.activeItem, 16);
                  // CraftBukkit start - fire PlayerItemConsumeEvent
                  ItemStack itemstack;
-@@ -3174,8 +3178,8 @@ public abstract class EntityLiving extends Entity {
+@@ -3178,8 +3182,8 @@ public abstract class EntityLiving extends Entity {
                  this.a(this.getRaisedHand(), itemstack);
                  // CraftBukkit end
                  this.clearActiveItem();

--- a/Spigot-Server-Patches/0406-Lag-compensate-eating.patch
+++ b/Spigot-Server-Patches/0406-Lag-compensate-eating.patch
@@ -7,7 +7,7 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c08e0a74a 100644
+index 15967aa7610de7c2aac7f67810ee05dea5b673f8..520e8a0eaaf72a81e701178ceca3bf8533ef4205 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -119,7 +119,7 @@ public abstract class EntityLiving extends Entity {
@@ -19,7 +19,7 @@ index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c
      protected int bl;
      private BlockPosition bE;
      private Optional<BlockPosition> bF;
-@@ -3015,6 +3015,11 @@ public abstract class EntityLiving extends Entity {
+@@ -3019,6 +3019,11 @@ public abstract class EntityLiving extends Entity {
          return ((Byte) this.datawatcher.get(EntityLiving.an) & 2) > 0 ? EnumHand.OFF_HAND : EnumHand.MAIN_HAND;
      }
  
@@ -31,7 +31,7 @@ index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c
      private void u() {
          if (this.isHandRaised()) {
              if (ItemStack.d(this.b(this.getRaisedHand()), this.activeItem)) {
-@@ -3024,7 +3029,13 @@ public abstract class EntityLiving extends Entity {
+@@ -3028,7 +3033,13 @@ public abstract class EntityLiving extends Entity {
                      this.b(this.activeItem, 5);
                  }
  
@@ -46,7 +46,7 @@ index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c
                      this.s();
                  }
              } else {
-@@ -3074,7 +3085,10 @@ public abstract class EntityLiving extends Entity {
+@@ -3078,7 +3089,10 @@ public abstract class EntityLiving extends Entity {
  
          if (!itemstack.isEmpty() && !this.isHandRaised() || forceUpdate) { // Paper use override flag
              this.activeItem = itemstack;
@@ -58,7 +58,7 @@ index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c
              if (!this.world.isClientSide) {
                  this.c(1, true);
                  this.c(2, enumhand == EnumHand.OFF_HAND);
-@@ -3098,7 +3112,10 @@ public abstract class EntityLiving extends Entity {
+@@ -3102,7 +3116,10 @@ public abstract class EntityLiving extends Entity {
                  }
              } else if (!this.isHandRaised() && !this.activeItem.isEmpty()) {
                  this.activeItem = ItemStack.b;
@@ -70,7 +70,7 @@ index f71ca4ee57d86c30d78c8292ced0531b963beabb..fd8b3d05238329adf3f638b1e04fd95c
              }
          }
  
-@@ -3220,7 +3237,10 @@ public abstract class EntityLiving extends Entity {
+@@ -3224,7 +3241,10 @@ public abstract class EntityLiving extends Entity {
          }
  
          this.activeItem = ItemStack.b;

--- a/Spigot-Server-Patches/0418-Entity-Jump-API.patch
+++ b/Spigot-Server-Patches/0418-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 9746346d6b9c432710f229f5355e4540c308ffb4..172b9de45f0f1b550acddc0c53b762c9e93f0d18 100644
+index c594c6c42f30b264f6b1028c5c188af13117e61d..8c7395e193fe0dbd1e74f4c52ab3e60a0537b0e5 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -2751,8 +2751,10 @@ public abstract class EntityLiving extends Entity {
+@@ -2755,8 +2755,10 @@ public abstract class EntityLiving extends Entity {
              } else if (this.aN() && (!this.onGround || d7 > d8)) {
                  this.c((Tag) TagsFluid.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.jumpTicks == 0) {

--- a/Spigot-Server-Patches/0454-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/Spigot-Server-Patches/0454-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 172b9de45f0f1b550acddc0c53b762c9e93f0d18..574d9ef4f4f0e95a66252b0428ff84c72d5bc32c 100644
+index 8c7395e193fe0dbd1e74f4c52ab3e60a0537b0e5..c399e86f0fb0ba12018501f7106505ae9631fc4e 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -2817,10 +2817,16 @@ public abstract class EntityLiving extends Entity {
+@@ -2821,10 +2821,16 @@ public abstract class EntityLiving extends Entity {
      protected void doTick() {}
  
      protected void collideNearby() {

--- a/Spigot-Server-Patches/0537-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/Spigot-Server-Patches/0537-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index ce823833a0b308aeb11902652157575eabf09e3b..1a61bc7c8a532d11981e47cadfd57e92894bf4dd 100644
+index b3ce0b94b0b2c293756d69b2d21a7ebbc696f294..449f3e594e9c2436aec1f9e05ed002e331379059 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
-@@ -2914,7 +2914,7 @@ public abstract class EntityLiving extends Entity {
+@@ -2918,7 +2918,7 @@ public abstract class EntityLiving extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress


### PR DESCRIPTION
See https://github.com/PaperMC/Paper/pull/4129#issuecomment-674165690
Got closed because I removed my old commit.

> Made the event cancellable and added the missing 1.16 materials to PlayerArmorChangeEvent.SlotType.
> 
> Should fix #4106 and also fix #2487