### PR TITLE
allow individual plugins to load datapacks [wip]

### DIFF
--- a/Spigot-API-Patches/0242-extend-ResourcePackFile-to-use-jar-based-datapacks-a.patch
+++ b/Spigot-API-Patches/0242-extend-ResourcePackFile-to-use-jar-based-datapacks-a.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
+Date: Tue, 22 Dec 2020 16:50:18 -0600
+Subject: [PATCH] extend ResourcePackFile to use jar based datapacks and remove
+ world datapacks from running first pass so plugin datapacks have a lower
+ priority than them.
+
+
+diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
+index 79890c68f1ad31f951dfdbd9a16dac500ec58c40..890abe719dd4d70c02bcaf8895c7d8eedfd266d1 100644
+--- a/src/main/java/org/bukkit/plugin/Plugin.java
++++ b/src/main/java/org/bukkit/plugin/Plugin.java
+@@ -171,6 +171,14 @@ public interface Plugin extends TabExecutor {
+     default org.slf4j.Logger getSLF4JLogger() {
+         return org.slf4j.LoggerFactory.getLogger(getLogger().getName());
+     }
++
++    /**
++     * Returns the file where the jar is located.
++     *
++     * @return The jar.
++     */
++    @NotNull
++    public File getFile();
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+index 04fa3991f6ce4e9dad804f28fc6c947695857089..0818dbd39b6d4c3354bdbb0332b98a98b3f16f2a 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPlugin.java
+@@ -111,7 +111,7 @@ public abstract class JavaPlugin extends PluginBase {
+      * @return File containing this plugin
+      */
+     @NotNull
+-    protected File getFile() {
++    public File getFile() { // paper - widen access for plugin datapacks
+         return file;
+     }
+ 
+diff --git a/src/test/java/org/bukkit/plugin/TestPlugin.java b/src/test/java/org/bukkit/plugin/TestPlugin.java
+index 6d450897187e810070f633e832034763a102a0b0..49b34e3f56ed6857062b35e7536bbb73fdbb8aba 100644
+--- a/src/test/java/org/bukkit/plugin/TestPlugin.java
++++ b/src/test/java/org/bukkit/plugin/TestPlugin.java
+@@ -121,4 +121,9 @@ public class TestPlugin extends PluginBase {
+     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+         throw new UnsupportedOperationException("Not supported.");
+     }
++    // paper start
++    @Override
++    public File getFile() {
++        throw new UnsupportedOperationException("Not supported.");
++    } // paper end
+ }

--- a/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
+++ b/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
@@ -4,13 +4,13 @@ Date: Tue, 15 Dec 2020 09:07:01 -0600
 Subject: [PATCH] Allow individual plugins to load datapacks
 
 
-diff --git a/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java b/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java
+diff --git a/src/main/java/io/papermc/paper/datapack/PluginDataPack.java b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ec8d5c32ea14bc4941a318d9b8177627950ebfa3
+index 0000000000000000000000000000000000000000..2c2f0a55c8e2314cff72a16015e39c056b3442a7
 --- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java
++++ b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
 @@ -0,0 +1,59 @@
-+package com.destroystokyo.paper.datapack;
++package io.papermc.paper.datapack;
 +
 +import net.minecraft.server.EnumResourcePackType;
 +import net.minecraft.server.MinecraftKey;
@@ -69,13 +69,13 @@ index 0000000000000000000000000000000000000000..ec8d5c32ea14bc4941a318d9b8177627
 +        return enabledByDefault;
 +    }
 +}
-diff --git a/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java b/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java
+diff --git a/src/main/java/io/papermc/paper/datapack/PluginSource.java b/src/main/java/io/papermc/paper/datapack/PluginSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bf44986a74db72478e5244c7c565ccd1bd6831f9
+index 0000000000000000000000000000000000000000..ac4a0924b042d586225c6ced813ce7470e365738
 --- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java
