### PR TITLE
Don't load an empty JsonList

### DIFF
--- a/Spigot-Server-Patches/0595-Don-t-load-an-empty-JsonList.patch
+++ b/Spigot-Server-Patches/0595-Don-t-load-an-empty-JsonList.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sun, 1 Nov 2020 15:50:16 +0100
+Subject: [PATCH] Don't load an empty JsonList
+
+
+diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
+index 9213bfb78e92b838189161045e3945588251b486..4e6794386633854b2cf920d52b3692d9082083e8 100644
+--- a/src/main/java/net/minecraft/server/JsonList.java
++++ b/src/main/java/net/minecraft/server/JsonList.java
+@@ -187,6 +187,7 @@ public abstract class JsonList<K, V extends JsonListEntry<K>> {
+ 
+             try {
+                 JsonArray jsonarray = (JsonArray) JsonList.b.fromJson(bufferedreader, JsonArray.class);
++                if (jsonarray == null) return; // Paper - the content of the file was just whitespace/EOF
+ 
+                 this.d.clear();
+                 Iterator iterator = jsonarray.iterator();


### PR DESCRIPTION
As it stands, `JsonList`s will throw NPEs if the file is empty, because GSON's `fromJson` returns `null` if the supplied `Reader` is at EOF. This usually means a botched file was provided, but a `null` is supposed to *only* happen in this specific case, so it's safe to assume that no data is also a safe or intended state.

This is an issue with all the JSON files (e.g. `banned-players.json`) with lists throwing NPEs when they've been nuked.

Related to #4174.