### PR TITLE
Properly pass the close reason for new inventory opens (#2658)

### DIFF
--- a/Spigot-Server-Patches/0237-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0237-InventoryCloseEvent-Reason-API.patch
@@ -88,15 +88,31 @@ index af3d0ffd6d8b3a7f794e5084551cd6d31df10fc1..a7dc4aabf10c9b9b10897e7540c4da9b
          this.o();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 922dfbf6963b9b4c02f056ff39900825c6ee071e..a96acce8b866b0976cc2077cbbfcd5d4fa17b3c3 100644
+index 922dfbf6963b9b4c02f056ff39900825c6ee071e..b838132b6e86f692b6576362e2b04aef96b4acfa 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2070,7 +2070,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -37,6 +37,7 @@ import org.bukkit.event.inventory.ClickType;
+ import org.bukkit.event.inventory.CraftItemEvent;
+ import org.bukkit.event.inventory.InventoryAction;
+ import org.bukkit.event.inventory.InventoryClickEvent;
++import org.bukkit.event.inventory.InventoryCloseEvent; // Paper
+ import org.bukkit.event.inventory.InventoryCreativeEvent;
+ import org.bukkit.event.inventory.InventoryType.SlotType;
+ import org.bukkit.event.player.AsyncPlayerChatEvent;
+@@ -2067,10 +2068,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+ 
+     @Override
+     public void a(PacketPlayInCloseWindow packetplayinclosewindow) {
++        // Paper start
++        handleContainerClose(packetplayinclosewindow, InventoryCloseEvent.Reason.PLAYER);
++    }
++    public void handleContainerClose(PacketPlayInCloseWindow packetplayinclosewindow, InventoryCloseEvent.Reason reason) {
++        // Paper end
          PlayerConnectionUtils.ensureMainThread(packetplayinclosewindow, this, this.player.getWorldServer());
  
          if (this.player.isFrozen()) return; // CraftBukkit
 -        CraftEventFactory.handleInventoryCloseEvent(this.player); // CraftBukkit
-+        CraftEventFactory.handleInventoryCloseEvent(this.player, org.bukkit.event.inventory.InventoryCloseEvent.Reason.PLAYER); // CraftBukkit // Paper
++        CraftEventFactory.handleInventoryCloseEvent(this.player, reason); // CraftBukkit // Paper
  
          this.player.o();
      }
@@ -136,9 +152,18 @@ index f841621a7fe1a2364f821ceb661972d6b03b3b9a..d1699502eac193f25d2fc369526596a0
          }
          // Spigot End
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index a1c318aa6501d9d0bdd53dc1fb8a99b7a782b4ce..51dce3aa8184b6f7566e29bf8e0285864f9b3a7f 100644
+index a1c318aa6501d9d0bdd53dc1fb8a99b7a782b4ce..ebcd2d043b3e6cf90b62eda1ea7a2d8c01f1c7a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -370,7 +370,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+         if (((EntityPlayer) getHandle()).playerConnection == null) return;
+         if (getHandle().activeContainer != getHandle().defaultContainer) {
+             // fire INVENTORY_CLOSE if one already open
+-            ((EntityPlayer) getHandle()).playerConnection.a(new PacketPlayInCloseWindow(getHandle().activeContainer.windowId));
++            ((EntityPlayer) getHandle()).playerConnection.handleContainerClose(new PacketPlayInCloseWindow(getHandle().activeContainer.windowId), org.bukkit.event.inventory.InventoryCloseEvent.Reason.OPEN_NEW); // Paper
+         }
+         EntityPlayer player = (EntityPlayer) getHandle();
+         Container container;
 @@ -436,8 +436,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
  
      @Override
