### PR TITLE
Fix IDE Debug JVM Flag for 1.16.2

### DIFF
--- a/Spigot-Server-Patches/0296-Hook-into-CB-plugin-rewrites.patch
+++ b/Spigot-Server-Patches/0296-Hook-into-CB-plugin-rewrites.patch
@@ -52,7 +52,7 @@ index ac48431777b70c200f9e4113c8a0c03957126e90..e944a0f941fc74e267437d43717ddee2
 +        if ( Boolean.getBoolean( "debug.rewriteForIde" ) )
 +        {
 +            // unversion incoming calls for pre-relocate debug work
-+            final String NMS_REVISION_PACKAGE = "v1_16_R1/";
++            final String NMS_REVISION_PACKAGE = "v1_16_R2/";
 +
 +            getAndRemove.put( "net/minecraft/".concat( "server/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );
 +            getAndRemove.put( "org/bukkit/".concat( "craftbukkit/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );


### PR DESCRIPTION
This re-implements my previous PR for this, except  this doesn't add to shit_to_check.md, because this is added from my previous PR