### PR TITLE
Fix deop kicking non-whitelisted player when white list is not enabled

### DIFF
--- a/Spigot-Server-Patches/0583-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/Spigot-Server-Patches/0583-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <Blake.Galbreath@GMail.com>
+Date: Sat, 3 Oct 2020 22:00:27 -0500
+Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
+ not enabled
+
+
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 883c17f00b3766b1e4e308bf9baf0ab07d6475bf..26bbfeba138f506200aad667b6f910b8fc0d2d6a 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -1890,6 +1890,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         if (this.aM()) {
+             PlayerList playerlist = commandlistenerwrapper.getServer().getPlayerList();
+             WhiteList whitelist = playerlist.getWhitelist();
++            if (!((DedicatedServer)getServer()).getDedicatedServerProperties().whiteList.get()) return; // Paper - white list not enabled
+             List<EntityPlayer> list = Lists.newArrayList(playerlist.getPlayers());
+             Iterator iterator = list.iterator();
+ 


### PR DESCRIPTION
Fixes #4150 by returning early if the whitelist is disabled (same logic from legacy versions)