### PR TITLE
Add API to get the Material of Boats and Minecarts

### DIFF
--- a/Spigot-API-Patches/0248-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
+++ b/Spigot-API-Patches/0248-Add-API-to-get-Material-from-Boats-and-Minecarts.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Thu, 31 Dec 2020 12:48:38 +1000
+Subject: [PATCH] Add API to get Material from Boats and Minecarts
+
+
+diff --git a/src/main/java/org/bukkit/entity/Boat.java b/src/main/java/org/bukkit/entity/Boat.java
+index 24751b5c4e3bc24bdfa85af8f6fcba37413aa002..e0d0537606d4f9a3fe588ebf7d02f314c0359335 100644
+--- a/src/main/java/org/bukkit/entity/Boat.java
++++ b/src/main/java/org/bukkit/entity/Boat.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.entity;
+ 
++import org.bukkit.Material;
+ import org.bukkit.TreeSpecies;
+ import org.jetbrains.annotations.NotNull;
+ 
+@@ -103,4 +104,14 @@ public interface Boat extends Vehicle {
+      */
+     @Deprecated
+     public void setWorkOnLand(boolean workOnLand);
++
++    // Paper start
++    /**
++     * Gets the {@link Material} that represents this Boat type.
++     *
++     * @return the boat material.
++     */
++    @NotNull
++    public Material getBoatMaterial();
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/entity/Minecart.java b/src/main/java/org/bukkit/entity/Minecart.java
+index 95c79c5fa0c4e30201f887da6467ce5f81c8a255..53b042f8ebbbf6ee77435b93d4e89371375cc515 100644
+--- a/src/main/java/org/bukkit/entity/Minecart.java
++++ b/src/main/java/org/bukkit/entity/Minecart.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.entity;
+ 
++import org.bukkit.Material;
+ import org.bukkit.block.data.BlockData;
+ import org.bukkit.material.MaterialData;
+ import org.bukkit.util.Vector;
+@@ -143,4 +144,14 @@ public interface Minecart extends Vehicle {
+      * @return the current block offset for this minecart.
+      */
+     public int getDisplayBlockOffset();
++
++    // Paper start
++    /**
++     * Gets the {@link Material} that represents this Minecart type.
++     *
++     * @return the minecart material.
++     */
++    @NotNull
++    public Material getMinecartMaterial();
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0628-Implement-API-to-get-Material-from-Boats-and-Minecar.patch
+++ b/Spigot-Server-Patches/0628-Implement-API-to-get-Material-from-Boats-and-Minecar.patch
@@ -1,0 +1,100 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Thu, 31 Dec 2020 12:48:19 +1000
+Subject: [PATCH] Implement API to get Material from Boats and Minecarts
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityBoat.java b/src/main/java/net/minecraft/server/EntityBoat.java
+index fdfdf83c28c3065fa89fba9e44b3da99f9791e0e..da84cf98022b771bdf0c9d0b284aa7d4d59318e0 100644
+--- a/src/main/java/net/minecraft/server/EntityBoat.java
++++ b/src/main/java/net/minecraft/server/EntityBoat.java
+@@ -216,6 +216,7 @@ public class EntityBoat extends Entity {
+ 
+     }
+ 
++    public final Item getBoatItem() { return this.g(); } // Paper - OBFHELPER
+     public Item g() {
+         switch (this.getType()) {
+             case OAK:
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
+index 271950903e8541194e4f6447f0d2aaae63920678..4a994dacd57bb4630b9c5645c084726045d64bcd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftBoat.java
+@@ -1,8 +1,10 @@
+ package org.bukkit.craftbukkit.entity;
+ 
+ import net.minecraft.server.EntityBoat;
++import org.bukkit.Material;
+ import org.bukkit.TreeSpecies;
+ import org.bukkit.craftbukkit.CraftServer;
++import org.bukkit.craftbukkit.util.CraftMagicNumbers;
+ import org.bukkit.entity.Boat;
+ import org.bukkit.entity.EntityType;
+ 
+@@ -66,6 +68,13 @@ public class CraftBoat extends CraftVehicle implements Boat {
+         getHandle().landBoats = workOnLand;
+     }
+ 
++    // Paper start
++    @Override
++    public Material getBoatMaterial() {
++        return CraftMagicNumbers.getMaterial(getHandle().getBoatItem());
++    }
++    // Paper end
++
+     @Override
+     public EntityBoat getHandle() {
+         return (EntityBoat) entity;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
+index d23f994f579bdd34e15703cc11bdd36572841146..52b4b15b2003f19f605e98a99396d1baedfe5f42 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecart.java
+@@ -3,6 +3,9 @@ package org.bukkit.craftbukkit.entity;
+ import net.minecraft.server.Blocks;
+ import net.minecraft.server.EntityMinecartAbstract;
+ import net.minecraft.server.IBlockData;
++import net.minecraft.server.Item;
++import net.minecraft.server.Items;
++import org.bukkit.Material;
+ import org.bukkit.block.data.BlockData;
+ import org.bukkit.craftbukkit.CraftServer;
+ import org.bukkit.craftbukkit.block.data.CraftBlockData;
+@@ -68,6 +71,38 @@ public abstract class CraftMinecart extends CraftVehicle implements Minecart {
+         getHandle().setDerailedVelocityMod(derailed);
+     }
+ 
++    // Paper start
++    @Override
++    public Material getMinecartMaterial() {
++        Item minecartItem;
++        switch (getHandle().getMinecartType()) {
++            case CHEST:
++                minecartItem = Items.CHEST_MINECART;
++                break;
++            case FURNACE:
++                minecartItem = Items.FURNACE_MINECART;
++                break;
++            case TNT:
++                minecartItem = Items.TNT_MINECART;
++                break;
++            case HOPPER:
++                minecartItem = Items.HOPPER_MINECART;
++                break;
++            case COMMAND_BLOCK:
++                minecartItem = Items.COMMAND_BLOCK_MINECART;
++                break;
++            case RIDEABLE:
++            case SPAWNER:
++                minecartItem = Items.MINECART;
++                break;
++            default:
++                throw new IllegalStateException("Unexpected value: " + getHandle().getMinecartType());
++        }
++
++        return CraftMagicNumbers.getMaterial(minecartItem);
++    }
++    // Paper end
++
+     @Override
+     public EntityMinecartAbstract getHandle() {
+         return (EntityMinecartAbstract) entity;


### PR DESCRIPTION
A lot of plugins currently have big switch statements to get the Material out of a Boat or Minecart. This PR adds API to get them.

For boats, this just calls an NMS method that has its own switch statement, but for Minecarts a switch statement had to be added in CraftMinecart. To prevent this exploding in cases where new cart types are added, it will default to the normal MINECART item in those cases. This is also important as there are cart types that are not represented as items, such as EntityMinecartType.SPAWNER