### PR TITLE
Fix curing villager makes equipment disappear

### DIFF
--- a/Spigot-Server-Patches/0614-Fix-curing-villager-makes-equipment-disappear.patch
+++ b/Spigot-Server-Patches/0614-Fix-curing-villager-makes-equipment-disappear.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Tue, 8 Dec 2020 22:06:56 -0600
+Subject: [PATCH] Fix curing villager makes equipment disappear
+
+This fixes the CB bug where curing a villager that is holding
+equipment (weapons/armor) causes the items to disappear instead of drop
+to the ground by forcing the items to drop instead of going to the drops
+field for the EntityDeathEvent which does not fire for entity conversions.
+
+diff --git a/src/main/java/net/minecraft/server/EntityZombieVillager.java b/src/main/java/net/minecraft/server/EntityZombieVillager.java
+index a5214914a1dd5effe249e6b9372d7ecf441ee1e1..e021c43b43839c00f81a01bfbec59c546d61ba50 100644
+--- a/src/main/java/net/minecraft/server/EntityZombieVillager.java
++++ b/src/main/java/net/minecraft/server/EntityZombieVillager.java
+@@ -180,7 +180,9 @@ public class EntityZombieVillager extends EntityZombie implements VillagerDataHo
+                     double d0 = (double) this.e(enumitemslot);
+ 
+                     if (d0 > 1.0D) {
++                        this.forceDrops = true; // Paper - fix SPIGOT-6207
+                         this.a(itemstack);
++                        this.forceDrops = false; // Paper - fix SPIGOT-6207
+                     }
+                 }
+             }


### PR DESCRIPTION
This fixes the CB bug where curing a villager that is holding equipment (weapons/armor) causes the items to disappear instead of drop to the ground by forcing the items to drop instead of going to the drops field for the EntityDeathEvent which does not fire for entity conversions.

https://hub.spigotmc.org/jira/browse/SPIGOT-6207