### PR TITLE
Fix MC-181190 curing zombie villager discount exploit

### DIFF
--- a/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Tue, 8 Dec 2020 20:14:20 -0600
+Subject: [PATCH] Fix curing zombie villager discount exploit
+
+This fixes the exploit used to gain absurd trading discounts with infecting
+and curing a villager on repeat by simply resetting the reputation when it
+is cured.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 5596d9f42523dbcbad47d21a4b2fdba39e3c5590..ae5ed3bd0b663092a4658b24cbd69d37b4e141cb 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -704,4 +704,9 @@ public class PaperWorldConfig {
+     private void fixClimbingBypassingCrammingRule() {
+         fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
+     }
++
++    public boolean fixCuringZombieVillagerDiscountExploit = true;
++    private void fixCuringExploit() {
++        fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index 0388d1099f2a6d436a5a5e58bbbdae3ddab969e7..9b35c8ad9efe9241fe442bc6ef2e9f62def386d8 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -39,7 +39,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+     @Nullable
+     private EntityHuman bv;
+     private byte bx;
+-    private final Reputation by;
++    private Reputation by; private void resetReputation() { this.by = new Reputation(); } // Paper - OBFHELPER
+     private long bz;
+     private long bA;
+     private int bB;
+@@ -923,6 +923,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+     @Override
+     public void a(ReputationEvent reputationevent, Entity entity) {
+         if (reputationevent == ReputationEvent.a) {
++            if (world.paperConfig.fixCuringZombieVillagerDiscountExploit) this.resetReputation(); // Paper - fix MC-181190
+             this.by.a(entity.getUniqueID(), ReputationType.MAJOR_POSITIVE, 20);
+             this.by.a(entity.getUniqueID(), ReputationType.MINOR_POSITIVE, 25);
+         } else if (reputationevent == ReputationEvent.e) {


### PR DESCRIPTION
This fixes the exploit used to gain absurd trading discounts with infecting
and curing a villager on repeat by simply resetting the reputation when it
is cured.