### PR TITLE
Add option to hide server gui in config

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -269,10 +269,10 @@ index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c9430b50c490
+index 0000000000000000000000000000000000000000..6987cd37d83d42d8e7b489815eca0e7853c63ed8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,187 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Throwables;
@@ -287,6 +287,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +import java.util.Map;
 +import java.util.concurrent.TimeUnit;
 +import java.util.logging.Level;
++import java.util.logging.Logger;
 +import java.util.regex.Pattern;
 +
 +import net.minecraft.server.MinecraftServer;
@@ -298,6 +299,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +
 +public class PaperConfig {
 +
++    private static final Logger LOGGER = Logger.getLogger("Minecraft");
 +    private static File CONFIG_FILE;
 +    private static final String HEADER = "This is the main configuration file for Paper.\n"
 +            + "As you can see, there's tons to configure. Some options may impact gameplay, so use\n"
@@ -325,7 +327,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +            config.load(CONFIG_FILE);
 +        } catch (IOException ex) {
 +        } catch (InvalidConfigurationException ex) {
-+            Bukkit.getLogger().log(Level.SEVERE, "Could not load paper.yml, please correct your syntax errors", ex);
++            LOGGER.log(Level.SEVERE, "Could not load paper.yml, please correct your syntax errors", ex);
 +            throw Throwables.propagate(ex);
 +        }
 +        config.options().header(HEADER);
@@ -341,7 +343,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +    }
 +
 +    protected static void logError(String s) {
-+        Bukkit.getLogger().severe(s);
++        LOGGER.severe(s);
 +    }
 +
 +    protected static void fatal(String s) {
@@ -351,7 +353,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +
 +    protected static void log(String s) {
 +        if (verbose) {
-+            Bukkit.getLogger().info(s);
++            LOGGER.info(s);
 +        }
 +    }
 +
@@ -371,7 +373,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +                    } catch (InvocationTargetException ex) {
 +                        throw Throwables.propagate(ex.getCause());
 +                    } catch (Exception ex) {
-+                        Bukkit.getLogger().log(Level.SEVERE, "Error invoking " + method, ex);
++                        LOGGER.log(Level.SEVERE, "Error invoking " + method, ex);
 +                    }
 +                }
 +            }
@@ -380,7 +382,7 @@ index 0000000000000000000000000000000000000000..68d3cb02dbfdc9d6f9d3682a2659c943
 +        try {
 +            config.save(CONFIG_FILE);
 +        } catch (IOException ex) {
-+            Bukkit.getLogger().log(Level.SEVERE, "Could not save " + CONFIG_FILE, ex);
++            LOGGER.log(Level.SEVERE, "Could not save " + CONFIG_FILE, ex);
 +        }
 +    }
 +
@@ -556,23 +558,15 @@ index f6335ed3eba55e939aa24b1eeb83026e61d92235..94b8cda9ce78aa22c14e88f3500bb981
      }
  
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 87045e72d097a4eb006654ea41f58ac803bbab3e..468d0cce2208bc21ec3d62590ac6e050a2037518 100644
+index 87045e72d097a4eb006654ea41f58ac803bbab3e..3c782597cd47eaec80367515b7be364ad6cbf3ab 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -145,6 +145,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -145,6 +145,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          org.spigotmc.SpigotConfig.init((java.io.File) options.valueOf("spigot-settings"));
          org.spigotmc.SpigotConfig.registerCommands();
          // Spigot end
