### PR TITLE
Only check for spooky season once an hour

### DIFF
--- a/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
+++ b/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Sauve <paul@technove.co>
+Date: Sun, 13 Dec 2020 17:53:08 -0600
+Subject: [PATCH] Only check for spooky season once an hour
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
+index 0a59e02d762a096cb3de62e0f8105cc5a5fab8d4..e3768a834d3591ade5685c8ea638b053861ecca6 100644
+--- a/src/main/java/net/minecraft/server/EntityBat.java
++++ b/src/main/java/net/minecraft/server/EntityBat.java
+@@ -221,13 +221,22 @@ public class EntityBat extends EntityAmbient {
+         }
+     }
+ 
++    // AirplaneL start - only check for spooky season once an hour
++    private static boolean isSpookySeason = false;
++    private static final int ONE_HOUR = 20 * 60 * 60;
++    private static int lastSpookyCheck = -ONE_HOUR;
+     private static boolean eJ() {
++        if (MinecraftServer.currentTick - lastSpookyCheck > ONE_HOUR) {
+         LocalDate localdate = LocalDate.now();
+         int i = localdate.get(ChronoField.DAY_OF_MONTH);
+         int j = localdate.get(ChronoField.MONTH_OF_YEAR);
++            isSpookySeason = j == 10 && i >= 20 || j == 11 && i <= 3;
++            lastSpookyCheck = MinecraftServer.currentTick;
++        }
+ 
+-        return j == 10 && i >= 20 || j == 11 && i <= 3;
++        return isSpookySeason;
+     }
++    // AirplaneL end
+ 
+     @Override
+     protected float b(EntityPose entitypose, EntitySize entitysize) {

--- a/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
+++ b/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
@@ -3,6 +3,7 @@ From: Paul Sauve <paul@technove.co>
 Date: Sun, 13 Dec 2020 17:53:08 -0600
 Subject: [PATCH] Only check for spooky season once an hour
 
+This patch was originally created for the AirplaneLite project (https://github.com/Technove/AirplaneLite) under the GPLv3 License.
 
 diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
 index 0a59e02d762a096cb3de62e0f8105cc5a5fab8d4..23d77340608a862508c0a78ed53a99c906dd3500 100644

--- a/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
+++ b/Spigot-Server-Patches/0622-Only-check-for-spooky-season-once-an-hour.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Only check for spooky season once an hour
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
-index 0a59e02d762a096cb3de62e0f8105cc5a5fab8d4..e3768a834d3591ade5685c8ea638b053861ecca6 100644
+index 0a59e02d762a096cb3de62e0f8105cc5a5fab8d4..23d77340608a862508c0a78ed53a99c906dd3500 100644
 --- a/src/main/java/net/minecraft/server/EntityBat.java
 +++ b/src/main/java/net/minecraft/server/EntityBat.java
 @@ -221,13 +221,22 @@ public class EntityBat extends EntityAmbient {
          }
      }
  
-+    // AirplaneL start - only check for spooky season once an hour
++    // Paper start - only check for spooky season once an hour
 +    private static boolean isSpookySeason = false;
 +    private static final int ONE_HOUR = 20 * 60 * 60;
 +    private static int lastSpookyCheck = -ONE_HOUR;
@@ -28,7 +28,7 @@ index 0a59e02d762a096cb3de62e0f8105cc5a5fab8d4..e3768a834d3591ade5685c8ea638b053
 -        return j == 10 && i >= 20 || j == 11 && i <= 3;
 +        return isSpookySeason;
      }
-+    // AirplaneL end
++    // Paper end
  
      @Override
      protected float b(EntityPose entitypose, EntitySize entitysize) {


### PR DESCRIPTION
(This patch is from [AirplaneLite](https://github.com/Technove/AirplaneLite))
Minecraft checks to see if it's halloween pretty often, this patch makes it so "spooky season" is only checked for every hour. This is a micro optimization, but (imo) it wouldn't hurt having.