### PR TITLE
Add EntityPotionEffectImmunityEvent

### DIFF
--- a/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityPotionEffectImmunityEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..86c1b8c3c17b49d0b4bfea4d9c2436a3d4d17ab4
+index 0000000000000000000000000000000000000000..2c0324eca4fcf9f387b7f84e962ceb7989d9a77d
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,77 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -21,6 +21,10 @@ index 0000000000000000000000000000000000000000..86c1b8c3c17b49d0b4bfea4d9c2436a3
 +import org.bukkit.potion.PotionEffectType;
 +import org.jetbrains.annotations.NotNull;
 +
++/**
++ * Is called when an {@Link org.bukkit.entity.LivingEntity} wouldn't be affected by a {@Link org.bukkit.potion.PotionEffect} because of immunity.
++ * Cancelling this event makes it possible for the entity to be affected by the given effect.
++ */
 +public class EntityPotionEffectImmunityEvent extends EntityEvent implements Cancellable {
 +    private static final HandlerList handlers = new HandlerList();
 +
@@ -54,16 +58,25 @@ index 0000000000000000000000000000000000000000..86c1b8c3c17b49d0b4bfea4d9c2436a3
 +        return handlers;
 +    }
 +
++    /**
++     * @return the cause why the effect was being added
++     */
 +    @NotNull
 +    public EntityPotionEffectEvent.Cause getCause() {
 +        return cause;
 +    }
 +
++    /**
++     * @return the potion effect that the entity is being immune to
++     */
 +    @NotNull
 +    public PotionEffect getEffect() {
 +        return effect;
 +    }
 +
++    /**
++     * The same as calling getEffect().getType()
++     */
 +    @NotNull
 +    public PotionEffectType getEffectType() {
 +        return effect.getType();
@@ -74,4 +87,3 @@ index 0000000000000000000000000000000000000000..86c1b8c3c17b49d0b4bfea4d9c2436a3
 +        return handlers;
 +    }
 +}
-\ No newline at end of file

--- a/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add EntityPotionEffectImmunityEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5cc5fb862a17d3f816318f08a34001cfea1e5769
+index 0000000000000000000000000000000000000000..86c1b8c3c17b49d0b4bfea4d9c2436a3d4d17ab4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
 @@ -0,0 +1,64 @@

