### PR TITLE
Improve zombie villager curing exploit fix

### DIFF
--- a/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
@@ -4,8 +4,8 @@ Date: Tue, 8 Dec 2020 20:14:20 -0600
 Subject: [PATCH] Fix curing zombie villager discount exploit
 
 This fixes the exploit used to gain absurd trading discounts with infecting
-and curing a villager on repeat by simply resetting the reputation when it
-is cured.
+and curing a villager on repeat by simply resetting the relevant part of
+the reputation when it is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index 6262246c4018c660705fbad028f297fc44e7197f..9ebe8771c2d5e843756868824740ef599ca8455f 100644
@@ -22,23 +22,34 @@ index 6262246c4018c660705fbad028f297fc44e7197f..9ebe8771c2d5e843756868824740ef59
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index 0388d1099f2a6d436a5a5e58bbbdae3ddab969e7..9b35c8ad9efe9241fe442bc6ef2e9f62def386d8 100644
+index 0388d1099f2a6d436a5a5e58bbbdae3ddab969e7..de9ea6770b8afc5e1020bef04ac6cca93b6b420c 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -39,7 +39,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
-     @Nullable
-     private EntityHuman bv;
-     private byte bx;
--    private final Reputation by;
-+    private Reputation by; private void resetReputation() { this.by = new Reputation(); } // Paper - OBFHELPER
-     private long bz;
-     private long bA;
-     private int bB;
-@@ -923,6 +923,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -923,6 +923,15 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
      @Override
      public void a(ReputationEvent reputationevent, Entity entity) {
          if (reputationevent == ReputationEvent.a) {
-+            if (world.paperConfig.fixCuringZombieVillagerDiscountExploit) this.resetReputation(); // Paper - fix MC-181190
++            // Paper start - fix MC-181190
++            if (world.paperConfig.fixCuringZombieVillagerDiscountExploit) {
++                final Reputation.a playerReputation = this.getReputation().getReputations().get(entity.getUniqueID());
++                if (playerReputation != null) {
++                    playerReputation.removeReputationForType(ReputationType.MAJOR_POSITIVE);
++                    playerReputation.removeReputationForType(ReputationType.MINOR_POSITIVE);
++                }
++            }
++            // Paper end
              this.by.a(entity.getUniqueID(), ReputationType.MAJOR_POSITIVE, 20);
              this.by.a(entity.getUniqueID(), ReputationType.MINOR_POSITIVE, 25);
          } else if (reputationevent == ReputationEvent.e) {
+diff --git a/src/main/java/net/minecraft/server/Reputation.java b/src/main/java/net/minecraft/server/Reputation.java
+index 7315cf5ee476ed45b4c2a56a723639b264672cb6..9ba1c10d1fda61221db399e0909cda5b0f57bc33 100644
+--- a/src/main/java/net/minecraft/server/Reputation.java
++++ b/src/main/java/net/minecraft/server/Reputation.java
+@@ -221,6 +221,7 @@ public class Reputation {
+ 
+         }
+ 
++        public final void removeReputationForType(ReputationType reputationType) { this.b(reputationType); } // Paper - OBFHELPER
+         public void b(ReputationType reputationtype) {
+             this.a.removeInt(reputationtype);
+         }


### PR DESCRIPTION
Instead of completely resetting a Villager's reputation for all players each time they are cured, we now only reset the relevant part of the reputation for only that player. This means the exploit is fixed and players cannot stack multiple cures until prices are down to 1, but doesn't have the same side effects that are commonly complained about with the current exploit fix.