### PR TITLE
Add Gradle Kotlin DSL snippet to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ dependencies {
  * Repository:
 ```kotlin
 repositories {
-    maven(url = "https://papermc.io/repo/repository/maven-public/")
+    maven("https://papermc.io/repo/repository/maven-public/")
 }
 ```
  * Artifact:

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ repositories {
  * Artifact:
 ```kotlin
 dependencies {
-    compileOnly("com.destroystokyo.paper", "paper-api", "1.16.4-R0.1-SNAPSHOT")
+    compileOnly("com.destroystokyo.paper:paper-api:1.16.4-R0.1-SNAPSHOT")
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ How To (Plugin Developers)
 
 **Or alternatively, with Gradle:**
 
+> Groovy DSL
  * Repository:
 ```groovy
 repositories {
@@ -55,6 +56,19 @@ repositories {
 ```groovy
 dependencies {
     compileOnly 'com.destroystokyo.paper:paper-api:1.16.4-R0.1-SNAPSHOT'
+}
+```
+> Kotlin DSL
+ * Repository:
+```kotlin
+repositories {
+    maven(url = "https://papermc.io/repo/repository/maven-public/")
+}
+```
+ * Artifact:
+```kotlin
+dependencies {
+    compileOnly("com.destroystokyo.paper", "paper-api", "1.16.4-R0.1-SNAPSHOT")
 }
 ```
 


### PR DESCRIPTION
I like the gradle Kotlin DSL more than the Groovy DSL. Whenever i wanted to use the paper-api, i had to adapt the groovy snippet for the kotlin DSL. I think it would be better if you had a snippet for both DSLs.