### PR TITLE
Fix MC-197271

### DIFF
--- a/Spigot-Server-Patches/0556-Fix-MC-197271.patch
+++ b/Spigot-Server-Patches/0556-Fix-MC-197271.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ishland <ishlandmc@yeah.net>
+Date: Sun, 23 Aug 2020 10:57:44 +0200
+Subject: [PATCH] Fix MC-197271
+
+This patch only fixes an issue for servers running OpenJ9.
+
+diff --git a/src/main/java/net/minecraft/server/RegistryGeneration.java b/src/main/java/net/minecraft/server/RegistryGeneration.java
+index 30db8342893e0af3028fbd8766642407cc109a5d..691f256427825a8e6b3eeaf317da2405954bff1d 100644
+--- a/src/main/java/net/minecraft/server/RegistryGeneration.java
++++ b/src/main/java/net/minecraft/server/RegistryGeneration.java
+@@ -28,11 +28,11 @@ public class RegistryGeneration {
+     public static final IRegistry<ProcessorList> g = a(IRegistry.aw, () -> {
+         return ProcessorLists.b;
+     });
+-    public static final IRegistry<WorldGenFeatureDefinedStructurePoolTemplate> h = a(IRegistry.ax, WorldGenFeaturePieces::a);
++    public static final IRegistry<WorldGenFeatureDefinedStructurePoolTemplate> h = a(IRegistry.ax, () -> WorldGenFeaturePieces.a()); // Paper - MC-197271
+     public static final IRegistry<BiomeBase> WORLDGEN_BIOME = a(IRegistry.ay, () -> {
+         return BiomeRegistry.a;
+     });
+-    public static final IRegistry<GeneratorSettingBase> j = a(IRegistry.ar, GeneratorSettingBase::i);
++    public static final IRegistry<GeneratorSettingBase> j = a(IRegistry.ar, () -> GeneratorSettingBase.i()); // Paper - MC-197271
+ 
+     private static <T> IRegistry<T> a(ResourceKey<? extends IRegistry<T>> resourcekey, Supplier<T> supplier) {
+         return a(resourcekey, Lifecycle.stable(), supplier);
+@@ -46,9 +46,9 @@ public class RegistryGeneration {
+         MinecraftKey minecraftkey = resourcekey.a();
+ 
+         RegistryGeneration.k.put(minecraftkey, supplier);
+-        IRegistryWritable<R> iregistrywritable = RegistryGeneration.l;
++        IRegistryWritable<R> iregistrywritable = (IRegistryWritable<R>) RegistryGeneration.l; // Paper - decompile fix
+ 
+-        return (IRegistryWritable) iregistrywritable.a(resourcekey, (Object) r0, lifecycle);
++        return (R) iregistrywritable.a((ResourceKey<R>) resourcekey, r0, lifecycle); // Paper - decompile fix
+     }
+ 
+     public static <T> T a(IRegistry<? super T> iregistry, String s, T t0) {
+@@ -56,11 +56,11 @@ public class RegistryGeneration {
+     }
+ 
+     public static <V, T extends V> T a(IRegistry<V> iregistry, MinecraftKey minecraftkey, T t0) {
+-        return ((IRegistryWritable) iregistry).a(ResourceKey.a(iregistry.f(), minecraftkey), t0, Lifecycle.stable());
++        return (T) ((IRegistryWritable) iregistry).a(ResourceKey.a(iregistry.f(), minecraftkey), t0, Lifecycle.stable()); // Paper - decompile fix
+     }
+ 
+     public static <V, T extends V> T a(IRegistry<V> iregistry, int i, ResourceKey<V> resourcekey, T t0) {
+-        return ((IRegistryWritable) iregistry).a(i, resourcekey, t0, Lifecycle.stable());
++        return (T) ((IRegistryWritable) iregistry).a(i, resourcekey, t0, Lifecycle.stable()); // Paper - decompile fix
+     }
+ 
+     public static void a() {}


### PR DESCRIPTION
This fixes an issue on OpenJ9 JVMs.

Patch author: @ishland
https://github.com/YatopiaMC/Yatopia/pull/144

Redundant with a release of OpenJ9 with this: https://github.com/eclipse/openj9/pull/10410
I'd say we should just keep the patch till it no longer applies (1.16.3/1.17), as by then the affected users should really update.