### PR TITLE
nerf nether search radius config

### DIFF
--- a/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0051-Add-configurable-portal-search-radius.patch
@@ -5,31 +5,39 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 416a6760883cb40367535c7c5acd779742bb8af5..dbc5b49b8dc7c877fb2d2c187a9fe604fb53bd33 100644
+index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601ccc1f26e37 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -196,4 +196,11 @@ public class PaperWorldConfig {
+@@ -196,4 +196,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
 +
 +    public int portalSearchRadius;
 +    public int portalCreateRadius;
++    public boolean portalSearchVanillaDimensionScaling;
 +    private void portalSearchRadius() {
 +        portalSearchRadius = getInt("portal-search-radius", 128);
 +        portalCreateRadius = getInt("portal-create-radius", 16);
++        portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..716ea2fced5dc9e9a790f25e68252d5bd445b9ce 100644
+index 52595b6534e2798b36b3a7c2d97451bd0ea2f3a0..eb67002cbb9aa9e40702282286fd9d98f3f4440e 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2528,7 +2528,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2528,7 +2528,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
                  double d4 = DimensionManager.a(this.world.getDimensionManager(), worldserver.getDimensionManager());
                  BlockPosition blockposition = new BlockPosition(MathHelper.a(this.locX() * d4, d0, d2), this.locY(), MathHelper.a(this.locZ() * d4, d1, d3));
                  // CraftBukkit start
 -                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, flag2 ? 16 : 128, 16);
-+                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, worldserver.paperConfig.portalSearchRadius, worldserver.paperConfig.portalCreateRadius); // Paper start - configurable portal radius
++                // Paper start
++                int portalSearchRadius = worldserver.paperConfig.portalSearchRadius;
++                if (world.paperConfig.portalSearchVanillaDimensionScaling && flag2) { // == THE_NETHER
++                    portalSearchRadius = (int) (portalSearchRadius / worldserver.getDimensionManager().getCoordinateScale());
++                }
++                // Paper end
++                CraftPortalEvent event = callPortalEvent(this, worldserver, blockposition, PlayerTeleportEvent.TeleportCause.NETHER_PORTAL, portalSearchRadius, worldserver.paperConfig.portalCreateRadius); // Paper start - configurable portal radius
                  if (event == null) {
                      return null;
                  }

--- a/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/Spigot-Server-Patches/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,12 +16,12 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index dbc5b49b8dc7c877fb2d2c187a9fe604fb53bd33..85f8a78c639f2c1aafd956bdb410ad301a9b9f73 100644
+index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730ac44aac8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -203,4 +203,9 @@ public class PaperWorldConfig {
-         portalSearchRadius = getInt("portal-search-radius", 128);
+@@ -205,4 +205,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
+         portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }
 +
 +    public boolean disableTeleportationSuffocationCheck;