@@ -168,9 +193,18 @@ index 23889ce169baf956cfb39f1ec21a8369f80c5555..25175230583bbd6fcfc864dcbae4111d
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 81fc5bcb24e94500bea1a78a369f6fd58865700e..fe88f7e62e547b9aa4ff273341aaee9209aed82b 100644
+index 81fc5bcb24e94500bea1a78a369f6fd58865700e..68d9cbfcecffd3eeff38c1fc8a0bd19a251cdec9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1170,7 +1170,7 @@ public class CraftEventFactory {
+ 
+     public static Container callInventoryOpenEvent(EntityPlayer player, Container container, boolean cancelled) {
+         if (player.activeContainer != player.defaultContainer) { // fire INVENTORY_CLOSE if one already open
+-            player.playerConnection.a(new PacketPlayInCloseWindow(player.activeContainer.windowId));
++            player.playerConnection.handleContainerClose(new PacketPlayInCloseWindow(player.activeContainer.windowId), InventoryCloseEvent.Reason.OPEN_NEW); // Paper
+         }
+ 
+         CraftServer server = player.world.getServer();
 @@ -1335,12 +1335,22 @@ public class CraftEventFactory {
          return event;
      }

--- a/Spigot-Server-Patches/0239-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/Spigot-Server-Patches/0239-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index a96acce8b866b0976cc2077cbbfcd5d4fa17b3c3..9ad024422fda6e6e8102210b604bc4a469b929e9 100644
+index b838132b6e86f692b6576362e2b04aef96b4acfa..9a09d8068650916e1a0365599436d8dc3df723d4 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1979,6 +1979,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1980,6 +1980,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      }
  
                      if (event.isCancelled()) {

--- a/Spigot-Server-Patches/0261-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0261-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -45,10 +45,10 @@ index c8a7d8092a2849b62a8d83d7970756fd76100025..2e5c71d6b7d120a308076d95a3d5b73c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 229759f09687a61954b9c247d7e312a5a5f182b4..b02d1abd65ca113de622328f520bd4c8b56e3409 100644
+index 9a09d8068650916e1a0365599436d8dc3df723d4..5e11568d662313ee9844dc26b069185f796111b4 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -76,6 +76,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -77,6 +77,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      // CraftBukkit start - multithreaded fields
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
@@ -56,7 +56,7 @@ index 229759f09687a61954b9c247d7e312a5a5f182b4..b02d1abd65ca113de622328f520bd4c8
      // CraftBukkit end
      private int j;
      private final Int2ShortMap k = new Int2ShortOpenHashMap();
-@@ -206,6 +207,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -207,6 +208,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          this.minecraftServer.getMethodProfiler().exit();
          // CraftBukkit start
          for (int spam; (spam = this.chatThrottle) > 0 && !chatSpamField.compareAndSet(this, spam, spam - 1); ) ;
@@ -64,7 +64,7 @@ index 229759f09687a61954b9c247d7e312a5a5f182b4..b02d1abd65ca113de622328f520bd4c8
          /* Use thread-safe field access instead
          if (this.chatThrottle > 0) {
              --this.chatThrottle;
-@@ -523,7 +525,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -524,7 +526,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      public void a(PacketPlayInTabComplete packetplayintabcomplete) {
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start

--- a/Spigot-Server-Patches/0301-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/Spigot-Server-Patches/0301-Call-player-spectator-target-events-and-improve-impl.patch
@@ -88,10 +88,10 @@ index d6586e2c36f89328ba482230ae7d6a050966ed27..d1f716067e6c71f523c7561b9ef92f42
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index b02d1abd65ca113de622328f520bd4c8b56e3409..58f6588f475e000aafede740adf4570d41a71009 100644
+index 5e11568d662313ee9844dc26b069185f796111b4..be6668446a643c47a9dcb97e41b03a2bd512ab0f 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1127,6 +1127,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1128,6 +1128,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      }
  
      // CraftBukkit start - Delegate to teleport(Location)

--- a/Spigot-Server-Patches/0306-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0306-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -20,10 +20,10 @@ index 098c99793c68ac916b52776f9a1cc2c6510c0057..15e1f9f65280043853544d3bf796f991
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 58f6588f475e000aafede740adf4570d41a71009..ef274f5eac1c3cea0f459955432b925e37866026 100644
+index be6668446a643c47a9dcb97e41b03a2bd512ab0f..094d2e6ed281303cd72dc2db38bf6ff4ab83b013 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -350,6 +350,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -351,6 +351,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -37,7 +37,7 @@ index 58f6588f475e000aafede740adf4570d41a71009..ef274f5eac1c3cea0f459955432b925e
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isExemptPlayer()) {
                  // CraftBukkit end
                      PlayerConnection.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", entity.getDisplayName().getString(), this.player.getDisplayName().getString(), d6, d7, d8);
-@@ -913,9 +920,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -914,9 +921,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          double d1 = this.player.locY();
                          double d2 = this.player.locZ();
                          double d3 = this.player.locY();
@@ -49,7 +49,7 @@ index 58f6588f475e000aafede740adf4570d41a71009..ef274f5eac1c3cea0f459955432b925e
                          float f = packetplayinflying.a(this.player.yaw);
                          float f1 = packetplayinflying.b(this.player.pitch);
                          double d7 = d4 - this.l;
-@@ -954,6 +961,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -955,6 +962,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                              } else {
                                  speed = player.abilities.walkSpeed * 10f;
                              }

--- a/Spigot-Server-Patches/0314-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/Spigot-Server-Patches/0314-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow digging into unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ef274f5eac1c3cea0f459955432b925e37866026..7f9e959377bbb2233c9e5971d8b87d8c60defa99 100644
+index 094d2e6ed281303cd72dc2db38bf6ff4ab83b013..d50f41ddeb81c2e46911ef0be01987aef72c9462 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1291,6 +1291,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1292,6 +1292,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:
@@ -21,7 +21,7 @@ index ef274f5eac1c3cea0f459955432b925e37866026..7f9e959377bbb2233c9e5971d8b87d8c
                  return;
              default:
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 36cf4c332054a350ae193637f895a45a8b04da9b..a32490f0eb754b065ee34c41465176db78b1625d 100644
+index b92b04ac7cba04a04eab35642369af41ec389a23..6250afbb7a9669aa3e402409e2f5da68f54b8970 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -80,8 +80,8 @@ public class PlayerInteractManager {

--- a/Spigot-Server-Patches/0315-Book-Size-Limits.patch
+++ b/Spigot-Server-Patches/0315-Book-Size-Limits.patch
@@ -22,7 +22,7 @@ index 478856f190a8d0177dee39dab4692fc54f9c8ed4..01d48da8b2f89ad3a615ad10c044c5f0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7f9e959377bbb2233c9e5971d8b87d8c60defa99..1d054e76e126bc3f0f604ecb2538f2f5fa3db338 100644
+index d50f41ddeb81c2e46911ef0be01987aef72c9462..bdf421123a7b62793466af902e18a13cf28eb447 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -14,6 +14,7 @@ import java.util.Optional;
@@ -33,7 +33,7 @@ index 7f9e959377bbb2233c9e5971d8b87d8c60defa99..1d054e76e126bc3f0f604ecb2538f2f5
  import org.apache.commons.lang3.StringUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -808,6 +809,42 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -809,6 +810,42 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInBEdit packetplayinbedit) {

--- a/Spigot-Server-Patches/0324-Fix-PlayerEditBookEvent.patch
+++ b/Spigot-Server-Patches/0324-Fix-PlayerEditBookEvent.patch
@@ -10,10 +10,10 @@ it impossible to properly cancel the event or modify the book meta
 cancelled writing
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 1d054e76e126bc3f0f604ecb2538f2f5fa3db338..071826eb4def7e2a09659b078da5c636b6929476 100644
+index bdf421123a7b62793466af902e18a13cf28eb447..e34d64b07f556bcf00423e931d5f8d3afcd8d9d9 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -884,9 +884,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -885,9 +885,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          itemstack2.a("pages", (NBTBase) nbttaglist);
                          this.player.a(packetplayinbedit.d(), CraftEventFactory.handleEditBookEvent(player, enumitemslot, itemstack1, itemstack2)); // CraftBukkit
                      } else {

--- a/Spigot-Server-Patches/0330-Fix-sign-edit-memory-leak.patch
+++ b/Spigot-Server-Patches/0330-Fix-sign-edit-memory-leak.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix sign edit memory leak
 when a player edits a sign, a reference to their Entity is never cleand up.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ee36989604006c849f9ffab5442fab3ed3bbb74b..2728e400b9f4a429e58cb0ec22c41cc3b8e141ab 100644
+index e34d64b07f556bcf00423e931d5f8d3afcd8d9d9..4825745c97ebaba9c39259502daf494f9a09e333 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2577,7 +2577,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2583,7 +2583,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              TileEntitySign tileentitysign = (TileEntitySign) tileentity;
  

--- a/Spigot-Server-Patches/0331-Limit-Client-Sign-length-more.patch
+++ b/Spigot-Server-Patches/0331-Limit-Client-Sign-length-more.patch
@@ -22,10 +22,10 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 2728e400b9f4a429e58cb0ec22c41cc3b8e141ab..18ea59a5b9bb3720696fc8732f9eab19674e8ddf 100644
+index 4825745c97ebaba9c39259502daf494f9a09e333..400af594ba3c87dc63c7bbb591d2507044c5e680 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -103,6 +103,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -104,6 +104,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private int E;
      private int receivedMovePackets;
      private int processedMovePackets;
@@ -33,7 +33,7 @@ index 2728e400b9f4a429e58cb0ec22c41cc3b8e141ab..18ea59a5b9bb3720696fc8732f9eab19
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
      public PlayerConnection(MinecraftServer minecraftserver, NetworkManager networkmanager, EntityPlayer entityplayer) {
-@@ -2593,6 +2594,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2599,6 +2600,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
              String[] lines = new String[4];
  
              for (int i = 0; i < astring.length; ++i) {

--- a/Spigot-Server-Patches/0342-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/Spigot-Server-Patches/0342-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index bbb3f88bb15c70aec7f4d223dd3c0cc986c6eb21..b8fa8a582c4e440990f7e9c426c40bb5
          this.f.accept(packet);
          if (this.tracker instanceof EntityPlayer) {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 18ea59a5b9bb3720696fc8732f9eab19674e8ddf..46329ecc93ba30c9af909d74215a5c7e26aa1abe 100644
+index 400af594ba3c87dc63c7bbb591d2507044c5e680..13b15b713b19334a75ab15602856d9fdc757c0b1 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2036,7 +2036,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2037,7 +2037,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
                      if (event.isCancelled() || this.player.inventory.getItemInHand() == null || this.player.inventory.getItemInHand().getItem() != origItem) {
                          // Refresh the current entity metadata

--- a/Spigot-Server-Patches/0352-Fix-CB-call-to-changed-postToMainThread-method.patch
+++ b/Spigot-Server-Patches/0352-Fix-CB-call-to-changed-postToMainThread-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CB call to changed postToMainThread method
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 6e5194e7b06b82ec256fce4124154051f4b2c7cc..76be1b78e3959e4237708a091ed9198eacfad834 100644
+index 13b15b713b19334a75ab15602856d9fdc757c0b1..1ee54e80a4a76f894c97198efbc3f064d93e661b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -285,7 +285,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -286,7 +286,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
          this.networkManager.getClass();
          // CraftBukkit - Don't wait

--- a/Spigot-Server-Patches/0374-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0374-Asynchronous-chunk-IO-and-loading.patch
@@ -3505,10 +3505,10 @@ index 8e79200b23f2dee612b0cbdcd6359a25dc2323cb..e7d9674e25c06090d57bba6c8229bc3b
          return this.m;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 76be1b78e3959e4237708a091ed9198eacfad834..ab45ee434964c770033e56e7aa9480736f45a67b 100644
+index 1ee54e80a4a76f894c97198efbc3f064d93e661b..f90ae950c72b50dadb8b83301baf5b24c71536e4 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -538,6 +538,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -539,6 +539,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
              minecraftServer.scheduleOnMain(() -> this.disconnect(new ChatMessage("disconnect.spam", new Object[0]))); // Paper
              return;
          }

--- a/Spigot-Server-Patches/0375-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/Spigot-Server-Patches/0375-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,10 +8,10 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ab45ee434964c770033e56e7aa9480736f45a67b..fc163511f6bb639c7934785ca34184df05cc019a 100644
+index f90ae950c72b50dadb8b83301baf5b24c71536e4..f1df55cfcaa3218d6e28df1448306a6f6e43ead6 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1009,7 +1009,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1010,7 +1010,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                  speed = player.abilities.walkSpeed * 10f;
                              }
                              // Paper start - Prevent moving into unloaded chunks
@@ -21,7 +21,7 @@ index ab45ee434964c770033e56e7aa9480736f45a67b..fc163511f6bb639c7934785ca34184df
                                  return;
                              }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index fa134406c7d0132971ad5d75f1e0f46667f94a01..48d4b0314eb0934fdaa445800eceed481a662c63 100644
+index dd956f5892bd79b5c614f3a85611e1238e679aed..6e2e5d7636c25c8fbb37cc96aac83f8b37828c1f 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -104,6 +104,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0390-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
+++ b/Spigot-Server-Patches/0390-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
@@ -19,10 +19,10 @@ index cf2850e21ac93ccc5ec95122f715be78bfdabb99..ad0203c9d61d9651fc81783ea223f161
          if (enumhand == EnumHand.MAIN_HAND) {
              return this.getEquipment(EnumItemSlot.MAINHAND);
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 12d94df37099b1b75226d684dd76a724e98a0598..00410d0c29c45d78f050ba38f278fa0c146f9da1 100644
+index f1df55cfcaa3218d6e28df1448306a6f6e43ead6..3c7c092d3a2f0bf61fd9f548ff6f37ed7da6d843 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1467,6 +1467,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1468,6 +1468,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }

--- a/Spigot-Server-Patches/0418-Prevent-teleporting-dead-entities.patch
+++ b/Spigot-Server-Patches/0418-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7c5c7e67dd8f1fdc726b2f2923f8d2e2bf864e6c..ff436b2424ebab9bc1e673b8f484e63d52d4940c 100644
+index 3c7c092d3a2f0bf61fd9f548ff6f37ed7da6d843..71920337361847f677533703229afa97d7067319 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1234,6 +1234,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1235,6 +1235,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
      }
  
      private void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<PacketPlayOutPosition.EnumPlayerTeleportFlags> set) {

--- a/Spigot-Server-Patches/0458-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0458-Load-Chunks-for-Login-Asynchronously.patch
@@ -18,7 +18,7 @@ index 4c4e6e154e0db23662484d6aa03f1d762a48badb..893a835593af2ea95a50607c8c2f2cdb
          boolean flag1 = this.playerChunkMap.b();
  
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d3e4b26798661b99686941e813aca50774db8ff6..810793ee13d0531dbbc233adc3d274cbcf3186b7 100644
+index 017e8ba5abbb5463357902cc66e46caf639f048e..26c2adb04d995bf5c5ba4c5eee471be067bf8ac4 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1284,7 +1284,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -31,7 +31,7 @@ index d3e4b26798661b99686941e813aca50774db8ff6..810793ee13d0531dbbc233adc3d274cb
  
      public void d(Vec3D vec3d) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 5d7be3c9841949a11a3207d0ff355b78e2e28e81..4860f84999b22aca6267efd42d920ff8bb868ca5 100644
+index 7f9bd9a35e5164294a0cfedaf540544c70d0df09..824f074740ad063815ca80dce679ceb532c8edc2 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -44,6 +44,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -51,7 +51,7 @@ index 5d7be3c9841949a11a3207d0ff355b78e2e28e81..4860f84999b22aca6267efd42d920ff8
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/LoginListener.java b/src/main/java/net/minecraft/server/LoginListener.java
-index c053c40a940bbfebbae48464d5f9e263f54af523..a6684a4d7410e5b7fceb93838787ebe5343967d2 100644
+index 0cb8f5a4a5cc5e302815af4c1ed325dfbc75235b..456cb9feebc8afef50cefb85b4d4c1dacd880ad2 100644
 --- a/src/main/java/net/minecraft/server/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/LoginListener.java
 @@ -66,7 +66,7 @@ public class LoginListener implements PacketLoginInListener {
@@ -73,10 +73,10 @@ index c053c40a940bbfebbae48464d5f9e263f54af523..a6684a4d7410e5b7fceb93838787ebe5
              if (entityplayer != null) {
                  this.g = LoginListener.EnumProtocolState.DELAY_ACCEPT;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index ff436b2424ebab9bc1e673b8f484e63d52d4940c..23002a66f3189d31c1b4382cdbd684e85320539a 100644
+index 71920337361847f677533703229afa97d7067319..dbe1d5f2fa43715e658377a6765e0a53093ede76 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -69,6 +69,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -70,6 +70,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final Logger LOGGER = LogManager.getLogger();
      public final NetworkManager networkManager;
      private final MinecraftServer minecraftServer;
@@ -84,7 +84,7 @@ index ff436b2424ebab9bc1e673b8f484e63d52d4940c..23002a66f3189d31c1b4382cdbd684e8
      public EntityPlayer player;
      private int e;
      private long lastKeepAlive = SystemUtils.getMonotonicMillis(); private void setLastPing(long lastPing) { this.lastKeepAlive = lastPing;}; private long getLastPing() { return this.lastKeepAlive;}; // Paper - OBFHELPER
-@@ -142,6 +143,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -143,6 +144,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
      // CraftBukkit end
  
      public void tick() {
@@ -100,7 +100,7 @@ index ff436b2424ebab9bc1e673b8f484e63d52d4940c..23002a66f3189d31c1b4382cdbd684e8
          this.syncPosition();
          this.player.lastX = this.player.locX();
          this.player.lastY = this.player.locY();
-@@ -183,7 +193,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -184,7 +194,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
              this.r = null;
              this.D = false;
              this.E = 0;
@@ -110,7 +110,7 @@ index ff436b2424ebab9bc1e673b8f484e63d52d4940c..23002a66f3189d31c1b4382cdbd684e8
          this.minecraftServer.getMethodProfiler().enter("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index a38b0f5dbc76214853034b0a4663d985e62111bf..2236c839acca60aef6364e6266fa047a331a01e5 100644
+index 4995fa3fda87dfb47c8050e57ca29a895b809482..40f2984e5ba7627ef4ce87133bed5df51a68fd65 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -54,11 +54,12 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0465-Implement-Brigadier-Mojang-API.patch
+++ b/Spigot-Server-Patches/0465-Implement-Brigadier-Mojang-API.patch
@@ -69,10 +69,10 @@ index 27c16946b589a36a47b612c8b10b2955ba2715b1..7608b5021d66c39b8121f33829cd09d7
      public boolean hasPermission(int i) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 23002a66f3189d31c1b4382cdbd684e85320539a..5f1e7e4bc3ae80f4ed61f2d65da1cf9935a3882a 100644
+index dbe1d5f2fa43715e658377a6765e0a53093ede76..e4a161f95c778815bcb240955d704b6bbc815565 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -578,8 +578,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -579,8 +579,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      ParseResults<CommandListenerWrapper> parseresults = this.minecraftServer.getCommandDispatcher().a().parse(stringreader, this.player.getCommandListener());
  
                      this.minecraftServer.getCommandDispatcher().a().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -87,7 +87,7 @@ index 23002a66f3189d31c1b4382cdbd684e85320539a..5f1e7e4bc3ae80f4ed61f2d65da1cf99
                      });
                  });
              }
-@@ -588,7 +592,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -589,7 +593,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              builder = builder.createOffset(builder.getInput().lastIndexOf(' ') + 1);
              completions.forEach(builder::suggest);

--- a/Spigot-Server-Patches/0467-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/Spigot-Server-Patches/0467-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 5f1e7e4bc3ae80f4ed61f2d65da1cf9935a3882a..7b079f0e594e24a7d8706c4ed5228c37c5fbe26d 100644
+index e4a161f95c778815bcb240955d704b6bbc815565..39090531e5cc77ef23c2a3b962b60586e28573ac 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -691,7 +691,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -692,7 +692,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
      @Override
      public void a(PacketPlayInPickItem packetplayinpickitem) {
          PlayerConnectionUtils.ensureMainThread(packetplayinpickitem, this, this.player.getWorldServer());

--- a/Spigot-Server-Patches/0491-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0491-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1146,10 +1146,10 @@ index fba7c9b5724114eab35a3d24febdee3cd3e30aa0..753d67c8a711d293bd70eb913c47ec81
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7b079f0e594e24a7d8706c4ed5228c37c5fbe26d..5c3266d0dfcb0687c18eb636d0183e061c14e822 100644
+index 39090531e5cc77ef23c2a3b962b60586e28573ac..b1aaf19df210fa98910d49535e56f5b26c72d26f 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1294,6 +1294,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1295,6 +1295,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
          this.A = this.e;
          this.player.setLocation(d0, d1, d2, f, f1);

--- a/Spigot-Server-Patches/0506-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/Spigot-Server-Patches/0506-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 5c3266d0dfcb0687c18eb636d0183e061c14e822..fa515ae73f2dffdae0ca6243901d973acac3de0c 100644
+index b1aaf19df210fa98910d49535e56f5b26c72d26f..14ae626be2ff07640e66bad5e6e538da8cadaf7b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1091,6 +1091,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1092,6 +1092,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
                              this.player.move(EnumMoveType.PLAYER, new Vec3D(d7, d8, d9));
                              this.player.setOnGround(packetplayinflying.b()); // CraftBukkit - SPIGOT-5810, SPIGOT-5835: reset by this.player.move

--- a/Spigot-Server-Patches/0510-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/Spigot-Server-Patches/0510-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index bc1dcb8dea7a648dd1389a5517f67b3ef94d7921..b6165816bc82f467f54747cb8fad9e4df92c161b 100644
+index 14ae626be2ff07640e66bad5e6e538da8cadaf7b..c1eb1cabc4221c380ad8ffdb8610141779021380 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2504,9 +2504,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2510,9 +2510,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinautorecipe, this, this.player.getWorldServer());
          this.player.resetIdleTimer();
          if (!this.player.isSpectator() && this.player.activeContainer.windowId == packetplayinautorecipe.b() && this.player.activeContainer.c(this.player) && this.player.activeContainer instanceof ContainerRecipeBook) {

--- a/Spigot-Server-Patches/0513-Add-permission-for-command-blocks.patch
+++ b/Spigot-Server-Patches/0513-Add-permission-for-command-blocks.patch
@@ -31,10 +31,10 @@ index 7e13b1cf6d92c3e0f2dab1ba1d42bd4f250e256c..3820acd65f3cd488dba964e6d9c45885
          } else {
              if (entityhuman.getWorld().isClientSide) {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 5d2e7f7c38efeff71a49356dc82e9d8b845cb284..dfbe66aad115b3977fadb190bda5c90aff089cf3 100644
+index c1eb1cabc4221c380ad8ffdb8610141779021380..243d85fb29aae9435bd8eb7fbf89d8a149f1145c 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -606,7 +606,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -607,7 +607,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinsetcommandblock, this, this.player.getWorldServer());
          if (!this.minecraftServer.getEnableCommandBlock()) {
              this.player.sendMessage(new ChatMessage("advMode.notEnabled"), SystemUtils.b);
@@ -43,7 +43,7 @@ index 5d2e7f7c38efeff71a49356dc82e9d8b845cb284..dfbe66aad115b3977fadb190bda5c90a
              this.player.sendMessage(new ChatMessage("advMode.notAllowed"), SystemUtils.b);
          } else {
              CommandBlockListenerAbstract commandblocklistenerabstract = null;
-@@ -669,7 +669,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -670,7 +670,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinsetcommandminecart, this, this.player.getWorldServer());
          if (!this.minecraftServer.getEnableCommandBlock()) {
              this.player.sendMessage(new ChatMessage("advMode.notEnabled"), SystemUtils.b);
@@ -53,7 +53,7 @@ index 5d2e7f7c38efeff71a49356dc82e9d8b845cb284..dfbe66aad115b3977fadb190bda5c90a
          } else {
              CommandBlockListenerAbstract commandblocklistenerabstract = packetplayinsetcommandminecart.a(this.player.world);
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 734855c1db3215d90b2743988f64af68aacb388e..6d192b27440ddfd34555005dafefbce6bbb67236 100644
+index 2aa43bc2c6645297750d628d714136e1b4ac8133..69b6518acfbf36409220fa0083a3b444ddc95cd9 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
 @@ -353,7 +353,7 @@ public class PlayerInteractManager {

--- a/Spigot-Server-Patches/0516-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0516-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -63,10 +63,10 @@ index 4f0b79be16dbc8b528095f8ebfe80d70ef6074ce..a7b6be15b6c5d99fd8adc60c2d7f31a0
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 6353387096c218f0d910343de1f1eadc66e31cc6..88d5ce53d76863961179d3d81419fb9c2990d4d6 100644
+index 243d85fb29aae9435bd8eb7fbf89d8a149f1145c..3ced849007b8af3a70a737c9a0f1b15bf4e57a2a 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2768,7 +2768,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2774,7 +2774,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      public void a(PacketPlayInDifficultyChange packetplayindifficultychange) {
          PlayerConnectionUtils.ensureMainThread(packetplayindifficultychange, this, this.player.getWorldServer());
          if (this.player.k(2) || this.isExemptPlayer()) {

--- a/Spigot-Server-Patches/0538-Move-range-check-for-block-placing-up.patch
+++ b/Spigot-Server-Patches/0538-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 522a88ab9592747d5d6c21cc5e0460dee05d8385..bc613281d18efac7bb926d84ec54653368b93f43 100644
+index 3ced849007b8af3a70a737c9a0f1b15bf4e57a2a..911a6e7c2c4af9130384774072b1c92831bb1767 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1427,15 +1427,19 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1428,15 +1428,19 @@ public class PlayerConnection implements PacketListenerPlayIn {
          BlockPosition blockposition = movingobjectpositionblock.getBlockPosition();
          EnumDirection enumdirection = movingobjectpositionblock.getDirection();
  

--- a/Spigot-Server-Patches/0554-Brand-support.patch
+++ b/Spigot-Server-Patches/0554-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 26576384981d6a80421402531d4249ef54eb618a..a3f482f7fbbb13fc0824914877225ed37664998c 100644
+index 911a6e7c2c4af9130384774072b1c92831bb1767..e0c3eab9aef950d91920076990215d79d2b710c6 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -4,6 +4,7 @@ import com.google.common.primitives.Doubles;
@@ -16,7 +16,7 @@ index 26576384981d6a80421402531d4249ef54eb618a..a3f482f7fbbb13fc0824914877225ed3
  import io.netty.util.concurrent.Future;
  import io.netty.util.concurrent.GenericFutureListener;
  import it.unimi.dsi.fastutil.ints.Int2ShortMap;
-@@ -107,6 +108,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -108,6 +109,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final int MAX_SIGN_LINE_LENGTH = Integer.getInteger("Paper.maxSignLength", 80);
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
@@ -25,7 +25,7 @@ index 26576384981d6a80421402531d4249ef54eb618a..a3f482f7fbbb13fc0824914877225ed3
      public PlayerConnection(MinecraftServer minecraftserver, NetworkManager networkmanager, EntityPlayer entityplayer) {
          this.minecraftServer = minecraftserver;
          this.networkManager = networkmanager;
-@@ -2727,6 +2730,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2733,6 +2736,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final MinecraftKey CUSTOM_REGISTER = new MinecraftKey("register");
      private static final MinecraftKey CUSTOM_UNREGISTER = new MinecraftKey("unregister");
  
@@ -34,7 +34,7 @@ index 26576384981d6a80421402531d4249ef54eb618a..a3f482f7fbbb13fc0824914877225ed3
      @Override
      public void a(PacketPlayInCustomPayload packetplayincustompayload) {
          PlayerConnectionUtils.ensureMainThread(packetplayincustompayload, this, this.player.getWorldServer());
-@@ -2754,6 +2759,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2760,6 +2765,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
              try {
                  byte[] data = new byte[packetplayincustompayload.data.readableBytes()];
                  packetplayincustompayload.data.readBytes(data);
@@ -51,7 +51,7 @@ index 26576384981d6a80421402531d4249ef54eb618a..a3f482f7fbbb13fc0824914877225ed3
                  server.getMessenger().dispatchIncomingMessage(player.getBukkitEntity(), packetplayincustompayload.tag.toString(), data);
              } catch (Exception ex) {
                  PlayerConnection.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -2763,6 +2778,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2769,6 +2784,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      }
  


### PR DESCRIPTION
When the Bukkit api is used to open an inventory, currently the close reason is `PLAYER`. But it should be `OPEN_NEW` which exists for this exact reason.

Problem was that the CB just hooks into the closing packet method directly where normally a packet is received from the client.

My solution is to overload that packet method to allow specifying the alternate reason.