### PR TITLE
Default the axis of portals

### DIFF
--- a/Spigot-Server-Patches/0578-Default-the-axis-of-portals.patch
+++ b/Spigot-Server-Patches/0578-Default-the-axis-of-portals.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Thu, 27 Aug 2020 16:21:24 +0200
+Subject: [PATCH] Default the axis of portals
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockPortalShape.java b/src/main/java/net/minecraft/server/BlockPortalShape.java
+index 6ef81aeb4c63bc6c23163796dbd977602ca2f540..042b6325cfcd13a56905e0d773ec34a18da6674e 100644
+--- a/src/main/java/net/minecraft/server/BlockPortalShape.java
++++ b/src/main/java/net/minecraft/server/BlockPortalShape.java
+@@ -227,7 +227,7 @@ public class BlockPortalShape {
+     public static ShapeDetectorShape a(WorldServer worldserver, BlockUtil.Rectangle blockutil_rectangle, EnumDirection.EnumAxis enumdirection_enumaxis, Vec3D vec3d, EntitySize entitysize, Vec3D vec3d1, float f, float f1, CraftPortalEvent portalEventInfo) { // CraftBukkit // PAIL rename toDetectorShape
+         BlockPosition blockposition = blockutil_rectangle.origin;
+         IBlockData iblockdata = worldserver.getType(blockposition);
+-        EnumDirection.EnumAxis enumdirection_enumaxis1 = (EnumDirection.EnumAxis) iblockdata.get(BlockProperties.E);
++        EnumDirection.EnumAxis enumdirection_enumaxis1 = iblockdata.contains(BlockProperties.E) ? iblockdata.get(BlockProperties.E) : EnumDirection.EnumAxis.X; // Paper - contains check like the caller does
+         double d0 = (double) blockutil_rectangle.side1;
+         double d1 = (double) blockutil_rectangle.side2;
+         int i = enumdirection_enumaxis == enumdirection_enumaxis1 ? 0 : 90;


### PR DESCRIPTION
Fixes PaperMC/Paper#4199.

I could never manage to reproduce the issue myself, but it isn't something I could imagine a plugin have much to do with.
This is a least-effort patch, and I'm not so sure it's a good way to do it.

Paperclip: https://owo.whats-th.is/9Bi8er3.jar