### PR TITLE
Add exception handlers for getChunkAtAsync convenience methods

### DIFF
--- a/Spigot-API-Patches/0132-Async-Chunks-API.patch
+++ b/Spigot-API-Patches/0132-Async-Chunks-API.patch
@@ -8,10 +8,10 @@ Adds API's to load or generate chunks asynchronously.
 Also adds utility methods to Entity to teleport asynchronously.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd87418526170054047977da4 100644
+index ff132bd7677e384debf2399ba9b1ffdb932541e9..210f1ccf7a26598ab6353374dcb5c6e6dd34c42f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -221,6 +221,467 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -221,6 +221,482 @@ public interface World extends PluginMessageRecipient, Metadatable {
      public default Chunk getChunkAt(long chunkKey) {
          return getChunkAt((int) chunkKey, (int) (chunkKey >> 32));
      }
@@ -63,7 +63,10 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
 +     */
 +    @Deprecated
 +    public default void getChunkAtAsync(int x, int z, @NotNull ChunkLoadCallback cb) {
-+        getChunkAtAsync(x, z, true).thenAccept(cb::onLoad);
++        getChunkAtAsync(x, z, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
++            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
++            return null;
++        });
 +    }
 +
 +    /**
@@ -86,7 +89,10 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
 +     */
 +    @Deprecated
 +    public default void getChunkAtAsync(@NotNull Location loc, @NotNull ChunkLoadCallback cb) {
-+        getChunkAtAsync(loc, true).thenAccept(cb::onLoad);
++        getChunkAtAsync(loc, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
++            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
++            return null;
++        });
 +    }
 +
 +    /**
@@ -109,7 +115,10 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
 +     */
 +    @Deprecated
 +    public default void getChunkAtAsync(@NotNull Block block, @NotNull ChunkLoadCallback cb) {
-+        getChunkAtAsync(block, true).thenAccept(cb::onLoad);
++        getChunkAtAsync(block, true).thenAccept(cb::onLoad).exceptionally((ex) -> {
++            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
++            return null;
++        });
 +    }
 +
 +    /**
@@ -131,7 +140,10 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
 +     *           will be executed synchronously
 +     */
 +    public default void getChunkAtAsync(int x, int z, @NotNull java.util.function.Consumer<Chunk> cb) {
-+        getChunkAtAsync(x, z, true).thenAccept(cb);
++        getChunkAtAsync(x, z, true).thenAccept(cb).exceptionally((ex) -> {
++            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
++            return null;
++        });
 +    }
 +
 +    /**
@@ -154,7 +166,10 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
 +     *           will be executed synchronously
 +     */
 +    public default void getChunkAtAsync(int x, int z, boolean gen, @NotNull java.util.function.Consumer<Chunk> cb) {
-+        getChunkAtAsync(x, z, gen).thenAccept(cb);
++        getChunkAtAsync(x, z, gen).thenAccept(cb).exceptionally((ex) -> {
++            Bukkit.getLogger().log(java.util.logging.Level.WARNING, "Exception in chunk load callback", ex);
++            return null;
++        });
 +    }
 +
 +    /**
@@ -480,7 +495,7 @@ index ff132bd7677e384debf2399ba9b1ffdb932541e9..a260f31d1bc00b6bd874185261700540
  
      /**
 diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
-index 5a8f833ddd488cb1d3f817aadbd67e9850b26681..06f41958b98d9f105a9735509b4eb50ebf0fbf60 100644
+index d6451c82e0189e2c591a0fc1f884e83931d5a41b..12729b6d9b3902c7c225655de273cb3c075fb695 100644
 --- a/src/main/java/org/bukkit/entity/Entity.java
 +++ b/src/main/java/org/bukkit/entity/Entity.java
 @@ -156,6 +156,33 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent

--- a/Spigot-API-Patches/0136-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/Spigot-API-Patches/0136-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -48,7 +48,7 @@ index 369ce9ff6c8bb97a64a8e229115564412e6e7654..e700875beb76dadd55b585aca748338d
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index a260f31d1bc00b6bd87418526170054047977da4..14555ceda572ba1f720fafaab12ea39df291fee6 100644
+index 210f1ccf7a26598ab6353374dcb5c6e6dd34c42f..3b9c41cc93943bdd569ac5ebe281753a3beb65dc 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -90,6 +90,38 @@ public interface World extends PluginMessageRecipient, Metadatable {

--- a/Spigot-API-Patches/0138-isChunkGenerated-API.patch
+++ b/Spigot-API-Patches/0138-isChunkGenerated-API.patch
@@ -34,7 +34,7 @@ index e700875beb76dadd55b585aca748338def286908..9c91c49ed7302c12fcb1d8e9bc58712e
      /**
       * Sets the position of this Location and returns itself
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 14555ceda572ba1f720fafaab12ea39df291fee6..abce2ae7a861e28c5732593e163f172ebe8430ad 100644
+index 3b9c41cc93943bdd569ac5ebe281753a3beb65dc..9b8f354d79e6aad67faf5fc587df76264ceeac37 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -254,6 +254,17 @@ public interface World extends PluginMessageRecipient, Metadatable {

--- a/Spigot-API-Patches/0156-Add-sun-related-API.patch
+++ b/Spigot-API-Patches/0156-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index abce2ae7a861e28c5732593e163f172ebe8430ad..51b2b6d3f5de413391957a42d6a9ccb69688e0eb 100644
+index 9b8f354d79e6aad67faf5fc587df76264ceeac37..11d5df94788794da99572c57baec12ee1e58e0b1 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1765,6 +1765,16 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -1780,6 +1780,16 @@ public interface World extends PluginMessageRecipient, Metadatable {
       */
      public void setFullTime(long time);
  

