### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/Spigot-API-Patches/0050-Fix-upstream-javadoc-warnings-and-errors.patch
+++ b/Spigot-API-Patches/0050-Fix-upstream-javadoc-warnings-and-errors.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadoc warnings and errors
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2606c80b8 100644
+index 87434ba914a6cda46dd8d81e555762d8bb40d173..acbd07d1b51eec6806283d99248cfa7b62893caf 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2087,6 +2087,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2124,6 +2124,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param count the number of particles
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -17,7 +17,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, @Nullable T data);
  
-@@ -2103,6 +2104,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2140,6 +2141,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param count the number of particles
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -25,7 +25,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, double x, double y, double z, int count, @Nullable T data);
  
-@@ -2153,6 +2155,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2190,6 +2192,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param offsetZ the maximum random offset on the Z axis
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -33,7 +33,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, double offsetX, double offsetY, double offsetZ, @Nullable T data);
  
-@@ -2173,6 +2176,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2210,6 +2213,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param offsetZ the maximum random offset on the Z axis
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -41,7 +41,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, @Nullable T data);
  
-@@ -2229,6 +2233,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2266,6 +2270,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       *              particle used (normally speed)
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -49,7 +49,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, double offsetX, double offsetY, double offsetZ, double extra, @Nullable T data);
  
-@@ -2251,6 +2256,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2288,6 +2293,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       *              particle used (normally speed)
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
@@ -57,7 +57,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, @Nullable T data);
  
-@@ -2274,6 +2280,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2311,6 +2317,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param force whether to send the particle to players within an extended
       *              range and encourage their client to render it regardless of
       *              settings
@@ -65,7 +65,7 @@ index fefbe857676bdab750379a9d6c120099817a83e8..833f4cb13e9d3d1d0daa1ac1202a70e2
       */
      public <T> void spawnParticle(@NotNull Particle particle, @NotNull Location location, int count, double offsetX, double offsetY, double offsetZ, double extra, @Nullable T data, boolean force);
  
