### PR TITLE
Add labels to the issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug---plugin-incompatibility.md
+++ b/.github/ISSUE_TEMPLATE/behavior-bug---plugin-incompatibility.md
@@ -1,6 +1,7 @@
 ---
 name: Behavior Bug / Plugin Incompatibility
 about: Server Bug or Plugin Incompatibility
+labels: "type: bug"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,6 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
+labels: "type: feature"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/performance-problem.md
+++ b/.github/ISSUE_TEMPLATE/performance-problem.md
@@ -1,6 +1,7 @@
 ---
 name: Performance problem
 about: Report performance problems or areas of concern
+labels: "type: performance"
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/server-crash---stacktrace.md
+++ b/.github/ISSUE_TEMPLATE/server-crash---stacktrace.md
@@ -1,6 +1,7 @@
 ---
 name: Server crash / Stacktrace
 about: Report server crashes and/or scary stacktraces
+labels: "type: bug"
 
 ---
 


### PR DESCRIPTION
This will make the issue templates automatically add labels to the created issues.
The outcome of this is a reduced burden on the triage team, though there will still be cases where the label assigned does not 100% fit (e.g. performance, question, etc).

https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/manually-creating-a-single-issue-template-for-your-repository