### PR TITLE
Fix username connecting with no texture being overwritten by usercache

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -46,4 +46,5 @@ ysl3000 <yannicklamprecht@live.de>
 KennyTV <jahnke.nassim@gmail.com>
 Machine_Maker <machine@machinemaker.me>
 Ivan Pekov <ivan@mrivanplays.com>
+Camotoy <20743703+Camotoy@users.noreply.github.com>
 ```

--- a/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
@@ -7,10 +7,10 @@ Establishes base extension of profile systems for future edits too
 
 diff --git a/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2751ce7f1556da07ef853807a588f096adf6ef7f
+index 0000000000000000000000000000000000000000..6ae316109c8e35fbb6b0aebdee3075beb1445f1b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/profile/CraftPlayerProfile.java
-@@ -0,0 +1,297 @@
+@@ -0,0 +1,301 @@
 +package com.destroystokyo.paper.profile;
 +
 +import com.destroystokyo.paper.PaperConfig;
@@ -179,9 +179,13 @@ index 0000000000000000000000000000000000000000..2751ce7f1556da07ef853807a588f096
 +        if ((profile.getName() == null || !hasTextures()) && profile.getId() != null) {
 +            GameProfile profile = userCache.getProfile(this.profile.getId());
 +            if (profile != null) {
-+                // if old has it, assume its newer, so overwrite, else use cached if it was set and ours wasn't
-+                copyProfileProperties(this.profile, profile);
-+                this.profile = profile;
++                if (this.profile.getName() == null) {
++                    // if old has it, assume its newer, so overwrite, else use cached if it was set and ours wasn't
++                    copyProfileProperties(this.profile, profile);
++                    this.profile = profile;
++                } else {
++                    copyProfileProperties(profile, this.profile);
++                }
 +            }
 +        }
 +        return this.profile.isComplete();


### PR DESCRIPTION
I went into detail about this bug on this comment in the Paper Discord: https://discord.com/channels/289587909051416579/555462289851940864/793550995426246676, but in summary:

Since this commit: https://github.com/PaperMC/Paper/commit/a70618cd5cb493fe9fe2a2a7375a7b1949d427d7#, any user connecting with no texture property in their GameProfile would have their GameProfile always overwritten by whatever was present in the usercache. If a user's name was changed and they kept the same UUID, this wouldn't go into effect because Paper would detect they had no textures, pull their information from the usercache, and use the usercache's name. 

This commit fixes this issue by only overwriting with the usercache if the current profile doesn't have a username, or if the cached profile has textures.