### PR TITLE
Add sendOpLevel API

### DIFF
--- a/Spigot-API-Patches/0259-Add-sendOpLevel-API.patch
+++ b/Spigot-API-Patches/0259-Add-sendOpLevel-API.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Tue, 29 Dec 2020 15:02:57 +0100
+Subject: [PATCH] Add sendOpLevel API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index ea5257cc94d084fe4e0b9d9685e51d8f70cb84cb..cb6464c89e02d29484554a9a2184996a256925d2 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1793,6 +1793,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     @Nullable
+     Firework boostElytra(@NotNull ItemStack firework);
++
++    /**
++     * Send a packet to the player indicating its operator status level.
++     * <p>
++     * <b>Note:</b> This will not persist across more than the current connection, and setting the player's operator
++     * status as a later point <i>will</i> override the effects of this.
++     *
++     * @param level The level to send to the player. Must be in {@code [0, 4]}.
++     * @throws IllegalArgumentException If the level is negative or greater than {@code 4} (i.e. not within {@code [0, 4]}).
++     */
++    void sendOpLevel(byte level);
+     // Paper end
+ 
+     // Spigot start

--- a/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
+++ b/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Mariell Hoversholm <proximyst@proximyst.com>
+Date: Tue, 29 Dec 2020 15:03:03 +0100
+Subject: [PATCH] Add sendOpLevel API
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 4bc9b3b08b42becfd66f39cb0d639bdcae18d45c..1eb44877e7384ae0a028a12b832684126b8d50ec 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -1056,6 +1056,11 @@ public abstract class PlayerList {
+     }
+ 
+     private void a(EntityPlayer entityplayer, int i) {
++        // Paper start - add recalculatePermissions parameter
++        this.sendPlayerOperatorStatus(entityplayer, i, true);
++    }
++    public void sendPlayerOperatorStatus(EntityPlayer entityplayer, int i, boolean recalculatePermissions) {
++        // Paper end
+         if (entityplayer.playerConnection != null) {
+             byte b0;
+ 
+@@ -1070,8 +1075,10 @@ public abstract class PlayerList {
+             entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityStatus(entityplayer, b0));
+         }
+ 
++        if (recalculatePermissions) { // Paper
+         entityplayer.getBukkitEntity().recalculatePermissions(); // CraftBukkit
+         this.server.getCommandDispatcher().a(entityplayer);
++        } // Paper
+     }
+ 
+     // Paper start
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 58caa3240b90cdc661e1e32e3f5c312ed62c3c21..7c18b22c7b93b6ca1189e481dde17476797b8fd5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2100,6 +2100,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+             ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
+             : null;
+     }
++
++    @Override
++    public void sendOpLevel(byte level) {
++        Preconditions.checkArgument(level >= 0 && level <= 4, "Level must be within [0, 4]");
++
++        this.getHandle().getMinecraftServer().getPlayerList().sendPlayerOperatorStatus(this.getHandle(), level, false);
++    }
+     // Paper end
+ 
+     // Spigot start


### PR DESCRIPTION
This adds an API to send an operator status level to the player.

---

Test code:

```kotlin
class SendOpLevel : BaseCommand() {
    override fun register(manager: PaperCommandManager<CommandSender>) {
        manager.command(manager.commandBuilder("sendop")
            .argument(
                ByteArgument.newBuilder<CommandSender>("level")
                    .withMin(0)
                    .withMax(4)
            )
            .senderType(Player::class.java)
            .handler {
                val level: Byte = it["level"]
                val player = it.sender as Player
                player.sendOpLevel(level)
            })
    }
}
```