### PR TITLE
Add config option to disable server gui

### DIFF
--- a/Spigot-Server-Patches/0704-Add-config-option-to-disable-server-gui.patch
+++ b/Spigot-Server-Patches/0704-Add-config-option-to-disable-server-gui.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Sat, 21 Nov 2020 00:41:55 -0800
+Subject: [PATCH] Add config option to disable server gui
+
+Adds a config option to disable the server gui, whether or not the nogui
+flag is passed at startup.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index efc1e42d606e1c9feb1a4871c0714933ae92a1b2..be9dc0b331c48fe77914efb956fc28188e18066d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -475,6 +475,11 @@ public class PaperConfig {
+         trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
+     }
+ 
++    public static final String DISABLE_SERVER_GUI_PATH = "settings.disable-server-gui";
++    private static void disableServerGui() {
++        getBoolean(DISABLE_SERVER_GUI_PATH, false);
++    }
++
+     public static boolean fixEntityPositionDesync = true;
+     private static void fixEntityPositionDesync() {
+         fixEntityPositionDesync = getBoolean("settings.fix-entity-position-desync", fixEntityPositionDesync);
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index 6818f8496ab76ee6ffc747bd6848b43830ec8914..c8933d520a4e4b2ceefd9c7bf5e05642e5ed6e01 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -234,6 +234,7 @@ public class Main {
+                 boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
+ 
+                 if (flag1 && !GraphicsEnvironment.isHeadless()) {
++                    if (!paperConfiguration.getBoolean(com.destroystokyo.paper.PaperConfig.DISABLE_SERVER_GUI_PATH, false)) // Paper
+                     dedicatedserver1.bd();
+                 }
+ 


### PR DESCRIPTION
Adds a config option to disable the server gui, whether or not the `nogui` flag is passed at startup.

cc @JRoy 