### PR TITLE
Guardian beam not rendering workaround

### DIFF
--- a/Spigot-Server-Patches/0637-Guardian-beam-workaround.patch
+++ b/Spigot-Server-Patches/0637-Guardian-beam-workaround.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gabscap <git@gabscap.de>
+Date: Sat, 19 Mar 2016 22:25:11 +0100
+Subject: [PATCH] Guardian beam workaround
+
+This patch is a workaround for MC-165595
+
+diff --git a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+index 88c3d7efaf467c1c1487f589c2cdbfb6aba734ec..1b9b43ee696575d986c25cafec07d863acb951a7 100644
+--- a/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
++++ b/src/main/java/net/minecraft/server/PacketPlayOutUpdateTime.java
+@@ -4,7 +4,7 @@ import java.io.IOException;
+ 
+ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
+ 
+-    private long a;
++    private long a; private final void setWorldAge(final long age) { this.a = age; } private final long getWorldAge() { return this.a; } // Paper - OBFHELPER
+     private long b;
+ 
+     public PacketPlayOutUpdateTime() {}
+@@ -19,6 +19,9 @@ public class PacketPlayOutUpdateTime implements Packet<PacketListenerPlayOut> {
+             }
+         }
+ 
++        // Paper start
++        this.setWorldAge(this.getWorldAge() % 192000);
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
This reintroduces the patch that fixed Waving Banners.
It was removed due to that being fixed but has since created a new problem with Guardian Beams not rendering so I've re-added the patch with a new name for its current reason.

Fixes: https://bugs.mojang.com/browse/MC-165595 & #4948