### PR TITLE
Fix villager trade menu not closing when unable to trade

### DIFF
--- a/Spigot-Server-Patches/0582-Fix-villager-trade-menu-not-closing-when-unable-to-t.patch
+++ b/Spigot-Server-Patches/0582-Fix-villager-trade-menu-not-closing-when-unable-to-t.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Mon, 21 Sep 2020 16:51:32 -0700
+Subject: [PATCH] Fix villager trade menu not closing when unable to trade
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index c10ff09dd005c0c8b3cd374d9de82e77efcd9097..94e56eeafbe20583b1e3643967d4a160b54c70a8 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -968,6 +968,12 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+         this.bg.setMemory(MemoryModuleType.LAST_SLEPT, this.world.getTime()); // CraftBukkit - decompile error
+         this.bg.removeMemory(MemoryModuleType.WALK_TARGET);
+         this.bg.removeMemory(MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE);
++        // Paper start
++        if (getTrader() != null ) {
++            getTrader().closeInventory();
++            setTradingPlayer(null);
++        }
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
Aims to fix #4313.

I'm trying to contribute more, but likely I am missing things so please go easy and I will try to fix everything that's missing.

So far I think I've handled the sleeping issue; when they get into a bed, it should close the inventory and cancel the trade.

As for when the workstation/jobsite is broken I'm a bit stuck at the moment. There are multiple blocks a villager can work at depending on the villager type. All inherited from `n.m.s.Block`, so I'm wondering if I need to patch `Block`'s break method to check if 1) it's in a village and 2) it's a claimed job site, and then look up the relevant villager that claimed it and remove its job site memory. Seems valid, can I get a sanity check before I try and tackle that?