### PR TITLE
Turn off spigot verbose world by default

### DIFF
--- a/Spigot-Server-Patches/0612-Set-spigots-verbose-world-setting-to-false-by-def.patch
+++ b/Spigot-Server-Patches/0612-Set-spigots-verbose-world-setting-to-false-by-def.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 2 Dec 2020 20:17:54 -0800
+Subject: [PATCH] Set spigots verbose world setting to false by def
+
+
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index 9859e0c964e4d1e7dc7689cb97f40643a8e5cdd7..61ad08b09cd2fe25471bb6c838b8bb3d8102e693 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -20,7 +20,7 @@ public class SpigotWorldConfig
+ 
+     public void init()
+     {
+-        this.verbose = getBoolean( "verbose", true );
++        this.verbose = getBoolean( "verbose", false ); // Paper
+ 
+         log( "-------- World Settings For [" + worldName + "] --------" );
+         SpigotConfig.readConfig( SpigotWorldConfig.class, this );


### PR DESCRIPTION
Paper's is off by default, and this is literally the first thing I always do when I spin up a new server for whatever reason. Really clears up the initial logs, especially if you have like 20 worlds or something crazy. 