--- a/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicklas Ahlskog <kivi@kivibot.fi>
+Date: Sun, 20 Dec 2020 18:13:01 +0200
+Subject: [PATCH] Add EntityPotionEffectImmunityEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..5cc5fb862a17d3f816318f08a34001cfea1e5769
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
+@@ -0,0 +1,64 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.event.entity.EntityPotionEffectEvent;
++import org.bukkit.potion.PotionEffect;
++import org.bukkit.potion.PotionEffectType;
++import org.jetbrains.annotations.NotNull;
++
++public class EntityPotionEffectImmunityEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++
++    @NotNull
++    private final EntityPotionEffectEvent.Cause cause;
++    @NotNull
++    private final PotionEffect effect;
++
++    private boolean cancelled;
++
++    public EntityPotionEffectImmunityEvent(@NotNull Entity what, @NotNull EntityPotionEffectEvent.Cause cause, @NotNull PotionEffect effect) {
++        super(what);
++        this.cause = cause;
++        this.effect = effect;
++        this.cancelled = false;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = true;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public EntityPotionEffectEvent.Cause getCause() {
++        return cause;
++    }
++
++    @NotNull
++    public PotionEffect getEffect() {
++        return effect;
++    }
++
++    @NotNull
++    public PotionEffectType getEffectType() {
++        return effect.getType();
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}
+\ No newline at end of file

--- a/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-API-Patches/0243-Add-EntityPotionEffectImmunityEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add EntityPotionEffectImmunityEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2c0324eca4fcf9f387b7f84e962ceb7989d9a77d
+index 0000000000000000000000000000000000000000..3bd01648af2a4bf970b1a5c9ea7afc0d1c381bb8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityPotionEffectImmunityEvent.java
 @@ -0,0 +1,77 @@
@@ -22,7 +22,7 @@ index 0000000000000000000000000000000000000000..2c0324eca4fcf9f387b7f84e962ceb79
 +import org.jetbrains.annotations.NotNull;
 +
 +/**
-+ * Is called when an {@Link org.bukkit.entity.LivingEntity} wouldn't be affected by a {@Link org.bukkit.potion.PotionEffect} because of immunity.
++ * Is called when a {@Link org.bukkit.entity.LivingEntity} wouldn't be affected by a {@Link org.bukkit.potion.PotionEffect} because of immunity.
 + * Cancelling this event makes it possible for the entity to be affected by the given effect.
 + */
 +public class EntityPotionEffectImmunityEvent extends EntityEvent implements Cancellable {
@@ -59,7 +59,7 @@ index 0000000000000000000000000000000000000000..2c0324eca4fcf9f387b7f84e962ceb79
 +    }
 +
 +    /**
-+     * @return the cause why the effect was being added
++     * @return the cause why the effect is being added
 +     */
 +    @NotNull
 +    public EntityPotionEffectEvent.Cause getCause() {

--- a/Spigot-Server-Patches/0619-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-Server-Patches/0619-Add-EntityPotionEffectImmunityEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add EntityPotionEffectImmunityEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..f92b167d30678ce5c6208425ac750ce58fce9d19 100644
+index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..18745f4a096669c933cd6939012c4fd4ce94450b 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -43,6 +43,8 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -22,7 +22,7 @@ index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..f92b167d30678ce5c6208425ac750ce5
          // CraftBukkit end
  
 -        if (!this.d(mobeffect)) {
-+        if (this.checkEffectImmunity(mobeffect, cause)) { // Paper
++        if (!this.canAddEffect(mobeffect, cause)) { // Paper
              return false;
          } else {
              MobEffect mobeffect1 = (MobEffect) this.effects.get(mobeffect.getMobEffect());
@@ -31,10 +31,10 @@ index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..f92b167d30678ce5c6208425ac750ce5
          }
      }
 +	
-+    // Paper start
-+    private boolean checkEffectImmunity(MobEffect mobEffect, EntityPotionEffectEvent.Cause cause) {
-+        if(this.d(mobEffect)) {
-+            return false;
++    // Paper start - OBFHELPER
++    private boolean canAddEffect(MobEffect mobEffect, EntityPotionEffectEvent.Cause cause) {
++        if (this.d(mobEffect)) {
++            return true;
 +        }
 +
 +        EntityPotionEffectImmunityEvent event = new EntityPotionEffectImmunityEvent(
@@ -42,7 +42,7 @@ index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..f92b167d30678ce5c6208425ac750ce5
 +            cause,
 +            CraftPotionUtil.toBukkit(mobEffect)
 +        );
-+        return event.callEvent();
++        return !event.callEvent();
 +    }
 +    // Paper end
  

--- a/Spigot-Server-Patches/0619-Add-EntityPotionEffectImmunityEvent.patch
+++ b/Spigot-Server-Patches/0619-Add-EntityPotionEffectImmunityEvent.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nicklas Ahlskog <kivi@kivibot.fi>
+Date: Sun, 20 Dec 2020 18:15:04 +0200
+Subject: [PATCH] Add EntityPotionEffectImmunityEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
+index b88bd19fc3ebaf3ae467b5ad35a155505db77e6c..f92b167d30678ce5c6208425ac750ce58fce9d19 100644
+--- a/src/main/java/net/minecraft/server/EntityLiving.java
++++ b/src/main/java/net/minecraft/server/EntityLiving.java
+@@ -43,6 +43,8 @@ import org.bukkit.event.entity.EntityTeleportEvent;
+ import org.bukkit.event.player.PlayerItemConsumeEvent;
+ // CraftBukkit end
+ 
++import io.papermc.paper.event.entity.EntityPotionEffectImmunityEvent; // Paper
++import org.bukkit.craftbukkit.potion.CraftPotionUtil; // Paper
+ 
+ public abstract class EntityLiving extends Entity {
+ 
+@@ -909,7 +911,7 @@ public abstract class EntityLiving extends Entity {
+         }
+         // CraftBukkit end
+ 
+-        if (!this.d(mobeffect)) {
++        if (this.checkEffectImmunity(mobeffect, cause)) { // Paper
+             return false;
+         } else {
+             MobEffect mobeffect1 = (MobEffect) this.effects.get(mobeffect.getMobEffect());
+@@ -941,6 +943,21 @@ public abstract class EntityLiving extends Entity {
+             }
+         }
+     }
++	
++    // Paper start
++    private boolean checkEffectImmunity(MobEffect mobEffect, EntityPotionEffectEvent.Cause cause) {
++        if(this.d(mobEffect)) {
++            return false;
++        }
++
++        EntityPotionEffectImmunityEvent event = new EntityPotionEffectImmunityEvent(
++            this.getBukkitEntity(),
++            cause,
++            CraftPotionUtil.toBukkit(mobEffect)
++        );
++        return event.callEvent();
++    }
++    // Paper end
+ 
+     public boolean d(MobEffect mobeffect) {
+         if (this.getMonsterType() == EnumMonsterType.UNDEAD) {


### PR DESCRIPTION
Allows plugins to selectively disable vanilla potion effect immunities. 
Can also be used to detect if immune mobs have been hit with those effects.

Somewhat related issue #3580