### PR TITLE
deprecate IllegalPacketEvent

### DIFF
--- a/Spigot-API-Patches/0043-IllegalPacketEvent.patch
+++ b/Spigot-API-Patches/0043-IllegalPacketEvent.patch
@@ -9,10 +9,10 @@ Lets plugins change the kick message and if it should kick or not.
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..37a17f0bb2b9028cf0d3d320f5528fcb950f0d2c
+index 0000000000000000000000000000000000000000..8d8e9b16f2a6707d2af7567c7682dfc5db51a737
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/IllegalPacketEvent.java
-@@ -0,0 +1,70 @@
+@@ -0,0 +1,74 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Bukkit;
@@ -22,6 +22,10 @@ index 0000000000000000000000000000000000000000..37a17f0bb2b9028cf0d3d320f5528fcb
 +import org.jetbrains.annotations.NotNull;
 +import org.jetbrains.annotations.Nullable;
 +
++/**
++ * @deprecated Not used
++ */
++@Deprecated
 +public class IllegalPacketEvent extends PlayerEvent {
 +    @Nullable private final String type;
 +    @Nullable private final String ex;

--- a/Spigot-Server-Patches/0169-Add-PlayerJumpEvent.patch
+++ b/Spigot-Server-Patches/0169-Add-PlayerJumpEvent.patch
@@ -5,19 +5,10 @@ Subject: [PATCH] Add PlayerJumpEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index e83f1bfe2b2c33b3bc6788de6998356430857855..240a50d0da11199a05292d803cf367e30a639331 100644
+index e83f1bfe2b2c33b3bc6788de6998356430857855..5429e91dec8aa29d8c641db09a1b4de0acd0f5bb 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -64,6 +64,8 @@ import org.bukkit.inventory.CraftingInventory;
- import org.bukkit.inventory.EquipmentSlot;
- import org.bukkit.inventory.InventoryView;
- import org.bukkit.util.NumberConversions;
-+import com.destroystokyo.paper.event.player.IllegalPacketEvent; // Paper
-+import com.destroystokyo.paper.event.player.PlayerJumpEvent; // Paper
- import co.aikar.timings.MinecraftTimings; // Paper
- // CraftBukkit end
- 
-@@ -1017,7 +1019,34 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1017,7 +1017,34 @@ public class PlayerConnection implements PacketListenerPlayIn {
                              boolean flag = d8 > 0.0D;
  
                              if (this.player.isOnGround() && !packetplayinflying.b() && flag) {
@@ -40,7 +31,7 @@ index e83f1bfe2b2c33b3bc6788de6998356430857855..240a50d0da11199a05292d803cf367e3
 +                                    to.setPitch(packetplayinflying.pitch);
 +                                }
 +
-+                                PlayerJumpEvent event = new PlayerJumpEvent(player, from, to);
++                                com.destroystokyo.paper.event.player.PlayerJumpEvent event = new com.destroystokyo.paper.event.player.PlayerJumpEvent(player, from, to);
 +
 +                                if (event.callEvent()) {
 +                                    this.player.jump();

--- a/Spigot-Server-Patches/0170-handle-PacketPlayInKeepAlive-async.patch
+++ b/Spigot-Server-Patches/0170-handle-PacketPlayInKeepAlive-async.patch
@@ -15,10 +15,10 @@ also adding some additional logging in order to help work out what is causing
 random disconnections for clients.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 240a50d0da11199a05292d803cf367e30a639331..8d0b1405655ad38d4849d0972d69a3f9cf4988cf 100644
+index 5429e91dec8aa29d8c641db09a1b4de0acd0f5bb..5b74b394bb832699d2d54030ee691fbe9648f170 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2621,14 +2621,18 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2619,14 +2619,18 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInKeepAlive packetplayinkeepalive) {

--- a/Spigot-Server-Patches/0172-revert-serverside-behavior-of-keepalives.patch
+++ b/Spigot-Server-Patches/0172-revert-serverside-behavior-of-keepalives.patch
@@ -17,10 +17,10 @@ from networking or during connections flood of chunk packets on slower clients,
  at the cost of dead connections being kept open for longer.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 8d0b1405655ad38d4849d0972d69a3f9cf4988cf..4bb4c9d4879ab6ee6e063b5b9a2acad0a52d2629 100644
+index 5b74b394bb832699d2d54030ee691fbe9648f170..479d3f9d5fd8d619655811b32e8182cc23a538f9 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -76,7 +76,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -74,7 +74,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private final MinecraftServer minecraftServer;
      public EntityPlayer player;
      private int e;
@@ -29,7 +29,7 @@ index 8d0b1405655ad38d4849d0972d69a3f9cf4988cf..4bb4c9d4879ab6ee6e063b5b9a2acad0
      private boolean awaitingKeepAlive; private void setPendingPing(boolean isPending) { this.awaitingKeepAlive = isPending;}; private boolean isPendingPing() { return this.awaitingKeepAlive;}; // Paper - OBFHELPER
      private long h; private void setKeepAliveID(long keepAliveID) { this.h = keepAliveID;}; private long getKeepAliveID() {return this.h; };  // Paper - OBFHELPER
      // CraftBukkit start - multithreaded fields
-@@ -107,6 +107,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -105,6 +105,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private int E;
      private int receivedMovePackets;
      private int processedMovePackets;
@@ -37,7 +37,7 @@ index 8d0b1405655ad38d4849d0972d69a3f9cf4988cf..4bb4c9d4879ab6ee6e063b5b9a2acad0
  
      public PlayerConnection(MinecraftServer minecraftserver, NetworkManager networkmanager, EntityPlayer entityplayer) {
          this.minecraftServer = minecraftserver;
-@@ -193,18 +194,25 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -191,18 +192,25 @@ public class PlayerConnection implements PacketListenerPlayIn {
          }
  
          this.minecraftServer.getMethodProfiler().enter("keepAlive");

--- a/Spigot-Server-Patches/0179-AsyncTabCompleteEvent.patch
+++ b/Spigot-Server-Patches/0179-AsyncTabCompleteEvent.patch
@@ -14,10 +14,10 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 4bb4c9d4879ab6ee6e063b5b9a2acad0a52d2629..30bdf7dff8fc611677b95918574d4ad42ddf1c6c 100644
+index 479d3f9d5fd8d619655811b32e8182cc23a538f9..c3651ff73c0831f0dd727f6358aa45fbaeebfb1d 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -564,10 +564,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -562,10 +562,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInTabComplete packetplayintabcomplete) {
@@ -30,7 +30,7 @@ index 4bb4c9d4879ab6ee6e063b5b9a2acad0a52d2629..30bdf7dff8fc611677b95918574d4ad4
              return;
          }
          // CraftBukkit end
-@@ -577,12 +577,35 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -575,12 +575,35 @@ public class PlayerConnection implements PacketListenerPlayIn {
              stringreader.skip();
          }
  

--- a/Spigot-Server-Patches/0208-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/Spigot-Server-Patches/0208-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 30bdf7dff8fc611677b95918574d4ad42ddf1c6c..7dd7289941253991d0a2aa22f9b058c116c14e82 100644
+index c3651ff73c0831f0dd727f6358aa45fbaeebfb1d..f92a1d69119af0c6baee83cd96c344695f23dc3c 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2633,7 +2633,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2631,7 +2631,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
              String[] lines = new String[4];
  
              for (int i = 0; i < list.size(); ++i) {

--- a/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
@@ -88,7 +88,7 @@ index 26f81c1af1dda7d0a78ca5815bfaf825ba913efd..415f0d74748484db0a211187a74b5d0b
          this.o();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7dd7289941253991d0a2aa22f9b058c116c14e82..577deb210f6d95b7502905f6af16e2e946edd8e2 100644
+index f92a1d69119af0c6baee83cd96c344695f23dc3c..7276807e0a22c640edc2c3e94c263f175f47d642 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -43,6 +43,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -99,7 +99,7 @@ index 7dd7289941253991d0a2aa22f9b058c116c14e82..577deb210f6d95b7502905f6af16e2e9
  import org.bukkit.event.inventory.InventoryCreativeEvent;
  import org.bukkit.event.inventory.InventoryType.SlotType;
  import org.bukkit.event.player.AsyncPlayerChatEvent;
-@@ -2163,10 +2164,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2161,10 +2162,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInCloseWindow packetplayinclosewindow) {
@@ -180,7 +180,7 @@ index a1c318aa6501d9d0bdd53dc1fb8a99b7a782b4ce..ebcd2d043b3e6cf90b62eda1ea7a2d8c
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0499a13549d19e9c81b4042219d8996fe1d86ae3..0a9e4dd47660748a80c40a2790ee197ceeb346b0 100644
+index 78c91d94e9940431def77f2559e64c9cab6d8b49..c04ad85d16ce358dfbd72d1d84fb39970aa6aef0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -813,7 +813,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0235-Refresh-player-inventory-when-cancelling-PlayerInter.patch
+++ b/Spigot-Server-Patches/0235-Refresh-player-inventory-when-cancelling-PlayerInter.patch
@@ -16,10 +16,10 @@ Refresh the player inventory when PlayerInteractEntityEvent is
 cancelled to avoid this problem.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 577deb210f6d95b7502905f6af16e2e946edd8e2..a62fcd57be08cce2aa51de078aa86e2eeb6f11e5 100644
+index 7276807e0a22c640edc2c3e94c263f175f47d642..251333ba81aa55d321b94fa1959306abcb6da636 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2076,6 +2076,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2074,6 +2074,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      }
  
                      if (event.isCancelled()) {

--- a/Spigot-Server-Patches/0257-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0257-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -45,10 +45,10 @@ index ca90b768b758b9fc074daf592e2140e60a9b8841..615ef87f4fa6a91febc6ce006b00c0ab
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index a62fcd57be08cce2aa51de078aa86e2eeb6f11e5..be2c94a8fb93ee024e035cc8557f230ee7c1c647 100644
+index 251333ba81aa55d321b94fa1959306abcb6da636..c15d0d0f6f0cfede9c22eba058f2323590f48df7 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -83,6 +83,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -81,6 +81,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      // CraftBukkit start - multithreaded fields
      private volatile int chatThrottle;
      private static final AtomicIntegerFieldUpdater chatSpamField = AtomicIntegerFieldUpdater.newUpdater(PlayerConnection.class, "chatThrottle");
@@ -56,7 +56,7 @@ index a62fcd57be08cce2aa51de078aa86e2eeb6f11e5..be2c94a8fb93ee024e035cc8557f230e
      // CraftBukkit end
      private int j;
      private final Int2ShortMap k = new Int2ShortOpenHashMap();
-@@ -218,6 +219,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -216,6 +217,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          this.minecraftServer.getMethodProfiler().exit();
          // CraftBukkit start
          for (int spam; (spam = this.chatThrottle) > 0 && !chatSpamField.compareAndSet(this, spam, spam - 1); ) ;
@@ -64,7 +64,7 @@ index a62fcd57be08cce2aa51de078aa86e2eeb6f11e5..be2c94a8fb93ee024e035cc8557f230e
          /* Use thread-safe field access instead
          if (this.chatThrottle > 0) {
              --this.chatThrottle;
-@@ -567,7 +569,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -565,7 +567,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      public void a(PacketPlayInTabComplete packetplayintabcomplete) {
          // PlayerConnectionUtils.ensureMainThread(packetplayintabcomplete, this, this.player.getWorldServer()); // Paper - run this async
          // CraftBukkit start

--- a/Spigot-Server-Patches/0297-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/Spigot-Server-Patches/0297-Call-player-spectator-target-events-and-improve-impl.patch
@@ -88,10 +88,10 @@ index 1e57e53c965a2e9335aa36926c44f7f3aa43af3c..b0f257cb35ff39d9dd6201235dc3ff5d
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index be2c94a8fb93ee024e035cc8557f230ee7c1c647..72ace986da7af07c4e765fc05399f898b869a119 100644
+index c15d0d0f6f0cfede9c22eba058f2323590f48df7..a534b36ebeb73da843973cc26cdffc91a8173a03 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1206,6 +1206,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1204,6 +1204,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      }
  
      // CraftBukkit start - Delegate to teleport(Location)

--- a/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/Spigot-Server-Patches/0302-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -20,10 +20,10 @@ index d8afb247f180b89f89cbed0f6e6c4fcc527799ff..6f410120018f95259e9e4f504ea1b588
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 72ace986da7af07c4e765fc05399f898b869a119..3a12052b805c84de8b3ed43cdc0f7fb81a4b1211 100644
+index a534b36ebeb73da843973cc26cdffc91a8173a03..c2fa077daad9d29e18b6d562f2870bd38177fb24 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -394,6 +394,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -392,6 +392,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  }
                  speed *= 2f; // TODO: Get the speed of the vehicle instead of the player
  
@@ -37,7 +37,7 @@ index 72ace986da7af07c4e765fc05399f898b869a119..3a12052b805c84de8b3ed43cdc0f7fb8
                  if (d10 - d9 > Math.max(100.0D, Math.pow((double) (org.spigotmc.SpigotConfig.movedTooQuicklyMultiplier * (float) i * speed), 2)) && !this.isExemptPlayer()) {
                  // CraftBukkit end
                      PlayerConnection.LOGGER.warn("{} (vehicle of {}) moved too quickly! {},{},{}", entity.getDisplayName().getString(), this.player.getDisplayName().getString(), d6, d7, d8);
-@@ -992,9 +999,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -990,9 +997,9 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          double d1 = this.player.locY();
                          double d2 = this.player.locZ();
                          double d3 = this.player.locY();
@@ -49,7 +49,7 @@ index 72ace986da7af07c4e765fc05399f898b869a119..3a12052b805c84de8b3ed43cdc0f7fb8
                          float f = packetplayinflying.a(this.player.yaw);
                          float f1 = packetplayinflying.b(this.player.pitch);
                          double d7 = d4 - this.l;
-@@ -1033,6 +1040,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1031,6 +1038,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                              } else {
                                  speed = player.abilities.walkSpeed * 10f;
                              }

--- a/Spigot-Server-Patches/0310-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/Spigot-Server-Patches/0310-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow digging into unloaded chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 3a12052b805c84de8b3ed43cdc0f7fb81a4b1211..1ea1066109814ae441f5ec3be2e72766bf6b67b7 100644
+index c2fa077daad9d29e18b6d562f2870bd38177fb24..cc141f02d5a2b1a5c50e5583d3537d5883762db1 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1370,6 +1370,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1368,6 +1368,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
              case START_DESTROY_BLOCK:
              case ABORT_DESTROY_BLOCK:
              case STOP_DESTROY_BLOCK:

--- a/Spigot-Server-Patches/0311-Book-Size-Limits.patch
+++ b/Spigot-Server-Patches/0311-Book-Size-Limits.patch
@@ -22,7 +22,7 @@ index ba7fdf482ef8536074fcc3867d7fc142fcfe8ce8..2aca8cc2be963b2b015e52cdec6b3843
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 1ea1066109814ae441f5ec3be2e72766bf6b67b7..07c42d062e6618f47afc9a35ae53277527ef7379 100644
+index cc141f02d5a2b1a5c50e5583d3537d5883762db1..8a322537f8418627d7fc6db2f1411bf5ca252dcc 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -20,6 +20,7 @@ import java.util.function.Consumer;
@@ -33,7 +33,7 @@ index 1ea1066109814ae441f5ec3be2e72766bf6b67b7..07c42d062e6618f47afc9a35ae532775
  import org.apache.commons.lang3.StringUtils;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -852,6 +853,42 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -850,6 +851,42 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      @Override
      public void a(PacketPlayInBEdit packetplayinbedit) {

--- a/Spigot-Server-Patches/0325-Fix-sign-edit-memory-leak.patch
+++ b/Spigot-Server-Patches/0325-Fix-sign-edit-memory-leak.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix sign edit memory leak
 when a player edits a sign, a reference to their Entity is never cleand up.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 07c42d062e6618f47afc9a35ae53277527ef7379..1705e223ec913b02793f2c329ff9401fbcf08178 100644
+index 8a322537f8418627d7fc6db2f1411bf5ca252dcc..237f4d381d9d81a1b13845ab3b594f7d99d2d94b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2684,7 +2684,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2682,7 +2682,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              TileEntitySign tileentitysign = (TileEntitySign) tileentity;
  

--- a/Spigot-Server-Patches/0326-Limit-Client-Sign-length-more.patch
+++ b/Spigot-Server-Patches/0326-Limit-Client-Sign-length-more.patch
@@ -22,10 +22,10 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 1705e223ec913b02793f2c329ff9401fbcf08178..192dc7d56769a8800ecfd150f68750ad89e1d08f 100644
+index 237f4d381d9d81a1b13845ab3b594f7d99d2d94b..05e5566bb42525b729dad9c31d6b1c3e4cfab6d0 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -110,6 +110,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -108,6 +108,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private int E;
      private int receivedMovePackets;
      private int processedMovePackets;
@@ -33,7 +33,7 @@ index 1705e223ec913b02793f2c329ff9401fbcf08178..192dc7d56769a8800ecfd150f68750ad
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
      public PlayerConnection(MinecraftServer minecraftserver, NetworkManager networkmanager, EntityPlayer entityplayer) {
-@@ -2698,7 +2699,17 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2696,7 +2697,17 @@ public class PlayerConnection implements PacketListenerPlayIn {
              String[] lines = new String[4];
  
              for (int i = 0; i < list.size(); ++i) {

--- a/Spigot-Server-Patches/0337-Update-entity-Metadata-for-all-tracked-players.patch
+++ b/Spigot-Server-Patches/0337-Update-entity-Metadata-for-all-tracked-players.patch
@@ -22,10 +22,10 @@ index 216445778ce8432fe2506cd7ac4312f43f42ba33..e9bc1d22825850a1f1ef3267428c1984
          this.f.accept(packet);
          if (this.tracker instanceof EntityPlayer) {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 192dc7d56769a8800ecfd150f68750ad89e1d08f..bd84eb771f0c098bbdad1539fc23b6573522e8d8 100644
+index 05e5566bb42525b729dad9c31d6b1c3e4cfab6d0..88d6dbfe6a64ad6e2f5916ca3e87cc2ac5f30227 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2131,7 +2131,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2129,7 +2129,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
                      if (event.isCancelled() || this.player.inventory.getItemInHand() == null || this.player.inventory.getItemInHand().getItem() != origItem) {
                          // Refresh the current entity metadata

--- a/Spigot-Server-Patches/0346-Fix-CB-call-to-changed-postToMainThread-method.patch
+++ b/Spigot-Server-Patches/0346-Fix-CB-call-to-changed-postToMainThread-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CB call to changed postToMainThread method
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index bd84eb771f0c098bbdad1539fc23b6573522e8d8..6c2af33d0807634a79aa092edc363d6561d0cadc 100644
+index 88d6dbfe6a64ad6e2f5916ca3e87cc2ac5f30227..ec20617e3f8982b92d6bcd73bc7b622b04bf2fd5 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -297,7 +297,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -295,7 +295,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
          this.networkManager.getClass();
          // CraftBukkit - Don't wait

--- a/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
@@ -161,7 +161,7 @@ index 944fd203e9f39d6c6fc9e270940c76c98067273a..a27dc38d1a29ed1d63d2f44b7984c2b6
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 9ead9b1ea1fafaa3d684c17efbae747386b7c587..9b8b49be032d7ceebcea8d7b98f999ed7166d0a1 100644
+index e4719a5e7e5ebd91257a9c9b83fa1adad70fd585..9ad822715c9358e5ac2a0e0a0800786a9cee7be3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -1,5 +1,6 @@
@@ -3505,10 +3505,10 @@ index 8e79200b23f2dee612b0cbdcd6359a25dc2323cb..e7d9674e25c06090d57bba6c8229bc3b
          return this.m;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 6c2af33d0807634a79aa092edc363d6561d0cadc..5e74436908c35bfbdba95a39119f115a9512786d 100644
+index ec20617e3f8982b92d6bcd73bc7b622b04bf2fd5..e4d47589d2368c373f920066309b4c5a757906c5 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -582,6 +582,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -580,6 +580,13 @@ public class PlayerConnection implements PacketListenerPlayIn {
              minecraftServer.scheduleOnMain(() -> this.disconnect(new ChatMessage("disconnect.spam", new Object[0]))); // Paper
              return;
          }

--- a/Spigot-Server-Patches/0369-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/Spigot-Server-Patches/0369-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,10 +8,10 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 5e74436908c35bfbdba95a39119f115a9512786d..38cd2768374b44b82060b07924b17f35c466806c 100644
+index e4d47589d2368c373f920066309b4c5a757906c5..ea6476aec59eec50323b0927b6261ebd077926be 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1086,7 +1086,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1084,7 +1084,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                                  speed = player.abilities.walkSpeed * 10f;
                              }
                              // Paper start - Prevent moving into unloaded chunks

--- a/Spigot-Server-Patches/0384-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
+++ b/Spigot-Server-Patches/0384-Fix-AssertionError-when-player-hand-set-to-empty-typ.patch
@@ -19,10 +19,10 @@ index 072fa0ba13bbad5a045cb7fd296fcca160718c8c..65187e7ce1e0ba32cc4a7547e570588c
          if (enumhand == EnumHand.MAIN_HAND) {
              return this.getEquipment(EnumItemSlot.MAINHAND);
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 38cd2768374b44b82060b07924b17f35c466806c..9deee3cf802d43c806008b573219c69f1d62cc61 100644
+index ea6476aec59eec50323b0927b6261ebd077926be..ec14c63fb20737aa9aab22d596bb4045a9a9c867 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1549,6 +1549,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1547,6 +1547,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
                  this.player.getBukkitEntity().updateInventory(); // SPIGOT-2524
                  return;
              }

--- a/Spigot-Server-Patches/0412-Prevent-teleporting-dead-entities.patch
+++ b/Spigot-Server-Patches/0412-Prevent-teleporting-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 9deee3cf802d43c806008b573219c69f1d62cc61..9b58dd080f318a2d197a6f60d40a48b728867b91 100644
+index ec14c63fb20737aa9aab22d596bb4045a9a9c867..8b464d2c05c636bd1412a9b68c9dcb484620da94 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1311,6 +1311,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1309,6 +1309,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
      }
  
      private void internalTeleport(double d0, double d1, double d2, float f, float f1, Set<PacketPlayOutPosition.EnumPlayerTeleportFlags> set) {

--- a/Spigot-Server-Patches/0452-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0452-Load-Chunks-for-Login-Asynchronously.patch
@@ -73,10 +73,10 @@ index 0b1baeab3075a741519c6875f7b4847ce6cad8fc..efb59a7409902aa3c4bf95337683346a
              if (entityplayer != null) {
                  this.g = LoginListener.EnumProtocolState.DELAY_ACCEPT;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 9b58dd080f318a2d197a6f60d40a48b728867b91..88a887f23fd5fc1acd03c1ef3a16a5b73b9c10d1 100644
+index 8b464d2c05c636bd1412a9b68c9dcb484620da94..7257c740334478cc30ad57d1d0d4effb6aa63ab5 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -76,6 +76,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -74,6 +74,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final Logger LOGGER = LogManager.getLogger();
      public final NetworkManager networkManager;
      private final MinecraftServer minecraftServer;
@@ -84,7 +84,7 @@ index 9b58dd080f318a2d197a6f60d40a48b728867b91..88a887f23fd5fc1acd03c1ef3a16a5b7
      public EntityPlayer player;
      private int e;
      private long lastKeepAlive = SystemUtils.getMonotonicMillis(); private void setLastPing(long lastPing) { this.lastKeepAlive = lastPing;}; private long getLastPing() { return this.lastKeepAlive;}; // Paper - OBFHELPER
-@@ -154,6 +155,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -152,6 +153,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
      // CraftBukkit end
  
      public void tick() {
@@ -100,7 +100,7 @@ index 9b58dd080f318a2d197a6f60d40a48b728867b91..88a887f23fd5fc1acd03c1ef3a16a5b7
          this.syncPosition();
          this.player.lastX = this.player.locX();
          this.player.lastY = this.player.locY();
-@@ -195,7 +205,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -193,7 +203,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
              this.r = null;
              this.D = false;
              this.E = 0;

--- a/Spigot-Server-Patches/0459-Implement-Brigadier-Mojang-API.patch
+++ b/Spigot-Server-Patches/0459-Implement-Brigadier-Mojang-API.patch
@@ -69,10 +69,10 @@ index 54a1988341a4a6e80ab40624280b7c92532d5db6..7073d697a5d35b9b72ea05d5608438ac
      public boolean hasPermission(int i) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 88a887f23fd5fc1acd03c1ef3a16a5b73b9c10d1..9a7a1ebc7b0d4b013575da622ee149249d39590c 100644
+index 7257c740334478cc30ad57d1d0d4effb6aa63ab5..c46bc102268ed1effd51b08c95ec1e2f4a538206 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -622,8 +622,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -620,8 +620,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                      ParseResults<CommandListenerWrapper> parseresults = this.minecraftServer.getCommandDispatcher().a().parse(stringreader, this.player.getCommandListener());
  
                      this.minecraftServer.getCommandDispatcher().a().getCompletionSuggestions(parseresults).thenAccept((suggestions) -> {
@@ -87,7 +87,7 @@ index 88a887f23fd5fc1acd03c1ef3a16a5b73b9c10d1..9a7a1ebc7b0d4b013575da622ee14924
                      });
                  });
              }
-@@ -632,7 +636,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -630,7 +634,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              builder = builder.createOffset(builder.getInput().lastIndexOf(' ') + 1);
              completions.forEach(builder::suggest);

--- a/Spigot-Server-Patches/0461-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/Spigot-Server-Patches/0461-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 9a7a1ebc7b0d4b013575da622ee149249d39590c..37b7925b0c6dea0920d67cacf3b1982e8034e202 100644
+index c46bc102268ed1effd51b08c95ec1e2f4a538206..2c1fbea9c9d46f7e9e79324eb97c9871c5be5a87 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -735,7 +735,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -733,7 +733,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
      @Override
      public void a(PacketPlayInPickItem packetplayinpickitem) {
          PlayerConnectionUtils.ensureMainThread(packetplayinpickitem, this, this.player.getWorldServer());

--- a/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1146,10 +1146,10 @@ index fba7c9b5724114eab35a3d24febdee3cd3e30aa0..b6ae589548bdc75052f4986069b3374c
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 37b7925b0c6dea0920d67cacf3b1982e8034e202..99b9da1f8f214082fb30070f7e853447e8ab0ccc 100644
+index 2c1fbea9c9d46f7e9e79324eb97c9871c5be5a87..57de31e07cf0986b64a1650dd28f9fee846a66aa 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1371,6 +1371,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1369,6 +1369,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
          this.A = this.e;
          this.player.setLocation(d0, d1, d2, f, f1);

--- a/Spigot-Server-Patches/0500-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/Spigot-Server-Patches/0500-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,10 +14,10 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 99b9da1f8f214082fb30070f7e853447e8ab0ccc..1a321d4857b5ae426b7e2bcfca8d0bc064559426 100644
+index 57de31e07cf0986b64a1650dd28f9fee846a66aa..73e95ca9cb7f83970ff096084a646dd4dcf23db7 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1168,6 +1168,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1166,6 +1166,11 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
                              this.player.move(EnumMoveType.PLAYER, new Vec3D(d7, d8, d9));
                              this.player.setOnGround(packetplayinflying.b()); // CraftBukkit - SPIGOT-5810, SPIGOT-5835: reset by this.player.move

--- a/Spigot-Server-Patches/0504-Add-and-implement-PlayerRecipeBookClickEvent.patch
+++ b/Spigot-Server-Patches/0504-Add-and-implement-PlayerRecipeBookClickEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add and implement PlayerRecipeBookClickEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 1a321d4857b5ae426b7e2bcfca8d0bc064559426..623ec94e5d3cdd67313510b41cbcbd609d067426 100644
+index 73e95ca9cb7f83970ff096084a646dd4dcf23db7..c33707d55c80341eaacd6c6a7526444ee5b2cc0a 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2604,9 +2604,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2602,9 +2602,15 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinautorecipe, this, this.player.getWorldServer());
          this.player.resetIdleTimer();
          if (!this.player.isSpectator() && this.player.activeContainer.windowId == packetplayinautorecipe.b() && this.player.activeContainer.c(this.player) && this.player.activeContainer instanceof ContainerRecipeBook) {

--- a/Spigot-Server-Patches/0507-Add-permission-for-command-blocks.patch
+++ b/Spigot-Server-Patches/0507-Add-permission-for-command-blocks.patch
@@ -31,10 +31,10 @@ index 7e13b1cf6d92c3e0f2dab1ba1d42bd4f250e256c..3820acd65f3cd488dba964e6d9c45885
          } else {
              if (entityhuman.getWorld().isClientSide) {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 623ec94e5d3cdd67313510b41cbcbd609d067426..d01950720cb769ad13713812abee32d05edfa46d 100644
+index c33707d55c80341eaacd6c6a7526444ee5b2cc0a..b1156e31ec45b7515734a440f07331cf731c3ab6 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -650,7 +650,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -648,7 +648,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinsetcommandblock, this, this.player.getWorldServer());
          if (!this.minecraftServer.getEnableCommandBlock()) {
              this.player.sendMessage(new ChatMessage("advMode.notEnabled"), SystemUtils.b);
@@ -43,7 +43,7 @@ index 623ec94e5d3cdd67313510b41cbcbd609d067426..d01950720cb769ad13713812abee32d0
              this.player.sendMessage(new ChatMessage("advMode.notAllowed"), SystemUtils.b);
          } else {
              CommandBlockListenerAbstract commandblocklistenerabstract = null;
-@@ -713,7 +713,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -711,7 +711,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          PlayerConnectionUtils.ensureMainThread(packetplayinsetcommandminecart, this, this.player.getWorldServer());
          if (!this.minecraftServer.getEnableCommandBlock()) {
              this.player.sendMessage(new ChatMessage("advMode.notEnabled"), SystemUtils.b);

--- a/Spigot-Server-Patches/0510-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0510-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -63,10 +63,10 @@ index 450c04c5a1153ea9d11d005f3be623bbf8b26ce6..157f8f5e5255312b916aef200810ad38
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index d01950720cb769ad13713812abee32d05edfa46d..8a07a7de26308ceb01aaeb54f1dddfe0a3565564 100644
+index b1156e31ec45b7515734a440f07331cf731c3ab6..aa7b907cee743640e30e25c95f3bbca49ec57e1e 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -2874,7 +2874,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2872,7 +2872,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      public void a(PacketPlayInDifficultyChange packetplayindifficultychange) {
          PlayerConnectionUtils.ensureMainThread(packetplayindifficultychange, this, this.player.getWorldServer());
          if (this.player.k(2) || this.isExemptPlayer()) {

--- a/Spigot-Server-Patches/0532-Move-range-check-for-block-placing-up.patch
+++ b/Spigot-Server-Patches/0532-Move-range-check-for-block-placing-up.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 8a07a7de26308ceb01aaeb54f1dddfe0a3565564..eae8ba055b0cd595a31ce4d99622366ce2cc9bb0 100644
+index aa7b907cee743640e30e25c95f3bbca49ec57e1e..da172db2ccda64a7160282440d5548bd7e7eda80 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -1504,15 +1504,19 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1502,15 +1502,19 @@ public class PlayerConnection implements PacketListenerPlayIn {
          BlockPosition blockposition = movingobjectpositionblock.getBlockPosition();
          EnumDirection enumdirection = movingobjectpositionblock.getDirection();
  

--- a/Spigot-Server-Patches/0547-Brand-support.patch
+++ b/Spigot-Server-Patches/0547-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c1002a04d14b 100644
+index da172db2ccda64a7160282440d5548bd7e7eda80..8a4a7888089a10416fc0cf88007b7a958e903a4c 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -5,6 +5,7 @@ import com.google.common.primitives.Doubles;
@@ -16,7 +16,7 @@ index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c100
  import io.netty.util.concurrent.Future;
  import io.netty.util.concurrent.GenericFutureListener;
  import it.unimi.dsi.fastutil.ints.Int2ShortMap;
-@@ -114,6 +115,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -112,6 +113,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final int MAX_SIGN_LINE_LENGTH = Integer.getInteger("Paper.maxSignLength", 80);
      private static final long KEEPALIVE_LIMIT = Long.getLong("paper.playerconnection.keepalive", 30) * 1000; // Paper - provide property to set keepalive limit
  
@@ -25,7 +25,7 @@ index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c100
      public PlayerConnection(MinecraftServer minecraftserver, NetworkManager networkmanager, EntityPlayer entityplayer) {
          this.minecraftServer = minecraftserver;
          this.networkManager = networkmanager;
-@@ -2833,6 +2836,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2831,6 +2834,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
      private static final MinecraftKey CUSTOM_REGISTER = new MinecraftKey("register");
      private static final MinecraftKey CUSTOM_UNREGISTER = new MinecraftKey("unregister");
  
@@ -34,7 +34,7 @@ index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c100
      @Override
      public void a(PacketPlayInCustomPayload packetplayincustompayload) {
          PlayerConnectionUtils.ensureMainThread(packetplayincustompayload, this, this.player.getWorldServer());
-@@ -2860,6 +2865,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2858,6 +2863,16 @@ public class PlayerConnection implements PacketListenerPlayIn {
              try {
                  byte[] data = new byte[packetplayincustompayload.data.readableBytes()];
                  packetplayincustompayload.data.readBytes(data);
@@ -51,7 +51,7 @@ index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c100
                  server.getMessenger().dispatchIncomingMessage(player.getBukkitEntity(), packetplayincustompayload.tag.toString(), data);
              } catch (Exception ex) {
                  PlayerConnection.LOGGER.error("Couldn\'t dispatch custom payload", ex);
-@@ -2869,6 +2884,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -2867,6 +2882,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
      }
  
@@ -65,7 +65,7 @@ index eae8ba055b0cd595a31ce4d99622366ce2cc9bb0..6cb6a6d2cdf25c7db0e3d2c79af2c100
          return (!this.player.joining && !this.networkManager.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0697f39459ffb3905b68010541b1f200bc92ad90..1a536de0397fdec40fe821ff45b2b10665cf807a 100644
+index fda5ead74838dd54045eb30b92384c6544e8b93d..8a4e574857fdcc5cf950371da606fcb07d78a9b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2190,6 +2190,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0569-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/Spigot-Server-Patches/0569-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -35,10 +35,10 @@ index 6aeea48d4cf4732f6a5a5dba12af873c2aee493b..fa0256a99c833e6035b8d3e873a93af2
          this.yaw = f;
          this.pitch = f1;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 6cb6a6d2cdf25c7db0e3d2c79af2c1002a04d14b..d622abf1013d500532cc6072e5cbb12248e983c2 100644
+index 8a4a7888089a10416fc0cf88007b7a958e903a4c..c0524ff9f49dffa4010bdeef301c0d7a059046d4 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -544,7 +544,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -542,7 +542,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
      public void a(PacketPlayInTeleportAccept packetplayinteleportaccept) {
          PlayerConnectionUtils.ensureMainThread(packetplayinteleportaccept, this, this.player.getWorldServer());
          if (packetplayinteleportaccept.b() == this.teleportAwait && this.teleportPos != null) { // CraftBukkit
@@ -47,7 +47,7 @@ index 6cb6a6d2cdf25c7db0e3d2c79af2c1002a04d14b..d622abf1013d500532cc6072e5cbb122
              this.o = this.teleportPos.x;
              this.p = this.teleportPos.y;
              this.q = this.teleportPos.z;
-@@ -1378,7 +1378,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1376,7 +1376,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          // CraftBukkit end
  
          this.A = this.e;

--- a/Spigot-Server-Patches/0582-Fix-for-large-move-vectors-crashing-server.patch
+++ b/Spigot-Server-Patches/0582-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index d622abf1013d500532cc6072e5cbb12248e983c2..563ae7355f4f4645d21f2fbd494a5b5656c5e664 100644
+index c0524ff9f49dffa4010bdeef301c0d7a059046d4..c1ce4d39e59d0e49996169dc9c26e8ccafde6e3e 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -369,19 +369,24 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -367,19 +367,24 @@ public class PlayerConnection implements PacketListenerPlayIn {
  
              if (entity != this.player && entity.getRidingPassenger() == this.player && entity == this.r) {
                  WorldServer worldserver = this.player.getWorldServer();
@@ -41,7 +41,7 @@ index d622abf1013d500532cc6072e5cbb12248e983c2..563ae7355f4f4645d21f2fbd494a5b56
  
  
                  // CraftBukkit start - handle custom speeds and skipped ticks
-@@ -1073,7 +1078,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1071,7 +1076,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          double d2 = this.player.locZ();
                          double d3 = this.player.locY();
                          double d4 = packetplayinflying.a(this.player.locX());double toX = d4; // Paper - OBFHELPER
@@ -50,7 +50,7 @@ index d622abf1013d500532cc6072e5cbb12248e983c2..563ae7355f4f4645d21f2fbd494a5b56
                          double d6 = packetplayinflying.c(this.player.locZ());double toZ = d6; // Paper - OBFHELPER
                          float f = packetplayinflying.a(this.player.yaw);
                          float f1 = packetplayinflying.b(this.player.pitch);
-@@ -1081,7 +1086,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -1079,7 +1084,12 @@ public class PlayerConnection implements PacketListenerPlayIn {
                          double d8 = d5 - this.m;
                          double d9 = d6 - this.n;
                          double d10 = this.player.getMot().g();

--- a/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
+++ b/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
@@ -37,10 +37,10 @@ index 7a84ea4116be070ab878e55b0cd919f3f3688f30..3ec8ba17ddf376aa98e2b74979b25449
                          NetworkManager.LOGGER.debug("Failed to sent packet", throwable);
                          this.sendPacket(new PacketPlayOutKickDisconnect(chatmessage), (future) -> {
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 563ae7355f4f4645d21f2fbd494a5b5656c5e664..a736d676ef5e3a25c144743af559bfb46e294db7 100644
+index c1ce4d39e59d0e49996169dc9c26e8ccafde6e3e..0aac84e9800788947bb75b04307ba6fffb57dab8 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -300,6 +300,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -298,6 +298,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          final IChatBaseComponent ichatbasecomponent = CraftChatMessage.fromString(s, true)[0];
          // CraftBukkit end
  


### PR DESCRIPTION
the server patch for the packet was removed in 62a5faf3 but the event wasn't deprecated. 
I also removed the reference to it in PlayerConnection that was kept because another patch had modified it. 