++++ b/src/main/java/io/papermc/paper/datapack/PluginSource.java
 @@ -0,0 +1,46 @@
-+package com.destroystokyo.paper.datapack;
++package io.papermc.paper.datapack;
 +
 +import net.minecraft.server.EnumResourcePackType;
 +import net.minecraft.server.PackSource;
@@ -122,13 +122,13 @@ index 0000000000000000000000000000000000000000..bf44986a74db72478e5244c7c565ccd1
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 5504facd2e453238caa71d98743be5416d4dd4fe..e95d4e0f1971c6b1c24e47e48fdd1d5cc7a990fd 100644
+index 5504facd2e453238caa71d98743be5416d4dd4fe..1ced0af1c23e9ebc5c2fbefbbf051d7680860f46 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -1,5 +1,6 @@
  package net.minecraft.server;
  
-+import com.destroystokyo.paper.datapack.PluginSource;
++import io.papermc.paper.datapack.PluginSource;
  import com.google.common.base.Strings;
  import com.google.common.collect.Lists;
  import com.mojang.authlib.GameProfile;
@@ -174,18 +174,6 @@ index 5504facd2e453238caa71d98743be5416d4dd4fe..e95d4e0f1971c6b1c24e47e48fdd1d5c
          server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
          // CraftBukkit end
  
-diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ae48df4b9b78bc3a687166fdaa7b8a60bd13ec35..a484f8e24772225812d26f411f8febfcd10f41fe 100644
---- a/src/main/java/net/minecraft/server/Main.java
-+++ b/src/main/java/net/minecraft/server/Main.java
-@@ -119,7 +119,6 @@ public class Main {
-             if (flag) {
-                 Main.LOGGER.warn("Safe mode active, only vanilla datapack will be loaded");
-             }
--
-             ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)});
-             // CraftBukkit start
-             File bukkitDataPackFolder = new File(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), "bukkit");
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 172fc9ef9c0d3444eb99f750a17d42f130d94f73..0d94a049c1e2311ea40fbc7e13277abbc3b0e1df 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
+++ b/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
@@ -1,0 +1,201 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
+Date: Tue, 15 Dec 2020 09:07:01 -0600
+Subject: [PATCH] Allow individual plugins to load datapacks
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java b/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ec8d5c32ea14bc4941a318d9b8177627950ebfa3
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/datapack/PluginDataPack.java
+@@ -0,0 +1,59 @@
++package com.destroystokyo.paper.datapack;
++
++import net.minecraft.server.EnumResourcePackType;
++import net.minecraft.server.MinecraftKey;
++import net.minecraft.server.ResourcePackFolder;
++import org.bukkit.plugin.Plugin;
++
++import java.io.File;
++import java.io.IOException;
++import java.io.InputStream;
++import java.util.Collection;
++import java.util.Set;
++import java.util.function.Predicate;
++
++public class PluginDataPack extends ResourcePackFolder {
++
++    private Plugin plugin;
++    private File file;
++    private boolean enabledByDefault;
++
++    public PluginDataPack(Plugin plugin, File file, boolean enabledByDefault) {
++        super(file);
++        this.plugin = plugin;
++        this.file = file;
++        this.enabledByDefault = enabledByDefault;
++    }
++
++    @Override
++    protected InputStream a(String s) throws IOException {
++        return super.a(s);
++    }
++
++    @Override
++    protected boolean c(String s) {
++        return super.c(s);
++    }
++
++    @Override
++    public Collection<MinecraftKey> a(EnumResourcePackType enumResourcePackType, String s, String s1, int i, Predicate<String> predicate) {
++        return super.a(enumResourcePackType, s, s1, i, predicate);
++    }
++
++    @Override
++    public Set<String> a(EnumResourcePackType enumResourcePackType) {
++        return super.a(enumResourcePackType);
++    }
++
++    public Plugin getPlugin() {
++        return plugin;
++    }
++
++    public File getPath() {
++        return file;
++    }
++
++    public boolean isEnabledByDefault() {
++        return enabledByDefault;
++    }
++}
+diff --git a/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java b/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bf44986a74db72478e5244c7c565ccd1bd6831f9
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/datapack/PluginSource.java
+@@ -0,0 +1,46 @@
++package com.destroystokyo.paper.datapack;
++
++import net.minecraft.server.EnumResourcePackType;
++import net.minecraft.server.PackSource;
++import net.minecraft.server.ResourcePackLoader;
++import net.minecraft.server.ResourcePackSource;
++import org.bukkit.plugin.Plugin;
++
++import java.io.File;
++import java.nio.file.Files;
++import java.util.ArrayList;
++import java.util.List;
++import java.util.function.Consumer;
++
++public class PluginSource implements ResourcePackSource {
++
++    private Plugin[] plugins;
++
++    public PluginSource(Plugin[] plugins) {
++        this.plugins = plugins;
++    }
++
++    @Override
++    public void a(Consumer<ResourcePackLoader> consumer, ResourcePackLoader.a creator) {
++        List<PluginDataPack> packs = new ArrayList<>();
++
++        for (Plugin plugin : plugins) {
++            File pack = new File(plugin.getDataFolder(), "datapack");
++            boolean enabledByDefault = Files.exists(pack.toPath());
++            PluginDataPack dataPack = new PluginDataPack(plugin, pack, enabledByDefault);
++            if (!dataPack.a(EnumResourcePackType.SERVER_DATA).isEmpty()) {
++                packs.add(dataPack);
++            }
++        }
++
++        for (PluginDataPack pack : packs) {
++            ResourcePackLoader resourcePack = ResourcePackLoader.a("plugin/" + pack.getPlugin().getName(), pack.isEnabledByDefault(),
++                () -> pack, creator, ResourcePackLoader.Position.TOP, PackSource.d);
++            if (resourcePack != null) {
++                consumer.accept(resourcePack);
++            }
++        }
++
++
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
+index 5504facd2e453238caa71d98743be5416d4dd4fe..e95d4e0f1971c6b1c24e47e48fdd1d5cc7a990fd 100644
+--- a/src/main/java/net/minecraft/server/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/DedicatedServer.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import com.destroystokyo.paper.datapack.PluginSource;
+ import com.google.common.base.Strings;
+ import com.google.common.collect.Lists;
+ import com.mojang.authlib.GameProfile;
+@@ -7,6 +8,7 @@ import com.mojang.authlib.GameProfileRepository;
+ import com.mojang.authlib.minecraft.MinecraftSessionService;
+ import com.mojang.datafixers.DataFixer;
+ import java.io.BufferedReader;
++import java.io.File;
+ import java.io.IOException;
+ import java.io.InputStreamReader;
+ import java.net.InetAddress;
+@@ -16,6 +18,7 @@ import java.util.Collections;
+ import java.util.List;
+ import java.util.Locale;
+ import java.util.Optional;
++import java.util.concurrent.CompletableFuture;
+ import java.util.function.BooleanSupplier;
+ import java.util.regex.Pattern;
+ import javax.annotation.Nullable;
+@@ -204,6 +207,25 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         // CraftBukkit start
+         // this.a((PlayerList) (new DedicatedPlayerList(this, this.customRegistry, this.worldNBTStorage))); // Spigot - moved up
+         server.loadPlugins();
++        // paper start - create a new repository but include the plugins this time and then reload the datapacks so they're included.
++        if (!options.has("safeMode")) {
++            ResourcePackRepository resourceRepo = new ResourcePackRepository(new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c), new PluginSource(server.getPluginManager().getPlugins()));
++
++            DataPackConfiguration newConfiguration = MinecraftServer.a(resourceRepo, datapackconfiguration == null ? DataPackConfiguration.a : datapackconfiguration, false);
++            CompletableFuture<DataPackResources> completablefuture = DataPackResources.a(resourceRepo.f(), CommandDispatcher.ServerType.DEDICATED, dedicatedserverproperties.functionPermissionLevel, SystemUtils.f(), Runnable::run);
++
++            DataPackResources datapackresources;
++
++            try {
++                datapackresources = completablefuture.get();
++                datapackresources.i();
++            } catch (Exception exception) {
++                DedicatedServer.LOGGER.warn("Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode", exception);
++                resourceRepo.close();
++            }
++            datapackconfiguration = newConfiguration;
++            resourcePackRepository = resourceRepo;
++        } // paper end
+         server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
+         // CraftBukkit end
+ 
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index ae48df4b9b78bc3a687166fdaa7b8a60bd13ec35..a484f8e24772225812d26f411f8febfcd10f41fe 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -119,7 +119,6 @@ public class Main {
+             if (flag) {
+                 Main.LOGGER.warn("Safe mode active, only vanilla datapack will be loaded");
+             }
+-
+             ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)});
+             // CraftBukkit start
+             File bukkitDataPackFolder = new File(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), "bukkit");
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 172fc9ef9c0d3444eb99f750a17d42f130d94f73..0d94a049c1e2311ea40fbc7e13277abbc3b0e1df 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -132,7 +132,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+     private long nextTick;
+     private long W; final long getTickOversleepMaxTime() { return this.W; } // Paper - OBFHELPER
+     private boolean X; final boolean hasExecutedTask() { return this.X; } // Paper - OBFHELPER
+-    private final ResourcePackRepository resourcePackRepository;
++    protected ResourcePackRepository resourcePackRepository; // paper - widen access
+     private final ScoreboardServer scoreboardServer;
+     @Nullable
+     private PersistentCommandStorage persistentCommandStorage;

