### PR TITLE
(1.16.4) Update note on broken event

### DIFF
--- a/SHIT_TO_CHECK.md
+++ b/SHIT_TO_CHECK.md
@@ -8,4 +8,7 @@
 * chunk generation seems slow with a lot of it happening
 * Fix IDE Debug JVM Flag for new versions of minecraft
 
-* Check if `PlayerEditBookEvent`: https://github.com/PaperMC/Paper/pull/1751
+* Check if `PlayerEditBookEvent`: https://github.com/PaperMC/Paper/pull/1751  
+The PlayerEditBookEvent is straight up not called anymore.  
+The method to call it must now be `PlayerConnection#a(List<String>, int)` (CB bug).  
+The item is presumably edited with the new page contents before it ever reaches this method?  

--- a/Spigot-Server-Patches/0293-Hook-into-CB-plugin-rewrites.patch
+++ b/Spigot-Server-Patches/0293-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index ac48431777b70c200f9e4113c8a0c03957126e90..fbaf078b154a0f376b4a5a076a50a5c306504663 100644
+index ac48431777b70c200f9e4113c8a0c03957126e90..1d78086cb94d24372f9fbe21463e21277e25eab7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -6,7 +6,9 @@ import java.io.FileOutputStream;
@@ -52,7 +52,7 @@ index ac48431777b70c200f9e4113c8a0c03957126e90..fbaf078b154a0f376b4a5a076a50a5c3
 +        if ( Boolean.getBoolean( "debug.rewriteForIde" ) )
 +        {
 +            // unversion incoming calls for pre-relocate debug work
-+            final String NMS_REVISION_PACKAGE = "v1_16_R2/";
++            final String NMS_REVISION_PACKAGE = "v1_16_R3/";
 +
 +            getAndRemove.put( "net/minecraft/".concat( "server/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );
 +            getAndRemove.put( "org/bukkit/".concat( "craftbukkit/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );


### PR DESCRIPTION
also fixes the IDE debug flag apparently