### PR TITLE
Fix lead dupe (#4814)

### DIFF
--- a/Spigot-Server-Patches/0622-Fix-lead-dupe-4814.patch
+++ b/Spigot-Server-Patches/0622-Fix-lead-dupe-4814.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Toshimichi0915 <main@toshimichi.net>
+Date: Fri, 25 Dec 2020 10:32:10 +0900
+Subject: [PATCH] Fix lead dupe (#4814)
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index e44e5652c12fbee51acedc1f911181b8443fae93..d9021fde3d0908dc89384617055874ac356a8fcf 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -2591,6 +2591,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+                 // CraftBukkit end
+ 
+                 this.world.getMethodProfiler().exitEnter("reloading");
++                // Paper start - Change lead drop timing to prevent dupe
++                if (this instanceof EntityInsentient) {
++                    ((EntityInsentient) this).unleash(true, true); // Paper drop lead
++                }
++                // Paper end
+                 Entity entity = this.getEntityType().a((World) worldserver);
+ 
+                 if (entity != null) {
+@@ -2604,10 +2609,6 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+                     // CraftBukkit start - Forward the CraftEntity to the new entity
+                     this.getBukkitEntity().setHandle(entity);
+                     entity.bukkitEntity = this.getBukkitEntity();
+-
+-                    if (this instanceof EntityInsentient) {
+-                        ((EntityInsentient) this).unleash(true, true); // Paper drop lead
+-                    }
+                     // CraftBukkit end
+                 }
+ 


### PR DESCRIPTION
This patch prevents lead from duping by unleashing the original entity before it is copied.
Normal TP and different dimension TP works as usual after this patch.