### PR TITLE
Fix NPE in getBedSpawnLocation

### DIFF
--- a/Spigot-Server-Patches/0568-Fix-NPE-in-getBedSpawnLocation.patch
+++ b/Spigot-Server-Patches/0568-Fix-NPE-in-getBedSpawnLocation.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Fri, 28 Aug 2020 12:01:25 -0400
+Subject: [PATCH] Fix NPE in getBedSpawnLocation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index b97be51c6859fa2d45c07c853980adb05d11b65f..715d2c5e888b4a5c955d2dee2429757a27b50b00 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -874,14 +874,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+     @Override
+     public Location getBedSpawnLocation() {
+-        World world = getHandle().server.getWorldServer(getHandle().getSpawnDimension()).getWorld();
++        WorldServer world = getHandle().server.getWorldServer(getHandle().getSpawnDimension()); // Paper - Fix NPE in getBedSpawnLocation
+         BlockPosition bed = getHandle().getSpawn();
+ 
+         if (world != null && bed != null) {
+-            Optional<Vec3D> spawnLoc = EntityHuman.getBed(((CraftWorld) world).getHandle(), bed, getHandle().getSpawnAngle(), getHandle().isSpawnForced(), true);
++            Optional<Vec3D> spawnLoc = EntityHuman.getBed(world, bed, getHandle().getSpawnAngle(), getHandle().isSpawnForced(), true); // Paper - Fix NPE in getBedSpawnLocation
+             if (spawnLoc.isPresent()) {
+                 Vec3D vec = spawnLoc.get();
+-                return new Location(world, vec.x, vec.y, vec.z);
++                return new Location(world.getWorld(), vec.x, vec.y, vec.z); // Paper - Fix NPE in getBedSpawnLocation
+             }
+         }
+         return null;


### PR DESCRIPTION
`MinecraftServer#getWorldSever` is nullable as of 1.16 and `CraftPlayer#getBedSpawnLocation` has not been updated to properly null check this.

This has been reported to me on the Essentials issue tracker/discord for so long now and I don't know how I didn't see this sooner.