### PR TITLE
Improve async task wait

### DIFF
--- a/Spigot-Server-Patches/0477-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/Spigot-Server-Patches/0477-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,17 +10,21 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 225709a27396cbfa29c16499728e42170a8fef08..1175f23558fe694bfb77dd478b0a3ec15109dd9b 100644
+index 225709a27396cbfa29c16499728e42170a8fef08..c3c5514a294f45358f6f0a582cb8713f35288682 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -771,6 +771,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
-         // CraftBukkit start
-         if (this.server != null) {
-             this.server.disablePlugins();
-+            this.server.waitForAsyncTasksShutdown(); // Paper
+@@ -821,6 +821,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         } catch (IOException ioexception1) {
+             MinecraftServer.LOGGER.error("Failed to unlock level {}", this.convertable.getLevelName(), ioexception1);
          }
-         // CraftBukkit end
-         if (this.getServerConnection() != null) {
++        // Paper start
++        if (this.server != null) {
++            this.server.waitForAsyncTasksShutdown();
++        }
++        // Paper end
+         // Spigot start
+         MCUtil.asyncExecutor.shutdown(); // Paper
+         try { MCUtil.asyncExecutor.awaitTermination(30, java.util.concurrent.TimeUnit.SECONDS); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index 2b2d292fdd13d86159a791acfd1e70217401e795..9319dccbe6a33001cfb27866fd1d078e73fcc1e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java

--- a/Spigot-Server-Patches/0511-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0511-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -39,10 +39,10 @@ index f5792b999ce42acb13ae9a62ceb2ddec39abe209..5504facd2e453238caa71d98743be541
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1175f23558fe694bfb77dd478b0a3ec15109dd9b..1439b874b9a825ea605c15aaacaecaed12218779 100644
+index c3c5514a294f45358f6f0a582cb8713f35288682..eac3625e065cc3e410b841e04b841e5a58c2c0cb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1524,11 +1524,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1528,11 +1528,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
      }
  

--- a/Spigot-Server-Patches/0541-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0541-Incremental-player-saving.patch
@@ -25,7 +25,7 @@ index 53b62057a3edc3c211c4bade3a01fb065a523fcf..669653b5cfb057b277e509b630fd73a8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index de70bce8d33a8f4e92d0b65e37cb1a624cb071e6..500d8914cc0faac53a728af016c85561c03491fe 100644
+index b5aed60f7e5a8a74033700e40a4ccc3d99a9ad3e..56677b8bf45af217c0a4a50fc7aea76ca012cbd7 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -43,6 +43,7 @@ import org.bukkit.inventory.MainHand;
@@ -37,10 +37,10 @@ index de70bce8d33a8f4e92d0b65e37cb1a624cb071e6..500d8914cc0faac53a728af016c85561
      public NetworkManager networkManager; // Paper
      public final MinecraftServer server;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1439b874b9a825ea605c15aaacaecaed12218779..3ef193958e653e7f39d97f11b9778a2242b3c985 100644
+index eac3625e065cc3e410b841e04b841e5a58c2c0cb..3892b5135b3da9481f3c74212d751417ff9b8e03 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1226,9 +1226,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1230,9 +1230,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          //if (autosavePeriod > 0 && this.ticks % autosavePeriod == 0) { // CraftBukkit // Paper - move down
              //MinecraftServer.LOGGER.debug("Autosave started"); // Paper
              serverAutoSave = (autosavePeriod > 0 && this.ticks % autosavePeriod == 0); // Paper

--- a/Spigot-Server-Patches/0570-Cache-block-data-strings.patch
+++ b/Spigot-Server-Patches/0570-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3ef193958e653e7f39d97f11b9778a2242b3c985..dc511024a771a343b0fbebda3492bac258293a07 100644
+index 3892b5135b3da9481f3c74212d751417ff9b8e03..c78b6cd1c8fbcd4f905139f153dac7b49bff6c3a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1831,6 +1831,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1835,6 +1835,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getPlayerList().reload();
              this.customFunctionData.a(this.dataPackResources.a());
              this.ak.a(this.dataPackResources.h());

--- a/Spigot-Server-Patches/0579-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/Spigot-Server-Patches/0579-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dc511024a771a343b0fbebda3492bac258293a07..9c4ea5265e55d99f95c0e54abb2dbe8987da12fc 100644
+index c78b6cd1c8fbcd4f905139f153dac7b49bff6c3a..20a89a94e5566b2430f3f19a7b59411f8f7545ce 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1896,6 +1896,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1900,6 +1900,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (this.aN()) {
              PlayerList playerlist = commandlistenerwrapper.getServer().getPlayerList();
              WhiteList whitelist = playerlist.getWhitelist();


### PR DESCRIPTION
Aikar made a change earlier this year in 55e17a8599205450358c6114003305e492cc9a92 to add a wait on shutdown for async tasks that have not completed.

This works most of the time, but a minor nuance I've noticed is that if an async task is in the middle of loading a chunk when the shutdown process hits this point, it blocks the load from finishing, causing the server to stall for the full 5 seconds before continuing and printing a warning.

Delaying this logic until after the world has been saved fixes this issue, since all chunks get a chance to finish loading.