### PR TITLE
Replacement tile can be null

### DIFF
--- a/Spigot-Server-Patches/0622-Replacement-tile-can-be-null.patch
+++ b/Spigot-Server-Patches/0622-Replacement-tile-can-be-null.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Fri, 25 Dec 2020 16:19:15 +0100
+Subject: [PATCH] Replacement tile can be null
+
+
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index 5b0b6edfa790918e56399ff6c83f3feb6e5aca49..a03ded889ea70fc9576dcc7a9acc833c901b915c 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -288,8 +288,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+         this.getServer().getLogger().log(Level.SEVERE, "Block at {0}, {1}, {2} is {3} but has {4}" + ". "
+                 + "Bukkit will attempt to fix this, but there may be additional damage that we cannot recover.", new Object[]{pos.getX(), pos.getY(), pos.getZ(), type, found});
+ 
+-        if (type instanceof ITileEntity) {
+-            TileEntity replacement = ((ITileEntity) type).createTile(this);
++        // Paper start - there may not always be a replacement tile; avoid the NPE
++        TileEntity replacement;
++        if (type instanceof ITileEntity
++            && (replacement = ((ITileEntity) type).createTile(this)) != null) {
++            // Paper end
+             replacement.world = this;
+             this.setTileEntity(pos, replacement);
+             return replacement;


### PR DESCRIPTION
The following log message was sent where it was shown a piston head may
cannot create a new tile, thus resulting in a fatal
`NullPointerException`:

```
[18:39:21] [Server thread/ERROR]: Block at 8 311, 31, -85 is Block{minecraft:moving_piston} but has net.minecraft.server.v1_16_R3.TileEntityFurnaceFurnace@157e066a. Bukkit will attempt to fix this, but there may be additional damage that we cannot recover.
[18:39:21] [Server thread/WARN]: Failed to handle packet for /127.0.0.1:53204
net.minecraft.server.v1_16_R3.ReportedException: Ticking player
	at net.minecraft.server.v1_16_R3.EntityPlayer.playerTick(EntityPlayer.java:597) ~[patched_1.16.4.jar:git-Paper-345]
	at net.minecraft.server.v1_16_R3.PlayerConnection.tick(PlayerConnection.java:176) ~[patched_1.16.4.jar:git-Paper-345]
	// ...
Caused by: java.lang.NullPointerException
	at net.minecraft.server.v1_16_R3.WorldServer.fixTileEntity(WorldServer.java:293) ~[patched_1.16.4.jar:git-Paper-345]
	at net.minecraft.server.v1_16_R3.WorldServer.getTileEntity(WorldServer.java:280) ~[patched_1.16.4.jar:git-Paper-345]
	// ...
```

This places a `null`-check on the created tile entity, as it may in fact
be `null`.