### PR TITLE
Clarify the JavaDocs for Entity.getEntitySpawnReason()

### DIFF
--- a/Spigot-API-Patches/0230-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
+++ b/Spigot-API-Patches/0230-Clarify-the-Javadocs-for-Entity.getEntitySpawnReason.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aurora <aurora@relanet.eu>
+Date: Sat, 3 Oct 2020 16:28:41 +0200
+Subject: [PATCH] Clarify the Javadocs for Entity.getEntitySpawnReason()
+
+
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index 9bae4704b306b1d04534072690355983856c7801..4d1970bec04c5a3cf01d214f583efb0e1d08380d 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -651,7 +651,7 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+     Chunk getChunk();
+ 
+     /**
+-     * @return The {@link org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason} that spawned this entity.
++     * @return The {@link org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason} that initially spawned this entity. <!-- Paper - added "initially" to clarify that the SpawnReason doesn't change after the Entity was initially spawned" -->
+      */
+     @NotNull
+     org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason();


### PR DESCRIPTION
This is in response to #4361 
The Entity always keeps the SpawnReason it was spawned with initially, even if it gets spawned again after that (for example when going through a portal or exiting a beehive). This can be confusing (or at least it completely confused me), which is why I'm trying to clarify the javadocs for that function.