### PR TITLE
Fix Wither Hostility Bug

### DIFF
--- a/Spigot-Server-Patches/0553-Wither-Bugfix.patch
+++ b/Spigot-Server-Patches/0553-Wither-Bugfix.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheShermanTanker <tanksherman27@gmail.com>
+Date: Wed, 19 Aug 2020 22:09:29 +0800
+Subject: [PATCH] Wither-Bugfix
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
+index 1074995e8c8a83f6cdb94019123fbffa309d5e08..268efdecd6c072dcb2aba16732d75b2dd53a6e69 100644
+--- a/src/main/java/net/minecraft/server/EntityWither.java
++++ b/src/main/java/net/minecraft/server/EntityWither.java
+@@ -49,7 +49,7 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+         this.goalSelector.a(6, new PathfinderGoalLookAtPlayer(this, EntityHuman.class, 8.0F));
+         this.goalSelector.a(7, new PathfinderGoalRandomLookaround(this));
+         this.targetSelector.a(1, new PathfinderGoalHurtByTarget(this, new Class[0]));
+-        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityInsentient.class, 0, false, false, EntityWither.bF));
++        this.targetSelector.a(2, new PathfinderGoalNearestAttackableTarget<>(this, EntityLiving.class, 0, false, false, EntityWither.bF));
+     }
+ 
+     @Override


### PR DESCRIPTION
Fixed a surprisingly under-reported bug where the Wither's main head is neutral to Players it can see, when it is supposed to be hostile to all non item or projectile entities that are not undead: https://www.reddit.com/r/Minecraft/comments/bt0ojy/wither_boss_is_neutral_towards_player_and_not/