--- a/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 85f8a78c639f2c1aafd956bdb410ad301a9b9f73..9b61407eac986b69c5d752f98ed586107de136c1 100644
+index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb13716669ff64d3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -208,4 +208,9 @@ public class PaperWorldConfig {
+@@ -210,4 +210,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }
@@ -25,7 +25,7 @@ index 85f8a78c639f2c1aafd956bdb410ad301a9b9f73..9b61407eac986b69c5d752f98ed58610
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 716ea2fced5dc9e9a790f25e68252d5bd445b9ce..02ad0b959e636d0f93cfd491b7b549364f92fbb6 100644
+index eb67002cbb9aa9e40702282286fd9d98f3f4440e..0f3f680306af918951321c92332d9ea8833ed4d2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2199,6 +2199,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/Spigot-Server-Patches/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b61407eac986b69c5d752f98ed586107de136c1..5336aa50e83e36ee8acbd7fd02f237ddd12eeac3 100644
+index 3ac2ac3db9b1c271b3c21930bb13716669ff64d3..3c78d3234054ce2dc46ef77decb6adb0cbd10620 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -213,4 +213,19 @@ public class PaperWorldConfig {
+@@ -215,4 +215,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/Spigot-Server-Patches/0069-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/Spigot-Server-Patches/0069-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5336aa50e83e36ee8acbd7fd02f237ddd12eeac3..7ed3bcd7b1ef1a371ad1a4c38f183cef022a5363 100644
+index 3c78d3234054ce2dc46ef77decb6adb0cbd10620..cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -228,4 +228,12 @@ public class PaperWorldConfig {
+@@ -230,4 +230,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/Spigot-Server-Patches/0073-Configurable-Chunk-Inhabited-Time.patch
+++ b/Spigot-Server-Patches/0073-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7ed3bcd7b1ef1a371ad1a4c38f183cef022a5363..4faedee40c731920d6fc0e032df71f8118ba9dbf 100644
+index cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0..74ba5dbb83c13ce1721619b755036a7864a1fb90 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -236,4 +236,14 @@ public class PaperWorldConfig {
+@@ -238,4 +238,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0079-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/Spigot-Server-Patches/0079-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4faedee40c731920d6fc0e032df71f8118ba9dbf..244ee374dc96b715d5d97883d99f53bc7776d6a8 100644
+index 74ba5dbb83c13ce1721619b755036a7864a1fb90..db2dddd12f54e6d15916c4cee623676541de37fb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -246,4 +246,10 @@ public class PaperWorldConfig {
+@@ -248,4 +248,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/Spigot-Server-Patches/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 244ee374dc96b715d5d97883d99f53bc7776d6a8..c3902e090ffa429db48927fbc6a244a110e799f2 100644
+index db2dddd12f54e6d15916c4cee623676541de37fb..1942f5224aaebb18adb591d6f70a419cfc1a7bdd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -252,4 +252,9 @@ public class PaperWorldConfig {
+@@ -254,4 +254,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/Spigot-Server-Patches/0092-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/Spigot-Server-Patches/0092-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c3902e090ffa429db48927fbc6a244a110e799f2..6f84479919aa9470cf700eb866ecb2e3798c17bb 100644
+index 1942f5224aaebb18adb591d6f70a419cfc1a7bdd..5baccb8d50c135ab20c38ffd0690f585514ce5af 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -257,4 +257,14 @@ public class PaperWorldConfig {
+@@ -259,4 +259,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/Spigot-Server-Patches/0095-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0095-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6f84479919aa9470cf700eb866ecb2e3798c17bb..0a5832ab88c2892b9198c2e367899c90a1d81df0 100644
+index 5baccb8d50c135ab20c38ffd0690f585514ce5af..eb04fdb172a50ec1f5b7fe78fa0e7655246abd60 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -267,4 +267,26 @@ public class PaperWorldConfig {
+@@ -269,4 +269,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }
@@ -518,7 +518,7 @@ index 0000000000000000000000000000000000000000..a1923aff2b5e2e867670a5a064a76791
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 1769e9b0f3d358253b6387491589916f7bb219fe..92edb4474167fa95fd36ae9ef86a9eafd29f9b23 100644
+index b56a3b6afbfd901344db8c562e4f0aabb0c0a3f3..3c2aaf4123e11c453741891d1664a6d44c62799c 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -73,6 +73,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0100-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0100-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0a5832ab88c2892b9198c2e367899c90a1d81df0..1f02038ac259529b555672978867128761d1bd39 100644
+index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..6eca3f300020006f02dd36253b522db442e3cc33 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,7 +2,6 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 0a5832ab88c2892b9198c2e367899c90a1d81df0..1f02038ac259529b5556729788671287
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -289,4 +288,14 @@ public class PaperWorldConfig {
+@@ -291,4 +290,14 @@ public class PaperWorldConfig {
              );
          }
      }
@@ -32,10 +32,10 @@ index 0a5832ab88c2892b9198c2e367899c90a1d81df0..1f02038ac259529b5556729788671287
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 92edb4474167fa95fd36ae9ef86a9eafd29f9b23..703267fe8a9b5e9d49d3b2dbe1da93def15d1b54 100644
+index 3c2aaf4123e11c453741891d1664a6d44c62799c..39ff3589582e19108c896220be1917fefd5e80a7 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2675,6 +2675,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2681,6 +2681,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      }
  
      public boolean bV() {

--- a/Spigot-Server-Patches/0114-Option-to-remove-corrupt-tile-entities.patch
+++ b/Spigot-Server-Patches/0114-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1f02038ac259529b555672978867128761d1bd39..33cb25555401203ff0760872e5b5243d508cb003 100644
+index 6eca3f300020006f02dd36253b522db442e3cc33..622affa0dc3cc1eadaed400511f2ca2cde3fca2a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -298,4 +298,9 @@ public class PaperWorldConfig {
+@@ -300,4 +300,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/Spigot-Server-Patches/0116-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/Spigot-Server-Patches/0116-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 33cb25555401203ff0760872e5b5243d508cb003..fe419fdda938d3825394f7c05e91453b518571c7 100644
+index 622affa0dc3cc1eadaed400511f2ca2cde3fca2a..e83216be5a00d5b927d8c2fc364551bd3077c974 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,6 +2,7 @@ package com.destroystokyo.paper;
@@ -16,7 +16,7 @@ index 33cb25555401203ff0760872e5b5243d508cb003..fe419fdda938d3825394f7c05e91453b
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -303,4 +304,12 @@ public class PaperWorldConfig {
+@@ -305,4 +306,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/Spigot-Server-Patches/0126-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0126-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fe419fdda938d3825394f7c05e91453b518571c7..5e1fc401913ecd12d2dc297f8ea388b0afb7dbd6 100644
+index e83216be5a00d5b927d8c2fc364551bd3077c974..2dc58b9f769ea43b737804456aafab47ecc143b8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -312,4 +312,14 @@ public class PaperWorldConfig {
+@@ -314,4 +314,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/Spigot-Server-Patches/0137-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0137-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e1fc401913ecd12d2dc297f8ea388b0afb7dbd6..c9d026c899d008419ec2bb7fab151bad80fcea8b 100644
+index 2dc58b9f769ea43b737804456aafab47ecc143b8..c611b5a63498f5ad1f50a75ccd5d7299e27df7e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -322,4 +322,10 @@ public class PaperWorldConfig {
+@@ -324,4 +324,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }
@@ -27,7 +27,7 @@ index 5e1fc401913ecd12d2dc297f8ea388b0afb7dbd6..c9d026c899d008419ec2bb7fab151bad
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 170dad8be525b40d764b6e63c981f7b73775a01b..97abed1cede09624748e40331a15a021939568be 100644
+index b61307a4a5b8b3bcf5b8d719f20f99cbb1970928..6271133af5425325ddfc3dc127b88b957561d4b1 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -183,6 +183,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0143-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0143-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c9d026c899d008419ec2bb7fab151bad80fcea8b..ca05b130de6b46764bc11e72a6f100bb96758ce1 100644
+index c611b5a63498f5ad1f50a75ccd5d7299e27df7e3..9d1cddc6038f0fd0286e4a32013ae98ff0b00dd1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -328,4 +328,10 @@ public class PaperWorldConfig {
+@@ -330,4 +330,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/Spigot-Server-Patches/0146-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0146-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ca05b130de6b46764bc11e72a6f100bb96758ce1..3d9bedbbcb18ef6b140dd8ad4b53e8ec6385a4fa 100644
+index 9d1cddc6038f0fd0286e4a32013ae98ff0b00dd1..90ca51dfdbb3045dd528450225cba96f5834166e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -334,4 +334,10 @@ public class PaperWorldConfig {
+@@ -336,4 +336,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3d9bedbbcb18ef6b140dd8ad4b53e8ec6385a4fa..6a3955fb0d39d856bd2bc823e38230ad7c471a8a 100644
+index 90ca51dfdbb3045dd528450225cba96f5834166e..6c692e58cde22003ecbf6dc5695799147c39905a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -340,4 +340,10 @@ public class PaperWorldConfig {
+@@ -342,4 +342,10 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/Spigot-Server-Patches/0184-Make-max-squid-spawn-height-configurable.patch
+++ b/Spigot-Server-Patches/0184-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6a3955fb0d39d856bd2bc823e38230ad7c471a8a..72f4ca9f98ca84c9a952ff0949a027fb13ffca3c 100644
+index 6c692e58cde22003ecbf6dc5695799147c39905a..3c39f1bb3d88baaaed4dd43c51faeef89bb5c6c2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -346,4 +346,9 @@ public class PaperWorldConfig {
+@@ -348,4 +348,9 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }

--- a/Spigot-Server-Patches/0207-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0207-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 126fd7cfe50885fb9c3277a69870a9cf5494c326..483dec5004145ca29ea9f971ad527575828031d7 100644
+index 48f0385c7203c7955de5a015f3dc42be2ab7b681..cebf1a623a9bec72d60fdd23dda01868ef6431d4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -356,4 +356,9 @@ public class PaperWorldConfig {
+@@ -358,4 +358,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }

--- a/Spigot-Server-Patches/0211-Block-Enderpearl-Travel-Exploit.patch
+++ b/Spigot-Server-Patches/0211-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 483dec5004145ca29ea9f971ad527575828031d7..f89f9072e54ba3feb84c3d29335b534484411a4f 100644
+index cebf1a623a9bec72d60fdd23dda01868ef6431d4..e8e1e7dafaf1c105b2f58cf3e118e3d665dc50ec 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -361,4 +361,10 @@ public class PaperWorldConfig {
+@@ -363,4 +363,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/Spigot-Server-Patches/0224-Make-shield-blocking-delay-configurable.patch
+++ b/Spigot-Server-Patches/0224-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f89f9072e54ba3feb84c3d29335b534484411a4f..7874f2f10a78f8356dd1ed6604cb1fa0f813b4d1 100644
+index e8e1e7dafaf1c105b2f58cf3e118e3d665dc50ec..3e4bd1d6718d3ad2498fe9bd72eaac45044ecb77 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -367,4 +367,9 @@ public class PaperWorldConfig {
+@@ -369,4 +369,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/Spigot-Server-Patches/0231-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/Spigot-Server-Patches/0231-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7874f2f10a78f8356dd1ed6604cb1fa0f813b4d1..f9fac60c88847ff0aba9863d4c7857c6758303ba 100644
+index 3e4bd1d6718d3ad2498fe9bd72eaac45044ecb77..4813f62d1e382d5ac6971b2244df3f13c80d1950 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -372,4 +372,9 @@ public class PaperWorldConfig {
+@@ -374,4 +374,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/Spigot-Server-Patches/0246-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/Spigot-Server-Patches/0246-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f9fac60c88847ff0aba9863d4c7857c6758303ba..5059b808804ee50ffa6c0cce175f737a7e4e2a50 100644
+index 4813f62d1e382d5ac6971b2244df3f13c80d1950..3562950df4868b1393790b1a1ff1fe0dc589c155 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -377,4 +377,9 @@ public class PaperWorldConfig {
+@@ -379,4 +379,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/Spigot-Server-Patches/0266-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0266-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5059b808804ee50ffa6c0cce175f737a7e4e2a50..e6894d2659ad400d333c72a0b736f02ab103264c 100644
+index 3562950df4868b1393790b1a1ff1fe0dc589c155..5ab0e7183e48134b7a0f736462516b1a8a333b04 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -382,4 +382,10 @@ public class PaperWorldConfig {
+@@ -384,4 +384,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/Spigot-Server-Patches/0270-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/Spigot-Server-Patches/0270-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e6894d2659ad400d333c72a0b736f02ab103264c..bdc8e4e30611dbe45f7a6a92de6508de5270821d 100644
+index 5ab0e7183e48134b7a0f736462516b1a8a333b04..f280dbff4a09bc611a9ca565c6d697d08801f53b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -388,4 +388,10 @@ public class PaperWorldConfig {
+@@ -390,4 +390,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bdc8e4e30611dbe45f7a6a92de6508de5270821d..480f3d69a5b599e822cc7acc171da2b816797f96 100644
+index f280dbff4a09bc611a9ca565c6d697d08801f53b..fbf3ccfb347a5ba6e895339e9576629d940d1aa4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -394,4 +394,9 @@ public class PaperWorldConfig {
+@@ -396,4 +396,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 480f3d69a5b599e822cc7acc171da2b816797f96..160de2b79219f526187ffeb9e49c565639612e90 100644
+index fbf3ccfb347a5ba6e895339e9576629d940d1aa4..38d25a12c6a52d8a83214e2a0f43a218cf15ceac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -399,4 +399,43 @@ public class PaperWorldConfig {
+@@ -401,4 +401,43 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
@@ -93,10 +93,10 @@ index e0f1eb19ea1ceebe00a428c753fec13d317869dd..fdd754a06fc6566b448d9847e210e7cd
  
          int k = MathHelper.floor(entity.locY() / 16.0D);
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 073660a67ece962981b388a8b0f5402ce2a430c6..ba18da7b9d069b1d553c2ae8838296351e3358aa 100644
+index 0d7f1a3f3861347479c90c8901b81429bf8629b2..53868afe6b8f7161a2fe30c23195e37cf00193a3 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2705,6 +2705,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2711,6 +2711,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          });
      }
  

--- a/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 160de2b79219f526187ffeb9e49c565639612e90..a4fb3961c69afaefe907860977c0c512301344e3 100644
+index 38d25a12c6a52d8a83214e2a0f43a218cf15ceac..ffe9b1a63d78925e1d77b9e730aef42fed6d58fa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -438,4 +438,10 @@ public class PaperWorldConfig {
+@@ -440,4 +440,10 @@ public class PaperWorldConfig {
                  break;
          }
      }

--- a/Spigot-Server-Patches/0361-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0361-incremental-chunk-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a4fb3961c69afaefe907860977c0c512301344e3..7313916909c50fe6d97776c236c533a6bf0eb122 100644
+index ffe9b1a63d78925e1d77b9e730aef42fed6d58fa..1278d09f70c1e97607ef20d87a178dc252c7f723 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -444,4 +444,19 @@ public class PaperWorldConfig {
+@@ -446,4 +446,19 @@ public class PaperWorldConfig {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }

--- a/Spigot-Server-Patches/0362-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0362-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7313916909c50fe6d97776c236c533a6bf0eb122..b10910beaff893bc722c83f472da847a0eab2a04 100644
+index 1278d09f70c1e97607ef20d87a178dc252c7f723..c45493e88bf7e8811be2759ff9ac19e3fe9d938a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index 7313916909c50fe6d97776c236c533a6bf0eb122..b10910beaff893bc722c83f472da847a
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -459,4 +461,38 @@ public class PaperWorldConfig {
+@@ -461,4 +463,38 @@ public class PaperWorldConfig {
      private void maxAutoSaveChunksPerTick() {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }

--- a/Spigot-Server-Patches/0363-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/Spigot-Server-Patches/0363-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b10910beaff893bc722c83f472da847a0eab2a04..55915bca7e97ff224ad246c153fad2ac37f48a24 100644
+index c45493e88bf7e8811be2759ff9ac19e3fe9d938a..384cb363eed794551bee6b0ec11ba1be92a3d7ac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -462,6 +462,16 @@ public class PaperWorldConfig {
+@@ -464,6 +464,16 @@ public class PaperWorldConfig {
          maxAutoSaveChunksPerTick = getInt("max-auto-save-chunks-per-tick", 24);
      }
  

--- a/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
+++ b/Spigot-Server-Patches/0364-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 55915bca7e97ff224ad246c153fad2ac37f48a24..d092a85f0839019139238acd0d86d84ab9567648 100644
+index 384cb363eed794551bee6b0ec11ba1be92a3d7ac..1ee2cced100626e48eb36ee14f84b9257c79a2f8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -505,4 +505,9 @@ public class PaperWorldConfig {
+@@ -507,4 +507,9 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }

--- a/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0371-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d092a85f0839019139238acd0d86d84ab9567648..e582f1555ca28a2d0a345bc39955ea43d0239f41 100644
+index 1ee2cced100626e48eb36ee14f84b9257c79a2f8..b913cd2dd0cd1b369b3f7b5a9d8b1be73f6d7920 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,10 +1,15 @@
@@ -24,7 +24,7 @@ index d092a85f0839019139238acd0d86d84ab9567648..e582f1555ca28a2d0a345bc39955ea43
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -510,4 +515,52 @@ public class PaperWorldConfig {
+@@ -512,4 +517,52 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index a27dc38d1a29ed1d63d2f44b7984c2b65be487d9..96aaaab5b7685c874463505f9d25e8a0
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e582f1555ca28a2d0a345bc39955ea43d0239f41..023050bee5ec88223d54dcba4d88f0ef4529c903 100644
+index b913cd2dd0cd1b369b3f7b5a9d8b1be73f6d7920..6aec502eb529d4090306e12e837117cde7e114eb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -563,4 +563,9 @@ public class PaperWorldConfig {
+@@ -565,4 +565,9 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/Spigot-Server-Patches/0377-Generator-Settings.patch
+++ b/Spigot-Server-Patches/0377-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 023050bee5ec88223d54dcba4d88f0ef4529c903..73f8954105cbf992d45fce089d990989969edabc 100644
+index 6aec502eb529d4090306e12e837117cde7e114eb..290e49cf0077909ad7ab8127c01ef93cf7b70b51 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -568,4 +568,9 @@ public class PaperWorldConfig {
+@@ -570,4 +570,9 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
+++ b/Spigot-Server-Patches/0383-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 73f8954105cbf992d45fce089d990989969edabc..cdfae2a4d89bdc528933734f56a922181559eace 100644
+index 290e49cf0077909ad7ab8127c01ef93cf7b70b51..e726b6213cf2e8f5b326f05c0438b8f1ee2b73c5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -573,4 +573,9 @@ public class PaperWorldConfig {
+@@ -575,4 +575,9 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/Spigot-Server-Patches/0388-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cdfae2a4d89bdc528933734f56a922181559eace..98858653a06c25c2bdb43b86c4115f050bdebf75 100644
+index e726b6213cf2e8f5b326f05c0438b8f1ee2b73c5..edda2121f8c1046478beaa77030ebb36d403b334 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -578,4 +578,9 @@ public class PaperWorldConfig {
+@@ -580,4 +580,9 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 98858653a06c25c2bdb43b86c4115f050bdebf75..0cae631634823c4e062cba5e98c0d7cb580c678c 100644
+index edda2121f8c1046478beaa77030ebb36d403b334..7fbd501d70dccf869a4454e2789a5d68f2e15754 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -583,4 +583,13 @@ public class PaperWorldConfig {
+@@ -585,4 +585,13 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/Spigot-Server-Patches/0401-Entity-Activation-Range-2.0.patch
+++ b/Spigot-Server-Patches/0401-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index ba18da7b9d069b1d553c2ae8838296351e3358aa..1fa7b82685a5e55d57d78abd5151f20e20178646 100644
+index 53868afe6b8f7161a2fe30c23195e37cf00193a3..2b0b8d975504850894cd25dc907eb522b4e9830f 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -163,7 +163,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -64,7 +64,7 @@ index ba18da7b9d069b1d553c2ae8838296351e3358aa..1fa7b82685a5e55d57d78abd5151f20e
      public void k(Entity entity) {
          this.a(entity, Entity::setPosition);
      }
-@@ -2723,6 +2733,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2729,6 +2739,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return this.ae;
      }
  
@@ -118,7 +118,7 @@ index d91503b3e46c6ded3d77da4feeb8350df5bf924c..dcc5b098bfe36ef7ee8536b3da65c4ce
          if (this.isPassenger() && this.getVehicle() instanceof EntityInsentient) {
              EntityInsentient entityinsentient = (EntityInsentient) this.getVehicle();
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index e86500d789a713d763c64448cfa7141a15d6b4bd..4cf740c3661aea67f12afeb564cb84db626ffa81 100644
+index 5efb7b990acc92801ee32a0a462f92f7c08ee2b1..3c16a28a8f2113ed6cf54c06421bde7b7dcf50c1 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -98,7 +98,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0402-Fix-items-vanishing-through-end-portal.patch
+++ b/Spigot-Server-Patches/0402-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 1fa7b82685a5e55d57d78abd5151f20e20178646..240675705fe52af6326b78ce0e3bf8ec0e8b50e1 100644
+index 2b0b8d975504850894cd25dc907eb522b4e9830f..c7d8dcb1d0678f7ea75f7447ba94a7af9cb8ec31 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -2635,6 +2635,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2641,6 +2641,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
              BlockPosition blockposition1;
  
              if (flag1) {

--- a/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0409-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0cae631634823c4e062cba5e98c0d7cb580c678c..a5b04bd80be0e1d2c474c5d298e56a09a3ab5b9d 100644
+index 7fbd501d70dccf869a4454e2789a5d68f2e15754..9e4591ddc4b755f4ff5a6f1078b51cb13db80480 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -592,4 +592,9 @@ public class PaperWorldConfig {
+@@ -594,4 +594,9 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
@@ -32,7 +32,7 @@ index a224a04ee1bb9705166913ef1c66aa031d87c270..4132cd4c6f13cfa1c0cda43daaa908ff
              }
          }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 240675705fe52af6326b78ce0e3bf8ec0e8b50e1..d728a3aae38c083fe8dfa28a8b8460545e99bcb9 100644
+index c7d8dcb1d0678f7ea75f7447ba94a7af9cb8ec31..e84dd63b26ebd9aa15e431e515ced5b6669455e2 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -189,6 +189,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0414-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/Spigot-Server-Patches/0414-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a5b04bd80be0e1d2c474c5d298e56a09a3ab5b9d..e37bad43c555531597eb9dae9879f5f8ee130847 100644
+index 9e4591ddc4b755f4ff5a6f1078b51cb13db80480..fe1c9dd8258ec8c3fdf343d4a44de2be2ae3d35f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -385,6 +385,11 @@ public class PaperWorldConfig {
+@@ -387,6 +387,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0415-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e37bad43c555531597eb9dae9879f5f8ee130847..a2009457089b0febc41b29f19708503197a1cd4e 100644
+index fe1c9dd8258ec8c3fdf343d4a44de2be2ae3d35f..525d702d78a609af987ebd2c32169b873e5c05ed 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -602,4 +602,9 @@ public class PaperWorldConfig {
+@@ -604,4 +604,9 @@ public class PaperWorldConfig {
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }

--- a/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a2009457089b0febc41b29f19708503197a1cd4e..7b35cbbf11d1b5ad746d184a4bd1eb74b1bdd245 100644
+index 525d702d78a609af987ebd2c32169b873e5c05ed..6c8e9d498c9a30a1aa88494ba09c3cae012a8fa1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -580,10 +580,21 @@ public class PaperWorldConfig {
+@@ -582,10 +582,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7b35cbbf11d1b5ad746d184a4bd1eb74b1bdd245..0dba910bbe6bd9f46b255a60070fd2a6668108bf 100644
+index 6c8e9d498c9a30a1aa88494ba09c3cae012a8fa1..cd248eb6be663e8be33f2c3c6b06b77b6d5753a4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -618,4 +618,9 @@ public class PaperWorldConfig {
+@@ -620,4 +620,9 @@ public class PaperWorldConfig {
      private void zombieVillagerInfectionChance() {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }

--- a/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
+++ b/Spigot-Server-Patches/0457-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0dba910bbe6bd9f46b255a60070fd2a6668108bf..670737120d1b2f82a1f73e6ad1b1fda3b121d9a9 100644
+index cd248eb6be663e8be33f2c3c6b06b77b6d5753a4..46ac6d91422423f1e03b86d3efa3241f2599000d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -623,4 +623,11 @@ public class PaperWorldConfig {
+@@ -625,4 +625,11 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/Spigot-Server-Patches/0458-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0458-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 5bec3b9692f64a792e26f89b4147644eaaf4ab11..0c0d2a1c120a4c091cb24ccaf3fa6756044fac79 100644
+index 0f9a67d584157a6605b289cf5a6bccb854ed9292..2361c2d40f3f53d26c398676b0a1b6ec832f29fc 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1880,11 +1880,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -70,7 +70,7 @@ index 5bec3b9692f64a792e26f89b4147644eaaf4ab11..0c0d2a1c120a4c091cb24ccaf3fa6756
                      // CraftBukkit end
                  }
  
-@@ -2687,7 +2695,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2693,7 +2701,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      }
  
      public boolean canPortal() {

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index c9164dfdb27ddf3709129c8aec54903a1df121ff..e33e889c291d37a821a4fbd40d9aac7b
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 670737120d1b2f82a1f73e6ad1b1fda3b121d9a9..d7fcf451e22215f1bfe5cfec456c890ede0d5a08 100644
+index 46ac6d91422423f1e03b86d3efa3241f2599000d..6463d3e4837d032a35654a035f42b8a805e0e286 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -630,4 +630,9 @@ public class PaperWorldConfig {
+@@ -632,4 +632,9 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/Spigot-Server-Patches/0494-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d7fcf451e22215f1bfe5cfec456c890ede0d5a08..b4dc487fd27a560a5c02f3bd64100b637ffaff35 100644
+index 6463d3e4837d032a35654a035f42b8a805e0e286..1655bca0502e7b871de4addaa163536d86547a02 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -635,4 +635,13 @@ public class PaperWorldConfig {
+@@ -637,4 +637,13 @@ public class PaperWorldConfig {
      private void viewDistance() {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }

--- a/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
+++ b/Spigot-Server-Patches/0506-Limit-lightning-strike-effect-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit lightning strike effect distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b4dc487fd27a560a5c02f3bd64100b637ffaff35..300d43fa45580f9a692cf72c14e12c51d4ed3a8b 100644
+index 1655bca0502e7b871de4addaa163536d86547a02..978062774c1db286bfb9b0ffdef19d880b1f249b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -644,4 +644,26 @@ public class PaperWorldConfig {
+@@ -646,4 +646,26 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/Spigot-Server-Patches/0508-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/Spigot-Server-Patches/0508-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 50f53c764b9b4934093b08418b92be5b02162588..dce88b30fc5b401266ee6395c6540ac404528ba9 100644
+index 48373bf947fc19a34caa34daeed980cc433bc600..896832d4742969e6cc2f58bbba281b4a60ef28b0 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -389,7 +389,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -17,7 +17,7 @@ index 50f53c764b9b4934093b08418b92be5b02162588..dce88b30fc5b401266ee6395c6540ac4
          if (valid) ((WorldServer) world).chunkCheck(this); // CraftBukkit
      }
  
-@@ -2898,6 +2898,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -2904,6 +2904,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
          return new AxisAlignedBB(vec3d, vec3d1);
      }
  
@@ -25,7 +25,7 @@ index 50f53c764b9b4934093b08418b92be5b02162588..dce88b30fc5b401266ee6395c6540ac4
      public void a(AxisAlignedBB axisalignedbb) {
          // CraftBukkit start - block invalid bounding boxes
          double minX = axisalignedbb.minX,
-@@ -3336,6 +3337,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3342,6 +3343,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      }
  
      public void setPositionRaw(double d0, double d1, double d2) {

--- a/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 300d43fa45580f9a692cf72c14e12c51d4ed3a8b..330f7325031846d2fc41415d5595526ad58a5db5 100644
+index 978062774c1db286bfb9b0ffdef19d880b1f249b..36ecdfce84141ac731b827e469ac842f5c666259 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -666,4 +666,9 @@ public class PaperWorldConfig {
+@@ -668,4 +668,9 @@ public class PaperWorldConfig {
              maxLightningFlashDistance = 512; // Vanilla value
          }
      }

--- a/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
+++ b/Spigot-Server-Patches/0561-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 330f7325031846d2fc41415d5595526ad58a5db5..48a2c6b4865f21df9c3cd79a91a3564361272e66 100644
+index 36ecdfce84141ac731b827e469ac842f5c666259..02bb85364560784adea47c877c13291c3d016b86 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -671,4 +671,14 @@ public class PaperWorldConfig {
+@@ -673,4 +673,14 @@ public class PaperWorldConfig {
      private void zombiesTargetTurtleEggs() {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }

--- a/Spigot-Server-Patches/0574-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-Server-Patches/0574-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index d1f09f413937bb6fa132ae707d461bf0139c26a9..f045cdacf2e7cd0e3e8cdaf2761cbfe0fec636a0 100644
+index 857c6699a8d582a56506b9083089e77faad6b492..0a47fb31922662d35306d0759e69799ceeca12c7 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -3376,4 +3376,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3382,4 +3382,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
  
          void accept(Entity entity, double d0, double d1, double d2);
      }

--- a/Spigot-Server-Patches/0576-Entity-isTicking.patch
+++ b/Spigot-Server-Patches/0576-Entity-isTicking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index f045cdacf2e7cd0e3e8cdaf2761cbfe0fec636a0..ec3c6b20c87d253d07f70e8a8b9b909df3683b36 100644
+index 0a47fb31922662d35306d0759e69799ceeca12c7..81ff0fd4587d0220f49573c393c8412e2b55d115 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -3381,5 +3381,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3387,5 +3387,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      public static int nextEntityId() {
          return entityCount.incrementAndGet();
      }

--- a/Spigot-Server-Patches/0579-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0579-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CME on adding a passenger in CreatureSpawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index ec3c6b20c87d253d07f70e8a8b9b909df3683b36..3309a3ea9dc895bc910238e10d993ff5f66d4240 100644
+index 81ff0fd4587d0220f49573c393c8412e2b55d115..50669b68ae130ec43ea52d2e62d55d633eecb042 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
-@@ -3079,7 +3079,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+@@ -3085,7 +3085,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
      }
  
      public Stream<Entity> cp() {

--- a/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
+++ b/Spigot-Server-Patches/0594-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 48a2c6b4865f21df9c3cd79a91a3564361272e66..18781133bfbe5d3aa12ba54a9c7826a8bc7cd0ac 100644
+index 02bb85364560784adea47c877c13291c3d016b86..424754a0183b071d20c86f0420cec784a8992e2b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -681,4 +681,12 @@ public class PaperWorldConfig {
+@@ -683,4 +683,12 @@ public class PaperWorldConfig {
              log("Using vanilla redstone algorithm.");
          }
      }

--- a/Spigot-Server-Patches/0599-Seed-based-feature-search.patch
+++ b/Spigot-Server-Patches/0599-Seed-based-feature-search.patch
@@ -16,10 +16,10 @@ changes but this should usually not happen. A config option to disable
 this improvement is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 18781133bfbe5d3aa12ba54a9c7826a8bc7cd0ac..35387d1154dd10a83ad0c66bb749523fb4333edc 100644
+index 424754a0183b071d20c86f0420cec784a8992e2b..a98e25917193043633e2120beb4fe2d49d0e4500 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -335,6 +335,12 @@ public class PaperWorldConfig {
+@@ -337,6 +337,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/Spigot-Server-Patches/0600-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 35387d1154dd10a83ad0c66bb749523fb4333edc..a1adbe298b948016fb1c2e25945676e7d1e7880c 100644
+index a98e25917193043633e2120beb4fe2d49d0e4500..b4d76494851601d61a69e2f060727a68f4461267 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -695,4 +695,17 @@ public class PaperWorldConfig {
+@@ -697,4 +697,17 @@ public class PaperWorldConfig {
              log("The Ender Dragon will be removed if she already exists without a portal.");
          }
      }

--- a/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a1adbe298b948016fb1c2e25945676e7d1e7880c..771e4e76e88156e255a6125f56e3cae297bbea6c 100644
+index b4d76494851601d61a69e2f060727a68f4461267..6262246c4018c660705fbad028f297fc44e7197f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -708,4 +708,9 @@ public class PaperWorldConfig {
+@@ -710,4 +710,9 @@ public class PaperWorldConfig {
          wanderingTraderSpawnChanceMin = getInt("wandering-trader.spawn-chance-min", wanderingTraderSpawnChanceMin);
          wanderingTraderSpawnChanceMax = getInt("wandering-trader.spawn-chance-max", wanderingTraderSpawnChanceMax);
      }
@@ -19,7 +19,7 @@ index a1adbe298b948016fb1c2e25945676e7d1e7880c..771e4e76e88156e255a6125f56e3cae2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 3309a3ea9dc895bc910238e10d993ff5f66d4240..d9021fde3d0908dc89384617055874ac356a8fcf 100644
+index 50669b68ae130ec43ea52d2e62d55d633eecb042..36fbe16e6f06fca3eb282cce5b8c5fcc87a0166d 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1483,6 +1483,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
@@ -8,10 +8,10 @@ and curing a villager on repeat by simply resetting the reputation when it
 is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 771e4e76e88156e255a6125f56e3cae297bbea6c..f2e09eef7b0b9edd7db890aef608f1788a312e10 100644
+index 6262246c4018c660705fbad028f297fc44e7197f..9ebe8771c2d5e843756868824740ef599ca8455f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -713,4 +713,9 @@ public class PaperWorldConfig {
+@@ -715,4 +715,9 @@ public class PaperWorldConfig {
      private void fixClimbingBypassingCrammingRule() {
          fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
      }

--- a/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/Spigot-Server-Patches/0631-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f2e09eef7b0b9edd7db890aef608f1788a312e10..df8a43cd7a561bc5471d9b2f300c7ca4c06e2c9c 100644
+index 9ebe8771c2d5e843756868824740ef599ca8455f..a555d040fdc58f7c89ef78e3e6851916fdd8462a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -718,4 +718,9 @@ public class PaperWorldConfig {
+@@ -720,4 +720,9 @@ public class PaperWorldConfig {
      private void fixCuringExploit() {
          fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
      }

--- a/Spigot-Server-Patches/0640-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/Spigot-Server-Patches/0640-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index df8a43cd7a561bc5471d9b2f300c7ca4c06e2c9c..80409c4b52a4bb7146760070dae0e04d49bdd6b3 100644
+index a555d040fdc58f7c89ef78e3e6851916fdd8462a..c42e5d9f9c9f67988383c4c25123d8a629ede9e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -359,6 +359,14 @@ public class PaperWorldConfig {
+@@ -361,6 +361,14 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  

--- a/Spigot-Server-Patches/0645-Configurable-door-breaking-difficulty.patch
+++ b/Spigot-Server-Patches/0645-Configurable-door-breaking-difficulty.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable door breaking difficulty
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 80409c4b52a4bb7146760070dae0e04d49bdd6b3..c46d5d6aa8246f0cecacba288ab3f51a41e112c8 100644
+index c42e5d9f9c9f67988383c4c25123d8a629ede9e3..c5495e02c3fe271b26f62ea2ec64e07957edf37e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -5,8 +5,12 @@ import java.util.EnumMap;
@@ -33,7 +33,7 @@ index 80409c4b52a4bb7146760070dae0e04d49bdd6b3..c46d5d6aa8246f0cecacba288ab3f51a
      public int cactusMaxHeight;
      public int reedMaxHeight;
      public int bambooMaxHeight;
-@@ -731,4 +740,23 @@ public class PaperWorldConfig {
+@@ -733,4 +742,23 @@ public class PaperWorldConfig {
      private void disableMobSpawnerSpawnEggTransformation() {
          disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
      }


### PR DESCRIPTION
Creating this PR for discussion;

Currently, the configuration does not take into account the fact that the nether portals search radius is nerf'd by /8 when heading into the nether, this causes issues between vanilla as our code does not take into account for this, and users without knowing would need to create settings for the nether to fix this behavior

the alternative is that we hard-apply this operation in the nether, which creates its own caveats such as hidden manipulation to the config, and issues with already created portals, this PR allows people to determine if they'd prefer the existing (broken by default) behavior in order to keep players happy or allow their config changes to apply as-is, etc; This is the only real "clean" way that I could see to do this without having to go into the art of trying to define custom configs for worlds

(I can totes spell stuff properly)