### PR TITLE
Add per-command perms for paper command

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -7,17 +7,25 @@ Loads each yml file for early init too so it can be used for early options
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276e88fe934
+index 0000000000000000000000000000000000000000..ed7e4220199f9c57d0ffe67f552027c0bade3af1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -0,0 +1,259 @@
+@@ -0,0 +1,286 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Functions;
++import com.google.common.base.Joiner;
++import com.google.common.collect.ImmutableSet;
 +import com.google.common.collect.Iterables;
 +import com.google.common.collect.Lists;
 +import com.google.common.collect.Maps;
-+import net.minecraft.server.*;
++import net.minecraft.server.ChunkCoordIntPair;
++import net.minecraft.server.ChunkProviderServer;
++import net.minecraft.server.Entity;
++import net.minecraft.server.EntityTypes;
++import net.minecraft.server.MinecraftKey;
++import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.WorldServer;
 +import org.apache.commons.lang3.tuple.MutablePair;
 +import org.apache.commons.lang3.tuple.Pair;
 +import org.bukkit.Bukkit;
@@ -33,45 +41,61 @@ index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276
 +import java.io.File;
 +import java.time.LocalDateTime;
 +import java.time.format.DateTimeFormatter;
-+import java.util.*;
++import java.util.ArrayList;
++import java.util.Arrays;
++import java.util.Collection;
++import java.util.Collections;
++import java.util.Iterator;
++import java.util.List;
++import java.util.Locale;
++import java.util.Map;
++import java.util.Set;
 +import java.util.stream.Collectors;
 +
 +public class PaperCommand extends Command {
++    private static final String BASE_PERM = "bukkit.command.paper.";
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version").build();
 +
 +    public PaperCommand(String name) {
 +        super(name);
 +        this.description = "Paper related commands";
-+        this.usageMessage = "/paper [heap | entity | reload | version]";
-+        this.setPermission("bukkit.command.paper");
++        this.usageMessage = "/paper [" + Joiner.on(" | ").join(SUBCOMMANDS) + "]";
++        this.setPermission("bukkit.command.paper;" + Joiner.on(';').join(SUBCOMMANDS.stream().map(s -> BASE_PERM + s).collect(Collectors.toSet())));
++    }
++
++    private static boolean testPermission(CommandSender commandSender, String permission) {
++        if (commandSender.hasPermission(BASE_PERM + permission) || commandSender.hasPermission("bukkit.command.paper")) return true;
++        commandSender.sendMessage(Bukkit.getPermissionMessage());
++        return false;
 +    }
 +
 +    @Override
 +    public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
 +        if (args.length <= 1)
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version");
++            return getListMatchingLast(sender, args, SUBCOMMANDS);
 +
 +        switch (args[0].toLowerCase(Locale.ENGLISH))
 +        {
 +            case "entity":
 +                if (args.length == 2)
-+                    return getListMatchingLast(args, "help", "list");
++                    return getListMatchingLast(sender, args, "help", "list");
 +                if (args.length == 3)
-+                    return getListMatchingLast(args, EntityTypes.getEntityNameList().stream().map(MinecraftKey::toString).sorted().toArray(String[]::new));
++                    return getListMatchingLast(sender, args, EntityTypes.getEntityNameList().stream().map(MinecraftKey::toString).sorted().toArray(String[]::new));
 +                break;
 +        }
 +        return Collections.emptyList();
 +    }
 +
 +    // Code from Mojang - copyright them
