### PR TITLE
Expose the Entity Counter to allow plugins to use valid and non-conflicting Entity Ids

### DIFF
--- a/Spigot-API-Patches/0227-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-API-Patches/0227-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Fri, 28 Aug 2020 01:41:31 +0200
+Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
+ non-conflicting Entity Ids
+
+
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index ac43afbf6230a481ab8cffbb3bc91b716316c00d..931ffa38faab86445a5d63364a47cb653ca3d4ed 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -116,5 +116,13 @@ public interface UnsafeValues {
+      * @return the translation key
+      */
+     String getTranslationKey(org.bukkit.entity.EntityType type);
++
++    /**
++     * Creates and returns the next EntityId available.
++     * <p>
++     * Use this when sending custom packets, so that there are no collisions on the client or server.
++     */
++    public int nextEntityId();
++
+     // Paper end
+ }

--- a/Spigot-Server-Patches/0581-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-Server-Patches/0581-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Fri, 28 Aug 2020 01:41:26 +0200
+Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
+ non-conflicting Entity Ids
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 5e1978d1c96dede07ead967c1e85a352348e7777..ebdbbeb1b55b428dde3ab1c9691cb153c6c2fe76 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -3374,4 +3374,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+ 
+         void accept(Entity entity, double d0, double d1, double d2);
+     }
++
++    // Paper start
++    public static int nextEntityId() {
++        return entityCount.incrementAndGet();
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 0b2bc20d1074757ab69eb6715d9b2d0d2065b2db..3ebaa9463e365831de37d8fa3cc191693f5b856f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -410,6 +410,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         return net.minecraft.server.EntityTypes.getByName(type.getName()).map(net.minecraft.server.EntityTypes::getDescriptionId).orElse(null);
+     }
+ 
++    public int nextEntityId() {
++        return net.minecraft.server.Entity.nextEntityId();
++    }
++
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
Basically without this (or reflection), people would have to send random (or very high value entity ids) for their packets, because otherwise "ghost events" get fired on the server for the completely wrong entities and other strange things might happen to the client (teleporting entities).

Using EntityIds provides the only safe way to have no collisions with regular server entities and also makes it easy for the plugin to track which packet-only entities it had.