### PR TITLE
Fix dumpitem command not checking sender

### DIFF
--- a/Spigot-Server-Patches/0511-Paper-dumpitem-command.patch
+++ b/Spigot-Server-Patches/0511-Paper-dumpitem-command.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Paper dumpitem command
 Let's you quickly view the item in your hands NBT data
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f60800c3bc06a38493e17b00b815f18cb87cc8bf..196648e65c6f58c18e19623474d69d780d542689 100644
+index f60800c3bc06a38493e17b00b815f18cb87cc8bf..0abfe19e204d20af0f8dedbeedb0ef98dfe9d3c8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -21,7 +21,9 @@ import org.bukkit.command.CommandSender;
@@ -46,11 +46,15 @@ index f60800c3bc06a38493e17b00b815f18cb87cc8bf..196648e65c6f58c18e19623474d69d78
              case "debug":
                  doDebug(sender, args);
                  break;
-@@ -164,6 +169,19 @@ public class PaperCommand extends Command {
+@@ -164,6 +169,23 @@ public class PaperCommand extends Command {
          return true;
      }
  
 +    private void doDumpItem(CommandSender sender) {
++        if (!(sender instanceof Player)) {
++            sender.sendMessage("Only players can use this command");
++            return;
++        }
 +        ItemStack itemInHand = ((CraftPlayer) sender).getItemInHand();
 +        net.minecraft.server.ItemStack itemStack = CraftItemStack.asNMSCopy(itemInHand);
 +        NBTTagCompound tag = itemStack.getTag();


### PR DESCRIPTION
/paper dumpitem makes a cast to CraftPlayer, we need a instance check before doing that.

Fixes #5024