### PR TITLE
Fix Portal Search Radius Scaling

### DIFF
--- a/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
@@ -21,7 +21,7 @@ index e2cb804fd40e236337c37d89dfc85a02486c1bf4..cff769a0cffd81501f919fad0c6456e1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..716ea2fced5dc9e9a790f25e68252d5bd445b9ce 100644
+index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..48fc1dbb35591ad153d00805e25b504a3c4673fe 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2528,7 +2528,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -29,7 +29,7 @@ index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..716ea2fced5dc9e9a790f25e68252d5b
                  BlockPosition blockposition = new BlockPosition(MathHelper.a(this.locX() * d4, d0, d2), this.locY(), MathHelper.a(this.locZ() * d4, d1, d3));
                  // CraftBukkit start
 -                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, flag2 ? 16 : 128, 16);
-+                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, worldserver.paperConfig.portalSearchRadius, worldserver.paperConfig.portalCreateRadius); // Paper start - configurable portal radius
++                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, (int) (worldserver.paperConfig.portalSearchRadius / worldserver.getDimensionManager().getCoordinateScale()), worldserver.paperConfig.portalCreateRadius); // Paper start - configurable portal radius
                  if (event == null) {
                      return null;
                  }


### PR DESCRIPTION
This PR makes sure that scaling is applied to the portal search radius.

This is consistent with Vanilla behaviour as of 1.16.2, see https://bugs.mojang.com/browse/MC-197538. I tested this change locally on 1.16.4 and it produced the same behaviour as single player.