### PR TITLE
 Toggles for special MobSpawner classes per world

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -460,15 +460,18 @@ index 0000000000000000000000000000000000000000..2c0514892d3993bef57ecf677cf8bb0f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b773d2be0
+index 0000000000000000000000000000000000000000..f84e9feec36f623f413e6d2b8eb25edb1e1358f7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,79 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
++import java.util.function.Predicate;
 +
++import org.apache.commons.lang.BooleanUtils;
 +import org.bukkit.Bukkit;
++import org.bukkit.World.Environment;
 +import org.bukkit.configuration.file.YamlConfiguration;
 +import org.spigotmc.SpigotWorldConfig;
 +
@@ -479,12 +482,14 @@ index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b
 +
 +    private final String worldName;
 +    private final SpigotWorldConfig spigotConfig;
++    private final Environment environment;
 +    private YamlConfiguration config;
 +    private boolean verbose;
 +
-+    public PaperWorldConfig(String worldName, SpigotWorldConfig spigotConfig) {
++    public PaperWorldConfig(String worldName, SpigotWorldConfig spigotConfig, Environment environment) {
 +        this.worldName = worldName;
 +        this.spigotConfig = spigotConfig;
++        this.environment = environment;
 +        this.config = PaperConfig.config;
 +        init();
 +    }
@@ -505,6 +510,12 @@ index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b
 +    private boolean getBoolean(String path, boolean def) {
 +        config.addDefault("world-settings.default." + path, def);
 +        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
++    }
++
++    private boolean getBoolean(String path, Predicate<Boolean> predicate) {
++        String val = getString(path, "default").toLowerCase();
++        Boolean bool = BooleanUtils.toBooleanObject(val, "true", "false", "default");
++        return predicate.test(bool);
 +    }
 +
 +    private double getDouble(String path, double def) {
@@ -634,7 +645,7 @@ index 6d1012cc652780189a5d849125abe09b27b88422..49649e70ee8bfb3dacd63a88a180f0f3
          Main.LOGGER.info("Forcing world upgrade! {}", convertable_conversionsession.getLevelName()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(convertable_conversionsession, datafixer, immutableset, flag);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 169822482d3e31ef4f625a82102adc6d478588a8..2ffa56f3580b524c3593505585410dc347e1780c 100644
+index 169822482d3e31ef4f625a82102adc6d478588a8..2b440b277ec51598657f85cec5bd574492c5f4eb 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -77,6 +77,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -650,7 +661,7 @@ index 169822482d3e31ef4f625a82102adc6d478588a8..2ffa56f3580b524c3593505585410dc3
  
      protected World(WorldDataMutable worlddatamutable, ResourceKey<World> resourcekey, final DimensionManager dimensionmanager, Supplier<GameProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.World.Environment env) {
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((WorldDataServer) worlddatamutable).getName()); // Spigot
-+        this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((WorldDataServer) worlddatamutable).getName(), this.spigotConfig); // Paper
++        this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((WorldDataServer) worlddatamutable).getName(), this.spigotConfig, env); // Paper
          this.generator = gen;
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit

--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -4387,7 +4387,7 @@ index ff41038ce6d2c1a8093bce3539070fa0ccfd61c2..ed0f9c5d29c4f88b7beee4b0ecdd7a56
          return VoxelShapes.b;
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 2ffa56f3580b524c3593505585410dc347e1780c..cb09b6947080f742b15b166e96e91231fcb5e79e 100644
+index 2b440b277ec51598657f85cec5bd574492c5f4eb..b20dcd1a81a060414f86c84a1e4e0fc767597ee4 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.SpigotTimings; // Spigot

--- a/Spigot-Server-Patches/0010-Configurable-cactus-and-reed-natural-growth-heights.patch
+++ b/Spigot-Server-Patches/0010-Configurable-cactus-and-reed-natural-growth-heights.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable cactus and reed natural growth heights
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b31109d2dadd29e8852468c19265066b773d2be0..d97288b27668e0544b05ce110bfc6a0834cc263d 100644
+index f84e9feec36f623f413e6d2b8eb25edb1e1358f7..52cbc4882a4d94f1b498fdfe4027e67161ce4a3b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -65,4 +65,13 @@ public class PaperWorldConfig {
+@@ -76,4 +76,13 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def);
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }

--- a/Spigot-Server-Patches/0011-Configurable-baby-zombie-movement-speed.patch
+++ b/Spigot-Server-Patches/0011-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d97288b27668e0544b05ce110bfc6a0834cc263d..29f35535fab41aee6d253de9f9bd566d0fc28d65 100644
+index 52cbc4882a4d94f1b498fdfe4027e67161ce4a3b..8111457861e4d9be98defc570b71cca7901de115 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -74,4 +74,15 @@ public class PaperWorldConfig {
+@@ -85,4 +85,15 @@ public class PaperWorldConfig {
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight);
  
      }

