### PR TITLE
Cache burn durations

### DIFF
--- a/Spigot-Server-Patches/0630-Cache-burn-durations.patch
+++ b/Spigot-Server-Patches/0630-Cache-burn-durations.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lukas <lukasalt98@gmail.com>
+Date: Sun, 27 Dec 2020 16:47:00 +0100
+Subject: [PATCH] Cache burn durations
+
+
+diff --git a/src/main/java/net/minecraft/server/TileEntityFurnace.java b/src/main/java/net/minecraft/server/TileEntityFurnace.java
+index 1d3c2dd93657fb5dc71ee6b444c585b54619d1e8..e75e676d196d9f5a3409ec50645fab611b0afdad 100644
+--- a/src/main/java/net/minecraft/server/TileEntityFurnace.java
++++ b/src/main/java/net/minecraft/server/TileEntityFurnace.java
+@@ -1,5 +1,6 @@
+ package net.minecraft.server;
+ 
++import com.google.common.collect.ImmutableMap;
+ import com.google.common.collect.Lists;
+ import com.google.common.collect.Maps;
+ import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
+@@ -83,7 +84,15 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+         this.c = recipes;
+     }
+ 
++    private static Map<Item, Integer> cachedBurnDurations = null; // Paper - cache burn durations
++
++    public static Map<Item, Integer> getBurnDurations() { return f(); } // Paper - OBFHELPER
+     public static Map<Item, Integer> f() {
++        // Paper start - cache burn durations
++        if(cachedBurnDurations != null) {
++            return cachedBurnDurations;
++        }
++        // Paper end
+         Map<Item, Integer> map = Maps.newLinkedHashMap();
+ 
+         a(map, (IMaterial) Items.LAVA_BUCKET, 20000);
+@@ -146,7 +155,10 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+         a(map, (IMaterial) Blocks.FLETCHING_TABLE, 300);
+         a(map, (IMaterial) Blocks.SMITHING_TABLE, 300);
+         a(map, (IMaterial) Blocks.COMPOSTER, 300);
+-        return map;
++        // Paper start - cache burn durations
++        cachedBurnDurations = ImmutableMap.copyOf(map);
++        return cachedBurnDurations;
++        // Paper end
+     }
+ 
+     // CraftBukkit start - add fields and methods
+@@ -400,7 +412,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+         } else {
+             Item item = itemstack.getItem();
+ 
+-            return (Integer) f().getOrDefault(item, 0);
++            return getBurnDurations().getOrDefault(item, 0); // Paper - cache burn durations
+         }
+     }
+ 
+@@ -409,7 +421,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+     }
+ 
+     public static boolean isFuel(ItemStack itemstack) {
+-        return f().containsKey(itemstack.getItem());
++        return getBurnDurations().containsKey(itemstack.getItem()); // Paper - cache burn durations
+     }
+ 
+     @Override


### PR DESCRIPTION
Cache the results of TileEntityFurnace.f() (which returns a map containing all fuel items along with their burn duration).  This optimizes the TileEntityFurnace.isFuel(ItemStack) function, which is called whenever a hopper pushes an item into a furnace 
( https://imgur.com/a/X4kndsx ).

