### PR TITLE
Fix regex mistake in CB NBT int deserialization

### DIFF
--- a/Spigot-Server-Patches/0552-Fix-regex-mistake-in-CB-NBT-int-deserialization.patch
+++ b/Spigot-Server-Patches/0552-Fix-regex-mistake-in-CB-NBT-int-deserialization.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: mbax <matt@phozop.net>
+Date: Mon, 17 Aug 2020 12:17:37 -0400
+Subject: [PATCH] Fix regex mistake in CB NBT int deserialization
+
+The existing regex is too open and allows for the absence of any actual
+number data, detecting an NBT entry of just the letter "i" in upper or
+lower case. This causes a single-character NBT entry to be processed as
+an integer ending in "i", passing an empty String to to Integer.parseInt,
+triggering an exception in loading the item.
+
+This commit forces numbers to be present prior to the ending "i"
+letter.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftNBTTagConfigSerializer.java b/src/main/java/org/bukkit/craftbukkit/util/CraftNBTTagConfigSerializer.java
+index b17faa25e6db28e8538cc21d7a651e4acdf0c580..373dfe726c5ec4f3011f77e08d3e0850ffecf5ed 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftNBTTagConfigSerializer.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftNBTTagConfigSerializer.java
+@@ -19,7 +19,7 @@ import net.minecraft.server.NBTTagString;
+ public class CraftNBTTagConfigSerializer {
+ 
+     private static final Pattern ARRAY = Pattern.compile("^\\[.*]");
+-    private static final Pattern INTEGER = Pattern.compile("[-+]?(?:0|[1-9][0-9]*)?i", Pattern.CASE_INSENSITIVE);
++    private static final Pattern INTEGER = Pattern.compile("[-+]?(?:0|[1-9][0-9]*)i", Pattern.CASE_INSENSITIVE); // Paper - fix regex
+     private static final Pattern DOUBLE = Pattern.compile("[-+]?(?:[0-9]+[.]?|[0-9]*[.][0-9]+)(?:e[-+]?[0-9]+)?d", Pattern.CASE_INSENSITIVE);
+     private static final MojangsonParser MOJANGSON_PARSER = new MojangsonParser(new StringReader(""));
+ 


### PR DESCRIPTION
The current regex for detecting a stored int with the PersistentDataContainer system allows for the absence of any actual number data, accepting an entry of just the letter "i" (case insensitive). Once detected as a stored int, it is substringed to drop the last (and only) character, passing an empty String to to `Integer.parseInt(String)`, which gives us a shiny exception.

This patch ensures numbers are present too.

Test code:
```java
// Create item
ItemStack item = new ItemStack(Material.STONE);
// Create a key
NamespacedKey key = new NamespacedKey(this, "Hug");
// Set meta with persistent data
ItemMeta itemMeta = item.getItemMeta();
itemMeta.setDisplayName("Hugs!");
itemMeta.getPersistentDataContainer().set(key, PersistentDataType.STRING, "I");
item.setItemMeta(itemMeta);
// Print for verification
System.out.println(item);
// Serialize
ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
BukkitObjectOutputStream dataOutput = new BukkitObjectOutputStream(outputStream);
dataOutput.writeObject(item);
dataOutput.close();
byte[] bytes = outputStream.toByteArray();
// Deserialize
ByteArrayInputStream inputStream = new ByteArrayInputStream(bytes);
BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream);
ItemStack itemRestored = (ItemStack) dataInput.readObject();
dataInput.close();
// Print for verification
System.out.println(itemRestored);
```


Output on latest Paper:
```
[12:45:33 INFO]: ItemStack{STONE x 1, UNSPECIFIC_META:{meta-type=UNSPECIFIC, display-name=Hugs!, PublicBukkitValues={myadorableplugin:hug=I}}}
[12:45:33 ERROR]: [org.bukkit.configuration.serialization.ConfigurationSerialization] Could not call method 'public static org.bukkit.inventory.meta.ItemMeta org.bukkit.craftbukkit.v1_16_R1.inventory.CraftMetaItem$SerializableMeta.deserialize(java.util.Map) throws java.lang.Throwable' of class org.bukkit.craftbukkit.v1_16_R1.inventory.CraftMetaItem$SerializableMeta for deserialization
java.lang.NumberFormatException: For input string: ""
        at java.lang.NumberFormatException.forInputString(Unknown Source) ~[?:1.8.0_261]
        at java.lang.Integer.parseInt(Unknown Source) ~[?:1.8.0_261]
        at java.lang.Integer.parseInt(Unknown Source) ~[?:1.8.0_261]
        at org.bukkit.craftbukkit.v1_16_R1.util.CraftNBTTagConfigSerializer.deserialize(CraftNBTTagConfigSerializer.java:80) ~[patched_1.16.1.jar:git-Paper-135]
        at org.bukkit.craftbukkit.v1_16_R1.util.CraftNBTTagConfigSerializer.deserialize(CraftNBTTagConfigSerializer.java:54) ~[patched_1.16.1.jar:git-Paper-135]
        at org.bukkit.craftbukkit.v1_16_R1.inventory.CraftMetaItem.<init>(CraftMetaItem.java:628) ~[patched_1.16.1.jar:git-Paper-135]
...[snipping it here because that's enough context]
```

Output on Paper with this PR's patch:
```
[12:52:18 INFO]: ItemStack{STONE x 1, UNSPECIFIC_META:{meta-type=UNSPECIFIC, display-name=Hugs!, PublicBukkitValues={myadorableplugin:hug=I}}}
[12:52:18 INFO]: ItemStack{STONE x 1, UNSPECIFIC_META:{meta-type=UNSPECIFIC, display-name=Hugs!, PublicBukkitValues={myadorableplugin:hug=I}}}
```