### PR TITLE
Re-add coral block tags

### DIFF
--- a/Spigot-API-Patches/0153-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0153-Add-Material-Tags.patch
@@ -204,10 +204,10 @@ index 0000000000000000000000000000000000000000..c91ea2a0679a7f3a5627b5a008e0b39d
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialTags.java b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b83b8d0ccc0d011c8cdcf026c91dcb1aeab9c596
+index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a9b1a046f
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialTags.java
-@@ -0,0 +1,549 @@
+@@ -0,0 +1,556 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -748,6 +748,13 @@ index 0000000000000000000000000000000000000000..b83b8d0ccc0d011c8cdcf026c91dcb1a
 +        .endsWith("_CORAL_FAN")
 +        .endsWith("_CORAL_WALL_FAN")
 +        .ensureSize("CORAL_FANS", 20);
++    
++    /**
++     * Covers the variants of coral blocks.
++     */
++    public static final MaterialSetTag CORAL_BLOCKS = new MaterialSetTag(keyFor("coral_blocks"))
++        .endsWith("_CORAL_BLOCK")
++        .ensureSize("CORAL_BLOCKS", 10);
 +
 +    /**
 +     * Covers all items that can be enchanted from the enchantment table or anvil.


### PR DESCRIPTION
The Coral Blocks tag was removed by mistake in this commit https://github.com/PaperMC/Paper/commit/be81b4f5c524fe1b6ea0af32a9f2e47c06223cc9

This adds it back.