### PR TITLE
Add API for sender UUIDs and fix CB not using sender UUID in chat

### DIFF
--- a/Spigot-API-Patches/0231-Add-senderUuid-to-sendMessage.patch
+++ b/Spigot-API-Patches/0231-Add-senderUuid-to-sendMessage.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 10 Oct 2020 23:55:06 +0200
+Subject: [PATCH] Add senderUuid to sendMessage
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 991f757a89d2e917186bb152a2f92bad8b6c2897..f0020af6a9c474dc599ccc663c331088cd94138a 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -5,6 +5,7 @@ import com.destroystokyo.paper.ClientOption; // Paper
+ import com.destroystokyo.paper.Title; // Paper
+ import com.destroystokyo.paper.profile.PlayerProfile; // Paper
+ import java.util.Date; // Paper
++import java.util.UUID; // Paper
+ import org.bukkit.BanEntry; // Paper
+ import org.bukkit.BanList; // Paper
+ import org.bukkit.Bukkit; // Paper
+@@ -1777,6 +1778,56 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     @NotNull
+     <T> T getClientOption(@NotNull ClientOption<T> option);
++
++    /**
++     * Sends this sender a message raw
++     *
++     * @param message Message to be displayed
++     * @param senderUuid The sender of this message; null for a system message
++     */
++    void sendRawMessage(@Nullable UUID senderUuid, @NotNull String message);
++
++    /**
++     * Sends this player a message
++     *
++     * @param message Message to be displayed
++     * @param senderUuid The sender of this message; null for a system message
++     */
++    void sendMessage(@Nullable UUID senderUuid, @NotNull String message);
++
++    /**
++     * Sends this player multiple messages
++     *
++     * @param messages An array of messages to be displayed
++     * @param senderUuid The sender of this message; null for a system message
++     */
++    void sendMessage(@Nullable UUID senderUuid, @NotNull String[] messages);
++
++    /**
++     * Sends the component to the player
++     *
++     * <p>If this player does not support sending full components then
++     * the component will be sent as legacy text.</p>
++     *
++     * @param component the component to send
++     * @param senderUuid The sender of this message; null for a system message
++     */
++    default void sendMessage(@Nullable UUID senderUuid, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
++        this.sendMessage(senderUuid, component.toLegacyText());
++    }
++
++    /**
++     * Sends an array of components as a single message to the player
++     *
++     * <p>If this player does not support sending full components then
++     * the components will be sent as legacy text.</p>
++     *
++     * @param components the components to send
++     * @param senderUuid The sender of this message; null for a system message
++     */
++    default void sendMessage(@Nullable UUID senderUuid, @NotNull net.md_5.bungee.api.chat.BaseComponent[] components) {
++        this.sendMessage(senderUuid, new net.md_5.bungee.api.chat.TextComponent(components).toLegacyText());
++    }
+     // Paper end
+ 
+     // Spigot start

--- a/Spigot-Server-Patches/0585-Add-senderUuid-to-sendMessage.patch
+++ b/Spigot-Server-Patches/0585-Add-senderUuid-to-sendMessage.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sun, 11 Oct 2020 00:02:58 +0200
+Subject: [PATCH] Add senderUuid to sendMessage
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 7e91e95941039cce630ed3eb88e1919e1d08c091..8d63664b8c8f35735d619dcb5e3f3e48d34df903 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -218,24 +218,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+     @Override
+     public void sendRawMessage(String message) {
++        // Paper start - add sender UUID
++        sendRawMessage(null, message);
++    }
++    @Override public void sendRawMessage(UUID senderUuid, String message) {
++        // Paper end
+         if (getHandle().playerConnection == null) return;
+ 
+         for (IChatBaseComponent component : CraftChatMessage.fromString(message)) {
+-            getHandle().playerConnection.sendPacket(new PacketPlayOutChat(component, ChatMessageType.CHAT, SystemUtils.b));
++            getHandle().playerConnection.sendPacket(new PacketPlayOutChat(component, ChatMessageType.CHAT, senderUuid != null ? senderUuid : SystemUtils.getNullUUID())); // Paper - senderUuid
+         }
+     }
+ 
+     @Override
+     public void sendMessage(String message) {
++        // Paper start - add sender UUID
++        sendMessage(null, message);
++    }
++    @Override public void sendMessage(UUID senderUuid, String message) {
++        // Paper end
+         if (!conversationTracker.isConversingModaly()) {
+-            this.sendRawMessage(message);
++            this.sendRawMessage(senderUuid, message); // Paper - senderUuid
+         }
+     }
+ 
+     @Override
+     public void sendMessage(String[] messages) {
++        // Paper start - add sender UUID
++        sendMessage(null, messages);
++    }
++    @Override public void sendMessage(UUID senderUuid, String[] messages) {
++        // Paper end
+         for (String message : messages) {
+-            sendMessage(message);
++            sendMessage(senderUuid, message); // Paper - senderUuid
+         }
+     }
+ 

