### PR TITLE
Add PlayerTriggerRaidEvent

### DIFF
--- a/Spigot-API-Patches/0236-Add-PlayerTriggerRaidEvent.patch
+++ b/Spigot-API-Patches/0236-Add-PlayerTriggerRaidEvent.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Sat, 14 Nov 2020 21:31:19 +0100
+Subject: [PATCH] Add PlayerTriggerRaidEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerTriggerRaidEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerTriggerRaidEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..883802c5084d8c247025a7dfa44fe80f4c74964c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerTriggerRaidEvent.java
+@@ -0,0 +1,51 @@
++package io.papermc.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when the server detects that a player has triggered a raid, but
++ * before the raid begins.
++ */
++public class PlayerTriggerRaidEvent extends PlayerEvent implements Cancellable {
++    private static final HandlerList HANDLERS = new HandlerList();
++    private boolean cancelled;
++
++    public PlayerTriggerRaidEvent(@NotNull Player who) {
++        super(who);
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * If cancelled, the player will still lose the {@link org.bukkit.potion.PotionEffectType#BAD_OMEN Bad Omen effect}.
++     */
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * If cancelled, the player will still lose the {@link org.bukkit.potion.PotionEffectType#BAD_OMEN Bad Omen effect}.
++     */
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLERS;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLERS;
++    }
++}

--- a/Spigot-Server-Patches/0600-Add-PlayerTriggerRaidEvent.patch
+++ b/Spigot-Server-Patches/0600-Add-PlayerTriggerRaidEvent.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: simpleauthority <jacob@algorithmjunkie.com>
+Date: Sat, 14 Nov 2020 21:31:25 +0100
+Subject: [PATCH] Add PlayerTriggerRaidEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/PersistentRaid.java b/src/main/java/net/minecraft/server/PersistentRaid.java
+index 826dcf9f7eedc3664d66170b97b2a19552a0dc60..0624e7516a3098417b794abd5c5f5d0221e7f1f4 100644
+--- a/src/main/java/net/minecraft/server/PersistentRaid.java
++++ b/src/main/java/net/minecraft/server/PersistentRaid.java
+@@ -1,6 +1,7 @@
+ package net.minecraft.server;
+ 
+ import com.google.common.collect.Maps;
++import io.papermc.paper.event.player.PlayerTriggerRaidEvent;
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Map;
+@@ -91,6 +92,13 @@ public class PersistentRaid extends PersistentBase {
+                 Raid raid = this.a(entityplayer.getWorldServer(), blockposition2);
+                 boolean flag = false;
+ 
++                // Paper start
++                if (!new PlayerTriggerRaidEvent(entityplayer.getBukkitEntity()).callEvent()) {
++                    entityplayer.removeEffect(MobEffects.BAD_OMEN);
++                    return null;
++                }
++                // Paper end
++
+                 if (!raid.isStarted()) {
+                     /* CraftBukkit - moved down
+                     if (!this.raids.containsKey(raid.getId())) {


### PR DESCRIPTION
Reimplements #2095, as its source repo was deleted. Credits to @simpleauthority.

---

These patches add the event `PlayerRaidTriggerEvent` that is fired when a player enters a village with the *Bad Omen* effect.

While initially working on this, I noticed that while I was able to cancel the raid that it the raid continued to attempt to start because of the Player's *Bad Omen* status. I've duplicated the effect removal upwards to the conditional which tests if the event is canceled. In this way, the event is fired once per player who enters a village with the *Bad Omen* effect.

I'm having second thoughts about removing the effect and whether or not this should be deferred to an implementing plugin.

![https://uwu.whats-th.is/5jNUkat.png](https://uwu.whats-th.is/5jNUkat.png)

```java
  @EventHandler
  public void onRaidTrigger(PlayerTriggerRaidEvent event) {
    Bukkit.broadcastMessage(event.getPlayer().getName() + " triggered an event; cancelling");
    event.setCancelled(true);
  }
```
