### PR TITLE
Fix Player#spawnParticle x/y/z precision loss

### DIFF
--- a/Spigot-Server-Patches/0604-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/Spigot-Server-Patches/0604-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Esophose <esophose@gmail.com>
+Date: Sat, 3 Oct 2020 18:57:47 -0600
+Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 47fccf065b3f87d78ddd97b56a65f9d97bb3c884..58caa3240b90cdc661e1e32e3f5c312ed62c3c21 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1953,7 +1953,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         if (data != null && !particle.getDataType().isInstance(data)) {
+             throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
+         }
+-        PacketPlayOutWorldParticles packetplayoutworldparticles = new PacketPlayOutWorldParticles(CraftParticle.toNMS(particle, data), true, (float) x, (float) y, (float) z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count);
++        PacketPlayOutWorldParticles packetplayoutworldparticles = new PacketPlayOutWorldParticles(CraftParticle.toNMS(particle, data), true, x, y, z, (float) offsetX, (float) offsetY, (float) offsetZ, (float) extra, count); // Paper - Fix x/y/z coordinate precision loss
+         getHandle().playerConnection.sendPacket(packetplayoutworldparticles);
+ 
+     }


### PR DESCRIPTION
Fixes precision loss due to downcasting from a double to a float for x/y/z coordinates when spawning particles through CraftPlayer#spawnParticle. This issue does not exist for CraftWorld#spawnParticle since it doesn't do the useless downcasting. This issue is only noticeable at extremely high coordinates. 

Before: https://gyazo.com/fd824ad0cf4f679a92e48bafadc2081c
After: https://gyazo.com/6d797a56ce86339c6312933606e27b76