### PR TITLE
Fix javadocs failing jenkins builds

### DIFF
--- a/Spigot-API-Patches/0218-Add-setMaxPlayers-API.patch
+++ b/Spigot-API-Patches/0218-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 62cc1c74c11f56dcbd1e24e9c5478497742e6351..7fd92462189be35808af67be1740345f186ce555 100644
+index 62cc1c74c11f56dcbd1e24e9c5478497742e6351..bfe842364ee0a4bf39dacdbb6972477d57a4ef8a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -171,6 +171,17 @@ public final class Bukkit {
@@ -16,7 +16,7 @@ index 62cc1c74c11f56dcbd1e24e9c5478497742e6351..7fd92462189be35808af67be1740345f
 +    /**
 +     * Set the maximum amount of players which can login to this server.
 +     *
-+     * @param the amount of players this server allows
++     * @param maxPlayers the amount of players this server allows
 +     */
 +    public static void setMaxPlayers(int maxPlayers) {
 +        server.setMaxPlayers(maxPlayers);
@@ -27,7 +27,7 @@ index 62cc1c74c11f56dcbd1e24e9c5478497742e6351..7fd92462189be35808af67be1740345f
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 6e01bf2d52e8bb6de7395f50c12f16c64aef72ae..bacb3ee9abe5fe26e02caa7f54fc4e6d5dd605fe 100644
+index 6e01bf2d52e8bb6de7395f50c12f16c64aef72ae..7c0a788900c93c29d14d8c45ac5ae3317cf4a94e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -144,6 +144,15 @@ public interface Server extends PluginMessageRecipient {
@@ -38,7 +38,7 @@ index 6e01bf2d52e8bb6de7395f50c12f16c64aef72ae..bacb3ee9abe5fe26e02caa7f54fc4e6d
 +    /**
 +     * Set the maximum amount of players which can login to this server.
 +     *
-+     * @param the amount of players this server allows
++     * @param maxPlayers the amount of players this server allows
 +     */
 +    public void setMaxPlayers(int maxPlayers);
 +    // Paper end


### PR DESCRIPTION
The missing variable in @param causes Jenkins to fail builds when generating Javadocs