### PR TITLE
Do not obfuscate air

### DIFF
--- a/Spigot-Server-Patches/0368-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0368-Anti-Xray.patch
@@ -98,10 +98,10 @@ index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5a69dde15f88ac051d25eaec4e07d1b030319c48
+index 0000000000000000000000000000000000000000..f475427af03a0bcd69a215daf3d0c1456ca57be1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,621 @@
+@@ -0,0 +1,622 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
@@ -186,7 +186,8 @@ index 0000000000000000000000000000000000000000..5a69dde15f88ac051d25eaec4e07d1b0
 +        for (String id : toObfuscate) {
 +            Block block = IRegistry.BLOCK.getOptional(new MinecraftKey(id)).orElse(null);
 +
-+            if (block != null) {
++            // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
++            if (block != null && !block.getBlockData().isAir()) {
 +                obfuscateGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(block.getBlockData())] = true;
 +            }
 +        }


### PR DESCRIPTION
For further details about the issue see https://github.com/PaperMC/Paper/pull/4123#issuecomment-675109506 and https://github.com/PaperMC/Paper/pull/4123#issuecomment-675138070. [This](https://github.com/PaperMC/Paper/blob/progress/1.16.2/Spigot-Server-Patches/0368-Anti-Xray.patch#L688) line prevents `flagDirty` from being invoked for blocks with negative y values, which throws an `ArrayIndexOutOfBoundsException` in 1.16.2. However, `flagDirty` is invoked if the array `obfuscateGlobal` is true for air. This is the case, when air is either added to `hidden-blocks` or `replacement-blocks` in engine-mode 2. This commit **does not** prevent adding air to the `hidden-blocks` list (as I often suggest) and thus being added to the chunk, but rather prevents "covered" air from being replaced (obfuscated) by other blocks, which makes no sense at all. In other words air isn't set to true in the `obfuscateGlobal` array, which prevents air from being replaced and prevents unnecessary block updates for air blocks (including the failing void block updates in 1.16.2).

Actually the same issue also exists in versions before 1.16.2 but without throwing an exception. Thus it might be a good idea to also apply these changes to other supported versions.