### PR TITLE
Added EntityItemDamageEvent

### DIFF
--- a/patches/api/0328-Added-EntityDamageItemEvent.patch
+++ b/patches/api/0328-Added-EntityDamageItemEvent.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 22 Dec 2020 13:51:06 -0800
+Subject: [PATCH] Added EntityDamageItemEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..13862939d7b633f08d5c70bfd2097c47278efcce
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityDamageItemEvent.java
+@@ -0,0 +1,77 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an item on or used by an entity takes durability damage as a result of being hit/used.
++ * <p>
++ * NOTE: default vanilla behaviour dictates that armor/tools picked up by
++ * mobs do not take damage (except via Thorns).
++ */
++public class EntityDamageItemEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++    private final ItemStack item;
++    private int damage;
++    private boolean cancelled;
++
++    public EntityDamageItemEvent(@NotNull Entity entity, @NotNull ItemStack item, int damage) {
++        super(entity);
++        this.item = item;
++        this.damage = damage;
++    }
++
++    /**
++     * Gets the item being damaged.
++     *
++     * @return the item
++     */
++    @NotNull
++    public ItemStack getItem() {
++        return item;
++    }
++
++    /**
++     * Gets the amount of durability damage this item will be taking.
++     *
++     * @return durability change
++     */
++    public int getDamage() {
++        return damage;
++    }
++
++    /**
++     * Sets the amount of durability damage this item will be taking.
++     *
++     * @param damage the damage amount to cause
++     */
++    public void setDamage(int damage) {
++        this.damage = damage;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/0744-Added-EntityDamageItemEvent.patch
+++ b/patches/server/0744-Added-EntityDamageItemEvent.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 22 Dec 2020 13:52:48 -0800
+Subject: [PATCH] Added EntityDamageItemEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index ae6638e44b5562436e8d3ad89167663c6f3961b1..3e5e358e24bd84a05785a9391526f316475e95ff 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -523,7 +523,7 @@ public final class ItemStack {
+         return this.getItem().getMaxDamage();
+     }
+ 
+-    public boolean hurt(int amount, Random random, @Nullable ServerPlayer player) {
++    public boolean hurt(int amount, Random random, @Nullable LivingEntity player) { // Paper - allow any living entity instead of only ServerPlayers
+         if (!this.isDamageableItem()) {
+             return false;
+         } else {
+@@ -541,8 +541,8 @@ public final class ItemStack {
+ 
+                 amount -= k;
+                 // CraftBukkit start
+-                if (player != null) {
+-                    PlayerItemDamageEvent event = new PlayerItemDamageEvent(player.getBukkitEntity(), CraftItemStack.asCraftMirror(this), amount);
++                if (player instanceof ServerPlayer serverPlayer) { // Paper
++                    PlayerItemDamageEvent event = new PlayerItemDamageEvent(serverPlayer.getBukkitEntity(), CraftItemStack.asCraftMirror(this), amount); // Paper
+                     event.getPlayer().getServer().getPluginManager().callEvent(event);
+ 
+                     if (amount != event.getDamage() || event.isCancelled()) {
+@@ -553,6 +553,14 @@ public final class ItemStack {
+                     }
+ 
+                     amount = event.getDamage();
++                    // Paper start - EntityDamageItemEvent
++                } else if (player != null) {
++                    io.papermc.paper.event.entity.EntityDamageItemEvent event = new io.papermc.paper.event.entity.EntityDamageItemEvent(player.getBukkitLivingEntity(), CraftItemStack.asCraftMirror(this), amount);
++                    if (!event.callEvent()) {
++                        return false;
++                    }
++                    amount = event.getDamage();
++                    // Paper end
+                 }
+                 // CraftBukkit end
+                 if (amount <= 0) {
+@@ -560,8 +568,8 @@ public final class ItemStack {
+                 }
+             }
+ 
+-            if (player != null && amount != 0) {
+-                CriteriaTriggers.ITEM_DURABILITY_CHANGED.trigger(player, this, this.getDamageValue() + amount);
++            if (player instanceof ServerPlayer serverPlayer && amount != 0) { // Paper
++                CriteriaTriggers.ITEM_DURABILITY_CHANGED.trigger(serverPlayer, this, this.getDamageValue() + amount); // Paper
+             }
+ 
+             j = this.getDamageValue() + amount;
+@@ -573,7 +581,7 @@ public final class ItemStack {
+     public <T extends LivingEntity> void hurtAndBreak(int amount, T entity, Consumer<T> breakCallback) {
+         if (!entity.level.isClientSide && (!(entity instanceof net.minecraft.world.entity.player.Player) || !((net.minecraft.world.entity.player.Player) entity).getAbilities().instabuild)) {
+             if (this.isDamageableItem()) {
+-                if (this.hurt(amount, entity.getRandom(), entity instanceof ServerPlayer ? (ServerPlayer) entity : null)) {
++                if (this.hurt(amount, entity.getRandom(), entity /*instanceof ServerPlayer ? (ServerPlayer) entity : null*/)) { // Paper - pass LivingEntity for EntityItemDamageEvent
+                     breakCallback.accept(entity);
+                     Item item = this.getItem();
+                     // CraftBukkit start - Check for item breaking


### PR DESCRIPTION
Barty made a comment that he was trying to cancel the durability damage armor took from thorns on armor stands. This event should cover that, and, well all other cases of items on other entities that took durability damage.