### PR TITLE
adding a noRelocation maven profile

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,7 @@ To generate and update the TOC: https://github.com/mzlogin/vim-markdown-toc -->
   * [My commit doesn't need a build, what do I do?](#my-commit-doesnt-need-a-build-what-do-i-do)
   * [Patching and building is *really* slow, what can I do?](#patching-and-building-is-really-slow-what-can-i-do)
   * [I wrote some API, how do I use it in Paper-Server?](#i-wrote-some-api-how-do-i-use-it-in-paper-server)
+  * [How can I use a debugger on the Paper Server?](#How can I use a debugger on the Paper Server?)  
 
 <!-- vim-markdown-toc -->
 
@@ -528,6 +529,15 @@ To install the API to your local maven repository, do the following:
 
 You can now use the API in your plugin to test it before PRing. You will also
 need to do this to build the Server with the implemented API.
+
+### How can I use a debugger on the Paper Server?
+
+To debug the paper server, do the following:
+
+- Activate the `noRelocation` maven profile, either on the command line when you build your project (`-PnoRelocation`), or in your build configuration in your IDE.
+- Create the server jar with the `noRelocation` profile active
+- Run the jar using your IDEs debugger
+- Add breakpoints and start debugging!
 
 [MiniMappingViewer]: https://minidigger.github.io/MiniMappingViewer/
 [yarn]: https://github.com/FabricMC/yarn

--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index 3fc047371e8f8a626e69697fad549d689c5dce89..a5d87d22cb1588d15e08da3b37e51c5e261c7799 100644
+index 3fc047371e8f8a626e69697fad549d689c5dce89..98ad942b4ebca02169e5f030b38ff847949c52f6 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,15 +1,14 @@
@@ -58,17 +58,17 @@ index 3fc047371e8f8a626e69697fad549d689c5dce89..a5d87d22cb1588d15e08da3b37e51c5e
 -            <artifactId>spigot-api</artifactId>
 +            <groupId>com.destroystokyo.paper</groupId>
 +            <artifactId>paper-api</artifactId>
-+            <version>${project.version}</version>
-+            <scope>compile</scope>
-+        </dependency>
-+        <dependency>
-+            <groupId>com.destroystokyo.paper</groupId>
-+            <artifactId>paper-mojangapi</artifactId>
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
          <dependency>
 -            <groupId>org.spigotmc</groupId>
++            <groupId>com.destroystokyo.paper</groupId>
++            <artifactId>paper-mojangapi</artifactId>
++            <version>${project.version}</version>
++            <scope>compile</scope>
++        </dependency>
++        <dependency>
 +            <groupId>io.papermc</groupId>
              <artifactId>minecraft-server</artifactId>
              <version>${minecraft.version}-SNAPSHOT</version>
@@ -167,7 +167,8 @@ index 3fc047371e8f8a626e69697fad549d689c5dce89..a5d87d22cb1588d15e08da3b37e51c5e
 -                            <descriptionProperty>spigot.desc</descriptionProperty>
 -                        </configuration>
 -                        <phase>initialize</phase>
--                        <goals>
++                        <phase>compile</phase>
+                         <goals>
 -                            <goal>describe</goal>
 -                        </goals>
 -                    </execution>
@@ -179,8 +180,7 @@ index 3fc047371e8f8a626e69697fad549d689c5dce89..a5d87d22cb1588d15e08da3b37e51c5e
 -                            <descriptionProperty>craftbukkit.desc</descriptionProperty>
 -                        </configuration>
 -                        <phase>initialize</phase>
-+                        <phase>compile</phase>
-                         <goals>
+-                        <goals>
 -                            <goal>describe</goal>
 +                            <goal>gitdescribe</goal>
                          </goals>
@@ -263,6 +263,44 @@ index 3fc047371e8f8a626e69697fad549d689c5dce89..a5d87d22cb1588d15e08da3b37e51c5e
                  <dependencies>
                      <dependency>
                          <groupId>org.codehaus.plexus</groupId>
+@@ -348,6 +371,37 @@
+     </build>
+ 
+     <profiles>
++        <profile>
++            <id>noRelocation</id>
++            <build>
++                <plugins>
++                    <plugin>
++                        <groupId>org.apache.maven.plugins</groupId>
++                        <artifactId>maven-shade-plugin</artifactId>
++                        <version>3.2.3</version>
++                        <executions>
++                            <execution>
++                                <phase>package</phase>
++                                <goals>
++                                    <goal>shade</goal>
++                                </goals>
++                                <configuration>
++                                    <relocations combine.self="override">
++                                    </relocations>
++                                </configuration>
++                            </execution>
++                        </executions>
++                        <dependencies>
++                            <dependency>
++                                <groupId>com.github.edwgiz</groupId>
++                                <artifactId>maven-shade-plugin.log4j2-cachefile-transformer</artifactId>
++                                <version>2.13.1</version>
++                            </dependency>
++                        </dependencies>
++                    </plugin>
++                </plugins>
++            </build>
++        </profile>
+         <profile>
+             <id>shadeSourcesJar</id>
+             <properties>
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index 036c870d991118e5c09eced8485b94579bc6782a..c6417a0594ffe2d3650ec54d44e575e347a1f724 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java


### PR DESCRIPTION
Just simplifies debugging. No need to remember to comment out stuff in the pom.xml and then forget you commented it out and the annoyingness that ensues. 