### PR TITLE
Updated Upstream (CraftBukkit/Spigot)

### DIFF
--- a/Spigot-Server-Patches/0063-Handle-Item-Meta-Inconsistencies.patch
+++ b/Spigot-Server-Patches/0063-Handle-Item-Meta-Inconsistencies.patch
@@ -194,7 +194,7 @@ index 721a1c6bd4505cb132e7004c45b795d4959389e3..9913d0136841dac35b6649cb1afbe1e9
  
      static Map<Enchantment, Integer> getEnchantments(net.minecraft.server.ItemStack item) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572094d1c64 100644
+index 60e04343b4b10b1de0bbd033b148a9da41b66aad..9a41ad703ce382670f11cf84c4644d53f0e3cd1d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 @@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableList;
@@ -205,7 +205,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
  import com.google.common.collect.Lists;
  import com.google.common.collect.Multimap;
  import com.google.common.collect.SetMultimap;
-@@ -23,6 +24,7 @@ import java.lang.reflect.InvocationTargetException;
+@@ -22,6 +23,7 @@ import java.lang.reflect.InvocationTargetException;
  import java.util.ArrayList;
  import java.util.Arrays;
  import java.util.Collection;
@@ -213,16 +213,16 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
  import java.util.EnumSet;
  import java.util.HashMap;
  import java.util.Iterator;
-@@ -32,6 +34,7 @@ import java.util.Locale;
- import java.util.Map;
+@@ -32,6 +34,7 @@ import java.util.Map;
  import java.util.NoSuchElementException;
+ import java.util.Objects;
  import java.util.Set;
 +import java.util.TreeMap; // Paper
  import java.util.logging.Level;
  import java.util.logging.Logger;
  import javax.annotation.Nonnull;
 @@ -271,7 +274,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-     private List<IChatBaseComponent> lore;
+     private List<String> lore; // null and empty are two different states internally
      private Integer customModelData;
      private NBTTagCompound blockData;
 -    private Map<Enchantment, Integer> enchantments;
