### PR TITLE
Pass entity to PortalCreateEvent if caused by one

### DIFF
--- a/Spigot-Server-Patches/0568-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/Spigot-Server-Patches/0568-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -1,0 +1,102 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Fri, 21 Aug 2020 20:57:54 +0200
+Subject: [PATCH] PortalCreateEvent needs to know its entity
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockBase.java b/src/main/java/net/minecraft/server/BlockBase.java
+index 440c959b1cbff2f406bb7e576b81860cf56f8858..8265ed4da0556c7e388834aaa2244da49efe85e9 100644
+--- a/src/main/java/net/minecraft/server/BlockBase.java
++++ b/src/main/java/net/minecraft/server/BlockBase.java
+@@ -68,6 +68,12 @@ public abstract class BlockBase {
+         PacketDebug.a(world, blockposition);
+     }
+ 
++    // Paper start - add ItemActionContext param
++    @Deprecated
++    public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag, ItemActionContext itemActionContext) {
++        this.onPlace(iblockdata, world, blockposition, iblockdata1, flag);
++    }
++    // Paper end
+     @Deprecated
+     public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) {
+         org.spigotmc.AsyncCatcher.catchOp("block onPlace"); // Spigot
+diff --git a/src/main/java/net/minecraft/server/BlockFire.java b/src/main/java/net/minecraft/server/BlockFire.java
+index 5ef90510b8bdac2dcf58cabfa78ba48a30a22a97..e2dd27be6b523c6e6668923c1b1900cb9251f39f 100644
+--- a/src/main/java/net/minecraft/server/BlockFire.java
++++ b/src/main/java/net/minecraft/server/BlockFire.java
+@@ -343,8 +343,10 @@ public class BlockFire extends BlockFireAbstract {
+     }
+ 
+     @Override
+-    public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) {
+-        super.onPlace(iblockdata, world, blockposition, iblockdata1, flag);
++    // Paper start - ItemActionContext param
++    public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag, ItemActionContext itemActionContext) {
++        super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
++        // Paper end
+         world.getBlockTickList().a(blockposition, this, a(world.random));
+     }
+ 
+diff --git a/src/main/java/net/minecraft/server/BlockFireAbstract.java b/src/main/java/net/minecraft/server/BlockFireAbstract.java
+index fcd989ade672a96d0905590484941ce4508dae4d..172e4b3eeecc3808a335b80bb44bc6be3d8dd33d 100644
+--- a/src/main/java/net/minecraft/server/BlockFireAbstract.java
++++ b/src/main/java/net/minecraft/server/BlockFireAbstract.java
+@@ -52,14 +52,17 @@ public abstract class BlockFireAbstract extends Block {
+         super.a(iblockdata, world, blockposition, entity);
+     }
+ 
++    // Paper start - ItemActionContext param
++    @Override public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) { this.onPlace(iblockdata, world, blockposition, iblockdata1, flag, null); }
+     @Override
+-    public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) {
++    public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag, ItemActionContext itemActionContext) {
++        // Paper end
+         if (!iblockdata1.a(iblockdata.getBlock())) {
+             if (a(world)) {
+                 Optional<BlockPortalShape> optional = BlockPortalShape.a((GeneratorAccess) world, blockposition, EnumDirection.EnumAxis.X);
+ 
+                 if (optional.isPresent()) {
+-                    ((BlockPortalShape) optional.get()).createPortal();
++                    ((BlockPortalShape) optional.get()).createPortal(itemActionContext); // Paper - pass ItemActionContext param
+                     return;
+                 }
+             }
+diff --git a/src/main/java/net/minecraft/server/BlockPortalShape.java b/src/main/java/net/minecraft/server/BlockPortalShape.java
+index b7635ab1625c5b2540e44aafc2b908749820f7e2..6ef81aeb4c63bc6c23163796dbd977602ca2f540 100644
+--- a/src/main/java/net/minecraft/server/BlockPortalShape.java
++++ b/src/main/java/net/minecraft/server/BlockPortalShape.java
+@@ -162,7 +162,10 @@ public class BlockPortalShape {
+     }
+ 
+     // CraftBukkit start - return boolean
+-    public boolean createPortal() {
++    // Paper start - ItemActionContext param
++    @Deprecated public boolean createPortal() { return this.createPortal(null); }
++    public boolean createPortal(ItemActionContext itemActionContext) {
++        // Paper end
+         org.bukkit.World bworld = this.b.getMinecraftWorld().getWorld();
+ 
+         // Copy below for loop
+@@ -174,7 +177,7 @@ public class BlockPortalShape {
+             blocks.add(state);
+         });
+ 
+-        PortalCreateEvent event = new PortalCreateEvent(blocks, bworld, null, PortalCreateEvent.CreateReason.FIRE);
++        PortalCreateEvent event = new PortalCreateEvent(blocks, bworld, itemActionContext == null || itemActionContext.getEntity() == null ? null : itemActionContext.getEntity().getBukkitEntity(), PortalCreateEvent.CreateReason.FIRE); // Paper - pass entity param
+         this.b.getMinecraftWorld().getMinecraftServer().server.getPluginManager().callEvent(event);
+ 
+         if (event.isCancelled()) {
+diff --git a/src/main/java/net/minecraft/server/ItemStack.java b/src/main/java/net/minecraft/server/ItemStack.java
+index ace50805bfebbf4c3485ba1de334d975830a7d3c..3adb29f004d2fee36f3ee9b21ee5417e84b64837 100644
+--- a/src/main/java/net/minecraft/server/ItemStack.java
++++ b/src/main/java/net/minecraft/server/ItemStack.java
+@@ -313,7 +313,7 @@ public final class ItemStack {
+                         IBlockData block = world.getType(newblockposition);
+ 
+                         if (!(block.getBlock() instanceof BlockTileEntity)) { // Containers get placed automatically
+-                            block.getBlock().onPlace(block, world, newblockposition, oldBlock, true);
++                            block.getBlock().onPlace(block, world, newblockposition, oldBlock, true, itemactioncontext); // Paper - pass itemactioncontext
+                         }
+ 
+                         world.notifyAndUpdatePhysics(newblockposition, null, oldBlock, block, world.getType(newblockposition), updateFlag, 512); // send null chunk as chunk.k() returns false by this point


### PR DESCRIPTION
Fixes #4076.

This still makes `#getEntity` return `null` if caused by
e.g. a dispenser with a flint and steel.