### PR TITLE
Add adventure Book and fix team colors

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -1309,14 +1309,73 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..4b20b557eaa958cf1ad1baf8d6cc17f3
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4d786ab41 100644
+index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba87203b7b 100644
 --- a/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-@@ -119,6 +119,63 @@ public interface BookMeta extends ItemMeta {
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
+  * Represents a book ({@link Material#WRITABLE_BOOK} or {@link
+  * Material#WRITTEN_BOOK}) that can have a title, an author, and pages.
+  */
+-public interface BookMeta extends ItemMeta {
++public interface BookMeta extends ItemMeta, net.kyori.adventure.inventory.Book { // Paper
+ 
+     /**
+      * Represents the generation (or level of copying) of a written book
+@@ -119,6 +119,117 @@ public interface BookMeta extends ItemMeta {
       */
      boolean hasPages();
  
 +    // Paper start
++    /**
++     * Gets the title of the book.
++     * <p>
++     * Plugins should check that hasTitle() returns true before calling this
++     * method.
++     *
++     * @return the title of the book
++     */
++    @Nullable
++    @Override
++    net.kyori.adventure.text.Component title();
++
++    /**
++     * Sets the title of the book.
++     * <p>
++     * Limited to 32 characters. Removes title when given null.
++     *
++     * @param title the title to set
++     * @return true if the title was successfully set
++     */
++    @NotNull
++    @Override
++    default BookMeta title(@Nullable net.kyori.adventure.text.Component title) {
++        this.setTitle(title == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
++        return this;
++    }
++
++    /**
++     * Gets the author of the book.
++     * <p>
++     * Plugins should check that hasAuthor() returns true before calling this
++     * method.
++     *
++     * @return the author of the book
++     */
++    @Nullable
++    @Override
++    net.kyori.adventure.text.Component author();
++
++    /**
++     * Sets the author of the book. Removes author when given null.
++     *
++     * @param author the author to set
++     */
++    @NotNull
++    @Override
++    default BookMeta author(@Nullable net.kyori.adventure.text.Component author) {
++        this.setAuthor(author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(author));
++        return this;
++    }
 +    /**
 +     * Gets the specified page in the book. The page must exist.
 +     * <p>
@@ -1342,41 +1401,45 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
 +    void page(int page, @NotNull net.kyori.adventure.text.Component data);
 +
 +    /**
-+     * Gets all the pages in the book.
-+     *
-+     * @return list of all the pages in the book
-+     */
-+    @NotNull List<net.kyori.adventure.text.Component> pages();
-+
-+    /**
-+     * Clears the existing book pages, and sets the book to use the provided
-+     * pages. Maximum 100 pages with 256 characters per page.
-+     *
-+     * @param pages A list of pages to set the book to use
-+     */
-+    void pages(@NotNull List<net.kyori.adventure.text.Component> pages);
-+
-+    /**
-+     * Clears the existing book pages, and sets the book to use the provided
-+     * pages. Maximum 50 pages with 256 characters per page.
-+     *
-+     * @param pages A list of strings, each being a page
-+     */
-+    void pages(@NotNull net.kyori.adventure.text.Component... pages);
-+
-+    /**
 +     * Adds new pages to the end of the book. Up to a maximum of 50 pages with
 +     * 256 characters per page.
 +     *
 +     * @param pages A list of strings, each being a page
 +     */
 +    void addPages(@NotNull net.kyori.adventure.text.Component... pages);
++
++    interface BookMetaBuilder extends Builder {
++
++        @NotNull
++        @Override
++        BookMetaBuilder title(@Nullable net.kyori.adventure.text.Component title);
++
++        @NotNull
++        @Override
++        BookMetaBuilder author(@Nullable net.kyori.adventure.text.Component author);
++
++        @NotNull
++        @Override
++        BookMetaBuilder addPage(@NotNull net.kyori.adventure.text.Component page);
++
++        @NotNull
++        @Override
++        BookMetaBuilder pages(@NotNull net.kyori.adventure.text.Component... pages);
++
++        @NotNull
++        @Override
++        BookMetaBuilder pages(@NotNull java.util.Collection<net.kyori.adventure.text.Component> pages);
++
++        @NotNull
++        @Override
++        BookMeta build();
++    }
 +    // Paper end
 +
      /**
       * Gets the specified page in the book. The given page must exist.
       * <p>
-@@ -126,8 +183,10 @@ public interface BookMeta extends ItemMeta {
+@@ -126,8 +237,10 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to get, in range [1, getPageCount()]
       * @return the page from the book
@@ -1387,7 +1450,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
      String getPage(int page);
  
      /**
-@@ -141,15 +200,19 @@ public interface BookMeta extends ItemMeta {
+@@ -141,15 +254,19 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to set, in range [1, getPageCount()]
       * @param data the data to set for that page
@@ -1407,7 +1470,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
      List<String> getPages();
  
      /**
-@@ -157,7 +220,9 @@ public interface BookMeta extends ItemMeta {
+@@ -157,7 +274,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 100 pages with 256 characters per page.
       *
       * @param pages A list of pages to set the book to use
@@ -1417,7 +1480,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
      void setPages(@NotNull List<String> pages);
  
      /**
-@@ -165,7 +230,9 @@ public interface BookMeta extends ItemMeta {
+@@ -165,7 +284,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 50 pages with 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -1427,7 +1490,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
      void setPages(@NotNull String... pages);
  
      /**
-@@ -173,7 +240,9 @@ public interface BookMeta extends ItemMeta {
+@@ -173,7 +294,9 @@ public interface BookMeta extends ItemMeta {
       * 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -1437,7 +1500,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
      void addPage(@NotNull String... pages);
  
      /**
-@@ -195,8 +264,10 @@ public interface BookMeta extends ItemMeta {
+@@ -195,8 +318,10 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to get
           * @return the page from the book
@@ -1448,7 +1511,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
          public BaseComponent[] getPage(int page) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -210,7 +281,9 @@ public interface BookMeta extends ItemMeta {
+@@ -210,7 +335,9 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to set
           * @param data the data to set for that page
@@ -1458,7 +1521,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
          public void setPage(int page, @Nullable BaseComponent... data) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -219,8 +292,10 @@ public interface BookMeta extends ItemMeta {
+@@ -219,8 +346,10 @@ public interface BookMeta extends ItemMeta {
           * Gets all the pages in the book.
           *
           * @return list of all the pages in the book
@@ -1469,7 +1532,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
          public List<BaseComponent[]> getPages() {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -230,7 +305,9 @@ public interface BookMeta extends ItemMeta {
+@@ -230,7 +359,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of pages to set the book to use
@@ -1479,7 +1542,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
          public void setPages(@NotNull List<BaseComponent[]> pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -240,7 +317,9 @@ public interface BookMeta extends ItemMeta {
+@@ -240,7 +371,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page
@@ -1489,7 +1552,7 @@ index 94852d50e88d0594b84b581cd627174043629995..e143081922c2027e8ca1db6f1e7eb5b4
          public void setPages(@NotNull BaseComponent[]... pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -250,7 +329,9 @@ public interface BookMeta extends ItemMeta {
+@@ -250,7 +383,9 @@ public interface BookMeta extends ItemMeta {
           * with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page
@@ -1885,7 +1948,7 @@ index 4bfaaea78c9b6aa5d392629aa943d26dbe6a7d4a..f09ff32cc3ffc16af379a378b1948991
  
      /**
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index da01d2926cc8a2485a3349ac1ebb32cad20e287c..812b7bfb686437c97884bfdff1be25657e654daf 100644
+index da01d2926cc8a2485a3349ac1ebb32cad20e287c..f0af10a5b9ad048be197ed5ec6c8ed2672eb3dd5 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
 @@ -22,14 +22,95 @@ public interface Team {
@@ -1958,7 +2021,7 @@ index da01d2926cc8a2485a3349ac1ebb32cad20e287c..812b7bfb686437c97884bfdff1be2565
 +     * @return team color, defaults to {@link ChatColor#RESET}
 +     * @throws IllegalStateException if this team has been unregistered
 +     */
-+    @NotNull net.kyori.adventure.text.format.NamedTextColor color() throws IllegalStateException;
++    @NotNull net.kyori.adventure.text.format.TextColor color() throws IllegalStateException;
 +
 +    /**
 +     * Sets the color of the team.

--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -1309,7 +1309,7 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..4b20b557eaa958cf1ad1baf8d6cc17f3
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/meta/BookMeta.java b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
-index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba87203b7b 100644
+index 94852d50e88d0594b84b581cd627174043629995..0cfd4b02cc2095da56b4dc8d4ea4e9b4a95f513c 100644
 --- a/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/BookMeta.java
 @@ -10,7 +10,7 @@ import org.jetbrains.annotations.Nullable;
@@ -1321,7 +1321,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
  
      /**
       * Represents the generation (or level of copying) of a written book
-@@ -119,6 +119,117 @@ public interface BookMeta extends ItemMeta {
+@@ -119,6 +119,111 @@ public interface BookMeta extends ItemMeta {
       */
      boolean hasPages();
  
@@ -1348,10 +1348,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
 +     */
 +    @NotNull
 +    @Override
-+    default BookMeta title(@Nullable net.kyori.adventure.text.Component title) {
-+        this.setTitle(title == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
-+        return this;
-+    }
++    BookMeta title(@Nullable net.kyori.adventure.text.Component title);
 +
 +    /**
 +     * Gets the author of the book.
@@ -1372,10 +1369,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
 +     */
 +    @NotNull
 +    @Override
-+    default BookMeta author(@Nullable net.kyori.adventure.text.Component author) {
-+        this.setAuthor(author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(author));
-+        return this;
-+    }
++    BookMeta author(@Nullable net.kyori.adventure.text.Component author);
 +    /**
 +     * Gets the specified page in the book. The page must exist.
 +     * <p>
@@ -1439,7 +1433,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      /**
       * Gets the specified page in the book. The given page must exist.
       * <p>
-@@ -126,8 +237,10 @@ public interface BookMeta extends ItemMeta {
+@@ -126,8 +231,10 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to get, in range [1, getPageCount()]
       * @return the page from the book
@@ -1450,7 +1444,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      String getPage(int page);
  
      /**
-@@ -141,15 +254,19 @@ public interface BookMeta extends ItemMeta {
+@@ -141,15 +248,19 @@ public interface BookMeta extends ItemMeta {
       *
       * @param page the page number to set, in range [1, getPageCount()]
       * @param data the data to set for that page
@@ -1470,7 +1464,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      List<String> getPages();
  
      /**
-@@ -157,7 +274,9 @@ public interface BookMeta extends ItemMeta {
+@@ -157,7 +268,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 100 pages with 256 characters per page.
       *
       * @param pages A list of pages to set the book to use
@@ -1480,7 +1474,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      void setPages(@NotNull List<String> pages);
  
      /**
-@@ -165,7 +284,9 @@ public interface BookMeta extends ItemMeta {
+@@ -165,7 +278,9 @@ public interface BookMeta extends ItemMeta {
       * pages. Maximum 50 pages with 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -1490,7 +1484,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      void setPages(@NotNull String... pages);
  
      /**
-@@ -173,7 +294,9 @@ public interface BookMeta extends ItemMeta {
+@@ -173,7 +288,9 @@ public interface BookMeta extends ItemMeta {
       * 256 characters per page.
       *
       * @param pages A list of strings, each being a page
@@ -1500,7 +1494,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
      void addPage(@NotNull String... pages);
  
      /**
-@@ -195,8 +318,10 @@ public interface BookMeta extends ItemMeta {
+@@ -195,8 +312,10 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to get
           * @return the page from the book
@@ -1511,7 +1505,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
          public BaseComponent[] getPage(int page) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -210,7 +335,9 @@ public interface BookMeta extends ItemMeta {
+@@ -210,7 +329,9 @@ public interface BookMeta extends ItemMeta {
           *
           * @param page the page number to set
           * @param data the data to set for that page
@@ -1521,7 +1515,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
          public void setPage(int page, @Nullable BaseComponent... data) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -219,8 +346,10 @@ public interface BookMeta extends ItemMeta {
+@@ -219,8 +340,10 @@ public interface BookMeta extends ItemMeta {
           * Gets all the pages in the book.
           *
           * @return list of all the pages in the book
@@ -1532,7 +1526,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
          public List<BaseComponent[]> getPages() {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -230,7 +359,9 @@ public interface BookMeta extends ItemMeta {
+@@ -230,7 +353,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of pages to set the book to use
@@ -1542,7 +1536,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
          public void setPages(@NotNull List<BaseComponent[]> pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -240,7 +371,9 @@ public interface BookMeta extends ItemMeta {
+@@ -240,7 +365,9 @@ public interface BookMeta extends ItemMeta {
           * pages. Maximum 50 pages with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page
@@ -1552,7 +1546,7 @@ index 94852d50e88d0594b84b581cd627174043629995..f4810ebcf1284bbbd67a0c29bc5ae8ba
          public void setPages(@NotNull BaseComponent[]... pages) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -250,7 +383,9 @@ public interface BookMeta extends ItemMeta {
+@@ -250,7 +377,9 @@ public interface BookMeta extends ItemMeta {
           * with 256 characters per page.
           *
           * @param pages A list of component arrays, each being a page

--- a/Spigot-API-Patches/0006-Adventure-Events.patch
+++ b/Spigot-API-Patches/0006-Adventure-Events.patch
@@ -118,7 +118,7 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..1268066e30ddb0cd3792ea4b3de894eb
  
      @Override
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..46fcabf9e48907462f785a2e7ccd9fda8ece8206 100644
+index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..11cc9da9ff23e4c84f203cb0e62a8624bfcf5260 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 @@ -11,26 +11,46 @@ import org.jetbrains.annotations.Nullable;
@@ -215,7 +215,7 @@ index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..46fcabf9e48907462f785a2e7ccd9fda
 +    @Deprecated // Paper
      public String getDeathMessage() {
 -        return deathMessage;
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.deathMessage); // Paper
++        return this.deathMessage == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.deathMessage); // Paper
      }
  
      /**
@@ -351,7 +351,7 @@ index c8384da69af61e1970f254a3a9c206ee81d7a989..992d1025ca02020e87a9ab5db83d2494
  
      /**
 diff --git a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
-index d06684aba7688ce06777dbd837a46856a9d7767f..b69b7509599a0d9a260d30585605c914b8e0d67c 100644
+index d06684aba7688ce06777dbd837a46856a9d7767f..fda3a43f1eac6c660f75a77acb882a9e6753a3f0 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerJoinEvent.java
 @@ -10,30 +10,60 @@ import org.jetbrains.annotations.Nullable;
@@ -402,7 +402,7 @@ index d06684aba7688ce06777dbd837a46856a9d7767f..b69b7509599a0d9a260d30585605c914
 +    @Deprecated // Paper
      public String getJoinMessage() {
 -        return joinMessage;
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.joinMessage); // Paper
++        return this.joinMessage == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.joinMessage); // Paper
      }
  
      /**
@@ -419,7 +419,7 @@ index d06684aba7688ce06777dbd837a46856a9d7767f..b69b7509599a0d9a260d30585605c914
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
-index 14c337f15fc804f52e52cb0a185aad38d89303a8..f50d7182f3b2729ff20dd1903e7b3483b9a5fa9e 100644
+index 14c337f15fc804f52e52cb0a185aad38d89303a8..2b3f57d1a1c79923a2173f52d9cf61da1f75b7fc 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
 @@ -10,35 +10,84 @@ import org.jetbrains.annotations.NotNull;
@@ -452,7 +452,7 @@ index 14c337f15fc804f52e52cb0a185aad38d89303a8..f50d7182f3b2729ff20dd1903e7b3483
 +     *
 +     * @return string kick reason
 +     */
-+    public @org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component leaveMessage() {
++    public @NotNull net.kyori.adventure.text.Component leaveMessage() {
 +        return this.leaveMessage;
 +    }
 +
@@ -461,7 +461,7 @@ index 14c337f15fc804f52e52cb0a185aad38d89303a8..f50d7182f3b2729ff20dd1903e7b3483
 +     *
 +     * @param leaveMessage leave message
 +     */
-+    public void leaveMessage(@org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component leaveMessage) {
++    public void leaveMessage(@NotNull net.kyori.adventure.text.Component leaveMessage) {
 +        this.leaveMessage = leaveMessage;
 +    }
 +
@@ -470,7 +470,7 @@ index 14c337f15fc804f52e52cb0a185aad38d89303a8..f50d7182f3b2729ff20dd1903e7b3483
       *
       * @return string kick reason
       */
-+    public @org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component reason() {
++    public @NotNull net.kyori.adventure.text.Component reason() {
 +        return this.kickReason;
 +    }
 +
@@ -479,7 +479,7 @@ index 14c337f15fc804f52e52cb0a185aad38d89303a8..f50d7182f3b2729ff20dd1903e7b3483
 +     *
 +     * @param kickReason kick reason
 +     */
-+    public void reason(@org.jetbrains.annotations.Nullable net.kyori.adventure.text.Component kickReason) {
++    public void reason(@NotNull net.kyori.adventure.text.Component kickReason) {
 +        this.kickReason = kickReason;
 +    }
 +    // Paper end
@@ -804,7 +804,7 @@ index fb066251f793ec3b41bfc075b9478901b15ee549..6800132c6288b4588fd02b08d26f016c
  
      /**
 diff --git a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
-index d70c25f404e994766a9ebce89a917c8d0719777c..4e6dec550f81c9f4a83a1bd620d9c311bf092b91 100644
+index d70c25f404e994766a9ebce89a917c8d0719777c..9b43bb24055b94328c569f7e0df6bd24c8ebfd2b 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerQuitEvent.java
 @@ -10,30 +10,59 @@ import org.jetbrains.annotations.Nullable;
@@ -854,7 +854,7 @@ index d70c25f404e994766a9ebce89a917c8d0719777c..4e6dec550f81c9f4a83a1bd620d9c311
 +    @Deprecated // Paper
      public String getQuitMessage() {
 -        return quitMessage;
-+        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.quitMessage); // Paper
++        return this.quitMessage == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.quitMessage); // Paper
      }
  
      /**

--- a/Spigot-API-Patches/0056-Add-UnknownCommandEvent.patch
+++ b/Spigot-API-Patches/0056-Add-UnknownCommandEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 diff --git a/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..2ef7233ec9a9306ad88a2a6737730a37f5f6aaeb
+index 0000000000000000000000000000000000000000..b7cb13239bab374336f23fbb9bfc91a12867383e
 --- /dev/null
 +++ b/src/main/java/org/bukkit/event/command/UnknownCommandEvent.java
 @@ -0,0 +1,116 @@
@@ -97,7 +97,7 @@ index 0000000000000000000000000000000000000000..2ef7233ec9a9306ad88a2a6737730a37
 +    @Nullable
 +    @Deprecated
 +    public String getMessage() {
-+        return LegacyComponentSerializer.legacySection().serialize(message);
++        return this.message == null ? null : LegacyComponentSerializer.legacySection().serialize(message);
 +    }
 +
 +
@@ -111,7 +111,7 @@ index 0000000000000000000000000000000000000000..2ef7233ec9a9306ad88a2a6737730a37
 +     */
 +    @Deprecated
 +    public void setMessage(@Nullable String message) {
-+        this.message = LegacyComponentSerializer.legacySection().deserialize(message);
++        this.message = message == null ? null : LegacyComponentSerializer.legacySection().deserialize(message);
 +    }
 +
 +    @NotNull

--- a/Spigot-API-Patches/0064-ProfileWhitelistVerifyEvent.patch
+++ b/Spigot-API-Patches/0064-ProfileWhitelistVerifyEvent.patch
@@ -9,7 +9,7 @@ Allows you to do dynamic whitelisting and change of kick message
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0676ed4f11d04eaa48f1c0bbf7fc8915abf2d6a3
+index 0000000000000000000000000000000000000000..8522d4786471f433cd7a0937b34506cb6c687ce2
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/profile/ProfileWhitelistVerifyEvent.java
 @@ -0,0 +1,147 @@
@@ -100,7 +100,7 @@ index 0000000000000000000000000000000000000000..0676ed4f11d04eaa48f1c0bbf7fc8915
 +    @Nullable
 +    @Deprecated
 +    public String getKickMessage() {
-+        return LegacyComponentSerializer.legacySection().serialize(this.kickMessage);
++        return this.kickMessage == null ? null : LegacyComponentSerializer.legacySection().serialize(this.kickMessage);
 +    }
 +
 +    /**
@@ -109,7 +109,7 @@ index 0000000000000000000000000000000000000000..0676ed4f11d04eaa48f1c0bbf7fc8915
 +     */
 +    @Deprecated
 +    public void setKickMessage(@Nullable String kickMessage) {
-+        this.kickMessage = LegacyComponentSerializer.legacySection().deserialize(kickMessage);
++        this.kickMessage = kickMessage == null ? null : LegacyComponentSerializer.legacySection().deserialize(kickMessage);
 +    }
 +
 +    /**

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2083,7 +2083,7 @@ index 9f6e797d34e5ad21a496c89f5a45ddb0638d3adc..115ee3785b4e0ba6a235bbb31b643aa5
          @Override
          public CraftMerchant getCraftMerchant() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2deaab8e6 100644
+index adc926f25c938fc0ba25586206d7daf89c6b7773..26b3ec8cf6a5413d649d48a52bd219b90c0b6b85 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -1,7 +1,8 @@
@@ -2096,7 +2096,7 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2
  import java.util.ArrayList;
  import java.util.List;
  import java.util.Map;
-@@ -225,6 +226,118 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -225,6 +226,130 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          this.generation = (generation == null) ? null : generation.ordinal();
      }
  
@@ -2107,8 +2107,20 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2
 +    }
 +
 +    @Override
++    public org.bukkit.inventory.meta.BookMeta title(net.kyori.adventure.text.Component title) {
++        this.setTitle(title == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title));
++        return this;
++    }
++
++    @Override
 +    public net.kyori.adventure.text.Component author() {
 +        return this.author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.author);
++    }
++
++    @Override
++    public org.bukkit.inventory.meta.BookMeta author(net.kyori.adventure.text.Component author) {
++        this.setAuthor(author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(author));
++        return this;
 +    }
 +
 +    @Override
@@ -2152,7 +2164,7 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2
 +    @Override
 +    public void addPages(net.kyori.adventure.text.Component... pages) {
 +        for (net.kyori.adventure.text.Component page : pages) {
-+            if (this.pages.size() >= MAX_PAGES && !OVERRIDE_CHECKS) {
++            if (this.pages.size() >= MAX_PAGES) {
 +                return;
 +            }
 +
@@ -2215,7 +2227,7 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2
      @Override
      public String getPage(final int page) {
          Validate.isTrue(isValidPage(page), "Invalid page number");
-@@ -336,7 +449,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -336,7 +461,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      }
  
      @Override

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2083,14 +2083,34 @@ index 9f6e797d34e5ad21a496c89f5a45ddb0638d3adc..115ee3785b4e0ba6a235bbb31b643aa5
          @Override
          public CraftMerchant getCraftMerchant() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index adc926f25c938fc0ba25586206d7daf89c6b7773..9cc2e18e5371dd020303764b97cb2d8635d84df8 100644
+index adc926f25c938fc0ba25586206d7daf89c6b7773..11e40528badd6b769c374c89a0d647f2deaab8e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-@@ -225,6 +225,58 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -1,7 +1,8 @@
+ package org.bukkit.craftbukkit.inventory;
+ 
+ import com.google.common.collect.ImmutableList;
+-import com.google.common.collect.ImmutableMap.Builder;
++import com.google.common.collect.ImmutableMap; // Paper
++import io.papermc.paper.adventure.PaperAdventure; // Paper
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Map;
+@@ -225,6 +226,118 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          this.generation = (generation == null) ? null : generation.ordinal();
      }
  
 +    // Paper start
++    @Override
++    public net.kyori.adventure.text.Component title() {
++        return this.title == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.title);
++    }
++
++    @Override
++    public net.kyori.adventure.text.Component author() {
++        return this.author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(this.author);
++    }
++
 +    @Override
 +    public net.kyori.adventure.text.Component page(final int page) {
 +        Validate.isTrue(isValidPage(page), "Invalid page number");
@@ -2114,17 +2134,19 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..9cc2e18e5371dd020303764b97cb2d86
 +    }
 +
 +    @Override
-+    public void pages(List<net.kyori.adventure.text.Component> pages) {
++    public BookMeta pages(List<net.kyori.adventure.text.Component> pages) {
 +        this.pages.clear();
 +        for (net.kyori.adventure.text.Component page : pages) {
 +            addPages(page);
 +        }
++        return this;
 +    }
 +
 +    @Override
-+    public void pages(net.kyori.adventure.text.Component... pages) {
++    public BookMeta pages(net.kyori.adventure.text.Component... pages) {
 +        this.pages.clear();
 +        addPages(pages);
++        return this;
 +    }
 +
 +    @Override
@@ -2141,10 +2163,88 @@ index adc926f25c938fc0ba25586206d7daf89c6b7773..9cc2e18e5371dd020303764b97cb2d86
 +            this.pages.add(io.papermc.paper.adventure.PaperAdventure.asVanilla(page));
 +        }
 +    }
++
++    private CraftMetaBook(net.kyori.adventure.text.Component title, net.kyori.adventure.text.Component author, List<net.kyori.adventure.text.Component> pages) {
++        super((org.bukkit.craftbukkit.inventory.CraftMetaItem) org.bukkit.Bukkit.getItemFactory().getItemMeta(org.bukkit.Material.WRITABLE_BOOK));
++        this.title = title == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(title);
++        this.author = author == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(author);
++        this.pages = pages.subList(0, Math.min(MAX_PAGES, pages.size())).stream().map(PaperAdventure::asVanilla).collect(java.util.stream.Collectors.toList());
++    }
++
++    static final class CraftMetaBookBuilder implements BookMetaBuilder {
++        private net.kyori.adventure.text.Component title = null;
++        private net.kyori.adventure.text.Component author = null;
++        private final List<net.kyori.adventure.text.Component> pages = new java.util.ArrayList<>();
++
++        @Override
++        public BookMetaBuilder title(net.kyori.adventure.text.Component title) {
++            this.title = title;
++            return this;
++        }
++
++        @Override
++        public BookMetaBuilder author(net.kyori.adventure.text.Component author) {
++            this.author = author;
++            return this;
++        }
++
++        @Override
++        public BookMetaBuilder addPage(net.kyori.adventure.text.Component page) {
++            this.pages.add(page);
++            return this;
++        }
++
++        @Override
++        public BookMetaBuilder pages(net.kyori.adventure.text.Component... pages) {
++            java.util.Collections.addAll(this.pages, pages);
++            return this;
++        }
++
++        @Override
++        public BookMetaBuilder pages(java.util.Collection<net.kyori.adventure.text.Component> pages) {
++            this.pages.addAll(pages);
++            return this;
++        }
++
++        @Override
++        public BookMeta build() {
++            return new CraftMetaBook(title, author, pages);
++        }
++    }
 +    // Paper end
      @Override
      public String getPage(final int page) {
          Validate.isTrue(isValidPage(page), "Invalid page number");
+@@ -336,7 +449,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+     }
+ 
+     @Override
+-    Builder<String, Object> serialize(Builder<String, Object> builder) {
++    ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
+         super.serialize(builder);
+ 
+         if (hasTitle()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+index 0ea7a9606b529ed6b8fa12d4e285e0eaea2fa93d..d8780baa7018617e27e99d00402669588a56a369 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBookSigned.java
+@@ -1,6 +1,6 @@
+ package org.bukkit.craftbukkit.inventory;
+ 
+-import com.google.common.collect.ImmutableMap.Builder;
++import com.google.common.collect.ImmutableMap; // Paper
+ import java.util.Map;
+ import net.minecraft.server.IChatBaseComponent;
+ import net.minecraft.server.IChatBaseComponent.ChatSerializer;
+@@ -118,7 +118,7 @@ class CraftMetaBookSigned extends CraftMetaBook implements BookMeta {
+     }
+ 
+     @Override
+-    Builder<String, Object> serialize(Builder<String, Object> builder) {
++    ImmutableMap.Builder<String, Object> serialize(ImmutableMap.Builder<String, Object> builder) {
+         super.serialize(builder);
+         return builder;
+     }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
 index dec0db24ae611736c99158ba4cb11015ad4b8575..a6873d4237a55b0bbbd13c951c18a8c4f8b445c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
@@ -2401,7 +2501,7 @@ index e3036fe23fa2be100044332c432d1ad5b4872823..d05959c7884d7ba19ff1a507c7d07c52
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
-index 0fba3d2a8d3bd7ec615d137e4625a7f357729d8d..c5aa30cda8e4218a1e77ff2b8f3dcb80ef5cf805 100644
+index 0fba3d2a8d3bd7ec615d137e4625a7f357729d8d..b900aaf66f25e41956e7a4370b887fd4ed530570 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
 @@ -27,6 +27,55 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
@@ -2443,7 +2543,7 @@ index 0fba3d2a8d3bd7ec615d137e4625a7f357729d8d..c5aa30cda8e4218a1e77ff2b8f3dcb80
 +        team.setSuffix(io.papermc.paper.adventure.PaperAdventure.asVanilla(suffix));
 +    }
 +    @Override
-+    public net.kyori.adventure.text.format.NamedTextColor color() throws IllegalStateException {
++    public net.kyori.adventure.text.format.TextColor color() throws IllegalStateException {
 +        CraftScoreboard scoreboard = checkState();
 +        if (team.getColor().getHexValue() == null) throw new IllegalStateException("Team colors must have hex values");
 +        net.kyori.adventure.text.format.TextColor color = net.kyori.adventure.text.format.TextColor.color(team.getColor().getHexValue());

--- a/Spigot-Server-Patches/0144-Add-system-property-to-disable-book-size-limits.patch
+++ b/Spigot-Server-Patches/0144-Add-system-property-to-disable-book-size-limits.patch
@@ -11,7 +11,7 @@ to make books with as much data as they want. Do not use this without
 limiting incoming data from packets in some other way.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index 11e40528badd6b769c374c89a0d647f2deaab8e6..d1e4699b3888fdb22b555a8c36e46615783d195e 100644
+index 26b3ec8cf6a5413d649d48a52bd219b90c0b6b85..fee739c03f8720ae4a21d4404ecab346f67b4255 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -36,6 +36,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
@@ -31,7 +31,16 @@ index 11e40528badd6b769c374c89a0d647f2deaab8e6..d1e4699b3888fdb22b555a8c36e46615
              return false;
          }
  
-@@ -350,7 +351,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -290,7 +291,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+     @Override
+     public void addPages(net.kyori.adventure.text.Component... pages) {
+         for (net.kyori.adventure.text.Component page : pages) {
+-            if (this.pages.size() >= MAX_PAGES) {
++            if (this.pages.size() >= MAX_PAGES && !OVERRIDE_CHECKS) { // Paper - Add override
+                 return;
+             }
+ 
+@@ -362,7 +363,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
              throw new IllegalArgumentException("Invalid page number " + page + "/" + pages.size());
          }
  
@@ -40,7 +49,7 @@ index 11e40528badd6b769c374c89a0d647f2deaab8e6..d1e4699b3888fdb22b555a8c36e46615
          pages.set(page - 1, CraftChatMessage.fromString(newText, true)[0]);
      }
  
-@@ -364,13 +365,13 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -376,13 +377,13 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      @Override
      public void addPage(final String... pages) {
          for (String page : pages) {

--- a/Spigot-Server-Patches/0144-Add-system-property-to-disable-book-size-limits.patch
+++ b/Spigot-Server-Patches/0144-Add-system-property-to-disable-book-size-limits.patch
@@ -11,10 +11,10 @@ to make books with as much data as they want. Do not use this without
 limiting incoming data from packets in some other way.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index 9cc2e18e5371dd020303764b97cb2d8635d84df8..37a7699b9df92b61d96fd2b5d293b10966b806a4 100644
+index 11e40528badd6b769c374c89a0d647f2deaab8e6..d1e4699b3888fdb22b555a8c36e46615783d195e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-@@ -35,6 +35,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -36,6 +36,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      static final int MAX_PAGES = 100;
      static final int MAX_PAGE_LENGTH = 320; // 256 limit + 64 characters to allow for psuedo colour codes
      static final int MAX_TITLE_LENGTH = 32;
@@ -22,7 +22,7 @@ index 9cc2e18e5371dd020303764b97cb2d8635d84df8..37a7699b9df92b61d96fd2b5d293b109
  
      protected String title;
      protected String author;
-@@ -197,7 +198,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -198,7 +199,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          if (title == null) {
              this.title = null;
              return true;
@@ -31,7 +31,7 @@ index 9cc2e18e5371dd020303764b97cb2d8635d84df8..37a7699b9df92b61d96fd2b5d293b109
              return false;
          }
  
-@@ -289,7 +290,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -350,7 +351,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
              throw new IllegalArgumentException("Invalid page number " + page + "/" + pages.size());
          }
  
@@ -40,7 +40,7 @@ index 9cc2e18e5371dd020303764b97cb2d8635d84df8..37a7699b9df92b61d96fd2b5d293b109
          pages.set(page - 1, CraftChatMessage.fromString(newText, true)[0]);
      }
  
-@@ -303,13 +304,13 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -364,13 +365,13 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      @Override
      public void addPage(final String... pages) {
          for (String page : pages) {


### PR DESCRIPTION
Makes BookMeta extend adventure's Book interface, implements methods in CraftMetaBook and implements a builder there as well.

Changes Team#color to return TextColor instead of NamedTextColor.