### PR TITLE
Fix Armor Stands dropping held items at different height than vanilla

### DIFF
--- a/Spigot-Server-Patches/0614-Fix-Armor-Stands-dropping-held-items-at-different-he.patch
+++ b/Spigot-Server-Patches/0614-Fix-Armor-Stands-dropping-held-items-at-different-he.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Thu, 10 Dec 2020 00:56:43 -0800
+Subject: [PATCH] Fix Armor Stands dropping held items at different height than
+ vanilla
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityArmorStand.java b/src/main/java/net/minecraft/server/EntityArmorStand.java
+index 8fef94ad9ac795311fb083a384ed98f1ea860f0a..fc3193a175f7a02160633cebe024ce1869d732a8 100644
+--- a/src/main/java/net/minecraft/server/EntityArmorStand.java
++++ b/src/main/java/net/minecraft/server/EntityArmorStand.java
+@@ -557,10 +557,11 @@ public class EntityArmorStand extends EntityLiving {
+         ItemStack itemstack;
+         int i;
+ 
++        this.forceDrops = true; // Paper - Drop held/worn items at same height as vanilla
+         for (i = 0; i < this.handItems.size(); ++i) {
+             itemstack = (ItemStack) this.handItems.get(i);
+             if (!itemstack.isEmpty()) {
+-                drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack)); // CraftBukkit - add to drops // Paper - mirror so we can destroy it later - though this call site was safe
++                this.dropItem(itemstack, 1.0f); // Paper - Drop held/worn items at same height as vanilla
+                 this.handItems.set(i, ItemStack.b);
+             }
+         }
+@@ -568,10 +569,11 @@ public class EntityArmorStand extends EntityLiving {
+         for (i = 0; i < this.armorItems.size(); ++i) {
+             itemstack = (ItemStack) this.armorItems.get(i);
+             if (!itemstack.isEmpty()) {
+-                drops.add(org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemstack)); // CraftBukkit - add to drops // Paper - mirror so we can destroy it later - though this call site was safe
++                this.dropItem(itemstack, 1.0f); // Paper - Drop held/worn items at same height as vanilla
+                 this.armorItems.set(i, ItemStack.b);
+             }
+         }
++        this.forceDrops = false; // Paper - Drop held/worn items at same height as vanilla
+         this.d(damagesource); // CraftBukkit - moved from above
+ 
+     }


### PR DESCRIPTION
In vanilla, an Armor Stand's held/worn items are dropped using `Block.dropItem` with the BlockPosition +1y above the BlockPosition of the Armor Stand, whereas in CraftBukkit and derivatives, the held/worn items are dropped with the rest of the death drops in the death event, at the entity's position. ([CB diff](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/browse/nms-patches/EntityArmorStand.patch#128))

This patch makes it so that the drops end up in the right location, but also causes the items to be in an EntityDropItemEvent instead of the death event.
Ideally we would still use the death event for all the drops, but I'm not sure the best way to do that while only modifying the drop position of the held/worn items, and not the Armor Stand item itself.

Fixes #4743 

alternative solution: refactor death drops to use EntityItem instead of ItemStack. API can still modify the ItemStack through the craftMirror, and although we can't expose the EntityItem to API, it shouldn't cause any issues.