### PR TITLE
Fix CME when adding a passenger during CreatureSpawnEvent (#4616)

### DIFF
--- a/Spigot-Server-Patches/0584-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0584-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Sun, 4 Oct 2020 19:55:25 -0700
+Subject: [PATCH] Fix CME on adding a passenger in CreatureSpawnEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index 28e2d3f0a5e2ab084175bf0bba88816f80089799..b845e488e3b9a4f19d1fcf169533046b7e72ba28 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -3077,7 +3077,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public Stream<Entity> co() {
+-        return Stream.concat(Stream.of(this), this.passengers.stream().flatMap(Entity::co));
++        return Stream.concat(Stream.of(this), com.google.common.collect.ImmutableList.copyOf(this.passengers).stream().flatMap(Entity::co)); // Paper
+     }
+ 
+     public boolean hasSinglePlayerPassenger() {


### PR DESCRIPTION
This fixes #4616, where a CME is thrown when adding a passenger to the spawned entity during CreatureSpawnEvent.

Tested using this same code from the linked issue:
```java
@EventHandler
public void onCreatureSpawnEvent(CreatureSpawnEvent e) {
    if (e.getEntity() instanceof Spider) {
        Entity creeper = e.getEntity().getWorld().spawnEntity(e.getEntity().getLocation(), EntityType.CREEPER);
        e.getEntity().addPassenger(creeper);
    }
}
```