--- a/Spigot-API-Patches/0178-Add-Heightmap-API.patch
+++ b/Spigot-API-Patches/0178-Add-Heightmap-API.patch
@@ -89,7 +89,7 @@ index d5d67b3d84cd88ed0f858497e68535ec0162c700..ec9eb042ee8354d17f8ad4230c4acc5f
       * Creates explosion at this location with given power
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 51b2b6d3f5de413391957a42d6a9ccb69688e0eb..cbd39760fd6e18a9d21794c468d874ca8a10d988 100644
+index 11d5df94788794da99572c57baec12ee1e58e0b1..85f549c7593c417d280fb31ce5cfdaf89f2f8dd2 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -160,6 +160,87 @@ public interface World extends PluginMessageRecipient, Metadatable {

--- a/Spigot-API-Patches/0201-World-view-distance-api.patch
+++ b/Spigot-API-Patches/0201-World-view-distance-api.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] World view distance api
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index cbd39760fd6e18a9d21794c468d874ca8a10d988..4511cb786a5618cc1b7ff5cbb97ef1fe8ff05e17 100644
+index 85f549c7593c417d280fb31ce5cfdaf89f2f8dd2..677c29d1e4a768c9349368f9ec618bc86d31a439 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3353,6 +3353,34 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -3368,6 +3368,34 @@ public interface World extends PluginMessageRecipient, Metadatable {
      int getViewDistance();
      // Spigot end
  

--- a/Spigot-API-Patches/0203-Spawn-Reason-API.patch
+++ b/Spigot-API-Patches/0203-Spawn-Reason-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Spawn Reason API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 4511cb786a5618cc1b7ff5cbb97ef1fe8ff05e17..ba5e6cca028df293a939db37ecf5857059554291 100644
+index 677c29d1e4a768c9349368f9ec618bc86d31a439..fe7d2e3ee04d0df51bfa1d64e21e6930ccc5e943 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index 4511cb786a5618cc1b7ff5cbb97ef1fe8ff05e17..ba5e6cca028df293a939db37ecf58570
  import org.bukkit.generator.ChunkGenerator;
  
  import java.util.ArrayList;
-@@ -2156,6 +2158,12 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2171,6 +2173,12 @@ public interface World extends PluginMessageRecipient, Metadatable {
      @NotNull
      public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException;
  
@@ -30,7 +30,7 @@ index 4511cb786a5618cc1b7ff5cbb97ef1fe8ff05e17..ba5e6cca028df293a939db37ecf58570
      /**
       * Spawn an entity of a specific class at the given {@link Location}, with
       * the supplied function run before the entity is added to the world.
-@@ -2173,7 +2181,28 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2188,7 +2196,28 @@ public interface World extends PluginMessageRecipient, Metadatable {
       *     {@link Entity} requested cannot be spawned
       */
      @NotNull

--- a/Spigot-API-Patches/0218-Add-moon-phase-API.patch
+++ b/Spigot-API-Patches/0218-Add-moon-phase-API.patch
@@ -47,7 +47,7 @@ index 0000000000000000000000000000000000000000..df05153397b42930cd53d37b30824c7e
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ba5e6cca028df293a939db37ecf5857059554291..e827e1a6f5c0f8410ed32dda8f17aa769b469999 100644
+index fe7d2e3ee04d0df51bfa1d64e21e6930ccc5e943..146c1f2048eefa25c44c921812832b9b42c5cba3 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -70,6 +70,12 @@ public interface World extends PluginMessageRecipient, Metadatable {


### PR DESCRIPTION
Developers using these methods will wonder less and reduce time spent debugging because `thenAccept` swallows exceptions in the absence of an exception handler.

At present, if a chunk load callback throws an unchecked exception, it will be stored in the CompletableFuture as an exceptional completion, and therefore left unreported.