### PR TITLE
Add #setMaxPlayers API

### DIFF
--- a/Spigot-API-Patches/0218-Add-setMaxPlayers-API.patch
+++ b/Spigot-API-Patches/0218-Add-setMaxPlayers-API.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 22 Aug 2020 23:59:25 +0200
+Subject: [PATCH] Add #setMaxPlayers API
+
+
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 62cc1c74c11f56dcbd1e24e9c5478497742e6351..7fd92462189be35808af67be1740345f186ce555 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -171,6 +171,17 @@ public final class Bukkit {
+         return server.getMaxPlayers();
+     }
+ 
++    // Paper start
++    /**
++     * Set the maximum amount of players which can login to this server.
++     *
++     * @param the amount of players this server allows
++     */
++    public static void setMaxPlayers(int maxPlayers) {
++        server.setMaxPlayers(maxPlayers);
++    }
++    // Paper end
++
+     /**
+      * Get the game port that the server runs on.
+      *
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index 6e01bf2d52e8bb6de7395f50c12f16c64aef72ae..bacb3ee9abe5fe26e02caa7f54fc4e6d5dd605fe 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -144,6 +144,15 @@ public interface Server extends PluginMessageRecipient {
+      */
+     public int getMaxPlayers();
+ 
++    // Paper start
++    /**
++     * Set the maximum amount of players which can login to this server.
++     *
++     * @param the amount of players this server allows
++     */
++    public void setMaxPlayers(int maxPlayers);
++    // Paper end
++
+     /**
+      * Get the game port that the server runs on.
+      *

--- a/Spigot-Server-Patches/0557-Add-setMaxPlayers-API.patch
+++ b/Spigot-Server-Patches/0557-Add-setMaxPlayers-API.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 22 Aug 2020 23:59:30 +0200
+Subject: [PATCH] Add #setMaxPlayers API
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index f9eb17cb6eda0b343240240720495751cf605385..33915eeb0229c0739d69b0ee2cb2251c9d99f87a 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -67,7 +67,7 @@ public abstract class PlayerList {
+     public final WorldNBTStorage playerFileData;
+     private boolean hasWhitelist;
+     private final IRegistryCustom.Dimension s;
+-    protected final int maxPlayers;
++    protected int maxPlayers; public final void setMaxPlayers(int maxPlayers) { this.maxPlayers = maxPlayers; } // Paper - remove final and add setter
+     private int viewDistance;
+     private EnumGamemode u;
+     private boolean v;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 7d83cf39ae4b78588a2cb5decccf53edfd448735..5f5b39b3b7e56e935d1f964fbfc3385a65b7e178 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -614,6 +614,13 @@ public final class CraftServer implements Server {
+         return playerList.getMaxPlayers();
+     }
+ 
++    // Paper start
++    @Override
++    public void setMaxPlayers(int maxPlayers) {
++        this.playerList.setMaxPlayers(maxPlayers);
++    }
++    // Paper end
++
+     // NOTE: These are dependent on the corresponding call in MinecraftServer
+     // so if that changes this will need to as well
+     @Override


### PR DESCRIPTION
Closes PaperMC/Paper#2028.

From what I can tell, the login process and whatnot uses the getter to get the max players (i.e. no caching happens).