### PR TITLE
fix-hopper-lag

### DIFF
--- a/Spigot-Server-Patches/0900-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
+++ b/Spigot-Server-Patches/0900-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch
@@ -1,0 +1,387 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Techcable <techcable@techcable.net>
+Date: Sun, 20 Dec 2020 14:21:32 +0100
+Subject: [PATCH] Fix hopper lag by making entities look for hoppers.
+
+Every tick hoppers try and find an block-inventory to extract from.
+If no tile entity is above the hopper (which there often isn't) it will
+do a bounding box search for minecart chests and minecart hoppers.
+If it can't find an inventory, it will then look for a dropped item,
+which is another bounding box search.
+This patch eliminates that expensive check by having dropped items and
+minecart hoppers/chests look for hoppers instead.
+Hoppers are tile entities meaning you can do a simple tile entity lookup
+to find the nearest hopper in range.
+Pushing out of hoppers causes a bouding box lookup, which this patch
+replaces with a tile entity lookup.
+
+This patch may causes a decrease in the performance of dropped items,
+which is why it can be disabled in the configuration.
+
+Co-authored-by: Yannick Lamprecht <yannicklamprecht@live.de>
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 921253a06daa414aed7dc6824effc65db09ea7a5..06ed2cf5edfe4fd894b51aa155164983cbe1f6b0 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -815,4 +815,14 @@ public class PaperWorldConfig {
+     private void allowUsingSignsInsideSpawnProtection() {
+         allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
+     }
++
++    public boolean isHopperPushBased;
++    private void isHopperPushBased() {
++        isHopperPushBased = getBoolean("hopper.push-based", true);
++    }
++
++    public int entitySearchForHopperDelay;
++    private void entitySearchForHopperDelay() {
++        entitySearchForHopperDelay = getInt("hopper.entity-search-for-hopper-delay", 200);
++    }
+ }
+diff --git a/src/main/java/io/papermc/paper/HopperPusher.java b/src/main/java/io/papermc/paper/HopperPusher.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..cb8c48272e88ac03695c015d38dc75f260c87826
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/HopperPusher.java
+@@ -0,0 +1,97 @@
++package io.papermc.paper;
++
++
++import net.minecraft.core.BlockPosition;
++import net.minecraft.server.MinecraftServer;
++import net.minecraft.world.entity.Entity;
++import net.minecraft.world.level.World;
++import net.minecraft.world.level.block.Blocks;
++import net.minecraft.world.level.block.entity.TileEntity;
++import net.minecraft.world.level.block.entity.TileEntityHopper;
++import net.minecraft.world.phys.AxisAlignedBB;
++
++
++public interface HopperPusher {
++
++    default TileEntityHopper findHopper() {
++        BlockPosition pos = new BlockPosition(((Entity) this).locX(), ((Entity) this).locY(), ((Entity) this).locZ()).down();
++        TileEntityHopper hopper = getHopper(((Entity) this).getWorld(), pos);
++        if (hopper == null) {
++            return null;
++        }
++        AxisAlignedBB hopperBoundingBox = hopper.getHopperLookupBoundingBox();
++        if (hopperBoundingBox.intersects(((Entity) this)
++            .getBoundingBox())) {
++            return hopper;
++        }
++        return null;
++    }
++
++    boolean acceptItem(TileEntityHopper hopper);
++
++    default boolean tryPutInHopper() {
++        if (!((Entity) this).getWorld().paperConfig.isHopperPushBased) {
++            return false;
++        }
++        CheckData checkData = getCheckData();
++        TileEntityHopper hopper = null;
++        if(!hasMoved()){
++            if (checkData.getHopperPosition() != null) {
++                hopper = getHopper(((Entity) this).getWorld(), checkData.getHopperPosition());
++            }
++        }
++        if(hopper == null && waitedLongEnoughOrMoved(checkData)) {
++            hopper = findHopper();
++            if (hopper != null) {
++                checkData.setHopperPosition(hopper.getBlockPosition());
++            }
++            checkData.updateLastChecked();
++        }
++        return hopper != null && hopper.canAcceptItems() && acceptItem(hopper);
++    }
++
++    default boolean waitedLongEnoughOrMoved(CheckData checkData){
++        return hasMoved() ||
++            net.minecraft.server.MinecraftServer.currentTick - checkData.getLastChecked() > ((Entity) this).getWorld().paperConfig.entitySearchForHopperDelay;
++    }
++
++    default boolean hasMoved(){
++        Entity entity = (Entity) this;
++        return (entity.locX() == entity.lastX && entity.locY() == entity.lastY && entity.locZ() == entity.lastZ);
++    }
++
++    static TileEntityHopper getHopper(World world, BlockPosition pos) {
++        if (world.getType(pos).getBlock() != Blocks.HOPPER) {
++            return null;
++        }
++        TileEntity tileEntity = world.getTileEntity(pos);
++        if (tileEntity instanceof TileEntityHopper) {
++            return (TileEntityHopper) tileEntity;
++        }
++        return null;
++    }
++
++    CheckData getCheckData();
++
++    class CheckData {
++
++        private long lastChecked;
++        private BlockPosition hopperPosition;
++
++        public void updateLastChecked() {
++            lastChecked = MinecraftServer.currentTick;
++        }
++
++        public long getLastChecked() {
++            return lastChecked;
++        }
++
++        public void setHopperPosition(BlockPosition hopperPosition) {
++            this.hopperPosition = hopperPosition;
++        }
++
++        public BlockPosition getHopperPosition() {
++            return hopperPosition;
++        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/world/entity/item/EntityItem.java b/src/main/java/net/minecraft/world/entity/item/EntityItem.java
+index 575833807ff647f30d7c2b7abcd01701c7dec85b..3cd49bdf9280e76ceee21254fc1f5065f3dab4e7 100644
+--- a/src/main/java/net/minecraft/world/entity/item/EntityItem.java
++++ b/src/main/java/net/minecraft/world/entity/item/EntityItem.java
+@@ -29,6 +29,7 @@ import net.minecraft.world.item.Item;
+ import net.minecraft.world.item.ItemStack;
+ import net.minecraft.world.item.Items;
+ import net.minecraft.world.level.World;
++import net.minecraft.world.level.block.entity.TileEntityHopper; // Paper - hopper fix
+ import net.minecraft.world.phys.Vec3D;
+ 
+ // CraftBukkit start
+@@ -39,7 +40,9 @@ import org.bukkit.event.player.PlayerPickupItemEvent;
+ // CraftBukkit end
+ import org.bukkit.event.player.PlayerAttemptPickupItemEvent; // Paper
+ 
+-public class EntityItem extends Entity {
++import io.papermc.paper.HopperPusher; // Paper
++
++public class EntityItem extends Entity implements HopperPusher {
+ 
+     private static final DataWatcherObject<ItemStack> ITEM = DataWatcher.a(EntityItem.class, DataWatcherRegistry.g);
+     public int age;
+@@ -69,6 +72,19 @@ public class EntityItem extends Entity {
+         this.setItemStack(itemstack);
+     }
+ 
++    // Paper start
++    @Override
++    public boolean acceptItem(TileEntityHopper hopper) {
++      return TileEntityHopper.canPickupItem(hopper, this);
++    }
++
++    private final HopperPusher.CheckData checkData = new CheckData();
++    @Override
++    public CheckData getCheckData() {
++        return checkData;
++    }
++    // Paper end
++
+     @Override
+     protected boolean playStepSound() {
+         return false;
+@@ -85,6 +101,7 @@ public class EntityItem extends Entity {
+             this.die();
+         } else {
+             super.tick();
++            if (tryPutInHopper()) return; // Paper
+             // CraftBukkit start - Use wall time for pickup and despawn timers
+             int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
+             if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
+@@ -178,6 +195,7 @@ public class EntityItem extends Entity {
+     // Spigot start - copied from above
+     @Override
+     public void inactiveTick() {
++        if (tryPutInHopper()) return; // Paper
+         // CraftBukkit start - Use wall time for pickup and despawn timers
+         int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
+         if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartContainer.java b/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartContainer.java
+index 0166d11cb540a536390f486e1069d6119d8d23d6..f4f81883d7f325688b79afe9c4e55541cd0a518b 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartContainer.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/EntityMinecartContainer.java
+@@ -24,6 +24,7 @@ import net.minecraft.world.inventory.Container;
+ import net.minecraft.world.item.ItemStack;
+ import net.minecraft.world.level.GameRules;
+ import net.minecraft.world.level.World;
++import net.minecraft.world.level.block.entity.TileEntityHopper; // Paper - hopper fix
+ import net.minecraft.world.level.storage.loot.LootTable;
+ import net.minecraft.world.level.storage.loot.LootTableInfo;
+ import net.minecraft.world.level.storage.loot.parameters.LootContextParameterSets;
+@@ -35,9 +36,10 @@ import org.bukkit.Location;
+ import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+ import org.bukkit.entity.HumanEntity;
+ import org.bukkit.inventory.InventoryHolder;
++import io.papermc.paper.HopperPusher; // Paper
+ // CraftBukkit end
+ 
+-public abstract class EntityMinecartContainer extends EntityMinecartAbstract implements IInventory, ITileInventory {
++public abstract class EntityMinecartContainer extends EntityMinecartAbstract implements IInventory, ITileInventory, HopperPusher {
+ 
+     private NonNullList<ItemStack> items;
+     private boolean c;
+@@ -72,6 +74,31 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+         return null;
+     }
+ 
++    // Paper start
++    @Override
++    public boolean acceptItem(TileEntityHopper hopper) {
++        return TileEntityHopper.acceptItem(hopper, this);
++    }
++
++    @Override
++    public void tick() {
++        super.tick();
++        tryPutInHopper();
++    }
++
++    @Override
++    public void inactiveTick() {
++        super.inactiveTick();
++        tryPutInHopper();
++    }
++
++    private final HopperPusher.CheckData checkData = new CheckData();
++    @Override
++    public CheckData getCheckData() {
++        return checkData;
++    }
++    // Paper end
++
+     @Override
+     public int getMaxStackSize() {
+         return maxStack;
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityHopper.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityHopper.java
+index 537dc52e5ff3325555ee6049bc7f277952983b76..c76cd906f59060608c0f7f3e6dc974bffb5054fc 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityHopper.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityHopper.java
+@@ -86,6 +86,12 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         this.j = -1;
+     }
+ 
++    // Paper start
++    public boolean canAcceptItems() {
++        return !this.hasCooldown() && !this.isInventoryFull() && this.getBlock().get(BlockHopper.ENABLED);
++    }
++    // Paper end
++
+     @Override
+     public void load(IBlockData iblockdata, NBTTagCompound nbttagcompound) {
+         super.load(iblockdata, nbttagcompound);
+@@ -145,7 +151,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+                 boolean result = this.a(() -> {
+                     return a((IHopper) this);
+                 });
+-                if (!result && this.world.spigotConfig.hopperCheck > 1) {
++                if (!result && this.world.spigotConfig.hopperCheck > 1 && !world.paperConfig.isHopperPushBased /* Paper */) {
+                     this.setCooldown(this.world.spigotConfig.hopperCheck);
+                 }
+                 // Spigot end
+@@ -180,6 +186,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         }
+     }
+ 
++    private final boolean isInventoryFull() { return j(); } // Paper - OBFHELPER
+     private boolean j() {
+         Iterator iterator = this.items.iterator();
+ 
+@@ -348,10 +355,20 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+             ((EntityMinecartHopper) hopper).setCooldown(hopper.getWorld().spigotConfig.hopperTransfer / 2);
+         }
+     }
++
++    public AxisAlignedBB getHopperLookupBoundingBox() {
++        // Change this if b(IHopper) ever changes
++        return getHopperLookupBoundingBox(this.getX(), this.getY() + 1.0D, this.getZ());
++    }
++
++    private static AxisAlignedBB getHopperLookupBoundingBox(double d0, double d1, double d2) {
++        // Change this if the above ever changes
++        return new AxisAlignedBB(d0 - 0.5D, d1 - 0.5D, d2 - 0.5D, d0 + 0.5D, d1 + 0.5D, d2 + 0.5D);
++    }
+     // Paper end
+ 
+     private boolean k() {
+-        IInventory iinventory = this.l();
++        IInventory iinventory = getInventory(getWorld(), getPosition().shift((this.getBlock().get(BlockHopper.FACING)))); // Paper
+ 
+         if (iinventory == null) {
+             return false;
+@@ -459,8 +476,21 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+     }
+ 
+     public static boolean a(IHopper ihopper) {
+-        IInventory iinventory = b(ihopper);
++        // Paper start
++        IInventory iinventory;
++        if (ihopper.getWorld().paperConfig.isHopperPushBased
++            && ihopper instanceof TileEntityHopper) {
++            BlockPosition pos = ((TileEntityHopper) ihopper).getPosition()
++                .up(); // Only pull from a above, because everything else comes to us
++            iinventory = getInventory(ihopper.getWorld(), pos);
++        } else {
++            iinventory = getSourceInventory(ihopper); // Use old behavior for BB entity searching
++        }
++        return acceptItem(ihopper, iinventory);
++    }
+ 
++    public static boolean acceptItem(IHopper ihopper, IInventory iinventory) {
++    // Paper end
+         if (iinventory != null) {
+             EnumDirection enumdirection = EnumDirection.DOWN;
+ 
+@@ -475,7 +505,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+                 }
+             });
+             // Paper end
+-        } else {
++        } else if (!ihopper.getWorld().paperConfig.isHopperPushBased || !(ihopper instanceof TileEntityHopper)) { // Paper - only search for entities in 'pull mode'
+             Iterator iterator = c(ihopper).iterator();
+ 
+             EntityItem entityitem;
+@@ -490,6 +520,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+ 
+             return true;
+         }
++        return false; // Paper
+     }
+ 
+     private static boolean a(IHopper ihopper, IInventory iinventory, int i, EnumDirection enumdirection) {// Paper - method unused as logic is inlined above
+@@ -539,6 +570,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return false;
+     }
+ 
++    public final static boolean canPickupItem(IInventory iinventory, EntityItem entityitem) { return a(iinventory, entityitem); } // Paper - OBFHELPER
+     public static boolean a(IInventory iinventory, EntityItem entityitem) {
+         boolean flag = false;
+         // CraftBukkit start
+@@ -644,6 +676,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return b(this.getWorld(), this.position.shift(enumdirection));
+     }
+ 
++    @Nullable public static final IInventory getSourceInventory(IHopper ihopper) { return b(ihopper); } // Paper - OBFHELPER
+     @Nullable
+     public static IInventory b(IHopper ihopper) {
+         return a(ihopper.getWorld(), ihopper.x(), ihopper.z() + 1.0D, ihopper.A());
+@@ -665,6 +698,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         return a(world, (double) blockposition.getX() + 0.5D, (double) blockposition.getY() + 0.5D, (double) blockposition.getZ() + 0.5D, true); // Paper
+     }
+ 
++    @Nullable public static IInventory getInventory(World world, BlockPosition position) { return a(world, position.getX(), position.getY(), position.getZ()); } // Paper - OBFHELPER
+     @Nullable
+     public static IInventory a(World world, double d0, double d1, double d2) { return a(world, d0, d1, d2, false); } // Paper - overload to default false
+     public static IInventory a(World world, double d0, double d1, double d2, boolean optimizeEntities) { // Paper
+@@ -721,6 +755,7 @@ public class TileEntityHopper extends TileEntityLootable implements IHopper, ITi
+         this.j = i;
+     }
+ 
++    private final boolean hasCooldown() { return m(); } // Paper - OBFHELPER
+     private boolean m() {
+         return this.j > 0;
+     }


### PR DESCRIPTION
Ported the mc 1.8 patch of Techcable to 1.16.5.
https://github.com/VictorML11/FluxSpigot/blob/master/PaperSpigot-Server-Patches/0006-Fix-hopper-lag-by-making-entities-look-for-hoppers.patch


A first test has shown that with 245k hoppers the load is reduced by ~50%.




> @electronicboy I had some thoughts regarding further Hopper logic optimizations. Will add it temporarily as a second patch file so that the change between hopper base fix and the further optimization is clearly separated first.
If everything is ok with it I'll be merged it into the original patch. Feel free to have a look if you would change anything there.


Added
- don't check hopper & bounding box collision if elapsed time since last check is not greater N ticks or item/cart is not moving
- skip hopper & bounding box check if checked previously and only hoper inventory was full -> get saved hopper block location and do inventory stuff
