### PR TITLE
Raytrace entities within collection

### DIFF
--- a/Spigot-API-Patches/0231-Raytrace-entities-within-collection.patch
+++ b/Spigot-API-Patches/0231-Raytrace-entities-within-collection.patch
@@ -5,16 +5,16 @@ Subject: [PATCH] Raytrace entities within collection
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e827e1a6f5c0f8410ed32dda8f17aa769b469999..b7fed2399a3dceb120da3a90da875d81f394d66a 100644
+index e827e1a6f5c0f8410ed32dda8f17aa769b469999..9414a6d58b7b926422ab658d5d1db288d98e7e1c 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1659,6 +1659,22 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -1659,6 +1659,23 @@ public interface World extends PluginMessageRecipient, Metadatable {
      @Nullable
      public RayTraceResult rayTraceEntities(@NotNull Location start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<Entity> filter);
  
++    // Paper start
 +    /**
 +     * Performs a ray trace that checks for entity collisions within predefined collection of entities
-+     * <p>
 +     *
 +     * @param direction the ray direction
 +     * @param maxDistance the maximum distance
@@ -22,11 +22,12 @@ index e827e1a6f5c0f8410ed32dda8f17aa769b469999..b7fed2399a3dceb120da3a90da875d81
 +     *    shrinked) by this value before doing collision checks
 +     * @param startPos the start position
 +     * @param entities Collection of entities to check against
-+     * @return the closest ray trace hit result, or <code>null</code> if there
++     * @return the closest ray trace hit result, or {@code null} if there
 +     *   is no hit
 +     */
 +    @Nullable
-+    public RayTraceResult rayTraceEntities(@NotNull Vector direction, double maxDistance, double raySize, @NotNull Vector startPos, @NotNull Collection<Entity> entities);
++    public RayTraceResult rayTraceEntities(@NotNull Vector direction, double maxDistance, double raySize, @NotNull Vector startPos, @NotNull Collection<? extends Entity> entities);
++    // Paper end
 +
      /**
       * Performs a ray trace that checks for block collisions using the blocks'

--- a/Spigot-API-Patches/0231-Raytrace-entities-within-collection.patch
+++ b/Spigot-API-Patches/0231-Raytrace-entities-within-collection.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: NeumimTo <chleba48@gmail.com>
+Date: Wed, 28 Oct 2020 10:52:19 +0100
+Subject: [PATCH] Raytrace entities within collection
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index e827e1a6f5c0f8410ed32dda8f17aa769b469999..b7fed2399a3dceb120da3a90da875d81f394d66a 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -1659,6 +1659,22 @@ public interface World extends PluginMessageRecipient, Metadatable {
+     @Nullable
+     public RayTraceResult rayTraceEntities(@NotNull Location start, @NotNull Vector direction, double maxDistance, double raySize, @Nullable Predicate<Entity> filter);
+ 
++    /**
++     * Performs a ray trace that checks for entity collisions within predefined collection of entities
++     * <p>
++     *
++     * @param direction the ray direction
++     * @param maxDistance the maximum distance
++     * @param raySize entity bounding boxes will be uniformly expanded (or
++     *    shrinked) by this value before doing collision checks
++     * @param startPos the start position
++     * @param entities Collection of entities to check against
++     * @return the closest ray trace hit result, or <code>null</code> if there
++     *   is no hit
++     */
++    @Nullable
++    public RayTraceResult rayTraceEntities(@NotNull Vector direction, double maxDistance, double raySize, @NotNull Vector startPos, @NotNull Collection<Entity> entities);
++
+     /**
+      * Performs a ray trace that checks for block collisions using the blocks'
+      * precise collision shapes.

--- a/Spigot-Server-Patches/0594-Raytrace-entities-within-collection.patch
+++ b/Spigot-Server-Patches/0594-Raytrace-entities-within-collection.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: NeumimTo <chleba48@gmail.com>
+Date: Wed, 28 Oct 2020 10:54:25 +0100
+Subject: [PATCH] Raytrace entities within collection
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 299f57ca2a65887a0d7e7c584fc1bd5c783b0db2..f6fe354948f7aa6fdfa22c6bcb20818c7d768961 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1304,6 +1304,11 @@ public class CraftWorld implements World {
+         BoundingBox aabb = BoundingBox.of(startPos, startPos).expandDirectional(dir).expand(raySize);
+         Collection<Entity> entities = this.getNearbyEntities(aabb, filter);
+ 
++        return rayTraceEntities(direction, maxDistance, raySize, startPos, entities);
++    }
++
++    @Override
++    public RayTraceResult rayTraceEntities(Vector direction, double maxDistance, double raySize, Vector startPos, Collection<Entity> entities) {
+         Entity nearestHitEntity = null;
+         RayTraceResult nearestHitResult = null;
+         double nearestDistanceSq = Double.MAX_VALUE;
+@@ -1326,6 +1331,7 @@ public class CraftWorld implements World {
+         return (nearestHitEntity == null) ? null : new RayTraceResult(nearestHitResult.getHitPosition(), nearestHitEntity, nearestHitResult.getHitBlockFace());
+     }
+ 
++
+     @Override
+     public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance) {
+         return this.rayTraceBlocks(start, direction, maxDistance, FluidCollisionMode.NEVER, false);

--- a/Spigot-Server-Patches/0594-Raytrace-entities-within-collection.patch
+++ b/Spigot-Server-Patches/0594-Raytrace-entities-within-collection.patch
@@ -5,26 +5,20 @@ Subject: [PATCH] Raytrace entities within collection
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 299f57ca2a65887a0d7e7c584fc1bd5c783b0db2..f6fe354948f7aa6fdfa22c6bcb20818c7d768961 100644
+index 299f57ca2a65887a0d7e7c584fc1bd5c783b0db2..9ee28222d8dbb3564d00e4ed18c4865ce5a62874 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1304,6 +1304,11 @@ public class CraftWorld implements World {
+@@ -1304,6 +1304,13 @@ public class CraftWorld implements World {
          BoundingBox aabb = BoundingBox.of(startPos, startPos).expandDirectional(dir).expand(raySize);
          Collection<Entity> entities = this.getNearbyEntities(aabb, filter);
  
++        // Paper start - add entities collection
 +        return rayTraceEntities(direction, maxDistance, raySize, startPos, entities);
 +    }
 +
 +    @Override
-+    public RayTraceResult rayTraceEntities(Vector direction, double maxDistance, double raySize, Vector startPos, Collection<Entity> entities) {
++    public RayTraceResult rayTraceEntities(Vector direction, double maxDistance, double raySize, Vector startPos, Collection<? extends Entity> entities) {
++        // Paper end
          Entity nearestHitEntity = null;
          RayTraceResult nearestHitResult = null;
          double nearestDistanceSq = Double.MAX_VALUE;
-@@ -1326,6 +1331,7 @@ public class CraftWorld implements World {
-         return (nearestHitEntity == null) ? null : new RayTraceResult(nearestHitResult.getHitPosition(), nearestHitEntity, nearestHitResult.getHitBlockFace());
-     }
- 
-+
-     @Override
-     public RayTraceResult rayTraceBlocks(Location start, Vector direction, double maxDistance) {
-         return this.rayTraceBlocks(start, direction, maxDistance, FluidCollisionMode.NEVER, false);


### PR DESCRIPTION
Adds method `World#raytrace` that takes a collection of entities instead of Predicate<Entity>
..another way to filter out entities we dont't want to check for ray intersection