### PR TITLE
Add ability to set number of players in ServerListPingEvent

### DIFF
--- a/Spigot-API-Patches/0231-Add-online-players-set-in-ServerListPingEvent.patch
+++ b/Spigot-API-Patches/0231-Add-online-players-set-in-ServerListPingEvent.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: kscottdev <kscottdev@gmail.com>
+Date: Sat, 24 Oct 2020 18:59:25 -0400
+Subject: [PATCH] Add online players set in ServerListPingEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+index 7a2a58bac8e721c3f0c64f69f77be07a51f76d58..6c0b29c1dde07d3209f8b62b6c3656f93ac8bfa5 100644
+--- a/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
++++ b/src/main/java/org/bukkit/event/server/ServerListPingEvent.java
+@@ -18,7 +18,7 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+     private static final HandlerList handlers = new HandlerList();
+     private final InetAddress address;
+     private String motd;
+-    private final int numPlayers;
++    private int numPlayers; // Paper
+     private int maxPlayers;
+ 
+     public ServerListPingEvent(@NotNull final InetAddress address, @NotNull final String motd, final int numPlayers, final int maxPlayers) {
+@@ -92,6 +92,17 @@ public class ServerListPingEvent extends ServerEvent implements Iterable<Player>
+         return numPlayers;
+     }
+ 
++    // Paper start
++    /**
++     * Set the number of players sent.
++     *
++     * @param numPlayers the number of players
++     */
++    public void setNumPlayers(final int numPlayers) {
++        this.numPlayers = numPlayers;
++    }
++    // Paper end
++
+     /**
+      * Get the maximum number of players sent.
+      *


### PR DESCRIPTION
Hi, I have no clue if I did this patch properly or not, but here it is.

This patch adds a setter to the numPlayers field in ServerListPingEvent. This removes the need for some packet listener shenanigans.

I tested with the following code:
```java
@EventHandler
public void onListPing(ServerListPingEvent event) {
    event.setNumPlayers(20);
}
```
and this performed as expected.

Though, when setting the event to an amount over the amount of actual online players, there is the following "visual artifact":
![img](https://i.imgur.com/WA6K8ti.png)
This is a client-side problem rather than a server-side, so there isn't much we could do.

Anyways, I hope I did this all right. I was debating adding a patch description, but that would basically be the same as the PR title, so I see no point  😛