### PR TITLE
Beehive block breaking in creative mode

### DIFF
--- a/Spigot-Server-Patches/0580-Dont-return-empty-list-when-beehive-breaking-in-crea.patch
+++ b/Spigot-Server-Patches/0580-Dont-return-empty-list-when-beehive-breaking-in-crea.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yasin <20637793+bertek41@users.noreply.github.com>
+Date: Sat, 12 Sep 2020 19:55:21 +0300
+Subject: [PATCH] Dont return empty list when beehive breaking in creative
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockBeehive.java b/src/main/java/net/minecraft/server/BlockBeehive.java
+index 7e2c63e4731ac2d234d5f90eb80d314cdede07ca..f1c58ed99881bbde309ace1833cca97ae7ee8f5e 100644
+--- a/src/main/java/net/minecraft/server/BlockBeehive.java
++++ b/src/main/java/net/minecraft/server/BlockBeehive.java
+@@ -188,7 +188,13 @@ public class BlockBeehive extends BlockTileEntity {
+                 EntityItem entityitem = new EntityItem(world, (double) blockposition.getX(), (double) blockposition.getY(), (double) blockposition.getZ(), itemstack);
+ 
+                 entityitem.defaultPickupDelay();
+-                world.addEntity(entityitem);
++                // Paper start
++                if (world.captureDrops != null) {
++                    world.captureDrops.add(entityitem);
++                } else {
++                    world.addEntity(entityitem);
++                }
++                // Paper end
+             }
+         }
+ 


### PR DESCRIPTION
When Beehive block have bee inside and you break block in creative mode block drops beehive item but BlockDropItemEvent#getItems returns empty list.

Related https://github.com/PaperMC/Paper/issues/4307