### PR TITLE
Add #getEligibleHumans to SkeletonHorseTrapEvent

### DIFF
--- a/Spigot-API-Patches/0124-SkeletonHorse-Additions.patch
+++ b/Spigot-API-Patches/0124-SkeletonHorse-Additions.patch
@@ -6,17 +6,21 @@ Subject: [PATCH] SkeletonHorse Additions
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d79dbcd689ffb8d87a197aa112fec678b576f80f
+index 0000000000000000000000000000000000000000..9ce2948dfaa56d0adf53fe9b6117a90d7773b771
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/SkeletonHorseTrapEvent.java
-@@ -0,0 +1,47 @@
+@@ -0,0 +1,62 @@
 +package com.destroystokyo.paper.event.entity;
 +
++import com.google.common.collect.ImmutableList;
++import org.bukkit.entity.HumanEntity;
 +import org.bukkit.entity.SkeletonHorse;
 +import org.bukkit.event.Cancellable;
 +import org.bukkit.event.HandlerList;
 +import org.bukkit.event.entity.EntityEvent;
 +import org.jetbrains.annotations.NotNull;
++
++import java.util.List;
 +
 +/**
 + * Event called when a player gets close to a skeleton horse and triggers the lightning trap
@@ -24,9 +28,15 @@ index 0000000000000000000000000000000000000000..d79dbcd689ffb8d87a197aa112fec678
 +public class SkeletonHorseTrapEvent extends EntityEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();
 +    private boolean cancelled;
++    private final List<HumanEntity> eligibleHumans;
 +
 +    public SkeletonHorseTrapEvent(@NotNull SkeletonHorse horse) {
++        this(horse, ImmutableList.of());
++    }
++
++    public SkeletonHorseTrapEvent(@NotNull SkeletonHorse horse, @NotNull List<HumanEntity> eligibleHumans) {
 +        super(horse);
++        this.eligibleHumans = eligibleHumans;
 +    }
 +
 +    @NotNull
@@ -43,6 +53,11 @@ index 0000000000000000000000000000000000000000..d79dbcd689ffb8d87a197aa112fec678
 +    @Override
 +    public void setCancelled(boolean cancel) {
 +        this.cancelled = cancel;
++    }
++
++    @NotNull
++    public List<HumanEntity> getEligibleHumans() {
++        return eligibleHumans;
 +    }
 +
 +    @NotNull

--- a/Spigot-Server-Patches/0250-SkeletonHorse-Additions.patch
+++ b/Spigot-Server-Patches/0250-SkeletonHorse-Additions.patch
@@ -30,15 +30,91 @@ index bb23e313b236ceb81c60d62833dc6f5afee044eb..a53d335f3af9df80bec3f94f81fb5ff0
      public void t(boolean flag) {
          if (flag != this.bx) {
              this.bx = flag;
+diff --git a/src/main/java/net/minecraft/server/IEntityAccess.java b/src/main/java/net/minecraft/server/IEntityAccess.java
+index 14400d0e4b0713e852861ed55e289e4dead95cea..90c94729edf8d18f33d72e872f7969abef0067a0 100644
+--- a/src/main/java/net/minecraft/server/IEntityAccess.java
++++ b/src/main/java/net/minecraft/server/IEntityAccess.java
+@@ -1,6 +1,9 @@
+ package net.minecraft.server;
+ 
++import com.google.common.collect.ImmutableList;
+ import com.google.common.collect.Lists;
++import org.bukkit.entity.HumanEntity;
++
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.UUID;
+@@ -106,6 +109,28 @@ public interface IEntityAccess {
+         return entityhuman;
+     }
+ 
++    // Paper start
++    default List<HumanEntity> findNearbyBukkitPlayers(double x, double y, double z, double radius, boolean notSpectator) {
++        return findNearbyBukkitPlayers(x, y, z, radius, notSpectator ? IEntitySelector.notSpectator() : IEntitySelector.canAITarget());
++    }
++
++    default List<HumanEntity> findNearbyBukkitPlayers(double x, double y, double z, double radius, @Nullable Predicate<Entity> predicate) {
++        ImmutableList.Builder<HumanEntity> builder = ImmutableList.builder();
++
++        for (EntityHuman human : this.getPlayers()) {
++            if (predicate == null || predicate.test(human)) {
++                double distanceSquared = human.getDistanceSquared(x, y, z);
++
++                if (radius < 0.0D || distanceSquared < radius * radius) {
++                    builder.add(human.getBukkitEntity());
++                }
++            }
++        }
++
++        return builder.build();
++    }
++    // Paper end
++
+     @Nullable
+     default EntityHuman findNearbyPlayer(Entity entity, double d0) {
+         return this.a(entity.locX(), entity.locY(), entity.locZ(), d0, false);
+diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
+index ff1ddb4db5406f81453a8f075033d00e06bce6a5..863f4464c688912b3e0ce61cbbbf263e38a3af4b 100644
+--- a/src/main/java/net/minecraft/server/IEntitySelector.java
++++ b/src/main/java/net/minecraft/server/IEntitySelector.java
+@@ -20,6 +20,7 @@ public final class IEntitySelector {
+     public static final Predicate<Entity> f = (entity) -> {
+         return !(entity instanceof EntityHuman) || !entity.isSpectator() && !((EntityHuman) entity).isCreative() && entity.world.getDifficulty() != EnumDifficulty.PEACEFUL;
+     };
++    public static Predicate<Entity> notSpectator() { return g; } // Paper - OBFHELPER
+     public static final Predicate<Entity> g = (entity) -> {
+         return !entity.isSpectator();
+     };
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalHorseTrap.java b/src/main/java/net/minecraft/server/PathfinderGoalHorseTrap.java
-index 8433a1a9a7de6a705a7fbecb593742ffa2e544f0..6a9af67d03737041a8f78c85a166c79a841ec8e5 100644
+index 8433a1a9a7de6a705a7fbecb593742ffa2e544f0..b0d1abeda19423d8adf0ff596442b00ac2e53357 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalHorseTrap.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalHorseTrap.java
-@@ -16,6 +16,7 @@ public class PathfinderGoalHorseTrap extends PathfinderGoal {
+@@ -1,8 +1,13 @@
+ package net.minecraft.server;
+ 
++import org.bukkit.entity.HumanEntity;
++
++import java.util.List;
++
+ public class PathfinderGoalHorseTrap extends PathfinderGoal {
+ 
+     private final EntityHorseSkeleton a;
++    private List<HumanEntity> eligiblePlayers; // Paper
+ 
+     public PathfinderGoalHorseTrap(EntityHorseSkeleton entityhorseskeleton) {
+         this.a = entityhorseskeleton;
+@@ -10,12 +15,13 @@ public class PathfinderGoalHorseTrap extends PathfinderGoal {
+ 
+     @Override
+     public boolean a() {
+-        return this.a.world.isPlayerNearby(this.a.locX(), this.a.locY(), this.a.locZ(), 10.0D);
++        return !(eligiblePlayers = this.a.world.findNearbyBukkitPlayers(this.a.locX(), this.a.locY(), this.a.locZ(), 10.0D, false)).isEmpty(); // Paper
+     }
+ 
      @Override
      public void e() {
          WorldServer worldserver = (WorldServer) this.a.world;
-+        if (!new com.destroystokyo.paper.event.entity.SkeletonHorseTrapEvent((org.bukkit.entity.SkeletonHorse) this.a.getBukkitEntity()).callEvent()) return; // Paper
++        if (!new com.destroystokyo.paper.event.entity.SkeletonHorseTrapEvent((org.bukkit.entity.SkeletonHorse) this.a.getBukkitEntity(), eligiblePlayers).callEvent()) return; // Paper
          DifficultyDamageScaler difficultydamagescaler = worldserver.getDamageScaler(this.a.getChunkCoordinates());
  
          this.a.t(false);

--- a/Spigot-Server-Patches/0394-Optimise-IEntityAccess-getPlayerByUUID.patch
+++ b/Spigot-Server-Patches/0394-Optimise-IEntityAccess-getPlayerByUUID.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise IEntityAccess#getPlayerByUUID
 Use the world entity map instead of iterating over all players
 
 diff --git a/src/main/java/net/minecraft/server/IEntityAccess.java b/src/main/java/net/minecraft/server/IEntityAccess.java
-index 14400d0e4b0713e852861ed55e289e4dead95cea..07dbdd560909c8ef64740d82f02bae3d67119ab9 100644
+index 90c94729edf8d18f33d72e872f7969abef0067a0..2639c17b7f6100533f33124f9e49990cd303d161 100644
 --- a/src/main/java/net/minecraft/server/IEntityAccess.java
 +++ b/src/main/java/net/minecraft/server/IEntityAccess.java
-@@ -243,6 +243,12 @@ public interface IEntityAccess {
+@@ -268,6 +268,12 @@ public interface IEntityAccess {
  
      @Nullable
      default EntityHuman b(UUID uuid) {

--- a/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
@@ -33,10 +33,10 @@ index 1afcf17a8ca4eb17125e2a9d066c5a15a3818417..3a70900c73e3a6c4f40cf74406534f4b
                              return true;
                          }
 diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
-index 94d90eb50a8b0ce104128ef016692ad91a883c2a..31eb6868c2de20a7aa7438dbabf7a5f790d75732 100644
+index 3913af9e27139538114580f7967cbf990d9307f7..56fc1777401ab0fbebbbaf21f33f63c078dc9505 100644
 --- a/src/main/java/net/minecraft/server/IEntitySelector.java
 +++ b/src/main/java/net/minecraft/server/IEntitySelector.java
-@@ -25,6 +25,7 @@ public final class IEntitySelector {
+@@ -26,6 +26,7 @@ public final class IEntitySelector {
      public static final Predicate<Entity> g = (entity) -> {
          return !entity.isSpectator();
      };

--- a/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -155,10 +155,10 @@ index 1c682a62b8fd871848ebe8ff0dc576da6bb28810..0af6c9395b5d98e6bfa162f651d0e8cb
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/IEntitySelector.java b/src/main/java/net/minecraft/server/IEntitySelector.java
-index 31eb6868c2de20a7aa7438dbabf7a5f790d75732..164d47fcf434e257d586d59141c524fb2c6e8561 100644
+index 56fc1777401ab0fbebbbaf21f33f63c078dc9505..b5e1a860a2569d7668330827614d221b60f3fc78 100644
 --- a/src/main/java/net/minecraft/server/IEntitySelector.java
 +++ b/src/main/java/net/minecraft/server/IEntitySelector.java
-@@ -42,11 +42,17 @@ public final class IEntitySelector {
+@@ -43,11 +43,17 @@ public final class IEntitySelector {
      }
  
      public static Predicate<Entity> a(Entity entity) {


### PR DESCRIPTION
Updated #1967.
Closes #1800.
Takes into account @electronicboy's request of having all eligible players be available through the API.