### PR TITLE
Throw proper exception on empty JsonList file

### DIFF
--- a/Spigot-Server-Patches/0683-Throw-proper-exception-on-empty-JsonList-file.patch
+++ b/Spigot-Server-Patches/0683-Throw-proper-exception-on-empty-JsonList-file.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sun, 1 Nov 2020 16:43:11 +0100
+Subject: [PATCH] Throw proper exception on empty JsonList file
+
+
+diff --git a/src/main/java/net/minecraft/server/JsonList.java b/src/main/java/net/minecraft/server/JsonList.java
+index 1fc0139cb9694ddea41f57d95774c3b47e8530c5..8da5f976109accc84b26ec4045776aa8a9799f3d 100644
+--- a/src/main/java/net/minecraft/server/JsonList.java
++++ b/src/main/java/net/minecraft/server/JsonList.java
+@@ -187,6 +187,7 @@ public abstract class JsonList<K, V extends JsonListEntry<K>> {
+ 
+             try {
+                 JsonArray jsonarray = (JsonArray) JsonList.b.fromJson(bufferedreader, JsonArray.class);
++                com.google.common.base.Preconditions.checkState(jsonarray != null, "The file \"" + this.c.getName() + "\" is either empty or corrupt"); // Paper
+ 
+                 this.d.clear();
+                 Iterator iterator = jsonarray.iterator();


### PR DESCRIPTION
Related to #4174, #4717.

As it stands, `JsonList` throws an NPE on `jsonarray.iterator()` when
the reader given is at EOF. This means there is an unintelligible
message shown to the player:

```
[16:44:31 ERROR]: Encountered an unexpected exception
java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonArray.iterator()" because "jsonarray" is null
	at net.minecraft.server.v1_16_R2.JsonList.load(JsonList.java:192) ~[patched_1.16.3.jar:git-Paper-248]
	at net.minecraft.server.v1_16_R2.DedicatedPlayerList.y(SourceFile:95) ~[patched_1.16.3.jar:git-Paper-248]
	...
```

This is clearly not understandable to the untrained eye: what is
`jsonarray`? What is `DedicatedPlayerList.y`?

This rather does a proper exception message:

```
[16:42:59 ERROR]: Encountered an unexpected exception
java.lang.NullPointerException: The file "banned-players.json" is either empty or corrupt
	at com.google.common.base.Preconditions.checkNotNull(Preconditions.java:787) ~[paper-1.16.3.jar:git-Paper-"8e6d90c2d"]
	at net.minecraft.server.v1_16_R2.JsonList.load(JsonList.java:190) ~[paper-1.16.3.jar:git-Paper-"8e6d90c2d"]
	at net.minecraft.server.v1_16_R2.DedicatedPlayerList.y(SourceFile:95) ~[paper-1.16.3.jar:git-Paper-"8e6d90c2d"]
	...
```

It is still an exception, which server owners may or may not understand,
but the message now says exactly what went wrong, and who would've
known, now we know what `DedicatedPlayerList.y` is, and we know what
file was broken.

This is more of a quality of life change, but it is certainly useful to
the server owners that come into `#paper-help` and the issue tracker
(#4174) to ask for help with unintelligible messages we need to open a
patched Paper project to make any sense out of.