--- a/Spigot-Server-Patches/0586-Use-sender-UUID-for-sending-player-messages.patch
+++ b/Spigot-Server-Patches/0586-Use-sender-UUID-for-sending-player-messages.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sun, 11 Oct 2020 00:05:44 +0200
+Subject: [PATCH] Use sender UUID for sending player messages
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 8e1655a975af24f6781a95be7030afa8f1b14472..d29a683b879110c8131840abb5072c94a52e569d 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -1483,8 +1483,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+ 
+     // CraftBukkit start - Support multi-line messages
+     public void sendMessage(IChatBaseComponent[] ichatbasecomponent) {
++        // Paper start - add sender uuid
++        sendMessage(ichatbasecomponent, null);
++    }
++    public void sendMessage(IChatBaseComponent[] ichatbasecomponent, UUID sender) {
++        // Paper end
+         for (IChatBaseComponent component : ichatbasecomponent) {
+-            this.sendMessage(component, SystemUtils.b);
++            this.sendMessage(component, sender != null ? sender : SystemUtils.getNullUUID()); // Paper
+         }
+     }
+     // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 05b3a7478195037927cd1a902b603862d9747e61..3fcde00ab10859bcbb57000719dadc30cc717a28 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -1837,11 +1837,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+                         PlayerConnection.this.minecraftServer.console.sendMessage(message);
+                         if (((LazyPlayerSet) queueEvent.getRecipients()).isLazy()) {
+                             for (Object player : PlayerConnection.this.minecraftServer.getPlayerList().players) {
+-                                ((EntityPlayer) player).sendMessage(CraftChatMessage.fromString(message));
++                                ((EntityPlayer) player).sendMessage(CraftChatMessage.fromString(message), PlayerConnection.this.player.getUniqueID()); // Paper - add sender UUID
+                             }
+                         } else {
+                             for (Player player : queueEvent.getRecipients()) {
+-                                player.sendMessage(message);
++                                player.sendMessage(PlayerConnection.this.player.getUniqueID(), message); // Paper - add sender UUID
+                             }
+                         }
+                         return null;
+@@ -1876,11 +1876,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+                 minecraftServer.console.sendMessage(s);
+                 if (((LazyPlayerSet) event.getRecipients()).isLazy()) {
+                     for (Object recipient : minecraftServer.getPlayerList().players) {
+-                        ((EntityPlayer) recipient).sendMessage(CraftChatMessage.fromString(s));
++                        ((EntityPlayer) recipient).sendMessage(CraftChatMessage.fromString(s), PlayerConnection.this.player.getUniqueID()); // Paper - add sender UUID
+                     }
+                 } else {
+                     for (Player recipient : event.getRecipients()) {
+-                        recipient.sendMessage(s);
++                        recipient.sendMessage(PlayerConnection.this.player.getUniqueID(), s); // Paper - add sender UUID
+                     }
+                 }
+             }


### PR DESCRIPTION
This PR does two things (both to achieve the same goal, though):

- Add a new API to `Player` to set the sender UUID of a message that is sent (as added in 20w21a);
- Fix CraftBukkit not using the sender UUID of chat when handling chat messages. Kudos to @egg82 for pointing this out.