### PR TITLE
Fix per-world settings not reloading

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -269,7 +269,7 @@ index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b9
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..05e0e6c8ef02687c11ee60dbeeefa41bac90548f
+index 0000000000000000000000000000000000000000..2c0514892d3993bef57ecf677cf8bb0fbe0216e4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -0,0 +1,185 @@
@@ -460,10 +460,10 @@ index 0000000000000000000000000000000000000000..05e0e6c8ef02687c11ee60dbeeefa41b
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a738657394bcccd859ef260a801736d44b234469
+index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b773d2be0
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,68 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
@@ -479,7 +479,7 @@ index 0000000000000000000000000000000000000000..a738657394bcccd859ef260a801736d4
 +
 +    private final String worldName;
 +    private final SpigotWorldConfig spigotConfig;
-+    private final YamlConfiguration config;
++    private YamlConfiguration config;
 +    private boolean verbose;
 +
 +    public PaperWorldConfig(String worldName, SpigotWorldConfig spigotConfig) {
@@ -490,6 +490,7 @@ index 0000000000000000000000000000000000000000..a738657394bcccd859ef260a801736d4
 +    }
 +
 +    public void init() {
++        this.config = PaperConfig.config; // grab updated reference
 +        log("-------- World Settings For [" + worldName + "] --------");
 +        PaperConfig.readConfig(PaperWorldConfig.class, this);
 +    }

--- a/Spigot-Server-Patches/0010-Configurable-cactus-and-reed-natural-growth-heights.patch
+++ b/Spigot-Server-Patches/0010-Configurable-cactus-and-reed-natural-growth-heights.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable cactus and reed natural growth heights
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a738657394bcccd859ef260a801736d44b234469..098bd3fba867c0e4c6c58748aa6e2e632737a948 100644
+index b31109d2dadd29e8852468c19265066b773d2be0..d97288b27668e0544b05ce110bfc6a0834cc263d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -64,4 +64,13 @@ public class PaperWorldConfig {
+@@ -65,4 +65,13 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def);
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }

--- a/Spigot-Server-Patches/0011-Configurable-baby-zombie-movement-speed.patch
+++ b/Spigot-Server-Patches/0011-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 098bd3fba867c0e4c6c58748aa6e2e632737a948..912611cf1aeccf5a82a789aab07d76723d4357cc 100644
+index d97288b27668e0544b05ce110bfc6a0834cc263d..29f35535fab41aee6d253de9f9bd566d0fc28d65 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -73,4 +73,15 @@ public class PaperWorldConfig {
+@@ -74,4 +74,15 @@ public class PaperWorldConfig {
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight);
  
      }
@@ -25,7 +25,7 @@ index 098bd3fba867c0e4c6c58748aa6e2e632737a948..912611cf1aeccf5a82a789aab07d7672
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index ebf46a3c31913bf6ec2aa13b8c9bac1c590b7d84..12f954723ac2f0058081d810ce83aed99532caad 100644
+index a3f608e3a06abfa4268278b6f1298ece36264a02..d07847876e22971b4a90f67d8281bf08361424e0 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
 @@ -21,7 +21,7 @@ import org.bukkit.event.entity.EntityTransformEvent;

