### PR TITLE
fixed VehicleEntityCollisionEvent not getting called in every case

### DIFF
--- a/patches/server/0930-fixed-entity-vehicle-collision-event-not-called.patch
+++ b/patches/server/0930-fixed-entity-vehicle-collision-event-not-called.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lukas81298 <lukas81298@gmail.com>
+Date: Tue, 12 Jan 2021 14:41:38 +0100
+Subject: [PATCH] fixed entity vehicle collision event not called
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
+index 3f31a3c17ecca6e93b794478129b95ecff4e1a9c..c71120fe57a76c4638be5dcbda5a756cc2d62ffc 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/AbstractMinecart.java
+@@ -143,7 +143,15 @@ public abstract class AbstractMinecart extends Entity {
+ 
+     @Override
+     public boolean canCollideWith(Entity other) {
+-        return Boat.canVehicleCollide(this, other);
++        // Paper start - fixed VehicleEntityCollisionEvent not called when colliding with player
++        boolean collides = Boat.canVehicleCollide(this, other);
++        if (!collides) {
++            return false;
++        }
++        org.bukkit.event.vehicle.VehicleEntityCollisionEvent collisionEvent = new org.bukkit.event.vehicle.VehicleEntityCollisionEvent((org.bukkit.entity.Vehicle) getBukkitEntity(), other.getBukkitEntity());
++
++        return collisionEvent.callEvent();
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
Fixes #5023.

Minecarts collide with other entities in the world in three different ways:
- when ticking the Minecart (EntityMinecraftAbstract.tick())
- when getCubes() is called
- when moving the Minecart, the relative movement is adjusted by colliding it with all entities in the Minecart's bounding box. This is done in Entity.g(Vec3d). 

Currently, the VehicleEntityCollisionEvent is only called in the 1st case. I've fixed this by calling the event when canCollideWithEntity(Entity) (obfuscated as j(.)) is called. This method is called in IEntityAccess.c(...).