### PR TITLE
Add summary to /paper chunkinfo command

### DIFF
--- a/Spigot-Server-Patches/0356-Chunk-debug-command.patch
+++ b/Spigot-Server-Patches/0356-Chunk-debug-command.patch
@@ -32,7 +32,7 @@ https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528273&page=com.atlass
 https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528577&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-528577
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f0a836db74ad3e20778d3863223bc9a35ff4ad41..9ead9b1ea1fafaa3d684c17efbae747386b7c587 100644
+index f0a836db74ad3e20778d3863223bc9a35ff4ad41..e4719a5e7e5ebd91257a9c9b83fa1adad70fd585 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -28,14 +28,14 @@ public class PaperCommand extends Command {
@@ -87,7 +87,7 @@ index f0a836db74ad3e20778d3863223bc9a35ff4ad41..9ead9b1ea1fafaa3d684c17efbae7473
              case "ver":
              case "version":
                  Command ver = org.bukkit.Bukkit.getServer().getCommandMap().getCommand("version");
-@@ -125,6 +146,96 @@ public class PaperCommand extends Command {
+@@ -125,6 +146,114 @@ public class PaperCommand extends Command {
          return true;
      }
  
@@ -106,6 +106,12 @@ index f0a836db74ad3e20778d3863223bc9a35ff4ad41..9ead9b1ea1fafaa3d684c17efbae7473
 +                worlds.add(world);
 +            }
 +        }
++
++        int accumulatedTotal = 0;
++        int accumulatedInactive = 0;
++        int accumulatedBorder = 0;
++        int accumulatedTicking = 0;
++        int accumulatedEntityTicking = 0;
 +
 +        for (org.bukkit.World bukkitWorld : worlds) {
 +            WorldServer world = ((CraftWorld)bukkitWorld).getHandle();
@@ -141,10 +147,22 @@ index f0a836db74ad3e20778d3863223bc9a35ff4ad41..9ead9b1ea1fafaa3d684c17efbae7473
 +                }
 +            }
 +
++            accumulatedTotal += total;
++            accumulatedInactive += inactive;
++            accumulatedBorder += border;
++            accumulatedTicking += ticking;
++            accumulatedEntityTicking += entityTicking;
++
 +            sender.sendMessage(ChatColor.BLUE + "Chunks in " + ChatColor.GREEN + bukkitWorld.getName() + ChatColor.DARK_AQUA + ":");
 +            sender.sendMessage(ChatColor.BLUE + "Total: " + ChatColor.DARK_AQUA + total + ChatColor.BLUE + " Inactive: " + ChatColor.DARK_AQUA
 +                               + inactive + ChatColor.BLUE + " Border: " + ChatColor.DARK_AQUA + border + ChatColor.BLUE + " Ticking: "
 +                               + ChatColor.DARK_AQUA + ticking + ChatColor.BLUE + " Entity: " + ChatColor.DARK_AQUA + entityTicking);
++        }
++        if (worlds.size() > 1) {
++            sender.sendMessage(ChatColor.BLUE + "Chunks in " + ChatColor.GREEN + "all listed worlds" + ChatColor.DARK_AQUA + ":");
++            sender.sendMessage(ChatColor.BLUE + "Total: " + ChatColor.DARK_AQUA + accumulatedTotal + ChatColor.BLUE + " Inactive: " + ChatColor.DARK_AQUA
++                               + accumulatedInactive + ChatColor.BLUE + " Border: " + ChatColor.DARK_AQUA + accumulatedBorder + ChatColor.BLUE + " Ticking: "
++                               + ChatColor.DARK_AQUA + accumulatedTicking + ChatColor.BLUE + " Entity: " + ChatColor.DARK_AQUA + accumulatedEntityTicking);
 +        }
 +    }
 +


### PR DESCRIPTION
If there is more than 1 world queried, it'll add a summary line with total from all queried worlds.

I think there is a better expression that `all listed worlds`, but I couldn't think of one - feel free to propose something better.

![image](https://user-images.githubusercontent.com/46570876/91225066-4bcfc280-e723-11ea-8a71-4569d4d6b0a3.png)

Closes https://github.com/PaperMC/Paper/issues/2341
