### PR TITLE
Fix ghost blocks in ticking view distance

### DIFF
--- a/Spigot-Server-Patches/0471-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0471-No-Tick-view-distance-implementation.patch
@@ -37,7 +37,7 @@ index a8ab4bcd55d7705542c87079bb9c27db1b381fe0..e884456fac00a81d251f75fb9eea9809
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 0bdd463a35d4b45fd6e50ab35046f1783600d3ee..b7bfdab0e8ba47cd78bff77efabc6a2a1936157b 100644
+index 0bdd463a35d4b45fd6e50ab35046f1783600d3ee..b88a0e6a27735e124ff2be2d44c8df4192298606 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -201,7 +201,51 @@ public class Chunk implements IChunkAccess {
@@ -92,6 +92,15 @@ index 0bdd463a35d4b45fd6e50ab35046f1783600d3ee..b7bfdab0e8ba47cd78bff77efabc6a2a
      }
  
      public final boolean isAnyNeighborsLoaded() {
+@@ -1085,7 +1129,7 @@ public class Chunk implements IChunkAccess {
+                     IBlockData iblockdata = this.getType(blockposition);
+                     IBlockData iblockdata1 = Block.b(iblockdata, (GeneratorAccess) this.world, blockposition);
+ 
+-                    this.world.setTypeAndData(blockposition, iblockdata1, 20);
++                    this.world.setTypeAndData(blockposition, iblockdata1, 20 | 2); // Paper - We send chunks before they're ticking ready, so we need to notify here
+                 }
+ 
+                 this.n[i].clear();
 diff --git a/src/main/java/net/minecraft/server/ChunkMapDistance.java b/src/main/java/net/minecraft/server/ChunkMapDistance.java
 index ef61f8e784b7ebd26293d627e8b8e1aef1be6e21..03b1a67aaf3ed75b7669a3157847affd678f8df4 100644
 --- a/src/main/java/net/minecraft/server/ChunkMapDistance.java


### PR DESCRIPTION
Fixes #4298.

Tuinity patch:
https://github.com/Spottedleaf/Tuinity/blob/576e2cc1af2bb0b9768da2b11871044801d63099/patches/server/0047-Fix-ghost-blocks-in-ticking-view-distance.patch