### PR TITLE
Replace all block states of a specified block

### DIFF
--- a/Spigot-Server-Patches/0363-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0363-Anti-Xray.patch
@@ -110,10 +110,10 @@ index 0000000000000000000000000000000000000000..2bfab782472b0b4f3a9cbb2b51183f28
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bba2dbaf9549690d929f546c2a4a845b03e86130
+index 0000000000000000000000000000000000000000..a6e2e3ac478801c30459a39e020a0f4354f4636b
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
-@@ -0,0 +1,627 @@
+@@ -0,0 +1,632 @@
 +package com.destroystokyo.paper.antixray;
 +
 +import java.util.ArrayList;
@@ -212,7 +212,12 @@ index 0000000000000000000000000000000000000000..bba2dbaf9549690d929f546c2a4a845b
 +
 +            // Don't obfuscate air because air causes unnecessary block updates and causes block updates to fail in the void
 +            if (block != null && !block.getBlockData().isAir()) {
-+                obfuscateGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(block.getBlockData())] = true;
++                // Replace all block states of a specified block
++                // No OBFHELPER for nms.BlockStateList#a() due to too many decompile errors
++                // The OBFHELPER should be getBlockDataList()
++                for (IBlockData blockData : block.getStates().a()) {
++                    obfuscateGlobal[ChunkSection.GLOBAL_PALETTE.getOrCreateIdFor(blockData)] = true;
++                }
 +            }
 +        }
 +


### PR DESCRIPTION
Up to now Anti-Xray did only replace blocks that have the default block state of the specified blocks in hidden-blocks (engine-mode: 1) or hidden-blocks and replacement-blocks (engine-mode: 2). Therefore it wasn't possible to replace for example chests facing south because chest refers to the default block state facing north. Supporting block states in these lists is overkill. Instead this commit makes Anti-Xray to replace all block states of a specified block. However, Anti-Xray will still place the default block states.

(Just an implementations note: Instead of using the `BlockStateList` we could actually do the same as when initializing the `solidGlobal` array a few lines below. Namely looping through all block data integer ids, get the block from the block data and check if the block has to be obfuscated. However, I prefer the current implementation.)