### PR TITLE
Improved the annotation test output

### DIFF
--- a/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
+++ b/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 3 Dec 2020 14:04:57 -0800
+Subject: [PATCH] Better AnnotationTest printout
+
+
+diff --git a/pom.xml b/pom.xml
+index 1c33b1f4d2366116dd45478b8ad9cdb51fd6bb57..35599164b24185bc51813ae58090f6f4bffdba4a 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -223,6 +223,19 @@
+                     <shadedArtifactAttached>true</shadedArtifactAttached>
+                 </configuration>
+             </plugin>
++            <plugin>
++                <groupId>org.apache.maven.plugins</groupId>
++                <artifactId>maven-surefire-plugin</artifactId>
++                <version>2.22.2</version>
++                <configuration>
++                    <properties>
++                        <property>
++                            <name>listener</name>
++                            <value>io.papermc.paper.JunitEventListener</value>
++                        </property>
++                    </properties>
++                </configuration>
++            </plugin>
+             <plugin>
+                 <groupId>org.apache.maven.plugins</groupId>
+                 <artifactId>maven-javadoc-plugin</artifactId>
+diff --git a/src/test/java/io/papermc/paper/JunitEventListener.java b/src/test/java/io/papermc/paper/JunitEventListener.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..072ac1a96394b8d494f42fca8dfe08115eaed3fe
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/JunitEventListener.java
+@@ -0,0 +1,6 @@
++package io.papermc.paper;
++
++import org.junit.runner.notification.RunListener;
++
++public class JunitEventListener extends RunListener {
++}
+diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
+index a48be38b159bec27ec398666b28620a9ea625547..4c2780c903ec354edac741b673a7174284a9849a 100644
+--- a/src/test/java/org/bukkit/AnnotationTest.java
++++ b/src/test/java/org/bukkit/AnnotationTest.java
+@@ -101,13 +101,18 @@ public class AnnotationTest {
+ 
+         Collections.sort(errors);
+ 
+-        System.out.println(errors.size() + " missing annotation(s):");
++        StringBuilder builder = new StringBuilder()
++            .append("There ")
++            .append(errors.size() != 1 ? "are " : "is ")
++            .append(errors.size())
++            .append(" missing annotation")
++            .append(errors.size() != 1 ? "s:\n" : ":\n");
++
+         for (String message : errors) {
+-            System.out.print("\t");
+-            System.out.println(message);
++            builder.append("\t").append(message).append("\n");
+         }
+ 
+-        Assert.fail("There " + errors.size() + " are missing annotation(s)");
++        Assert.fail(builder.toString());
+     }
+ 
+     private static void collectClasses(@NotNull File from, @NotNull Map<String, ClassNode> to) throws IOException {


### PR DESCRIPTION
Before you had to scroll up a bunch to see missing nullability annotations. Now, there is a nice printout right at the bottom. Apparently registering an empty class that extended junit's runlistener is enough to make the printout significantly better. I tried it w/o the empty class and it didn't change from the old style.

I also fixed a grammatical error in the error message.

![image](https://user-images.githubusercontent.com/15055071/101094803-d2413f00-3571-11eb-8202-2b6f3953aefc.png)
