### PR TITLE
Deprecate ProjectileCollideEvent in favor of ProjectileHitEvent

### DIFF
--- a/Spigot-API-Patches/0040-Add-ProjectileCollideEvent.patch
+++ b/Spigot-API-Patches/0040-Add-ProjectileCollideEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add ProjectileCollideEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..453663893021768ae21d4980ce17ffba55d9e129
+index 0000000000000000000000000000000000000000..250ff186f152699de3e03d0928108c63faba1124
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/entity/ProjectileCollideEvent.java
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,69 @@
 +package com.destroystokyo.paper.event.entity;
 +
 +import org.bukkit.entity.Entity;
@@ -23,7 +23,9 @@ index 0000000000000000000000000000000000000000..453663893021768ae21d4980ce17ffba
 + * Called when an projectile collides with an entity
 + * <p>
 + * This event is called <b>before</b> {@link org.bukkit.event.entity.EntityDamageByEntityEvent}, and cancelling it will allow the projectile to continue flying
++ * @deprecated Deprecated, prefer {@link org.bukkit.event.entity.ProjectileHitEvent}.
 + */
++@Deprecated
 +public class ProjectileCollideEvent extends EntityEvent implements Cancellable {
 +    @NotNull private final Entity collidedWith;
 +

--- a/Spigot-API-Patches/0256-Make-ProjectileHitEvent-cancellable.patch
+++ b/Spigot-API-Patches/0256-Make-ProjectileHitEvent-cancellable.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 29 Dec 2020 15:05:50 -0800
+Subject: [PATCH] Make ProjectileHitEvent cancellable
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+index 809c1098c16fe52eda47ae2335afab30e36746b2..4a734be2ca03711edf7c885242550701d8e5771c 100644
+--- a/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
++++ b/src/main/java/org/bukkit/event/entity/ProjectileHitEvent.java
+@@ -10,12 +10,14 @@ import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Called when a projectile hits an object
++ * <p> This Event is made cancellable by Paper
+  */
+-public class ProjectileHitEvent extends EntityEvent {
++public class ProjectileHitEvent extends EntityEvent implements org.bukkit.event.Cancellable { // Paper - implements Cancellable
+     private static final HandlerList handlers = new HandlerList();
+     private final Entity hitEntity;
+     private final Block hitBlock;
+     private final BlockFace hitFace;
++    private boolean cancelled; // Paper
+ 
+     public ProjectileHitEvent(@NotNull final Projectile projectile) {
+         this(projectile, null, null);
+@@ -88,4 +90,15 @@ public class ProjectileHitEvent extends EntityEvent {
+         return handlers;
+     }
+ 
++    // Paper start
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0122-Add-ProjectileCollideEvent.patch
+++ b/Spigot-Server-Patches/0122-Add-ProjectileCollideEvent.patch
@@ -4,72 +4,6 @@ Date: Fri, 16 Dec 2016 21:25:39 -0600
 Subject: [PATCH] Add ProjectileCollideEvent
 
 
-diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 2a86d4b8af5e436e82e003f50c1929702af700c4..93084633d487684fb598038d148670fe6a00b3ed 100644
---- a/src/main/java/net/minecraft/server/EntityArrow.java
-+++ b/src/main/java/net/minecraft/server/EntityArrow.java
-@@ -160,6 +160,17 @@ public abstract class EntityArrow extends IProjectile {
-                     }
-                 }
- 
-+                // Paper start - Call ProjectileCollideEvent
-+                // TODO: flag - noclip - call cancelled?
-+                if (object instanceof MovingObjectPositionEntity) {
-+                    com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileCollideEvent(this, (MovingObjectPositionEntity)object);
-+                    if (event.isCancelled()) {
-+                        object = null;
-+                        movingobjectpositionentity = null;
-+                    }
-+                }
-+                // Paper end
-+
-                 if (object != null && !flag) {
-                     this.a((MovingObjectPosition) object);
-                     this.impulse = true;
-diff --git a/src/main/java/net/minecraft/server/EntityFireball.java b/src/main/java/net/minecraft/server/EntityFireball.java
-index 1ee09cb383d762219bda89463f4b6af807799385..74ca38f8e4e1addc243c3f3b57021d26f0ce3c97 100644
---- a/src/main/java/net/minecraft/server/EntityFireball.java
-+++ b/src/main/java/net/minecraft/server/EntityFireball.java
-@@ -57,7 +57,16 @@ public abstract class EntityFireball extends IProjectile {
- 
-             MovingObjectPosition movingobjectposition = ProjectileHelper.a((Entity) this, this::a);
- 
--            if (movingobjectposition.getType() != MovingObjectPosition.EnumMovingObjectType.MISS) {
-+            // Paper start - Call ProjectileCollideEvent
-+            if (movingobjectposition instanceof MovingObjectPositionEntity) {
-+                com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = CraftEventFactory.callProjectileCollideEvent(this, (MovingObjectPositionEntity)movingobjectposition);
-+                if (event.isCancelled()) {
-+                    movingobjectposition = null;
-+                }
-+            }
-+            // Paper end
-+
-+            if (movingobjectposition != null && movingobjectposition.getType() != MovingObjectPosition.EnumMovingObjectType.MISS) { // Paper - add null check in case cancelled
-                 this.a(movingobjectposition);
- 
-                 // CraftBukkit start - Fire ProjectileHitEvent
-diff --git a/src/main/java/net/minecraft/server/EntityProjectile.java b/src/main/java/net/minecraft/server/EntityProjectile.java
-index 7391fd31148dbde60e34955841a296f454ac768e..53a8ea7d1eff84abe6c49464d556aa2788a6abcb 100644
---- a/src/main/java/net/minecraft/server/EntityProjectile.java
-+++ b/src/main/java/net/minecraft/server/EntityProjectile.java
-@@ -41,7 +41,17 @@ public abstract class EntityProjectile extends IProjectile {
-         }
- 
-         if (movingobjectposition.getType() != MovingObjectPosition.EnumMovingObjectType.MISS && !flag) {
-+            // Paper start - Call ProjectileCollideEvent
-+            if (movingobjectposition instanceof MovingObjectPositionEntity) {
-+                com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileCollideEvent(this, (MovingObjectPositionEntity)movingobjectposition);
-+                if (event.isCancelled()) {
-+                    movingobjectposition = null;
-+                }
-+            }
-+            if (movingobjectposition != null) {
-+            // Paper end
-             this.a(movingobjectposition);
-+            } // Paper
-         }
- 
-         this.checkBlockCollisions();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 index be74f172383f270e3f1ec194044f024e7b040694..8fbaaa7d287ecd13203ae7362b552c5f11858066 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
@@ -79,8 +13,8 @@ index be74f172383f270e3f1ec194044f024e7b040694..8fbaaa7d287ecd13203ae7362b552c5f
      }
  
 +    // Paper start
-+    public static com.destroystokyo.paper.event.entity.ProjectileCollideEvent callProjectileCollideEvent(Entity entity, MovingObjectPositionEntity position) {
-+        Projectile projectile = (Projectile) entity.getBukkitEntity();
++    public static com.destroystokyo.paper.event.entity.ProjectileCollideEvent callProjectileCollideEvent(org.bukkit.entity.Entity entity, MovingObjectPositionEntity position) {
++        Projectile projectile = (Projectile) entity;
 +        org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
 +        com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);
 +        Bukkit.getPluginManager().callEvent(event);

--- a/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
+++ b/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
@@ -147,11 +147,11 @@ index 7affb75a97e49b67861b24de38ef83e72b0abd5a..ce596bd1268eb7d6d20709fe1e00a59c
      public boolean s_() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 50047901625527e90d4d2ceb2572f30811f2ee76..6b62317f6a5e8a9bb8fdfc901835d0c28d3eeeda 100644
+index ab10c4dac2ffc55c7b5f208c8ad48a228745de35..cc1fdfe172e692fe36011523059d6a06c2f74ac8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1207,6 +1207,14 @@ public class CraftEventFactory {
-         Projectile projectile = (Projectile) entity.getBukkitEntity();
+         Projectile projectile = (Projectile) entity;
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);
 +

--- a/Spigot-Server-Patches/0503-Expose-Arrow-getItemStack.patch
+++ b/Spigot-Server-Patches/0503-Expose-Arrow-getItemStack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Arrow getItemStack
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 93084633d487684fb598038d148670fe6a00b3ed..402684ee2a42eefc843df663a1f3af9a8a66a0bb 100644
+index 2a86d4b8af5e436e82e003f50c1929702af700c4..cbdf95c57454c1ccf971807f0c3f0b4a6f4b2713 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
-@@ -520,6 +520,7 @@ public abstract class EntityArrow extends IProjectile {
+@@ -509,6 +509,7 @@ public abstract class EntityArrow extends IProjectile {
          }
      }
  

--- a/Spigot-Server-Patches/0530-Fix-arrows-never-despawning-MC-125757.patch
+++ b/Spigot-Server-Patches/0530-Fix-arrows-never-despawning-MC-125757.patch
@@ -9,7 +9,7 @@ instead of getting stuck in a never despawn state (bubble columns,
 etc).
 
 diff --git a/src/main/java/net/minecraft/server/EntityArrow.java b/src/main/java/net/minecraft/server/EntityArrow.java
-index 402684ee2a42eefc843df663a1f3af9a8a66a0bb..1e7f5957d879d1ba8cf2b29cf9397b8e204e4381 100644
+index cbdf95c57454c1ccf971807f0c3f0b4a6f4b2713..e7ddbe402720616762f799727ee6095cf9473975 100644
 --- a/src/main/java/net/minecraft/server/EntityArrow.java
 +++ b/src/main/java/net/minecraft/server/EntityArrow.java
 @@ -133,6 +133,7 @@ public abstract class EntityArrow extends IProjectile {
@@ -20,7 +20,7 @@ index 402684ee2a42eefc843df663a1f3af9a8a66a0bb..1e7f5957d879d1ba8cf2b29cf9397b8e
              this.c = 0;
              Vec3D vec3d2 = this.getPositionVector();
  
-@@ -254,6 +255,7 @@ public abstract class EntityArrow extends IProjectile {
+@@ -243,6 +244,7 @@ public abstract class EntityArrow extends IProjectile {
  
      }
  

--- a/Spigot-Server-Patches/0629-Optimized-tick-ready-check.patch
+++ b/Spigot-Server-Patches/0629-Optimized-tick-ready-check.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimized tick ready check
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 9ed21f434c5fb019b74dfe9ee0b802ccc5c07fd8..97654e0744ef00e9db7b6d473a468b38dce80345 100644
+index 9ed21f434c5fb019b74dfe9ee0b802ccc5c07fd8..277c051f814d25dd7c57cdba268ea044873c88d5 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -793,13 +793,13 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0641-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-Server-Patches/0641-Implemented-BlockFailedDispenseEvent.patch
@@ -29,7 +29,7 @@ index 65c212690d8ba7c8ea55d4d3b6af1ba3d9f4a7f6..22ab5a861920e1902c64301c3b06cf95
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 345bce7bbf0a9391d70be7aa5530d394273842aa..4534d22aec95cf247daf7575472acd0eba91a3c9 100644
+index 8ce692bdaa5c0015f0c3e6b47e18fd297ff97b80..d8c77f70845e21b787234e1c02a1650ebc34a8a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -4,6 +4,7 @@ import com.google.common.base.Function;

--- a/Spigot-Server-Patches/0643-Make-ProjectileHitEvent-cancellable.patch
+++ b/Spigot-Server-Patches/0643-Make-ProjectileHitEvent-cancellable.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 29 Dec 2020 15:06:32 -0800
+Subject: [PATCH] Make ProjectileHitEvent cancellable
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityFireball.java b/src/main/java/net/minecraft/server/EntityFireball.java
+index 1ee09cb383d762219bda89463f4b6af807799385..7cd60c1b9c347a0d77c1f541e268450a52dd945c 100644
+--- a/src/main/java/net/minecraft/server/EntityFireball.java
++++ b/src/main/java/net/minecraft/server/EntityFireball.java
+@@ -61,7 +61,7 @@ public abstract class EntityFireball extends IProjectile {
+                 this.a(movingobjectposition);
+ 
+                 // CraftBukkit start - Fire ProjectileHitEvent
+-                if (this.dead) {
++                if (false && this.dead) { // Paper - don't call this event a second time
+                     CraftEventFactory.callProjectileHitEvent(this, movingobjectposition);
+                 }
+                 // CraftBukkit end
+diff --git a/src/main/java/net/minecraft/server/IProjectile.java b/src/main/java/net/minecraft/server/IProjectile.java
+index 9f5ce64a60fe7c312399ee416b11b84213dd3bee..bbc089b41fcbe0141f13591db2cb44b9e688cac4 100644
+--- a/src/main/java/net/minecraft/server/IProjectile.java
++++ b/src/main/java/net/minecraft/server/IProjectile.java
+@@ -118,7 +118,7 @@ public abstract class IProjectile extends Entity {
+     }
+ 
+     protected void a(MovingObjectPosition movingobjectposition) {
+-        org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition); // CraftBukkit - Call event
++        if (!org.bukkit.craftbukkit.event.CraftEventFactory.callProjectileHitEvent(this, movingobjectposition)) return; // CraftBukkit - Call event // Paper - make cancellable
+         MovingObjectPosition.EnumMovingObjectType movingobjectposition_enummovingobjecttype = movingobjectposition.getType();
+ 
+         if (movingobjectposition_enummovingobjecttype == MovingObjectPosition.EnumMovingObjectType.ENTITY) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index d8c77f70845e21b787234e1c02a1650ebc34a8a3..d6a821e656d6581938105819404d9b27326d8457 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1284,9 +1284,9 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static void callProjectileHitEvent(Entity entity, MovingObjectPosition position) {
++    public static boolean callProjectileHitEvent(Entity entity, MovingObjectPosition position) { // Paper - make cancellable
+         if (position.getType() == MovingObjectPosition.EnumMovingObjectType.MISS) {
+-            return;
++            return true; // Paper - make cancellable
+         }
+ 
+         Block hitBlock = null;
+@@ -1303,7 +1303,13 @@ public class CraftEventFactory {
+         }
+ 
+         ProjectileHitEvent event = new ProjectileHitEvent((Projectile) entity.getBukkitEntity(), hitEntity, hitBlock, hitFace);
+-        entity.world.getServer().getPluginManager().callEvent(event);
++        // Paper start - make cancellable
++        boolean cancelled = !event.callEvent();
++        if (!cancelled && hitEntity != null) {
++            cancelled = callProjectileCollideEvent(entity.getBukkitEntity(), (MovingObjectPositionEntity) position).isCancelled();
++        }
++        return !cancelled;
++        // Paper end
+     }
+ 
+     public static ExpBottleEvent callExpBottleEvent(Entity entity, int exp) {


### PR DESCRIPTION
Also deprecate ProjectileCollideEvent, and fix a bug with ProjectileHitEvent being called twice for fireballs