--- a/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
+++ b/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
@@ -6,30 +6,29 @@ Subject: [PATCH] Allow individual plugins to load datapacks
 
 diff --git a/src/main/java/io/papermc/paper/datapack/PluginDataPack.java b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d108e71f086d3e3d12fd43b103577983c5263308
+index 0000000000000000000000000000000000000000..50608567cd3f9d8822a85944669a2984314de1f8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,25 @@
 +package io.papermc.paper.datapack;
 +
 +import net.minecraft.server.ResourcePackFile;
-+import org.bukkit.plugin.Plugin;
 +
 +import java.io.File;
 +
 +public class PluginDataPack extends ResourcePackFile {
 +
-+    private Plugin plugin;
++    private String name;
 +    private boolean enabledByDefault;
 +
-+    public PluginDataPack(Plugin plugin, File file, boolean enabledByDefault) {
++    public PluginDataPack(String name, File file, boolean enabledByDefault) {
 +        super(file);
-+        this.plugin = plugin;
++        this.name = name;
 +        this.enabledByDefault = enabledByDefault;
 +    }
 +
-+    public Plugin getPlugin() {
-+        return plugin;
++    public String getName() {
++        return name;
 +    }
 +
 +    public boolean isEnabledByDefault() {
@@ -38,44 +37,48 @@ index 0000000000000000000000000000000000000000..d108e71f086d3e3d12fd43b103577983
 +}
 diff --git a/src/main/java/io/papermc/paper/datapack/PluginSource.java b/src/main/java/io/papermc/paper/datapack/PluginSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5c76becccd2797536e67beaef9b9274a697a12f0
+index 0000000000000000000000000000000000000000..10a08118beda6b24533ae054f37acfb78d74bd7e
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datapack/PluginSource.java
-@@ -0,0 +1,42 @@
+@@ -0,0 +1,46 @@
 +package io.papermc.paper.datapack;
 +
 +import net.minecraft.server.EnumResourcePackType;
 +import net.minecraft.server.PackSource;
 +import net.minecraft.server.ResourcePackLoader;
 +import net.minecraft.server.ResourcePackSource;
-+import org.bukkit.plugin.Plugin;
++import org.apache.commons.io.FilenameUtils;
 +
++import java.io.File;
 +import java.util.ArrayList;
 +import java.util.List;
 +import java.util.function.Consumer;
 +
 +public class PluginSource implements ResourcePackSource {
 +
-+    private Plugin[] plugins;
++    private File pluginFolder;
 +
-+    public PluginSource(Plugin[] plugins) {
-+        this.plugins = plugins;
++    public PluginSource(File pluginFolder) {
++        this.pluginFolder = pluginFolder;
 +    }
 +
 +    @Override
 +    public void a(Consumer<ResourcePackLoader> consumer, ResourcePackLoader.a creator) {
 +        List<PluginDataPack> packs = new ArrayList<>();
 +
-+        for (Plugin plugin : plugins) {
-+            PluginDataPack dataPack = new PluginDataPack(plugin, plugin.getFile(), true);
-+            if (!dataPack.a(EnumResourcePackType.SERVER_DATA).isEmpty()) {
-+                packs.add(dataPack);
++        if (pluginFolder.exists()) {
++            for (File file : pluginFolder.listFiles((dir, name) -> name.endsWith(".jar"))) {
++                PluginDataPack dataPack = new PluginDataPack(FilenameUtils.removeExtension(file.getName()), file, true);
++                if (!dataPack.a(EnumResourcePackType.SERVER_DATA).isEmpty()) {
++                    packs.add(dataPack);
++                }
++
 +            }
 +        }
 +
 +        for (PluginDataPack pack : packs) {
-+            ResourcePackLoader resourcePack = ResourcePackLoader.a("entry/" + pack.getPlugin().getName(), false,
-+                () -> pack, creator, ResourcePackLoader.Position.BOTTOM, PackSource.c);
++            ResourcePackLoader resourcePack = ResourcePackLoader.a("entry/" + pack.getName(), false,
++                () -> pack, creator, ResourcePackLoader.Position.BOTTOM, PackSource.d);
 +            if (resourcePack != null) {
 +                consumer.accept(resourcePack);
 +            }
@@ -84,69 +87,24 @@ index 0000000000000000000000000000000000000000..5c76becccd2797536e67beaef9b9274a
 +
 +    }
 +}
-diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 5504facd2e453238caa71d98743be5416d4dd4fe..95fc55c12099abbccd92bc56dd4186d4d54d4715 100644
---- a/src/main/java/net/minecraft/server/DedicatedServer.java
-+++ b/src/main/java/net/minecraft/server/DedicatedServer.java
-@@ -1,5 +1,6 @@
- package net.minecraft.server;
- 
-+import io.papermc.paper.datapack.PluginSource;
- import com.google.common.base.Strings;
- import com.google.common.collect.Lists;
- import com.mojang.authlib.GameProfile;
-@@ -7,6 +8,7 @@ import com.mojang.authlib.GameProfileRepository;
- import com.mojang.authlib.minecraft.MinecraftSessionService;
- import com.mojang.datafixers.DataFixer;
- import java.io.BufferedReader;
-+import java.io.File;
- import java.io.IOException;
- import java.io.InputStreamReader;
- import java.net.InetAddress;
-@@ -16,6 +18,7 @@ import java.util.Collections;
- import java.util.List;
- import java.util.Locale;
- import java.util.Optional;
-+import java.util.concurrent.CompletableFuture;
- import java.util.function.BooleanSupplier;
- import java.util.regex.Pattern;
- import javax.annotation.Nullable;
-@@ -204,6 +207,25 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
-         // CraftBukkit start
-         // this.a((PlayerList) (new DedicatedPlayerList(this, this.customRegistry, this.worldNBTStorage))); // Spigot - moved up
-         server.loadPlugins();
-+        // paper start - create a new repository but include the plugins and world this time and then reload the datapacks so they're included.
-+        if (!options.has("safeMode")) {
-+            ResourcePackRepository resourceRepo = new ResourcePackRepository(new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c), new PluginSource(server.getPluginManager().getPlugins()));
-+
-+            DataPackConfiguration newConfiguration = MinecraftServer.a(resourceRepo, datapackconfiguration == null ? DataPackConfiguration.a : datapackconfiguration, false);
-+            CompletableFuture<DataPackResources> completablefuture = DataPackResources.a(resourceRepo.f(), CommandDispatcher.ServerType.DEDICATED, dedicatedserverproperties.functionPermissionLevel, SystemUtils.f(), Runnable::run);
-+
-+            DataPackResources datapackresources;
-+
-+            try {
-+                datapackresources = completablefuture.get();
-+                datapackresources.i();
-+            } catch (Exception exception) {
-+                DedicatedServer.LOGGER.warn("Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode", exception);
-+                resourceRepo.close();
-+            }
-+            datapackconfiguration = newConfiguration;
-+            resourcePackRepository = resourceRepo;
-+        } // paper end
-         server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
-         // CraftBukkit end
- 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ae48df4b9b78bc3a687166fdaa7b8a60bd13ec35..5ad768b0b5b6744c5d147d3e5087e1a1acfa3de4 100644
+index ae48df4b9b78bc3a687166fdaa7b8a60bd13ec35..c659974bfbef97737b5e03397848bcd977dde342 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -120,7 +120,7 @@ public class Main {
+@@ -14,6 +14,7 @@ import java.nio.file.Paths;
+ import java.util.Optional;
+ import java.util.concurrent.CompletableFuture;
+ import java.util.function.BooleanSupplier;
++import io.papermc.paper.datapack.PluginSource;
+ import joptsimple.NonOptionArgumentSpec;
+ import joptsimple.OptionParser;
+ import joptsimple.OptionSet;
+@@ -120,7 +121,7 @@ public class Main {
                  Main.LOGGER.warn("Safe mode active, only vanilla datapack will be loaded");
              }
  
 -            ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)});
-+            ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla()});//, new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)}); // Paper - Don't load world resource packs for first pass.
++            ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c), new PluginSource((File) optionset.valueOf("plugins"))}); // paper - add in PluginSource for plugin datapacks
              // CraftBukkit start
              File bukkitDataPackFolder = new File(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), "bukkit");
              if (!bukkitDataPackFolder.exists()) {

--- a/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
+++ b/Spigot-Server-Patches/0616-Allow-individual-plugins-to-load-datapacks.patch
@@ -6,63 +6,30 @@ Subject: [PATCH] Allow individual plugins to load datapacks
 
 diff --git a/src/main/java/io/papermc/paper/datapack/PluginDataPack.java b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2c2f0a55c8e2314cff72a16015e39c056b3442a7
+index 0000000000000000000000000000000000000000..d108e71f086d3e3d12fd43b103577983c5263308
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datapack/PluginDataPack.java
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,26 @@
 +package io.papermc.paper.datapack;
 +
-+import net.minecraft.server.EnumResourcePackType;
-+import net.minecraft.server.MinecraftKey;
-+import net.minecraft.server.ResourcePackFolder;
++import net.minecraft.server.ResourcePackFile;
 +import org.bukkit.plugin.Plugin;
 +
 +import java.io.File;
-+import java.io.IOException;
-+import java.io.InputStream;
-+import java.util.Collection;
-+import java.util.Set;
-+import java.util.function.Predicate;
 +
-+public class PluginDataPack extends ResourcePackFolder {
++public class PluginDataPack extends ResourcePackFile {
 +
 +    private Plugin plugin;
-+    private File file;
 +    private boolean enabledByDefault;
 +
 +    public PluginDataPack(Plugin plugin, File file, boolean enabledByDefault) {
 +        super(file);
 +        this.plugin = plugin;
-+        this.file = file;
 +        this.enabledByDefault = enabledByDefault;
-+    }
-+
-+    @Override
-+    protected InputStream a(String s) throws IOException {
-+        return super.a(s);
-+    }
-+
-+    @Override
-+    protected boolean c(String s) {
-+        return super.c(s);
-+    }
-+
-+    @Override
-+    public Collection<MinecraftKey> a(EnumResourcePackType enumResourcePackType, String s, String s1, int i, Predicate<String> predicate) {
-+        return super.a(enumResourcePackType, s, s1, i, predicate);
-+    }
-+
-+    @Override
-+    public Set<String> a(EnumResourcePackType enumResourcePackType) {
-+        return super.a(enumResourcePackType);
 +    }
 +
 +    public Plugin getPlugin() {
 +        return plugin;
-+    }
-+
-+    public File getPath() {
-+        return file;
 +    }
 +
 +    public boolean isEnabledByDefault() {
@@ -71,10 +38,10 @@ index 0000000000000000000000000000000000000000..2c2f0a55c8e2314cff72a16015e39c05
 +}
 diff --git a/src/main/java/io/papermc/paper/datapack/PluginSource.java b/src/main/java/io/papermc/paper/datapack/PluginSource.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ac4a0924b042d586225c6ced813ce7470e365738
+index 0000000000000000000000000000000000000000..5c76becccd2797536e67beaef9b9274a697a12f0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/datapack/PluginSource.java
-@@ -0,0 +1,46 @@
+@@ -0,0 +1,42 @@
 +package io.papermc.paper.datapack;
 +
 +import net.minecraft.server.EnumResourcePackType;
@@ -83,8 +50,6 @@ index 0000000000000000000000000000000000000000..ac4a0924b042d586225c6ced813ce747
 +import net.minecraft.server.ResourcePackSource;
 +import org.bukkit.plugin.Plugin;
 +
-+import java.io.File;
-+import java.nio.file.Files;
 +import java.util.ArrayList;
 +import java.util.List;
 +import java.util.function.Consumer;
@@ -102,17 +67,15 @@ index 0000000000000000000000000000000000000000..ac4a0924b042d586225c6ced813ce747
 +        List<PluginDataPack> packs = new ArrayList<>();
 +
 +        for (Plugin plugin : plugins) {
-+            File pack = new File(plugin.getDataFolder(), "datapack");
-+            boolean enabledByDefault = Files.exists(pack.toPath());
-+            PluginDataPack dataPack = new PluginDataPack(plugin, pack, enabledByDefault);
++            PluginDataPack dataPack = new PluginDataPack(plugin, plugin.getFile(), true);
 +            if (!dataPack.a(EnumResourcePackType.SERVER_DATA).isEmpty()) {
 +                packs.add(dataPack);
 +            }
 +        }
 +
 +        for (PluginDataPack pack : packs) {
-+            ResourcePackLoader resourcePack = ResourcePackLoader.a("plugin/" + pack.getPlugin().getName(), pack.isEnabledByDefault(),
-+                () -> pack, creator, ResourcePackLoader.Position.TOP, PackSource.d);
++            ResourcePackLoader resourcePack = ResourcePackLoader.a("entry/" + pack.getPlugin().getName(), false,
++                () -> pack, creator, ResourcePackLoader.Position.BOTTOM, PackSource.c);
 +            if (resourcePack != null) {
 +                consumer.accept(resourcePack);
 +            }
@@ -122,7 +85,7 @@ index 0000000000000000000000000000000000000000..ac4a0924b042d586225c6ced813ce747
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/DedicatedServer.java b/src/main/java/net/minecraft/server/DedicatedServer.java
-index 5504facd2e453238caa71d98743be5416d4dd4fe..1ced0af1c23e9ebc5c2fbefbbf051d7680860f46 100644
+index 5504facd2e453238caa71d98743be5416d4dd4fe..95fc55c12099abbccd92bc56dd4186d4d54d4715 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServer.java
 @@ -1,5 +1,6 @@
@@ -152,7 +115,7 @@ index 5504facd2e453238caa71d98743be5416d4dd4fe..1ced0af1c23e9ebc5c2fbefbbf051d76
          // CraftBukkit start
          // this.a((PlayerList) (new DedicatedPlayerList(this, this.customRegistry, this.worldNBTStorage))); // Spigot - moved up
          server.loadPlugins();
-+        // paper start - create a new repository but include the plugins this time and then reload the datapacks so they're included.
++        // paper start - create a new repository but include the plugins and world this time and then reload the datapacks so they're included.
 +        if (!options.has("safeMode")) {
 +            ResourcePackRepository resourceRepo = new ResourcePackRepository(new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c), new PluginSource(server.getPluginManager().getPlugins()));
 +
@@ -174,6 +137,19 @@ index 5504facd2e453238caa71d98743be5416d4dd4fe..1ced0af1c23e9ebc5c2fbefbbf051d76
          server.enablePlugins(org.bukkit.plugin.PluginLoadOrder.STARTUP);
          // CraftBukkit end
  
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index ae48df4b9b78bc3a687166fdaa7b8a60bd13ec35..5ad768b0b5b6744c5d147d3e5087e1a1acfa3de4 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -120,7 +120,7 @@ public class Main {
+                 Main.LOGGER.warn("Safe mode active, only vanilla datapack will be loaded");
+             }
+ 
+-            ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla(), new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)});
++            ResourcePackRepository resourcepackrepository = new ResourcePackRepository(new ResourcePackSource[]{new ResourcePackSourceVanilla()});//, new ResourcePackSourceFolder(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), PackSource.c)}); // Paper - Don't load world resource packs for first pass.
+             // CraftBukkit start
+             File bukkitDataPackFolder = new File(convertable_conversionsession.getWorldFolder(SavedFile.DATAPACKS).toFile(), "bukkit");
+             if (!bukkitDataPackFolder.exists()) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 172fc9ef9c0d3444eb99f750a17d42f130d94f73..0d94a049c1e2311ea40fbc7e13277abbc3b0e1df 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -187,3 +163,17 @@ index 172fc9ef9c0d3444eb99f750a17d42f130d94f73..0d94a049c1e2311ea40fbc7e13277abb
      private final ScoreboardServer scoreboardServer;
      @Nullable
      private PersistentCommandStorage persistentCommandStorage;
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+index 49dc0c441b9dd7e7745cf15ced67f383ebee1f99..caf77f8cede7988554b73109e020957eb11df215 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/MinecraftInternalPlugin.java
+@@ -129,4 +129,9 @@ public class MinecraftInternalPlugin extends PluginBase {
+     public List<String> onTabComplete(CommandSender sender, Command command, String alias, String[] args) {
+         throw new UnsupportedOperationException("Not supported.");
+     }
++    // paper start
++    @Override
++    public File getFile() {
++        throw new UnsupportedOperationException("Not supported.");
++    } // paper end
+ }


### PR DESCRIPTION
Tried making it so each plugin could also be its own datapack last night. Just create a folder named datapack in the plugin data folder, put some data in it and then it'll load onto the server [plugins](https://cdn.discordapp.com/attachments/308735693587349505/788595783531364362/unknown.png) seemed to continue working on /minecraft:reload.

it's draft because I didn't finish working on it, just made it functional and so the question I have is this something that makes sense to have? more of the game is being run through these datapacks and they can do quite a bit so I feel it makes sense to allow plugin to also be a datapack if it wants to be. This is probably something that would work well with https://github.com/PaperMC/Paper/pull/3625 assuming that machine went with hooking into the serialization system. 

If this is wanted what I would want to add is:
- ability to get the datapack folder,
- ability to change the datapack folder name so it's not just "datapack,"

The only current issue I noticed was that when you restart the server the plugin datapacks give a warning in the console because they are not loaded for the first pass (in the Main class when the game first populates the "vanilla/builtin" datapack) 