### PR TITLE
✨ Villager resetOffers API

### DIFF
--- a/Spigot-API-Patches/0229-Villager-resetOffers.patch
+++ b/Spigot-API-Patches/0229-Villager-resetOffers.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Mon, 7 Oct 2019 00:15:28 -0500
+Subject: [PATCH] Villager#resetOffers
+
+
+diff --git a/src/main/java/org/bukkit/entity/AbstractVillager.java b/src/main/java/org/bukkit/entity/AbstractVillager.java
+index d2b0c08554dba4d34b37b440f1d77ae0e64cb99e..7fbe31c4fd69d4fca7ef96c0a56b0e0204d60cf4 100644
+--- a/src/main/java/org/bukkit/entity/AbstractVillager.java
++++ b/src/main/java/org/bukkit/entity/AbstractVillager.java
+@@ -21,4 +21,11 @@ public interface AbstractVillager extends Breedable, NPC, InventoryHolder, Merch
+     @NotNull
+     @Override
+     Inventory getInventory();
++
++    // Paper start
++    /**
++     * Reset this villager's trade offers
++     */
++    public void resetOffers();
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0583-Villager-resetOffers.patch
+++ b/Spigot-Server-Patches/0583-Villager-resetOffers.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Blake Galbreath <blake.galbreath@gmail.com>
+Date: Mon, 7 Oct 2019 00:15:37 -0500
+Subject: [PATCH] Villager#resetOffers
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+index 68fd780bc76ecf3c463f38c137fd8d4f036cdcbd..a50be19c5aac8d380565cebd85deffe32a439abb 100644
+--- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
+@@ -85,6 +85,13 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+         return this.tradingPlayer != null;
+     }
+ 
++    // Paper start
++    public void resetOffers() {
++        this.trades = new MerchantRecipeList();
++        this.updateTrades();
++    }
++    // Paper end
++
+     @Override
+     public MerchantRecipeList getOffers() {
+         if (this.trades == null) {
+@@ -207,6 +214,7 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+         return this.world;
+     }
+ 
++    protected final void updateTrades() { eW(); } // Paper - OBFHELPER
+     protected abstract void eW();
+ 
+     protected void a(MerchantRecipeList merchantrecipelist, VillagerTrades.IMerchantRecipeOption[] avillagertrades_imerchantrecipeoption, int i) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java
+index 18520fec054b3bcdf73aaca95c665e7a1254b76f..e9c5c26818cc42e67db90809263dab184501af75 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftAbstractVillager.java
+@@ -71,4 +71,11 @@ public class CraftAbstractVillager extends CraftAgeable implements AbstractVilla
+     public HumanEntity getTrader() {
+         return getMerchant().getTrader();
+     }
++
++    // Paper start
++    @Override
++    public void resetOffers() {
++        getHandle().resetOffers();
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Without this API (or reflection), there isn't really a good way to easily reset the trades of a villager/wandering trader without spawning in a new entity and copying it's trades (obviously quite inefficient).