### PR TITLE
Add cancellable TargetHitEvent for when Target Blocks are hit by Projectiles

### DIFF
--- a/Spigot-API-Patches/0246-Add-TargetHitEvent-API.patch
+++ b/Spigot-API-Patches/0246-Add-TargetHitEvent-API.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Wed, 25 Nov 2020 23:21:32 -0800
+Subject: [PATCH] Add TargetHitEvent API
+
+
+diff --git a/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java b/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..cc067ae118af9957b1b9f5c8d45f63f9154f4942
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/TargetHitEvent.java
+@@ -0,0 +1,69 @@
++package io.papermc.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockFace;
++import org.bukkit.entity.Projectile;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.ProjectileHitEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a Target Block is hit by a projectile.
++ * <p>
++ * Cancelling this event will stop the Target from emitting a redstone signal,
++ * and in the case that the shooter is a player, will stop them from receiving
++ * advancement criteria.
++ */
++public class TargetHitEvent extends ProjectileHitEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++    private int signalStrength;
++
++    public TargetHitEvent(@NotNull Projectile projectile, @NotNull Block block, @NotNull BlockFace blockFace, int signalStrength) {
++        super(projectile, null, block, blockFace);
++        this.signalStrength = signalStrength;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    /**
++     * Gets the strength of the redstone signal to be emitted by the Target block
++     *
++     * @return the strength of the redstone signal to be emitted
++     */
++    public int getSignalStrength() {
++        return signalStrength;
++    }
++
++    /**
++     * Sets the strength of the redstone signal to be emitted by the Target block
++     *
++     * @param signalStrength the strength of the redstone signal to be emitted
++     */
++    public void setSignalStrength(int signalStrength) {
++        if (signalStrength < 0 || signalStrength > 15) {
++            throw new IllegalArgumentException("Signal strength out of range (" + signalStrength + "), must be in range [0,15]");
++        }
++        this.signalStrength = signalStrength;
++    }
++}

--- a/Spigot-Server-Patches/0625-Implement-TargetHitEvent.patch
+++ b/Spigot-Server-Patches/0625-Implement-TargetHitEvent.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Wed, 25 Nov 2020 23:20:44 -0800
+Subject: [PATCH] Implement TargetHitEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockTarget.java b/src/main/java/net/minecraft/server/BlockTarget.java
+index 23b298577d8a60ca241abc228732f66ebbe7a7b1..642d7c14bc404d94c8a4f551b984fe235a3816eb 100644
+--- a/src/main/java/net/minecraft/server/BlockTarget.java
++++ b/src/main/java/net/minecraft/server/BlockTarget.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import io.papermc.paper.event.block.TargetHitEvent; // Paper - Need to import because 'io' class exists in nms
+ import java.util.Random;
+ 
+ public class BlockTarget extends Block {
+@@ -14,6 +15,10 @@ public class BlockTarget extends Block {
+     @Override
+     public void a(World world, IBlockData iblockdata, MovingObjectPositionBlock movingobjectpositionblock, IProjectile iprojectile) {
+         int i = a((GeneratorAccess) world, iblockdata, movingobjectpositionblock, (Entity) iprojectile);
++        // Paper start
++    }
++    private static void awardTargetHitCriteria(IProjectile iprojectile, MovingObjectPositionBlock movingobjectpositionblock, int i) {
++        // Paper end
+         Entity entity = iprojectile.getShooter();
+ 
+         if (entity instanceof EntityPlayer) {
+@@ -29,6 +34,20 @@ public class BlockTarget extends Block {
+         int i = a(movingobjectpositionblock, movingobjectpositionblock.getPos());
+         int j = entity instanceof EntityArrow ? 20 : 8;
+ 
++        // Paper start
++        if (entity instanceof IProjectile) {
++            final IProjectile projectile = (IProjectile) entity;
++            final org.bukkit.craftbukkit.block.CraftBlock craftBlock = org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, movingobjectpositionblock.getBlockPosition());
++            final org.bukkit.block.BlockFace blockFace = org.bukkit.craftbukkit.block.CraftBlock.notchToBlockFace(movingobjectpositionblock.getDirection());
++            final TargetHitEvent targetHitEvent = new TargetHitEvent((org.bukkit.entity.Projectile) projectile.getBukkitEntity(), craftBlock, blockFace, i);
++            if (targetHitEvent.callEvent()) {
++                i = targetHitEvent.getSignalStrength();
++                awardTargetHitCriteria(projectile, movingobjectpositionblock, i);
++            } else {
++                return i;
++            }
++        }
++        // Paper end
+         if (!generatoraccess.getBlockTickList().a(movingobjectpositionblock.getBlockPosition(), iblockdata.getBlock())) {
+             a(generatoraccess, iblockdata, i, movingobjectpositionblock.getBlockPosition(), j);
+         }


### PR DESCRIPTION
This PR adds and implements `TargetHitEvent`, which is called when a target block is hit by a projectile. Cancelling the event stops the target block from emitting a redstone signal, and if the projectile's shooter is a player, stops the player from receiving advancement criteria. The event also includes methods to get and set the resulting redstone signal strength from the target hit.