### PR TITLE
Add doors to material tags

### DIFF
--- a/Spigot-API-Patches/0153-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0153-Add-Material-Tags.patch
@@ -204,10 +204,10 @@ index 0000000000000000000000000000000000000000..c91ea2a0679a7f3a5627b5a008e0b39d
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialTags.java b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0328532bb4848d55a719c96ea3df4ac545b5b05a
+index 0000000000000000000000000000000000000000..ce19324d4667e8632615b16402743a9c00694d31
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialTags.java
-@@ -0,0 +1,533 @@
+@@ -0,0 +1,548 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -304,6 +304,13 @@ index 0000000000000000000000000000000000000000..0328532bb4848d55a719c96ea3df4ac5
 +     */
 +    public static final MaterialSetTag COOKED_FISH = new MaterialSetTag(keyFor("cooked_fish"))
 +        .add(Material.COOKED_COD, Material.COOKED_SALMON);
++
++    /**
++     * Covers all variants of doors.
++     */
++    public static final MaterialSetTag DOORS = new MaterialSetTag(keyFor("doors"))
++        .endsWith("_DOOR")
++        .ensureSize("DOORS", 9);
 +
 +    /**
 +     * Covers all dyes.
@@ -540,6 +547,14 @@ index 0000000000000000000000000000000000000000..0328532bb4848d55a719c96ea3df4ac5
 +    public static final MaterialSetTag TRAPDOORS = new MaterialSetTag(keyFor("trapdoors"))
 +        .endsWith("_TRAPDOOR")
 +        .ensureSize("TRAPDOORS", 9);
++
++    /**
++     * Covers all wood variants of doors.
++     */
++    public static final MaterialSetTag WOODEN_DOORS = new MaterialSetTag(keyFor("wooden_doors"))
++        .endsWith("_DOOR")
++        .not(Material.IRON_DOOR)
++        .ensureSize("WOODEN_DOORS", 8);
 +
 +    /**
 +     * Covers all wood variants of fences.


### PR DESCRIPTION
Doors were missing from MaterialTags. This PR adds them.

Its my first Paper-PR, so I hope I got the patches right. Its a bit confusing 