### PR TITLE
Fix MC-4 (oldest MC bug) item position desync

### DIFF
--- a/Spigot-Server-Patches/0616-MC-4-Fix-item-position-desync.patch
+++ b/Spigot-Server-Patches/0616-MC-4-Fix-item-position-desync.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Tue, 8 Dec 2020 20:24:52 -0600
+Subject: [PATCH] MC-4: Fix item position desync
+
+This fixes item position desync (MC-4) by running the item coordinates
+through the encode/decode methods of the packet that causes the precision
+loss, which forces the server to lose the same precision as the client
+keeping them in sync.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index cdf1177ca7b4b1b0808176c455f62b395146da50..26db8a5d92d494e5f6ba9498d5a1aa555642a92b 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -469,4 +469,9 @@ public class PaperConfig {
+     private static void trackPluginScoreboards() {
+         trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
+     }
++
++    public static boolean fixEntityPositionDesync = true;
++    private static void fixEntityPositionDesync() {
++        fixEntityPositionDesync = getBoolean("settings.fix-entity-position-desync", fixEntityPositionDesync);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
+index ba73d14437cfdf07ef0f1f6266131c113c2741fd..f41aaa7623c052b9f4044898d1bdee898c03057a 100644
+--- a/src/main/java/net/minecraft/server/EntityItem.java
++++ b/src/main/java/net/minecraft/server/EntityItem.java
+@@ -523,4 +523,16 @@ public class EntityItem extends Entity {
+     public Packet<?> P() {
+         return new PacketPlayOutSpawnEntity(this);
+     }
++
++    // Paper start - fix MC-4
++    public void setPositionRaw(double x, double y, double z) {
++        if (com.destroystokyo.paper.PaperConfig.fixEntityPositionDesync) {
++            // encode/decode from PacketPlayOutEntity
++            x = MathHelper.floorLong(x * 4096.0D) * (1 / 4096.0D);
++            y = MathHelper.floorLong(y * 4096.0D) * (1 / 4096.0D);
++            z = MathHelper.floorLong(z * 4096.0D) * (1 / 4096.0D);
++        }
++        super.setPositionRaw(x, y, z);
++    }
++    // Paper end - fix MC-4
+ }
+diff --git a/src/main/java/net/minecraft/server/MathHelper.java b/src/main/java/net/minecraft/server/MathHelper.java
+index 1731a1bca5ad02fd8cd8701f49c10cb74ee6f503..2e7721a650c5a351b3584665bd236f92ef577761 100644
+--- a/src/main/java/net/minecraft/server/MathHelper.java
++++ b/src/main/java/net/minecraft/server/MathHelper.java
+@@ -7,7 +7,7 @@ import java.util.function.IntPredicate;
+ public class MathHelper {
+ 
+     public static final float a = c(2.0F);
+-    private static final float[] b = (float[]) SystemUtils.a((Object) (new float[65536]), (afloat) -> {
++    private static final float[] b = (float[]) SystemUtils.a((new float[65536]), (afloat) -> { // Paper - decompile error
+         for (int i = 0; i < afloat.length; ++i) {
+             afloat[i] = (float) Math.sin((double) i * 3.141592653589793D * 2.0D / 65536.0D);
+         }
+@@ -47,6 +47,7 @@ public class MathHelper {
+         return d0 < (double) i ? i - 1 : i;
+     }
+ 
++    public static long floorLong(double d0) { return d(d0); } // Paper - OBFHELPER
+     public static long d(double d0) {
+         long i = (long) d0;
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutEntity.java b/src/main/java/net/minecraft/server/PacketPlayOutEntity.java
+index e5da2b19c1177ba7f88f0aaad9d810bb313ce67b..8e48407fd405ac4c3eece7762b8155c5d0f00fa0 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutEntity.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutEntity.java
+@@ -15,11 +15,11 @@ public class PacketPlayOutEntity implements Packet<PacketListenerPlayOut> {
+     protected boolean i;
+ 
+     public static long a(double d0) {
+-        return MathHelper.d(d0 * 4096.0D);
++        return MathHelper.d(d0 * 4096.0D); // Paper - check EntityItem#setPositionRaw on update
+     }
+ 
+     public static Vec3D a(long i, long j, long k) {
+-        return (new Vec3D((double) i, (double) j, (double) k)).a(2.44140625E-4D);
++        return (new Vec3D((double) i, (double) j, (double) k)).a(2.44140625E-4D); // Paper - check EntityItem#setPositionRaw on update
+     }
+ 
+     public PacketPlayOutEntity() {}


### PR DESCRIPTION
This fixes item position desync (MC-4) by running the item coordinates
through the encryption/decryption methods of the packet that causes the
precision loss, which forces the server to lose the same precision as
the client keeping them in sync.