### PR TITLE
Introducing: isArmor()

### DIFF
--- a/Spigot-API-Patches/0258-Adding-isArmor-boolean-to-Material.patch
+++ b/Spigot-API-Patches/0258-Adding-isArmor-boolean-to-Material.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TheFruxz <cedricspitzer@outlook.de>
+Date: Wed, 6 Jan 2021 02:19:21 +0100
+Subject: [PATCH] Adding isArmor boolean to Material
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index 4ba991b79f13219182df35b4ce0c5cf57cbd208b..3cba88b8661fd09ea5a9c1cd3fa5821f042a6a3f 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -1,5 +1,6 @@
+ package org.bukkit;
+ 
++import com.destroystokyo.paper.MaterialTags; // Paper
+ import com.google.common.collect.Maps;
+ import java.lang.reflect.Constructor;
+ import java.util.Locale;
+@@ -3581,6 +3582,13 @@ public enum Material implements Keyed {
+         return false;
+     }
+ 
++    /**
++     * @return If the type is an armor
++     */
++    public boolean isArmor() {
++        return MaterialTags.HELMETS.isTagged(this) || MaterialTags.CHESTPLATES.isTagged(this) || MaterialTags.LEGGINGS.isTagged(this) || MaterialTags.BOOTS.isTagged(this)
++    }
++
+     /**
+      * Return the translation key for the Material, so the client can translate it into the active
+      * locale when using a TranslatableComponent.

--- a/Spigot-API-Patches/0258-Adding-isArmor-boolean-to-Material.patch
+++ b/Spigot-API-Patches/0258-Adding-isArmor-boolean-to-Material.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Adding isArmor boolean to Material
 
 
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index 4ba991b79f13219182df35b4ce0c5cf57cbd208b..3cba88b8661fd09ea5a9c1cd3fa5821f042a6a3f 100644
+index 4ba991b79f13219182df35b4ce0c5cf57cbd208b..bd7a9f299740f861e0ee782563d73a66b972b83e 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -1,5 +1,6 @@
@@ -23,7 +23,7 @@ index 4ba991b79f13219182df35b4ce0c5cf57cbd208b..3cba88b8661fd09ea5a9c1cd3fa5821f
 +     * @return If the type is an armor
 +     */
 +    public boolean isArmor() {
-+        return MaterialTags.HELMETS.isTagged(this) || MaterialTags.CHESTPLATES.isTagged(this) || MaterialTags.LEGGINGS.isTagged(this) || MaterialTags.BOOTS.isTagged(this)
++        return MaterialTags.HELMETS.isTagged(this) || MaterialTags.CHESTPLATES.isTagged(this) || MaterialTags.LEGGINGS.isTagged(this) || MaterialTags.BOOTS.isTagged(this);
 +    }
 +
      /**


### PR DESCRIPTION
# Good evening, good morning!
Oh! Here I am again, also again with a pull request! Today I would like to introduce my newest change: "isArmor()".

# The beginning
I've been working on Minecraft plugin related projects for quite some time now and there's always one thing that caught my eye a bit. What is the best or fastest way to check if a material is an Armor or not? Well, with the MaterialTags this is not a problem anymore, but within the Material class this is not really defined.

# The reason
I noticed a short time ago that Paper added a nice isAir() boolean to the Material class, then it immediately popped into my head that you could also set up the Armor check with isArmor(). That's the reason for this pull request and I hope that this change will be helpful/intuitive for some Paper plugin developers out there!

# The End
Also to you first a thanks that you have looked at my text, and/or also my changes. I hope you stay healthy in this difficult time!

With kind regards
@TheFruxz