### PR TITLE
Added ServerResourcesReloadedEvent

### DIFF
--- a/Spigot-API-Patches/0253-Added-ServerResourcesReloadedEvent.patch
+++ b/Spigot-API-Patches/0253-Added-ServerResourcesReloadedEvent.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 2 Dec 2020 20:04:16 -0800
+Subject: [PATCH] Added ServerResourcesReloadedEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java b/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..7a8d6815c17a107039399298f7ac9f0612faee02
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/server/ServerResourcesReloadedEvent.java
+@@ -0,0 +1,48 @@
++package io.papermc.paper.event.server;
++
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.server.ServerEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when resources such as datapacks are reloaded (e.g. /minecraft:reload)
++ * <p>
++ *     Intended for use to re-register custom recipes, advancements that may be lost during a reload like this.
++ * </p>
++ */
++public class ServerResourcesReloadedEvent extends ServerEvent {
++
++    public static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final Cause cause;
++
++    public ServerResourcesReloadedEvent(@NotNull Cause cause) {
++        this.cause = cause;
++    }
++
++    /**
++     * Gets the cause of the resource reload.
++     *
++     * @return the reload cause
++     */
++    @NotNull
++    public Cause getCause() {
++        return cause;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public enum Cause {
++        COMMAND,
++        PLUGIN,
++    }
++}

--- a/Spigot-Server-Patches/0639-Added-ServerResourcesReloadedEvent.patch
+++ b/Spigot-Server-Patches/0639-Added-ServerResourcesReloadedEvent.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 2 Dec 2020 20:04:01 -0800
+Subject: [PATCH] Added ServerResourcesReloadedEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/CommandReload.java b/src/main/java/net/minecraft/server/CommandReload.java
+index 08e472b71cf85b854eaa831881577ce2c3c03b11..4558147a51be6713c11bda6a60fd5ca3a953c096 100644
+--- a/src/main/java/net/minecraft/server/CommandReload.java
++++ b/src/main/java/net/minecraft/server/CommandReload.java
+@@ -6,13 +6,14 @@ import java.util.Collection;
+ import java.util.Iterator;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
++import io.papermc.paper.event.server.ServerResourcesReloadedEvent; // Paper
+ 
+ public class CommandReload {
+ 
+     private static final Logger LOGGER = LogManager.getLogger();
+ 
+     public static void a(Collection<String> collection, CommandListenerWrapper commandlistenerwrapper) {
+-        commandlistenerwrapper.getServer().a(collection).exceptionally((throwable) -> {
++        commandlistenerwrapper.getServer().reloadServerResources(collection, ServerResourcesReloadedEvent.Cause.COMMAND).exceptionally((throwable) -> { // Paper
+             CommandReload.LOGGER.warn("Failed to execute reload", throwable);
+             commandlistenerwrapper.sendFailureMessage(new ChatMessage("commands.reload.failure"));
+             return null;
+@@ -42,7 +43,7 @@ public class CommandReload {
+         SaveData savedata = minecraftserver.getSaveData();
+         Collection<String> collection = resourcepackrepository.d();
+         Collection<String> collection1 = a(resourcepackrepository, savedata, collection);
+-        minecraftserver.a(collection1);
++        minecraftserver.reloadServerResources(collection1, ServerResourcesReloadedEvent.Cause.PLUGIN); // Paper
+     }
+     // CraftBukkit end
+ 
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 172fc9ef9c0d3444eb99f750a17d42f130d94f73..a7cd98a7cd7fed95e37a178f732339e204650b10 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -2,9 +2,6 @@ package net.minecraft.server;
+ 
+ import com.google.common.base.Splitter;
+ import com.google.common.collect.ImmutableList;
+-import co.aikar.timings.Timings;
+-import com.destroystokyo.paper.event.server.PaperServerListPingEvent;
+-import com.google.common.base.Stopwatch;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+ import com.google.common.collect.Sets;
+@@ -63,13 +60,11 @@ import org.apache.logging.log4j.Logger;
+ import com.google.common.collect.ImmutableSet;
+ // import jline.console.ConsoleReader; // Paper
+ import joptsimple.OptionSet;
+-import org.bukkit.Bukkit;
+-import org.bukkit.craftbukkit.CraftServer;
+-import org.bukkit.craftbukkit.Main;
+ import org.bukkit.event.server.ServerLoadEvent;
+ // CraftBukkit end
+ import co.aikar.timings.MinecraftTimings; // Paper
+ import io.papermc.paper.util.PaperJvmChecker; // Paper
++import io.papermc.paper.event.server.ServerResourcesReloadedEvent; // Paper
+ import org.spigotmc.SlackActivityAccountant; // Spigot
+ 
+ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
+@@ -1808,7 +1803,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         return this.customFunctionData;
+     }
+ 
++    // Paper start - add cause
++    @Deprecated
+     public CompletableFuture<Void> a(Collection<String> collection) {
++        return this.reloadServerResources(collection, ServerResourcesReloadedEvent.Cause.PLUGIN);
++    }
++    public CompletableFuture<Void> reloadServerResources(Collection<String> collection, ServerResourcesReloadedEvent.Cause cause) {
++        // Paper end
+         CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
+             Stream<String> stream = collection.stream(); // CraftBukkit - decompile error
+             ResourcePackRepository resourcepackrepository = this.resourcePackRepository;
+@@ -1824,6 +1825,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+             this.resourcePackRepository.a(collection);
+             this.saveData.a(a(this.resourcePackRepository));
+             datapackresources.i();
++            new ServerResourcesReloadedEvent(cause).callEvent(); // Paper
+             if (Thread.currentThread() != this.serverThread) return; // Paper
+             //this.getPlayerList().savePlayers(); // Paper - we don't need to do this
+             this.getPlayerList().reload();


### PR DESCRIPTION
closes #4244 

Adds an event plugins can use to re-register recipes, events. The ServerLoadEvent did not cover all situations in which a plugin would need to re-register stuff