### PR TITLE
Restore overrides changing visibility

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -2284,7 +2284,7 @@ index 277d7a124e9a21803fe4d5a66fc0b311df2cfba7..02c09f39848399a86d46bd17569b4f01
          double d0 = this.b();
          double d1 = this.c();
 diff --git a/src/main/java/net/minecraft/server/BaseBlockPosition.java b/src/main/java/net/minecraft/server/BaseBlockPosition.java
-index 7f803529d67cdea2d809743e34d6d3d456a114d7..6b6ea0b33b10a9517b7af55fb8292fe245e3ca1e 100644
+index 7f803529d67cdea2d809743e34d6d3d456a114d7..f6a5ebd4c7ec045c8dd6841831f8fcc0b32d964e 100644
 --- a/src/main/java/net/minecraft/server/BaseBlockPosition.java
 +++ b/src/main/java/net/minecraft/server/BaseBlockPosition.java
 @@ -16,9 +16,9 @@ public class BaseBlockPosition implements Comparable<BaseBlockPosition> {
@@ -2300,6 +2300,25 @@ index 7f803529d67cdea2d809743e34d6d3d456a114d7..6b6ea0b33b10a9517b7af55fb8292fe2
  
      public BaseBlockPosition(int i, int j, int k) {
          this.a = i;
+@@ -62,15 +62,15 @@ public class BaseBlockPosition implements Comparable<BaseBlockPosition> {
+         return this.e;
+     }
+ 
+-    protected void o(int i) {
++    public void o(int i) { // Paper - protected -> public
+         this.a = i;
+     }
+ 
+-    protected void p(int i) {
++    public void p(int i) { // Paper - protected -> public
+         this.b = i;
+     }
+ 
+-    protected void q(int i) {
++    public void q(int i) { // Paper - protected -> public
+         this.e = i;
+     }
+ 
 @@ -106,6 +106,7 @@ public class BaseBlockPosition implements Comparable<BaseBlockPosition> {
          return this.distanceSquared(iposition.getX(), iposition.getY(), iposition.getZ(), true) < d0 * d0;
      }
@@ -3078,7 +3097,7 @@ index 390d79187bc822187d1ba1102c418fa588e8f121..68f1a101174f4a2f7ab5556a5b733f75
          super(entitytypes, world);
      }
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 06b2c9bdf109ab829142b8125506a3f36bc5260b..c19b17bbf1a816f65cfbfcbdf57c7cb2350cb841 100644
+index 05b1aa66d1dc7bad96236c0cf2c85ddf209a5422..5da6528672d0f14766ca99ce5d2cc40b5035896c 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -160,6 +160,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -3114,7 +3133,7 @@ index 07c48d777a71a979fb1f0063eef2e613e448d2eb..8a5d6869c269369d45cfe4e61853c442
          super(entitytypes, world);
          this.f = 5;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 4faf653a3a929b8043403f485d7de8eeddfac733..dd140b5e55c8ffea7e60962602435c2bd992c048 100644
+index 0e23f117432680346a31b4b43b29ba6981a5c30a..5a06220f876c868ac2ddb4aeaad9f91f0804f2a5 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -93,6 +93,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -4333,7 +4352,7 @@ index ff41038ce6d2c1a8093bce3539070fa0ccfd61c2..ed0f9c5d29c4f88b7beee4b0ecdd7a56
          return VoxelShapes.b;
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a5c1f82dfc80c839c38fa6139b83d3aebeae9155..bf199902c599c7129e42fece0e84e9bc7277050f 100644
+index 733aa2d69e1813a234c39a412e0e7b8857bcdf7b..557a265712695180c4cb1cf49c4e0a5441554e86 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.SpigotTimings; // Spigot


### PR DESCRIPTION
These overrides were in fact not useless.
They changed the visibility of the superclass' methods.
Removing them can (and has) cause issues with plugins using NMS, and it's little maintenance cost for us.

Issue caused in: https://github.com/PaperMC/Paper/commit/9788250b1090713057c6ca39827f52c463fee11c?branch=9788250b1090713057c6ca39827f52c463fee11c&diff=split#diff-5681bcc94a28d03302268d906ba29b93R2378
Fixes #4094.