### PR TITLE
[CI-SKIP] Require /version, not build num

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug---plugin-incompatibility.md
+++ b/.github/ISSUE_TEMPLATE/behavior-bug---plugin-incompatibility.md
@@ -19,8 +19,8 @@ ___This may include a build schematic, a video, or detailed instructions to help
 ### Plugin list:
 ___A list of your plugins___
 
-### Paper build number:
-___This can be found by running `/version` on your server. `latest` is not a proper version number; we require the output of `/version` so we can properly track down the issue.___
+### Paper version:
+___Paste the output of running `/version` on your server WITH the Minecraft version. `latest` is not a version; we require the output of `/version` so we can properly track down the issue.___
 
 ### Anything else:
 ___Anything else you think may help us resolve the problem___

--- a/.github/ISSUE_TEMPLATE/performance-problem.md
+++ b/.github/ISSUE_TEMPLATE/performance-problem.md
@@ -23,5 +23,5 @@ ___Gist/pastebin/hastebin links___
 ___The more information we receive, the quicker and more effective we can be at finding the solution to the
 issue.___
 
-### Paper build number:
-___This can be found by running `/version` on your server. `latest` is not a proper version number; we require the output of `/version` so we can properly track down the issue.___
+### Paper version:
+___Paste the output of running `/version` on your server WITH the Minecraft version. `latest` is not a version; we require the output of `/version` so we can properly track down the issue.___

--- a/.github/ISSUE_TEMPLATE/server-crash---stacktrace.md
+++ b/.github/ISSUE_TEMPLATE/server-crash---stacktrace.md
@@ -21,5 +21,5 @@ ___A list of your plugins___
 ### Actions to reproduce (if known):
 ___This may include a build schematic, a video, or detailed instructions to help reconstruct the issue___
 
-### Paper build number:
-___This can be found by running `/version` on your server. `latest` is not a proper version number; we require the output of `/version` so we can properly track down the issue.___
+### Paper version:
+___Paste the output of running `/version` on your server WITH the Minecraft version. `latest` is not a version; we require the output of `/version` so we can properly track down the issue.___


### PR DESCRIPTION
Require version instead of build num.