-@@ -2299,6 +2306,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2336,6 +2343,7 @@ public interface World extends PluginMessageRecipient, Metadatable {
       * @param force whether to send the particle to players within an extended
       *              range and encourage their client to render it regardless of
       *              settings

--- a/Spigot-API-Patches/0096-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-API-Patches/0096-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -515,10 +515,10 @@ index b32de827cf8d1780861c271b4215276fdaab7165..1020002ff7127877db2d7e096f2c5217
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index f36360e9dbfa6daa3450c275764ea1e90e446da6..068eb8dbd31b3456a8ce48e045d98a4d291eba27 100644
+index fd4786fd4f6086c0baf86fcb0507bb5f56bc40f1..89bffbb6d2fe6448a72ff6308b70e6a95a6919ab 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2511,7 +2511,57 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2548,7 +2548,57 @@ public interface World extends PluginMessageRecipient, Metadatable {
       *             the type of this depends on {@link Particle#getDataType()}
       * @param <T> Type
       */

--- a/Spigot-API-Patches/0111-Expand-Explosions-API.patch
+++ b/Spigot-API-Patches/0111-Expand-Explosions-API.patch
@@ -106,10 +106,10 @@ index 4cf22afc3c1f1cc19b6e5350043431215908a612..af2ee43f2c5133668c18710f526a107d
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 068eb8dbd31b3456a8ce48e045d98a4d291eba27..1f02f9a96eac55e14383a8a381be6473c014442f 100644
+index 89bffbb6d2fe6448a72ff6308b70e6a95a6919ab..a076279b6cee7475cbbecda5d2565e427883d264 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1364,6 +1364,88 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -1401,6 +1401,88 @@ public interface World extends PluginMessageRecipient, Metadatable {
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/Spigot-API-Patches/0201-World-view-distance-api.patch
+++ b/Spigot-API-Patches/0201-World-view-distance-api.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] World view distance api
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 85f549c7593c417d280fb31ce5cfdaf89f2f8dd2..677c29d1e4a768c9349368f9ec618bc86d31a439 100644
+index 2c5d5caf4b934f0d5253a6e5c2f182fdc081f048..db69ed0b8e30e89a3587ef285ca7d06f51e8b2f8 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3368,6 +3368,34 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -3405,6 +3405,34 @@ public interface World extends PluginMessageRecipient, Metadatable {
      int getViewDistance();
      // Spigot end
  

--- a/Spigot-API-Patches/0203-Spawn-Reason-API.patch
+++ b/Spigot-API-Patches/0203-Spawn-Reason-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Spawn Reason API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 677c29d1e4a768c9349368f9ec618bc86d31a439..fe7d2e3ee04d0df51bfa1d64e21e6930ccc5e943 100644
+index db69ed0b8e30e89a3587ef285ca7d06f51e8b2f8..703488b1693cae99c8f8a1a7bad34695b6cc51bf 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index 677c29d1e4a768c9349368f9ec618bc86d31a439..fe7d2e3ee04d0df51bfa1d64e21e6930
  import org.bukkit.generator.ChunkGenerator;
  
  import java.util.ArrayList;
-@@ -2171,6 +2173,12 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2208,6 +2210,12 @@ public interface World extends PluginMessageRecipient, Metadatable {
      @NotNull
      public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException;
  
@@ -30,7 +30,7 @@ index 677c29d1e4a768c9349368f9ec618bc86d31a439..fe7d2e3ee04d0df51bfa1d64e21e6930
      /**
       * Spawn an entity of a specific class at the given {@link Location}, with
       * the supplied function run before the entity is added to the world.
-@@ -2188,7 +2196,28 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -2225,7 +2233,28 @@ public interface World extends PluginMessageRecipient, Metadatable {
       *     {@link Entity} requested cannot be spawned
       */
      @NotNull

--- a/Spigot-Server-Patches/0136-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/Spigot-Server-Patches/0136-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -278,10 +278,10 @@ index a3ddf7be4c7ea588098381b8f05b2bad5b388853..99b20fa5feff0f766124d4ec9474852e
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 948639d629d0126c914b1b4d20f7dfaa6137e63e..be55c6c63607f14d457b24b381fcf213d36f6f33 100644
+index 54a2324ac61dc0d70155dfc085dcc518a946138a..7b8440c58471315d7b8af786ba8daddc1625865f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1805,7 +1805,7 @@ public class CraftWorld implements World {
+@@ -1822,7 +1822,7 @@ public class CraftWorld implements World {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new EntityTNTPrimed(world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/Spigot-Server-Patches/0212-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-Server-Patches/0212-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -43,10 +43,10 @@ index 8e005ead10a9ac738b0e626239926bbf30e16695..78e99f072304fbddec95fed488b4b147
  
              if (this.a(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index be55c6c63607f14d457b24b381fcf213d36f6f33..ad9c067037c1575ac5fe7003b663eb0612deb11b 100644
+index 7b8440c58471315d7b8af786ba8daddc1625865f..88774ab77801476c16506699ad2d53c4e360e20a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2317,11 +2317,17 @@ public class CraftWorld implements World {
+@@ -2334,11 +2334,17 @@ public class CraftWorld implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/Spigot-Server-Patches/0216-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/Spigot-Server-Patches/0216-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ad9c067037c1575ac5fe7003b663eb0612deb11b..b092a01bc061563cb095b3d81e8595c26bf1e85e 100644
+index 88774ab77801476c16506699ad2d53c4e360e20a..4028996bcd0317dc487680ecbca30563c68fbe10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1485,6 +1485,10 @@ public class CraftWorld implements World {
+@@ -1502,6 +1502,10 @@ public class CraftWorld implements World {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new EntityBoat(world, x, y, z);
              entity.setPositionRotation(x, y, z, yaw, pitch);

--- a/Spigot-Server-Patches/0271-Optimize-CraftBlockData-Creation.patch
+++ b/Spigot-Server-Patches/0271-Optimize-CraftBlockData-Creation.patch
@@ -26,7 +26,7 @@ index 8bcca73ae48ee822d32a6d23be2e1056a376e5f6..62e7c6cb1b363d1ee626c4405f8c30e7
          public void a() {
              if (!this.getBlock().o()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 4dc3856cdadc91af227b7ae3f6e9b973d9fd4111..d79946ecc15c7a822267b8fa58323e6c1bc2ab6d 100644
+index 0a377b2026d147abe3d0ec44ed605a20d4664fea..41a32f2c77f2e7b79a067a0ce15c894e53ed8709 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 @@ -509,7 +509,17 @@ public class CraftBlockData implements BlockData {
@@ -46,4 +46,4 @@ index 4dc3856cdadc91af227b7ae3f6e9b973d9fd4111..d79946ecc15c7a822267b8fa58323e6c
 +        // Paper end
          return MAP.getOrDefault(data.getBlock().getClass(), CraftBlockData::new).apply(data);
      }
- }
+ 

--- a/Spigot-Server-Patches/0279-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0279-Improve-death-events.patch
@@ -324,35 +324,8 @@ index 415f0d74748484db0a211187a74b5d0b51ffe1cd..1e57e53c965a2e9335aa36926c44f7f3
              }
          }
      }
-diff --git a/src/main/java/org/bukkit/craftbukkit/CraftSound.java b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-index 9a2e6bedfc50fba10f37c01d825f80415bfb69d3..a4afe638515471159d505a5e402a934206d8c1f5 100644
---- a/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-+++ b/src/main/java/org/bukkit/craftbukkit/CraftSound.java
-@@ -1003,6 +1003,22 @@ public enum CraftSound {
-     WEATHER_RAIN_ABOVE("weather.rain.above");
-     private final String minecraftKey;
- 
-+    // Paper start - cancellable death event
-+    public static CraftSound getBySoundEffect(final SoundEffect effect) {
-+        MinecraftKey key = IRegistry.SOUND_EVENT.getKey(effect);
-+        Preconditions.checkArgument(key != null, "Key for sound effect %s not found?", effect.toString());
-+
-+        return valueOf(key.getKey().replace('.', '_').toUpperCase(java.util.Locale.ENGLISH));
-+    }
-+
-+    public static Sound getSoundByEffect(final SoundEffect effect) {
-+        return Sound.valueOf(getBySoundEffect(effect).name());
-+    }
-+
-+    public static SoundEffect getSoundEffect(final Sound sound) {
-+        return getSoundEffect(getSound(sound));
-+    }
-+    // Paper end
-     CraftSound(String minecraftKey) {
-         this.minecraftKey = minecraftKey;
-     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0f3fd7baf158923b30380eaa4be1c24114a8bd51..ef8396415cae1de269414e134d5fd02b43f3b729 100644
+index 27fa6f5c2e806da2bef12fb7ffbb0f9e90725594..2a243970e629dae83a223ad995f587361f91451f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1784,7 +1784,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -373,7 +346,7 @@ index 0f3fd7baf158923b30380eaa4be1c24114a8bd51..ef8396415cae1de269414e134d5fd02b
  
      public void injectScaledMaxHealth(Collection<AttributeModifiable> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1c806c97bf77cb3a71086d51110605b147bdbfbf..2222d3fdb9920f5662d42c0303bd05a4a07483c7 100644
+index 1c806c97bf77cb3a71086d51110605b147bdbfbf..efec8e6c41a67956c9ffceddedda976c6c1286d3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -791,9 +791,16 @@ public class CraftEventFactory {
@@ -419,7 +392,7 @@ index 1c806c97bf77cb3a71086d51110605b147bdbfbf..2222d3fdb9920f5662d42c0303bd05a4
 +        event.setReviveHealth(event.getEntity().getAttribute(org.bukkit.attribute.Attribute.GENERIC_MAX_HEALTH).getValue());
 +        event.setShouldPlayDeathSound(!victim.silentDeath && !victim.isSilent());
 +        net.minecraft.server.SoundEffect soundEffect = victim.getDeathSoundEffect();
-+        event.setDeathSound(soundEffect != null ? org.bukkit.craftbukkit.CraftSound.getSoundByEffect(soundEffect) : null);
++        event.setDeathSound(soundEffect != null ? org.bukkit.craftbukkit.CraftSound.getBukkit(soundEffect) : null);
 +        event.setDeathSoundCategory(org.bukkit.SoundCategory.valueOf(victim.getSoundCategory().name()));
 +        event.setDeathSoundVolume(victim.getDeathSoundVolume());
 +        event.setDeathSoundPitch(victim.getSoundPitch());

--- a/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0352-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -198,10 +198,10 @@ index de2bdd55213613f439cd797bfe01986c8851eaa4..644167d400e0f4af142f0afe6a11cae4
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index eb4dd0708930b0c5388a88c193d1c17978e42f48..07657d884f45959a69998ec510bf14e940e62056 100644
+index 2dd749a375aaa2e89ffdafe986ef331234086929..7287f595c89e0548252a2c39464d4a06d7f71bb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1937,15 +1937,21 @@ public class CraftWorld implements World {
+@@ -1954,15 +1954,21 @@ public class CraftWorld implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/Spigot-Server-Patches/0355-Implement-CraftBlockSoundGroup.patch
+++ b/Spigot-Server-Patches/0355-Implement-CraftBlockSoundGroup.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement CraftBlockSoundGroup
 
 diff --git a/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..99f99330d01fc61ce8ede9f225b0c42bd8f9ded1
+index 0000000000000000000000000000000000000000..8183c94ff4883e1af02e82098f1f80cffdb793aa
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/block/CraftBlockSoundGroup.java
 @@ -0,0 +1,38 @@
@@ -25,43 +25,43 @@ index 0000000000000000000000000000000000000000..99f99330d01fc61ce8ede9f225b0c42b
 +
 +    @Override
 +    public Sound getBreakSound() {
-+        return CraftSound.getSoundByEffect(soundEffectType.getBreakSound());
++        return CraftSound.getBukkit(soundEffectType.getBreakSound());
 +    }
 +
 +    @Override
 +    public Sound getStepSound() {
-+        return CraftSound.getSoundByEffect(soundEffectType.getStepSound());
++        return CraftSound.getBukkit(soundEffectType.getStepSound());
 +    }
 +
 +    @Override
 +    public Sound getPlaceSound() {
-+        return CraftSound.getSoundByEffect(soundEffectType.getPlaceSound());
++        return CraftSound.getBukkit(soundEffectType.getPlaceSound());
 +    }
 +
 +    @Override
 +    public Sound getHitSound() {
-+        return CraftSound.getSoundByEffect(soundEffectType.getHitSound());
++        return CraftSound.getBukkit(soundEffectType.getHitSound());
 +    }
 +
 +    @Override
 +    public Sound getFallSound() {
-+        return CraftSound.getSoundByEffect(soundEffectType.getFallSound());
++        return CraftSound.getBukkit(soundEffectType.getFallSound());
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/SoundEffectType.java b/src/main/java/net/minecraft/server/SoundEffectType.java
-index 957799e034ad8bc7201815b849244b7a809fb666..2301b38ac3b488809d2f624055ad3e23663d3fdb 100644
+index 5ed0cddfe6357031644e9e59e6674aa1505ddd8c..7ca11e3ff908b5521688734de2a67577daa58f83 100644
 --- a/src/main/java/net/minecraft/server/SoundEffectType.java
 +++ b/src/main/java/net/minecraft/server/SoundEffectType.java
 @@ -51,10 +51,10 @@ public class SoundEffectType {
      public static final SoundEffectType U = new SoundEffectType(1.0F, 1.0F, SoundEffects.BLOCK_GILDED_BLACKSTONE_BREAK, SoundEffects.BLOCK_GILDED_BLACKSTONE_STEP, SoundEffects.BLOCK_GILDED_BLACKSTONE_PLACE, SoundEffects.BLOCK_GILDED_BLACKSTONE_HIT, SoundEffects.BLOCK_GILDED_BLACKSTONE_FALL);
      public final float V;
      public final float W;
--    private final SoundEffect X;
-+    private final SoundEffect X; public final SoundEffect getBreakSound() { return this.X; } // Paper - OBFHELPER
+-    public final SoundEffect X; // PAIL private -> public, rename breakSound
++    public final SoundEffect X; public final SoundEffect getBreakSound() { return this.X; } // PAIL private -> public, rename breakSound // Paper - OBFHELPER 
      private final SoundEffect Y;
      private final SoundEffect Z;
--    private final SoundEffect aa;
-+    private final SoundEffect aa; public final SoundEffect getHitSound() { return this.aa; } // Paper - OBFHELPER
+-    public final SoundEffect aa; // PAIL private -> public, rename hitSound
++    public final SoundEffect aa; public final SoundEffect getHitSound() { return this.aa; } // PAIL private -> public, rename hitSound // Paper - OBFHELPER
      private final SoundEffect ab;
  
      public SoundEffectType(float f, float f1, SoundEffect soundeffect, SoundEffect soundeffect1, SoundEffect soundeffect2, SoundEffect soundeffect3, SoundEffect soundeffect4) {

--- a/Spigot-Server-Patches/0362-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0362-Anti-Xray.patch
@@ -100,15 +100,14 @@ index 0000000000000000000000000000000000000000..df7e4183d8842f5be8ae9d0698f8fa90
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae73fb52fc
+index 0000000000000000000000000000000000000000..b879f1796912bb8467202e946ccf0c9270d1589d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,615 @@
+@@ -0,0 +1,605 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
-+import java.util.LinkedHashSet;
-+import java.util.LinkedList;
++import java.util.HashSet;
 +import java.util.List;
 +import java.util.Set;
 +import java.util.concurrent.Executor;
@@ -128,7 +127,6 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +    private final int maxChunkSectionIndex;
 +    private final int updateRadius;
 +    private final IBlockData[] predefinedBlockData;
-+    private final IBlockData[] predefinedBlockDataFull;
 +    private final IBlockData[] predefinedBlockDataStone;
 +    private final IBlockData[] predefinedBlockDataNetherrack;
 +    private final IBlockData[] predefinedBlockDataEndStone;
@@ -154,7 +152,6 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +        if (engineMode == EngineMode.HIDE) {
 +            toObfuscate = paperWorldConfig.hiddenBlocks;
 +            predefinedBlockData = null;
-+            predefinedBlockDataFull = null;
 +            predefinedBlockDataStone = new IBlockData[] {Blocks.STONE.getBlockData()};
 +            predefinedBlockDataNetherrack = new IBlockData[] {Blocks.NETHERRACK.getBlockData()};
 +            predefinedBlockDataEndStone = new IBlockData[] {Blocks.END_STONE.getBlockData()};
@@ -164,30 +161,25 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +            predefinedBlockDataBitsEndStoneGlobal = new int[] {ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(Blocks.END_STONE.getBlockData())};
 +        } else {
 +            toObfuscate = new ArrayList<>(paperWorldConfig.replacementBlocks);
-+            List<IBlockData> predefinedBlockDataList = new LinkedList<IBlockData>();
++            Set<IBlockData> predefinedBlockDataSet = new HashSet<IBlockData>();
 +
 +            for (String id : paperWorldConfig.hiddenBlocks) {
 +                Block block = IRegistry.BLOCK.getOptional(new MinecraftKey(id)).orElse(null);
 +
 +                if (block != null && !block.isTileEntity()) {
 +                    toObfuscate.add(id);
-+                    predefinedBlockDataList.add(block.getBlockData());
++                    predefinedBlockDataSet.add(block.getBlockData());
 +                }
 +            }
 +
-+            // The doc of the LinkedHashSet(Collection<? extends E> c) constructor doesn't specify that the insertion order is the predictable iteration order of the specified Collection, although it is in the implementation
-+            Set<IBlockData> predefinedBlockDataSet = new LinkedHashSet<IBlockData>();
-+            // Therefore addAll(Collection<? extends E> c) is used, which guarantees this order in the doc
-+            predefinedBlockDataSet.addAll(predefinedBlockDataList);
 +            predefinedBlockData = predefinedBlockDataSet.size() == 0 ? new IBlockData[] {Blocks.DIAMOND_ORE.getBlockData()} : predefinedBlockDataSet.toArray(new IBlockData[0]);
-+            predefinedBlockDataFull = predefinedBlockDataSet.size() == 0 ? new IBlockData[] {Blocks.DIAMOND_ORE.getBlockData()} : predefinedBlockDataList.toArray(new IBlockData[0]);
 +            predefinedBlockDataStone = null;
 +            predefinedBlockDataNetherrack = null;
 +            predefinedBlockDataEndStone = null;
-+            predefinedBlockDataBitsGlobal = new int[predefinedBlockDataFull.length];
++            predefinedBlockDataBitsGlobal = new int[predefinedBlockData.length];
 +
-+            for (int i = 0; i < predefinedBlockDataFull.length; i++) {
-+                predefinedBlockDataBitsGlobal[i] = ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(predefinedBlockDataFull[i]);
++            for (int i = 0; i < predefinedBlockData.length; i++) {
++                predefinedBlockDataBitsGlobal[i] = ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(predefinedBlockData[i]);
 +            }
 +
 +            predefinedBlockDataBitsStoneGlobal = null;
@@ -221,8 +213,8 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +        this.maxBlockYUpdatePosition = (maxChunkSectionIndex + 1) * 16 + updateRadius - 1;
 +    }
 +
-+    private int getPredefinedBlockDataFullLength() {
-+        return engineMode == EngineMode.HIDE ? 1 : predefinedBlockDataFull.length;
++    private int getPredefinedBlockDataLength() {
++        return engineMode == EngineMode.HIDE ? 1 : predefinedBlockData.length;
 +    }
 +
 +    @Override
@@ -280,7 +272,7 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +
 +    // Actually these fields should be variables inside the obfuscate method but in sync mode or with SingleThreadExecutor in async mode it's okay (even without ThreadLocal)
 +    // If an ExecutorService with multiple threads is used, ThreadLocal must be used here
-+    private final ThreadLocal<int[]> predefinedBlockDataBits = ThreadLocal.withInitial(() -> new int[getPredefinedBlockDataFullLength()]);
++    private final ThreadLocal<int[]> predefinedBlockDataBits = ThreadLocal.withInitial(() -> new int[getPredefinedBlockDataLength()]);
 +    private static final ThreadLocal<boolean[]> solid = ThreadLocal.withInitial(() -> new boolean[Block.REGISTRY_ID.size()]);
 +    private static final ThreadLocal<boolean[]> obfuscate = ThreadLocal.withInitial(() -> new boolean[Block.REGISTRY_ID.size()]);
 +    // These boolean arrays represent chunk layers, true means don't obfuscate, false means obfuscate
@@ -330,12 +322,10 @@ index 0000000000000000000000000000000000000000..ac2dd0841dc849c3ceabb5ea899594ae
 +                if (chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex) == ChunkSection.GLOBAL_PALETTE) {
 +                    predefinedBlockDataBitsTemp = engineMode == EngineMode.HIDE ? chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.NETHER ? predefinedBlockDataBitsNetherrackGlobal : chunkPacketInfoAntiXray.getChunk().world.getWorld().getEnvironment() == Environment.THE_END ? predefinedBlockDataBitsEndStoneGlobal : predefinedBlockDataBitsStoneGlobal : predefinedBlockDataBitsGlobal;
 +                } else {
-+                    // If it's this.predefinedBlockData, use this.predefinedBlockDataFull instead
-+                    IBlockData[] predefinedBlockDataFull = chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex) == predefinedBlockData ? this.predefinedBlockDataFull : chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex);
 +                    predefinedBlockDataBitsTemp = predefinedBlockDataBits;
 +
 +                    for (int i = 0; i < predefinedBlockDataBitsTemp.length; i++) {
-+                        predefinedBlockDataBitsTemp[i] = chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex).getOrCreateIdFor(predefinedBlockDataFull[i]);
++                        predefinedBlockDataBitsTemp[i] = chunkPacketInfoAntiXray.getDataPalette(chunkSectionIndex).getOrCreateIdFor(chunkPacketInfoAntiXray.getPredefinedObjects(chunkSectionIndex)[i]);
 +                    }
 +                }
 +

--- a/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
@@ -4015,7 +4015,7 @@ index ccb37f6828fe2edb9358c93daa9f67edeef1f920..a999683d6d16d3704c76b1af95255ad3
      }
      public void removeTicketsForSpawn(int radiusInBlocks, BlockPosition spawn) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e741d1f966869b057652a93a1ef1785ad152f303..204ad44454732345be78c5c428dfb178344a96bb 100644
+index dd3c24b4de393f4eaca88484ccf94b620fd28bdc..191660c6c3fd7272daec09f8986a3668479cc6ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -75,6 +75,7 @@ import net.minecraft.server.IBlockData;
@@ -4058,7 +4058,7 @@ index e741d1f966869b057652a93a1ef1785ad152f303..204ad44454732345be78c5c428dfb178
  
              // fall through to load
              // we do this so we do not re-read the chunk data on disk
-@@ -2467,6 +2469,34 @@ public class CraftWorld implements World {
+@@ -2484,6 +2486,34 @@ public class CraftWorld implements World {
      public DragonBattle getEnderDragonBattle() {
          return (getHandle().getDragonBattle() == null) ? null : new CraftDragonBattle(getHandle().getDragonBattle());
      }

--- a/Spigot-Server-Patches/0380-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
+++ b/Spigot-Server-Patches/0380-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix spawning of hanging entities that are not ItemFrames and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 204ad44454732345be78c5c428dfb178344a96bb..20aeec95138a08accc4cb7b1f2d80d63bb9bf920 100644
+index 191660c6c3fd7272daec09f8986a3668479cc6ed..f826f656efd54672c20cb3240d7ef7acd834b9f5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1858,7 +1858,12 @@ public class CraftWorld implements World {
+@@ -1875,7 +1875,12 @@ public class CraftWorld implements World {
                  height = 9;
              }
  

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -607,7 +607,7 @@ index 0f46aac9d021dc115718b1e36b8fbe28cbc820c6..b8ab8150b7dfe9e34910d35f565083e8
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 5ff95f971c01fc010441dcc9099492cb627b3f0c..265dafc2e2afc98d2490fa8707a5b72a5543bc9e 100644
+index 0dac8af6680a7dc4ecbedf70707297690fb1e694..b479a25044ecf8c1a791729d643cf8dc90193b2b 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -464,8 +464,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -626,10 +626,10 @@ index 5ff95f971c01fc010441dcc9099492cb627b3f0c..265dafc2e2afc98d2490fa8707a5b72a
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5ef12e85d7374c137e2d7ff3e0571995070cc222..f35dda50fd9015a793708d214c648d75f9f87e2b 100644
+index e800c7cdfa2a9d5ee8e3969ed14e7453e82d9450..b2a225088753a38a3119b4db1d99de8c4529c175 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2518,10 +2518,39 @@ public class CraftWorld implements World {
+@@ -2535,10 +2535,39 @@ public class CraftWorld implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1222,10 +1222,10 @@ index d7b9d9fd3a3b607278a3d72b0b306b0be2aa30ad..6fd852db6bcfbfbf84ec2acf6d23b08a
      public static <T> TicketType<T> a(String s, Comparator<T> comparator) {
          return new TicketType<>(s, comparator, 0L);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f35dda50fd9015a793708d214c648d75f9f87e2b..ae1f9dde6887988ca682f53cba316ce506dbc9c1 100644
+index b2a225088753a38a3119b4db1d99de8c4529c175..9cdef96fe912b14be02f10c9b16464d987085f76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2508,6 +2508,10 @@ public class CraftWorld implements World {
+@@ -2525,6 +2525,10 @@ public class CraftWorld implements World {
              return future;
          }
  
@@ -1237,7 +1237,7 @@ index f35dda50fd9015a793708d214c648d75f9f87e2b..ae1f9dde6887988ca682f53cba316ce5
              net.minecraft.server.Chunk chunk = (net.minecraft.server.Chunk) either.left().orElse(null);
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 708636e9ce98a8e83ffb3854e14912d135a58c1d..0697f39459ffb3905b68010541b1f200bc92ad90 100644
+index e28309cefff2b2c1c5c1c200a67c3d1ca3cc65b0..fda5ead74838dd54045eb30b92384c6544e8b93d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -766,6 +766,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0495-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/Spigot-Server-Patches/0495-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,7 +44,7 @@ index 9319dccbe6a33001cfb27866fd1d078e73fcc1e7..f27d734a1d94ff749f1d28f2509f4a0d
          printSaveWarning = false;
          console.autosavePeriod = configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ae1f9dde6887988ca682f53cba316ce506dbc9c1..d266671305f1f14849ced7c52df817502ff750da 100644
+index 9cdef96fe912b14be02f10c9b16464d987085f76..24546615dcd9b4f5fa140137ff59d8efe9e3b52f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -407,9 +407,22 @@ public class CraftWorld implements World {
@@ -112,7 +112,7 @@ index ae1f9dde6887988ca682f53cba316ce506dbc9c1..d266671305f1f14849ced7c52df81750
          world.getChunkProvider().getChunkAt(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2514,6 +2529,7 @@ public class CraftWorld implements World {
+@@ -2531,6 +2546,7 @@ public class CraftWorld implements World {
          }
          return this.world.getChunkProvider().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.server.Chunk chunk = (net.minecraft.server.Chunk) either.left().orElse(null);

--- a/Spigot-Server-Patches/0537-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/Spigot-Server-Patches/0537-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d266671305f1f14849ced7c52df817502ff750da..4ab3db10e26dc9739c5afcfc423d1c68a2c4d1c9 100644
+index 24546615dcd9b4f5fa140137ff59d8efe9e3b52f..e50a16991cf3f5df04c9410b211a13c33bbe91d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2592,6 +2592,7 @@ public class CraftWorld implements World {
+@@ -2609,6 +2609,7 @@ public class CraftWorld implements World {
              lightning.teleportAndSync( loc.getX(), loc.getY(), loc.getZ() );
              lightning.isEffect = true;
              lightning.isSilent = isSilent;


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
721e678d Fix javadoc in previous commit
19b7b7bd #561: Add clear weather World API
5929c808 #552: Add the ability to retrieve hit, step, fall, and other sounds from blocks.

CraftBukkit Changes:
e1ebdd92 #771: Add clear weather World API
424598d2 #752: Add the ability to retrieve hit, step, fall, and other sounds from blocks.