### PR TITLE
Use ItemStack#setAmount for ShapelessRecipe

### DIFF
--- a/Spigot-API-Patches/0168-Add-ItemStack-Recipe-API-helper-methods.patch
+++ b/Spigot-API-Patches/0168-Add-ItemStack-Recipe-API-helper-methods.patch
@@ -34,7 +34,7 @@ index 84062dd719cb8a6142dc8c806777cb208c6b42b2..ddcf84e6609abe8379cca2ff99983ce3
 +    // Paper start
 +    @NotNull
 +    public ShapelessRecipe addIngredient(@NotNull ItemStack item) {
-+        return addIngredient(1, item);
++        return addIngredient(item.getAmount(), item);
 +    }
 +
 +    @NotNull


### PR DESCRIPTION
This simply just uses the ItemStack amount when you pass it to ShapelessRecipe#addIngredient(ItemStack).