### PR TITLE
Only consider chunks Loaded if at BORDER status

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -3929,7 +3929,7 @@ index 8bdda63a2807635e8780481244251f6e35c13627..36a7e41cc5036345929ebf4d2fa160a8
          int j = 0;
          ChunkSection[] achunksection = chunk.getSections();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index ce324c1c3ae1b7cddf962a6eb93f91000fa41d50..49686f1f39417f8c7d6e0a58fb428fa34335fb0f 100644
+index ce324c1c3ae1b7cddf962a6eb93f91000fa41d50..0f82376ac386ce4dfcf2799fbd92a32ca37095e5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -21,9 +21,9 @@ public class PlayerChunk {
@@ -3954,7 +3954,7 @@ index ce324c1c3ae1b7cddf962a6eb93f91000fa41d50..49686f1f39417f8c7d6e0a58fb428fa3
      public PlayerChunk(ChunkCoordIntPair chunkcoordintpair, int i, LightEngine lightengine, PlayerChunk.c playerchunk_c, PlayerChunk.d playerchunk_d) {
          this.statusFutures = new AtomicReferenceArray(PlayerChunk.CHUNK_STATUSES.size());
          this.fullChunkFuture = PlayerChunk.UNLOADED_CHUNK_FUTURE;
-@@ -54,8 +56,47 @@ public class PlayerChunk {
+@@ -54,16 +56,63 @@ public class PlayerChunk {
          this.ticketLevel = this.oldTicketLevel;
          this.n = this.oldTicketLevel;
          this.a(i);
@@ -4000,14 +4000,16 @@ index ce324c1c3ae1b7cddf962a6eb93f91000fa41d50..49686f1f39417f8c7d6e0a58fb428fa3
 +    // Paper end
 +
      // CraftBukkit start
-     public Chunk getFullChunk() {
+-    public Chunk getFullChunk() {
++    public final Chunk getFullChunk() { // Paper - final for inline
          if (!getChunkState(this.oldTicketLevel).isAtLeast(PlayerChunk.State.BORDER)) return null; // note: using oldTicketLevel for isLoaded checks
-@@ -64,6 +105,14 @@ public class PlayerChunk {
+         CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> statusFuture = this.getStatusFutureUnchecked(ChunkStatus.FULL);
+         Either<IChunkAccess, PlayerChunk.Failure> either = (Either<IChunkAccess, PlayerChunk.Failure>) statusFuture.getNow(null);
          return either == null ? null : (Chunk) either.left().orElse(null);
      }
      // CraftBukkit end
 +    // Paper start - "real" get full chunk immediately
-+    public Chunk getFullChunkIfCached() {
++    public final Chunk getFullChunkIfCached() {
 +        // Note: Copied from above without ticket level check
 +        CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> statusFuture = this.getStatusFutureUnchecked(ChunkStatus.FULL);
 +        Either<IChunkAccess, PlayerChunk.Failure> either = (Either<IChunkAccess, PlayerChunk.Failure>) statusFuture.getNow(null);
@@ -4017,24 +4019,57 @@ index ce324c1c3ae1b7cddf962a6eb93f91000fa41d50..49686f1f39417f8c7d6e0a58fb428fa3
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
          CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture = (CompletableFuture) this.statusFutures.get(chunkstatus.c());
-@@ -75,14 +124,17 @@ public class PlayerChunk {
+@@ -75,20 +124,23 @@ public class PlayerChunk {
          return getChunkStatus(this.ticketLevel).b(chunkstatus) ? this.getStatusFutureUnchecked(chunkstatus) : PlayerChunk.UNLOADED_CHUNK_ACCESS_FUTURE;
      }
  
+-    public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> a() {
 +    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> getTickingFuture() { return this.a(); } // Paper - OBFHELPER
-     public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> a() {
++    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> a() { // Paper - final for inline
          return this.tickingFuture;
      }
  
+-    public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> b() {
 +    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> getEntityTickingFuture() { return this.b(); } // Paper - OBFHELPER
-     public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> b() {
++    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> b() { // Paper - final for inline
          return this.entityTickingFuture;
      }
  
+-    public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> c() {
 +    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> getFullChunkFuture() { return this.c(); } // Paper - OBFHELPER
-     public CompletableFuture<Either<Chunk, PlayerChunk.Failure>> c() {
++    public final CompletableFuture<Either<Chunk, PlayerChunk.Failure>> c() { // Paper - final for inline
          return this.fullChunkFuture;
      }
+ 
+     @Nullable
+-    public Chunk getChunk() {
++    public final Chunk getChunk() { // Paper - final for inline
+         CompletableFuture<Either<Chunk, PlayerChunk.Failure>> completablefuture = this.a();
+         Either<Chunk, PlayerChunk.Failure> either = (Either) completablefuture.getNow(null); // CraftBukkit - decompile error
+ 
+@@ -113,7 +165,7 @@ public class PlayerChunk {
+         return null;
+     }
+ 
+-    public CompletableFuture<IChunkAccess> getChunkSave() {
++    public final CompletableFuture<IChunkAccess> getChunkSave() { // Paper - final for inline
+         return this.chunkSave;
+     }
+ 
+@@ -254,11 +306,11 @@ public class PlayerChunk {
+         });
+     }
+ 
+-    public ChunkCoordIntPair i() {
++    public final ChunkCoordIntPair i() { // Paper - final for inline
+         return this.location;
+     }
+ 
+-    public int getTicketLevel() {
++    public final int getTicketLevel() { // Paper - final for inline
+         return this.ticketLevel;
+     }
+ 
 @@ -329,13 +381,27 @@ public class PlayerChunk {
  
          this.hasBeenLoaded |= flag3;
@@ -4352,7 +4387,7 @@ index ff41038ce6d2c1a8093bce3539070fa0ccfd61c2..ed0f9c5d29c4f88b7beee4b0ecdd7a56
          return VoxelShapes.b;
      }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 3150f4a0a8f1f8256c7e296f479b632b47bc6620..f69c2055a33a9396e0df6554aa4e498ba0fd4e71 100644
+index 3150f4a0a8f1f8256c7e296f479b632b47bc6620..4059aaf6da1bfe6003e2d94ce33e32eb1aaa93c9 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -22,6 +22,7 @@ import org.bukkit.craftbukkit.SpigotTimings; // Spigot
@@ -4372,19 +4407,32 @@ index 3150f4a0a8f1f8256c7e296f479b632b47bc6620..f69c2055a33a9396e0df6554aa4e498b
          this.generator = gen;
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
-@@ -212,6 +213,39 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
-         return (Chunk) this.getChunkAt(i, j, ChunkStatus.FULL);
+@@ -203,17 +204,50 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+         return i < 0 || i >= 256;
      }
  
+-    public Chunk getChunkAtWorldCoords(BlockPosition blockposition) {
++    public final Chunk getChunkAtWorldCoords(BlockPosition blockposition) { // Paper - help inline
+         return this.getChunkAt(blockposition.getX() >> 4, blockposition.getZ() >> 4);
+     }
+ 
+     @Override
+-    public Chunk getChunkAt(int i, int j) {
+-        return (Chunk) this.getChunkAt(i, j, ChunkStatus.FULL);
++    public final Chunk getChunkAt(int i, int j) { // Paper - final to help inline
++        return (Chunk) this.getChunkAt(i, j, ChunkStatus.FULL, true); // Paper - avoid a method jump
++    }
++
 +    // Paper start - if loaded
 +    @Nullable
 +    @Override
-+    public IChunkAccess getChunkIfLoadedImmediately(int x, int z) {
++    public final IChunkAccess getChunkIfLoadedImmediately(int x, int z) {
 +        return ((WorldServer)this).chunkProvider.getChunkAtIfLoadedImmediately(x, z);
-+    }
-+
-+    @Override
-+    public IBlockData getTypeIfLoaded(BlockPosition blockposition) {
+     }
+ 
+     @Override
+-    public IChunkAccess getChunkAt(int i, int j, ChunkStatus chunkstatus, boolean flag) {
++    public final IBlockData getTypeIfLoaded(BlockPosition blockposition) {
 +        // CraftBukkit start - tree generation
 +        if (captureTreeGeneration) {
 +            CraftBlockState previous = capturedBlockStates.get(blockposition);
@@ -4409,9 +4457,20 @@ index 3150f4a0a8f1f8256c7e296f479b632b47bc6620..f69c2055a33a9396e0df6554aa4e498b
 +    }
 +    // Paper end
 +
-     @Override
-     public IChunkAccess getChunkAt(int i, int j, ChunkStatus chunkstatus, boolean flag) {
++    @Override
++    public final IChunkAccess getChunkAt(int i, int j, ChunkStatus chunkstatus, boolean flag) { // Paper - final for inline
          IChunkAccess ichunkaccess = this.getChunkProvider().getChunkAt(i, j, chunkstatus, flag);
+ 
+         if (ichunkaccess == null && flag) {
+@@ -224,7 +258,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+     }
+ 
+     @Override
+-    public boolean setTypeAndData(BlockPosition blockposition, IBlockData iblockdata, int i) {
++    public final boolean setTypeAndData(BlockPosition blockposition, IBlockData iblockdata, int i) { // Paper - final for inline
+         return this.a(blockposition, iblockdata, i, 512);
+     }
+ 
 @@ -370,8 +404,9 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
      public void a(BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1) {}

--- a/Spigot-Server-Patches/0065-Add-World-Util-Methods.patch
+++ b/Spigot-Server-Patches/0065-Add-World-Util-Methods.patch
@@ -6,19 +6,25 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8d8da7885df69fd98f2b4715e4b6b4aa992bde27..ca073af1c88721a856ad5a1878db24f3d94135e6 100644
+index 8ae490f5dbf9afc467f82fd7ea863bc9e247203b..884e166826a73e0210f3c215d68cdf1a4bd00355 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -250,6 +250,22 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -245,11 +245,27 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+     }
+ 
+     @Override
+-    public Fluid getFluidIfLoaded(BlockPosition blockposition) {
++    public final Fluid getFluidIfLoaded(BlockPosition blockposition) {
+         IChunkAccess chunk = this.getChunkIfLoadedImmediately(blockposition.getX() >> 4, blockposition.getZ() >> 4);
  
          return chunk == null ? null : chunk.getFluid(blockposition);
      }
 +
-+    public boolean isLoadedAndInBounds(BlockPosition blockposition) {
++    public final boolean isLoadedAndInBounds(BlockPosition blockposition) { // Paper - final for inline
 +        return getWorldBorder().isInBounds(blockposition) && getChunkIfLoadedImmediately(blockposition.getX() >> 4, blockposition.getZ() >> 4) != null;
 +    }
 +
-+    public Chunk getChunkIfLoaded(int x, int z) {
++    public Chunk getChunkIfLoaded(int x, int z) { // Overridden in WorldServer for ABI compat which has final
 +        return ((WorldServer) this).getChunkProvider().getChunkAtIfLoadedImmediately(x, z);
 +    }
 +    public final Chunk getChunkIfLoaded(BlockPosition blockposition) {
@@ -26,7 +32,7 @@ index 8d8da7885df69fd98f2b4715e4b6b4aa992bde27..ca073af1c88721a856ad5a1878db24f3
 +    }
 +
 +    //  reduces need to do isLoaded before getType
-+    public IBlockData getTypeIfLoadedAndInBounds(BlockPosition blockposition) {
++    public final IBlockData getTypeIfLoadedAndInBounds(BlockPosition blockposition) {
 +        return getWorldBorder().isInBounds(blockposition) ? getTypeIfLoaded(blockposition) : null;
 +    }
      // Paper end

--- a/Spigot-Server-Patches/0125-Optimize-World.isLoaded-BlockPosition-Z.patch
+++ b/Spigot-Server-Patches/0125-Optimize-World.isLoaded-BlockPosition-Z.patch
@@ -6,18 +6,17 @@ Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 1cc5321cc82c7561d805771a95408fb69ebaa800..9be2ab36eca6c268135e043904b7e0e8459b893b 100644
+index 61b21f82c44a51cc75e6e89b8b2f2467b0b5113a..f7b97f923891e3d0afe406dbc52a6eff5770f9c6 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -252,6 +252,11 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -252,6 +252,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return chunk == null ? null : chunk.getFluid(blockposition);
      }
  
-+    public boolean isLoaded(BlockPosition blockposition) {
++    public final boolean isLoaded(BlockPosition blockposition) {
 +        return getChunkIfLoaded(blockposition.getX() >> 4, blockposition.getZ() >> 4) != null; // Paper
 +    }
 +
-+
-     public boolean isLoadedAndInBounds(BlockPosition blockposition) {
+     public final boolean isLoadedAndInBounds(BlockPosition blockposition) { // Paper - final for inline
          return getWorldBorder().isInBounds(blockposition) && getChunkIfLoadedImmediately(blockposition.getX() >> 4, blockposition.getZ() >> 4) != null;
      }

--- a/Spigot-Server-Patches/0164-Fix-MC-117075-TE-Unload-Lag-Spike.patch
+++ b/Spigot-Server-Patches/0164-Fix-MC-117075-TE-Unload-Lag-Spike.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix MC-117075: TE Unload Lag Spike
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 9be2ab36eca6c268135e043904b7e0e8459b893b..83559b3a5b72729f6d75590cf322dd2507783bd1 100644
+index f7b97f923891e3d0afe406dbc52a6eff5770f9c6..269996130b85997bed4622eea781e3e9c0684c81 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -674,7 +674,11 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -673,7 +673,11 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          gameprofilerfiller.enter("blockEntities");
          timings.tileEntityTick.startTiming(); // Spigot
          if (!this.tileEntityListUnload.isEmpty()) {

--- a/Spigot-Server-Patches/0178-use-CB-BlockState-implementations-for-captured-block.patch
+++ b/Spigot-Server-Patches/0178-use-CB-BlockState-implementations-for-captured-block.patch
@@ -18,7 +18,7 @@ the blockstate that will be valid for restoration, as opposed to dropping
 information on restoration when the event is cancelled.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 83559b3a5b72729f6d75590cf322dd2507783bd1..1b15ccd6c05d1ed965c03cd50f7488e26741c2ed 100644
+index 269996130b85997bed4622eea781e3e9c0684c81..dc00ad1607dc6b05f8cb13470046d72f17aa115b 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -71,7 +71,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -30,7 +30,7 @@ index 83559b3a5b72729f6d75590cf322dd2507783bd1..1b15ccd6c05d1ed965c03cd50f7488e2
      public Map<BlockPosition, TileEntity> capturedTileEntities = new HashMap<>();
      public List<EntityItem> captureDrops;
      public long ticksPerAnimalSpawns;
-@@ -294,7 +294,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -293,7 +293,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public boolean a(BlockPosition blockposition, IBlockData iblockdata, int i, int j) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -39,7 +39,7 @@ index 83559b3a5b72729f6d75590cf322dd2507783bd1..1b15ccd6c05d1ed965c03cd50f7488e2
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, blockposition, i);
                  this.capturedBlockStates.put(blockposition.immutableCopy(), blockstate);
-@@ -314,7 +314,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -313,7 +313,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              // CraftBukkit start - capture blockstates
              boolean captured = false;
              if (this.captureBlockStates && !this.capturedBlockStates.containsKey(blockposition)) {
@@ -48,7 +48,7 @@ index 83559b3a5b72729f6d75590cf322dd2507783bd1..1b15ccd6c05d1ed965c03cd50f7488e2
                  this.capturedBlockStates.put(blockposition.immutableCopy(), blockstate);
                  captured = true;
              }
-@@ -572,7 +572,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -571,7 +571,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public IBlockData getType(BlockPosition blockposition) {
          // CraftBukkit start - tree generation
          if (captureTreeGeneration) {

--- a/Spigot-Server-Patches/0248-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0248-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -19,10 +19,10 @@ index 6352051ab937d4d365e823a7112e76dc3ec34225..92ddf96f7db08a2b390ef3f49b0643f9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 651791f27b796b081a52b8d8735a51e2f940e5df..2f08328dabeb8e5c3734d4005d7086ec133f6f9d 100644
+index 6ebf3884a289d0be081d43d012ac10796740cc1e..909e01e458d729f277797bf1dca564f927318460 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -802,6 +802,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -801,6 +801,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              // Paper end
          }
      }

--- a/Spigot-Server-Patches/0326-BlockDestroyEvent.patch
+++ b/Spigot-Server-Patches/0326-BlockDestroyEvent.patch
@@ -11,10 +11,10 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5ae5caf23e9614bb506c8aa0d511e73c54abf903..4f38cba90c01cb7d076cf4de7a4e24e808cb1098 100644
+index 42307f0ed23c413f86edf3ac2783f258560ac969..abc73ccc26d1496434009ba09e2e08dbe5784d7b 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -500,8 +500,20 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -499,8 +499,20 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              return false;
          } else {
              Fluid fluid = this.getFluid(blockposition);

--- a/Spigot-Server-Patches/0346-Optimize-Captured-TileEntity-Lookup.patch
+++ b/Spigot-Server-Patches/0346-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 4f38cba90c01cb7d076cf4de7a4e24e808cb1098..02291c5120ab462173a2578ab7b7a2aca210d8d7 100644
+index abc73ccc26d1496434009ba09e2e08dbe5784d7b..120435364ad0febefcb7285bf3b527d6b1aedb15 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -905,12 +905,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -904,12 +904,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              return null;
          } else {
              // CraftBukkit start

--- a/Spigot-Server-Patches/0347-Add-Heightmap-API.patch
+++ b/Spigot-Server-Patches/0347-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 02291c5120ab462173a2578ab7b7a2aca210d8d7..a77c3895756e752e232f9a8abfc5851b1d4ef47f 100644
+index 120435364ad0febefcb7285bf3b527d6b1aedb15..0d3c470f66b6d5a7a711e6109d9ff9e06cb5318a 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -610,8 +610,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -609,8 +609,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          }
      }
  

--- a/Spigot-Server-Patches/0366-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0366-Anti-Xray.patch
@@ -1370,7 +1370,7 @@ index 09da0cc8f02c504191dfec8be93e6cf67c6afb78..9ee7e1e93659beb747b8fe2b926522b1
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index a77c3895756e752e232f9a8abfc5851b1d4ef47f..79d3f19eb8acbed35a4eb11157d548d79e6ea5a6 100644
+index 0d3c470f66b6d5a7a711e6109d9ff9e06cb5318a..1408c83fc3f1be7dc0ff09ebd3cc09a7f99ab188 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -1402,7 +1402,7 @@ index a77c3895756e752e232f9a8abfc5851b1d4ef47f..79d3f19eb8acbed35a4eb11157d548d7
          this.generator = gen;
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
-@@ -373,6 +377,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -372,6 +376,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
              // CraftBukkit end
  
              IBlockData iblockdata1 = chunk.setType(blockposition, iblockdata, (i & 64) != 0, (i & 1024) == 0); // CraftBukkit custom NO_PLACE flag

--- a/Spigot-Server-Patches/0373-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/Spigot-Server-Patches/0373-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -21,7 +21,7 @@ index 4abfbd86bed491f157f29234f739e4429a4efa8f..342d519ad8df0c781b592af0c39c0b80
                                  return;
                              }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 79d3f19eb8acbed35a4eb11157d548d79e6ea5a6..88c4faf64a577cc38fb0e80bee7ae7f24cbe445f 100644
+index 1408c83fc3f1be7dc0ff09ebd3cc09a7f99ab188..67b45b044350c9555eca6c6616966cf2e5d8513d 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -104,6 +104,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -38,7 +38,7 @@ index 79d3f19eb8acbed35a4eb11157d548d79e6ea5a6..88c4faf64a577cc38fb0e80bee7ae7f2
      public ResourceKey<DimensionManager> getTypeKey() {
          return typeKey;
      }
-@@ -999,14 +1006,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -998,14 +1005,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      }
  
      public boolean p(BlockPosition blockposition) {
@@ -55,7 +55,7 @@ index 79d3f19eb8acbed35a4eb11157d548d79e6ea5a6..88c4faf64a577cc38fb0e80bee7ae7f2
  
              return ichunkaccess == null ? false : ichunkaccess.getType(blockposition).a((IBlockAccess) this, blockposition, entity, enumdirection);
          }
-@@ -1127,7 +1134,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1126,7 +1133,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
          for (int i1 = i; i1 < j; ++i1) {
              for (int j1 = k; j1 < l; ++j1) {

--- a/Spigot-Server-Patches/0374-Reduce-sync-loads.patch
+++ b/Spigot-Server-Patches/0374-Reduce-sync-loads.patch
@@ -298,10 +298,10 @@ index 032464901e02392df4966c68cce8d06f2bd6b6f8..55feb186e4f3f7985efdf7c4410ed423
              this.serverThreadQueue.awaitTasks(completablefuture::isDone);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.popChunkWait(); // Paper - async chunk debug
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 88c4faf64a577cc38fb0e80bee7ae7f24cbe445f..8426bf5b16bbe7c9a8b1582e1dac0298898eb263 100644
+index 67b45b044350c9555eca6c6616966cf2e5d8513d..188517b27f301e33911e3e1c65c1a8f95af631c1 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1067,7 +1067,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1066,7 +1066,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
          for (int i1 = i; i1 <= j; ++i1) {
              for (int j1 = k; j1 <= l; ++j1) {
@@ -310,7 +310,7 @@ index 88c4faf64a577cc38fb0e80bee7ae7f24cbe445f..8426bf5b16bbe7c9a8b1582e1dac0298
  
                  if (chunk != null) {
                      chunk.a(entity, axisalignedbb, list, predicate);
-@@ -1088,7 +1088,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1087,7 +1087,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
          for (int i1 = i; i1 < j; ++i1) {
              for (int j1 = k; j1 < l; ++j1) {
@@ -319,7 +319,7 @@ index 88c4faf64a577cc38fb0e80bee7ae7f24cbe445f..8426bf5b16bbe7c9a8b1582e1dac0298
  
                  if (chunk != null) {
                      chunk.a(entitytypes, axisalignedbb, list, predicate);
-@@ -1111,7 +1111,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1110,7 +1110,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
          for (int i1 = i; i1 < j; ++i1) {
              for (int j1 = k; j1 < l; ++j1) {

--- a/Spigot-Server-Patches/0393-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0393-Optimize-Hoppers.patch
@@ -485,10 +485,10 @@ index c6e6c54a3eb5d725b71f2ec2bb27dd8e2aceabde..c79ebe2343cc14f113c0cc6496c20e7d
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8426bf5b16bbe7c9a8b1582e1dac0298898eb263..303d82bf4ba21b4a74805750650d07778b30d875 100644
+index 188517b27f301e33911e3e1c65c1a8f95af631c1..2477912af13545cdd2b2ec397cbe7c93d895be9b 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1099,8 +1099,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1098,8 +1098,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return list;
      }
  

--- a/Spigot-Server-Patches/0408-Optimise-getChunkAt-calls-for-loaded-chunks.patch
+++ b/Spigot-Server-Patches/0408-Optimise-getChunkAt-calls-for-loaded-chunks.patch
@@ -64,22 +64,3 @@ index dce9c62c0cf37a37994537b74dfdc2286c60fae2..f7055ee0f2d497502f6a8b03544a5595
          }
      }
  
-diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 77c611a5366943031624b07e64d069f3f1d2e49a..b95ff5ee16abeeef81690d9f47979bac603360d7 100644
---- a/src/main/java/net/minecraft/server/World.java
-+++ b/src/main/java/net/minecraft/server/World.java
-@@ -286,6 +286,14 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
- 
-     @Override
-     public Chunk getChunkAt(int i, int j) {
-+        // Paper start - optimise this for loaded chunks
-+        if (Thread.currentThread() == this.serverThread) {
-+            Chunk ifLoaded = ((WorldServer) this).getChunkProvider().getChunkAtIfLoadedMainThread(i, j);
-+            if (ifLoaded != null) {
-+                return ifLoaded;
-+            }
-+        }
-+        // Paper end
-         return (Chunk) this.getChunkAt(i, j, ChunkStatus.FULL);
-     }
- 

--- a/Spigot-Server-Patches/0411-Optimise-random-block-ticking.patch
+++ b/Spigot-Server-Patches/0411-Optimise-random-block-ticking.patch
@@ -243,10 +243,10 @@ index 2ce40da2a8e28e80b4cb2cb827f45ddd4601d93a..e025eef4761faa946c6bb39e3ab151ac
  
      public BlockPosition getHomePos() { // Paper - public
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index b95ff5ee16abeeef81690d9f47979bac603360d7..b3b2ae829b246764a18d22868d441579aaa68f3f 100644
+index 768a05cd8d3ce025feca12593bb0844de1f481f7..df7386a8356e7191dfa06b3ab59537c13cc6ff9b 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -1417,10 +1417,18 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1408,10 +1408,18 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public abstract ITagRegistry p();
  
      public BlockPosition a(int i, int j, int k, int l) {

--- a/Spigot-Server-Patches/0441-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0441-Improved-Watchdog-Support.patch
@@ -304,10 +304,10 @@ index 1fe1df445ba56b2f176ee25502a774aa0a7bd00b..916a6a1fc1ccc73e4fb974ad77310d16
          a(SystemUtils.e);
          a(SystemUtils.f);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index b3b2ae829b246764a18d22868d441579aaa68f3f..fc77588e325e9c18092c877c5e845e60ffd29b4c 100644
+index df7386a8356e7191dfa06b3ab59537c13cc6ff9b..df6299d81a6d6450272b9aaba397df523cb9e862 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -806,6 +806,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -797,6 +797,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
                          gameprofilerfiller.exit();
                      } catch (Throwable throwable) {
@@ -315,7 +315,7 @@ index b3b2ae829b246764a18d22868d441579aaa68f3f..fc77588e325e9c18092c877c5e845e60
                          // Paper start - Prevent tile entity and entity crashes
                          String msg = "TileEntity threw exception at " + tileentity.world.getWorld().getName() + ":" + tileentity.position.getX() + "," + tileentity.position.getY() + "," + tileentity.position.getZ();
                          System.err.println(msg);
-@@ -881,6 +882,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -872,6 +873,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          try {
              consumer.accept(entity);
          } catch (Throwable throwable) {

--- a/Spigot-Server-Patches/0473-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0473-No-Tick-view-distance-implementation.patch
@@ -142,7 +142,7 @@ index df3150072fd36dac28d83309e50342c9cfa326b3..0b5ddff008d151ad03a1f382a8f24494
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
              worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 4074c1f8f8b71544df9aa6e8d59c5703f2036fd9..2784ea71b9f5ee93f6de8e5a3a135457f1be17a3 100644
+index 69c7bbf6a83b07a3af62b8fabaa851c7f7dc9a98..bd5643cae88b0c510a630b6166d95368c7405ae6 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -57,6 +57,18 @@ public class PlayerChunk {
@@ -598,10 +598,10 @@ index 40f2984e5ba7627ef4ce87133bed5df51a68fd65..4c16da52f4402b21be2df3fdf5999427
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index fc77588e325e9c18092c877c5e845e60ffd29b4c..ce3a74d980e5551f4af5ae28f83f4c6e84bd96e7 100644
+index df6299d81a6d6450272b9aaba397df523cb9e862..54403c34e256d5264111048806b42404a9705b44 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -473,8 +473,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -464,8 +464,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
                  this.b(blockposition, iblockdata1, iblockdata2);
              }
  

--- a/Spigot-Server-Patches/0482-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/Spigot-Server-Patches/0482-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -157,10 +157,10 @@ index 9823fb5eebbfee026d3173c81368cf6e3e901f92..f263177e3d41fd5720c430be3dcb1b5e
  
                      this.world.getMethodProfiler().enter("explosion_blocks");
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index ce3a74d980e5551f4af5ae28f83f4c6e84bd96e7..17b6a4fb6c1893f000efaeaaf36e152e3da34893 100644
+index 54403c34e256d5264111048806b42404a9705b44..fd761c57980f6030f270a44f6492a00f12749703 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -371,6 +371,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -362,6 +362,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
      public boolean a(BlockPosition blockposition, IBlockData iblockdata, int i, int j) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/Spigot-Server-Patches/0566-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0566-Optimize-redstone-algorithm.patch
@@ -1137,10 +1137,10 @@ index 7b3ccded0451f7b6634aeca0bdc1b5cc94f52b96..6abc3d4cfbe8f5cc1dbe83031d90ee8d
                  c(iblockdata, world, blockposition);
                  world.a(blockposition, false);
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 17b6a4fb6c1893f000efaeaaf36e152e3da34893..eaa285393454771052fae7676d2983ec2efae10b 100644
+index fd761c57980f6030f270a44f6492a00f12749703..eec338649edbdaebbe694a23ccb7a8b5cd5f9a15 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
-@@ -607,6 +607,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -598,6 +598,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
  
      }
  
@@ -1148,7 +1148,7 @@ index 17b6a4fb6c1893f000efaeaaf36e152e3da34893..eaa285393454771052fae7676d2983ec
      public void a(BlockPosition blockposition, Block block, BlockPosition blockposition1) {
          if (!this.isClientSide) {
              IBlockData iblockdata = this.getType(blockposition);
-@@ -1232,6 +1233,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+@@ -1223,6 +1224,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
          return this.getBlockFacePower(blockposition.down(), EnumDirection.DOWN) > 0 ? true : (this.getBlockFacePower(blockposition.up(), EnumDirection.UP) > 0 ? true : (this.getBlockFacePower(blockposition.north(), EnumDirection.NORTH) > 0 ? true : (this.getBlockFacePower(blockposition.south(), EnumDirection.SOUTH) > 0 ? true : (this.getBlockFacePower(blockposition.west(), EnumDirection.WEST) > 0 ? true : this.getBlockFacePower(blockposition.east(), EnumDirection.EAST) > 0))));
      }
  

--- a/Spigot-Server-Patches/0581-Only-consider-chunks-Loaded-if-at-BORDER-status.patch
+++ b/Spigot-Server-Patches/0581-Only-consider-chunks-Loaded-if-at-BORDER-status.patch
@@ -1,0 +1,156 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aikar <aikar@aikar.co>
+Date: Sat, 12 Sep 2020 22:20:55 -0400
+Subject: [PATCH] Only consider chunks Loaded if at BORDER status
+
+This greatly improves performance as it drastically reduces the amount
+of Entities and Tile Entities that are "registered" into the world, as
+purely "cached" chunks will no longer have their entities hanging out in the world.
+
+Additionally this fixes our Entity Add To World and Entity Remove From World events
+
+Those events have not been firing correctly since MC changed how chunks work here.
+
+Now the server will only consider a chunk "loaded" if it's got a ticket putting
+it at level 33 or lower, which matches the public Bukkit API.
+
+diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
+index 299d7d7a55532930e2d4340a6cfe77a5fd8a0a0c..15c0a06139bffc6a7f83a1d47f2a708f14d264ec 100644
+--- a/src/main/java/net/minecraft/server/Chunk.java
++++ b/src/main/java/net/minecraft/server/Chunk.java
+@@ -791,6 +791,7 @@ public class Chunk implements IChunkAccess {
+         int chunkX = this.loc.x;
+         int chunkZ = this.loc.z;
+         ChunkProviderServer chunkProvider = ((WorldServer)this.world).getChunkProvider();
++        chunkProvider.playerChunkMap.loadChunk(this); // Paper - move load logic from the entering full status to when it enters border status instead
+         for (int dx = -NEIGHBOUR_CACHE_RADIUS; dx <= NEIGHBOUR_CACHE_RADIUS; ++dx) {
+             for (int dz = -NEIGHBOUR_CACHE_RADIUS; dz <= NEIGHBOUR_CACHE_RADIUS; ++dz) {
+                 Chunk neighbour = chunkProvider.getChunkAtIfLoadedMainThreadNoCache(chunkX + dx, chunkZ + dz);
+@@ -862,6 +863,11 @@ public class Chunk implements IChunkAccess {
+         this.loadedTicketLevel = false;
+         this.resetNeighbours();
+         // Paper end
++        // Paper start - move unload logic from the actual full unload to be when it leaves border status
++        chunkProvider.playerChunkMap.loadedChunks.remove(loc.longKey);
++        setLoaded(false);
++        this.world.unloadChunk(this);
++        // Paper end
+     }
+     // CraftBukkit end
+ 
+diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+index 45c142c227bc258bbd5c8c03c6012663dccf8f3f..de5c45ec773474ad6a7b572e9a248c8f8ee0f94f 100644
+--- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
++++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
+@@ -19,6 +19,7 @@ import java.util.function.Supplier;
+ import javax.annotation.Nullable;
+ import com.destroystokyo.paper.exception.ServerInternalException;
+ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap; // Paper
++import it.unimi.dsi.fastutil.longs.LongIterator; // Paper
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+@@ -822,7 +823,10 @@ public class ChunkProviderServer extends IChunkProvider {
+             //List<PlayerChunk> list = Lists.newArrayList(this.playerChunkMap.f()); // Paper
+             //Collections.shuffle(list); // Paper
+             // Paper - moved up
+-            final int[] chunksTicked = {0}; this.playerChunkMap.forEachVisibleChunk((playerchunk) -> { // Paper - safe iterator incase chunk loads, also no wrapping
++            final int[] chunksTicked = {0};
++            this.playerChunkMap.forEachVisibleChunk((playerchunk) -> {
++            //for (LongIterator iterator = this.playerChunkMap.loadedChunks.iterator() ; iterator.hasNext() ; ) { // Paper - iterate only loaded chunks
++                //PlayerChunk playerchunk = this.playerChunkMap.getVisibleChunk(iterator.nextLong());// Paper - iterate only loaded chunks
+                 Optional<Chunk> optional = ((Either) playerchunk.a().getNow(PlayerChunk.UNLOADED_CHUNK)).left();
+ 
+                 if (optional.isPresent()) {
+@@ -850,7 +854,7 @@ public class ChunkProviderServer extends IChunkProvider {
+                         }
+                     }
+                 }
+-            });
++            });// Paper - use for instead of forEachVisibleChunk
+             this.world.getMethodProfiler().enter("customSpawners");
+             if (flag1) {
+                 try (co.aikar.timings.Timing ignored = this.world.timings.miscMobSpawning.startTiming()) { // Paper - timings
+diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+index fcd3388d88aad6e897b73e2c823267ada327cbda..5d3322f9f068fa74a000d58990dec6001f8ad1ab 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
++++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+@@ -1021,16 +1021,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                 this.a(i, playerchunk);
+             } else {
+                 if (this.pendingUnload.remove(i, playerchunk) && ichunkaccess != null) {
++                    // Paper start - coment out and move to ChunkUnloadEvent
+                     if (ichunkaccess instanceof Chunk) {
+-                        ((Chunk) ichunkaccess).setLoaded(false);
++                        //((Chunk) ichunkaccess).setLoaded(false);
+                     }
+ 
+                     //this.saveChunk(ichunkaccess);// Paper - delay
+-                    if (this.loadedChunks.remove(i) && ichunkaccess instanceof Chunk) {
+-                        Chunk chunk = (Chunk) ichunkaccess;
+-
+-                        this.world.unloadChunk(chunk);
+-                    }
++//                    if (this.loadedChunks.remove(i) && ichunkaccess instanceof Chunk) {
++//                        Chunk chunk = (Chunk) ichunkaccess;
++//
++//                        this.world.unloadChunk(chunk);
++//                    }
++                    // Paper end
+                     this.autoSaveQueue.remove(playerchunk); // Paper
+ 
+                     try {
+@@ -1293,6 +1295,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                     return PlayerChunk.getChunkState(playerchunk.getTicketLevel());
+                 });
+                 chunk.addEntities();
++                // Paper start
++                return chunk;
++            } // Paper
++            });
++        }, (runnable) -> {
++
++            this.mailboxMain.a(ChunkTaskQueueSorter.a(runnable, playerchunk.i().pair(), () -> 1)); // Paper - final loads are always urgent!
++        });
++    }
++    public void loadChunk(Chunk chunk) {
++        if (true) {
++            if (true) {
++                ChunkCoordIntPair chunkcoordintpair = chunk.getPos();
++                // Paper end
+                 if (this.loadedChunks.add(chunkcoordintpair.pair())) {
+                     chunk.setLoaded(true);
+                     this.world.a(chunk.getTileEntities().values());
+@@ -1328,17 +1344,21 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                         list.forEach(chunk::b);
+                     }
+                 }
+-
+-                return chunk;
+-                } // Paper
+-            });
+-        }, (runnable) -> {
+-            Mailbox mailbox = this.mailboxMain;
+-            long i = playerchunk.i().pair();
+-
+-            playerchunk.getClass();
+-            mailbox.a(ChunkTaskQueueSorter.a(runnable, i, () -> 1)); // Paper - final loads are always urgent!
+-        });
++                // Paper start
++            }
++        }
++        // Move code up
++//                return chunk;
++//                } // Paper
++//            });
++//        }, (runnable) -> {
++//            Mailbox mailbox = this.mailboxMain;
++//            long i = playerchunk.i().pair();
++//
++//            playerchunk.getClass();
++//            mailbox.a(ChunkTaskQueueSorter.a(runnable, i, () -> 1)); // Paper - final loads are always urgent!
++//        });
++        // Paper end
+     }
+ 
+     // Paper start


### PR DESCRIPTION
------------------
DOWNLOAD LINK: https://cdn.discordapp.com/attachments/748269415497465927/754945012080312370/loaded-chunks-r2.jar

While initial smoke test looks to be ok, this build presents a high risk of entity and tile entity lost if there is a bug that I did not see in my own testing.

It is super imperative that you have backups before testing this!

------------------
This greatly improves performance as it drastically reduces the amount
of Entities and Tile Entities that are "registered" into the world, as
purely "cached" chunks will no longer have their entities hanging out in the world.

Additionally this fixes our Entity Add To World and Entity Remove From World events

Those events have not been firing correctly since MC changed how chunks work here.

Now the server will only consider a chunk "loaded" if it's got a ticket putting
it at level 33 or lower, which matches the public Bukkit API.

------------------

Before this, there are a ton of chunks in memory in a 'cached' state, they aren't considered "loaded" in the api, they arent in any players view distance, are not force loaded. 

When they are loaded and unloaded don't align with our expectation of "load/unload" events. 

Leaving A LOT of extra entities in memory. meaning more entities to iterate for ticking (which will then be "skipped" because not in correct chunk") same with tile entities. also same issue applies for iterating chunks too, iterating far more than will end up being ticked resulting in a lot of checks to then skip it. 

This change cuts it out so the iteration only operates on stuff in a loaded state now.