### PR TITLE
Add toggle for saving projectiles in chunks

### DIFF
--- a/Spigot-Server-Patches/0600-Add-toggle-for-saving-projectiles-in-chunks.patch
+++ b/Spigot-Server-Patches/0600-Add-toggle-for-saving-projectiles-in-chunks.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Wed, 18 Nov 2020 23:51:38 +0000
+Subject: [PATCH] Add toggle for saving projectiles in chunks
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index ff0e4447b6574e91bf8815de4e04ce881ed7026d..09a03d6a19b1bcf09a2eca81c68cac7fb1423c9b 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -686,4 +686,9 @@ public class PaperWorldConfig {
+             log("The Ender Dragon will be removed if she already exists without a portal.");
+         }
+     }
++    
++    public boolean saveProjectilesInChunks = true;
++    private void saveProjectilesInChunks() {
++        saveProjectilesInChunks = getBoolean("save-projectiles-in-chunks", saveProjectilesInChunks);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+index 8e7da2c5f3852920ec5fbcdd2bff4d299e6aa499..539883ca5304b78fb3c4560635527ed6067f7a0a 100644
+--- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
++++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
+@@ -509,6 +509,9 @@ public class ChunkRegionLoader {
+                     if (entity.dead || hasPlayerPassenger(entity)) {
+                         continue;
+                     }
++                    if (entity instanceof IProjectile && !worldserver.paperConfig.saveProjectilesInChunks) {
++                        continue; // Paper - Toggle save projectiles in chunks
++                    }
+                     // Paper end
+                     if (entity.d(nbttagcompound4)) {
+                         chunk.d(true);


### PR DESCRIPTION
Adds a toggle for saving projectiles in chunks, useless for lobbies, spit/arrow/firework etc crashes.

Fixes #2659 
Can fix [MC-125757](https://bugs.mojang.com/browse/MC-125757)