### PR TITLE
Add per-player block reach

### DIFF
--- a/Spigot-API-Patches/0243-Add-per-player-block-reach.patch
+++ b/Spigot-API-Patches/0243-Add-per-player-block-reach.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Camotoy <20743703+Camotoy@users.noreply.github.com>
+Date: Sun, 3 Jan 2021 11:28:57 -0500
+Subject: [PATCH] Add per-player block reach
+
+Plugins are able to specify the server-accepted block range of a specific player.
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index a23c08c48ec627147d94ab4bf4fdf4dae1edeaca..42217e4381b81062712bd1df463fac8bcb9d33b9 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1791,6 +1791,36 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     @Nullable
+     Firework boostElytra(@NotNull ItemStack firework);
++
++    /**
++     * This number is squared for all internal block calculations.
++     *
++     * @return the maximum survival block range of the player. This number will never be lower than 6.
++     */
++    int getSurvivalBlockRange();
++
++    /**
++     * Set a custom maximum survival block range for the player.
++     *
++     * @param range the block range to set for the player. This value will be set to 6 if the given number is lower,
++     *              to prevent block ghosting issues.
++     */
++    void setSurvivalBlockRange(int range);
++
++    /**
++     * This number is squared for all internal block calculations.
++     *
++     * @return the maximum creative block range of the player. This number will never be lower than 7.
++     */
++    int getCreativeBlockRange();
++
++    /**
++     * Set a custom maximum creative block range for the player.
++     *
++     * @param range the block range to set for the player. This value will be set to 7 if the given number is lower,
++     *              to prevent block ghosting issues.
++     */
++    void setCreativeBlockRange(int range);
+     // Paper end
+ 
+     // Spigot start

