### PR TITLE
Maded Title-Objects directy sendable to receivers

### DIFF
--- a/Spigot-API-Patches/0016-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-API-Patches/0016-Player-Tab-List-and-Title-APIs.patch
@@ -3,21 +3,28 @@ From: Techcable <Techcable@outlook.com>
 Date: Mon, 29 Feb 2016 20:02:40 -0600
 Subject: [PATCH] Player Tab List and Title APIs
 
+Co-authored-by: Fruxz <cedricspitzer@outlook.de>
 
 diff --git a/src/main/java/com/destroystokyo/paper/Title.java b/src/main/java/com/destroystokyo/paper/Title.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4fe18540f77143ee7cd7e94d3aa279ae744289e4
+index 0000000000000000000000000000000000000000..5105dfcee646718cd8abc79d1d8062a580b4e923
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Title.java
-@@ -0,0 +1,373 @@
+@@ -0,0 +1,417 @@
 +package com.destroystokyo.paper;
 +
 +import net.md_5.bungee.api.chat.BaseComponent;
 +import net.md_5.bungee.api.chat.TextComponent;
 +
++import org.bukkit.Bukkit;
 +import org.bukkit.entity.Player;
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
++
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.List;
 +
 +import static com.google.common.base.Preconditions.checkArgument;
 +import static com.google.common.base.Preconditions.checkNotNull;
@@ -236,6 +243,44 @@ index 0000000000000000000000000000000000000000..4fe18540f77143ee7cd7e94d3aa279ae
 +        return this.fadeOut;
 +    }
 +
++    /**
++     * Sends the title directly to an player
++     *
++     * @param player the receiver of the title
++     */
++    public void send(@NotNull Player player) {
++        player.sendTitle(this);
++    }
++
++    /**
++     * Sends the title directly to the defined players
++     *
++     * @param players the receivers of the title
++     */
++    public void send(@NotNull Collection<? extends Player> players) {
++        for (Player player : players) {
++            player.sendTitle(this);
++        }
++    }
++
++    /**
++     * Sends the title directly to the defined players
++     *
++     * @param players the receivers of the title
++     */
++    public void send(@NotNull Player[] players) {
++        for (Player player : players) {
++            player.sendTitle(this);
++        }
++    }
++
++    /**
++     * Sends the title directly to all online players
++     */
++    public void broadcast() {
++        send(Bukkit.getOnlinePlayers());
++    }
++
 +    @NotNull
 +    public static Builder builder() {
 +        return new Builder();
@@ -388,7 +433,7 @@ index 695d80d8aabdbb4a6553d5446a8f7ea766b52472..c12087cd9551ad254867c428139bdf38
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
- 
+
  import java.net.InetSocketAddress;
  import java.util.UUID;
 +import com.destroystokyo.paper.Title; // Paper
@@ -510,5 +555,5 @@ index 695d80d8aabdbb4a6553d5446a8f7ea766b52472..c12087cd9551ad254867c428139bdf38
 +     */
 +    public void hideTitle();
      // Paper end
- 
+
      /**


### PR DESCRIPTION
Hey, I closed my old ACTIVE PR and I opened this new PR to fix my errors and corrections from the last one and thus add the feature. From the last PR ( #4628 ):

> Hey!
> 
> This is my first submission of a change to PaperMC/Paper (API).
> 
> I myself think that title objects should also be sent by themselves (like in ParticleBuilder). Therefore I made this suggestion for improvement.

Thank you very much for your support and thank you for the feedback as these are my first PRs.

With kind regards
Fruxz (@TheFruxz)

_Special thanks to @Proximyst_
