### PR TITLE
Adjust bStats data sending delay

### DIFF
--- a/Spigot-Server-Patches/0005-Paper-Metrics.patch
+++ b/Spigot-Server-Patches/0005-Paper-Metrics.patch
@@ -15,16 +15,15 @@ decisions on behalf of the project.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e4923ca371012188793b284cb0ed4280c31f50b6
+index 0000000000000000000000000000000000000000..0b9e689d57705965721b5c55bc45d36657f360e4
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
-@@ -0,0 +1,664 @@
+@@ -0,0 +1,670 @@
 +package com.destroystokyo.paper;
 +
 +import net.minecraft.server.MinecraftServer;
 +import org.bukkit.Bukkit;
 +import org.bukkit.configuration.file.YamlConfiguration;
-+import org.bukkit.craftbukkit.util.CraftLegacy;
 +import org.bukkit.craftbukkit.util.CraftMagicNumbers;
 +import org.bukkit.plugin.Plugin;
 +
@@ -39,6 +38,9 @@ index 0000000000000000000000000000000000000000..e4923ca371012188793b284cb0ed4280
 +import java.net.URL;
 +import java.util.*;
 +import java.util.concurrent.Callable;
++import java.util.concurrent.Executors;
++import java.util.concurrent.ScheduledExecutorService;
++import java.util.concurrent.TimeUnit;
 +import java.util.logging.Level;
 +import java.util.logging.Logger;
 +import java.util.regex.Matcher;
@@ -51,6 +53,10 @@ index 0000000000000000000000000000000000000000..e4923ca371012188793b284cb0ed4280
 + * Check out https://bStats.org/ to learn more about bStats!
 + */
 +public class Metrics {
++
++    // Executor service for requests
++    // We use an executor service because the Bukkit scheduler is affected by server lags
++    private final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
 +
 +    // The version of this bStats class
 +    public static final int B_STATS_VERSION = 1;
@@ -107,16 +113,16 @@ index 0000000000000000000000000000000000000000..e4923ca371012188793b284cb0ed4280
 +     * Starts the Scheduler which submits our data every 30 minutes.
 +     */
 +    private void startSubmitting() {
-+        final Timer timer = new Timer(true);
-+        timer.scheduleAtFixedRate(new TimerTask() {
-+            @Override
-+            public void run() {
-+                submitData();
-+            }
-+        }, 1000 * 60 * 5, 1000 * 60 * 30);
-+        // Submit the data every 30 minutes, first time after 5 minutes to give other plugins enough time to start
-+        // WARNING: Changing the frequency has no effect but your plugin WILL be blocked/deleted!
-+        // WARNING: Just don't do it!
++        final Runnable submitTask = this::submitData;
++
++        // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the
++        // bStats backend. To circumvent this problem, we introduce some randomness into the initial and second delay.
++        // WARNING: You must not modify any part of this Metrics class, including the submit delay or frequency!
++        // WARNING: Modifying this code will get your plugin banned on bStats. Just don't do it!
++        long initialDelay = (long) (1000 * 60 * (3 + Math.random() * 3));
++        long secondDelay = (long) (1000 * 60 * (Math.random() * 30));
++        scheduler.schedule(submitTask, initialDelay, TimeUnit.MILLISECONDS);
++        scheduler.scheduleAtFixedRate(submitTask, initialDelay + secondDelay, 1000 * 60 * 30, TimeUnit.MILLISECONDS);
 +    }
 +
 +    /**

--- a/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
@@ -41,19 +41,23 @@ This also moves all plugins who register "delayed init" tasks to occur just befo
 are properly accounted for and wont trip watchdog on init.
 
 diff --git a/src/main/java/com/destroystokyo/paper/Metrics.java b/src/main/java/com/destroystokyo/paper/Metrics.java
-index e4923ca371012188793b284cb0ed4280c31f50b6..03c95b30d8a0557482d39468c058e7966114f824 100644
+index 081f8d86503b4ab1a704c9fc5ec8a38fd2795427..cef9b0fa633c8b16bb5b99ff94b7b77526034b06 100644
 --- a/src/main/java/com/destroystokyo/paper/Metrics.java
 +++ b/src/main/java/com/destroystokyo/paper/Metrics.java
-@@ -90,6 +90,9 @@ public class Metrics {
-         timer.scheduleAtFixedRate(new TimerTask() {
-             @Override
-             public void run() {
-+                if (MinecraftServer.getServer().hasStopped()) {
-+                    return;
-+                }
-                 submitData();
-             }
-         }, 1000 * 60 * 5, 1000 * 60 * 30);
+@@ -92,7 +92,12 @@ public class Metrics {
+      * Starts the Scheduler which submits our data every 30 minutes.
+      */
+     private void startSubmitting() {
+-        final Runnable submitTask = this::submitData;
++        final Runnable submitTask = () -> {
++            if (MinecraftServer.getServer().hasStopped()) {
++                return;
++            }
++            submitData();
++        };
+ 
+         // Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the
+         // bStats backend. To circumvent this problem, we introduce some randomness into the initial and second delay.
 diff --git a/src/main/java/net/minecraft/server/CrashReport.java b/src/main/java/net/minecraft/server/CrashReport.java
 index 95e6a6de7ccfc4445d0ac19c5f874c0d533b1712..cc6e6f245ee5e73bd570cf42381bf55ee0b364d3 100644
 --- a/src/main/java/net/minecraft/server/CrashReport.java


### PR DESCRIPTION
Many servers tend to restart at a fixed time at xx:00 which causes an uneven distribution of requests on the bStats backend. To circumvent this problem, this commit introduces some randomness for the initial and second delay.

This matches the behavior of the bStats Metrics class version 1.8.