### PR TITLE
add a call if listener registered helper to event

### DIFF
--- a/Spigot-API-Patches/0023-Add-a-call-helper-to-Event.patch
+++ b/Spigot-API-Patches/0023-Add-a-call-helper-to-Event.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add a call helper to Event
 Reduces diff in Server patches
 
 diff --git a/src/main/java/org/bukkit/event/Event.java b/src/main/java/org/bukkit/event/Event.java
-index 18d0636b749913bfdcea8eebc7d0840d192fb071..8ec56cd6b8e0f5c5dd8c7c88b4671e18dcf109d0 100644
+index 18d0636b749913bfdcea8eebc7d0840d192fb071..79effb45f71e1ce8df2134407a1ad1f44fcaeb50 100644
 --- a/src/main/java/org/bukkit/event/Event.java
 +++ b/src/main/java/org/bukkit/event/Event.java
-@@ -35,6 +35,22 @@ public abstract class Event {
+@@ -35,6 +35,31 @@ public abstract class Event {
          this.async = isAsync;
      }
  
@@ -26,6 +26,15 @@ index 18d0636b749913bfdcea8eebc7d0840d192fb071..8ec56cd6b8e0f5c5dd8c7c88b4671e18
 +        } else {
 +            return true;
 +        }
++    }
++
++    /**
++     * Calls the event if at least one listener is registered and tests if cancelled.
++     *
++     * @return false if event was cancelled, if cancellable. otherwise true.
++     */
++    public boolean callEventIfListenerRegistered() {
++        return getHandlers().getRegisteredListeners().length == 0 || callEvent();
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
I saw the need in some of the pr's where such a simple check took multiple lines of code. This PR follows the same reason why the initial patch was created.

Instead of writing something like this:

```java
if(PlayerChunkUnloadEvent.getHandlerList().getRegisteredListeners().length > 0){
     new PlayerChunkUnloadEvent(this.getBukkitEntity().getWorld().getChunkAt(chunkcoordintpair.longKey), this.getBukkitEntity()).callEvent();
}
```

it will be shortened to this and reduces patch size:

```java
new PlayerChunkUnloadEvent(this.getBukkitEntity().getWorld().getChunkAt(chunkcoordintpair.longKey), this.getBukkitEntity()). callEventIfListenerRegistered();
```

Don't know why this wasn't present before.
