### PR TITLE
Fix Entity Teleportation and cancel velocity if teleported

### DIFF
--- a/Spigot-Server-Patches/0575-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/Spigot-Server-Patches/0575-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Tue, 25 Aug 2020 20:45:36 -0400
+Subject: [PATCH] Fix Entity Teleportation and cancel velocity if teleported
+
+Uses correct setPositionRotation for Entity teleporting instead of setLocation
+as this is how Vanilla teleports entities.
+
+Cancel any pending motion when teleported.
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 45e7e30892d031df42ae72de28ba4bbe8e1a6cd5..1ee01486f880992c2694f1dd637e9828b1d40c2d 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -1318,6 +1318,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public void setPositionRotation(double d0, double d1, double d2, float f, float f1) {
++        this.mot = new Vec3D(0, 0, 0); // Paper - cancel entity velocity if teleported
+         this.g(d0, d1, d2);
+         this.yaw = f;
+         this.pitch = f1;
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index e0c3eab9aef950d91920076990215d79d2b710c6..ba25a4b5baa2759a664dc80c259cd08baa3fbba3 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -501,7 +501,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+     public void a(PacketPlayInTeleportAccept packetplayinteleportaccept) {
+         PlayerConnectionUtils.ensureMainThread(packetplayinteleportaccept, this, this.player.getWorldServer());
+         if (packetplayinteleportaccept.b() == this.teleportAwait && this.teleportPos != null) { // CraftBukkit
+-            this.player.setLocation(this.teleportPos.x, this.teleportPos.y, this.teleportPos.z, this.player.yaw, this.player.pitch);
++            this.player.setPositionRotation(this.teleportPos.x, this.teleportPos.y, this.teleportPos.z, this.player.yaw, this.player.pitch); // Paper - use proper setPositionRotation for teleportation
+             this.o = this.teleportPos.x;
+             this.p = this.teleportPos.y;
+             this.q = this.teleportPos.z;
+@@ -1302,7 +1302,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         // CraftBukkit end
+ 
+         this.A = this.e;
+-        this.player.setLocation(d0, d1, d2, f, f1);
++        this.player.setPositionRotation(d0, d1, d2, f, f1); // Paper - use proper setPositionRotation for teleportation
+         this.player.forceCheckHighPriority(); // Paper
+         this.player.playerConnection.sendPacket(new PacketPlayOutPosition(d0 - d3, d1 - d4, d2 - d5, f - f2, f1 - f3, set, this.teleportAwait));
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index b1fdc5737d332c6210d57793468da1eda8f8b9d2..6ceb2d50c59b63a337364605f8a5280d905f2662 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -547,7 +547,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         }
+ 
+         // entity.setLocation() throws no event, and so cannot be cancelled
+-        entity.setLocation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
++        entity.setPositionRotation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch()); // Paper - use proper setPosition, as per vanilla teleporting
+         // SPIGOT-619: Force sync head rotation also
+         entity.setHeadRotation(location.getYaw());
+         ((net.minecraft.server.WorldServer) entity.world).chunkCheck(entity); // Spigot - register to new chunk


### PR DESCRIPTION
Uses correct setPositionRotation for Entity teleporting instead of setLocation
as this is how Vanilla teleports entities.

Cancel any pending motion when teleported.
------

This change should hopefully help resolve issues with entity teleportation causing major chunk loading issues resulting in hung servers and out of memory.

Please help with testing by running a test build:
https://cdn.discordapp.com/attachments/748269415497465927/750022487944724571/fix-entity-teleport-r2.jar
