### PR TITLE
Make EntityUnleashEvent cancellable

### DIFF
--- a/patches/api/0329-Make-EntityUnleashEvent-cancellable.patch
+++ b/patches/api/0329-Make-EntityUnleashEvent-cancellable.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 3 Jan 2021 21:25:39 -0800
+Subject: [PATCH] Make EntityUnleashEvent cancellable
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/EntityUnleashEvent.java b/src/main/java/org/bukkit/event/entity/EntityUnleashEvent.java
+index e0e068799a1868c8e561869015f41f553ef4fbdb..95248d0f5cf9b62d31a4883955b9088a7fc8a3b3 100644
+--- a/src/main/java/org/bukkit/event/entity/EntityUnleashEvent.java
++++ b/src/main/java/org/bukkit/event/entity/EntityUnleashEvent.java
+@@ -6,11 +6,20 @@ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+  * Called immediately prior to an entity being unleashed.
++ * <p>
++ * Cancelling this event when either:
++ * <ul>
++ *     <li>the leashed entity dies,</li>
++ *     <li>the entity changes dimension, or</li>
++ *     <li>the client has disconnected the leash</li>
++ * </ul>
++ * will have no effect.
+  */
+-public class EntityUnleashEvent extends EntityEvent {
++public class EntityUnleashEvent extends EntityEvent implements org.bukkit.event.Cancellable { // Paper
+     private static final HandlerList handlers = new HandlerList();
+     private final UnleashReason reason;
+     private boolean dropLeash; // Paper
++    private boolean cancelled; // Paper
+ 
+     // Paper start - drop leash variable
+     @Deprecated
+@@ -53,6 +62,16 @@ public class EntityUnleashEvent extends EntityEvent {
+     public void setDropLeash(boolean dropLeash) {
+         this.dropLeash = dropLeash;
+     }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
+     // Paper end
+ 
+     @NotNull

--- a/patches/server/0746-Make-EntityUnleashEvent-cancellable.patch
+++ b/patches/server/0746-Make-EntityUnleashEvent-cancellable.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 3 Jan 2021 21:25:31 -0800
+Subject: [PATCH] Make EntityUnleashEvent cancellable
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index a8e5be1c941755b3e5b335d8211ca70a6c6fc32f..bada11542390b7575466f0e7062470665b8266c4 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -1448,7 +1448,7 @@ public abstract class Mob extends LivingEntity {
+         if (flag1 && this.isLeashed()) {
+             // Paper start - drop leash variable
+             EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), UnleashReason.UNKNOWN, true);
+-            this.level.getCraftServer().getPluginManager().callEvent(event); // CraftBukkit
++            if (!event.callEvent()) { return flag1; }
+             this.dropLeash(true, event.isDropLeash());
+             // Paper end
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/PathfinderMob.java b/src/main/java/net/minecraft/world/entity/PathfinderMob.java
+index d16a7bab5495d58ea9e6811d4b507667cfa3d264..94bf73eb54e302a9d41fbf8b0a487d2660adcd0e 100644
+--- a/src/main/java/net/minecraft/world/entity/PathfinderMob.java
++++ b/src/main/java/net/minecraft/world/entity/PathfinderMob.java
+@@ -49,7 +49,7 @@ public abstract class PathfinderMob extends Mob {
+                 if (f > entity.level.paperConfig.maxLeashDistance) { // Paper
+                     // Paper start - drop leash variable
+                     EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), EntityUnleashEvent.UnleashReason.DISTANCE, true);
+-                    this.level.getCraftServer().getPluginManager().callEvent(event); // CraftBukkit
++                    if (!event.callEvent()) { return; }
+                     this.dropLeash(true, event.isDropLeash());
+                     // Paper end
+                 }
+@@ -61,7 +61,7 @@ public abstract class PathfinderMob extends Mob {
+             if (f > entity.level.paperConfig.maxLeashDistance) { // Paper
+                 // Paper start - drop leash variable
+                 EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), EntityUnleashEvent.UnleashReason.DISTANCE, true);
+-                this.level.getCraftServer().getPluginManager().callEvent(event); // CraftBukkit
++                if (!event.callEvent()) return;
+                 this.dropLeash(true, event.isDropLeash());
+                 // Paper end
+                 this.goalSelector.disableControlFlag(Goal.Flag.MOVE);


### PR DESCRIPTION
Closes #4780 

One thing to note. Should it be possible to cancel the event if the leashed entity dies? I tested if the player dies and you do stay leashed to it, but if the leashed entity dies, maybe it should unleash regardless of event cancellation.