### PR TITLE
Fix villager boat exploit

### DIFF
--- a/Spigot-Server-Patches/0648-Fix-villager-boat-exploit.patch
+++ b/Spigot-Server-Patches/0648-Fix-villager-boat-exploit.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Mon, 11 Jan 2021 12:43:51 -0800
+Subject: [PATCH] Fix villager boat exploit
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index d2a7fa1595ed4bc9fea0238af42f70889e07b262..46e1723f4042d3fef5bc73552d496968a532342c 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -542,6 +542,15 @@ public abstract class PlayerList {
+ 
+                 for (Iterator iterator = entity.getAllPassengers().iterator(); iterator.hasNext(); entity1.dead = true) {
+                     entity1 = (Entity) iterator.next();
++                    // Paper start
++                    if (entity1 instanceof EntityVillagerAbstract) {
++                        final EntityVillagerAbstract villager = (EntityVillagerAbstract) entity1;
++                        final EntityHuman human = villager.getTrader();
++                        if (human != null) {
++                            villager.setTradingPlayer(null);
++                        }
++                    }
++                    // Paper end
+                     worldserver.removeEntity(entity1);
+                 }
+ 


### PR DESCRIPTION
Patches the exploit to bypass villager restock times, demonstrated here: 