### PR TITLE
Add ignore discounts API

### DIFF
--- a/Spigot-API-Patches/0232-Add-ignore-discounts-API.patch
+++ b/Spigot-API-Patches/0232-Add-ignore-discounts-API.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Mon, 9 Nov 2020 20:33:38 +0100
+Subject: [PATCH] Add ignore discounts API
+
+
+diff --git a/src/main/java/org/bukkit/inventory/MerchantRecipe.java b/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+index 1fb4a1c53791776f9c5a952a592f15fc35cb2703..2be2f3fe655c417bfc8f8e840f9e9415d168f37e 100644
+--- a/src/main/java/org/bukkit/inventory/MerchantRecipe.java
++++ b/src/main/java/org/bukkit/inventory/MerchantRecipe.java
+@@ -28,6 +28,7 @@ public class MerchantRecipe implements Recipe {
+     private boolean experienceReward;
+     private int villagerExperience;
+     private float priceMultiplier;
++    private boolean ignoreDiscounts; // Paper
+ 
+     public MerchantRecipe(@NotNull ItemStack result, int maxUses) {
+         this(result, 0, maxUses, false);
+@@ -38,6 +39,12 @@ public class MerchantRecipe implements Recipe {
+     }
+ 
+     public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier) {
++        // Paper start - add ignoreDiscounts param
++        this(result, uses, maxUses, experienceReward, villagerExperience, priceMultiplier, false);
++    }
++    public MerchantRecipe(@NotNull ItemStack result, int uses, int maxUses, boolean experienceReward, int villagerExperience, float priceMultiplier, boolean ignoreDiscounts) {
++        this.ignoreDiscounts = ignoreDiscounts;
++        // Paper end
+         this.result = result;
+         this.uses = uses;
+         this.maxUses = maxUses;
+@@ -172,4 +179,20 @@ public class MerchantRecipe implements Recipe {
+     public void setPriceMultiplier(float priceMultiplier) {
+         this.priceMultiplier = priceMultiplier;
+     }
++
++    // Paper start
++    /**
++     * @return Whether all discounts on this trade should be ignored.
++     */
++    public boolean shouldIgnoreDiscounts() {
++        return ignoreDiscounts;
++    }
++
++    /**
++     * @param ignoreDiscounts Whether all discounts on this trade should be ignored.
++     */
++    public void setIgnoreDiscounts(boolean ignoreDiscounts) {
++        this.ignoreDiscounts = ignoreDiscounts;
++    }
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0594-Add-ignore-discounts-API.patch
+++ b/Spigot-Server-Patches/0594-Add-ignore-discounts-API.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Mon, 9 Nov 2020 20:44:51 +0100
+Subject: [PATCH] Add ignore discounts API
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index 039d5cc20a6de46b0812b428e2f6526905ece2bf..0388d1099f2a6d436a5a5e58bbbdae3ddab969e7 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -391,6 +391,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+ 
+             while (iterator.hasNext()) {
+                 MerchantRecipe merchantrecipe = (MerchantRecipe) iterator.next();
++                if (merchantrecipe.ignoreDiscounts) continue; // Paper
+ 
+                 // CraftBukkit start
+                 int bonus = -MathHelper.d((float) i * merchantrecipe.getPriceMultiplier());
+@@ -410,6 +411,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+ 
+             while (iterator1.hasNext()) {
+                 MerchantRecipe merchantrecipe1 = (MerchantRecipe) iterator1.next();
++                if (merchantrecipe1.ignoreDiscounts) continue; // Paper
+                 double d0 = 0.3D + 0.0625D * (double) j;
+                 int k = (int) Math.floor(d0 * (double) merchantrecipe1.a().getCount());
+ 
+diff --git a/src/main/java/net/minecraft/server/MerchantRecipe.java b/src/main/java/net/minecraft/server/MerchantRecipe.java
+index e42382a5c385c27b6322b03e87870eb20b21cb22..67ce246432b4ed2ab9604eef799801109a461714 100644
+--- a/src/main/java/net/minecraft/server/MerchantRecipe.java
++++ b/src/main/java/net/minecraft/server/MerchantRecipe.java
+@@ -14,6 +14,7 @@ public class MerchantRecipe {
+     private int demand;
+     public float priceMultiplier;
+     public int xp;
++    public boolean ignoreDiscounts; // Paper
+     // CraftBukkit start
+     private CraftMerchantRecipe bukkitHandle;
+ 
+@@ -22,7 +23,7 @@ public class MerchantRecipe {
+     }
+ 
+     public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2, int uses, int maxUses, int experience, float priceMultiplier, CraftMerchantRecipe bukkit) {
+-        this(itemstack, itemstack1, itemstack2, uses, maxUses, experience, priceMultiplier);
++        this(itemstack, itemstack1, itemstack2, uses, maxUses, experience, priceMultiplier, bukkit.shouldIgnoreDiscounts()); // Paper - shouldIgnoreDiscounts
+         this.bukkitHandle = bukkit;
+     }
+     // CraftBukkit end
+@@ -54,6 +55,7 @@ public class MerchantRecipe {
+ 
+         this.specialPrice = nbttagcompound.getInt("specialPrice");
+         this.demand = nbttagcompound.getInt("demand");
++        this.ignoreDiscounts = nbttagcompound.getBoolean("Paper.IgnoreDiscounts"); // Paper
+     }
+ 
+     public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, int i, int j, float f) {
+@@ -65,10 +67,19 @@ public class MerchantRecipe {
+     }
+ 
+     public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2, int i, int j, int k, float f) {
+-        this(itemstack, itemstack1, itemstack2, i, j, k, f, 0);
++        // Paper start - add ignoreDiscounts param
++        this(itemstack, itemstack1, itemstack2, i, j, k, f, false);
++    }
++    public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2, int i, int j, int k, float f, boolean ignoreDiscounts) {
++        this(itemstack, itemstack1, itemstack2, i, j, k, f, 0, ignoreDiscounts);
+     }
+ 
+     public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2, int i, int j, int k, float f, int l) {
++        this(itemstack, itemstack1, itemstack2, i, j, k, f, l, false);
++    }
++    public MerchantRecipe(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2, int i, int j, int k, float f, int l, boolean ignoreDiscounts) {
++        this.ignoreDiscounts = ignoreDiscounts;
++        // Paper end
+         this.rewardExp = true;
+         this.xp = 1;
+         this.buyingItem1 = itemstack;
+@@ -184,6 +195,7 @@ public class MerchantRecipe {
+         nbttagcompound.setFloat("priceMultiplier", this.priceMultiplier);
+         nbttagcompound.setInt("specialPrice", this.specialPrice);
+         nbttagcompound.setInt("demand", this.demand);
++        nbttagcompound.setBoolean("Paper.IgnoreDiscounts", this.ignoreDiscounts); // Paper
+         return nbttagcompound;
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
+index e198251617bfd6b0fe932d8bfa5dfcafdac919c2..fb6cd6add6a687a90e1a2d05c83baed368f248dc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchantRecipe.java
+@@ -17,7 +17,12 @@ public class CraftMerchantRecipe extends MerchantRecipe {
+     }
+ 
+     public CraftMerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int experience, float priceMultiplier) {
+-        super(result, uses, maxUses, experienceReward, experience, priceMultiplier);
++        // Paper start - add ignoreDiscounts param
++        this(result, uses, maxUses, experienceReward, experience, priceMultiplier, false);
++    }
++    public CraftMerchantRecipe(ItemStack result, int uses, int maxUses, boolean experienceReward, int experience, float priceMultiplier, boolean ignoreDiscounts) {
++        super(result, uses, maxUses, experienceReward, experience, priceMultiplier, ignoreDiscounts);
++        // Paper end
+         this.handle = new net.minecraft.server.MerchantRecipe(
+                 net.minecraft.server.ItemStack.b,
+                 net.minecraft.server.ItemStack.b,
+@@ -81,6 +86,18 @@ public class CraftMerchantRecipe extends MerchantRecipe {
+         handle.priceMultiplier = priceMultiplier;
+     }
+ 
++    // Paper start
++    @Override
++    public boolean shouldIgnoreDiscounts() {
++        return this.handle.ignoreDiscounts;
++    }
++
++    @Override
++    public void setIgnoreDiscounts(boolean ignoreDiscounts) {
++        this.handle.ignoreDiscounts = ignoreDiscounts;
++    }
++    // Paper end
++
+     public net.minecraft.server.MerchantRecipe toMinecraft() {
+         List<ItemStack> ingredients = getIngredients();
+         Preconditions.checkState(!ingredients.isEmpty(), "No offered ingredients");
+@@ -95,7 +112,7 @@ public class CraftMerchantRecipe extends MerchantRecipe {
+         if (recipe instanceof CraftMerchantRecipe) {
+             return (CraftMerchantRecipe) recipe;
+         } else {
+-            CraftMerchantRecipe craft = new CraftMerchantRecipe(recipe.getResult(), recipe.getUses(), recipe.getMaxUses(), recipe.hasExperienceReward(), recipe.getVillagerExperience(), recipe.getPriceMultiplier());
++            CraftMerchantRecipe craft = new CraftMerchantRecipe(recipe.getResult(), recipe.getUses(), recipe.getMaxUses(), recipe.hasExperienceReward(), recipe.getVillagerExperience(), recipe.getPriceMultiplier(), recipe.shouldIgnoreDiscounts()); // Paper - shouldIgnoreDiscounts
+             craft.setIngredients(recipe.getIngredients());
+ 
+             return craft;


### PR DESCRIPTION
Ported:
- <https://github.com/Minevictus/Papercut/blob/ver/1.16.4/patches/api/0010-Ignore-discounts-API.patch>
- <https://github.com/Minevictus/Papercut/blob/ver/1.16.4/patches/server/0017-Ignore-discounts-API.patch>

This adds a new API that lets us ignore recipes in discounts. One can for example use this API as follows:

```java
    for (MerchantRecipe recipe : recipes) {
      ItemStack result = recipe.getResult();
      if (result.getType() != Material.ENCHANTED_BOOK) {
        continue;
      }

      // Snip: fetch `enchantmentPrice`.
      recipe.setIgnoreDiscounts(!enchantmentPrice.areDiscountsEnabled());
    }
```

CC: @BillyGalbreath 