### PR TITLE
Optimized tile tick ready check

### DIFF
--- a/Spigot-Server-Patches/0629-Optimized-tick-ready-check.patch
+++ b/Spigot-Server-Patches/0629-Optimized-tick-ready-check.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lukas <lukasalt98@gmail.com>
+Date: Sun, 27 Dec 2020 17:19:51 +0100
+Subject: [PATCH] Optimized tick ready check
+
+
+diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
+index 9ed21f434c5fb019b74dfe9ee0b802ccc5c07fd8..97654e0744ef00e9db7b6d473a468b38dce80345 100644
+--- a/src/main/java/net/minecraft/server/World.java
++++ b/src/main/java/net/minecraft/server/World.java
+@@ -793,13 +793,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+             if (!tileentity.isRemoved() && tileentity.hasWorld()) {
+                 BlockPosition blockposition = tileentity.getPosition();
+ 
+-                if (this.getChunkProvider().a(blockposition) && this.getWorldBorder().a(blockposition)) {
++                Chunk chunk; PlayerChunk playerChunk; if ((chunk = tileentity.getCurrentChunk()) != null && (playerChunk = chunk.playerChunk) != null && playerChunk.isTickingReady() && this.getWorldBorder().isInBounds(blockposition)) { // Paper - optimized tick ready check by inlining ChunkProviderServer.a(BlockPosition). Chunk lookup is no longer required and we can use the PlayerChunk directly available through the tile entity
+                     try {
+                         gameprofilerfiller.a(() -> {
+                             return String.valueOf(TileEntityTypes.a(tileentity.getTileType()));
+                         });
+                         tileentity.tickTimer.startTiming(); // Spigot
+-                        if (tileentity.getTileType().isValidBlock(this.getType(blockposition).getBlock())) {
++                        if (tileentity.getTileType().isValidBlock(chunk.getType(blockposition).getBlock())) { // Paper - reuse the chunk from above, do not look it up again
+                             ((ITickable) tileentity).tick();
+                         } else {
+                             tileentity.w();
+@@ -833,9 +833,11 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                 this.tileEntityListTick.remove(tileTickPosition--);
+                 // Spigot end
+                 //this.tileEntityList.remove(tileentity); // Paper - remove unused list
+-                if (this.isLoaded(tileentity.getPosition())) {
+-                    this.getChunkAtWorldCoords(tileentity.getPosition()).removeTileEntity(tileentity.getPosition());
++                // Paper - prevent double chunk lookups
++                Chunk chunk; if ((chunk = this.getChunkIfLoaded(tileentity.getPosition())) != null) { // inlined contents of this.isLoaded(BlockPosition). Reuse the returned chunk instead of looking it up again
++                    chunk.removeTileEntity(tileentity.getPosition());
+                 }
++                // Paper end
+             }
+         }
+ 
+@@ -854,8 +856,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
+                     }
+                     // CraftBukkit end */
+ 
+-                    if (this.isLoaded(tileentity1.getPosition())) {
+-                        Chunk chunk = this.getChunkAtWorldCoords(tileentity1.getPosition());
++                    Chunk chunk; if ((chunk = this.getChunkIfLoaded(tileentity1.getPosition())) != null) {  // Paper - inlined contents of this.isLoaded(BlockPosition). Reuse the returned chunk instead of looking it up again
++                        // Chunk chunk = this.getChunkAtWorldCoords(tileentity1.getPosition()); // Paper - already computed above
+                         IBlockData iblockdata = chunk.getType(tileentity1.getPosition());
+ 
+                         chunk.setTileEntity(tileentity1.getPosition(), tileentity1);


### PR DESCRIPTION
Before a tile entity is ticked, it is first checked if the chunk it is inside is ready to be ticked. This check takes about 5% of the tick wall time according to YourKit's sampling on a server with lots of tile entities. This patch inlines the contents of ChunkProviderServer.a(BlockPosition). The lookup of the chunk `PlayerChunk playerChunk = this.getChunk(MCUtil.getCoordinateKey(blockposition));`, which is pretty inefficient, is no longer required as the PlayerChunk is directly available through the TileEntity. 