@@ -248,7 +248,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
          }
  
          if (meta.hasAttributeModifiers()) {
-@@ -399,13 +402,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -386,13 +389,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -264,7 +264,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
  
          for (int i = 0; i < ench.size(); i++) {
              String id = ((NBTTagCompound) ench.get(i)).getString(ENCHANTMENTS_ID.NBT);
-@@ -557,13 +560,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -545,13 +548,13 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -280,7 +280,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
          for (Map.Entry<?, ?> entry : ench.entrySet()) {
              // Doctor older enchants
              String enchantKey = entry.getKey().toString();
-@@ -815,14 +818,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -803,14 +806,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Override
      public Map<Enchantment, Integer> getEnchants() {
@@ -297,7 +297,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
          }
  
          if (ignoreRestrictions || level >= ench.getStartLevel() && level <= ench.getMaxLevel()) {
-@@ -1203,7 +1206,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1191,7 +1194,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.customModelData = this.customModelData;
              clone.blockData = this.blockData;
              if (this.enchantments != null) {
@@ -306,7 +306,7 @@ index dec0db24ae611736c99158ba4cb11015ad4b8575..55a3d9d3805bd2b14f853faecd47e572
              }
              if (this.hasAttributeModifiers()) {
                  clone.attributeModifiers = LinkedHashMultimap.create(this.attributeModifiers);
-@@ -1435,4 +1438,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1423,4 +1426,22 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              return HANDLED_TAGS;
          }
      }

--- a/Spigot-Server-Patches/0115-Add-EntityZapEvent.patch
+++ b/Spigot-Server-Patches/0115-Add-EntityZapEvent.patch
@@ -38,10 +38,10 @@ index 824e172f06e57f86010836a1006a14d0a3b0bda3..eedec25373cfc8adec7ac8a99b146770
              entitywitch.prepare(worldserver, worldserver.getDamageScaler(entitywitch.getChunkCoordinates()), EnumMobSpawn.CONVERSION, (GroupDataEntity) null, (NBTTagCompound) null);
              entitywitch.setNoAI(this.isNoAI());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8c1602d786fbc67c43ba36a77150eac4e594eae9..7991262ec11b3a61ae0c681bcb1c7152b81d61a2 100644
+index dde25528de07857175b00ff85612d738eb43b9ec..e5fd59e3bd652c853735bea8ebb1005bff7b3244 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1084,6 +1084,14 @@ public class CraftEventFactory {
+@@ -1082,6 +1082,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0120-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-Server-Patches/0120-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index fda68abbdd7c970048ba710d7ef35214f2aaa74c..2c2d44562f732c75532cda910db5ce67
  
                  this.die();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7991262ec11b3a61ae0c681bcb1c7152b81d61a2..ce9e87b2e348c4b07a4dcbc81f82e115eeb3ebe8 100644
+index e5fd59e3bd652c853735bea8ebb1005bff7b3244..be74f172383f270e3f1ec194044f024e7b040694 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -123,6 +123,7 @@ import org.bukkit.entity.ThrownPotion;
+@@ -121,6 +121,7 @@ import org.bukkit.entity.ThrownPotion;
  import org.bukkit.entity.Vehicle;
  import org.bukkit.entity.Villager;
  import org.bukkit.entity.Villager.Profession;
@@ -29,7 +29,7 @@ index 7991262ec11b3a61ae0c681bcb1c7152b81d61a2..ce9e87b2e348c4b07a4dcbc81f82e115
  import org.bukkit.event.Cancellable;
  import org.bukkit.event.Event;
  import org.bukkit.event.Event.Result;
-@@ -1043,6 +1044,17 @@ public class CraftEventFactory {
+@@ -1041,6 +1042,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0122-Add-ProjectileCollideEvent.patch
+++ b/Spigot-Server-Patches/0122-Add-ProjectileCollideEvent.patch
@@ -71,10 +71,10 @@ index 7391fd31148dbde60e34955841a296f454ac768e..53a8ea7d1eff84abe6c49464d556aa27
  
          this.checkBlockCollisions();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ce9e87b2e348c4b07a4dcbc81f82e115eeb3ebe8..299fd2dd5b718acce790ac18f1fbbb23a148ed56 100644
+index be74f172383f270e3f1ec194044f024e7b040694..8fbaaa7d287ecd13203ae7362b552c5f11858066 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1188,6 +1188,16 @@ public class CraftEventFactory {
+@@ -1186,6 +1186,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/Spigot-Server-Patches/0142-Add-system-property-to-disable-book-size-limits.patch
+++ b/Spigot-Server-Patches/0142-Add-system-property-to-disable-book-size-limits.patch
@@ -11,10 +11,10 @@ to make books with as much data as they want. Do not use this without
 limiting incoming data from packets in some other way.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index adc926f25c938fc0ba25586206d7daf89c6b7773..95ec299687cd4410146f71bd3429bd12ac291a26 100644
+index b609caf567989d850e140437971871749ad47f2e..437b22f1a038092438538013d399499153070de3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-@@ -35,6 +35,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -37,6 +37,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      static final int MAX_PAGES = 100;
      static final int MAX_PAGE_LENGTH = 320; // 256 limit + 64 characters to allow for psuedo colour codes
      static final int MAX_TITLE_LENGTH = 32;
@@ -22,7 +22,7 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..95ec299687cd4410146f71bd3429bd12
  
      protected String title;
      protected String author;
-@@ -197,7 +198,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -239,7 +240,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          if (title == null) {
              this.title = null;
              return true;
@@ -31,28 +31,21 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..95ec299687cd4410146f71bd3429bd12
              return false;
          }
  
-@@ -237,7 +238,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
-             throw new IllegalArgumentException("Invalid page number " + page + "/" + pages.size());
+@@ -301,7 +302,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+     String validatePage(String page) {
+         if (page == null) {
+             page = "";
+-        } else if (page.length() > MAX_PAGE_LENGTH) {
++        } else if (page.length() > MAX_PAGE_LENGTH && !OVERRIDE_CHECKS) { // Paper - Add override
+             page = page.substring(0, MAX_PAGE_LENGTH);
          }
- 
--        String newText = text == null ? "" : text.length() > MAX_PAGE_LENGTH ? text.substring(0, MAX_PAGE_LENGTH) : text;
-+        String newText = text == null ? "" : text.length() > MAX_PAGE_LENGTH && !OVERRIDE_CHECKS ? text.substring(0, MAX_PAGE_LENGTH) : text;
-         pages.set(page - 1, CraftChatMessage.fromString(newText, true)[0]);
-     }
- 
-@@ -251,13 +252,13 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
-     @Override
-     public void addPage(final String... pages) {
-         for (String page : pages) {
--            if (this.pages.size() >= MAX_PAGES) {
-+            if (this.pages.size() >= MAX_PAGES && !OVERRIDE_CHECKS) {
-                 return;
-             }
- 
-             if (page == null) {
-                 page = "";
--            } else if (page.length() > MAX_PAGE_LENGTH) {
-+            } else if (page.length() > MAX_PAGE_LENGTH && !OVERRIDE_CHECKS) { // Paper - Add override
-                 page = page.substring(0, MAX_PAGE_LENGTH);
-             }
- 
+         return page;
+@@ -311,7 +312,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+         // asserted: page != null
+         if (this.pages == null) {
+             this.pages = new ArrayList<String>();
+-        } else if (this.pages.size() >= MAX_PAGES) {
++        } else if (this.pages.size() >= MAX_PAGES && !OVERRIDE_CHECKS) {// Paper - Add override
+             return;
+         }
+         this.pages.add(page);

--- a/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -20,10 +20,10 @@ index 295b27d122d84d6b1147aaedc9bbfb0f278e1cba..4bb901966f7b1b6537a2b6b1dc0f0bdf
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 299fd2dd5b718acce790ac18f1fbbb23a148ed56..68befc17134bfd4c453275ab2d11485ad7450e7c 100644
+index 8fbaaa7d287ecd13203ae7362b552c5f11858066..1e55416a7478397e86d0fb1d40ba75234509e425 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -585,16 +585,32 @@ public class CraftEventFactory {
+@@ -583,16 +583,32 @@ public class CraftEventFactory {
              EntityExperienceOrb xp = (EntityExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/Spigot-Server-Patches/0178-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/Spigot-Server-Patches/0178-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -131,10 +131,10 @@ index 26cc40e57f5b73b9c32859bff37c4a3d94904c56..feeae1a9eb309ae4101783b191bb2bff
  
      private T createSnapshot(T tileEntity) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 15022ada0c2fd0f4302b45c55f46d0fdd3bfd57f..af15656cc4b4c1e9da4fc8a5bfffa95eb6caf903 100644
+index 81f6bf5533288ed90e2f1f4d421d54195d9650c7..4a266b95afea5c3853774752f94e287234fa5726 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -17,10 +17,12 @@ public class CraftSign extends CraftBlockEntityState<TileEntitySign> implements
+@@ -18,10 +18,12 @@ public class CraftSign extends CraftBlockEntityState<TileEntitySign> implements
  
      public CraftSign(final Block block) {
          super(block, TileEntitySign.class);

--- a/Spigot-Server-Patches/0182-ExperienceOrbMergeEvent.patch
+++ b/Spigot-Server-Patches/0182-ExperienceOrbMergeEvent.patch
@@ -8,10 +8,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 68befc17134bfd4c453275ab2d11485ad7450e7c..f4242870654ea6faa6829348717cd2f3c3407679 100644
+index 1e55416a7478397e86d0fb1d40ba75234509e425..3ccd30d036deb9fc4112641a24e20c89f2d2b8eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -595,7 +595,7 @@ public class CraftEventFactory {
+@@ -593,7 +593,7 @@ public class CraftEventFactory {
                      if (e instanceof EntityExperienceOrb) {
                          EntityExperienceOrb loopItem = (EntityExperienceOrb) e;
                          // Paper start

--- a/Spigot-Server-Patches/0190-Add-ArmorStand-Item-Meta.patch
+++ b/Spigot-Server-Patches/0190-Add-ArmorStand-Item-Meta.patch
@@ -264,10 +264,10 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 55a3d9d3805bd2b14f853faecd47e572094d1c64..7d5c3a37c497e326ea0bb4c1725fd2d3dc857790 100644
+index 9a41ad703ce382670f11cf84c4644d53f0e3cd1d..41627c49decca02635036c970674f958e4de1b4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -1430,6 +1430,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1418,6 +1418,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaCrossbow.CHARGED.NBT,
                          CraftMetaCrossbow.CHARGED_PROJECTILES.NBT,
                          CraftMetaSuspiciousStew.EFFECTS.NBT,

--- a/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index cbffebfe323ff4ddec792c49ebc3391fc9ac35ac..73a33eff97d26e5b3542d787344013e18e52db68 100644
+index e59d54755542b9053e64618495a3fa79cb084915..6f04a8cf06cf76f433ffcd81d0e41e9b36509948 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
 @@ -155,7 +155,7 @@ public abstract class EntityHuman extends EntityLiving {
@@ -193,10 +193,10 @@ index 78c91d94e9940431def77f2559e64c9cab6d8b49..c04ad85d16ce358dfbd72d1d84fb3997
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f4242870654ea6faa6829348717cd2f3c3407679..52762d75edd35dd3bc9668e3f7a3c79be279b783 100644
+index 3ccd30d036deb9fc4112641a24e20c89f2d2b8eb..50047901625527e90d4d2ceb2572f30811f2ee76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1173,7 +1173,7 @@ public class CraftEventFactory {
+@@ -1171,7 +1171,7 @@ public class CraftEventFactory {
  
      public static Container callInventoryOpenEvent(EntityPlayer player, Container container, boolean cancelled) {
          if (player.activeContainer != player.defaultContainer) { // fire INVENTORY_CLOSE if one already open
@@ -205,7 +205,7 @@ index f4242870654ea6faa6829348717cd2f3c3407679..52762d75edd35dd3bc9668e3f7a3c79b
          }
  
          CraftServer server = player.world.getServer();
-@@ -1338,8 +1338,18 @@ public class CraftEventFactory {
+@@ -1336,8 +1336,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
+++ b/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
@@ -147,10 +147,10 @@ index 7affb75a97e49b67861b24de38ef83e72b0abd5a..ce596bd1268eb7d6d20709fe1e00a59c
      public boolean s_() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 52762d75edd35dd3bc9668e3f7a3c79be279b783..6458cd6823ea066588742f8105048001395e4dde 100644
+index 50047901625527e90d4d2ceb2572f30811f2ee76..6b62317f6a5e8a9bb8fdfc901835d0c28d3eeeda 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1209,6 +1209,14 @@ public class CraftEventFactory {
+@@ -1207,6 +1207,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/Spigot-Server-Patches/0258-Add-hand-to-bucket-events.patch
+++ b/Spigot-Server-Patches/0258-Add-hand-to-bucket-events.patch
@@ -126,10 +126,10 @@ index 46624d1832eb76aed688da5e1cf6c7dc304d610b..c8a990ab5db73b9e13b60b55f10142fe
      public float v() {
          return this.worldData.d();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6458cd6823ea066588742f8105048001395e4dde..1c806c97bf77cb3a71086d51110605b147bdbfbf 100644
+index 6b62317f6a5e8a9bb8fdfc901835d0c28d3eeeda..94a3a40fd14ecfcda8ca6a29edb2787f4babb154 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -234,7 +234,7 @@ public class CraftEventFactory {
+@@ -232,7 +232,7 @@ public class CraftEventFactory {
      public static Entity entityDamage; // For use in EntityDamageByEntityEvent
  
      // helper methods
@@ -138,7 +138,7 @@ index 6458cd6823ea066588742f8105048001395e4dde..1c806c97bf77cb3a71086d51110605b1
          int spawnSize = Bukkit.getServer().getSpawnRadius();
  
          if (world.getDimensionKey() != World.OVERWORLD) return true;
-@@ -413,6 +413,20 @@ public class CraftEventFactory {
+@@ -411,6 +411,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, WorldServer world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, net.minecraft.server.Item item) {
@@ -159,7 +159,7 @@ index 6458cd6823ea066588742f8105048001395e4dde..1c806c97bf77cb3a71086d51110605b1
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -425,10 +439,10 @@ public class CraftEventFactory {
+@@ -423,10 +437,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/Spigot-Server-Patches/0279-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0279-Improve-death-events.patch
@@ -119,7 +119,7 @@ index 09d076db37507b17797635df232a568752c97584..3bcebb89c9f9a5243d1d215a47d7d5e6
      public void saveData(NBTTagCompound nbttagcompound) {
          super.saveData(nbttagcompound);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index b00c7fda9aa7328848e0aff3a5897063f8a5abd6..1dc5bad650c3035005175c9d5e37d91994e3d97f 100644
+index 9f08c6dd5e4c6859f9e8017eb1d0f388f6aba0d3..0b05588d9ad01c10edf1ca12c303207ab6069c0a 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -96,7 +96,7 @@ public abstract class EntityLiving extends Entity {
@@ -346,10 +346,10 @@ index 27fa6f5c2e806da2bef12fb7ffbb0f9e90725594..2a243970e629dae83a223ad995f58736
  
      public void injectScaledMaxHealth(Collection<AttributeModifiable> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1c806c97bf77cb3a71086d51110605b147bdbfbf..efec8e6c41a67956c9ffceddedda976c6c1286d3 100644
+index 94a3a40fd14ecfcda8ca6a29edb2787f4babb154..8a5a583e49e037aeeeb38c38fc2a83b1048cf382 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -791,9 +791,16 @@ public class CraftEventFactory {
+@@ -789,9 +789,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(EntityLiving victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -366,7 +366,7 @@ index 1c806c97bf77cb3a71086d51110605b147bdbfbf..efec8e6c41a67956c9ffceddedda976c
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -809,8 +816,15 @@ public class CraftEventFactory {
+@@ -807,8 +814,15 @@ public class CraftEventFactory {
          CraftPlayer entity = victim.getBukkitEntity();
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
          event.setKeepInventory(keepInventory);
@@ -382,7 +382,7 @@ index 1c806c97bf77cb3a71086d51110605b147bdbfbf..efec8e6c41a67956c9ffceddedda976c
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -827,6 +841,31 @@ public class CraftEventFactory {
+@@ -825,6 +839,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0283-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
+++ b/Spigot-Server-Patches/0283-Implement-an-API-for-CanPlaceOn-and-CanDestroy-NBT-v.patch
@@ -32,10 +32,10 @@ index dc7a320c83802159aab2440b4fca26543be2524a..892f99c8b9385e80381058ead72d4346
          this.s = this::l;
          if (this.i.canRead() && this.i.peek() == '#') {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff88ec5cbd 100644
+index 41627c49decca02635036c970674f958e4de1b4d..ccf1c5d27f83d6a82a0fdb6ff839b7628538c705 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -85,6 +85,12 @@ import org.bukkit.persistence.PersistentDataContainer;
+@@ -84,6 +84,12 @@ import org.bukkit.persistence.PersistentDataContainer;
  import static org.spigotmc.ValidateUtils.*;
  // Spigot end
  
@@ -48,7 +48,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
  /**
   * Children must include the following:
   *
-@@ -268,6 +274,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -267,6 +273,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      @Specific(Specific.To.NBT)
      static final ItemMetaKey BLOCK_DATA = new ItemMetaKey("BlockStateTag");
      static final ItemMetaKey BUKKIT_CUSTOM_TAG = new ItemMetaKey("PublicBukkitValues");
@@ -57,8 +57,8 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
 +    static final ItemMetaKey CAN_PLACE_ON = new ItemMetaKey("CanPlaceOn");
 +    // Paper end
  
-     private IChatBaseComponent displayName;
-     private IChatBaseComponent locName;
+     // We store the raw original JSON representation of all text data. See SPIGOT-5063, SPIGOT-5656, SPIGOT-5304
+     private String displayName;
 @@ -280,6 +290,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      private int hideFlag;
      private boolean unbreakable;
@@ -86,7 +86,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
          this.unhandledTags.putAll(meta.unhandledTags);
          this.persistentDataContainer.putAll(meta.persistentDataContainer.getRaw());
  
-@@ -393,6 +416,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -380,6 +403,31 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  persistentDataContainer.put(key, compound.get(key));
              }
          }
@@ -118,7 +118,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
  
          Set<String> keys = tag.getKeys();
          for (String key : keys) {
-@@ -530,6 +578,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -518,6 +566,34 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              setDamage(damage);
          }
  
@@ -153,7 +153,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
          String internal = SerializableMeta.getString(map, "internal", true);
          if (internal != null) {
              ByteArrayInputStream buf = new ByteArrayInputStream(Base64.decodeBase64(internal));
-@@ -658,6 +734,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -646,6 +722,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          if (hasDamage()) {
              itemTag.setInt(DAMAGE.NBT, damage);
          }
@@ -177,7 +177,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
  
          for (Map.Entry<String, NBTBase> e : unhandledTags.entrySet()) {
              itemTag.set(e.getKey(), e.getValue());
-@@ -674,6 +767,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -662,6 +755,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -196,19 +196,19 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
 +    }
 +    // Paper end
 +
-     NBTTagList createStringList(List<IChatBaseComponent> list) {
-         if (list == null || list.isEmpty()) {
+     NBTTagList createStringList(List<String> list) {
+         if (list == null) {
              return null;
-@@ -757,7 +865,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -745,7 +853,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
      @Overridden
      boolean isEmpty() {
--        return !(hasDisplayName() || hasLocalizedName() || hasEnchants() || hasLore() || hasCustomModelData() || hasBlockData() || hasRepairCost() || !unhandledTags.isEmpty() || !persistentDataContainer.isEmpty() || hideFlag != 0 || isUnbreakable() || hasDamage() || hasAttributeModifiers());
-+        return !(hasDisplayName() || hasLocalizedName() || hasEnchants() || hasLore() || hasCustomModelData() || hasBlockData() || hasRepairCost() || !unhandledTags.isEmpty() || !persistentDataContainer.isEmpty() || hideFlag != 0 || isUnbreakable() || hasDamage() || hasAttributeModifiers() || hasPlaceableKeys() || hasDestroyableKeys()); // Paper - Implement an API for CanPlaceOn and CanDestroy NBT values
+-        return !(hasDisplayName() || hasLocalizedName() || hasEnchants() || (lore != null) || hasCustomModelData() || hasBlockData() || hasRepairCost() || !unhandledTags.isEmpty() || !persistentDataContainer.isEmpty() || hideFlag != 0 || isUnbreakable() || hasDamage() || hasAttributeModifiers());
++        return !(hasDisplayName() || hasLocalizedName() || hasEnchants() || (lore != null) || hasCustomModelData() || hasBlockData() || hasRepairCost() || !unhandledTags.isEmpty() || !persistentDataContainer.isEmpty() || hideFlag != 0 || isUnbreakable() || hasDamage() || hasAttributeModifiers() || hasPlaceableKeys() || hasDestroyableKeys()); // Paper - Implement an API for CanPlaceOn and CanDestroy NBT values
      }
  
      @Override
-@@ -1157,7 +1265,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1145,7 +1253,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                  && (this.hideFlag == that.hideFlag)
                  && (this.isUnbreakable() == that.isUnbreakable())
                  && (this.hasDamage() ? that.hasDamage() && this.damage == that.damage : !that.hasDamage())
@@ -221,7 +221,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
      }
  
      /**
-@@ -1192,6 +1304,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1180,6 +1292,10 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          hash = 61 * hash + (hasDamage() ? this.damage : 0);
          hash = 61 * hash + (hasAttributeModifiers() ? this.attributeModifiers.hashCode() : 0);
          hash = 61 * hash + version;
@@ -232,7 +232,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
          return hash;
      }
  
-@@ -1216,6 +1332,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1204,6 +1320,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              clone.unbreakable = this.unbreakable;
              clone.damage = this.damage;
              clone.version = this.version;
@@ -247,7 +247,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
              return clone;
          } catch (CloneNotSupportedException e) {
              throw new Error(e);
-@@ -1273,6 +1397,24 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1261,6 +1385,24 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
              builder.put(DAMAGE.BUKKIT, damage);
          }
  
@@ -272,7 +272,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
          final Map<String, NBTBase> internalTags = new HashMap<String, NBTBase>(unhandledTags);
          serializeInternal(internalTags);
          if (!internalTags.isEmpty()) {
-@@ -1437,6 +1579,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1425,6 +1567,8 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
                          CraftMetaArmorStand.SHOW_ARMS.NBT,
                          CraftMetaArmorStand.SMALL.NBT,
                          CraftMetaArmorStand.MARKER.NBT,
@@ -281,7 +281,7 @@ index 7d5c3a37c497e326ea0bb4c1725fd2d3dc857790..4220c9a5e3f8cb6738451d1eaf100aff
                          // Paper end
                          CraftMetaCompass.LODESTONE_DIMENSION.NBT,
                          CraftMetaCompass.LODESTONE_POS.NBT,
-@@ -1464,4 +1608,147 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1452,4 +1596,147 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
      }
      // Paper end
  

--- a/Spigot-Server-Patches/0411-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/Spigot-Server-Patches/0411-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2222d3fdb9920f5662d42c0303bd05a4a07483c7..c86e012931e4112152fbf72dac15fb357ac7f6b0 100644
+index 8a5a583e49e037aeeeb38c38fc2a83b1048cf382..a41bc1450401afef3c6f847cf833ce07b94bc1a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -336,13 +336,18 @@ public class CraftEventFactory {
+@@ -334,13 +334,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/Spigot-Server-Patches/0458-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0458-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -102,10 +102,10 @@ index 7a061f1f072f57042bb32ff187b0f916545e2e48..0fd3a7ebddfd22d6640307452f525d1c
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9c67045920efe05c9acba5a40062358255dbfeac..0f19205376fa0948dbba4a18f1bc68a5115cf05f 100644
+index a41bc1450401afef3c6f847cf833ce07b94bc1a8..d3a0dbe9617c2393591c01920764bf098db868ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -811,7 +811,8 @@ public class CraftEventFactory {
+@@ -809,7 +809,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/Spigot-Server-Patches/0513-Improve-Legacy-Component-serialization-size.patch
+++ b/Spigot-Server-Patches/0513-Improve-Legacy-Component-serialization-size.patch
@@ -7,10 +7,10 @@ Don't constantly send format: false for all formatting options when parent alrea
 has it false
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-index e796e956114d232601c91e6d45d721fd6952241b..8c6130746c8774a8bd7a565dd999f8b901179e73 100644
+index 50a85af76501e1202286df3cf9fb6af9ea542f87..1d2c77817cc5627ff49d6b1000c25866003f4d47 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftChatMessage.java
-@@ -45,6 +45,7 @@ public final class CraftChatMessage {
+@@ -47,6 +47,7 @@ public final class CraftChatMessage {
          // Separate pattern with no group 3, new lines are part of previous string
          private static final Pattern INCREMENTAL_PATTERN_KEEP_NEWLINES = Pattern.compile("(" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + "[0-9a-fk-orx])|((?:(?:https?):\\/\\/)?(?:[-\\w_\\.]{2,}\\.[a-z]{2,4}.*?(?=[\\.\\?!,;:]?(?:[" + String.valueOf(org.bukkit.ChatColor.COLOR_CHAR) + " ]|$))))", Pattern.CASE_INSENSITIVE);
          // ChatColor.b does not explicitly reset, its more of empty
@@ -18,7 +18,7 @@ index e796e956114d232601c91e6d45d721fd6952241b..8c6130746c8774a8bd7a565dd999f8b9
          private static final ChatModifier RESET = ChatModifier.a.setBold(false).setItalic(false).setUnderline(false).setStrikethrough(false).setRandom(false);
  
          private final List<IChatBaseComponent> list = new ArrayList<IChatBaseComponent>();
-@@ -66,6 +67,7 @@ public final class CraftChatMessage {
+@@ -68,6 +69,7 @@ public final class CraftChatMessage {
              Matcher matcher = (keepNewlines ? INCREMENTAL_PATTERN_KEEP_NEWLINES : INCREMENTAL_PATTERN).matcher(message);
              String match = null;
              boolean needsAdd = false;
@@ -26,7 +26,7 @@ index e796e956114d232601c91e6d45d721fd6952241b..8c6130746c8774a8bd7a565dd999f8b9
              while (matcher.find()) {
                  int groupId = 0;
                  while ((match = matcher.group(++groupId)) == null) {
-@@ -111,7 +113,26 @@ public final class CraftChatMessage {
+@@ -113,7 +115,26 @@ public final class CraftChatMessage {
                              throw new AssertionError("Unexpected message format");
                          }
                      } else { // Color resets formatting

--- a/Spigot-Server-Patches/0516-Convert-legacy-attributes-in-Item-Meta.patch
+++ b/Spigot-Server-Patches/0516-Convert-legacy-attributes-in-Item-Meta.patch
@@ -30,10 +30,10 @@ index bf3b236b2090fe4dd67e2f87b0b27c8d7186cb48..c5dd25add39298342a6f4b2a05e137de
      public CraftAttributeMap(AttributeMapBase handle) {
          this.handle = handle;
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index 4220c9a5e3f8cb6738451d1eaf100aff88ec5cbd..e49aa5dd5f8ef8f0c6ad4c4d776adf628c3aa980 100644
+index ccf1c5d27f83d6a82a0fdb6ff839b7628538c705..99495722455b27ba90523c6d6dfd874aa2a8b3fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -492,7 +492,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -479,7 +479,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
  
              AttributeModifier attribMod = CraftAttributeInstance.convert(nmsModifier);
  

--- a/Spigot-Server-Patches/0519-Support-components-in-ItemMeta.patch
+++ b/Spigot-Server-Patches/0519-Support-components-in-ItemMeta.patch
@@ -17,49 +17,49 @@ index b8770066a86df25d6ba9ecf74d846c730d228c01..2eb45e8e05b1a2ad6b8fcb204f2d2b06
              return IChatBaseComponent.ChatSerializer.a.toJson(ichatbasecomponent);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-index e49aa5dd5f8ef8f0c6ad4c4d776adf628c3aa980..4616b3e99b511a83b349d607c7d9faac79baf8df 100644
+index 99495722455b27ba90523c6d6dfd874aa2a8b3fe..c981568c252843c5be5ebdc2554cd172f5f4b16c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
-@@ -873,11 +873,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-         return CraftChatMessage.fromComponent(displayName);
+@@ -861,11 +861,23 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         return CraftChatMessage.fromJSONComponent(displayName);
      }
  
 +    // Paper start
 +    @Override
 +    public net.md_5.bungee.api.chat.BaseComponent[] getDisplayNameComponent() {
-+        return net.md_5.bungee.chat.ComponentSerializer.parse(IChatBaseComponent.ChatSerializer.componentToJson(displayName));
++        return net.md_5.bungee.chat.ComponentSerializer.parse(displayName);
 +    }
 +    // Paper end
      @Override
      public final void setDisplayName(String name) {
-         this.displayName = CraftChatMessage.fromStringOrNull(name);
+         this.displayName = CraftChatMessage.fromStringOrNullToJSON(name);
      }
  
 +    // Paper start
 +    @Override
 +    public void setDisplayNameComponent(net.md_5.bungee.api.chat.BaseComponent[] component) {
-+        this.displayName = IChatBaseComponent.ChatSerializer.jsonToComponent(net.md_5.bungee.chat.ComponentSerializer.toString(component));
++        this.displayName = net.md_5.bungee.chat.ComponentSerializer.toString(component);
 +    }
 +    // Paper end
      @Override
      public boolean hasDisplayName() {
          return displayName != null;
-@@ -1008,6 +1020,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
-         return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromComponent));
+@@ -996,6 +1008,14 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         return this.lore == null ? null : new ArrayList<String>(Lists.transform(this.lore, CraftChatMessage::fromJSONComponent));
      }
  
 +    // Paper start
 +    @Override
 +    public List<net.md_5.bungee.api.chat.BaseComponent[]> getLoreComponents() {
 +        return this.lore == null ? null : new ArrayList<>(this.lore.stream().map(entry ->
-+            net.md_5.bungee.chat.ComponentSerializer.parse(IChatBaseComponent.ChatSerializer.componentToJson(entry)
-+        )).collect(java.util.stream.Collectors.toList()));
++            net.md_5.bungee.chat.ComponentSerializer.parse(entry)
++        ).collect(java.util.stream.Collectors.toList()));
 +    }
 +    // Paper end
      @Override
-     public void setLore(List<String> lore) { // too tired to think if .clone is better
-         if (lore == null) {
-@@ -1022,6 +1042,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     public void setLore(List<String> lore) {
+         if (lore == null || lore.isEmpty()) {
+@@ -1010,6 +1030,21 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
      }
  
@@ -70,10 +70,10 @@ index e49aa5dd5f8ef8f0c6ad4c4d776adf628c3aa980..4616b3e99b511a83b349d607c7d9faac
 +            this.lore = null;
 +        } else {
 +            if (this.lore == null) {
-+                safelyAdd(lore, this.lore = new ArrayList<>(lore.size()), Integer.MAX_VALUE);
++                safelyAdd(lore, this.lore = new ArrayList<>(lore.size()), false);
 +            } else {
 +                this.lore.clear();
-+                safelyAdd(lore, this.lore, Integer.MAX_VALUE);
++                safelyAdd(lore, this.lore, false);
 +            }
 +        }
 +    }
@@ -81,13 +81,13 @@ index e49aa5dd5f8ef8f0c6ad4c4d776adf628c3aa980..4616b3e99b511a83b349d607c7d9faac
      @Override
      public boolean hasCustomModelData() {
          return customModelData != null;
-@@ -1483,6 +1518,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+@@ -1471,6 +1506,11 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
          }
  
          for (Object object : addFrom) {
 +            // Paper start - support components
 +            if(object instanceof net.md_5.bungee.api.chat.BaseComponent[]) {
-+                addTo.add(IChatBaseComponent.ChatSerializer.jsonToComponent(net.md_5.bungee.chat.ComponentSerializer.toString((net.md_5.bungee.api.chat.BaseComponent[]) object)));
++                addTo.add(net.md_5.bungee.chat.ComponentSerializer.toString((net.md_5.bungee.api.chat.BaseComponent[]) object));
 +            } else
 +            // Paper end
              if (!(object instanceof String)) {

--- a/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
+++ b/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
@@ -106,10 +106,10 @@ index ba3db09763d94d730c3fe8662e4dbb24e0636786..3506473f9b9f4c747f7b737d9bd02bef
  
      private void a(IInventory iinventory, ItemStack itemstack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2fe655e0b7655cc9b4ce1509c6d6cfd51860c006..90d8631ddd95833f0b981ff22f1669ba8337d552 100644
+index d3a0dbe9617c2393591c01920764bf098db868ad..6d73a10bfaba8044f1cdc5e7d3bf3cfca61eb0e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1546,19 +1546,44 @@ public class CraftEventFactory {
+@@ -1515,19 +1515,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0622-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/Spigot-Server-Patches/0622-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 71306b6ee6456ae6d4120fda86eb934bdb494973..3f678fde45919061dfc75030b7ce355b4dda9e3a 100644
+index 6d73a10bfaba8044f1cdc5e7d3bf3cfca61eb0e1..345bce7bbf0a9391d70be7aa5530d394273842aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -269,6 +269,10 @@ public class CraftEventFactory {
+@@ -267,6 +267,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
560b65c4 #707, SPIGOT-5063, SPIGOT-5304, SPIGOT-5656, SPIGOT-3206, SPIGOT-5350, SPIGOT-5980, SPIGOT-4672: Persist the exact internal text representation where possible.

Spigot Changes:
ff439d1e Rebuild patches