### PR TITLE
Fix hex colors not working in some kick messages

### DIFF
--- a/Spigot-Server-Patches/0155-Block-player-logins-during-server-shutdown.patch
+++ b/Spigot-Server-Patches/0155-Block-player-logins-during-server-shutdown.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Block player logins during server shutdown
 
 
 diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
-index dfdc7598a47cc60d0877d2e48aea017cab92c8a2..a9ec9f123f94df2368347ef9e6673cfb80186cf4 100644
+index dfdc7598a47cc60d0877d2e48aea017cab92c8a2..4217fdd952cb51a00e0e46d3f7f84f056e4594ca 100644
 --- a/src/main/java/net/minecraft/server/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/LoginListener.java
 @@ -48,6 +48,12 @@ public class LoginListener implements PacketLoginInListener {
@@ -14,7 +14,7 @@ index dfdc7598a47cc60d0877d2e48aea017cab92c8a2..a9ec9f123f94df2368347ef9e6673cfb
      public void tick() {
 +        // Paper start - Do not allow logins while the server is shutting down
 +        if (!MinecraftServer.getServer().isRunning()) {
-+            this.disconnect(new ChatMessage(org.spigotmc.SpigotConfig.restartMessage));
++            this.disconnect(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(org.spigotmc.SpigotConfig.restartMessage)[0]);
 +            return;
 +        }
 +        // Paper end

--- a/Spigot-Server-Patches/0566-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/Spigot-Server-Patches/0566-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Thu, 27 Aug 2020 16:57:25 -0400
+Subject: [PATCH] Fix hex colors not working in some kick messages
+
+
+diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
+index ad9324a6052d9fedd40fb8b0899c6ded6e60b315..5dde738b7499fbf432dc3dbae295eb96d5b90347 100644
+--- a/src/main/java/net/minecraft/server/HandshakeListener.java
++++ b/src/main/java/net/minecraft/server/HandshakeListener.java
+@@ -26,7 +26,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+         switch (packethandshakinginsetprotocol.b()) {
+             case LOGIN:
+                 this.c.setProtocol(EnumProtocol.LOGIN);
+-                ChatMessage chatmessage;
++                IChatBaseComponent chatmessage; // Paper - Fix hex colors not working in some kick messages
+ 
+                 // CraftBukkit start - Connection throttle
+                 try {
+@@ -37,7 +37,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                     synchronized (throttleTracker) {
+                         if (throttleTracker.containsKey(address) && !"127.0.0.1".equals(address.getHostAddress()) && currentTime - throttleTracker.get(address) < connectionThrottle) {
+                             throttleTracker.put(address, currentTime);
+-                            chatmessage = new ChatMessage(com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage); // Paper - Configurable connection throttle kick message
++                            chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(com.destroystokyo.paper.PaperConfig.connectionThrottleKickMessage, true)[0]; // Paper - Configurable connection throttle kick message // Paper - Fix hex colors not working in some kick messages
+                             this.c.sendPacket(new PacketLoginOutDisconnect(chatmessage));
+                             this.c.close(chatmessage);
+                             return;
+@@ -64,11 +64,11 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                 // CraftBukkit end
+ 
+                 if (packethandshakinginsetprotocol.c() > SharedConstants.getGameVersion().getProtocolVersion()) {
+-                    chatmessage = new ChatMessage( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getGameVersion().getName() ) ); // Spigot
++                    chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedServerMessage.replaceAll("'", "''"), SharedConstants.getGameVersion().getName() ) , true)[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
+                     this.c.sendPacket(new PacketLoginOutDisconnect(chatmessage));
+                     this.c.close(chatmessage);
+                 } else if (packethandshakinginsetprotocol.c() < SharedConstants.getGameVersion().getProtocolVersion()) {
+-                    chatmessage = new ChatMessage( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getGameVersion().getName() ) ); // Spigot
++                    chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString( java.text.MessageFormat.format( org.spigotmc.SpigotConfig.outdatedClientMessage.replaceAll("'", "''"), SharedConstants.getGameVersion().getName() ) , true)[0]; // Spigot // Paper - Fix hex colors not working in some kick messages
+                     this.c.sendPacket(new PacketLoginOutDisconnect(chatmessage));
+                     this.c.close(chatmessage);
+                 } else {
+@@ -82,7 +82,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                     if (event.callEvent()) {
+                         // If we've failed somehow, let the client know so and go no further.
+                         if (event.isFailed()) {
+-                            chatmessage = new ChatMessage(event.getFailMessage());
++                            chatmessage = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(event.getFailMessage(), true)[0]; // Paper - Fix hex colors not working in some kick messages
+                             this.getNetworkManager().sendPacket(new PacketLoginOutDisconnect(chatmessage));
+                             this.getNetworkManager().close(chatmessage);
+                             return;
+diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
+index 456cb9feebc8afef50cefb85b4d4c1dacd880ad2..57a3a8d09427012e5c8aba5085d187c6be047652 100644
+--- a/src/main/java/net/minecraft/server/LoginListener.java
++++ b/src/main/java/net/minecraft/server/LoginListener.java
+@@ -84,14 +84,7 @@ public class LoginListener implements PacketLoginInListener {
+     // CraftBukkit start
+     @Deprecated
+     public void disconnect(String s) {
+-        try {
+-            IChatBaseComponent ichatbasecomponent = new ChatComponentText(s);
+-            LoginListener.LOGGER.info("Disconnecting {}: {}", this.d(), s);
+-            this.networkManager.sendPacket(new PacketLoginOutDisconnect(ichatbasecomponent));
+-            this.networkManager.close(ichatbasecomponent);
+-        } catch (Exception exception) {
+-            LoginListener.LOGGER.error("Error whilst disconnecting player", exception);
+-        }
++        disconnect(org.bukkit.craftbukkit.util.CraftChatMessage.fromString(s, true)[0]); // Paper - Fix hex colors not working in some kick messages
+     }
+     // CraftBukkit end
+ 


### PR DESCRIPTION
Fixes a problem where some config-configured messages would not be run through the md_5-hex-color-thing-a-ma-jig causing hex color codes to not be properly displayed.

Related to #3858