--- a/Spigot-Server-Patches/0619-Add-per-player-block-reach.patch
+++ b/Spigot-Server-Patches/0619-Add-per-player-block-reach.patch
@@ -1,0 +1,129 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Camotoy <20743703+Camotoy@users.noreply.github.com>
+Date: Sun, 3 Jan 2021 11:38:07 -0500
+Subject: [PATCH] Add per-player block reach
+
+Plugins are able to specify the server-accepted block range of a specific player.
+
+diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
+index 3e1f88bce8e0ba95f73bca204549db0c65b1465e..c1c6033b8a017939d1cfe6b65a795a5f451450d2 100644
+--- a/src/main/java/net/minecraft/server/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/PlayerConnection.java
+@@ -142,8 +142,8 @@ public class PlayerConnection implements PacketListenerPlayIn {
+     private int lastDropTick = MinecraftServer.currentTick;
+     private int lastBookTick  = MinecraftServer.currentTick;
+     private int dropCount = 0;
+-    private static final int SURVIVAL_PLACE_DISTANCE_SQUARED = 6 * 6;
+-    private static final int CREATIVE_PLACE_DISTANCE_SQUARED = 7 * 7;
++    //private static final int SURVIVAL_PLACE_DISTANCE_SQUARED = 6 * 6; // Paper - use player-defined block reach instead
++    //private static final int CREATIVE_PLACE_DISTANCE_SQUARED = 7 * 7; // Paper - use player-defined block reach instead
+ 
+     // Get position of last block hit for BlockDamageLevel.STOPPED
+     private double lastPosX = Double.MAX_VALUE;
+@@ -1524,14 +1524,14 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         // Paper start - move check up
+         Location eyeLoc = this.getPlayer().getEyeLocation();
+         double reachDistance = NumberConversions.square(eyeLoc.getX() - blockposition.getX()) + NumberConversions.square(eyeLoc.getY() - blockposition.getY()) + NumberConversions.square(eyeLoc.getZ() - blockposition.getZ());
+-        if (reachDistance > (this.getPlayer().getGameMode() == org.bukkit.GameMode.CREATIVE ? CREATIVE_PLACE_DISTANCE_SQUARED : SURVIVAL_PLACE_DISTANCE_SQUARED)) {
++        if (reachDistance > (this.getPlayer().getGameMode() == org.bukkit.GameMode.CREATIVE ? this.getPlayer().getCreativeBlockReachSquared() : this.getPlayer().getSurvivalBlockReachSquared())) { // Paper - use individual player block reach
+             return;
+         }
+         // Paper end - move check up
+ 
+         this.player.resetIdleTimer();
+         if (blockposition.getY() < this.minecraftServer.getMaxBuildHeight()) {
+-            if (this.teleportPos == null && this.player.h((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < 64.0D && worldserver.a((EntityHuman) this.player, blockposition)) {
++            if (this.teleportPos == null && this.player.h((double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D) < this.getPlayer().getMaxBlockPlaceReachSquared() && worldserver.a((EntityHuman) this.player, blockposition)) { // Paper - use individual player block reach
+                 // CraftBukkit start - Check if we can actually do something over this large a distance
+                 // Paper - move check up
+                 this.player.clearActiveItem(); // SPIGOT-4706
+diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+index 485b609bb5387b0f8a46c1201177cdc6d183ad91..2bec046d2d618348718e10d13d1d4ceef08b6cba 100644
+--- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
++++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+@@ -129,7 +129,7 @@ public class PlayerInteractManager {
+         double d2 = this.player.locZ() - ((double) blockposition.getZ() + 0.5D);
+         double d3 = d0 * d0 + d1 * d1 + d2 * d2;
+ 
+-        if (d3 > 36.0D) {
++        if (d3 > this.player.getBukkitEntity().getMaxBlockDestroyReachSquared()) { // Paper - use individual player block reach
+             this.player.playerConnection.sendPacket(new PacketPlayOutBlockBreak(blockposition, this.world.getType(blockposition), packetplayinblockdig_enumplayerdigtype, false, "too far"));
+         } else if (blockposition.getY() >= i) {
+             this.player.playerConnection.sendPacket(new PacketPlayOutBlockBreak(blockposition, this.world.getType(blockposition), packetplayinblockdig_enumplayerdigtype, false, "too high"));
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 58caa3240b90cdc661e1e32e3f5c312ed62c3c21..314a0161b9a81244549756a8ebd97ca63f317a03 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -146,6 +146,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private String resourcePackHash;
+     private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
+     private long lastSaveTime;
++    private int survivalBlockReach = 6;
++    private int survivalBlockReachSquared = 36;
++    private int creativeBlockReach = 7;
++    private int creativeBlockReachSquared = 49;
++    private double maxBlockPlaceReachSquared = 64D;
++    private double maxBlockDestroyReachSquared = 36D;
+     // Paper end
+ 
+     public CraftPlayer(CraftServer server, EntityPlayer entity) {
+@@ -2100,6 +2106,59 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
+             : null;
+     }
++
++    @Override
++    public int getSurvivalBlockRange() {
++        return survivalBlockReach;
++    }
++
++    public int getSurvivalBlockReachSquared() {
++        return survivalBlockReachSquared;
++    }
++
++    @Override
++    public void setSurvivalBlockRange(int range) {
++        Preconditions.checkPositionIndex(6, range, "Survival block reach cannot be smaller than 6!"); // Ensure range can't be set lower than vanilla defaults, or else block ghosting will occur for vanilla clients
++        survivalBlockReach = range;
++        survivalBlockReachSquared = survivalBlockReach * survivalBlockReach;
++        setMaxBlockReach();
++    }
++
++    @Override
++    public int getCreativeBlockRange() {
++        return creativeBlockReach;
++    }
++
++    public int getCreativeBlockReachSquared() {
++        return creativeBlockReachSquared;
++    }
++
++    @Override
++    public void setCreativeBlockRange(int range) {
++        Preconditions.checkPositionIndex(7, range, "Creative block reach cannot be smaller than 7!"); // Ensure range can't be set lower than vanilla defaults, or else block ghosting will occur for vanilla clients
++        creativeBlockReach = range;
++        creativeBlockReachSquared = creativeBlockReach * creativeBlockReach;
++        setMaxBlockReach();
++    }
++
++    public double getMaxBlockPlaceReachSquared() {
++        return maxBlockPlaceReachSquared;
++    }
++
++    public double getMaxBlockDestroyReachSquared() {
++        return maxBlockDestroyReachSquared;
++    }
++
++    /**
++     * Set the upper bounds for both block destroying and block placing
++     */
++    private void setMaxBlockReach() {
++        int maxBlockReach = Math.max(survivalBlockReach, creativeBlockReach);
++        int maxBlockPlaceReach =  maxBlockReach + 1;
++        maxBlockPlaceReachSquared = maxBlockPlaceReach * maxBlockPlaceReach;
++        int maxBlockDestroyReach = maxBlockReach - 1;
++        maxBlockDestroyReachSquared = maxBlockDestroyReach * maxBlockDestroyReach;
++    }
+     // Paper end
+ 
+     // Spigot start


### PR DESCRIPTION
This commit implements the outline I presented in #4908. Most importantly, I have confirmed that all vanilla values remain correct without modification from the API, and when resetting block range back to their vanilla values. Please do let me know if there's something I can improve (especially documentation).

I'm also willing to release these patches under MIT, if there is a process for that. 

Fixes #4908