### PR TITLE
Fix MC-99259 Wither Boss Bar doesn't update until invulnerability period is over

### DIFF
--- a/Spigot-Server-Patches/0553-Fix-MC-99259-Wither-Boss-Bar-doesn-t-update-until-in.patch
+++ b/Spigot-Server-Patches/0553-Fix-MC-99259-Wither-Boss-Bar-doesn-t-update-until-in.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Thu, 20 Aug 2020 19:24:13 -0700
+Subject: [PATCH] Fix MC-99259 Wither Boss Bar doesn't update until
+ invulnerability period is over
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityWither.java b/src/main/java/net/minecraft/server/EntityWither.java
+index 1511212cbfbece279d9f66473bd6b5bc46b9e8e0..29bb74e51e73ab5b1ccc814b6599e0baf4d8094c 100644
+--- a/src/main/java/net/minecraft/server/EntityWither.java
++++ b/src/main/java/net/minecraft/server/EntityWither.java
+@@ -343,8 +343,9 @@ public class EntityWither extends EntityMonster implements IRangedEntity {
+                 this.heal(1.0F, EntityRegainHealthEvent.RegainReason.REGEN); // CraftBukkit
+             }
+ 
+-            this.bossBattle.setProgress(this.getHealth() / this.getMaxHealth());
++            //this.bossBattle.setProgress(this.getHealth() / this.getMaxHealth()); // Paper - Moved down
+         }
++        this.bossBattle.setProgress(this.getHealth() / this.getMaxHealth()); // Paper - Fix MC-99259 (Boss bar does not update until Wither invulnerability period ends)
+     }
+ 
+     public static boolean c(IBlockData iblockdata) {


### PR DESCRIPTION
This fix was as simple as suggested by the code review on the issue at Mojira https://bugs.mojang.com/browse/MC-99259

I simply moved the call outside of the if/else block so it is called whether the Wither is invulnerable or not