### PR TITLE
Allow disabling mob spawner spawn egg transformation

### DIFF
--- a/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BrodyBeckwith <brody@beckwith.dev>
+Date: Fri, 9 Oct 2020 20:30:12 -0400
+Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index ae5ed3bd0b663092a4658b24cbd69d37b4e141cb..3542746c427192ef836675af1acd002b20fd0649 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -709,4 +709,9 @@ public class PaperWorldConfig {
+     private void fixCuringExploit() {
+         fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
+     }
++
++    public boolean disableMobSpawnerSpawnEggTransformation = false;
++    private void disableMobSpawnerSpawnEggTransformation() {
++        disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/ItemMonsterEgg.java b/src/main/java/net/minecraft/server/ItemMonsterEgg.java
+index 76c585299096ab3719bf23b32f1ce046202a9818..a236e0441fc20270b4c44ed5a7d5b94297949226 100644
+--- a/src/main/java/net/minecraft/server/ItemMonsterEgg.java
++++ b/src/main/java/net/minecraft/server/ItemMonsterEgg.java
+@@ -34,7 +34,7 @@ public class ItemMonsterEgg extends Item {
+             EnumDirection enumdirection = itemactioncontext.getClickedFace();
+             IBlockData iblockdata = world.getType(blockposition);
+ 
+-            if (iblockdata.a(Blocks.SPAWNER)) {
++            if (!world.paperConfig.disableMobSpawnerSpawnEggTransformation && iblockdata.a(Blocks.SPAWNER)) { // Paper
+                 TileEntity tileentity = world.getTileEntity(blockposition);
+ 
+                 if (tileentity instanceof TileEntityMobSpawner) {


### PR DESCRIPTION
This patch adds a config option to make it so you can no longer change the entity type of a mob spawner with a spawn egg. While this can be done in a plugin by cancelling the interact event when a player right clicks a spawner block, it would also cause the mob/entity from the egg not to spawn as well.