### PR TITLE
More explicit phrasing when listing missing dependencies

### DIFF
--- a/scripts/requireDeps.sh
+++ b/scripts/requireDeps.sh
@@ -4,7 +4,7 @@ set -ue
 # Check if an application is on the PATH.
 # If it is not, return with non-zero.
 _is_dep_available() {
-	command -v "$1" >/dev/null || (echo "$1 ${2:-was not found and is a required dependency}"; return 1)
+	command -v "$1" >/dev/null || (echo "\"$1\" ${2:-package was not found and is a required dependency}"; return 1)
 }
 
 if [ -z "${1:-}" ]; then


### PR DESCRIPTION
While attempting to build Paper from source, it took me much longer than one might expect to realize that "patch" is actually a piece of software -- GNU Patch. Having been unfamiliar with it, I scoured the internet searching for the mysterious literal patch file that Paper was looking for, all to no avail... More explicit phrasing would assist in debugging when building for newbies.