### PR TITLE
[CI-SKIP] Make travis use 'build' instead of 'patch'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ git:
 before_install:
   - git config --global user.email "travis-ci@travis-ci.com"
   - git config --global user.name "Travis CI"
-  - ./paper patch
+  - ./paper build
 cache:
   directories:
     - '$HOME/.m2/repository'


### PR DESCRIPTION
Closes #4277.

The fact it `mvn install`s the API should also make it generate JavaDocs.
This also has the added effect of only accepting compilable PRs.