### PR TITLE
Make Paper Safe Again

### DIFF
--- a/Spigot-API-Patches/0022-Use-ASM-for-event-executors.patch
+++ b/Spigot-API-Patches/0022-Use-ASM-for-event-executors.patch
@@ -179,13 +179,12 @@ index 0000000000000000000000000000000000000000..b6e7d8ee8d903ebf975d60bec0e08603
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/asm/ClassDefiner.java b/src/main/java/com/destroystokyo/paper/event/executor/asm/ClassDefiner.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..beed9e6e07a9080f1c059e08220839090553d0a4
+index 0000000000000000000000000000000000000000..f79685b48bb581277a6891927988b6f7a4389dc4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/executor/asm/ClassDefiner.java
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +package com.destroystokyo.paper.event.executor.asm;
 +
-+import com.destroystokyo.paper.utils.UnsafeUtils;
 +import org.jetbrains.annotations.NotNull;
 +
 +public interface ClassDefiner {
@@ -288,47 +287,6 @@ index 0000000000000000000000000000000000000000..ac99477e9f2c08041aeff31abc1d1ede
 +                }
 +            }
 +        }
-+    }
-+}
-diff --git a/src/main/java/com/destroystokyo/paper/utils/UnsafeUtils.java b/src/main/java/com/destroystokyo/paper/utils/UnsafeUtils.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..72e48e8efdf750d77fc1f9d5fa7dc279e88aa9a7
---- /dev/null
-+++ b/src/main/java/com/destroystokyo/paper/utils/UnsafeUtils.java
-@@ -0,0 +1,35 @@
-+package com.destroystokyo.paper.utils;
-+
-+import org.jetbrains.annotations.Nullable;
-+import sun.misc.Unsafe;
-+
-+import java.lang.reflect.Field;
-+
-+public class UnsafeUtils {
-+    private UnsafeUtils() {}
-+
-+    private static final Unsafe UNSAFE;
-+    static {
-+        Unsafe unsafe;
-+        try {
-+            Class c = Class.forName("sun.misc.Unsafe");
-+            Field f = c.getDeclaredField("theUnsafe");
-+            f.setAccessible(true);
-+            unsafe = (Unsafe) f.get(null);
-+        } catch (ClassNotFoundException | NoSuchFieldException | SecurityException e) {
-+            unsafe = null;
-+        } catch (IllegalAccessException e) {
-+            throw new AssertionError(e);
-+        }
-+        UNSAFE = unsafe;
-+    }
-+
-+    public static boolean isUnsafeSupported() {
-+        return UNSAFE != null;
-+    }
-+
-+    @Nullable
-+    public static Unsafe getUnsafe() {
-+        return UNSAFE;
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/plugin/EventExecutor.java b/src/main/java/org/bukkit/plugin/EventExecutor.java


### PR DESCRIPTION
Removes unused unsafe utils, as suggested by billy

(they cause issues if you compile with java 11, and dum warnings)