### PR TITLE
Fix console spam when removing chests in water

### DIFF
--- a/Spigot-Server-Patches/0660-Fix-console-spam-when-removing-chests-in-water.patch
+++ b/Spigot-Server-Patches/0660-Fix-console-spam-when-removing-chests-in-water.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Thu, 19 Nov 2020 02:07:10 +0000
+Subject: [PATCH] Fix console spam when removing chests in water
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockChest.java b/src/main/java/net/minecraft/server/BlockChest.java
+index 12a0230448dd8d56f6dc20e23cacaf0b8a9433d1..c4ff93a6b908c1bd157c7fe45b504909b189d09c 100644
+--- a/src/main/java/net/minecraft/server/BlockChest.java
++++ b/src/main/java/net/minecraft/server/BlockChest.java
+@@ -195,7 +195,7 @@ public class BlockChest extends BlockChestAbstract<TileEntityChest> implements I
+     @Override
+     public void remove(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) {
+         if (!iblockdata.a(iblockdata1.getBlock())) {
+-            TileEntity tileentity = world.getTileEntity(blockposition);
++            TileEntity tileentity = world.getTileEntity(blockposition, false); // Paper - Don't validate TE - Fix console spam when removing chests in water
+ 
+             if (tileentity instanceof IInventory) {
+                 InventoryUtils.dropInventory(world, blockposition, (IInventory) tileentity);


### PR DESCRIPTION
Fixes this annoying thing ***every time*** a player destroys a chest in water.

> [21:19:09 ERROR]: Block at 10, 62, -195 is Block{minecraft:water} but has net.minecraft.server.v1_16_R3.TileEntityChest@4db2bcbf. Bukkit will attempt to fix this, but there may be additional damage that we cannot recover.

Fixes #3318 
Fixes #4729 