### PR TITLE
PlayerChunkLoadEvent / PlayerChunkUnloadEvent

### DIFF
--- a/Spigot-API-Patches/0242-Player-Chunk-Load-Unload-Events.patch
+++ b/Spigot-API-Patches/0242-Player-Chunk-Load-Unload-Events.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ysl3000 <yannicklamprecht@live.de>
+Date: Mon, 5 Oct 2020 21:24:45 +0200
+Subject: [PATCH] Player Chunk Load/Unload Events
+
+
+diff --git a/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java b/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2c1cda1126e577a88f19071e958eddb5a38785af
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/packet/PlayerChunkLoadEvent.java
+@@ -0,0 +1,42 @@
++package io.papermc.paper.event.packet;
++
++import org.bukkit.Chunk;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.world.ChunkEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Is called when a {@link org.bukkit.entity.Player} receives a {@link org.bukkit.Chunk}
++ * <p>
++ * Can for example be used for spawning a fake entity when the player receives a chunk.
++ *
++ * Should only be used for packet/clientside related stuff.
++ * Not intended for modifying server side state.
++ */
++public class PlayerChunkLoadEvent extends ChunkEvent {
++
++    private static final HandlerList handlers = new HandlerList();
++    private final Player player;
++
++    public PlayerChunkLoadEvent(@NotNull Chunk chunk, @NotNull Player player) {
++        super(chunk);
++        this.player = player;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public Player getPlayer() {
++        return player;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java b/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..12163a7b0591a7d022dc7eb9ee6608a1b6c39d9b
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/packet/PlayerChunkUnloadEvent.java
+@@ -0,0 +1,40 @@
++package io.papermc.paper.event.packet;
++
++import org.bukkit.Chunk;
++import org.bukkit.entity.Player;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.world.ChunkEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Is called when a {@link Player} receives a chunk unload packet.
++ *
++ * Should only be used for packet/clientside related stuff.
++ * Not intended for modifying server side.
++ */
++public class PlayerChunkUnloadEvent extends ChunkEvent {
++
++    private static final HandlerList handlers = new HandlerList();
++    private final Player player;
++
++    public PlayerChunkUnloadEvent(@NotNull Chunk chunk, @NotNull Player player) {
++        super(chunk);
++        this.player = player;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public Player getPlayer() {
++        return player;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0617-Player-Chunk-Load-Unload-Events.patch
+++ b/Spigot-Server-Patches/0617-Player-Chunk-Load-Unload-Events.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ysl3000 <yannicklamprecht@live.de>
+Date: Mon, 5 Oct 2020 21:25:16 +0200
+Subject: [PATCH] Player Chunk Load/Unload Events
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 976c44c8eeecc513fa11de55b80317550f621407..7240b885d96eb2df187b6229449af1a893a4524e 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -16,6 +16,8 @@ import java.util.OptionalInt;
+ import java.util.Random;
+ import java.util.UUID;
+ import javax.annotation.Nullable;
++import io.papermc.paper.event.packet.PlayerChunkLoadEvent; // Paper
++import io.papermc.paper.event.packet.PlayerChunkUnloadEvent; // Paper
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ 
+@@ -1938,11 +1940,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     public void a(ChunkCoordIntPair chunkcoordintpair, Packet<?> packet, Packet<?> packet1) {
+         this.playerConnection.sendPacket(packet1);
+         this.playerConnection.sendPacket(packet);
++        // Paper start
++        if(PlayerChunkLoadEvent.getHandlerList().getRegisteredListeners().length > 0){
++            new PlayerChunkLoadEvent(this.getBukkitEntity().getWorld().getChunkAt(chunkcoordintpair.longKey), this.getBukkitEntity()).callEvent();
++        }
++        // Paper end
+     }
+ 
+     public void a(ChunkCoordIntPair chunkcoordintpair) {
+         if (this.isAlive()) {
+             this.playerConnection.sendPacket(new PacketPlayOutUnloadChunk(chunkcoordintpair.x, chunkcoordintpair.z));
++            // Paper start
++            if(PlayerChunkUnloadEvent.getHandlerList().getRegisteredListeners().length > 0){
++                new PlayerChunkUnloadEvent(this.getBukkitEntity().getWorld().getChunkAt(chunkcoordintpair.longKey), this.getBukkitEntity()).callEvent();
++            }
++            // Paper end
+         }
+ 
+     }


### PR DESCRIPTION
Adds the following:

1. PlayerChunkLoadEvent / PlayerChunkUnloadEvent (Can be used to autorespawn fake entities when client receives chunk)



Probably Mini appreciate at least the two events for his lightweight Citizens replacement.