### PR TITLE
Expose LivingEntity hurt direction

### DIFF
--- a/Spigot-API-Patches/0243-Expose-LivingEntity-hurt-direction.patch
+++ b/Spigot-API-Patches/0243-Expose-LivingEntity-hurt-direction.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
+Date: Sun, 13 Dec 2020 05:32:12 +0200
+Subject: [PATCH] Expose LivingEntity hurt direction
+
+
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index e535750d01a6c1bf4b1fe94df518166213da9b08..9f0645dc5f76ee9ef73d88f768025429e5a9edf7 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -835,5 +835,19 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * @param quantity quantity of item
+      */
+     void playPickupItemAnimation(@NotNull Item item, int quantity);
++
++    /**
++     * Gets player hurt direction
++     *
++     * @return hurt direction
++     */
++    float getHurtDirection();
++
++    /**
++     * Sets player hurt direction
++     *
++     * @param hurtDirection hurt direction
++     */
++    void setHurtDirection(float hurtDirection);
+     // Paper end
+ }

--- a/Spigot-Server-Patches/0620-Expose-LivingEntity-hurt-direction.patch
+++ b/Spigot-Server-Patches/0620-Expose-LivingEntity-hurt-direction.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mark Vainomaa <mikroskeem@mikroskeem.eu>
+Date: Sun, 13 Dec 2020 05:32:05 +0200
+Subject: [PATCH] Expose LivingEntity hurt direction
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index dd3287f953a1a24d2406816b3c0ae176476b6452..0294ff10dc8edb24aabfbe1589048a405c356ef0 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -69,7 +69,7 @@ public abstract class EntityLiving extends Entity {
+     public int am;
+     public int hurtTicks;
+     public int hurtDuration;
+-    public float ap;
++    public float ap; public final float getHurtDirection() { return ap; } public final void setHurtDirection(float hurtDirection) { this.ap = hurtDirection; } // Paper - OBFHELPER
+     public int deathTicks;
+     public float ar;
+     public float as;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 1fc356d0b74c1cbb19bf7527088f1f61b6da5422..16e69cfd4994fd6850ee3635ea819379412351c9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -815,5 +815,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+     public void playPickupItemAnimation(org.bukkit.entity.Item item, int quantity) {
+         getHandle().receive(((CraftItem) item).getHandle(), quantity);
+     }
++
++    @Override
++    public float getHurtDirection() {
++        return getHandle().getHurtDirection();
++    }
++
++    @Override
++    public void setHurtDirection(float hurtDirection) {
++        getHandle().setHurtDirection(hurtDirection);
++    }
+     // Paper end
+ }


### PR DESCRIPTION
Helps implementing a cosmetical fix to https://bugs.mojang.com/browse/MC-26678

Example (for [DamageTilt mod](https://github.com/Charles445/DamageTilt)):
```kotlin
    @EventHandler
    fun on(event: EntityKnockbackByEntityEvent) {
        val victim = event.entity as? Player ?: return

        if (!victim.listeningPluginChannels.contains("damagetilt:attackedatyaw")) {
            return
        }

        // Send hurt direction
        victim.sendPluginMessage(plugin, "damagetilt:attackedatyaw", ByteArrayOutputStream().also { baos ->
            DataOutputStream(baos).also { dos ->
                dos.writeFloat(victim.getHurtDirection())
            }
        }.toByteArray())
    }
```