### PR TITLE
Add PlayerTradeWithVillagerEvent (1.16)

### DIFF
--- a/Spigot-API-Patches/0219-Add-PlayerTradeWithVillagerEvent.patch
+++ b/Spigot-API-Patches/0219-Add-PlayerTradeWithVillagerEvent.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bermudalocket <github@eigenstuff.net>
+Date: Wed, 19 Aug 2020 12:28:24 -0400
+Subject: [PATCH] Add PlayerTradeWithVillagerEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeWithVillagerEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeWithVillagerEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..af063d54208558f375e1436ed4da19bdfb8d783d
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerTradeWithVillagerEvent.java
+@@ -0,0 +1,66 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.AbstractVillager;
++import org.bukkit.entity.Player;
++import org.bukkit.entity.Villager;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.MerchantRecipe;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a player trades with a villager.
++ */
++public class PlayerTradeWithVillagerEvent extends PlayerEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private final AbstractVillager villager;
++    private final MerchantRecipe recipe;
++
++    /**
++     * Constructor for a new PlayerTradeWithVillagerEvent.
++     *
++     * @param player the player involved in this trade.
++     * @param villager the villager involved in this trade.
++     * @param recipe The MerchantRecipe representing this trade.
++     */
++    public PlayerTradeWithVillagerEvent(@NotNull Player player, @NotNull AbstractVillager villager, @NotNull MerchantRecipe recipe) {
++        super(player);
++        this.villager = villager;
++        this.recipe = recipe;
++    }
++
++    /**
++     * Returns the villager involved in this trade. Note that this method
++     * returns an AbstractVillager and thus you might need to check
++     * whether it is a Villager or a Wandering Trader.
++     *
++     * @return the villager involved in this trade.
++     */
++    @NotNull
++    public AbstractVillager getVillager() {
++        return villager;
++    }
++
++    /**
++     * Returns the MerchantRecipe representing this trade.
++     *
++     * @return the MerchantRecipe representing this trade.
++     */
++    @NotNull
++    public MerchantRecipe getRecipe() {
++        return recipe;
++    }
++
++    @Override
++    @NotNull
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}

--- a/Spigot-Server-Patches/0553-Implement-PlayerTradeWithVillagerEvent.patch
+++ b/Spigot-Server-Patches/0553-Implement-PlayerTradeWithVillagerEvent.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: bermudalocket <github@eigenstuff.net>
+Date: Wed, 19 Aug 2020 12:28:11 -0400
+Subject: [PATCH] Implement PlayerTradeWithVillagerEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+index 81823b5d5ef17479583fda0121c95091175fdf1e..f4c494a56fd0ca2257c421a3157e48b0905f4fa3 100644
+--- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+@@ -106,6 +106,7 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+         this.b(merchantrecipe);
+         if (this.tradingPlayer instanceof EntityPlayer) {
+             CriterionTriggers.s.a((EntityPlayer) this.tradingPlayer, this, merchantrecipe.getSellingItem());
++            Bukkit.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerTradeWithVillagerEvent(((EntityPlayer) this.tradingPlayer).getBukkitEntity(), (org.bukkit.entity.AbstractVillager) this.getBukkitEntity(), merchantrecipe.asBukkit())); // Paper
+         }
+ 
+     }


### PR DESCRIPTION
This is an updated version of #1862, which was created pre-1.14 and never merged due to changes in 1.14. I opted for a new PR due to said changes.

Updated test code:

```
package com.bermudalocket.playertradewithvillagereventtestplugin;

import com.destroystokyo.paper.event.player.PlayerTradeWithVillagerEvent;
import org.bukkit.event.EventHandler;
import org.bukkit.event.Listener;
import org.bukkit.plugin.java.JavaPlugin;

public final class PlayerTradeWithVillagerEventTestPlugin extends JavaPlugin implements Listener {

    @Override
    public void onEnable() {
        this.getServer().getPluginManager().registerEvents(this, this);
    }

    @EventHandler
    public void onPlayerTradeWithVillager(PlayerTradeWithVillagerEvent event) {
        System.out.println("----------------------------------------");
        System.out.println("Caught PlayerTradeWithVillagerEvent.");
        System.out.println("Player: " + event.getPlayer());
        System.out.println("Villager: " + event.getVillager());
        System.out.println("Trade: " + event.getRecipe());
        System.out.println("----------------------------------------");
    }

}
```

produces:

```
[13:38:24 INFO]: ----------------------------------------
[13:38:24 INFO]: Caught PlayerTradeWithVillagerEvent.
[13:38:24 INFO]: Player: CraftPlayer{name=bermudalocket}
[13:38:24 INFO]: Villager: CraftVillager
[13:38:24 INFO]: Trade: org.bukkit.craftbukkit.v1_16_R1.inventory.CraftMerchantRecipe@f61f767
[13:38:24 INFO]: ----------------------------------------
```