### PR TITLE
Fix typo in 0368-Asynchronous-chunk-IO-and-loading.patch

### DIFF
--- a/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0368-Asynchronous-chunk-IO-and-loading.patch
@@ -199,7 +199,7 @@ index e4719a5e7e5ebd91257a9c9b83fa1adad70fd585..9ad822715c9358e5ac2a0e0a0800786a
                  doChunkInfo(sender, args);
                  break;
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 346da105776a0ae0cb06ed69f1f8f9160695bb85..0fcabd12408a8209da5cb3332e217f98983aec02 100644
+index 346da105776a0ae0cb06ed69f1f8f9160695bb85..38f81c88107cc5c9ac6264d7778b121eb3e7a784 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -257,7 +257,7 @@ index 346da105776a0ae0cb06ed69f1f8f9160695bb85..0fcabd12408a8209da5cb3332e217f98
 +        }
 +
 +        if (!asyncChunks) {
-+            log("Async Chunks: Disabled - Chunks will be managed synchronosuly, and will cause tremendous lag.");
++            log("Async Chunks: Disabled - Chunks will be managed synchronously, and will cause tremendous lag.");
 +        } else {
 +            ChunkTaskManager.initGlobalLoadThreads(threads);
 +            log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");


### PR DESCRIPTION
On line 260 of 0368-Asynchronous-chunk-IO-and-loading.patch it has the typo "synchronosuly" I simply changed that to "synchronously". Nothing big, but I simply noticed this when I was looking in PaperConfig.java