### PR TITLE
Add OBSTRUCTED result to BedEnterResult enum

### DIFF
--- a/Spigot-API-Patches/0244-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/Spigot-API-Patches/0244-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 24 Dec 2020 12:43:30 -0800
+Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java b/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+index c7d57e286c11eaa578ff6fd457b02a9ff829aa71..24b371b11347abf31fda4dadde8e0a7af60b181b 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBedEnterEvent.java
+@@ -37,6 +37,12 @@ public class PlayerBedEnterEvent extends PlayerEvent implements Cancellable {
+          * Entering the bed is prevented due to the player being too far away.
+          */
+         TOO_FAR_AWAY,
++        // Paper start
++        /**
++         * Bed was obstructed.
++         */
++        OBSTRUCTED,
++        // Paper end
+         /**
+          * Entering the bed is prevented due to there being monsters nearby.
+          */

--- a/Spigot-Server-Patches/0622-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/Spigot-Server-Patches/0622-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -1,0 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 24 Dec 2020 12:43:39 -0800
+Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 71306b6ee6456ae6d4120fda86eb934bdb494973..3f678fde45919061dfc75030b7ce355b4dda9e3a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -269,6 +269,10 @@ public class CraftEventFactory {
+                         return BedEnterResult.TOO_FAR_AWAY;
+                     case NOT_SAFE:
+                         return BedEnterResult.NOT_SAFE;
++                        // Paper start
++                    case OBSTRUCTED:
++                        return BedEnterResult.OBSTRUCTED;
++                        // Paper end
+                     default:
+                         return BedEnterResult.OTHER_PROBLEM;
+                 }


### PR DESCRIPTION
idk if OBSTRUCTED was added later or something, but it the bed event was missing it as an option.