### PR TITLE
Patch SPIGOT-6086 for all invalid locations

### DIFF
--- a/Spigot-Server-Patches/0581-Don-t-mark-dirty-in-invalid-locations-SPIGOT-6086.patch
+++ b/Spigot-Server-Patches/0581-Don-t-mark-dirty-in-invalid-locations-SPIGOT-6086.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sun, 27 Sep 2020 16:25:24 +0200
+Subject: [PATCH] Don't mark dirty in invalid locations (SPIGOT-6086)
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
+index 31684667a6a76fc83feb657def40bd34599ae159..6ef71230ef8fac4d9bc2d48a433521d541027e96 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunk.java
++++ b/src/main/java/net/minecraft/server/PlayerChunk.java
+@@ -359,6 +359,7 @@ public class PlayerChunk {
+     }
+ 
+     public void a(BlockPosition blockposition) {
++        if (!blockposition.isValidLocation()) return; // Paper - SPIGOT-6086 for all invalid locations; avoid acquiring locks
+         Chunk chunk = this.getSendingChunk(); // Paper - no-tick view distance
+ 
+         if (chunk != null) {


### PR DESCRIPTION
md_5's patch for SPIGOT-6086 only applies to locations over the world,
not those under or outside it.

Reproduction:

* Run a plugin with:
```java
  @EventHandler
  public void onEvent(StructureGrowEvent event) {
    Location location = event.getLocation();
    event.getBlocks().add(location.subtract(0, 255, 0).getBlock().getState(false));
  }
```
* Place a tree and let it grow naturally.

Fixes #4577.