### PR TITLE
Do not create unnecessary copies of the passenger list

### DIFF
--- a/Spigot-Server-Patches/0681-do-not-create-unnecessary-copies-of-passenger-list.patch
+++ b/Spigot-Server-Patches/0681-do-not-create-unnecessary-copies-of-passenger-list.patch
@@ -1,0 +1,239 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lukas81298 <lukas81298@gmail.com>
+Date: Sun, 13 Dec 2020 13:42:55 +0100
+Subject: [PATCH] do not create unnecessary copies of passenger list
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index e87e1b04e13593f1efa4d1c59cb9e433f2b3c694..534238688be75c53058dcfeabcdf86d9c0504089 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2138,7 +2138,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     protected boolean q(Entity entity) {
+-        return this.getPassengers().size() < 1;
++        return this.passengers.size() < 1; // Paper - do not copy list
+     }
+ 
+     public final float getCollisionBorderSize() { return bg(); } // Paper - OBFHELPER
+@@ -2234,7 +2234,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public boolean isVehicle() {
+-        return !this.getPassengers().isEmpty();
++        return !this.passengers.isEmpty(); // Paper - do not copy list
+     }
+ 
+     public boolean bt() {
+@@ -3046,7 +3046,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public boolean w(Entity entity) {
+-        Iterator iterator = this.getPassengers().iterator();
++        Iterator iterator = this.passengers.iterator(); // Paper - do not copy list
+ 
+         Entity entity1;
+ 
+@@ -3062,7 +3062,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     }
+ 
+     public boolean a(Class<? extends Entity> oclass) {
+-        Iterator iterator = this.getPassengers().iterator();
++        Iterator iterator = this.passengers.iterator(); // Paper - do not copy list
+ 
+         Entity entity;
+ 
+@@ -3079,7 +3079,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+ 
+     public Collection<Entity> getAllPassengers() {
+         Set<Entity> set = Sets.newHashSet();
+-        Iterator iterator = this.getPassengers().iterator();
++        Iterator iterator = this.passengers.iterator(); // Paper - do not copy list
+ 
+         while (iterator.hasNext()) {
+             Entity entity = (Entity) iterator.next();
+@@ -3105,7 +3105,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     private void a(boolean flag, Set<Entity> set) {
+         Entity entity;
+ 
+-        for (Iterator iterator = this.getPassengers().iterator(); iterator.hasNext(); entity.a(flag, set)) {
++        for (Iterator iterator = this.passengers.iterator(); iterator.hasNext(); entity.a(flag, set)) { // Paper - do not copy list
+             entity = (Entity) iterator.next();
+             if (!flag || EntityPlayer.class.isAssignableFrom(entity.getClass())) {
+                 set.add(entity);
+diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
+index baa4a61114e7460c74027e1519332f0dd9582647..15ce9f90306d062f36d1651d7426813e897523bf 100644
+--- a/src/main/java/net/minecraft/server/EntityBoat.java
++++ b/src/main/java/net/minecraft/server/EntityBoat.java
+@@ -272,7 +272,7 @@ public class EntityBoat extends Entity {
+         super.tick();
+         this.r();
+         if (this.cs()) {
+-            if (this.getPassengers().isEmpty() || !(this.getPassengers().get(0) instanceof EntityHuman)) {
++            if (this.passengers.isEmpty() || !(this.passengers.get(0) instanceof EntityHuman)) { // Paper - do not copy list
+                 this.a(false, false);
+             }
+ 
+@@ -335,7 +335,7 @@ public class EntityBoat extends Entity {
+                 Entity entity = (Entity) list.get(j);
+ 
+                 if (!entity.w(this)) {
+-                    if (flag && this.getPassengers().size() < 2 && !entity.isPassenger() && entity.getWidth() < this.getWidth() && entity instanceof EntityLiving && !(entity instanceof EntityWaterAnimal) && !(entity instanceof EntityHuman)) {
++                    if (flag && this.passengers.size() < 2 && !entity.isPassenger() && entity.getWidth() < this.getWidth() && entity instanceof EntityLiving && !(entity instanceof EntityWaterAnimal) && !(entity instanceof EntityHuman)) { // Paper - do not copy passenger list
+                         entity.startRiding(this);
+                     } else {
+                         this.collide(entity);
+@@ -682,8 +682,8 @@ public class EntityBoat extends Entity {
+             float f = 0.0F;
+             float f1 = (float) ((this.dead ? 0.009999999776482582D : this.bc()) + entity.bb());
+ 
+-            if (this.getPassengers().size() > 1) {
+-                int i = this.getPassengers().indexOf(entity);
++            if (this.passengers.size() > 1) { // Paper - do not copy list
++                int i = this.passengers.indexOf(entity); // Paper - do not copy list
+ 
+                 if (i == 0) {
+                     f = 0.2F;
+@@ -702,7 +702,7 @@ public class EntityBoat extends Entity {
+             entity.yaw += this.ak;
+             entity.setHeadRotation(entity.getHeadRotation() + this.ak);
+             this.a(entity);
+-            if (entity instanceof EntityAnimal && this.getPassengers().size() > 1) {
++            if (entity instanceof EntityAnimal && this.passengers.size() > 1) { // Paper - do not copy list
+                 int j = entity.getId() % 2 == 0 ? 90 : 270;
+ 
+                 entity.n(((EntityAnimal) entity).aA + (float) j);
+@@ -862,13 +862,13 @@ public class EntityBoat extends Entity {
+ 
+     @Override
+     protected boolean q(Entity entity) {
+-        return this.getPassengers().size() < 2 && !this.a((Tag) TagsFluid.WATER);
++        return this.passengers.size() < 2 && !this.a((Tag) TagsFluid.WATER); // Paper - do not copy list
+     }
+ 
+     @Nullable
+     @Override
+     public Entity getRidingPassenger() {
+-        List<Entity> list = this.getPassengers();
++        List<Entity> list = this.passengers; // Paper - do not copy list
+ 
+         return list.isEmpty() ? null : (Entity) list.get(0);
+     }
+diff --git a/src/main/java/net/minecraft/server/EntityHorseAbstract.java b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
+index 2a91f07ca9c4dc0cb3b5aef5c9c1db7f69773530..5f9ee870697de306f595120bec05ba98d2fcb534 100644
+--- a/src/main/java/net/minecraft/server/EntityHorseAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
+@@ -910,7 +910,7 @@ public abstract class EntityHorseAbstract extends EntityAnimal implements IInven
+     @Nullable
+     @Override
+     public Entity getRidingPassenger() {
+-        return this.getPassengers().isEmpty() ? null : (Entity) this.getPassengers().get(0);
++        return this.passengers.isEmpty() ? null : (Entity) this.passengers.get(0); // Paper - do not copy list
+     }
+ 
+     @Nullable
+diff --git a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+index 022dfdc5b6af4b243e7e4da8660e8e41d04e1a30..be859a1b41254b299a507d03e453dc8efee6f3dd 100644
+--- a/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
++++ b/src/main/java/net/minecraft/server/EntityMinecartAbstract.java
+@@ -522,7 +522,7 @@ public abstract class EntityMinecartAbstract extends Entity {
+ 
+         vec3d1 = new Vec3D(d8 * d4 / d6, vec3d1.y, d8 * d5 / d6);
+         this.setMot(vec3d1);
+-        Entity entity = this.getPassengers().isEmpty() ? null : (Entity) this.getPassengers().get(0);
++        Entity entity = this.passengers.isEmpty() ? null : (Entity) this.passengers.get(0); // Paper - do not copy list
+ 
+         if (entity instanceof EntityHuman) {
+             Vec3D vec3d2 = entity.getMot();
+diff --git a/src/main/java/net/minecraft/server/EntityPig.java b/src/main/java/net/minecraft/server/EntityPig.java
+index ee94c2827cfc53f7a37e61d8c1c0c30a52374cf8..01ca5983cade997b1f0d27fdf495c74c6daa0922 100644
+--- a/src/main/java/net/minecraft/server/EntityPig.java
++++ b/src/main/java/net/minecraft/server/EntityPig.java
+@@ -39,7 +39,7 @@ public class EntityPig extends EntityAnimal implements ISteerable, ISaddleable {
+     @Nullable
+     @Override
+     public Entity getRidingPassenger() {
+-        return this.getPassengers().isEmpty() ? null : (Entity) this.getPassengers().get(0);
++        return this.passengers.isEmpty() ? null : (Entity) this.passengers.get(0); // Paper - do not copy list
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityRavager.java b/src/main/java/net/minecraft/server/EntityRavager.java
+index fd1ac7df68a0caebe35290cdf7a9c37519342b61..e78f158d9c682c60d42c17e0f171d492552e4079 100644
+--- a/src/main/java/net/minecraft/server/EntityRavager.java
++++ b/src/main/java/net/minecraft/server/EntityRavager.java
+@@ -93,7 +93,7 @@ public class EntityRavager extends EntityRaider {
+     @Nullable
+     @Override
+     public Entity getRidingPassenger() {
+-        return this.getPassengers().isEmpty() ? null : (Entity) this.getPassengers().get(0);
++        return this.passengers.isEmpty() ? null : (Entity) this.passengers.get(0); // Paper - do not copy list
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+index 3960a975e74ed81c45819fe5e0f01c6c18252982..f2a9396c2ec64c79391782249db7507f12a69a9e 100644
+--- a/src/main/java/net/minecraft/server/EntityTrackerEntry.java
++++ b/src/main/java/net/minecraft/server/EntityTrackerEntry.java
+@@ -74,10 +74,10 @@ public class EntityTrackerEntry {
+ 
+     public final void tick() { this.a(); } // Paper - OBFHELPER
+     public void a() {
+-        List<Entity> list = this.tracker.getPassengers();
++        List<Entity> list = this.tracker.passengers; // Paper - do not copy list
+ 
+         if (!list.equals(this.p)) {
+-            this.p = list;
++            this.p = com.google.common.collect.ImmutableList.copyOf(list); // Paper - only copy list if something has changed
+             this.broadcastIncludingSelf(new PacketPlayOutMount(this.tracker)); // CraftBukkit
+         }
+ 
+@@ -348,7 +348,7 @@ public class EntityTrackerEntry {
+             }
+         }
+ 
+-        if (!this.tracker.getPassengers().isEmpty()) {
++        if (!this.tracker.passengers.isEmpty()) { // Paper - do not create copy of list
+             consumer.accept(new PacketPlayOutMount(this.tracker));
+         }
+ 
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutMount.java b/src/main/java/net/minecraft/server/PacketPlayOutMount.java
+index 1d495e53fb4330ac4235721238d09e7163b2cd20..c4387df2f5c66c350184407b7f5a4db80542d1f6 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutMount.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutMount.java
+@@ -12,7 +12,7 @@ public class PacketPlayOutMount implements Packet<PacketListenerPlayOut> {
+ 
+     public PacketPlayOutMount(Entity entity) {
+         this.a = entity.getId();
+-        List<Entity> list = entity.getPassengers();
++        List<Entity> list = entity.passengers; // Paper - do not create a copy of the list
+ 
+         this.b = new int[list.size()];
+ 
+diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTame.java b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
+index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..8757c6487a433b1fa5c46b50c559aeca82f84b8d 100644
+--- a/src/main/java/net/minecraft/server/PathfinderGoalTame.java
++++ b/src/main/java/net/minecraft/server/PathfinderGoalTame.java
+@@ -47,7 +47,7 @@ public class PathfinderGoalTame extends PathfinderGoal {
+     @Override
+     public void e() {
+         if (!this.entity.isTamed() && this.entity.getRandom().nextInt(50) == 0) {
+-            Entity entity = (Entity) this.entity.getPassengers().get(0);
++            Entity entity = this.entity.passengers.isEmpty() ? null : this.entity.passengers.get(0); // Paper - do not copy list, fixed array out of bounds exception as well
+ 
+             if (entity == null) {
+                 return;
+diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+index 49008cdec739b19409fdaf1b0ed806a6c0e93200..e16cd5da219e41f16f9c04fd95b79fe5cf10f6b8 100644
+--- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
++++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
+@@ -2252,7 +2252,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+                 list.add(entity);
+             }
+ 
+-            if (!entity.getPassengers().isEmpty()) {
++            if (!entity.passengers.isEmpty()) { // Paper - do not copy list
+                 list1.add(entity);
+             }
+         }


### PR DESCRIPTION
The getPassengers() method of the Entity classes creates a copy of the passenger list on every call. In many cases, the elements of the returned list are not modified or just the length of the elements is checked. As this involves unnecessary overhead and pressure on the garbage collector, I've replace the calls to this method with direct accesses to the "passengers" field wherever it is safe that it is processed synchronously and the list is not changed.