-+    public static List<String> getListMatchingLast(String[] args, String... matches) {
-+        return getListMatchingLast(args, (Collection) Arrays.asList(matches));
++    public static List<String> getListMatchingLast(CommandSender sender, String[] args, String... matches) {
++        return getListMatchingLast(sender, args, (Collection) Arrays.asList(matches));
 +    }
 +
 +    public static boolean matches(String s, String s1) {
 +        return s1.regionMatches(true, 0, s, 0, s.length());
 +    }
 +
-+    public static List<String> getListMatchingLast(String[] strings, Collection<?> collection) {
++    public static List<String> getListMatchingLast(CommandSender sender, String[] strings, Collection<?> collection) {
 +        String last = strings[strings.length - 1];
 +        ArrayList<String> results = Lists.newArrayList();
 +
@@ -81,7 +105,7 @@ index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276
 +            while (iterator.hasNext()) {
 +                String s1 = (String) iterator.next();
 +
-+                if (matches(last, s1)) {
++                if (matches(last, s1) && (sender.hasPermission(BASE_PERM + s1) || sender.hasPermission("bukkit.command.paper"))) {
 +                    results.add(s1);
 +                }
 +            }
@@ -111,7 +135,9 @@ index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276
 +            sender.sendMessage(ChatColor.RED + "Usage: " + usageMessage);
 +            return false;
 +        }
-+
++        if (SUBCOMMANDS.contains(args[0].toLowerCase(Locale.ENGLISH))) {
++            if (!testPermission(sender, args[0].toLowerCase(Locale.ENGLISH))) return true;
++        }
 +        switch (args[0].toLowerCase(Locale.ENGLISH))  {
 +            case "heap":
 +                dumpHeap(sender);
@@ -123,6 +149,7 @@ index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276
 +                doReload(sender);
 +                break;
 +            case "ver":
++                if (!testPermission(sender, "version")) break; // "ver" needs a special check because it's an alias. All other commands are checked up before the switch statement (because they are present in the SUBCOMMANDS set)
 +            case "version":
 +                Command ver = org.bukkit.Bukkit.getServer().getCommandMap().getCommand("version");
 +                if (ver != null) {
@@ -662,7 +689,7 @@ index 4c5683bcb45ea500adb0775fc81f296bb2583f80..1606a7b4727fffef27d6bb08633b652b
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ab11efee28224852f4984ce7235494d83ba7fe7f..a19242d717f7f9c254e6127fb2cb2f202be2d78a 100644
+index 7c52aa2eabbf1eb09a3749f71fdaf2430e75a225..9b3f9b11abe89cabb3044766dda60a8842c149f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -808,6 +808,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
+++ b/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add MinecraftKey Information to Objects
 Stores the reference to the objects respective MinecraftKey
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 5e819f7ac4049d3d2b5ce814263b3276e88fe934..d37cf906988863840ed99875c7567843cb38a9fc 100644
+index ed7e4220199f9c57d0ffe67f552027c0bade3af1..411aebed946991b899205fcc1fcf7f3bf83718c0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -181,7 +181,7 @@ public class PaperCommand extends Command {
+@@ -208,7 +208,7 @@ public class PaperCommand extends Command {
  
                  Collection<Entity> entities = world.entitiesById.values();
                  entities.forEach(e -> {

--- a/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -11,10 +11,10 @@ This will ensure that dead entities are skipped from iteration since
 they shouldn't of been in the list in the first place.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index d37cf906988863840ed99875c7567843cb38a9fc..600b1a36bb1287af4c0d91e52b7a30e7a3588ce4 100644
+index 411aebed946991b899205fcc1fcf7f3bf83718c0..aa606e66c874d5147074b85cc9a5ceef71175740 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -182,6 +182,7 @@ public class PaperCommand extends Command {
+@@ -209,6 +209,7 @@ public class PaperCommand extends Command {
                  Collection<Entity> entities = world.entitiesById.values();
                  entities.forEach(e -> {
                      MinecraftKey key = e.getMinecraftKey();

--- a/Spigot-Server-Patches/0357-Chunk-debug-command.patch
+++ b/Spigot-Server-Patches/0357-Chunk-debug-command.patch
@@ -32,33 +32,36 @@ https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528273&page=com.atlass
 https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528577&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-528577
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 600b1a36bb1287af4c0d91e52b7a30e7a3588ce4..2522ec624c53ca0718a8abbcb9c96d104f2f67fa 100644
+index aa606e66c874d5147074b85cc9a5ceef71175740..7dfed07e54f1f0be0c01ee161f56dc421b91baaa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -28,14 +28,14 @@ public class PaperCommand extends Command {
+@@ -10,8 +10,10 @@ import net.minecraft.server.ChunkCoordIntPair;
+ import net.minecraft.server.ChunkProviderServer;
+ import net.minecraft.server.Entity;
+ import net.minecraft.server.EntityTypes;
++import net.minecraft.server.MCUtil;
+ import net.minecraft.server.MinecraftKey;
+ import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.PlayerChunk;
+ import net.minecraft.server.WorldServer;
+ import org.apache.commons.lang3.tuple.MutablePair;
+ import org.apache.commons.lang3.tuple.Pair;
+@@ -41,7 +43,7 @@ import java.util.stream.Collectors;
+ 
+ public class PaperCommand extends Command {
+     private static final String BASE_PERM = "bukkit.command.paper.";
+-    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version").build();
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo").build();
+ 
      public PaperCommand(String name) {
          super(name);
-         this.description = "Paper related commands";
--        this.usageMessage = "/paper [heap | entity | reload | version]";
-+        this.usageMessage = "/paper [heap | entity | reload | version | debug | chunkinfo]";
-         this.setPermission("bukkit.command.paper");
-     }
- 
-     @Override
-     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
-         if (args.length <= 1)
--            return getListMatchingLast(args, "heap", "entity", "reload", "version");
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "chunkinfo");
- 
-         switch (args[0].toLowerCase(Locale.ENGLISH))
-         {
-@@ -45,6 +45,21 @@ public class PaperCommand extends Command {
+@@ -69,6 +71,21 @@ public class PaperCommand extends Command {
                  if (args.length == 3)
-                     return getListMatchingLast(args, EntityTypes.getEntityNameList().stream().map(MinecraftKey::toString).sorted().toArray(String[]::new));
+                     return getListMatchingLast(sender, args, EntityTypes.getEntityNameList().stream().map(MinecraftKey::toString).sorted().toArray(String[]::new));
                  break;
 +            case "debug":
 +                if (args.length == 2) {
-+                    return getListMatchingLast(args, "help", "chunks");
++                    return getListMatchingLast(sender, args, "help", "chunks");
 +                }
 +                break;
 +            case "chunkinfo":
@@ -68,13 +71,13 @@ index 600b1a36bb1287af4c0d91e52b7a30e7a3588ce4..2522ec624c53ca0718a8abbcb9c96d10
 +                    worldNames.add(world.getName());
 +                }
 +                if (args.length == 2) {
-+                    return getListMatchingLast(args, worldNames);
++                    return getListMatchingLast(sender, args, worldNames);
 +                }
 +                break;
          }
          return Collections.emptyList();
      }
-@@ -109,6 +124,12 @@ public class PaperCommand extends Command {
+@@ -135,6 +152,12 @@ public class PaperCommand extends Command {
              case "reload":
                  doReload(sender);
                  break;
@@ -85,9 +88,9 @@ index 600b1a36bb1287af4c0d91e52b7a30e7a3588ce4..2522ec624c53ca0718a8abbcb9c96d10
 +                doChunkInfo(sender, args);
 +                break;
              case "ver":
+                 if (!testPermission(sender, "version")) break; // "ver" needs a special check because it's an alias. All other commands are checked up before the switch statement (because they are present in the SUBCOMMANDS set)
              case "version":
-                 Command ver = org.bukkit.Bukkit.getServer().getCommandMap().getCommand("version");
-@@ -125,6 +146,114 @@ public class PaperCommand extends Command {
+@@ -152,6 +175,114 @@ public class PaperCommand extends Command {
          return true;
      }
  

--- a/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
@@ -161,7 +161,7 @@ index 944fd203e9f39d6c6fc9e270940c76c98067273a..a27dc38d1a29ed1d63d2f44b7984c2b6
  
      public static Timing getTickList(WorldServer worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 2522ec624c53ca0718a8abbcb9c96d104f2f67fa..5bb90675ed813070e61e1598d0c812b20d340328 100644
+index 901c16ef303d4744ec8043a506dd894215dd1b6a..a6aa757137d644c1fe342e23f6d025e0f4dd5aac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -1,5 +1,6 @@
@@ -169,26 +169,18 @@ index 2522ec624c53ca0718a8abbcb9c96d104f2f67fa..5bb90675ed813070e61e1598d0c812b2
  
 +import com.destroystokyo.paper.io.chunk.ChunkTaskManager;
  import com.google.common.base.Functions;
- import com.google.common.collect.Iterables;
- import com.google.common.collect.Lists;
-@@ -28,14 +29,14 @@ public class PaperCommand extends Command {
+ import com.google.common.base.Joiner;
+ import com.google.common.collect.ImmutableSet;
+@@ -43,7 +44,7 @@ import java.util.stream.Collectors;
+ 
+ public class PaperCommand extends Command {
+     private static final String BASE_PERM = "bukkit.command.paper.";
+-    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo").build();
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting").build();
+ 
      public PaperCommand(String name) {
          super(name);
-         this.description = "Paper related commands";
--        this.usageMessage = "/paper [heap | entity | reload | version | debug | chunkinfo]";
-+        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo]";
-         this.setPermission("bukkit.command.paper");
-     }
- 
-     @Override
-     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
-         if (args.length <= 1)
--            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "chunkinfo");
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo");
- 
-         switch (args[0].toLowerCase(Locale.ENGLISH))
-         {
-@@ -127,6 +128,9 @@ public class PaperCommand extends Command {
+@@ -155,6 +156,9 @@ public class PaperCommand extends Command {
              case "debug":
                  doDebug(sender, args);
                  break;

--- a/Spigot-Server-Patches/0371-Reduce-sync-loads.patch
+++ b/Spigot-Server-Patches/0371-Reduce-sync-loads.patch
@@ -11,25 +11,27 @@ it must be enabled by setting the startup flag -Dpaper.debug-sync-loads=true
 To get a debug log for sync loads, the command is /paper syncloadinfo
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 9ad822715c9358e5ac2a0e0a0800786a9cee7be3..c80af89b4ad0223577ed9513dcab0a784cc964e4 100644
+index 12f5e4b8b5d231b54405339518536aebf6a9d8fc..ebb17a2efde002f1384b5ad8f4f4576e9a3cc675 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -1,10 +1,14 @@
+@@ -1,12 +1,16 @@
  package com.destroystokyo.paper;
  
  import com.destroystokyo.paper.io.chunk.ChunkTaskManager;
 +import com.destroystokyo.paper.io.SyncLoadFinder;
  import com.google.common.base.Functions;
+ import com.google.common.base.Joiner;
+ import com.google.common.collect.ImmutableSet;
  import com.google.common.collect.Iterables;
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
 +import com.google.gson.JsonObject;
 +import com.google.gson.internal.Streams;
 +import com.google.gson.stream.JsonWriter;
- import net.minecraft.server.*;
- import org.apache.commons.lang3.tuple.MutablePair;
- import org.apache.commons.lang3.tuple.Pair;
-@@ -19,6 +23,9 @@ import org.bukkit.craftbukkit.CraftWorld;
+ import net.minecraft.server.ChunkCoordIntPair;
+ import net.minecraft.server.ChunkProviderServer;
+ import net.minecraft.server.Entity;
+@@ -29,6 +33,9 @@ import org.bukkit.craftbukkit.CraftWorld;
  import org.bukkit.entity.Player;
  
  import java.io.File;
@@ -38,25 +40,17 @@ index 9ad822715c9358e5ac2a0e0a0800786a9cee7be3..c80af89b4ad0223577ed9513dcab0a78
 +import java.io.StringWriter;
  import java.time.LocalDateTime;
  import java.time.format.DateTimeFormatter;
- import java.util.*;
-@@ -29,14 +36,14 @@ public class PaperCommand extends Command {
+ import java.util.ArrayList;
+@@ -44,7 +51,7 @@ import java.util.stream.Collectors;
+ 
+ public class PaperCommand extends Command {
+     private static final String BASE_PERM = "bukkit.command.paper.";
+-    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting").build();
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting", "syncloadinfo").build();
+ 
      public PaperCommand(String name) {
          super(name);
-         this.description = "Paper related commands";
--        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo]";
-+        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo | syncloadinfo]";
-         this.setPermission("bukkit.command.paper");
-     }
- 
-     @Override
-     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
-         if (args.length <= 1)
--            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo");
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo", "syncloadinfo");
- 
-         switch (args[0].toLowerCase(Locale.ENGLISH))
-         {
-@@ -134,6 +141,9 @@ public class PaperCommand extends Command {
+@@ -162,6 +169,9 @@ public class PaperCommand extends Command {
              case "chunkinfo":
                  doChunkInfo(sender, args);
                  break;
@@ -64,9 +58,9 @@ index 9ad822715c9358e5ac2a0e0a0800786a9cee7be3..c80af89b4ad0223577ed9513dcab0a78
 +                this.doSyncLoadInfo(sender, args);
 +                break;
              case "ver":
+                 if (!testPermission(sender, "version")) break; // "ver" needs a special check because it's an alias. All other commands are checked up before the switch statement (because they are present in the SUBCOMMANDS set)
              case "version":
-                 Command ver = org.bukkit.Bukkit.getServer().getCommandMap().getCommand("version");
-@@ -150,6 +160,40 @@ public class PaperCommand extends Command {
+@@ -179,6 +189,40 @@ public class PaperCommand extends Command {
          return true;
      }
  

--- a/Spigot-Server-Patches/0472-Fix-Light-Command.patch
+++ b/Spigot-Server-Patches/0472-Fix-Light-Command.patch
@@ -7,10 +7,29 @@ This lets you run /paper fixlight <chunkRadius> (max 5) to automatically
 fix all light data in the chunks.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 2079bb001ea2678f6181f913262a9b7731fae778..7367781d360a8eb3a1b22de5c0b57dd98e6763d6 100644
+index ebb17a2efde002f1384b5ad8f4f4576e9a3cc675..5f25167054d58d74c13d11ef2685ed83808ff31f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -20,6 +20,7 @@ import org.bukkit.command.Command;
+@@ -11,13 +11,18 @@ import com.google.common.collect.Maps;
+ import com.google.gson.JsonObject;
+ import com.google.gson.internal.Streams;
+ import com.google.gson.stream.JsonWriter;
++import net.minecraft.server.BlockPosition;
++import net.minecraft.server.Chunk;
+ import net.minecraft.server.ChunkCoordIntPair;
+ import net.minecraft.server.ChunkProviderServer;
+ import net.minecraft.server.Entity;
++import net.minecraft.server.EntityPlayer;
+ import net.minecraft.server.EntityTypes;
++import net.minecraft.server.LightEngineThreaded;
+ import net.minecraft.server.MCUtil;
+ import net.minecraft.server.MinecraftKey;
+ import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.PacketPlayOutLightUpdate;
+ import net.minecraft.server.PlayerChunk;
+ import net.minecraft.server.WorldServer;
+ import org.apache.commons.lang3.tuple.MutablePair;
+@@ -30,6 +35,7 @@ import org.bukkit.command.Command;
  import org.bukkit.command.CommandSender;
  import org.bukkit.craftbukkit.CraftServer;
  import org.bukkit.craftbukkit.CraftWorld;
@@ -18,24 +37,29 @@ index 2079bb001ea2678f6181f913262a9b7731fae778..7367781d360a8eb3a1b22de5c0b57dd9
  import org.bukkit.entity.Player;
  
  import java.io.File;
-@@ -36,14 +37,14 @@ public class PaperCommand extends Command {
+@@ -38,10 +44,12 @@ import java.io.PrintStream;
+ import java.io.StringWriter;
+ import java.time.LocalDateTime;
+ import java.time.format.DateTimeFormatter;
++import java.util.ArrayDeque;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collection;
+ import java.util.Collections;
++import java.util.Deque;
+ import java.util.Iterator;
+ import java.util.List;
+ import java.util.Locale;
+@@ -51,7 +59,7 @@ import java.util.stream.Collectors;
+ 
+ public class PaperCommand extends Command {
+     private static final String BASE_PERM = "bukkit.command.paper.";
+-    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting", "syncloadinfo").build();
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting", "syncloadinfo", "fixlight").build();
+ 
      public PaperCommand(String name) {
          super(name);
-         this.description = "Paper related commands";
--        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo | syncloadinfo]";
-+        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo | syncloadinfo | fixlight]";
-         this.setPermission("bukkit.command.paper");
-     }
- 
-     @Override
-     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
-         if (args.length <= 1)
--            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo", "syncloadinfo");
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo", "syncloadinfo", "fixlight");
- 
-         switch (args[0].toLowerCase(Locale.ENGLISH))
-         {
-@@ -144,6 +145,9 @@ public class PaperCommand extends Command {
+@@ -172,6 +180,9 @@ public class PaperCommand extends Command {
              case "syncloadinfo":
                  this.doSyncLoadInfo(sender, args);
                  break;
@@ -43,9 +67,9 @@ index 2079bb001ea2678f6181f913262a9b7731fae778..7367781d360a8eb3a1b22de5c0b57dd9
 +                this.doFixLight(sender, args);
 +                break;
              case "ver":
+                 if (!testPermission(sender, "version")) break; // "ver" needs a special check because it's an alias. All other commands are checked up before the switch statement (because they are present in the SUBCOMMANDS set)
              case "version":
-                 Command ver = org.bukkit.Bukkit.getServer().getCommandMap().getCommand("version");
-@@ -160,6 +164,77 @@ public class PaperCommand extends Command {
+@@ -189,6 +200,77 @@ public class PaperCommand extends Command {
          return true;
      }
  

--- a/Spigot-Server-Patches/0511-Paper-dumpitem-command.patch
+++ b/Spigot-Server-Patches/0511-Paper-dumpitem-command.patch
@@ -6,10 +6,18 @@ Subject: [PATCH] Paper dumpitem command
 Let's you quickly view the item in your hands NBT data
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f60800c3bc06a38493e17b00b815f18cb87cc8bf..0abfe19e204d20af0f8dedbeedb0ef98dfe9d3c8 100644
+index 0619e6d0901ecd656aebd66522c08379916a8b78..46b5d07be1e187129fa7f2dd62397ed34b4a9e15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -21,7 +21,9 @@ import org.bukkit.command.CommandSender;
+@@ -22,6 +22,7 @@ import net.minecraft.server.LightEngineThreaded;
+ import net.minecraft.server.MCUtil;
+ import net.minecraft.server.MinecraftKey;
+ import net.minecraft.server.MinecraftServer;
++import net.minecraft.server.NBTTagCompound;
+ import net.minecraft.server.PacketPlayOutLightUpdate;
+ import net.minecraft.server.PlayerChunk;
+ import net.minecraft.server.WorldServer;
+@@ -36,7 +37,9 @@ import org.bukkit.command.CommandSender;
  import org.bukkit.craftbukkit.CraftServer;
  import org.bukkit.craftbukkit.CraftWorld;
  import org.bukkit.craftbukkit.entity.CraftPlayer;
@@ -19,24 +27,16 @@ index f60800c3bc06a38493e17b00b815f18cb87cc8bf..0abfe19e204d20af0f8dedbeedb0ef98
  
  import java.io.File;
  import java.io.FileOutputStream;
-@@ -37,14 +39,14 @@ public class PaperCommand extends Command {
+@@ -59,7 +62,7 @@ import java.util.stream.Collectors;
+ 
+ public class PaperCommand extends Command {
+     private static final String BASE_PERM = "bukkit.command.paper.";
+-    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting", "syncloadinfo", "fixlight").build();
++    private static final ImmutableSet<String> SUBCOMMANDS = ImmutableSet.<String>builder().add("heap", "entity", "reload", "version", "debug", "chunkinfo", "dumpwaiting", "syncloadinfo", "fixlight", "dumpitem").build();
+ 
      public PaperCommand(String name) {
          super(name);
-         this.description = "Paper related commands";
--        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo | syncloadinfo | fixlight]";
-+        this.usageMessage = "/paper [heap | entity | reload | version | debug | dumpwaiting | chunkinfo | syncloadinfo | fixlight | dumpitem]";
-         this.setPermission("bukkit.command.paper");
-     }
- 
-     @Override
-     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
-         if (args.length <= 1)
--            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo", "syncloadinfo", "fixlight");
-+            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "dumpwaiting", "chunkinfo", "syncloadinfo", "fixlight", "dumpitem");
- 
-         switch (args[0].toLowerCase(Locale.ENGLISH))
-         {
-@@ -133,6 +135,9 @@ public class PaperCommand extends Command {
+@@ -168,6 +171,9 @@ public class PaperCommand extends Command {
              case "reload":
                  doReload(sender);
                  break;
@@ -46,15 +46,11 @@ index f60800c3bc06a38493e17b00b815f18cb87cc8bf..0abfe19e204d20af0f8dedbeedb0ef98
              case "debug":
                  doDebug(sender, args);
                  break;
-@@ -164,6 +169,23 @@ public class PaperCommand extends Command {
+@@ -200,6 +206,19 @@ public class PaperCommand extends Command {
          return true;
      }
  
 +    private void doDumpItem(CommandSender sender) {
-+        if (!(sender instanceof Player)) {
-+            sender.sendMessage("Only players can use this command");
-+            return;
-+        }
 +        ItemStack itemInHand = ((CraftPlayer) sender).getItemInHand();
 +        net.minecraft.server.ItemStack itemStack = CraftItemStack.asNMSCopy(itemInHand);
 +        NBTTagCompound tag = itemStack.getTag();

--- a/Spigot-Server-Patches/0678-Clear-SyncLoadInfo.patch
+++ b/Spigot-Server-Patches/0678-Clear-SyncLoadInfo.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Clear SyncLoadInfo
 This patch merely adds the extra argument "clear" after /paper syncloadinfo to clear currently stored syncload info.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 0abfe19e204d20af0f8dedbeedb0ef98dfe9d3c8..fa385aac361fb73fd974a8a13dc9bc86e2707451 100644
+index 352f1ce8ecfc8457d141c10f7ce698bea45b342b..4994f0e3934c4c3a7dd74b92a9a7c6c1b9a17614 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -262,6 +262,13 @@ public class PaperCommand extends Command {
+@@ -295,6 +295,13 @@ public class PaperCommand extends Command {
              sender.sendMessage(ChatColor.RED + "This command requires the server startup flag '-Dpaper.debug-sync-loads=true' to be set.");
              return;
          }


### PR DESCRIPTION
Closes #4066 
Adds per-subcommand permissions for the paper command (including for tabcompletions)