### PR TITLE
[CI-SKIP] fixed sed -i for bsd sed

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -11,6 +11,18 @@ nms="$spigotdecompiledir/net/minecraft/server"
 cb="src/main/java/net/minecraft/server"
 gitcmd="git -c commit.gpgsign=false"
 
+# https://stackoverflow.com/a/38595160
+# https://stackoverflow.com/a/800644
+if sed --version >/dev/null 2>&1; then
+  strip_cr() {
+    sed -i -- "s/\r//" "$@"
+  }
+else
+  strip_cr () {
+    sed -i "" "s/$(printf '\r')//" "$@"
+  }
+fi
+
 patch=$(which patch 2>/dev/null)
 if [ "x$patch" == "x" ]; then
     patch="$basedir/hctap.exe"
@@ -53,7 +65,7 @@ do
 
     echo "Patching $file < $patchFile"
     set +e
-    sed -i 's/\r//' "$nms/$file" > /dev/null
+    strip_cr "$nms/$file" > /dev/null
     set -e
 
     "$patch" -s -d src/main/java/ "net/minecraft/server/$file" < "$patchFile"


### PR DESCRIPTION
When running `./paper patch` on my mac, I noticed in the init.sh script that I was getting an error during replacement of the `\r` character. But I found a fix in the CraftBukkit scripts so I just moved that over to the init.sh script. 


EDIT: just to note, I tested it on my mac, as well as my linux machine and it works fine for both those now. no errors