### PR TITLE
fix book page limit length

### DIFF
--- a/Spigot-Server-Patches/0311-Book-Size-Limits.patch
+++ b/Spigot-Server-Patches/0311-Book-Size-Limits.patch
@@ -22,7 +22,7 @@ index ba7fdf482ef8536074fcc3867d7fc142fcfe8ce8..2aca8cc2be963b2b015e52cdec6b3843
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index cc141f02d5a2b1a5c50e5583d3537d5883762db1..4673efa3f540a6dc2c01a2a601a7c06ee791e8b4 100644
+index cc141f02d5a2b1a5c50e5583d3537d5883762db1..6ad02246267f4d95f82164b70c30ac2955c563fe 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -20,6 +20,7 @@ import java.util.function.Consumer;
@@ -41,7 +41,7 @@ index cc141f02d5a2b1a5c50e5583d3537d5883762db1..4673efa3f540a6dc2c01a2a601a7c06e
 +        ItemStack testStack = packetplayinbedit.getBook();
 +        if (!server.isPrimaryThread() && !testStack.isEmpty() && testStack.getTag() != null) {
 +            NBTTagList pageList = testStack.getTag().getList("pages", 8);
-+            if (pageList.size() > 50) {
++            if (pageList.size() > 100) {
 +                PlayerConnection.LOGGER.warn(this.player.getName() + " tried to send a book with too many pages");
 +                minecraftServer.scheduleOnMain(() -> this.disconnect("Book too large!"));
 +                return;


### PR DESCRIPTION
The vanilla client limits the book to 100 pages, so the check should reflect that as well. (previously was 50 pages)