### PR TITLE
Add API for quit reason

### DIFF
--- a/Spigot-API-Patches/0235-Add-API-for-quit-reason.patch
+++ b/Spigot-API-Patches/0235-Add-API-for-quit-reason.patch
@@ -1,0 +1,68 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 14 Nov 2020 16:19:58 +0100
+Subject: [PATCH] Add API for quit reason
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+index d70c25f404e994766a9ebce89a917c8d0719777c..af52a5dfb452da11e51cad9c882cae1533cba520 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
+@@ -10,10 +10,17 @@ import org.jetbrains.annotations.Nullable;
+  */
+ public class PlayerQuitEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();
++    private final QuitReason reason; // Paper
+     private String quitMessage;
+ 
+     public PlayerQuitEvent(@NotNull final Player who, @Nullable final String quitMessage) {
++        // Paper start
++        this(who, quitMessage, null);
++    }
++    public PlayerQuitEvent(@NotNull final Player who, @Nullable final String quitMessage, @Nullable QuitReason quitReason) {
+         super(who);
++        this.reason = quitReason == null ? QuitReason.DISCONNECTED : quitReason;
++        // Paper end
+         this.quitMessage = quitMessage;
+     }
+ 
+@@ -46,4 +53,39 @@ public class PlayerQuitEvent extends PlayerEvent {
+     public static HandlerList getHandlerList() {
+         return handlers;
+     }
++
++    // Paper start
++    @NotNull
++    public QuitReason getReason() {
++        return this.reason;
++    }
++
++    public enum QuitReason {
++        /**
++         * The player left on their own behalf.
++         * <p>
++         * This does not mean they pressed the disconnect button in their client, but rather that the client severed the
++         * connection themselves. This may occur if no keep-alive packet is received on their side, among other things.
++         */
++        DISCONNECTED,
++
++        /**
++         * The player was kicked from the server.
++         */
++        KICKED,
++
++        /**
++         * The player has timed out.
++         */
++        TIMED_OUT,
++
++        /**
++         * The player's connection has entered an erroneous state.
++         * <p>
++         * Reasons for this may include invalid packets, invalid data, and uncaught exceptions in the packet handler,
++         * among others.
++         */
++        ERRONEOUS_STATE,
++    }
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0599-Add-API-for-quit-reason.patch
+++ b/Spigot-Server-Patches/0599-Add-API-for-quit-reason.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Sat, 14 Nov 2020 16:19:52 +0100
+Subject: [PATCH] Add API for quit reason
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 59d47a9f75450573b26b82b6f432af7bdc46a783..976c44c8eeecc513fa11de55b80317550f621407 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -127,6 +127,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+     double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
+ 
+     boolean needsChunkCenterUpdate; // Paper - no-tick view distance
++    public org.bukkit.event.player.PlayerQuitEvent.QuitReason quitReason = null; // Paper - there are a lot of changes to do if we change all methods leading to the event
+ 
+     public EntityPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
+         super(worldserver, worldserver.getSpawn(), worldserver.v(), gameprofile);
+diff --git a/src/main/java/net/minecraft/server/NetworkManager.java b/src/main/java/net/minecraft/server/NetworkManager.java
+index 7a84ea4116be070ab878e55b0cd919f3f3688f30..3ec8ba17ddf376aa98e2b74979b2544922712560 100644
+--- a/src/main/java/net/minecraft/server/NetworkManager.java
++++ b/src/main/java/net/minecraft/server/NetworkManager.java
+@@ -119,12 +119,15 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+ 
+             this.u = true;
+             if (this.channel.isOpen()) {
++                EntityPlayer player = this.getPlayer(); // Paper
+                 if (throwable instanceof TimeoutException) {
+                     NetworkManager.LOGGER.debug("Timeout", throwable);
++                    if (player != null) player.quitReason = org.bukkit.event.player.PlayerQuitEvent.QuitReason.TIMED_OUT; // Paper
+                     this.close(new ChatMessage("disconnect.timeout"));
+                 } else {
+                     ChatMessage chatmessage = new ChatMessage("disconnect.genericReason", new Object[]{"Internal Exception: " + throwable});
+ 
++                    if (player != null) player.quitReason = org.bukkit.event.player.PlayerQuitEvent.QuitReason.ERRONEOUS_STATE; // Paper
+                     if (flag) {
+                         NetworkManager.LOGGER.debug("Failed to sent packet", throwable);
+                         this.sendPacket(new PacketPlayOutKickDisconnect(chatmessage), (future) -> {
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 563ae7355f4f4645d21f2fbd494a5b5656c5e664..a736d676ef5e3a25c144743af559bfb46e294db7 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -300,6 +300,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         final IChatBaseComponent ichatbasecomponent = CraftChatMessage.fromString(s, true)[0];
+         // CraftBukkit end
+ 
++        this.player.quitReason = org.bukkit.event.player.PlayerQuitEvent.QuitReason.KICKED; // Paper
+         this.networkManager.sendPacket(new PacketPlayOutKickDisconnect(ichatbasecomponent), (future) -> {
+             this.networkManager.close(ichatbasecomponent);
+         });
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 38f26e25cb7d022c0bec5a5928db70611a0d347a..1faefcb5d23e2b86932611ba850fb7b60de896c7 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -509,7 +509,7 @@ public abstract class PlayerList {
+             entityplayer.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
+         }
+ 
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game", entityplayer.quitReason); // Paper - quit reason
+         if (entityplayer.didPlayerJoinEvent) cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
+         entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
+ 


### PR DESCRIPTION
The following has been tested:
- Disconnect from menu -> DISCONNECTED
- EssentialsX kick -> KICKED
- Suspend server JVM -> DISCONNECTED
- Suspend client JVM -> TIMED_OUT
- Call #exceptionCaught -> ERRONEOUS_STATE

Suspension was done through `kill -STOP` and subsequently `kill -CONT`
after the player has (been) disconnected.

Closes #254.