### PR TITLE
Fix armor stands still doing entity collision

### DIFF
--- a/Spigot-Server-Patches/0247-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0247-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -18,6 +18,18 @@ index 6352051ab937d4d365e823a7112e76dc3ec34225..92ddf96f7db08a2b390ef3f49b0643f9
 +        armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
 +    }
  }
+diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
+index f2938b115aa34158e76da9f974f5746ed43630e1..0330bdf46a3baba169dd226261094a18a6aecf54 100644
+--- a/src/main/java/net/minecraft/server/EntityArmorStand.java
++++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
+@@ -314,6 +314,7 @@ public class EntityArmorStand extends EntityLiving {
+ 
+     @Override
+     protected void collideNearby() {
++        if (!world.paperConfig.armorStandEntityLookups) return; // Paper
+         List<Entity> list = this.world.getEntities(this, this.getBoundingBox(), EntityArmorStand.br);
+ 
+         for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
 index 6ebf3884a289d0be081d43d012ac10796740cc1e..909e01e458d729f277797bf1dca564f927318460 100644
 --- a/src/main/java/net/minecraft/server/World.java

--- a/Spigot-Server-Patches/0255-Implement-Expanded-ArmorStand-API.patch
+++ b/Spigot-Server-Patches/0255-Implement-Expanded-ArmorStand-API.patch
@@ -8,10 +8,10 @@ Add the following:
 - Enable/Disable slot interactions
 
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index f2938b115aa34158e76da9f974f5746ed43630e1..c83f7a0baee28c93b035a4bee68eb26374d50a79 100644
+index 0330bdf46a3baba169dd226261094a18a6aecf54..554bf021f05165438ef4a0db75f9654b4d4b5480 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
-@@ -387,6 +387,7 @@ public class EntityArmorStand extends EntityLiving {
+@@ -388,6 +388,7 @@ public class EntityArmorStand extends EntityLiving {
          return enumitemslot;
      }
  

--- a/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
@@ -20,7 +20,7 @@ index 92ddf96f7db08a2b390ef3f49b0643f9d90bbea4..414b9077317022e4efc0b1e547d7f387
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index c83f7a0baee28c93b035a4bee68eb26374d50a79..3b01b560f29e5d2c765f28b53e79119503fcfbac 100644
+index 554bf021f05165438ef4a0db75f9654b4d4b5480..fc86ae2519c8ff54ff7c5e45d7c45fcc16eefca0 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -46,9 +46,16 @@ public class EntityArmorStand extends EntityLiving {
@@ -69,7 +69,7 @@ index c83f7a0baee28c93b035a4bee68eb26374d50a79..3b01b560f29e5d2c765f28b53e791195
          NBTTagCompound nbttagcompound1 = nbttagcompound.getCompound("Pose");
  
          this.g(nbttagcompound1);
-@@ -602,7 +617,29 @@ public class EntityArmorStand extends EntityLiving {
+@@ -603,7 +618,29 @@ public class EntityArmorStand extends EntityLiving {
  
      @Override
      public void tick() {
@@ -99,7 +99,7 @@ index c83f7a0baee28c93b035a4bee68eb26374d50a79..3b01b560f29e5d2c765f28b53e791195
          Vector3f vector3f = (Vector3f) this.datawatcher.get(EntityArmorStand.c);
  
          if (!this.headPose.equals(vector3f)) {
-@@ -725,29 +762,36 @@ public class EntityArmorStand extends EntityLiving {
+@@ -726,29 +763,36 @@ public class EntityArmorStand extends EntityLiving {
      public void setHeadPose(Vector3f vector3f) {
          this.headPose = vector3f;
          this.datawatcher.set(EntityArmorStand.c, vector3f);

--- a/Spigot-Server-Patches/0280-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0280-Improve-death-events.patch
@@ -47,10 +47,10 @@ index e4afda074cdbbc4b1d81844fb60602392de8941c..18a79f9c61c0263526cd632f032d17bd
  
      protected void l(double d0, double d1, double d2) {
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index 3b01b560f29e5d2c765f28b53e79119503fcfbac..5c3d2bbf7b2ae22347d251c90c85388779c2cd44 100644
+index fc86ae2519c8ff54ff7c5e45d7c45fcc16eefca0..41d5dd7f08775a68984da24c92ee244c1b69426b 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
-@@ -703,7 +703,8 @@ public class EntityArmorStand extends EntityLiving {
+@@ -704,7 +704,8 @@ public class EntityArmorStand extends EntityLiving {
  
      @Override
      public void killEntity() {

--- a/Spigot-Server-Patches/0460-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0460-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -66,10 +66,10 @@ index 063c5ce566644a59652dec9b306f9f9282560589..7df29df2d6023e549e1fba0b5b1d1c1a
  
      public float a(Explosion explosion, IBlockAccess iblockaccess, BlockPosition blockposition, IBlockData iblockdata, Fluid fluid, float f) {
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index 5c3d2bbf7b2ae22347d251c90c85388779c2cd44..937fa3c69a5cba2fc2fa4506dc34ff8a37dae19c 100644
+index 41d5dd7f08775a68984da24c92ee244c1b69426b..aff83945242c843d8cfd8dffc4c33298f38fb9f2 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
-@@ -559,7 +559,7 @@ public class EntityArmorStand extends EntityLiving {
+@@ -560,7 +560,7 @@ public class EntityArmorStand extends EntityLiving {
          for (i = 0; i < this.handItems.size(); ++i) {
              itemstack = (ItemStack) this.handItems.get(i);
              if (!itemstack.isEmpty()) {
@@ -78,7 +78,7 @@ index 5c3d2bbf7b2ae22347d251c90c85388779c2cd44..937fa3c69a5cba2fc2fa4506dc34ff8a
                  this.handItems.set(i, ItemStack.b);
              }
          }
-@@ -567,7 +567,7 @@ public class EntityArmorStand extends EntityLiving {
+@@ -568,7 +568,7 @@ public class EntityArmorStand extends EntityLiving {
          for (i = 0; i < this.armorItems.size(); ++i) {
              itemstack = (ItemStack) this.armorItems.get(i);
              if (!itemstack.isEmpty()) {


### PR DESCRIPTION
This fixes an issue where armor stands will continue to do entity collision checks despite the config setting in paper.yml being false.

Will help against players who attempt to crash servers via the "new" method with using a ton of armor stands in a single area.