### PR TITLE
Zero pad chunks before saving

### DIFF
--- a/Spigot-Server-Patches/0599-Zero-pad-chunks-before-saving-them-to-the-disk.patch
+++ b/Spigot-Server-Patches/0599-Zero-pad-chunks-before-saving-them-to-the-disk.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Toon Schoenmakers <nighteyes1993@gmail.com>
+Date: Mon, 12 Oct 2020 18:59:12 +0200
+Subject: [PATCH] Zero pad chunks before saving them to the disk
+
+This makes the unused data inside region files more repeatable.
+Which will result in better compression in case the entire world directory
+is compressed (like in backups). Which will naturally result in smaller backups.
+
+diff --git a/src/main/java/net/minecraft/server/RegionFile.java b/src/main/java/net/minecraft/server/RegionFile.java
+index 1751fb6934d9242e475c1a44b2a4a1ade6987766..e969625d246f4657b4e802ac6a9d11e5c3b2e8c3 100644
+--- a/src/main/java/net/minecraft/server/RegionFile.java
++++ b/src/main/java/net/minecraft/server/RegionFile.java
+@@ -513,13 +513,14 @@ public class RegionFile implements AutoCloseable {
+         }
+ 
+     }
++    private static final ByteBuffer zero = ByteBuffer.allocateDirect(4096);
+     // Paper end
+     class ChunkBuffer extends ByteArrayOutputStream {
+ 
+         private final ChunkCoordIntPair b;
+ 
+         public ChunkBuffer(ChunkCoordIntPair chunkcoordintpair) {
+-            super(8096);
++            super(8192); // Paper
+             super.write(0);
+             super.write(0);
+             super.write(0);
+@@ -532,6 +533,17 @@ public class RegionFile implements AutoCloseable {
+             ByteBuffer bytebuffer = ByteBuffer.wrap(this.buf, 0, this.count);
+ 
+             bytebuffer.putInt(0, this.count - 5 + 1);
++
++            // Paper start
++            int size = (this.count + 4095) & ~4095;
++
++            // increase the limit to be the next chunk of 4096
++            bytebuffer.limit(size);
++
++            // now just fill the rest with zeros from our static buffer
++            bytebuffer.put(zero);
++            // Paper end
++
+             RegionFile.this.a(this.b, bytebuffer);
+         }
+     }


### PR DESCRIPTION
This way the world is better compressable and backups will be smaller. I made an external tool that does this after the fact and it can make backups of the entire world around 5 to 20% smaller in my testings.