--- a/Spigot-Server-Patches/0012-Configurable-fishing-time-ranges.patch
+++ b/Spigot-Server-Patches/0012-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 29f35535fab41aee6d253de9f9bd566d0fc28d65..02f4342b23ad4a3ad0ed09affe7ce5e572354668 100644
+index 8111457861e4d9be98defc570b71cca7901de115..29a9bb37ccd916adaa8953a262d4b7a9e41bf318 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -85,4 +85,12 @@ public class PaperWorldConfig {
+@@ -96,4 +96,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/Spigot-Server-Patches/0013-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/Spigot-Server-Patches/0013-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 02f4342b23ad4a3ad0ed09affe7ce5e572354668..4982fd2842342fe9a37123e34af0040ec580cf2d 100644
+index 29a9bb37ccd916adaa8953a262d4b7a9e41bf318..97c10fbb80b20ac1494fc0a4637184b24275a5e4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -93,4 +93,9 @@ public class PaperWorldConfig {
+@@ -104,4 +104,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }

--- a/Spigot-Server-Patches/0014-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/Spigot-Server-Patches/0014-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4982fd2842342fe9a37123e34af0040ec580cf2d..eb3185250812f5c2b2d24a2de6b2248d280b771e 100644
+index 97c10fbb80b20ac1494fc0a4637184b24275a5e4..2ecabbb07c9a95c5262e4d4a851f7bf0ee332745 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -98,4 +98,20 @@ public class PaperWorldConfig {
+@@ -109,4 +109,20 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }

--- a/Spigot-Server-Patches/0015-Allow-for-toggling-of-spawn-chunks.patch
+++ b/Spigot-Server-Patches/0015-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eb3185250812f5c2b2d24a2de6b2248d280b771e..b2dfad6a75c18b81c76539b7327a85da98ccf810 100644
+index 2ecabbb07c9a95c5262e4d4a851f7bf0ee332745..2ae606172d3e032118b3814ef46c79e2a12c020b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -114,4 +114,10 @@ public class PaperWorldConfig {
+@@ -125,4 +125,10 @@ public class PaperWorldConfig {
          softDespawnDistance = softDespawnDistance*softDespawnDistance;
          hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
      }
@@ -20,7 +20,7 @@ index eb3185250812f5c2b2d24a2de6b2248d280b771e..b2dfad6a75c18b81c76539b7327a85da
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index e24c5e20f128e787f0a0e58716944dd8748f73c1..3f2ca3874f743c635fd6a7f6c18d554425a0c056 100644
+index 619ec7ee90d353fea628b86db66b3396fbaabc0a..46168a57e4c20b84fa1afff5386603de22162308 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -165,6 +165,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0016-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/Spigot-Server-Patches/0016-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b2dfad6a75c18b81c76539b7327a85da98ccf810..60c38406c599b5952855b3dc18fc3defa9d62ca4 100644
+index 2ae606172d3e032118b3814ef46c79e2a12c020b..3b94751f327e98a779f3644c6addfad0ebfcea1e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -120,4 +120,14 @@ public class PaperWorldConfig {
+@@ -131,4 +131,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }

--- a/Spigot-Server-Patches/0027-Configurable-top-of-nether-void-damage.patch
+++ b/Spigot-Server-Patches/0027-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 60c38406c599b5952855b3dc18fc3defa9d62ca4..a005c4398336dba3b5e3ef716f44f2eda7306442 100644
+index 3b94751f327e98a779f3644c6addfad0ebfcea1e..39360e5eacc21d4d44b0de0965b370b739e2a620 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -130,4 +130,19 @@ public class PaperWorldConfig {
+@@ -141,4 +141,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }

--- a/Spigot-Server-Patches/0030-Configurable-end-credits.patch
+++ b/Spigot-Server-Patches/0030-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a005c4398336dba3b5e3ef716f44f2eda7306442..88f5a415770da5dfcf7af95045f547e0761adc8b 100644
+index 39360e5eacc21d4d44b0de0965b370b739e2a620..a1554c810564eb91d5e8353ed33aeead93c89817 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -145,4 +145,10 @@ public class PaperWorldConfig {
+@@ -156,4 +156,10 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/Spigot-Server-Patches/0032-Optimize-explosions.patch
+++ b/Spigot-Server-Patches/0032-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88f5a415770da5dfcf7af95045f547e0761adc8b..41d03030741f2bc5dd904957be546de82be61a47 100644
+index a1554c810564eb91d5e8353ed33aeead93c89817..5ca859401a89c01a2356df933facaa02bce58622 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -151,4 +151,10 @@ public class PaperWorldConfig {
+@@ -162,4 +162,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }
@@ -135,7 +135,7 @@ index 775306d7e59ff135004e54d2d055bd05edba7e61..4d3cb70f1567b042e1605b3063770656
  
          this.methodProfiler.exitEnter("connection");
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index fb26ec91ecdeaa94a6247c064b7c6191a43927eb..d8ff91fea7d00f035bac0fa7378dcf675a719857 100644
+index 9e4a3a8dc36bfa0edf6e54a3353cc78661a75934..fae643a44f2c60300995b4990fdeea238cdee45e 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -84,6 +84,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0033-Disable-explosion-knockback.patch
+++ b/Spigot-Server-Patches/0033-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 41d03030741f2bc5dd904957be546de82be61a47..623186e8503ff1debabc409b27fd3d29dcd5ced8 100644
+index 5ca859401a89c01a2356df933facaa02bce58622..86a12c678b3a46e6bb64fa53d4ef38b2ab3d8e33 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -157,4 +157,9 @@ public class PaperWorldConfig {
+@@ -168,4 +168,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }

--- a/Spigot-Server-Patches/0034-Disable-thunder.patch
+++ b/Spigot-Server-Patches/0034-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 623186e8503ff1debabc409b27fd3d29dcd5ced8..0770de735f3cf4eb46c4ffd5b76eb393ad94a166 100644
+index 86a12c678b3a46e6bb64fa53d4ef38b2ab3d8e33..be7f9131fa644b732d1ac911ae180dc0ea7b4dce 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -162,4 +162,9 @@ public class PaperWorldConfig {
+@@ -173,4 +173,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
+++ b/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0770de735f3cf4eb46c4ffd5b76eb393ad94a166..870b50b1b981943eaba874fe26d89e111405969a 100644
+index be7f9131fa644b732d1ac911ae180dc0ea7b4dce..221a9d26969caf3f11dee6116f80b7f23d815e84 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -167,4 +167,9 @@ public class PaperWorldConfig {
+@@ -178,4 +178,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }

--- a/Spigot-Server-Patches/0036-Configurable-mob-spawner-tick-rate.patch
+++ b/Spigot-Server-Patches/0036-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 870b50b1b981943eaba874fe26d89e111405969a..8f45fa5ca878428a9ce6b18df075d3f09b2cf757 100644
+index 221a9d26969caf3f11dee6116f80b7f23d815e84..ed3c08876d6c76282bb4069406bb23e50e1b96be 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -172,4 +172,9 @@ public class PaperWorldConfig {
+@@ -183,4 +183,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
+++ b/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8f45fa5ca878428a9ce6b18df075d3f09b2cf757..1d8d1a4e387f205f6c1c9b608f20e30763dec01a 100644
+index ed3c08876d6c76282bb4069406bb23e50e1b96be..9c7dc0a55c88ff77587002a2c798996dab817e42 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -177,4 +177,9 @@ public class PaperWorldConfig {
+@@ -188,4 +188,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }

--- a/Spigot-Server-Patches/0043-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/Spigot-Server-Patches/0043-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1d8d1a4e387f205f6c1c9b608f20e30763dec01a..68132778ebafbb65077b82df8fcd8cdda319ffab 100644
+index 9c7dc0a55c88ff77587002a2c798996dab817e42..1c7e0de350d8c1b2e1c6c55a12eaa701075fd52b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -182,4 +182,9 @@ public class PaperWorldConfig {
+@@ -193,4 +193,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/Spigot-Server-Patches/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/Spigot-Server-Patches/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 68132778ebafbb65077b82df8fcd8cdda319ffab..e2cb804fd40e236337c37d89dfc85a02486c1bf4 100644
+index 1c7e0de350d8c1b2e1c6c55a12eaa701075fd52b..940102aaea2429f45d18c927c0b1bf2293f9bdd0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -187,4 +187,9 @@ public class PaperWorldConfig {
+@@ -198,4 +198,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }

--- a/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e2cb804fd40e236337c37d89dfc85a02486c1bf4..cff769a0cffd81501f919fad0c6456e1268bd223 100644
+index 940102aaea2429f45d18c927c0b1bf2293f9bdd0..d4f4b6d6420efe37e37b058800b9c7cb38d84f27 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -192,4 +192,11 @@ public class PaperWorldConfig {
+@@ -203,4 +203,11 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }

--- a/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cff769a0cffd81501f919fad0c6456e1268bd223..a6c02f676f4206f2f59862530999cd74a2e0c20f 100644
+index d4f4b6d6420efe37e37b058800b9c7cb38d84f27..202738c4c131bfc32da7047816f7398258fed21a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -199,4 +199,9 @@ public class PaperWorldConfig {
+@@ -210,4 +210,9 @@ public class PaperWorldConfig {
          portalSearchRadius = getInt("portal-search-radius", 128);
          portalCreateRadius = getInt("portal-create-radius", 16);
      }

--- a/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a6c02f676f4206f2f59862530999cd74a2e0c20f..1f229e68349f49d7c461b1d9895a70968304be7f 100644
+index 202738c4c131bfc32da7047816f7398258fed21a..5a515247bc3b4cf37df7496d467f4542ad8348a8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -204,4 +204,9 @@ public class PaperWorldConfig {
+@@ -215,4 +215,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }

--- a/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1f229e68349f49d7c461b1d9895a70968304be7f..4c956da69261d3092cd9abb1b98f7c9a220cc91e 100644
+index 5a515247bc3b4cf37df7496d467f4542ad8348a8..1c8111e5f29866065a99597cf705d24379612a6a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -209,4 +209,19 @@ public class PaperWorldConfig {
+@@ -220,4 +220,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/Spigot-Server-Patches/0069-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/Spigot-Server-Patches/0069-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4c956da69261d3092cd9abb1b98f7c9a220cc91e..6998ec2d7550094498649deb9028988700982e04 100644
+index 1c8111e5f29866065a99597cf705d24379612a6a..373e7a9a5da94d9cc036a166f976db8022be0e8b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -224,4 +224,12 @@ public class PaperWorldConfig {
+@@ -235,4 +235,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/Spigot-Server-Patches/0073-Configurable-Chunk-Inhabited-Time.patch
+++ b/Spigot-Server-Patches/0073-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6998ec2d7550094498649deb9028988700982e04..6babdde2910162a03b8abbcbb7db1f78eb3376c2 100644
+index 373e7a9a5da94d9cc036a166f976db8022be0e8b..d12d35033dd315616ccca40042c4812e337852a8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -232,4 +232,14 @@ public class PaperWorldConfig {
+@@ -243,4 +243,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0079-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/Spigot-Server-Patches/0079-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6babdde2910162a03b8abbcbb7db1f78eb3376c2..f433b1e46b1e97fa60f1bd32a1403189217d3afd 100644
+index d12d35033dd315616ccca40042c4812e337852a8..f620321d3fdcbb6cc5c0579746b28fc23b27d1b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -242,4 +242,10 @@ public class PaperWorldConfig {
+@@ -253,4 +253,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/Spigot-Server-Patches/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f433b1e46b1e97fa60f1bd32a1403189217d3afd..004e1cdfeef75c79889a1a7334773ab933c62086 100644
+index f620321d3fdcbb6cc5c0579746b28fc23b27d1b7..3da5563d66220344e8f9fe0adc93d23d91891fde 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -248,4 +248,9 @@ public class PaperWorldConfig {
+@@ -259,4 +259,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/Spigot-Server-Patches/0092-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/Spigot-Server-Patches/0092-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 004e1cdfeef75c79889a1a7334773ab933c62086..fd09df36c0f28f77b1f6c32b4e68da8a3ab59aa9 100644
+index 3da5563d66220344e8f9fe0adc93d23d91891fde..c013c106e510cc827821749447fb88544b5a8cab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -253,4 +253,14 @@ public class PaperWorldConfig {
+@@ -264,4 +264,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/Spigot-Server-Patches/0095-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0095-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd09df36c0f28f77b1f6c32b4e68da8a3ab59aa9..64da34a840dc433670675a30062b8b17c29dd0c4 100644
+index c013c106e510cc827821749447fb88544b5a8cab..81ddab22013ba6c3cd74b11b1a9449b3f90fe647 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -263,4 +263,26 @@ public class PaperWorldConfig {
+@@ -274,4 +274,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/Spigot-Server-Patches/0100-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0100-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 64da34a840dc433670675a30062b8b17c29dd0c4..3599aa415076525a4529664b9b9f0339b2eff730 100644
+index 81ddab22013ba6c3cd74b11b1a9449b3f90fe647..a1afebb0e502712a674807d6873399dafa89e211 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -2,7 +2,6 @@ package com.destroystokyo.paper;
- 
- import java.util.List;
- 
--import org.bukkit.Bukkit;
- import org.bukkit.configuration.file.YamlConfiguration;
- import org.spigotmc.SpigotWorldConfig;
- 
-@@ -285,4 +284,14 @@ public class PaperWorldConfig {
+@@ -296,4 +296,14 @@ public class PaperWorldConfig {
              );
          }
      }

--- a/Spigot-Server-Patches/0114-Option-to-remove-corrupt-tile-entities.patch
+++ b/Spigot-Server-Patches/0114-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3599aa415076525a4529664b9b9f0339b2eff730..74d0a591d3033b5ea4f2b0be8027d7096de66d8a 100644
+index a1afebb0e502712a674807d6873399dafa89e211..cf8a950d17bdb61dca58e6b587405691b7b8974e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -294,4 +294,9 @@ public class PaperWorldConfig {
+@@ -306,4 +306,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/Spigot-Server-Patches/0116-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/Spigot-Server-Patches/0116-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 74d0a591d3033b5ea4f2b0be8027d7096de66d8a..64a34e48d55ef94507896982115be438e9632f6e 100644
+index cf8a950d17bdb61dca58e6b587405691b7b8974e..442501b180c66e7687831315c74e8a1edf73654d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -2,6 +2,7 @@ package com.destroystokyo.paper;
- 
- import java.util.List;
- 
-+import org.bukkit.Bukkit;
- import org.bukkit.configuration.file.YamlConfiguration;
- import org.spigotmc.SpigotWorldConfig;
- 
-@@ -299,4 +300,12 @@ public class PaperWorldConfig {
+@@ -311,4 +311,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/Spigot-Server-Patches/0126-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0126-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 64a34e48d55ef94507896982115be438e9632f6e..c221e9501998de14194bd91018efbc113308198c 100644
+index 442501b180c66e7687831315c74e8a1edf73654d..56f55835ebc89f97032d1eece6c70422001a336d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -308,4 +308,14 @@ public class PaperWorldConfig {
+@@ -319,4 +319,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/Spigot-Server-Patches/0137-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0137-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c221e9501998de14194bd91018efbc113308198c..11106a20ccc161f18c1d5491785e44bb84f8a821 100644
+index 56f55835ebc89f97032d1eece6c70422001a336d..742b26afbf752069a1e8f96ce8c7bb7652d1ce6f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -318,4 +318,10 @@ public class PaperWorldConfig {
+@@ -329,4 +329,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }

--- a/Spigot-Server-Patches/0143-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0143-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 11106a20ccc161f18c1d5491785e44bb84f8a821..7f22cdc26d26d6d937506f901a8a0ed1d0a9f780 100644
+index 742b26afbf752069a1e8f96ce8c7bb7652d1ce6f..fe4e4c033ae2a9b9386ca46462c0fd877526d190 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -324,4 +324,10 @@ public class PaperWorldConfig {
+@@ -335,4 +335,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/Spigot-Server-Patches/0146-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0146-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7f22cdc26d26d6d937506f901a8a0ed1d0a9f780..295b27d122d84d6b1147aaedc9bbfb0f278e1cba 100644
+index fe4e4c033ae2a9b9386ca46462c0fd877526d190..8ef12fccb7bc6273c2998ff61c62ffe36915a852 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -330,4 +330,10 @@ public class PaperWorldConfig {
+@@ -341,4 +341,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 295b27d122d84d6b1147aaedc9bbfb0f278e1cba..4bb901966f7b1b6537a2b6b1dc0f0bdfd4338ce6 100644
+index 8ef12fccb7bc6273c2998ff61c62ffe36915a852..b78b1d43906700290b547d6b0b20e84e17253a12 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -336,4 +336,10 @@ public class PaperWorldConfig {
+@@ -347,4 +347,10 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/Spigot-Server-Patches/0184-Make-max-squid-spawn-height-configurable.patch
+++ b/Spigot-Server-Patches/0184-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4bb901966f7b1b6537a2b6b1dc0f0bdfd4338ce6..4571fd98a9faeb461666fc5c262a95b9e7fa04b6 100644
+index b78b1d43906700290b547d6b0b20e84e17253a12..a6d30f6a6b07b699571e75df4bd4fe41bab1a09e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -342,4 +342,9 @@ public class PaperWorldConfig {
+@@ -353,4 +353,9 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }

--- a/Spigot-Server-Patches/0193-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/Spigot-Server-Patches/0193-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4571fd98a9faeb461666fc5c262a95b9e7fa04b6..924cc5b2dc7764fdf9185d32bb5c09225250778d 100644
+index a6d30f6a6b07b699571e75df4bd4fe41bab1a09e..602940c9f643f8686517d631ebd790a2e6787672 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -188,6 +188,11 @@ public class PaperWorldConfig {
+@@ -199,6 +199,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  

--- a/Spigot-Server-Patches/0207-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0207-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 924cc5b2dc7764fdf9185d32bb5c09225250778d..e3e529c00122eaf04c7085b1074c5dd124419513 100644
+index 602940c9f643f8686517d631ebd790a2e6787672..0f04ad9ee5f3e94209a52a9e3b70409cec194505 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -352,4 +352,9 @@ public class PaperWorldConfig {
+@@ -363,4 +363,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }

--- a/Spigot-Server-Patches/0211-Block-Enderpearl-Travel-Exploit.patch
+++ b/Spigot-Server-Patches/0211-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e3e529c00122eaf04c7085b1074c5dd124419513..0c8160aa7098f117d2a174ffd944741b11818d10 100644
+index 0f04ad9ee5f3e94209a52a9e3b70409cec194505..1a266d8ef099bbf260a327b5c950bec4287b35d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -357,4 +357,10 @@ public class PaperWorldConfig {
+@@ -368,4 +368,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/Spigot-Server-Patches/0224-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0224-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0c8160aa7098f117d2a174ffd944741b11818d10..de80d2d874d1787335fd393f3ffed0cd36e3af9e 100644
+index 1a266d8ef099bbf260a327b5c950bec4287b35d6..a64b9e23219ad19d8f3cc7969b7f0b322aae6193 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -363,4 +363,9 @@ public class PaperWorldConfig {
+@@ -374,4 +374,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/Spigot-Server-Patches/0231-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/Spigot-Server-Patches/0231-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de80d2d874d1787335fd393f3ffed0cd36e3af9e..6e7e00678295b5b714a1be4753626e21ab469fd6 100644
+index a64b9e23219ad19d8f3cc7969b7f0b322aae6193..354355dcdf4efda2ba3ac777cd0f065d41784456 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -368,4 +368,9 @@ public class PaperWorldConfig {
+@@ -379,4 +379,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/Spigot-Server-Patches/0246-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0246-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6e7e00678295b5b714a1be4753626e21ab469fd6..54d7f6efcf42d4c7a8c209dfe3c5485318afafe3 100644
+index 354355dcdf4efda2ba3ac777cd0f065d41784456..0ef19690d46750a63635539c8f5cc3babf68ec22 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -373,4 +373,9 @@ public class PaperWorldConfig {
+@@ -384,4 +384,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
@@ -31,7 +31,7 @@ index 96c229e5dd214d32478fe4d5b96e77d8ba2bc93c..2592a59e9506cee901802a3bdc78db88
  
          for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index fa095bb55c09a3b5f8ab70bcce5a03c7eb93dcfa..7affb75a97e49b67861b24de38ef83e72b0abd5a 100644
+index 077b8bd715507471038c72b53fd26473800ce3ad..c97ad5e47f75dbbb6b2d4a7503b93bf4393d89dc 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -801,6 +801,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0266-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0266-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 54d7f6efcf42d4c7a8c209dfe3c5485318afafe3..5ea60c713426f11e420360a08a9ea1039d4f6b02 100644
+index 0ef19690d46750a63635539c8f5cc3babf68ec22..320adc8210477f5466fd43017c1c593af82baf8c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -378,4 +378,10 @@ public class PaperWorldConfig {
+@@ -389,4 +389,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/Spigot-Server-Patches/0270-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/Spigot-Server-Patches/0270-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5ea60c713426f11e420360a08a9ea1039d4f6b02..d8afb247f180b89f89cbed0f6e6c4fcc527799ff 100644
+index 320adc8210477f5466fd43017c1c593af82baf8c..c113523d43e4b64416b55c407f0650b47dbb5435 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -384,4 +384,10 @@ public class PaperWorldConfig {
+@@ -395,4 +395,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d8afb247f180b89f89cbed0f6e6c4fcc527799ff..6f410120018f95259e9e4f504ea1b588c2b4622b 100644
+index c113523d43e4b64416b55c407f0650b47dbb5435..370d97ced123327832875f4247b4d14589bf98b0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -390,4 +390,9 @@ public class PaperWorldConfig {
+@@ -401,4 +401,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6f410120018f95259e9e4f504ea1b588c2b4622b..a9a3dbbe7608d1f0dc122fe8d49928e7e3fa1438 100644
+index 370d97ced123327832875f4247b4d14589bf98b0..15889e6a08e70ef957d96539ef19186c5cd35443 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -395,4 +395,43 @@ public class PaperWorldConfig {
+@@ -406,4 +406,43 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a9a3dbbe7608d1f0dc122fe8d49928e7e3fa1438..e9c03546c42657dd5f5d4c6f71bd7e0cc7e2cb15 100644
+index 15889e6a08e70ef957d96539ef19186c5cd35443..6d65591379b4fbe0479a9436380d4092a361fd8e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -434,4 +434,10 @@ public class PaperWorldConfig {
+@@ -445,4 +445,10 @@ public class PaperWorldConfig {
                  break;
          }
      }

--- a/Spigot-Server-Patches/0361-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0361-incremental-chunk-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e9c03546c42657dd5f5d4c6f71bd7e0cc7e2cb15..d1ff673d8b5aafac58b082c9abc9257f0b2dfb15 100644
+index 6d65591379b4fbe0479a9436380d4092a361fd8e..b3ec3b949156cbbde777cc974ec147ceec4e9bab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -440,4 +440,19 @@ public class PaperWorldConfig {
+@@ -451,4 +451,19 @@ public class PaperWorldConfig {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }

--- a/Spigot-Server-Patches/0362-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0362-Anti-Xray.patch
@@ -5,20 +5,21 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d18c4a2c8 100644
+index b3ec3b949156cbbde777cc974ec147ceec4e9bab..490395e4e431ec1d092da5560e6c9e140963425b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,7 +1,9 @@
+@@ -1,8 +1,10 @@
  package com.destroystokyo.paper;
  
 +import java.util.Arrays;
  import java.util.List;
+ import java.util.function.Predicate;
  
 +import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+ import org.apache.commons.lang.BooleanUtils;
  import org.bukkit.Bukkit;
- import org.bukkit.configuration.file.YamlConfiguration;
- import org.spigotmc.SpigotWorldConfig;
-@@ -455,4 +457,33 @@ public class PaperWorldConfig {
+ import org.bukkit.World.Environment;
+@@ -466,4 +468,33 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
@@ -1383,7 +1384,7 @@ index 420bf7116def909d3dd7dc9a799723446ddf8f7f..300cbb8b01d94e7eb0cded0c8e118103
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f2d2258feadab1a1cb5fffdabc8d90949b980342..8c725507caaa7729e1b6b56b14a111765e9427f7 100644
+index ce7376fbd2bd905b02b9944b2f83d1cb762db06f..1180d234e0bbb99a9f9c61ee626830cc90957275 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -1410,7 +1411,7 @@ index f2d2258feadab1a1cb5fffdabc8d90949b980342..8c725507caaa7729e1b6b56b14a11176
 -    protected World(WorldDataMutable worlddatamutable, ResourceKey<World> resourcekey, final DimensionManager dimensionmanager, Supplier<GameProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.World.Environment env) {
 +    protected World(WorldDataMutable worlddatamutable, ResourceKey<World> resourcekey, final DimensionManager dimensionmanager, Supplier<GameProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((WorldDataServer) worlddatamutable).getName()); // Spigot
-         this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((WorldDataServer) worlddatamutable).getName(), this.spigotConfig); // Paper
+         this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((WorldDataServer) worlddatamutable).getName(), this.spigotConfig, env); // Paper
 +        this.chunkPacketBlockController = this.paperConfig.antiXray ? new ChunkPacketBlockControllerAntiXray(this, executor) : ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
          this.generator = gen;
          this.world = new CraftWorld((WorldServer) this, gen, env);

--- a/Spigot-Server-Patches/0363-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0363-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b9410e3affed4004548acdc9355ac14d18c4a2c8..90e8defde0ef84f3146c8664805d6f11b84c593d 100644
+index 490395e4e431ec1d092da5560e6c9e140963425b..11f4c9b611eaf20e524c8074bac234f871a11f5d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -458,6 +458,16 @@ public class PaperWorldConfig {
+@@ -469,6 +469,16 @@ public class PaperWorldConfig {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
  

--- a/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 90e8defde0ef84f3146c8664805d6f11b84c593d..36eff622d5638f1bd11b7b4ebe97036205ccf88b 100644
+index 11f4c9b611eaf20e524c8074bac234f871a11f5d..fe6281844eb701ea8f5c919036fb875705aefe67 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -496,4 +496,9 @@ public class PaperWorldConfig {
+@@ -507,4 +507,9 @@ public class PaperWorldConfig {
          }
          log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }

--- a/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
@@ -5,26 +5,29 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 36eff622d5638f1bd11b7b4ebe97036205ccf88b..fb84e7ca2873bcb5fed80b7ce58cf38a376289ed 100644
+index fe6281844eb701ea8f5c919036fb875705aefe67..5ab09fb3357d083ea4dd7866d349ac9208eee3ed 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,10 +1,15 @@
+@@ -1,13 +1,18 @@
  package com.destroystokyo.paper;
  
  import java.util.Arrays;
 +import java.util.EnumMap;
 +import java.util.HashMap;
  import java.util.List;
+ import java.util.function.Predicate;
 +import java.util.Map;
  
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+ import org.apache.commons.lang.BooleanUtils;
  import org.bukkit.Bukkit;
+ import org.bukkit.World.Environment;
 +import org.bukkit.Material;
 +import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -501,4 +506,52 @@ public class PaperWorldConfig {
+@@ -512,4 +517,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fb84e7ca2873bcb5fed80b7ce58cf38a376289ed..617a8af814dc224762dc21669392960cc1702693 100644
+index 5ab09fb3357d083ea4dd7866d349ac9208eee3ed..6712dc40f887742dd969ce8af0a0576cd18a04ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -554,4 +554,9 @@ public class PaperWorldConfig {
+@@ -565,4 +565,9 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/Spigot-Server-Patches/0377-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0377-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 617a8af814dc224762dc21669392960cc1702693..505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3 100644
+index 6712dc40f887742dd969ce8af0a0576cd18a04ae..14c7407f6aae8a62ac22249b29c030c8967c34c0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -559,4 +559,9 @@ public class PaperWorldConfig {
+@@ -570,4 +570,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3..45191d101b38953a53ef6a21c0c1592cac42b2aa 100644
+index 14c7407f6aae8a62ac22249b29c030c8967c34c0..fdc7e91abb28fa4bbf4aaec15537183af7d15bae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -564,4 +564,9 @@ public class PaperWorldConfig {
+@@ -575,4 +575,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 45191d101b38953a53ef6a21c0c1592cac42b2aa..7453becf8c56bd41a7e532c08c4f274026eadefb 100644
+index fdc7e91abb28fa4bbf4aaec15537183af7d15bae..80b403152bdc62f85c7d08d3ca9c7937b60589b2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -569,4 +569,9 @@ public class PaperWorldConfig {
+@@ -580,4 +580,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7453becf8c56bd41a7e532c08c4f274026eadefb..4438d567dd779650533c7128ae8b25b8fd369836 100644
+index 80b403152bdc62f85c7d08d3ca9c7937b60589b2..0d90cde33a05c7b57018aea30d2f611863e3bfac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -574,4 +574,13 @@ public class PaperWorldConfig {
+@@ -585,4 +585,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
@@ -485,7 +485,7 @@ index d9be182a574daaedcc7a106c759c2bde2e4eb19a..c6df2318762dc6542e73f18ed9a3172e
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index ea4acb47edb1b22d11e932a1b33f4297a18265f4..67a38ed5ec173ece6f072540b9fbb47400bb5af0 100644
+index 195109f7c4af4e80f512da4ab69826bde988e9c4..bddc4672bdf4a92260378304d6f97475fe69f3ea 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1102,8 +1102,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4438d567dd779650533c7128ae8b25b8fd369836..89f6de173225315783a09aae2fe77a3ede2b78d5 100644
+index 0d90cde33a05c7b57018aea30d2f611863e3bfac..ecc34cf7e18d2d7776e814fd490b66101ee7c887 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -583,4 +583,9 @@ public class PaperWorldConfig {
+@@ -594,4 +594,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/Spigot-Server-Patches/0414-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/Spigot-Server-Patches/0414-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 89f6de173225315783a09aae2fe77a3ede2b78d5..fd0e58574f4f07913161be489d031a011f059f8e 100644
+index ecc34cf7e18d2d7776e814fd490b66101ee7c887..7c44efd438fc2560262c107847967e17ee027950 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -381,6 +381,11 @@ public class PaperWorldConfig {
+@@ -392,6 +392,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd0e58574f4f07913161be489d031a011f059f8e..f0f94ac2432ad79d2957b7f723fe7eb9cbd36507 100644
+index 7c44efd438fc2560262c107847967e17ee027950..45a386bfe01739b956d49880fe9ede870826286c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -593,4 +593,9 @@ public class PaperWorldConfig {
+@@ -604,4 +604,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0f94ac2432ad79d2957b7f723fe7eb9cbd36507..1b49c214998a5a9b424472df040d634d9fcc0c4a 100644
+index 45a386bfe01739b956d49880fe9ede870826286c..5c9bcab8eedefc01e631f2d7531d36d8c9956d52 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -571,10 +571,21 @@ public class PaperWorldConfig {
+@@ -582,10 +582,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b49c214998a5a9b424472df040d634d9fcc0c4a..d7e22e1bf886800adbe8ed7baa3349e5d2ee1818 100644
+index 5c9bcab8eedefc01e631f2d7531d36d8c9956d52..33be4b50b17561e94087f1f9707682ab2acdf824 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -609,4 +609,9 @@ public class PaperWorldConfig {
+@@ -620,4 +620,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d7e22e1bf886800adbe8ed7baa3349e5d2ee1818..de95bd406173c38fa8a745c201b5cd5fbec91702 100644
+index 33be4b50b17561e94087f1f9707682ab2acdf824..9502fcc618795a79f73c8da0becc897ce85bb9c1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -614,4 +614,11 @@ public class PaperWorldConfig {
+@@ -625,4 +625,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de95bd406173c38fa8a745c201b5cd5fbec91702..9e55c800eb8b4dd4930dbf730bb6d106a2029036 100644
+index 9502fcc618795a79f73c8da0becc897ce85bb9c1..4026c57bf82691ca722bc459de0dfcacce6303a3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -621,4 +621,9 @@ public class PaperWorldConfig {
+@@ -632,4 +632,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
@@ -607,7 +607,7 @@ index 0f46aac9d021dc115718b1e36b8fbe28cbc820c6..b8ab8150b7dfe9e34910d35f565083e8
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 0dac8af6680a7dc4ecbedf70707297690fb1e694..b479a25044ecf8c1a791729d643cf8dc90193b2b 100644
+index bf404ebc2353c9bef1b927321d203827b2a94298..b44a89c387144382a9a899574affbdd09ce7250c 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -464,8 +464,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9e55c800eb8b4dd4930dbf730bb6d106a2029036..62e25da19c7ffc13ef1f7dcc375585afd79bb59f 100644
+index 4026c57bf82691ca722bc459de0dfcacce6303a3..4ecc4ba6b70bed750357925711cf63d83bfa7bd3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -626,4 +626,13 @@ public class PaperWorldConfig {
+@@ -637,4 +637,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62e25da19c7ffc13ef1f7dcc375585afd79bb59f..dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43 100644
+index 4ecc4ba6b70bed750357925711cf63d83bfa7bd3..6c18b0d58899cd81c070d4d501551ec69283c342 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -635,4 +635,26 @@ public class PaperWorldConfig {
+@@ -646,4 +646,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43..5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8 100644
+index 6c18b0d58899cd81c070d4d501551ec69283c342..e863032c8d255452ea6b6ec1c9822da06338519a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -657,4 +657,9 @@ public class PaperWorldConfig {
+@@ -668,4 +668,9 @@ public class PaperWorldConfig {
              maxLightningFlashDistance = 512; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8..8923314d731dea5c2707dbb271b8b0819d826a2e 100644
+index e863032c8d255452ea6b6ec1c9822da06338519a..3cb27a15423cccc6c35489c4aecfebbce6fce5d3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -662,4 +662,14 @@ public class PaperWorldConfig {
+@@ -673,4 +673,14 @@ public class PaperWorldConfig {
      private void zombiesTargetTurtleEggs() {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
@@ -1138,7 +1138,7 @@ index 7b3ccded0451f7b6634aeca0bdc1b5cc94f52b96..7f9ca45d403000d26d84198d8f88cd48
                  c(iblockdata, world, blockposition);
                  world.a(blockposition, false);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8d59391befcbc2542a79758d2021ef51df59d815..cbfbdd4c7d91afb779aaf6aa79f9c681078b9b27 100644
+index d9a6dfbf75d7d0cb2632af0fcfcecd9d799927ad..ae8031644c41dbd5b2af00f5a7e7771d64e61564 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -598,6 +598,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
+++ b/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8923314d731dea5c2707dbb271b8b0819d826a2e..9a0ade5875c34487a65f82f9380f9d25b4432586 100644
+index 3cb27a15423cccc6c35489c4aecfebbce6fce5d3..cb19a38f2082ed7a46580c1e8989113a3eae9135 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -672,4 +672,12 @@ public class PaperWorldConfig {
+@@ -683,4 +683,12 @@ public class PaperWorldConfig {
              log("Using vanilla redstone algorithm.");
          }
      }

--- a/Spigot-Server-Patches/0599-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0599-Seed-based-feature-search.patch
@@ -16,10 +16,10 @@ changes but this should usually not happen. A config option to disable
 this improvement is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9a0ade5875c34487a65f82f9380f9d25b4432586..ff0e4447b6574e91bf8815de4e04ce881ed7026d 100644
+index cb19a38f2082ed7a46580c1e8989113a3eae9135..736b2e911e8e2652e19b1b27c72fcffd843074b9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -331,6 +331,12 @@ public class PaperWorldConfig {
+@@ -342,6 +342,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -81,7 +81,7 @@ index c3bd58069d8dbdf36f70f1dafd7c24000f31708b..a62c87bceab2c9700a7b3925f208b0ff
                              StructureStart<?> structurestart = structuremanager.a(SectionPosition.a(ichunkaccess.getPos(), 0), this, ichunkaccess);
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 822b587cc92bb25ec8618fd9d86ce2c9233a69b6..9ed21f434c5fb019b74dfe9ee0b802ccc5c07fd8 100644
+index 58716e7f5267c05f70f73b449b2448166474b0ab..1a2f16f78fb16c5a618611808c46963d00fd9c13 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -1451,8 +1451,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ff0e4447b6574e91bf8815de4e04ce881ed7026d..80b0c08cef9a5326492b1faec020929fca59ff77 100644
+index 736b2e911e8e2652e19b1b27c72fcffd843074b9..f8dd92a28cd18f14649adf2568e6bc77fb3c2fc2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -686,4 +686,17 @@ public class PaperWorldConfig {
+@@ -697,4 +697,17 @@ public class PaperWorldConfig {
              log("The Ender Dragon will be removed if she already exists without a portal.");
          }
      }

--- a/Spigot-Server-Patches/0604-Allow-toggling-special-MobSpawners-per-world.patch
+++ b/Spigot-Server-Patches/0604-Allow-toggling-special-MobSpawners-per-world.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Wed, 26 Aug 2020 11:00:52 -0700
+Subject: [PATCH] Allow toggling special MobSpawners per world
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index f8dd92a28cd18f14649adf2568e6bc77fb3c2fc2..e3d308820b397446a94ce44656094d955ef9411a 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -196,6 +196,21 @@ public class PaperWorldConfig {
+         mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
+     }
+ 
++    public boolean catSpawning;
++    public boolean patrolSpawning;
++    public boolean phantomSpawning;
++    public boolean villagerTraderSpawning;
++    public boolean villageSiegeSpawning;
++    private void mobSpawnerSettings() {
++        // values of "default" or null will default to true only if the world environment is normal (aka overworld)
++        Predicate<Boolean> predicate = (bool) -> (bool != null && bool) || (bool == null && environment == Environment.NORMAL);
++        catSpawning = getBoolean("mob-spawning.village-cats", predicate);
++        patrolSpawning = getBoolean("mob-spawning.raid-patrols", predicate);
++        phantomSpawning = getBoolean("mob-spawning.phantoms", predicate);
++        villagerTraderSpawning = getBoolean("mob-spawning.wandering-traders", predicate);
++        villageSiegeSpawning = getBoolean("mob-spawning.village-sieges", predicate);
++    }
++
+     public int containerUpdateTickRate;
+     private void containerUpdateTickRate() {
+         containerUpdateTickRate = getInt("container-update-tick-rate", 1);
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 0108a1a68572df562349688e93f8134cb14d6116..8214163c0de0cf1b5212dc6d4288b0fb2a05dcb4 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -402,7 +402,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+             boolean flag = generatorsettings.isDebugWorld();
+             long i = generatorsettings.getSeed();
+             long j = BiomeManager.a(i);
+-            List<MobSpawner> list = ImmutableList.of(new MobSpawnerPhantom(), new MobSpawnerPatrol(), new MobSpawnerCat(), new VillageSiege(), new MobSpawnerTrader(iworlddataserver));
++            List<MobSpawner> list = ImmutableList.of(new MobSpawnerPhantom(), new MobSpawnerPatrol(), new MobSpawnerCat(), new VillageSiege(), new MobSpawnerTrader(iworlddataserver)); // Paper - This list is unused as we make these configurable in `Allow toggling special MobSpawners per world`. If this list changes, that patch likely needs updating.
+             RegistryMaterials<WorldDimension> registrymaterials = generatorsettings.d();
+             WorldDimension worlddimension = (WorldDimension) registrymaterials.a(dimensionKey);
+             DimensionManager dimensionmanager;
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 5b0b6edfa790918e56399ff6c83f3feb6e5aca49..d173d378fb9701d1a8ad6dd4545a904677012309 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -231,7 +231,25 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+         this.L = new ObjectLinkedOpenHashSet();
+         this.Q = flag1;
+         this.server = minecraftserver;
+-        this.mobSpawners = list;
++        // Paper start - enable/disable MobSpawners per world
++        final com.google.common.collect.ImmutableList.Builder<MobSpawner> mobSpawnersBuilder = com.google.common.collect.ImmutableList.builder();
++        if (this.paperConfig.phantomSpawning) {
++            mobSpawnersBuilder.add(new MobSpawnerPhantom());
++        }
++        if (this.paperConfig.patrolSpawning) {
++            mobSpawnersBuilder.add(new MobSpawnerPatrol());
++        }
++        if (this.paperConfig.catSpawning) {
++            mobSpawnersBuilder.add(new MobSpawnerCat());
++        }
++        if (this.paperConfig.villageSiegeSpawning) {
++            mobSpawnersBuilder.add(new VillageSiege());
++        }
++        if (this.paperConfig.villagerTraderSpawning) {
++            mobSpawnersBuilder.add(new MobSpawnerTrader(iworlddataserver));
++        }
++        this.mobSpawners = mobSpawnersBuilder.build();
++        // Paper end
+         // CraftBukkit start
+         this.worldDataServer = (WorldDataServer) iworlddataserver;
+         worldDataServer.world = this;

--- a/Spigot-Server-Patches/0605-Make-Wandering-Traders-spawn-below-the-roof-if-confi.patch
+++ b/Spigot-Server-Patches/0605-Make-Wandering-Traders-spawn-below-the-roof-if-confi.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Wed, 26 Aug 2020 11:10:18 -0700
+Subject: [PATCH] Make Wandering Traders spawn below the roof if configured to
+ spawn in a dimension with a roof
+
+
+diff --git a/src/main/java/net/minecraft/server/MobSpawnerTrader.java b/src/main/java/net/minecraft/server/MobSpawnerTrader.java
+index 8d89f51182444852062d549d23c00a93e601eb38..f4e24e4685dd327902c3aaf360806043ed4e0e96 100644
+--- a/src/main/java/net/minecraft/server/MobSpawnerTrader.java
++++ b/src/main/java/net/minecraft/server/MobSpawnerTrader.java
+@@ -132,7 +132,17 @@ public class MobSpawnerTrader implements MobSpawner {
+             int k = blockposition.getX() + this.a.nextInt(i * 2) - i;
+             int l = blockposition.getZ() + this.a.nextInt(i * 2) - i;
+             int i1 = iworldreader.a(HeightMap.Type.WORLD_SURFACE, k, l);
+-            BlockPosition blockposition2 = new BlockPosition(k, i1, l);
++            // Paper start
++            BlockPosition.MutableBlockPosition blockposition2 = new BlockPosition.MutableBlockPosition(k, i1, l);
++            if (iworldreader.getDimensionManager().hasCeiling()) {
++                do {
++                    blockposition2.c(EnumDirection.DOWN);
++                } while (!iworldreader.getType(blockposition2).isAir());
++                do {
++                    blockposition2.c(EnumDirection.DOWN);
++                } while (iworldreader.getType(blockposition2).isAir() && blockposition2.getY() > 0);
++            }
++            // Paper end
+ 
+             if (SpawnerCreature.a(EntityPositionTypes.Surface.ON_GROUND, iworldreader, blockposition2, EntityTypes.WANDERING_TRADER)) {
+                 blockposition1 = blockposition2;


### PR DESCRIPTION
Paper-config-files.patch:
- Adds a getBoolean with a Predicate to PaperWorldConfig to allow for the default behavior to respect level type in the same way as vanilla

Allow-toggling-special-MobSpawners-per-world.patch:
- Adds toggles for each MobSpawner subclass instead of using an ImmutableList of all of them for dim type overworld and an empty ImmutableList for any other.

Make-Wandering-Traders-spawn-below-the-roof-if-confi.patch:
- Adds a fix so that when Wandering Traders spawn in the Nether, they will spawn below the roof like other nether mobs instead of on top of it