### PR TITLE
Add API to get exact interaction point in PlayerInteractEvent

### DIFF
--- a/Spigot-API-Patches/0258-Add-API-to-get-exact-interaction-point-in-PlayerInte.patch
+++ b/Spigot-API-Patches/0258-Add-API-to-get-exact-interaction-point-in-PlayerInte.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Mon, 4 Jan 2021 16:40:55 +1000
+Subject: [PATCH] Add API to get exact interaction point in PlayerInteractEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+index 1208e1f8c2163d83c5b12bbb9b7ac044c72380e0..a01f86e6aba8b66ecc713da0787cd861e2930a2a 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerInteractEvent.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.event.player;
+ 
++import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.block.Block;
+ import org.bukkit.block.BlockFace;
+@@ -34,22 +35,30 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
+     private Result useClickedBlock;
+     private Result useItemInHand;
+     private EquipmentSlot hand;
++    private Location interactionPoint; // Paper
+ 
+     public PlayerInteractEvent(@NotNull final Player who, @NotNull final Action action, @Nullable final ItemStack item, @Nullable final Block clickedBlock, @NotNull final BlockFace clickedFace) {
+         this(who, action, item, clickedBlock, clickedFace, EquipmentSlot.HAND);
+     }
+ 
+     public PlayerInteractEvent(@NotNull final Player who, @NotNull final Action action, @Nullable final ItemStack item, @Nullable final Block clickedBlock, @NotNull final BlockFace clickedFace, @Nullable final EquipmentSlot hand) {
++        // Paper start - Add interactionPoint
++        this(who, action, item, clickedBlock, clickedFace, hand, null);
++    }
++
++    public PlayerInteractEvent(@NotNull final Player who, @NotNull final Action action, @Nullable final ItemStack item, @Nullable final Block clickedBlock, @NotNull final BlockFace clickedFace, @Nullable final EquipmentSlot hand, @Nullable final Location interactionPoint) {
+         super(who);
+         this.action = action;
+         this.item = item;
+         this.blockClicked = clickedBlock;
+         this.blockFace = clickedFace;
+         this.hand = hand;
++        this.interactionPoint = interactionPoint;
+ 
+         useItemInHand = Result.DEFAULT;
+         useClickedBlock = clickedBlock == null ? Result.DENY : Result.ALLOW;
+     }
++    // Paper end
+ 
+     /**
+      * Returns the action type
+@@ -221,6 +230,18 @@ public class PlayerInteractEvent extends PlayerEvent implements Cancellable {
+         return hand;
+     }
+ 
++    // Paper start
++    /**
++     * The exact point at which the interaction occurred. May be null.
++     *
++     * @return the exact interaction point. May be null.
++     */
++    @Nullable
++    public Location getInteractionPoint() {
++        return interactionPoint;
++    }
++    // Paper end
++
+     @NotNull
+     @Override
+     public HandlerList getHandlers() {

--- a/Spigot-Server-Patches/0648-Implement-API-to-expose-exact-interaction-point.patch
+++ b/Spigot-Server-Patches/0648-Implement-API-to-expose-exact-interaction-point.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Mon, 4 Jan 2021 16:40:27 +1000
+Subject: [PATCH] Implement API to expose exact interaction point
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+index 485b609bb5387b0f8a46c1201177cdc6d183ad91..114e986e5132e5e4bb42d0f08a067429bce53ba6 100644
+--- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
++++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
+@@ -461,7 +461,7 @@ public class PlayerInteractManager {
+             cancelledBlock = true;
+         }
+ 
+-        PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(entityplayer, Action.RIGHT_CLICK_BLOCK, blockposition, movingobjectpositionblock.getDirection(), itemstack, cancelledBlock, enumhand);
++        PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(entityplayer, Action.RIGHT_CLICK_BLOCK, blockposition, movingobjectpositionblock.getDirection(), itemstack, cancelledBlock, enumhand, movingobjectpositionblock.getPos()); // Paper
+         firedInteract = true;
+         interactResult = event.useItemInHand() == Event.Result.DENY;
+         interactPosition = blockposition.immutableCopy();
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 4534d22aec95cf247daf7575472acd0eba91a3c9..c762015e1402b59bf28dae7f947e7737fbac5c1d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -64,9 +64,11 @@ import net.minecraft.server.NPC;
+ import net.minecraft.server.PacketPlayInCloseWindow;
+ import net.minecraft.server.Raid;
+ import net.minecraft.server.Unit;
++import net.minecraft.server.Vec3D;
+ import net.minecraft.server.World;
+ import net.minecraft.server.WorldServer;
+ import org.bukkit.Bukkit;
++import org.bukkit.Location;
+ import org.bukkit.Material;
+ import org.bukkit.NamespacedKey;
+ import org.bukkit.Server;
+@@ -466,7 +468,13 @@ public class CraftEventFactory {
+         return callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
+     }
+ 
++    // Paper start - Add interactionPoint
+     public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, boolean cancelledBlock, EnumHand hand) {
++        return callPlayerInteractEvent(who, action, position, direction, itemstack, cancelledBlock, hand, null);
++    }
++
++    public static PlayerInteractEvent callPlayerInteractEvent(EntityHuman who, Action action, BlockPosition position, EnumDirection direction, ItemStack itemstack, boolean cancelledBlock, EnumHand hand, Vec3D hitVec) {
++        // Paper end
+         Player player = (who == null) ? null : (Player) who.getBukkitEntity();
+         CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
+ 
+@@ -492,7 +500,10 @@ public class CraftEventFactory {
+             itemInHand = null;
+         }
+ 
+-        PlayerInteractEvent event = new PlayerInteractEvent(player, action, itemInHand, blockClicked, blockFace, (hand == null) ? null : ((hand == EnumHand.OFF_HAND) ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND));
++        // Paper start
++        Location interactionPoint =  hitVec == null ? null : new Location(craftWorld, hitVec.x, hitVec.y, hitVec.z);
++        PlayerInteractEvent event = new PlayerInteractEvent(player, action, itemInHand, blockClicked, blockFace, (hand == null) ? null : ((hand == EnumHand.OFF_HAND) ? EquipmentSlot.OFF_HAND : EquipmentSlot.HAND), interactionPoint);
++        // Paper end
+         if (cancelledBlock) {
+             event.setUseInteractedBlock(Event.Result.DENY);
+         }


### PR DESCRIPTION
Adds an API method to get the exact position that was interacted with in a PlayerInteractEvent, rather than just the block.

