### PR TITLE
Significantly improve performance of the end generation

### DIFF
--- a/Spigot-Server-Patches/0601-Significantly-improve-performance-of-the-end-generat.patch
+++ b/Spigot-Server-Patches/0601-Significantly-improve-performance-of-the-end-generat.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperCoder7979 <25208576+SuperCoder7979@users.noreply.github.com>
+Date: Tue, 3 Nov 2020 23:48:05 -0600
+Subject: [PATCH] Significantly improve performance of the end generation
+
+This patch implements a noise cache for the end which significantly reduces the computation time of generation. This results in about a 3x improvement.
+
+Original code by SuperCoder7979 and Gegy in Lithium, licensed under LGPL-3.0 (Source: https://github.com/jellysquid3/lithium-fabric)
+
+Co-authored-by: Gegy <gegy1000@gmail.com>
+Co-authored-by: Dylan Xaldin <Puremin0rez515@gmail.com>
+Co-authored-by: pop4959 <pop4959@gmail.com>
+
+diff --git a/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java b/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
+index 9c15cd303ccc2928be4e3e7080e74e8314d7e0f2..70924c2942f6cc668eb4d11afdb42a966bd5edc8 100644
+--- a/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
++++ b/src/main/java/net/minecraft/server/WorldChunkManagerTheEnd.java
+@@ -3,6 +3,7 @@ package net.minecraft.server;
+ import com.google.common.collect.ImmutableList;
+ import com.mojang.serialization.Codec;
+ import com.mojang.serialization.codecs.RecordCodecBuilder;
++import it.unimi.dsi.fastutil.HashCommon; // Paper
+ import java.util.List;
+ 
+ public class WorldChunkManagerTheEnd extends WorldChunkManager {
+@@ -22,6 +23,16 @@ public class WorldChunkManagerTheEnd extends WorldChunkManager {
+     private final BiomeBase k;
+     private final BiomeBase l;
+     private final BiomeBase m;
++    // Paper start
++    private static final class NoiseCache {
++        public long[] keys = new long[8192];
++        public float[] values = new float[8192];
++        public NoiseCache() {
++            java.util.Arrays.fill(keys, Long.MIN_VALUE);
++        }
++    }
++    private static final ThreadLocal<java.util.Map<NoiseGenerator3Handler, NoiseCache>> noiseCache = ThreadLocal.withInitial(java.util.WeakHashMap::new);
++    // Paper end
+ 
+     public WorldChunkManagerTheEnd(IRegistry<BiomeBase> iregistry, long i) {
+         this(iregistry, i, (BiomeBase) iregistry.d(Biomes.THE_END), (BiomeBase) iregistry.d(Biomes.END_HIGHLANDS), (BiomeBase) iregistry.d(Biomes.END_MIDLANDS), (BiomeBase) iregistry.d(Biomes.SMALL_END_ISLANDS), (BiomeBase) iregistry.d(Biomes.END_BARRENS));
+@@ -76,13 +87,27 @@ public class WorldChunkManagerTheEnd extends WorldChunkManager {
+ 
+         f = MathHelper.a(f, -100.0F, 80.0F);
+ 
++        NoiseCache cache = noiseCache.get().computeIfAbsent(noisegenerator3handler, m -> new NoiseCache()); // Paper
+         for (int k1 = -12; k1 <= 12; ++k1) {
+             for (int l1 = -12; l1 <= 12; ++l1) {
+                 long i2 = (long) (k + k1);
+                 long j2 = (long) (l + l1);
+ 
+-                if (i2 * i2 + j2 * j2 > 4096L && noisegenerator3handler.a((double) i2, (double) j2) < -0.8999999761581421D) {
+-                    float f1 = (MathHelper.e((float) i2) * 3439.0F + MathHelper.e((float) j2) * 147.0F) % 13.0F + 9.0F;
++                // Paper start - Significantly improve end generation performance by using a noise cache
++                long key = ChunkCoordIntPair.pair((int) i2, (int) j2);
++                int index = (int) HashCommon.mix(key) & 8191;
++                float f1 = Float.MIN_VALUE;
++                if (cache.keys[index] == key) {
++                    f1 = cache.values[index];
++                } else {
++                    if (i2 * i2 + j2 * j2 > 4096L && noisegenerator3handler.a((double) i2, (double) j2) < -0.8999999761581421D) {
++                        f1 = (MathHelper.e((float) i2) * 3439.0F + MathHelper.e((float) j2) * 147.0F) % 13.0F + 9.0F;
++                    }
++                    cache.keys[index] = key;
++                    cache.values[index] = f1;
++                }
++                if (f1 != Float.MIN_VALUE) {
++                    // Paper end
+                     float f2 = (float) (i1 - k1 * 2);
+                     float f3 = (float) (j1 - l1 * 2);
+                     float f4 = 100.0F - MathHelper.c(f2 * f2 + f3 * f3) * f1;


### PR DESCRIPTION
# Description 
This patch implements a noise cache for the end which significantly reduces the computation time of generation. This results in about a 3x improvement.

Noise is the largest bottleneck in the ends generation, so by caching this where possible, the end now becomes the fastest world generated out of the three dimensions.

The terrain generated remains exactly the same as vanilla (seed for seed).

# Testing Results
All testing results were done using [Chunky](https://www.spigotmc.org/resources/chunky.81534/) as a way to test the maximum chunks per second that could be achieved when generating the world.

**Testing procedure used the following commands on a fresh world using level seed `1`**
```
chunky world world_the_end
chunky center 5000 5000
chunky radius 1000
chunky start
```
**Paper `#261`**  
Completion time: 280026ms [4 minutes 42 seconds]  
Chunks per second: 57 cps

**Paper `#261` (with this patch)**  
Completion time: 86997ms [1 minute 24 seconds]  
Chunks per second: 185 cps

The results are even more significant the larger of a radius you pregenerate, cutting hours upon hours off total world generation time.

# PR Notes
It's been years since I've contributed to Paper so forgive me if I missed anything :P I've tried my best to reduce diff as much as possible.

The authoring situation on the patch looks silly, but I wanted to credit everyone involved in making this happen as much as possible.