-+        // Paper start
-+        try {
-+            com.destroystokyo.paper.PaperConfig.init((java.io.File) options.valueOf("paper-settings"));
-+        } catch (Exception e) {
-+            DedicatedServer.LOGGER.error("Unable to load server configuration", e);
-+            return false;
-+        }
-+        com.destroystokyo.paper.PaperConfig.registerCommands();
-+        // Paper end
- 
++        com.destroystokyo.paper.PaperConfig.registerCommands(); // Paper
+
          this.setPVP(dedicatedserverproperties.pvp);
          this.setAllowFlight(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
@@ -599,7 +593,7 @@ index 5cecefc7e1c3b61c47563245fb1ffed16ec0851f..9ca142e2a841e686c5647de46f0f6992
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 4da97dbcf95b1e782ef80956c5d128972b2c3ed5..059b9634aeffc6f710d40112f5f8d9b877f2c7a3 100644
+index 4da97dbcf95b1e782ef80956c5d128972b2c3ed5..c99999fe2d9726f76fc6d96799fff86facbaae77 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -65,6 +65,12 @@ public class Main {
@@ -615,7 +609,22 @@ index 4da97dbcf95b1e782ef80956c5d128972b2c3ed5..059b9634aeffc6f710d40112f5f8d9b8
              java.nio.file.Path java_nio_file_path1 = Paths.get("eula.txt");
              EULA eula = new EULA(java_nio_file_path1);
  
-@@ -206,6 +212,16 @@ public class Main {
+@@ -166,6 +172,14 @@ public class Main {
+
+             convertable_conversionsession.a((IRegistryCustom) iregistrycustom_dimension, (SaveData) object);
+             */
++            // Paper start
++            try {
++                com.destroystokyo.paper.PaperConfig.init((java.io.File) optionset.valueOf("paper-settings"));
++            } catch (Exception e) {
++                Main.LOGGER.error("Unable to load server configuration", e);
++                return;
++            }
++            // Paper end
+             final DedicatedServer dedicatedserver = (DedicatedServer) MinecraftServer.a((thread) -> {
+                 DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataConverterRegistry.a(), minecraftsessionservice, gameprofilerepository, usercache, WorldLoadListenerLogger::new);
+
+@@ -206,6 +220,16 @@ public class Main {
  
      }
  
@@ -718,7 +727,7 @@ index 0986d666b777b9992f8cbbffef964717cabe91df..159c0c671833a8973b543fd83d8b6b33
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 9c98589c2db92720b4ae054ee74ef7ab0dac891a..f187c7d127c356861c30141efeafcef0057878ec 100644
+index 8b2c7b6da2c6793e1cb1498f26693fb23dd3fa3e..112a6d3ebe2f0b57f4e3c09d4ec342123af5f550 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {

--- a/Spigot-Server-Patches/0005-Paper-Metrics.patch
+++ b/Spigot-Server-Patches/0005-Paper-Metrics.patch
@@ -647,10 +647,10 @@ index 0000000000000000000000000000000000000000..f2a0a9f5d86820ce8098301256d2faf3
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 68d3cb02dbfdc9d6f9d3682a2659c9430b50c490..b367bb8ea184489f433f8acc798466c38816ae62 100644
+index 6987cd37d83d42d8e7b489815eca0e7853c63ed8..3613638db9cd67072cec8e0a29aecf1e18fd30e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -42,6 +42,7 @@ public class PaperConfig {
+@@ -44,6 +44,7 @@ public class PaperConfig {
      private static boolean verbose;
      private static boolean fatalError;
      /*========================================================================*/
@@ -658,7 +658,7 @@ index 68d3cb02dbfdc9d6f9d3682a2659c9430b50c490..b367bb8ea184489f433f8acc798466c3
  
      public static void init(File configFile) {
          CONFIG_FILE = configFile;
-@@ -84,6 +85,11 @@ public class PaperConfig {
+@@ -86,6 +87,11 @@ public class PaperConfig {
          for (Map.Entry<String, Command> entry : commands.entrySet()) {
              MinecraftServer.getServer().server.getCommandMap().register(entry.getKey(), "Paper", entry.getValue());
          }

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -667,11 +667,11 @@ index 0000000000000000000000000000000000000000..944fd203e9f39d6c6fc9e270940c76c9
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 357856e5abcbc91452fa5b09643522f04843f71d..4479f74daef573bcbb6757186440bf47a3aef912 100644
+index 3613638db9cd67072cec8e0a29aecf1e18fd30e2..6599de17d8a3373c9878788f4f835839605811d8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -14,12 +14,15 @@ import java.util.concurrent.TimeUnit;
- import java.util.logging.Level;
+@@ -15,12 +15,15 @@ import java.util.logging.Level;
+ import java.util.logging.Logger;
  import java.util.regex.Pattern;
  
 +import com.google.common.collect.Lists;
@@ -686,7 +686,7 @@ index 357856e5abcbc91452fa5b09643522f04843f71d..4479f74daef573bcbb6757186440bf47
  
  public class PaperConfig {
  
-@@ -188,4 +191,27 @@ public class PaperConfig {
+@@ -190,4 +193,27 @@ public class PaperConfig {
          config.addDefault(path, def);
          return config.getString(path, config.getString(path));
      }
@@ -846,7 +846,7 @@ index 1ca6d656cd2c7bbf12df6368ad7d953765d03e36..042031d2b7cb2f56d422145ffa7589fa
  
      private void a(long i, Consumer<Chunk> consumer) {
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 7d9161b9e3996098d0f257661e39036e82d3f88a..52621ab74c8af1ab0c38e8df28cb7dc7153096a3 100644
+index bd47979e11d900b5b31c995751dfefbf0a2706b9..d30c4d5a4ee83e21ba9269c0b92af2b72b85d3cc 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -1,5 +1,6 @@
@@ -923,7 +923,7 @@ index 11891990d90b789192d9081787c1e844646121ae..2a48d85f0490991eb323ef550cb6148d
                  int k = 0;
                  CustomFunction.c[] acustomfunction_c = customfunction.b();
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 468d0cce2208bc21ec3d62590ac6e050a2037518..b5d1dbf889138699c877f13382557ce377e70e72 100644
+index 3c782597cd47eaec80367515b7be364ad6cbf3ab..41fa258aabb9d8c8dea56b1f5c112092e6a60679 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -26,8 +26,9 @@ import org.apache.logging.log4j.Logger;
@@ -937,7 +937,7 @@ index 468d0cce2208bc21ec3d62590ac6e050a2037518..b5d1dbf889138699c877f13382557ce3
  import org.bukkit.event.server.RemoteServerCommandEvent;
  // CraftBukkit end
  
-@@ -376,7 +377,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -368,7 +369,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
      }
  
      public void handleCommandQueue() {
@@ -946,7 +946,7 @@ index 468d0cce2208bc21ec3d62590ac6e050a2037518..b5d1dbf889138699c877f13382557ce3
          while (!this.serverCommandQueue.isEmpty()) {
              ServerCommand servercommand = (ServerCommand) this.serverCommandQueue.remove(0);
  
-@@ -391,7 +392,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -383,7 +384,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              // CraftBukkit end
          }
  
@@ -955,7 +955,7 @@ index 468d0cce2208bc21ec3d62590ac6e050a2037518..b5d1dbf889138699c877f13382557ce3
      }
  
      @Override
-@@ -627,6 +628,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -619,6 +620,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
  
      @Override
      public String executeRemoteCommand(String s) {
@@ -963,7 +963,7 @@ index 468d0cce2208bc21ec3d62590ac6e050a2037518..b5d1dbf889138699c877f13382557ce3
          this.remoteControlCommandListener.clearMessages();
          this.executeSync(() -> {
              // CraftBukkit start - fire RemoteServerCommandEvent
-@@ -635,10 +637,39 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -627,10 +629,39 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              if (event.isCancelled()) {
                  return;
              }
@@ -1614,7 +1614,7 @@ index e8ff43662b8397229cb19ea26342b66c88807379..3b8f56c0f0507ebdd9ac20be70688b4c
              this.g.clear();
              this.f.clear();
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 67fdd560f8136d83a13f75e265d5f5dd11871375..8f51a1e5e37566001e1d419065ce730768c1b342 100644
+index b9ffd000c97111678d45fd55dc9c207ebadc140e..f1d0e2faffb3ef27f5a41d06d0ff7d787f1098f5 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
 @@ -9,11 +9,12 @@ import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;

--- a/Spigot-Server-Patches/0019-Add-version-history-to-version-command.patch
+++ b/Spigot-Server-Patches/0019-Add-version-history-to-version-command.patch
@@ -192,14 +192,14 @@ index 0000000000000000000000000000000000000000..aac3f66cb23d260729c2a48d8710a9de
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 5f49ab337ffb02b2d77f1722a30821564f86657a..aade5e291b80c5362c8fd8cf09faca8e631e0554 100644
+index 41fa258aabb9d8c8dea56b1f5c112092e6a60679..a1402c8f13d8f907ed8fae84f00af9bb1d40f928 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -154,6 +154,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-             return false;
-         }
-         com.destroystokyo.paper.PaperConfig.registerCommands();
-+        com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
-         // Paper end
- 
+@@ -147,6 +147,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         org.spigotmc.SpigotConfig.registerCommands();
+         // Spigot end
+         com.destroystokyo.paper.PaperConfig.registerCommands(); // Paper
++        com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // Paper - load version history now
+
          this.setPVP(dedicatedserverproperties.pvp);
+         this.setAllowFlight(dedicatedserverproperties.allowFlight);

--- a/Spigot-Server-Patches/0060-Default-loading-permissions.yml-before-plugins.patch
+++ b/Spigot-Server-Patches/0060-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a62f4bbb973b9cb6d1ee53f56a0897d70ae176af..f207abbe757ad403a29a7a012903aaa88d5b1685 100644
+index 6599de17d8a3373c9878788f4f835839605811d8..56ec093f5e7b79d608dbbdc232543cdbd8b7a3f7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -214,4 +214,9 @@ public class PaperConfig {
+@@ -216,4 +216,9 @@ public class PaperConfig {
                  " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
                  " - Server Name: " + timingsServerName);
      }

--- a/Spigot-Server-Patches/0076-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/Spigot-Server-Patches/0076-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f207abbe757ad403a29a7a012903aaa88d5b1685..7d726757d1083011a09c9f2ca37c33a81360e964 100644
+index 56ec093f5e7b79d608dbbdc232543cdbd8b7a3f7..839c1e8e264006171f50660eaa2ade4457ca8563 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -219,4 +219,9 @@ public class PaperConfig {
+@@ -221,4 +221,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }

--- a/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
+++ b/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Player Collision
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7d726757d1083011a09c9f2ca37c33a81360e964..3d9a98936cfe933fd71fb82f07e1ba54d5d35800 100644
+index 839c1e8e264006171f50660eaa2ade4457ca8563..718746da0d5e2d3e464b930d62c5d0d60b1f3f39 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -224,4 +224,9 @@ public class PaperConfig {
+@@ -226,4 +226,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = Math.max(getInt("settings.region-file-cache-size", 256), 4);
      }

--- a/Spigot-Server-Patches/0097-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/Spigot-Server-Patches/0097-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3d9a98936cfe933fd71fb82f07e1ba54d5d35800..6fbf9ab53c8b7fab93b55d815060033f945d56cd 100644
+index 718746da0d5e2d3e464b930d62c5d0d60b1f3f39..eff1eacbe242ae6341896eadb9bcac41e9e4eb31 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -229,4 +229,9 @@ public class PaperConfig {
+@@ -231,4 +231,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }

--- a/Spigot-Server-Patches/0099-Optimize-UserCache-Thread-Safe.patch
+++ b/Spigot-Server-Patches/0099-Optimize-UserCache-Thread-Safe.patch
@@ -10,10 +10,10 @@ Additionally, move Saving of the User cache to be done async, incase
 the user never changed the default setting for Spigot's save on stop only.
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index aade5e291b80c5362c8fd8cf09faca8e631e0554..2d74d14385c7e705cb210bcfc0780f4c9c6a1cda 100644
+index a1402c8f13d8f907ed8fae84f00af9bb1d40f928..cac742d3f3356e19807129e21a150523c5425b9c 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -210,7 +210,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -202,7 +202,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
          if (this.convertNames()) {

--- a/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add setting for proxy online mode status
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6fbf9ab53c8b7fab93b55d815060033f945d56cd..5827ef1e3eb35a11867ee4f92f301e1b0245c0fa 100644
+index eff1eacbe242ae6341896eadb9bcac41e9e4eb31..dd610d50c5f3c58278fb00687fec08afea6aed7b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
+@@ -24,6 +24,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
  import org.bukkit.configuration.file.YamlConfiguration;
  import co.aikar.timings.Timings;
  import co.aikar.timings.TimingsManager;
@@ -16,7 +16,7 @@ index 6fbf9ab53c8b7fab93b55d815060033f945d56cd..5827ef1e3eb35a11867ee4f92f301e1b
  
  public class PaperConfig {
  
-@@ -234,4 +235,13 @@ public class PaperConfig {
+@@ -236,4 +237,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }

--- a/Spigot-Server-Patches/0110-Configurable-packet-in-spam-threshold.patch
+++ b/Spigot-Server-Patches/0110-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5827ef1e3eb35a11867ee4f92f301e1b0245c0fa..23c9e0f317073bb9c327ec49e0b0586d2123e4e9 100644
+index dd610d50c5f3c58278fb00687fec08afea6aed7b..15a10d25d9cff1071582865c907f743bfddc4bd7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -244,4 +244,13 @@ public class PaperConfig {
+@@ -246,4 +246,13 @@ public class PaperConfig {
      public static boolean isProxyOnlineMode() {
          return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }

--- a/Spigot-Server-Patches/0111-Configurable-flying-kick-messages.patch
+++ b/Spigot-Server-Patches/0111-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 23c9e0f317073bb9c327ec49e0b0586d2123e4e9..c4086de778cc2ccc958b1a94dd6e9cdb5065076c 100644
+index 15a10d25d9cff1071582865c907f743bfddc4bd7..4b3af00af4bc9cebb2c894aaeb57976e751625d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -253,4 +253,11 @@ public class PaperConfig {
+@@ -255,4 +255,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }

--- a/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c4086de778cc2ccc958b1a94dd6e9cdb5065076c..5fa63d7ca20b88a44d8800b3ebf74e4c0e376d0b 100644
+index 4b3af00af4bc9cebb2c894aaeb57976e751625d6..8c829f309e8086b3c924235802ba55ba3bf873eb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -260,4 +260,9 @@ public class PaperConfig {
+@@ -262,4 +262,9 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }

--- a/Spigot-Server-Patches/0165-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/Spigot-Server-Patches/0165-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5fa63d7ca20b88a44d8800b3ebf74e4c0e376d0b..cee8740e644c492e3d71fd58791e7d52d57e856d 100644
+index 8c829f309e8086b3c924235802ba55ba3bf873eb..d6028fea356cad7743c76095d09e008d84627c33 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index 5fa63d7ca20b88a44d8800b3ebf74e4c0e376d0b..cee8740e644c492e3d71fd58791e7d52
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -265,4 +266,9 @@ public class PaperConfig {
+@@ -267,4 +268,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }

--- a/Spigot-Server-Patches/0203-Make-player-data-saving-configurable.patch
+++ b/Spigot-Server-Patches/0203-Make-player-data-saving-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make player data saving configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index cee8740e644c492e3d71fd58791e7d52d57e856d..f22bed69f690f6e4754b87dd61cebe9c6627b12d 100644
+index d6028fea356cad7743c76095d09e008d84627c33..bc72902eb211368c3db45972ddb5504d9f41cb79 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -271,4 +271,13 @@ public class PaperConfig {
+@@ -273,4 +273,13 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
@@ -17,7 +17,7 @@ index cee8740e644c492e3d71fd58791e7d52d57e856d..f22bed69f690f6e4754b87dd61cebe9c
 +    private static void savePlayerData() {
 +        savePlayerData = getBoolean("settings.save-player-data", savePlayerData);
 +        if(!savePlayerData) {
-+            Bukkit.getLogger().log(Level.WARNING, "Player Data Saving is currently disabled. Any changes to your players data, " +
++            LOGGER.log(Level.WARNING, "Player Data Saving is currently disabled. Any changes to your players data, " +
 +                    "such as inventories, experience points, advancements and the like will not be saved when they log out.");
 +        }
 +    }

--- a/Spigot-Server-Patches/0223-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/Spigot-Server-Patches/0223-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f22bed69f690f6e4754b87dd61cebe9c6627b12d..c8a7d8092a2849b62a8d83d7970756fd76100025 100644
+index bc72902eb211368c3db45972ddb5504d9f41cb79..9c0a3ec0c3f6c4f9c03cfa2d34a2ebadc0182f6d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -280,4 +280,12 @@ public class PaperConfig {
+@@ -282,4 +282,12 @@ public class PaperConfig {
                      "such as inventories, experience points, advancements and the like will not be saved when they log out.");
          }
      }
@@ -48,7 +48,7 @@ index f22bed69f690f6e4754b87dd61cebe9c6627b12d..c8a7d8092a2849b62a8d83d7970756fd
 +    private static void useAlternativeLuckFormula() {
 +        useAlternativeLuckFormula = getBoolean("settings.use-alternative-luck-formula", false);
 +        if (useAlternativeLuckFormula) {
-+            Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
++            LOGGER.log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
 +        }
 +    }
  }

--- a/Spigot-Server-Patches/0258-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0258-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,11 +22,11 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c8a7d8092a2849b62a8d83d7970756fd76100025..2e5c71d6b7d120a308076d95a3d5b73c5aca8bc9 100644
+index 9c0a3ec0c3f6c4f9c03cfa2d34a2ebadc0182f6d..288245ee7f941eb6bbdd9ce356214239ae6029e0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -288,4 +288,18 @@ public class PaperConfig {
-             Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
+@@ -290,4 +290,18 @@ public class PaperConfig {
+             LOGGER.log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }
 +

--- a/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,10 +9,10 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2e5c71d6b7d120a308076d95a3d5b73c5aca8bc9..1b21911c3e4fd1d4a3305176bb8477c370256906 100644
+index 288245ee7f941eb6bbdd9ce356214239ae6029e0..2fa61b57fd7362a9e642f5f77c33ef87a7ada827 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
+@@ -26,6 +26,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
  import co.aikar.timings.Timings;
  import co.aikar.timings.TimingsManager;
  import org.spigotmc.SpigotConfig;
@@ -20,7 +20,7 @@ index 2e5c71d6b7d120a308076d95a3d5b73c5aca8bc9..1b21911c3e4fd1d4a3305176bb8477c3
  
  public class PaperConfig {
  
-@@ -289,6 +290,14 @@ public class PaperConfig {
+@@ -291,6 +292,14 @@ public class PaperConfig {
          }
      }
  
@@ -81,7 +81,7 @@ index 1cf214eaca80feae283f6524605976022f856116..e66050b87ace6544636e10123ad09631
  
      public static boolean bungee;
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index 121c7ff60195f9904b8afb3a305e97bbcb80a738..07936eeba2a1aa68d52f4183f663ce362c816a54 100644
+index 121c7ff60195f9904b8afb3a305e97bbcb80a738..aab21a5e5f3336b14240ca43a4bf837b46033f5e 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -5,6 +5,7 @@ import java.lang.management.MonitorInfo;
@@ -112,13 +112,16 @@ index 121c7ff60195f9904b8afb3a305e97bbcb80a738..07936eeba2a1aa68d52f4183f663ce36
      }
  
      private static long monotonicMillis()
-@@ -56,10 +63,18 @@ public class WatchdogThread extends Thread
+@@ -56,10 +63,21 @@ public class WatchdogThread extends Thread
      {
          while ( !stopping )
          {
 -            //
 -            if ( lastTick != 0 && monotonicMillis() > lastTick + timeoutTime && !Boolean.getBoolean("disable.watchdog")) // Paper - Add property to disable
 +            // Paper start
++            if (Bukkit.getServer() == null) { // This is pre-init
++                continue;
++            }
 +            Logger log = Bukkit.getServer().getLogger();
 +            long currentTime = monotonicMillis();
 +            if ( lastTick != 0 && currentTime > lastTick + earlyWarningEvery && !Boolean.getBoolean("disable.watchdog") )
@@ -134,7 +137,7 @@ index 121c7ff60195f9904b8afb3a305e97bbcb80a738..07936eeba2a1aa68d52f4183f663ce36
                  log.log( Level.SEVERE, "------------------------------" );
                  log.log( Level.SEVERE, "The server has stopped responding! This is (probably) not a Paper bug." ); // Paper
                  log.log( Level.SEVERE, "If you see a plugin in the Server thread dump below, then please report it to that author" );
-@@ -89,29 +104,46 @@ public class WatchdogThread extends Thread
+@@ -89,29 +107,46 @@ public class WatchdogThread extends Thread
                      }
                  }
                  // Paper end

--- a/Spigot-Server-Patches/0265-Use-a-Queue-for-Queueing-Commands.patch
+++ b/Spigot-Server-Patches/0265-Use-a-Queue-for-Queueing-Commands.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Queue for Queueing Commands
 Lists are bad as Queues mmmkay.
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 3bdde27a52c88b5f0621bdaf30ccd1ac00160b64..54ef6eeb8866915f03fb16413c8b5f36a7501f82 100644
+index f33aa630b2094578b9ece13a289e2930f1aba917..651b9feecb8d797b5f7b6e2ef2cf9a9cf7018884 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -36,7 +36,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
@@ -18,7 +18,7 @@ index 3bdde27a52c88b5f0621bdaf30ccd1ac00160b64..54ef6eeb8866915f03fb16413c8b5f36
      private RemoteStatusListener remoteStatusListener;
      public final RemoteControlCommandListener remoteControlCommandListener;
      private RemoteControlListener remoteControlListener;
-@@ -389,8 +389,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -381,8 +381,10 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
  
      public void handleCommandQueue() {
          MinecraftTimings.serverCommandTimer.startTiming(); // Spigot

--- a/Spigot-Server-Patches/0292-Configurable-connection-throttle-kick-message.patch
+++ b/Spigot-Server-Patches/0292-Configurable-connection-throttle-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1b21911c3e4fd1d4a3305176bb8477c370256906..d5c97bb6503c9bfafd819dd62397b9decd515df5 100644
+index 2fa61b57fd7362a9e642f5f77c33ef87a7ada827..30ac7b432b0ec79f0c568cc1a8ac7b7e6739ae76 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -273,6 +273,11 @@ public class PaperConfig {
+@@ -275,6 +275,11 @@ public class PaperConfig {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
  

--- a/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d5c97bb6503c9bfafd819dd62397b9decd515df5..478856f190a8d0177dee39dab4692fc54f9c8ed4 100644
+index 30ac7b432b0ec79f0c568cc1a8ac7b7e6739ae76..aeed492c9628ce5880166519fef2c164120ec2b9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -8,6 +8,7 @@ import java.io.IOException;
@@ -25,7 +25,7 @@ index d5c97bb6503c9bfafd819dd62397b9decd515df5..478856f190a8d0177dee39dab4692fc5
  import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
-@@ -244,7 +245,7 @@ public class PaperConfig {
+@@ -246,7 +247,7 @@ public class PaperConfig {
      }
  
      public static boolean isProxyOnlineMode() {
@@ -34,7 +34,7 @@ index d5c97bb6503c9bfafd819dd62397b9decd515df5..478856f190a8d0177dee39dab4692fc5
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -316,4 +317,21 @@ public class PaperConfig {
+@@ -318,4 +319,21 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }

--- a/Spigot-Server-Patches/0312-Book-Size-Limits.patch
+++ b/Spigot-Server-Patches/0312-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 478856f190a8d0177dee39dab4692fc54f9c8ed4..01d48da8b2f89ad3a615ad10c044c5f0a08ee4ed 100644
+index aeed492c9628ce5880166519fef2c164120ec2b9..5f5b3db12bc394bdd315161de9f0a0f90da0dd8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -334,4 +334,11 @@ public class PaperConfig {
+@@ -336,4 +336,11 @@ public class PaperConfig {
              velocitySecretKey = secret.getBytes(StandardCharsets.UTF_8);
          }
      }

--- a/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 01d48da8b2f89ad3a615ad10c044c5f0a08ee4ed..f9b1b198299166759fe0bd0a36d8d88c626e06a4 100644
+index 5f5b3db12bc394bdd315161de9f0a0f90da0dd8a..a3141a890ce2738325f991d745cd6edf77d6ec0f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
+@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
  import com.google.common.collect.Lists;
  import net.minecraft.server.MinecraftServer;
  import org.bukkit.Bukkit;
@@ -16,7 +16,7 @@ index 01d48da8b2f89ad3a615ad10c044c5f0a08ee4ed..f9b1b198299166759fe0bd0a36d8d88c
  import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
-@@ -279,6 +280,11 @@ public class PaperConfig {
+@@ -281,6 +282,11 @@ public class PaperConfig {
          connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
      }
  

--- a/Spigot-Server-Patches/0370-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0370-Asynchronous-chunk-IO-and-loading.patch
@@ -199,7 +199,7 @@ index 9ead9b1ea1fafaa3d684c17efbae747386b7c587..9b8b49be032d7ceebcea8d7b98f999ed
                  doChunkInfo(sender, args);
                  break;
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3c034d0354bbc3cb7bd68d499ed01b96f79eeeb8..0f4b4b26bda48084dacff2bf79cc6df288405607 100644
+index a3141a890ce2738325f991d745cd6edf77d6ec0f..2cac295a86ad94c0752e9a7b346cbd2c620067c5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -209,7 +209,7 @@ index 3c034d0354bbc3cb7bd68d499ed01b96f79eeeb8..0f4b4b26bda48084dacff2bf79cc6df2
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -347,4 +348,54 @@ public class PaperConfig {
+@@ -349,4 +350,54 @@ public class PaperConfig {
          maxBookPageSize = getInt("settings.book-size.page-max", maxBookPageSize);
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
@@ -2495,7 +2495,7 @@ index b49420bdbdd00148fc5f9a21d3f4953457b2cdc6..032464901e02392df4966c68cce8d06f
          } finally {
              playerChunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 10e84aa154d8a84a591ef1a16c14b3421c484bc7..efafe3247e302539a851b7fce0a9d7be79d64f99 100644
+index 2dc4f1b689d2a2af9ae42156d954eb5284297ec0..b09d9436d17159edd6733ab4856be44578353e3e 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -6,6 +6,7 @@ import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
@@ -2938,13 +2938,13 @@ index 2507bdf7bfa65f1bc728a46322d2a570e566e32c..c470c6527b214026c230feaae0c0875c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index d80235349ea8cc868b720b69f7f0812184e895c8..95f3abe47a5ef4268bc6b7cdde94cba30303d786 100644
+index f7c18beb9bd499375a4a57b25efb862062142217..9b776068f0e55eecc971073571b067df5329c762 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -172,6 +172,7 @@ public class Main {
- 
-             convertable_conversionsession.a((IRegistryCustom) iregistrycustom_dimension, (SaveData) object);
-             */
+@@ -180,6 +180,7 @@ public class Main {
+                 return;
+             }
+             // Paper end
 +            Class.forName("net.minecraft.server.VillagerTrades");// Paper - load this sync so it won't fail later async
              final DedicatedServer dedicatedserver = (DedicatedServer) MinecraftServer.a((thread) -> {
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataConverterRegistry.a(), minecraftsessionservice, gameprofilerepository, usercache, WorldLoadListenerLogger::new);
@@ -4127,7 +4127,7 @@ index 22ac5f2bf0f2e4214855f3b1eb259a67b4c60776..f36c85802dc2d6260058b2a77f225f32
      public boolean teleport(Location location) {
          return teleport(location, TeleportCause.PLUGIN);
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index 07936eeba2a1aa68d52f4183f663ce362c816a54..5bdcdcf9e85b73086722783bff26321d03382bb9 100644
+index aab21a5e5f3336b14240ca43a4bf837b46033f5e..5187eec90fdf3d46a00fc58a02f76530e619f80c 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -6,6 +6,7 @@ import java.lang.management.ThreadInfo;
@@ -4138,7 +4138,7 @@ index 07936eeba2a1aa68d52f4183f663ce362c816a54..5bdcdcf9e85b73086722783bff26321d
  import net.minecraft.server.MinecraftServer;
  import org.bukkit.Bukkit;
  
-@@ -112,6 +113,7 @@ public class WatchdogThread extends Thread
+@@ -115,6 +116,7 @@ public class WatchdogThread extends Thread
                  // Paper end - Different message for short timeout
                  log.log( Level.SEVERE, "------------------------------" );
                  log.log( Level.SEVERE, "Server thread dump (Look for plugins here before reporting to Paper!):" ); // Paper

--- a/Spigot-Server-Patches/0419-Optimise-TickListServer-by-rewriting-it.patch
+++ b/Spigot-Server-Patches/0419-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,10 +42,10 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 0f4b4b26bda48084dacff2bf79cc6df288405607..2901236b1c6bd5d27c9d40f9e5b3756144e14faa 100644
+index 2cac295a86ad94c0752e9a7b346cbd2c620067c5..c60a940a751dadc9b8376dbe1abf3f053515ac3d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -349,6 +349,13 @@ public class PaperConfig {
+@@ -351,6 +351,13 @@ public class PaperConfig {
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
  

--- a/Spigot-Server-Patches/0423-Remote-Connections-shouldn-t-hold-up-shutdown.patch
+++ b/Spigot-Server-Patches/0423-Remote-Connections-shouldn-t-hold-up-shutdown.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Remote Connections shouldn't hold up shutdown
 Bugs in the connection logic appears to leave stale connections even, preventing shutdown
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 54ef6eeb8866915f03fb16413c8b5f36a7501f82..fa72eae6befb9d05244b65bcaaed35e9fb492027 100644
+index 651b9feecb8d797b5f7b6e2ef2cf9a9cf7018884..a54b653462860042da242956fed253427240122a 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -355,11 +355,11 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -347,11 +347,11 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
          }
  
          if (this.remoteControlListener != null) {

--- a/Spigot-Server-Patches/0431-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/Spigot-Server-Patches/0431-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -42,10 +42,10 @@ index 11fe3524f38f7756ebd0e3807678e8848fd2217d..884b59d478aa7de49906520e77866a79
      public static final Timing commandFunctionsTimer = Timings.ofSafe("Command Functions");
      public static final Timing connectionTimer = Timings.ofSafe("Connection Handler");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2901236b1c6bd5d27c9d40f9e5b3756144e14faa..56b32e2319c5f89d12c0ca4ea0211c6d7cbb366f 100644
+index c60a940a751dadc9b8376dbe1abf3f053515ac3d..1489ca959f7100d186b727644ce72fc4bbe51453 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -405,4 +405,9 @@ public class PaperConfig {
+@@ -407,4 +407,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }

--- a/Spigot-Server-Patches/0433-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0433-Add-tick-times-API-and-mspt-command.patch
@@ -75,10 +75,10 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 56b32e2319c5f89d12c0ca4ea0211c6d7cbb366f..273ed1c5537a69256f1020646f5cd0c13d50f170 100644
+index 1489ca959f7100d186b727644ce72fc4bbe51453..f7611b8848dac3711924b3893ac942b60098eac1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -69,6 +69,7 @@ public class PaperConfig {
+@@ -71,6 +71,7 @@ public class PaperConfig {
  
          commands = new HashMap<String, Command>();
          commands.put("paper", new PaperCommand("paper"));

--- a/Spigot-Server-Patches/0439-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0439-Improved-Watchdog-Support.patch
@@ -67,10 +67,10 @@ index 95e6a6de7ccfc4445d0ac19c5f874c0d533b1712..cc6e6f245ee5e73bd570cf42381bf55e
              throwable = throwable.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index fa72eae6befb9d05244b65bcaaed35e9fb492027..03b38e2c53376db25864a0c6f00f786c4dae215d 100644
+index a54b653462860042da242956fed253427240122a..f4ffab0597e14d6cd32e220e757da69145f0080d 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -238,7 +238,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -230,7 +230,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              long j = SystemUtils.getMonotonicNanos() - i;
              String s = String.format(Locale.ROOT, "%.3fs", (double) j / 1.0E9D);
  
@@ -79,7 +79,7 @@ index fa72eae6befb9d05244b65bcaaed35e9fb492027..03b38e2c53376db25864a0c6f00f786c
              if (dedicatedserverproperties.announcePlayerAchievements != null) {
                  ((GameRules.GameRuleBoolean) this.getGameRules().get(GameRules.ANNOUNCE_ADVANCEMENTS)).a(dedicatedserverproperties.announcePlayerAchievements, (MinecraftServer) this);
              }
-@@ -362,6 +362,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -354,6 +354,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
              //this.remoteStatusListener.b(); // Paper - don't wait for remote connections
          }
  
@@ -87,7 +87,7 @@ index fa72eae6befb9d05244b65bcaaed35e9fb492027..03b38e2c53376db25864a0c6f00f786c
          System.exit(0); // CraftBukkit
      }
  
-@@ -695,7 +696,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -687,7 +688,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
      @Override
      public void stop() {
          super.stop();
@@ -491,7 +491,7 @@ index aefea3a9a8b9b75c62bd20018be7cd166a213001..123de5ac9026508e21cdc225f0962f5c
          String[] split = restartScript.split( " " );
          if ( split.length > 0 && new File( split[0] ).isFile() )
 diff --git a/src/main/java/org/spigotmc/WatchdogThread.java b/src/main/java/org/spigotmc/WatchdogThread.java
-index 5bdcdcf9e85b73086722783bff26321d03382bb9..513c1041c34ebb3ac1775674a3f4526693759c08 100644
+index 5187eec90fdf3d46a00fc58a02f76530e619f80c..0c1acb53776dd6885ec11f85bc162e2610fbc1e8 100644
 --- a/src/main/java/org/spigotmc/WatchdogThread.java
 +++ b/src/main/java/org/spigotmc/WatchdogThread.java
 @@ -13,6 +13,7 @@ import org.bukkit.Bukkit;
@@ -510,8 +510,8 @@ index 5bdcdcf9e85b73086722783bff26321d03382bb9..513c1041c34ebb3ac1775674a3f45266
              instance = new WatchdogThread( timeoutTime * 1000L, restart );
              instance.start();
          }
-@@ -67,12 +69,13 @@ public class WatchdogThread extends Thread
-             // Paper start
+@@ -70,12 +72,13 @@ public class WatchdogThread extends Thread
+             }
              Logger log = Bukkit.getServer().getLogger();
              long currentTime = monotonicMillis();
 -            if ( lastTick != 0 && currentTime > lastTick + earlyWarningEvery && !Boolean.getBoolean("disable.watchdog") )
@@ -527,7 +527,7 @@ index 5bdcdcf9e85b73086722783bff26321d03382bb9..513c1041c34ebb3ac1775674a3f45266
                  lastEarlyWarning = currentTime;
                  if (isLongTimeout) {
                  // Paper end
-@@ -114,7 +117,7 @@ public class WatchdogThread extends Thread
+@@ -117,7 +120,7 @@ public class WatchdogThread extends Thread
                  log.log( Level.SEVERE, "------------------------------" );
                  log.log( Level.SEVERE, "Server thread dump (Look for plugins here before reporting to Paper!):" ); // Paper
                  ChunkTaskManager.dumpAllChunkLoadInfo(); // Paper
@@ -536,7 +536,7 @@ index 5bdcdcf9e85b73086722783bff26321d03382bb9..513c1041c34ebb3ac1775674a3f45266
                  log.log( Level.SEVERE, "------------------------------" );
                  //
                  // Paper start - Only print full dump on long timeouts
-@@ -135,9 +138,24 @@ public class WatchdogThread extends Thread
+@@ -138,9 +141,24 @@ public class WatchdogThread extends Thread
  
                  if ( isLongTimeout )
                  {

--- a/Spigot-Server-Patches/0480-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/Spigot-Server-Patches/0480-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 273ed1c5537a69256f1020646f5cd0c13d50f170..e750aedfad992635019d1abd7c880f4829b1e41d 100644
+index f7611b8848dac3711924b3893ac942b60098eac1..00983c7deeae34c88a8be571a8265e1f691da94d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -411,4 +411,17 @@ public class PaperConfig {
+@@ -413,4 +413,17 @@ public class PaperConfig {
      private static void midTickChunkTasks() {
          midTickChunkTasks = getInt("settings.chunk-tasks-per-tick", midTickChunkTasks);
      }

--- a/Spigot-Server-Patches/0485-Add-option-for-console-having-all-permissions.patch
+++ b/Spigot-Server-Patches/0485-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e750aedfad992635019d1abd7c880f4829b1e41d..d393e37f50e2815da6b486ff0c3e277fa3413f3e 100644
+index 00983c7deeae34c88a8be571a8265e1f691da94d..edcd4c4c6ae00b601021afdd756f70e4ad9070b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -424,4 +424,9 @@ public class PaperConfig {
+@@ -426,4 +426,9 @@ public class PaperConfig {
  
      }
  

--- a/Spigot-Server-Patches/0500-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/Spigot-Server-Patches/0500-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d393e37f50e2815da6b486ff0c3e277fa3413f3e..53b62057a3edc3c211c4bade3a01fb065a523fcf 100644
+index edcd4c4c6ae00b601021afdd756f70e4ad9070b7..997b348899ba69ae0d99e06a44db9ed38ba79671 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -429,4 +429,10 @@ public class PaperConfig {
+@@ -431,4 +431,10 @@ public class PaperConfig {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }
  

--- a/Spigot-Server-Patches/0512-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0512-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -26,10 +26,10 @@ index bc71070c670d1a64c60b9f19711a5e8a50ace56e..9efc743e028650ccc9cda5a2c9deb183
              return 0;
          }
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 03b38e2c53376db25864a0c6f00f786c4dae215d..f55dc28f3e220966199ec718a437e50ef4b76027 100644
+index f4ffab0597e14d6cd32e220e757da69145f0080d..67e8445bb0b2c50fe2177a4cc14b792ed034bce2 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -321,7 +321,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+@@ -313,7 +313,7 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
  
      @Override
      public void updateWorldSettings() {

--- a/Spigot-Server-Patches/0542-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0542-Incremental-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 53b62057a3edc3c211c4bade3a01fb065a523fcf..669653b5cfb057b277e509b630fd73a843b42b24 100644
+index 997b348899ba69ae0d99e06a44db9ed38ba79671..91ded7ea2237ff40411e5033618fd09271b6b4ba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -435,4 +435,15 @@ public class PaperConfig {
+@@ -437,4 +437,15 @@ public class PaperConfig {
          allowPistonDuplication = getBoolean("settings.unsupported-settings.allow-piston-duplication", config.getBoolean("settings.unsupported-settings.allow-tnt-duplication", false));
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }

--- a/Spigot-Server-Patches/0559-Prevent-headless-pistons-from-being-created.patch
+++ b/Spigot-Server-Patches/0559-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 669653b5cfb057b277e509b630fd73a843b42b24..a01b28d47669cbc36a9e6c47deb5135bec231948 100644
+index 91ded7ea2237ff40411e5033618fd09271b6b4ba..b33823e973e589a4c8dc8d079dfb3f217cfdb71b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -436,6 +436,12 @@ public class PaperConfig {
+@@ -438,6 +438,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/Spigot-Server-Patches/0563-Buffer-joins-to-world.patch
+++ b/Spigot-Server-Patches/0563-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a01b28d47669cbc36a9e6c47deb5135bec231948..9be3a3e0752a31ca465e3e50bbdad05951a28739 100644
+index b33823e973e589a4c8dc8d079dfb3f217cfdb71b..270ea039b9c5e7b63fa11df9b8e4bc462315048d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -452,4 +452,9 @@ public class PaperConfig {
+@@ -454,4 +454,9 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/Spigot-Server-Patches/0579-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/Spigot-Server-Patches/0579-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 9be3a3e0752a31ca465e3e50bbdad05951a28739..053da5119404ded5e3cf6bb55967cc8ffba47de6 100644
+index 270ea039b9c5e7b63fa11df9b8e4bc462315048d..efa8fd5972b5e115509e58d3286c2f1ad6c37224 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -457,4 +457,9 @@ public class PaperConfig {
+@@ -459,4 +459,9 @@ public class PaperConfig {
      private static void maxJoinsPerTick() {
          maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
      }

--- a/Spigot-Server-Patches/0591-Add-option-to-hide-server-gui-in-config.patch
+++ b/Spigot-Server-Patches/0591-Add-option-to-hide-server-gui-in-config.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: JRoy <joshroy126@gmail.com>
+Date: Sun, 18 Oct 2020 18:21:46 -0400
+Subject: [PATCH] Add option to hide server gui in config
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index efa8fd5972b5e115509e58d3286c2f1ad6c37224..51a4f01518676fc65d42ac0b50f7418997eb9376 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -464,4 +464,9 @@ public class PaperConfig {
+     private static void trackPluginScoreboards() {
+         trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
+     }
++
++    public static boolean hideServerGui;
++    private static void hideServerGui() {
++        hideServerGui = getBoolean("settings.hide-server-gui", false);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index e8ef0b114a9c9fc1cc669f087b1ec621b35bfb4e..3c53a4a27316e5e777615afd35603c74e4039ff6 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -200,7 +200,7 @@ public class Main {
+                 dedicatedserver1.c(optionset.has(optionspec2));
+                 dedicatedserver1.b((String) optionset.valueOf(optionspec12));
+                 */
+-                boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
++                boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui") && !com.destroystokyo.paper.PaperConfig.hideServerGui; // Paper - Add option to hide server gui in config
+ 
+                 if (flag1 && !GraphicsEnvironment.isHeadless()) {
+                     dedicatedserver1.bc();


### PR DESCRIPTION
This adds a config option (`settings.hide-server-gui`) to hide the server gui without needing to type `nogui` into arguments.

To accomplish this, I needed to move `PaperConfig`'s init out of `DedicatedServer`'s init and into `nms.Main`. This is because we need the the logic to run the GUI happens *before* the config was written. While moving this logic to before the server starts, I had to remove some of PaperConfig (and classes it calls)'s dependence on the server being started (pretty much all logger calls).