### PR TITLE
Fix PlayerEditBookEvent

### DIFF
--- a/Spigot-Server-Patches/0594-Fix-PlayerEditBookEvent.patch
+++ b/Spigot-Server-Patches/0594-Fix-PlayerEditBookEvent.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Tue, 3 Nov 2020 22:52:07 +0100
+Subject: [PATCH] Fix PlayerEditBookEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 17f093213f7023ab0aaae793874371fc0144c4f2..63ae6d57654861ca3f37de58019e560c98b96bb3 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -979,7 +979,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+             NBTTagList nbttaglist = new NBTTagList();
+ 
+             list.stream().map(NBTTagString::a).forEach(nbttaglist::add);
+-            itemstack.a("pages", (NBTBase) nbttaglist);
++            // Paper start - call PlayerEditBookEvent for non-signing
++            ItemStack cloned = itemstack.cloneItemStack();
++            cloned.getOrCreateTagAndSet("pages", (NBTBase) nbttaglist);
++            this.player.inventory.setItem(i, CraftEventFactory.handleEditBookEvent(player, i, itemstack, cloned));
++            this.player.updateInventory(this.player.activeContainer); // Editing the book may result in its data persisting client-side
++            // Paper end
+         }
+     }
+ 
+@@ -1009,6 +1014,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+ 
+             itemstack1.a("pages", (NBTBase) nbttaglist);
+             this.player.inventory.setItem(i, CraftEventFactory.handleEditBookEvent(player, i, itemstack, itemstack1)); // CraftBukkit
++            this.player.updateInventory(this.player.activeContainer); // Paper - editing the book may result in its data persisting client-side
+         }
+     }
+ 

--- a/UPDATE_NOTES.md
+++ b/UPDATE_NOTES.md
@@ -7,8 +7,3 @@
 * lighting is bork (load chunk, fly away, come back, everything or parts are black)
 * chunk generation seems slow with a lot of it happening
 * Fix IDE Debug JVM Flag for new versions of minecraft
-
-* Check if `PlayerEditBookEvent`: https://github.com/PaperMC/Paper/pull/1751  
-The PlayerEditBookEvent is straight up not called anymore.  
-The method to call it must now be `PlayerConnection#a(List<String>, int)` (CB bug).  
-The item is presumably edited with the new page contents before it ever reaches this method?  


### PR DESCRIPTION
When not signing a book, it will never call the event.
When signing the book and cancelled, it may not reflect the cancellation to the client due to the inventory not updating.