--- a/Spigot-Server-Patches/0012-Configurable-fishing-time-ranges.patch
+++ b/Spigot-Server-Patches/0012-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 912611cf1aeccf5a82a789aab07d76723d4357cc..7d9976ce6bf86e6fdfd0c7770104cee0db363a6d 100644
+index 29f35535fab41aee6d253de9f9bd566d0fc28d65..02f4342b23ad4a3ad0ed09affe7ce5e572354668 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -84,4 +84,12 @@ public class PaperWorldConfig {
+@@ -85,4 +85,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/Spigot-Server-Patches/0013-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/Spigot-Server-Patches/0013-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d9976ce6bf86e6fdfd0c7770104cee0db363a6d..6d6a68cb1b952da8308ac9ce5b54694bc9ba0e30 100644
+index 02f4342b23ad4a3ad0ed09affe7ce5e572354668..4982fd2842342fe9a37123e34af0040ec580cf2d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -92,4 +92,9 @@ public class PaperWorldConfig {
+@@ -93,4 +93,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }

--- a/Spigot-Server-Patches/0014-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/Spigot-Server-Patches/0014-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6d6a68cb1b952da8308ac9ce5b54694bc9ba0e30..2845686411615245137cfe1a155088a865a4d3a0 100644
+index 4982fd2842342fe9a37123e34af0040ec580cf2d..eb3185250812f5c2b2d24a2de6b2248d280b771e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -97,4 +97,20 @@ public class PaperWorldConfig {
+@@ -98,4 +98,20 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }
@@ -30,7 +30,7 @@ index 6d6a68cb1b952da8308ac9ce5b54694bc9ba0e30..2845686411615245137cfe1a155088a8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityInsentient.java b/src/main/java/net/minecraft/server/EntityInsentient.java
-index 5df3ca8c0a272392cec2cf10b15494f9f63d171c..71e8d8c0c4c5ec1ebb67a4cf5ce3c751a5fd052a 100644
+index 59af58e1aed678b8eac83f2346f5822aff700fb7..c80d7f72a55ae92587ba8a4618787fb712bdaf23 100644
 --- a/src/main/java/net/minecraft/server/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/server/EntityInsentient.java
 @@ -698,14 +698,14 @@ public abstract class EntityInsentient extends EntityLiving {

--- a/Spigot-Server-Patches/0015-Allow-for-toggling-of-spawn-chunks.patch
+++ b/Spigot-Server-Patches/0015-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2845686411615245137cfe1a155088a865a4d3a0..8ee2b9bb1bce698fce50ac1b3fc477fcafd0542c 100644
+index eb3185250812f5c2b2d24a2de6b2248d280b771e..b2dfad6a75c18b81c76539b7327a85da98ccf810 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -113,4 +113,10 @@ public class PaperWorldConfig {
+@@ -114,4 +114,10 @@ public class PaperWorldConfig {
          softDespawnDistance = softDespawnDistance*softDespawnDistance;
          hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
      }
@@ -20,7 +20,7 @@ index 2845686411615245137cfe1a155088a865a4d3a0..8ee2b9bb1bce698fce50ac1b3fc477fc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 9836de9a748a5d7828d02a1831561f0d35d4b577..abdad96225985e5c216394f64d646755a3992333 100644
+index 8703a001c9d2bf114b140a94f20e0cf7e57361f9..ebf719d45cd07082ef794028592fbd923177134d 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -165,6 +165,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0016-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/Spigot-Server-Patches/0016-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8ee2b9bb1bce698fce50ac1b3fc477fcafd0542c..d59b82b7bb1f6d1b231f4e394e0a67a3d154d7be 100644
+index b2dfad6a75c18b81c76539b7327a85da98ccf810..60c38406c599b5952855b3dc18fc3defa9d62ca4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -119,4 +119,14 @@ public class PaperWorldConfig {
+@@ -120,4 +120,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }
@@ -24,7 +24,7 @@ index 8ee2b9bb1bce698fce50ac1b3fc477fcafd0542c..d59b82b7bb1f6d1b231f4e394e0a67a3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index f44048171d70f183f0bbdfb835211fba6da73cb4..d8766f302ed6512d3b4e8bb6508a71e5c8910b54 100644
+index bbb66e90aba2332c7c87a173639efc6ad61f5d53..47e1845ca967210d15bf2beba32442ec8b1bde34 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1765,6 +1765,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -36,7 +36,7 @@ index f44048171d70f183f0bbdfb835211fba6da73cb4..d8766f302ed6512d3b4e8bb6508a71e5
      public EntityItem a(ItemStack itemstack, float f) {
          if (itemstack.isEmpty()) {
 diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
-index 53f49e76fe54392b4bb905b6990835820397877d..fbb795ac767fee6d88cfa9f7f17c6a1f89bbbf2d 100644
+index 55e6d9a94c648bac68b80a76eda041fb952db09f..6b226c04d40adff8b0f1d28c0cc79439df002b3d 100644
 --- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
 @@ -85,6 +85,17 @@ public class EntityFallingBlock extends Entity {
@@ -58,7 +58,7 @@ index 53f49e76fe54392b4bb905b6990835820397877d..fbb795ac767fee6d88cfa9f7f17c6a1f
                  blockposition = this.getChunkCoordinates();
                  boolean flag = this.block.getBlock() instanceof BlockConcretePowder;
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index ea4ecd9833c33cf3bf0257030f63d0c1693ad9ff..71404a34d27dd7771ea1145085a6a6e4dc7589b0 100644
+index b448467a92650e1bd3d5fac7de685550b7e891df..2b8ed9d14bd6dd9330712741859eb77ba0194153 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 @@ -54,6 +54,12 @@ public class EntityTNTPrimed extends Entity {

--- a/Spigot-Server-Patches/0027-Configurable-top-of-nether-void-damage.patch
+++ b/Spigot-Server-Patches/0027-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d59b82b7bb1f6d1b231f4e394e0a67a3d154d7be..f7a0a33e49cadf9b2bd43f118c106937760da762 100644
+index 60c38406c599b5952855b3dc18fc3defa9d62ca4..a005c4398336dba3b5e3ef716f44f2eda7306442 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -129,4 +129,19 @@ public class PaperWorldConfig {
+@@ -130,4 +130,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }

--- a/Spigot-Server-Patches/0030-Configurable-end-credits.patch
+++ b/Spigot-Server-Patches/0030-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f7a0a33e49cadf9b2bd43f118c106937760da762..50dec5cb5e924301842300e8fc80cb671b6b9173 100644
+index a005c4398336dba3b5e3ef716f44f2eda7306442..88f5a415770da5dfcf7af95045f547e0761adc8b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -144,4 +144,10 @@ public class PaperWorldConfig {
+@@ -145,4 +145,10 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -20,7 +20,7 @@ index f7a0a33e49cadf9b2bd43f118c106937760da762..50dec5cb5e924301842300e8fc80cb67
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 7036a7556c5f859308540ec2f5643e40634c166e..76883dd525e074995d08ff20d0d74afcb3b11c2f 100644
+index 829dd175930e87d1286be0a2265846d9c55e9389..8794b8a7eeaa31fb544b39d9a8a39af47e2f9c21 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -61,7 +61,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0032-Optimize-explosions.patch
+++ b/Spigot-Server-Patches/0032-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 50dec5cb5e924301842300e8fc80cb671b6b9173..f038d3f7dc7d1034a3ee9f2384a85642f224836e 100644
+index 88f5a415770da5dfcf7af95045f547e0761adc8b..41d03030741f2bc5dd904957be546de82be61a47 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -150,4 +150,10 @@ public class PaperWorldConfig {
+@@ -151,4 +151,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }

--- a/Spigot-Server-Patches/0033-Disable-explosion-knockback.patch
+++ b/Spigot-Server-Patches/0033-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f038d3f7dc7d1034a3ee9f2384a85642f224836e..25e0717186366af580e512eedfd403b8efc64a75 100644
+index 41d03030741f2bc5dd904957be546de82be61a47..623186e8503ff1debabc409b27fd3d29dcd5ced8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -156,4 +156,9 @@ public class PaperWorldConfig {
+@@ -157,4 +157,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }

--- a/Spigot-Server-Patches/0034-Disable-thunder.patch
+++ b/Spigot-Server-Patches/0034-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 25e0717186366af580e512eedfd403b8efc64a75..41436a4ead736dc925ca77d4cabf925f4e492d68 100644
+index 623186e8503ff1debabc409b27fd3d29dcd5ced8..0770de735f3cf4eb46c4ffd5b76eb393ad94a166 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -161,4 +161,9 @@ public class PaperWorldConfig {
+@@ -162,4 +162,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
+++ b/Spigot-Server-Patches/0035-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 41436a4ead736dc925ca77d4cabf925f4e492d68..f53d8b96757cbedc5fbb16195952a7da5c07164f 100644
+index 0770de735f3cf4eb46c4ffd5b76eb393ad94a166..870b50b1b981943eaba874fe26d89e111405969a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -166,4 +166,9 @@ public class PaperWorldConfig {
+@@ -167,4 +167,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }

--- a/Spigot-Server-Patches/0036-Configurable-mob-spawner-tick-rate.patch
+++ b/Spigot-Server-Patches/0036-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f53d8b96757cbedc5fbb16195952a7da5c07164f..428deed56dae597291670bea8c8a6a67ce4d940f 100644
+index 870b50b1b981943eaba874fe26d89e111405969a..8f45fa5ca878428a9ce6b18df075d3f09b2cf757 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -171,4 +171,9 @@ public class PaperWorldConfig {
+@@ -172,4 +172,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
+++ b/Spigot-Server-Patches/0039-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 428deed56dae597291670bea8c8a6a67ce4d940f..a4da22ea65d5fdba38f8dc331919088f9ca99aed 100644
+index 8f45fa5ca878428a9ce6b18df075d3f09b2cf757..1d8d1a4e387f205f6c1c9b608f20e30763dec01a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -176,4 +176,9 @@ public class PaperWorldConfig {
+@@ -177,4 +177,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }
@@ -19,7 +19,7 @@ index 428deed56dae597291670bea8c8a6a67ce4d940f..a4da22ea65d5fdba38f8dc331919088f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 76883dd525e074995d08ff20d0d74afcb3b11c2f..d0cc45637e8bb57c3d6ede6e4e49e492671f4292 100644
+index 8794b8a7eeaa31fb544b39d9a8a39af47e2f9c21..aed80f8a4a39d677ee0ea82f8795c5c8fdedcd6c 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -80,6 +80,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0043-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/Spigot-Server-Patches/0043-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a4da22ea65d5fdba38f8dc331919088f9ca99aed..345ac63e281bb3372b2ae879d587d658243581ba 100644
+index 1d8d1a4e387f205f6c1c9b608f20e30763dec01a..68132778ebafbb65077b82df8fcd8cdda319ffab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -181,4 +181,9 @@ public class PaperWorldConfig {
+@@ -182,4 +182,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/Spigot-Server-Patches/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/Spigot-Server-Patches/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 345ac63e281bb3372b2ae879d587d658243581ba..62e793b71b313146b86b466421e7a5f894bef9df 100644
+index 68132778ebafbb65077b82df8fcd8cdda319ffab..e2cb804fd40e236337c37d89dfc85a02486c1bf4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -186,4 +186,9 @@ public class PaperWorldConfig {
+@@ -187,4 +187,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
@@ -19,7 +19,7 @@ index 345ac63e281bb3372b2ae879d587d658243581ba..62e793b71b313146b86b466421e7a5f8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
-index dd7ceb679c1b03c419bb2a2799328aed889b1caf..cb7cf185cc93813de97fbab830856573af8b6e73 100644
+index a737b9cae678a5a3006ee6a00a1f1ddf7bb4e07c..563340d410f76ec1df90403879b835ebd9e6b533 100644
 --- a/src/main/java/net/minecraft/server/EntitySlime.java
 +++ b/src/main/java/net/minecraft/server/EntitySlime.java
 @@ -285,7 +285,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {

--- a/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 62e793b71b313146b86b466421e7a5f894bef9df..cd47a4ca069df26969de3051c2aac80540093818 100644
+index e2cb804fd40e236337c37d89dfc85a02486c1bf4..cff769a0cffd81501f919fad0c6456e1268bd223 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -191,4 +191,11 @@ public class PaperWorldConfig {
+@@ -192,4 +192,11 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
@@ -34,7 +34,7 @@ index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..716ea2fced5dc9e9a790f25e68252d5b
                      return null;
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index d0cc45637e8bb57c3d6ede6e4e49e492671f4292..64b310347db500a0b89b3c520a2a6fd795133deb 100644
+index aed80f8a4a39d677ee0ea82f8795c5c8fdedcd6c..553b2729a3a50a35e68602da451fbd69a9dfbe9b 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -875,7 +875,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cd47a4ca069df26969de3051c2aac80540093818..abbf59bb91021821876a8960e8f77fac24457ec4 100644
+index cff769a0cffd81501f919fad0c6456e1268bd223..a6c02f676f4206f2f59862530999cd74a2e0c20f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -198,4 +198,9 @@ public class PaperWorldConfig {
+@@ -199,4 +199,9 @@ public class PaperWorldConfig {
          portalSearchRadius = getInt("portal-search-radius", 128);
          portalCreateRadius = getInt("portal-create-radius", 16);
      }
@@ -30,7 +30,7 @@ index cd47a4ca069df26969de3051c2aac80540093818..abbf59bb91021821876a8960e8f77fac
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 671cab3efd94b81b0d71af3e096ffe9108d36258..2cc50f8d91c4ea8632ad72fce6aa585916ca8dd7 100644
+index 04a3700c6d4caffcf5b8f7867d12d42ac4478a37..a1e00c468e77bfa995f117207ad3208bdc7ec028 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -783,7 +783,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index abbf59bb91021821876a8960e8f77fac24457ec4..04430aae52205ee167662004e45c145b9d2e8bed 100644
+index a6c02f676f4206f2f59862530999cd74a2e0c20f..1f229e68349f49d7c461b1d9895a70968304be7f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -203,4 +203,9 @@ public class PaperWorldConfig {
+@@ -204,4 +204,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }

--- a/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04430aae52205ee167662004e45c145b9d2e8bed..d8b9d87bca6eb95c2cea91e4d8466b9792582d52 100644
+index 1f229e68349f49d7c461b1d9895a70968304be7f..4c956da69261d3092cd9abb1b98f7c9a220cc91e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -208,4 +208,19 @@ public class PaperWorldConfig {
+@@ -209,4 +209,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }
@@ -30,7 +30,7 @@ index 04430aae52205ee167662004e45c145b9d2e8bed..d8b9d87bca6eb95c2cea91e4d8466b97
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 17be0b56f8eeafd1f2ee01bc3b654f7f926c837c..2fb014c2a20363c94045dd834f771cfd9baf37cd 100644
+index 1bd522f84f034552e4a82fc07f93ce32c5532f81..2a86d4b8af5e436e82e003f50c1929702af700c4 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
 @@ -245,7 +245,7 @@ public abstract class EntityArrow extends IProjectile {

--- a/Spigot-Server-Patches/0070-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/Spigot-Server-Patches/0070-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d8b9d87bca6eb95c2cea91e4d8466b9792582d52..92d1dffbf436a21943b4a6aa0fabf54f064e6046 100644
+index 4c956da69261d3092cd9abb1b98f7c9a220cc91e..6998ec2d7550094498649deb9028988700982e04 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -223,4 +223,12 @@ public class PaperWorldConfig {
+@@ -224,4 +224,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/Spigot-Server-Patches/0074-Configurable-Chunk-Inhabited-Time.patch
+++ b/Spigot-Server-Patches/0074-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 92d1dffbf436a21943b4a6aa0fabf54f064e6046..725958efab3dd05e04b7b18e169230762ef800d0 100644
+index 6998ec2d7550094498649deb9028988700982e04..6babdde2910162a03b8abbcbb7db1f78eb3376c2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -231,4 +231,14 @@ public class PaperWorldConfig {
+@@ -232,4 +232,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0080-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/Spigot-Server-Patches/0080-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 725958efab3dd05e04b7b18e169230762ef800d0..fe2c8001897dc6d66ce0d24ddb1a5d3b79810294 100644
+index 6babdde2910162a03b8abbcbb7db1f78eb3376c2..f433b1e46b1e97fa60f1bd32a1403189217d3afd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -241,4 +241,10 @@ public class PaperWorldConfig {
+@@ -242,4 +242,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }
@@ -20,7 +20,7 @@ index 725958efab3dd05e04b7b18e169230762ef800d0..fe2c8001897dc6d66ce0d24ddb1a5d3b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java b/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
-index 7268a1e8f28145c923033bfc4bcaae1fcfdb72fb..2dfc9b3769257a6dcec6ff83bcc904e62018b2dc 100644
+index 5eb62e9b9a228eaa50526e4203998246783a33d0..7b29d47dfdef7611db58068af285f76d92a9f12a 100644
 --- a/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
 +++ b/src/main/java/net/minecraft/server/BlockDirtSnowSpreadable.java
 @@ -31,6 +31,7 @@ public abstract class BlockDirtSnowSpreadable extends BlockDirtSnow {

--- a/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fe2c8001897dc6d66ce0d24ddb1a5d3b79810294..538e6751f3bda77ba32256158d2a6a25025b360c 100644
+index f433b1e46b1e97fa60f1bd32a1403189217d3afd..004e1cdfeef75c79889a1a7334773ab933c62086 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -247,4 +247,9 @@ public class PaperWorldConfig {
+@@ -248,4 +248,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/Spigot-Server-Patches/0093-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/Spigot-Server-Patches/0093-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 538e6751f3bda77ba32256158d2a6a25025b360c..fd3793c55b8021b9fc61ce6be585a8c9b477aba2 100644
+index 004e1cdfeef75c79889a1a7334773ab933c62086..fd09df36c0f28f77b1f6c32b4e68da8a3ab59aa9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -252,4 +252,14 @@ public class PaperWorldConfig {
+@@ -253,4 +253,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd3793c55b8021b9fc61ce6be585a8c9b477aba2..05ea87a473228f5b386258fae3943f3f4561eaa6 100644
+index fd09df36c0f28f77b1f6c32b4e68da8a3ab59aa9..64da34a840dc433670675a30062b8b17c29dd0c4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -262,4 +262,26 @@ public class PaperWorldConfig {
+@@ -263,4 +263,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 05ea87a473228f5b386258fae3943f3f4561eaa6..ac76bdd7e1d91b0d242539c4495948cdfbb622e0 100644
+index 64da34a840dc433670675a30062b8b17c29dd0c4..3599aa415076525a4529664b9b9f0339b2eff730 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,7 +2,6 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 05ea87a473228f5b386258fae3943f3f4561eaa6..ac76bdd7e1d91b0d242539c4495948cd
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -284,4 +283,14 @@ public class PaperWorldConfig {
+@@ -285,4 +284,14 @@ public class PaperWorldConfig {
              );
          }
      }

--- a/Spigot-Server-Patches/0115-Option-to-remove-corrupt-tile-entities.patch
+++ b/Spigot-Server-Patches/0115-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ac76bdd7e1d91b0d242539c4495948cdfbb622e0..6cb717a63f52d757b0b323408d2fc0c3d7db77da 100644
+index 3599aa415076525a4529664b9b9f0339b2eff730..74d0a591d3033b5ea4f2b0be8027d7096de66d8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -293,4 +293,9 @@ public class PaperWorldConfig {
+@@ -294,4 +294,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/Spigot-Server-Patches/0117-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/Spigot-Server-Patches/0117-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6cb717a63f52d757b0b323408d2fc0c3d7db77da..e43aee3757b6765d898b50ebfff1a28071638558 100644
+index 74d0a591d3033b5ea4f2b0be8027d7096de66d8a..64a34e48d55ef94507896982115be438e9632f6e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,6 +2,7 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 6cb717a63f52d757b0b323408d2fc0c3d7db77da..e43aee3757b6765d898b50ebfff1a280
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -298,4 +299,12 @@ public class PaperWorldConfig {
+@@ -299,4 +300,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }
@@ -30,7 +30,7 @@ index 6cb717a63f52d757b0b323408d2fc0c3d7db77da..e43aee3757b6765d898b50ebfff1a280
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFallingBlock.java b/src/main/java/net/minecraft/server/EntityFallingBlock.java
-index f7cd0fadc8aadc5c3b1655ee70e81a2a3e848b8c..f5cd0c6e3b6d375fb227802e3620dab52f0f4de4 100644
+index bdeabfaeb17778a12ab4ad72689a72b043efcff4..0fbcf454c2db2427055123424c6d10cfbb939c17 100644
 --- a/src/main/java/net/minecraft/server/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/server/EntityFallingBlock.java
 @@ -233,6 +233,13 @@ public class EntityFallingBlock extends Entity {

--- a/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e43aee3757b6765d898b50ebfff1a28071638558..255b4081314162cbe344b008158c6f4584795fb8 100644
+index 64a34e48d55ef94507896982115be438e9632f6e..c221e9501998de14194bd91018efbc113308198c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -307,4 +307,14 @@ public class PaperWorldConfig {
+@@ -308,4 +308,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 255b4081314162cbe344b008158c6f4584795fb8..04ee0856a8c62e1afb438d4fddf40e605e82a074 100644
+index c221e9501998de14194bd91018efbc113308198c..11106a20ccc161f18c1d5491785e44bb84f8a821 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -317,4 +317,10 @@ public class PaperWorldConfig {
+@@ -318,4 +318,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }
@@ -27,7 +27,7 @@ index 255b4081314162cbe344b008158c6f4584795fb8..04ee0856a8c62e1afb438d4fddf40e60
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index e720917159089e80dc8589ef7345644b44409c3d..cad87c5f4cea45233c6266794f6e4dd9fd2c1fd9 100644
+index 170dad8be525b40d764b6e63c981f7b73775a01b..97abed1cede09624748e40331a15a021939568be 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -183,6 +183,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -39,7 +39,7 @@ index e720917159089e80dc8589ef7345644b44409c3d..cad87c5f4cea45233c6266794f6e4dd9
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index f62653d5507a1f62e0521dc901283c2735b14e91..60ee57139a86492c290b33808ca35300dcf96f54 100644
+index 3c36b6ea1d130a150afb4116d18af93de9236cad..1b23da5c34704bbc00dd050bdf418a937002d784 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2791,8 +2791,11 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04ee0856a8c62e1afb438d4fddf40e605e82a074..0cc7ad571eba249199a2e5e8ec567a874241c903 100644
+index 11106a20ccc161f18c1d5491785e44bb84f8a821..7f22cdc26d26d6d937506f901a8a0ed1d0a9f780 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -323,4 +323,10 @@ public class PaperWorldConfig {
+@@ -324,4 +324,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0cc7ad571eba249199a2e5e8ec567a874241c903..e30f48caf2ce4f48f371b2594b765c27bc9e9778 100644
+index 7f22cdc26d26d6d937506f901a8a0ed1d0a9f780..295b27d122d84d6b1147aaedc9bbfb0f278e1cba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -329,4 +329,10 @@ public class PaperWorldConfig {
+@@ -330,4 +330,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }
@@ -21,7 +21,7 @@ index 0cc7ad571eba249199a2e5e8ec567a874241c903..e30f48caf2ce4f48f371b2594b765c27
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 5c6d48ef6e2159a5d74b83e64bace61eaad97aec..749c6e21cbd01a81196476728def640ba46a5783 100644
+index 8d7b77e01c5031953ab3a4811c8397503b52a0e3..7b9188a33c079155a7ff5b0e5de854550324f0f1 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
 @@ -226,7 +226,7 @@ public class EntityCreeper extends EntityMonster {

--- a/Spigot-Server-Patches/0175-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0175-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e30f48caf2ce4f48f371b2594b765c27bc9e9778..2d8b354d707e8b5b0e7cd644fb93bc8f1c4009f1 100644
+index 295b27d122d84d6b1147aaedc9bbfb0f278e1cba..4bb901966f7b1b6537a2b6b1dc0f0bdfd4338ce6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -335,4 +335,10 @@ public class PaperWorldConfig {
+@@ -336,4 +336,10 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
@@ -20,7 +20,7 @@ index e30f48caf2ce4f48f371b2594b765c27bc9e9778..2d8b354d707e8b5b0e7cd644fb93bc8f
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7239e9b9d072af9d1610fd2e06a123505e31a110..cc2f749ae12a165581328e6dab39fa74e08a7222 100644
+index 299fd2dd5b718acce790ac18f1fbbb23a148ed56..68befc17134bfd4c453275ab2d11485ad7450e7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -585,16 +585,32 @@ public class CraftEventFactory {

--- a/Spigot-Server-Patches/0185-Make-max-squid-spawn-height-configurable.patch
+++ b/Spigot-Server-Patches/0185-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2d8b354d707e8b5b0e7cd644fb93bc8f1c4009f1..48fa2483fc657b36b8f2fd7d8b35703cff2698a5 100644
+index 4bb901966f7b1b6537a2b6b1dc0f0bdfd4338ce6..4571fd98a9faeb461666fc5c262a95b9e7fa04b6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -341,4 +341,9 @@ public class PaperWorldConfig {
+@@ -342,4 +342,9 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }
@@ -21,7 +21,7 @@ index 2d8b354d707e8b5b0e7cd644fb93bc8f1c4009f1..48fa2483fc657b36b8f2fd7d8b35703c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySquid.java b/src/main/java/net/minecraft/server/EntitySquid.java
-index 37bac48f0427fef629f38ac416536248f05d0ff9..6a436c6edb4f2f17bbb165ff6497c15e476d3317 100644
+index 77b48d03caea9eb8f70792c3e1cae457a2885c81..050c4bdac8519250157b77c3221c99bd49e53a22 100644
 --- a/src/main/java/net/minecraft/server/EntitySquid.java
 +++ b/src/main/java/net/minecraft/server/EntitySquid.java
 @@ -169,7 +169,8 @@ public class EntitySquid extends EntityWaterAnimal {

--- a/Spigot-Server-Patches/0194-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/Spigot-Server-Patches/0194-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 48fa2483fc657b36b8f2fd7d8b35703cff2698a5..3804c7cf96087cdf94fd5fbdce4ebcdafa9e0019 100644
+index 4571fd98a9faeb461666fc5c262a95b9e7fa04b6..924cc5b2dc7764fdf9185d32bb5c09225250778d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -187,6 +187,11 @@ public class PaperWorldConfig {
+@@ -188,6 +188,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  
@@ -21,7 +21,7 @@ index 48fa2483fc657b36b8f2fd7d8b35703cff2698a5..3804c7cf96087cdf94fd5fbdce4ebcda
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 700cc4161163308c72f66c688a6afc1663e38284..de781fce74e5300be508f25aac23f402f97a2874 100644
+index c21d5e87f5ce7f9193d75848bfc89dc294bb8733..04dda158dd42a5e995ed376904e0505b97ffe1c4 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -1037,6 +1037,7 @@ public abstract class EntityHuman extends EntityLiving {

--- a/Spigot-Server-Patches/0208-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0208-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3804c7cf96087cdf94fd5fbdce4ebcdafa9e0019..873f81c74a94f6d76edd45e34ddc476dc525b47c 100644
+index 924cc5b2dc7764fdf9185d32bb5c09225250778d..e3e529c00122eaf04c7085b1074c5dd124419513 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -351,4 +351,9 @@ public class PaperWorldConfig {
+@@ -352,4 +352,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }
@@ -20,7 +20,7 @@ index 3804c7cf96087cdf94fd5fbdce4ebcdafa9e0019..873f81c74a94f6d76edd45e34ddc476d
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 49f051a1f47c73a66cc462b3eecf72c4e932b648..9a55d1e6f4c6632c1f27d8c1fac55abc3c3d8204 100644
+index 7e9a077a6e6af34c06910d1381399eed81f9fc20..d340ec2fed8a4308d1fd2e998e6716e42d84fb98 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -1086,7 +1086,11 @@ public abstract class EntityHuman extends EntityLiving {

--- a/Spigot-Server-Patches/0212-Block-Enderpearl-Travel-Exploit.patch
+++ b/Spigot-Server-Patches/0212-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 873f81c74a94f6d76edd45e34ddc476dc525b47c..69009246f12cc3acb0055af746e01097fa668e1b 100644
+index e3e529c00122eaf04c7085b1074c5dd124419513..0c8160aa7098f117d2a174ffd944741b11818d10 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -356,4 +356,10 @@ public class PaperWorldConfig {
+@@ -357,4 +357,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/Spigot-Server-Patches/0225-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0225-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 69009246f12cc3acb0055af746e01097fa668e1b..35075ffac394153e28039809e0ed48fe066a6223 100644
+index 0c8160aa7098f117d2a174ffd944741b11818d10..de80d2d874d1787335fd393f3ffed0cd36e3af9e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -362,4 +362,9 @@ public class PaperWorldConfig {
+@@ -363,4 +363,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }
@@ -19,7 +19,7 @@ index 69009246f12cc3acb0055af746e01097fa668e1b..35075ffac394153e28039809e0ed48fe
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index ddcaa435f87171bd3940089c30ba6eea73546e1f..7175a1146fbad4aa91f898a45415432bc27976da 100644
+index 0bfc3a7a532a166497eff75ed355f05c96e216c4..5ecb82078f884946e83a15b254196e39986b7424 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -3199,7 +3199,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0232-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/Spigot-Server-Patches/0232-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 35075ffac394153e28039809e0ed48fe066a6223..6352051ab937d4d365e823a7112e76dc3ec34225 100644
+index de80d2d874d1787335fd393f3ffed0cd36e3af9e..6e7e00678295b5b714a1be4753626e21ab469fd6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -367,4 +367,9 @@ public class PaperWorldConfig {
+@@ -368,4 +368,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/Spigot-Server-Patches/0247-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0247-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6352051ab937d4d365e823a7112e76dc3ec34225..92ddf96f7db08a2b390ef3f49b0643f9d90bbea4 100644
+index 6e7e00678295b5b714a1be4753626e21ab469fd6..54d7f6efcf42d4c7a8c209dfe3c5485318afafe3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -372,4 +372,9 @@ public class PaperWorldConfig {
+@@ -373,4 +373,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
@@ -19,7 +19,7 @@ index 6352051ab937d4d365e823a7112e76dc3ec34225..92ddf96f7db08a2b390ef3f49b0643f9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index f2938b115aa34158e76da9f974f5746ed43630e1..0330bdf46a3baba169dd226261094a18a6aecf54 100644
+index 96c229e5dd214d32478fe4d5b96e77d8ba2bc93c..2592a59e9506cee901802a3bdc78db8832700fd8 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -314,6 +314,7 @@ public class EntityArmorStand extends EntityLiving {
@@ -31,7 +31,7 @@ index f2938b115aa34158e76da9f974f5746ed43630e1..0330bdf46a3baba169dd226261094a18
  
          for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 6ebf3884a289d0be081d43d012ac10796740cc1e..909e01e458d729f277797bf1dca564f927318460 100644
+index 6003201197a89fa6c46c35d711a53db690295b1e..23a38825b71ea981538f32368705e7a7b98dadaf 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -801,6 +801,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 92ddf96f7db08a2b390ef3f49b0643f9d90bbea4..414b9077317022e4efc0b1e547d7f387610146dc 100644
+index 54d7f6efcf42d4c7a8c209dfe3c5485318afafe3..5ea60c713426f11e420360a08a9ea1039d4f6b02 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -377,4 +377,10 @@ public class PaperWorldConfig {
+@@ -378,4 +378,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }
@@ -20,7 +20,7 @@ index 92ddf96f7db08a2b390ef3f49b0643f9d90bbea4..414b9077317022e4efc0b1e547d7f387
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
-index 554bf021f05165438ef4a0db75f9654b4d4b5480..fc86ae2519c8ff54ff7c5e45d7c45fcc16eefca0 100644
+index 9b71e3207b0f41ab34871d5f4d7e87d90bc6446d..4e6f195965af2108631f373a3a2987826e4317de 100644
 --- a/src/main/java/net/minecraft/server/EntityArmorStand.java
 +++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
 @@ -46,9 +46,16 @@ public class EntityArmorStand extends EntityLiving {
@@ -137,7 +137,7 @@ index 554bf021f05165438ef4a0db75f9654b4d4b5480..fc86ae2519c8ff54ff7c5e45d7c45fcc
          this.datawatcher.set(EntityArmorStand.bh, vector3f);
      }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index db84ddd62b627764ff5debc56095d37e81c94605..3a6e5cb459fb9866cf2e377b803501152ab7ce69 100644
+index 51d1d9abcb66bef329fa2396e9e338b9d962733b..83d98b705875fa543de4f37b1234ad65e4e0604a 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2514,6 +2514,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0271-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/Spigot-Server-Patches/0271-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 414b9077317022e4efc0b1e547d7f387610146dc..098c99793c68ac916b52776f9a1cc2c6510c0057 100644
+index 5ea60c713426f11e420360a08a9ea1039d4f6b02..d8afb247f180b89f89cbed0f6e6c4fcc527799ff 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -383,4 +383,10 @@ public class PaperWorldConfig {
+@@ -384,4 +384,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/Spigot-Server-Patches/0303-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0303-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 098c99793c68ac916b52776f9a1cc2c6510c0057..15e1f9f65280043853544d3bf796f991df2482de 100644
+index d8afb247f180b89f89cbed0f6e6c4fcc527799ff..6f410120018f95259e9e4f504ea1b588c2b4622b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -389,4 +389,9 @@ public class PaperWorldConfig {
+@@ -390,4 +390,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 15e1f9f65280043853544d3bf796f991df2482de..21910dfd1a533e923a8a73e92fea25685a07b445 100644
+index 6f410120018f95259e9e4f504ea1b588c2b4622b..a9a3dbbe7608d1f0dc122fe8d49928e7e3fa1438 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -394,4 +394,43 @@ public class PaperWorldConfig {
+@@ -395,4 +395,43 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 21910dfd1a533e923a8a73e92fea25685a07b445..44811683cfe47adbdce6c8bd627bdbeb13ce114c 100644
+index a9a3dbbe7608d1f0dc122fe8d49928e7e3fa1438..e9c03546c42657dd5f5d4c6f71bd7e0cc7e2cb15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -433,4 +433,10 @@ public class PaperWorldConfig {
+@@ -434,4 +434,10 @@ public class PaperWorldConfig {
                  break;
          }
      }
@@ -21,7 +21,7 @@ index 21910dfd1a533e923a8a73e92fea25685a07b445..44811683cfe47adbdce6c8bd627bdbeb
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5816c8b367923a1722665b86e7fdcbe39cf51ee1..8886572361e56e8006bcdf2b066267336634cd7d 100644
+index 44991803a489a42842f79ce51bdd53a73ef35d71..12866eec621d9ae8801d50bdda13e757f303010e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -605,6 +605,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas

--- a/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 44811683cfe47adbdce6c8bd627bdbeb13ce114c..e7c73a4ddbb42aa52112147a60c8a761bfd3d07b 100644
+index e9c03546c42657dd5f5d4c6f71bd7e0cc7e2cb15..d1ff673d8b5aafac58b082c9abc9257f0b2dfb15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -439,4 +439,19 @@ public class PaperWorldConfig {
+@@ -440,4 +440,19 @@ public class PaperWorldConfig {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }

--- a/Spigot-Server-Patches/0363-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0363-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..75c30889ec186dbae35159d9a4a38494fad0f6df 100644
+index d1ff673d8b5aafac58b082c9abc9257f0b2dfb15..b9410e3affed4004548acdc9355ac14d18c4a2c8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index e7c73a4ddbb42aa52112147a60c8a761bfd3d07b..75c30889ec186dbae35159d9a4a38494
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -454,4 +456,33 @@ public class PaperWorldConfig {
+@@ -455,4 +457,33 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }

--- a/Spigot-Server-Patches/0364-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0364-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 75c30889ec186dbae35159d9a4a38494fad0f6df..18874a9b57cafb5c5c4fbcf87a3ecfd9ebb96440 100644
+index b9410e3affed4004548acdc9355ac14d18c4a2c8..90e8defde0ef84f3146c8664805d6f11b84c593d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -457,6 +457,16 @@ public class PaperWorldConfig {
+@@ -458,6 +458,16 @@ public class PaperWorldConfig {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
  

--- a/Spigot-Server-Patches/0365-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0365-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 18874a9b57cafb5c5c4fbcf87a3ecfd9ebb96440..a24bace235f72e15af84f6d64a1c7fa4334a57c0 100644
+index 90e8defde0ef84f3146c8664805d6f11b84c593d..36eff622d5638f1bd11b7b4ebe97036205ccf88b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -495,4 +495,9 @@ public class PaperWorldConfig {
+@@ -496,4 +496,9 @@ public class PaperWorldConfig {
          }
          log("Anti-Xray: " + (antiXray ? "enabled" : "disabled") + " / Engine Mode: " + engineMode.getDescription() + " / Up to " + ((maxChunkSectionIndex + 1) * 16) + " blocks / Update Radius: " + updateRadius);
      }

--- a/Spigot-Server-Patches/0372-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0372-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a24bace235f72e15af84f6d64a1c7fa4334a57c0..53ededbb615ec608e91ee87f46301a3c2964a7a3 100644
+index 36eff622d5638f1bd11b7b4ebe97036205ccf88b..fb84e7ca2873bcb5fed80b7ce58cf38a376289ed 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,10 +1,15 @@
@@ -24,7 +24,7 @@ index a24bace235f72e15af84f6d64a1c7fa4334a57c0..53ededbb615ec608e91ee87f46301a3c
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -500,4 +505,52 @@ public class PaperWorldConfig {
+@@ -501,4 +506,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 53ededbb615ec608e91ee87f46301a3c2964a7a3..5479c544ed43bf4e3d04626d5a1ff3c3084f9d4e 100644
+index fb84e7ca2873bcb5fed80b7ce58cf38a376289ed..617a8af814dc224762dc21669392960cc1702693 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -553,4 +553,9 @@ public class PaperWorldConfig {
+@@ -554,4 +554,9 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -573,7 +573,7 @@ index 7278e39d7fb47737b783c482f4c74a82ded163f8..5b60777c63d54b74b3de5a7373f64ba9
  
              this.p = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 1a8d8bc120fec876c528029dcc2804519caa569f..bb79467c6bb0ed44057802dde6cd40fa81c8d4fd 100644
+index c776f9bf65dedab951e3176bd74f854522503024..147af78e4bf95dd4f3f346b839287e37c0f3b8e1 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -89,6 +89,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0378-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0378-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5479c544ed43bf4e3d04626d5a1ff3c3084f9d4e..c6df5b21a6c1563a2b1150837baac33213a33ad0 100644
+index 617a8af814dc224762dc21669392960cc1702693..505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -558,4 +558,9 @@ public class PaperWorldConfig {
+@@ -559,4 +559,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0384-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0384-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c6df5b21a6c1563a2b1150837baac33213a33ad0..1977df762aa8ce317e5a2b8abd5f0e8fea54fba6 100644
+index 505fbd2e2bc5858d7400f07bf7319d0e32a1d0f3..45191d101b38953a53ef6a21c0c1592cac42b2aa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -563,4 +563,9 @@ public class PaperWorldConfig {
+@@ -564,4 +564,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0389-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0389-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1977df762aa8ce317e5a2b8abd5f0e8fea54fba6..d2c66aeb45f87091d5b521af811fc8cb741456df 100644
+index 45191d101b38953a53ef6a21c0c1592cac42b2aa..7453becf8c56bd41a7e532c08c4f274026eadefb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -568,4 +568,9 @@ public class PaperWorldConfig {
+@@ -569,4 +569,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0390-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0390-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d2c66aeb45f87091d5b521af811fc8cb741456df..16026c35d0433a5adb72a9eba91d0ebb39fc1c19 100644
+index 7453becf8c56bd41a7e532c08c4f274026eadefb..4438d567dd779650533c7128ae8b25b8fd369836 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -573,4 +573,13 @@ public class PaperWorldConfig {
+@@ -574,4 +574,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0410-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0410-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 16026c35d0433a5adb72a9eba91d0ebb39fc1c19..3a348c7ac4c9f2719b4158d67459699d109186b2 100644
+index 4438d567dd779650533c7128ae8b25b8fd369836..89f6de173225315783a09aae2fe77a3ede2b78d5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -582,4 +582,9 @@ public class PaperWorldConfig {
+@@ -583,4 +583,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/Spigot-Server-Patches/0415-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/Spigot-Server-Patches/0415-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3a348c7ac4c9f2719b4158d67459699d109186b2..5e01208d8bc963cc4bf8a5b6cabbf788b594917b 100644
+index 89f6de173225315783a09aae2fe77a3ede2b78d5..fd0e58574f4f07913161be489d031a011f059f8e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -380,6 +380,11 @@ public class PaperWorldConfig {
+@@ -381,6 +381,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/Spigot-Server-Patches/0416-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0416-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e01208d8bc963cc4bf8a5b6cabbf788b594917b..7a15bbf1bdb965bdfc71f03b2e2b9add06200e72 100644
+index fd0e58574f4f07913161be489d031a011f059f8e..f0f94ac2432ad79d2957b7f723fe7eb9cbd36507 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -592,4 +592,9 @@ public class PaperWorldConfig {
+@@ -593,4 +593,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0419-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0419-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7a15bbf1bdb965bdfc71f03b2e2b9add06200e72..29eaa572648113216a267462a79da7e3741d1cfe 100644
+index f0f94ac2432ad79d2957b7f723fe7eb9cbd36507..1b49c214998a5a9b424472df040d634d9fcc0c4a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -570,10 +570,21 @@ public class PaperWorldConfig {
+@@ -571,10 +571,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;
@@ -36,7 +36,7 @@ index 7a15bbf1bdb965bdfc71f03b2e2b9add06200e72..29eaa572648113216a267462a79da7e3
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index d1be6ef1a04c8bc98929421e73c0712086f147d5..371063fb37a354a4c23601aa2ba787dd65380ce4 100644
+index d06dd36bd83f6f2f785e5262dd67928eb6afd70a..19b8bc22d784f21bbc9cebb9689abda70de808f9 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -85,6 +85,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 29eaa572648113216a267462a79da7e3741d1cfe..51d30a92cbc1052b690b5565e403123c39f864da 100644
+index 1b49c214998a5a9b424472df040d634d9fcc0c4a..d7e22e1bf886800adbe8ed7baa3349e5d2ee1818 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -608,4 +608,9 @@ public class PaperWorldConfig {
+@@ -609,4 +609,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0458-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0458-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 51d30a92cbc1052b690b5565e403123c39f864da..a8ab4bcd55d7705542c87079bb9c27db1b381fe0 100644
+index d7e22e1bf886800adbe8ed7baa3349e5d2ee1818..de95bd406173c38fa8a745c201b5cd5fbec91702 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -613,4 +613,11 @@ public class PaperWorldConfig {
+@@ -614,4 +614,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a8ab4bcd55d7705542c87079bb9c27db1b381fe0..e884456fac00a81d251f75fb9eea98092dc96408 100644
+index de95bd406173c38fa8a745c201b5cd5fbec91702..9e55c800eb8b4dd4930dbf730bb6d106a2029036 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -620,4 +620,9 @@ public class PaperWorldConfig {
+@@ -621,4 +621,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
@@ -124,7 +124,7 @@ index ef61f8e784b7ebd26293d627e8b8e1aef1be6e21..03b1a67aaf3ed75b7669a3157847affd
                  if (flag1) {
                      ChunkMapDistance.this.j.a(ChunkTaskQueueSorter.a(() -> {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index a70721a051f524862003b9fb1dda79cf9ad64db0..f6e04a116367010e23116161aca648c44535e2b7 100644
+index 4a927cb12b6dc9352550717d1128cb6b9080b8a7..563b5f10649a165180f7f39ff8bce4c79508ae97 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -119,6 +119,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0495-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0495-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e884456fac00a81d251f75fb9eea98092dc96408..1296e576526f41635e6d61289e38ee17efcbd837 100644
+index 9e55c800eb8b4dd4930dbf730bb6d106a2029036..62e25da19c7ffc13ef1f7dcc375585afd79bb59f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -625,4 +625,13 @@ public class PaperWorldConfig {
+@@ -626,4 +626,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0507-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0507-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1296e576526f41635e6d61289e38ee17efcbd837..c2023f2c345afb108062f05568321f433ad71e1f 100644
+index 62e25da19c7ffc13ef1f7dcc375585afd79bb59f..dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -634,4 +634,26 @@ public class PaperWorldConfig {
+@@ -635,4 +635,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/Spigot-Server-Patches/0561-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0561-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c2023f2c345afb108062f05568321f433ad71e1f..6738f9f6089931f654f770c21ccfd9995abc8d90 100644
+index dd8ed18ae93aed4b9a4f11460de5ce23d8fd8c43..5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -656,4 +656,9 @@ public class PaperWorldConfig {
+@@ -657,4 +657,9 @@ public class PaperWorldConfig {
              maxLightningFlashDistance = 512; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0563-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0563-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6738f9f6089931f654f770c21ccfd9995abc8d90..26287b3e4007c02b9d78d60453fa16d3cfaae638 100644
+index 5e2ae5758d6e649d00f8047c7ab0d263fd7f96e8..8923314d731dea5c2707dbb271b8b0819d826a2e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -661,4 +661,14 @@ public class PaperWorldConfig {
+@@ -662,4 +662,14 @@ public class PaperWorldConfig {
      private void zombiesTargetTurtleEggs() {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }

--- a/Spigot-Server-Patches/0595-Toggle-for-removing-existing-dragon.patch
+++ b/Spigot-Server-Patches/0595-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26287b3e4007c02b9d78d60453fa16d3cfaae638..4aacf8a5b2e98b0f8c1e27569ff7591fee32c725 100644
+index 8923314d731dea5c2707dbb271b8b0819d826a2e..9a0ade5875c34487a65f82f9380f9d25b4432586 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -671,4 +671,12 @@ public class PaperWorldConfig {
+@@ -672,4 +672,12 @@ public class PaperWorldConfig {
              log("Using vanilla redstone algorithm.");
          }
      }


### PR DESCRIPTION
This fixes the per-world settings on paper.yml not reloading on `/paper reload`. The problem was the world config holds an old reference to the main config. The fix was to simply update the reference so per-world could use the newly reloaded values on `init()`

This is only noisy because it adds a line to the config, which force updates every patch afterwards that touched the config too :3 For a clearer view of what I'm changing here, I've already done this to Purpur a long time ago [here](https://github.com/pl3xgaming/Purpur/blob/ver/1.16.4/patches/server/0060-Fix-reloading-paper.yml.patch).