### PR TITLE
Add `curl` requirement for building paper.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -63,8 +63,8 @@ you will most likely use this for WSL), `homebrew` (macOS / Linux), and more:
 - A Java 8 or later JDK (packages vary, use Google/DuckDuckGo/etc.).  
 If you need one, you can find them on [AdoptOpenJDK](https://adoptopenjdk.net/).
 - `maven` (often package `maven`; can be found on
-[Apache's site](https://maven.apache.org/download.cgi) too).
-- `curl` (package `curl` everywhere);
+[Apache's site](https://maven.apache.org/download.cgi) too);
+- `curl` (package `curl` everywhere).
 
 If you're on Windows, check
 [the section on WSL](#patching-and-building-is-really-slow-what-can-i-do).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,6 +64,7 @@ you will most likely use this for WSL), `homebrew` (macOS / Linux), and more:
 If you need one, you can find them on [AdoptOpenJDK](https://adoptopenjdk.net/).
 - `maven` (often package `maven`; can be found on
 [Apache's site](https://maven.apache.org/download.cgi) too).
+- `curl` (package `curl` everywhere);
 
 If you're on Windows, check
 [the section on WSL](#patching-and-building-is-really-slow-what-can-i-do).

--- a/scripts/requireDeps.sh
+++ b/scripts/requireDeps.sh
@@ -12,6 +12,7 @@ if [ -z "${1:-}" ]; then
     _is_dep_available git
     _is_dep_available patch
     _is_dep_available mvn
+    _is_dep_available curl
 
     # Ensure we don't have a JAVA_HOME set first.
     # Maven should work fine without the JAVA_HOME var as long as the JDK is on the PATH.


### PR DESCRIPTION
This adds the requirement of `curl` to CONTRIBUTING.md.

While this may seem obvious to many people, when I installed Debian on my machine, I wasn't able to build Paper and I wasn't able to figure it out until the next day when I needed to install curl for a separate program.