### PR TITLE
Add issue template config

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: PaperMC Discord
+    url: http://discord.gg/papermc
+    about: If you are having issues with timings or have other minor issues, come ask us on our Discord server!


### PR DESCRIPTION
This issue template config will disable the "Create blank issue" option and add a link to the discord server.

For an example, check out [my fork's issue creation page](https://github.com/Chew/Paper/issues/new/choose)