### PR TITLE
Add API to get Tile Entities in a Chunk by Predicate

### DIFF
--- a/Spigot-API-Patches/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/Spigot-API-Patches/0134-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,33 +5,52 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index fa576096e908f8fbdbef53e1bd91215ac9e73ed6..b4ef6297f78d1f0c216e718024a21e6aa07cd1c6 100644
+index fa576096e908f8fbdbef53e1bd91215ac9e73ed6..98263d896f316983609432c45b85401a2692432d 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
-@@ -103,13 +103,26 @@ public interface Chunk extends PersistentDataHolder {
+@@ -1,6 +1,8 @@
+ package org.bukkit;
+ 
+ import java.util.Collection;
++import java.util.function.Predicate;
++
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockState;
+ import org.bukkit.block.data.BlockData;
+@@ -103,13 +105,36 @@ public interface Chunk extends PersistentDataHolder {
      @NotNull
      Entity[] getEntities();
  
 +    // Paper start
-+    /**
-+     * Get a list of all tile entities in the chunk.
-+     *
-+     * @return The tile entities.
-+     */
-+    @NotNull
-+    default BlockState[] getTileEntities() {
-+        return getTileEntities(true);
-+    }
-+
      /**
       * Get a list of all tile entities in the chunk.
       *
-+     * @param useSnapshot Take snapshots or direct references
       * @return The tile entities.
       */
      @NotNull
 -    BlockState[] getTileEntities();
++    default BlockState[] getTileEntities() {
++        return getTileEntities(true);
++    }
++
++    /**
++     * Get a list of all tile entities in the chunk.
++     *
++     * @param useSnapshot Take snapshots or direct references
++     * @return The tile entities.
++     */
++    @NotNull
 +    BlockState[] getTileEntities(boolean useSnapshot);
++
++    /**
++     * Get a list of all tile entities that match a given predicate in the chunk.
++     *
++     * @param blockPredicate The predicate of blocks to return tile entities for
++     * @param useSnapshot Take snapshots or direct references
++     * @return The tile entities.
++     */
++    @NotNull
++    Collection<BlockState> getTileEntities(@NotNull Predicate<Block> blockPredicate, boolean useSnapshot);
 +    // Paper end
  
      /**

--- a/Spigot-Server-Patches/0265-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/Spigot-Server-Patches/0265-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,10 +5,21 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 1a312a868f6a65e7d4a53406825e9efd96d98607..4aeae5ef72c2d929c86b4f9575f2c162710f99f0 100644
+index 1a312a868f6a65e7d4a53406825e9efd96d98607..569c0dd3d22c6ae154d3184905f5c09f9cbee238 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -130,9 +130,16 @@ public class CraftChunk implements Chunk {
+@@ -3,8 +3,10 @@ package org.bukkit.craftbukkit;
+ import com.google.common.base.Preconditions;
+ import com.google.common.base.Predicates;
+ import java.lang.ref.WeakReference;
++import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collection;
++import java.util.List;
+ import java.util.function.Predicate;
+ import net.minecraft.server.BiomeStorage;
+ import net.minecraft.server.BlockPosition;
+@@ -130,9 +132,16 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -25,12 +36,38 @@ index 1a312a868f6a65e7d4a53406825e9efd96d98607..4aeae5ef72c2d929c86b4f9575f2c162
          int index = 0;
          net.minecraft.server.Chunk chunk = getHandle();
  
-@@ -144,7 +151,7 @@ public class CraftChunk implements Chunk {
+@@ -144,11 +153,33 @@ public class CraftChunk implements Chunk {
              }
  
              BlockPosition position = (BlockPosition) obj;
 -            entities[index++] = worldServer.getWorld().getBlockAt(position.getX(), position.getY(), position.getZ()).getState();
 +            entities[index++] = worldServer.getWorld().getBlockAt(position.getX(), position.getY(), position.getZ()).getState(useSnapshot); // Paper
++        }
++
++        return entities;
++    }
++
++    // Paper start
++    @Override
++    public Collection<BlockState> getTileEntities(Predicate<Block> blockPredicate, boolean useSnapshot) {
++        Preconditions.checkNotNull(blockPredicate, "blockPredicate");
++        if (!isLoaded()) {
++            getWorld().getChunkAt(x, z); // Transient load for this tick
++        }
++        net.minecraft.server.Chunk chunk = getHandle();
++
++        List<BlockState> entities = new ArrayList<>();
++
++        for (BlockPosition position : chunk.tileEntities.keySet()) {
++            Block block = worldServer.getWorld().getBlockAt(position.getX(), position.getY(), position.getZ());
++            if (blockPredicate.test(block)) {
++                entities.add(block.getState(useSnapshot));
++            }
          }
  
          return entities;
+     }
++    // Paper end
+ 
+     @Override
+     public boolean isLoaded() {

--- a/Spigot-Server-Patches/0362-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0362-Anti-Xray.patch
@@ -985,7 +985,7 @@ index 0000000000000000000000000000000000000000..333763936897befda5bb6c077944d266
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 71efd1efab43d5aeabba2ad385016b616f4e4849..4ff3eff58fa8007eca7eec22ef53d23705a98ed9 100644
+index db8de2a5478cdc1ee9157251c3d3d5e2ffaa7953..379291bca1cadbb5d82451d7b2c484bc89386172 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -426,7 +426,7 @@ public class Chunk implements IChunkAccess {
@@ -1437,10 +1437,10 @@ index 3c7752769fb6a2da644f9d41ef783de9772ce5f7..1ad867b6b8c743ab03a3c0c1a75fc92e
          convertable = convertable_conversionsession;
          uuid = WorldUUID.getUUID(convertable_conversionsession.folder.toFile());
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 4aeae5ef72c2d929c86b4f9575f2c162710f99f0..d40ef8353b2c025309144b4123d6a7dff04a9c62 100644
+index 569c0dd3d22c6ae154d3184905f5c09f9cbee238..f09e783e38bbe4d8e825abf77884b9cb307bcce4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -42,7 +42,7 @@ public class CraftChunk implements Chunk {
+@@ -44,7 +44,7 @@ public class CraftChunk implements Chunk {
      private final WorldServer worldServer;
      private final int x;
      private final int z;
@@ -1449,7 +1449,7 @@ index 4aeae5ef72c2d929c86b4f9575f2c162710f99f0..d40ef8353b2c025309144b4123d6a7df
      private static final byte[] emptyLight = new byte[2048];
  
      public CraftChunk(net.minecraft.server.Chunk chunk) {
-@@ -264,7 +264,7 @@ public class CraftChunk implements Chunk {
+@@ -288,7 +288,7 @@ public class CraftChunk implements Chunk {
                  NBTTagCompound data = new NBTTagCompound();
                  cs[i].getBlocks().a(data, "Palette", "BlockStates");
  

--- a/Spigot-Server-Patches/0379-Performance-improvement-for-Chunk.getEntities.patch
+++ b/Spigot-Server-Patches/0379-Performance-improvement-for-Chunk.getEntities.patch
@@ -10,10 +10,10 @@ operation. This patch will reduce the load of plugins which for example
 implement custom moblimits and depend on Chunk.getEntities().
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index d40ef8353b2c025309144b4123d6a7dff04a9c62..26210b233bb40565326cf25f568dca0984ce7313 100644
+index f09e783e38bbe4d8e825abf77884b9cb307bcce4..531d5e41dfbfbfe8da0676207f6325a0bca97a9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -115,14 +115,14 @@ public class CraftChunk implements Chunk {
+@@ -117,14 +117,14 @@ public class CraftChunk implements Chunk {
          Entity[] entities = new Entity[count];
  
          for (int i = 0; i < 16; i++) {

--- a/Spigot-Server-Patches/0479-Optimize-NibbleArray-to-use-pooled-buffers.patch
+++ b/Spigot-Server-Patches/0479-Optimize-NibbleArray-to-use-pooled-buffers.patch
@@ -353,10 +353,10 @@ index 6b70df646c6a690ab9437ead96c5ff097e4e12d2..a22f0cccecc85b4e4fe4603bcfa213f1
                      this.d &= ~(1 << k);
                      if (nibblearray != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 26210b233bb40565326cf25f568dca0984ce7313..42b47634437135a9e9b608283f3ce81c98ca181a 100644
+index 531d5e41dfbfbfe8da0676207f6325a0bca97a9a..b345b7658b7de28787cb10255d7d881bc1493003 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -275,14 +275,14 @@ public class CraftChunk implements Chunk {
+@@ -299,14 +299,14 @@ public class CraftChunk implements Chunk {
                      sectionSkyLights[i] = emptyLight;
                  } else {
                      sectionSkyLights[i] = new byte[2048];


### PR DESCRIPTION
Currently, if someone wants to get all sign BlockState instances in a chunk, they end up parsing BlockEntity data of *all* BlockEntities in the chunk.

This means that a simple task like scanning sign lines ends up loading the contents of every container.

This API adds another method that takes a `Predicate<Block>`, to allow plugins to filter down by factors such as material, position, biome, etc. Due to the non-certain number of results here, some optimisations from the non-predicate version had to be omitted (pre-allocating array size).