### PR TITLE
Return chat component with empty text instead of throwing exception. …

### DIFF
--- a/Spigot-API-Patches/0261-Return-chat-component-with-empty-text-instead-of-thr.patch
+++ b/Spigot-API-Patches/0261-Return-chat-component-with-empty-text-instead-of-thr.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CDFN <codefun@protonmail.com>
+Date: Tue, 7 Jul 2020 17:53:23 +0200
+Subject: [PATCH] Return chat component with empty text instead of throwing
+ exception
+
+
+diff --git a/src/main/java/org/bukkit/inventory/InventoryView.java b/src/main/java/org/bukkit/inventory/InventoryView.java
+index 14346d83bc99581b18e53d19af03708c0bf22cf7..2d0a12d3f0603ba06db3f3216faa720445a286a7 100644
+--- a/src/main/java/org/bukkit/inventory/InventoryView.java
++++ b/src/main/java/org/bukkit/inventory/InventoryView.java
+@@ -449,7 +449,7 @@ public abstract class InventoryView {
+     /**
+      * Get the title of this inventory window.
+      *
+-     * @return The title.
++     * @return The title or empty string when title is {@code null}. <!-- Paper -->
+      */
+     @NotNull
+     public abstract String getTitle();

--- a/Spigot-Server-Patches/0653-Return-chat-component-with-empty-text-instead-of-thr.patch
+++ b/Spigot-Server-Patches/0653-Return-chat-component-with-empty-text-instead-of-thr.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CDFN <codefun@protonmail.com>
+Date: Tue, 7 Jul 2020 17:53:23 +0200
+Subject: [PATCH] Return chat component with empty text instead of throwing
+ exception
+
+
+diff --git a/src/main/java/net/minecraft/server/Container.java b/src/main/java/net/minecraft/server/Container.java
+index 1eba0ccad798ee0d9e9d573e58a8dcd5363b6ffd..3de58cd344c37451873aa8a12b5d9e65f390ec8f 100644
+--- a/src/main/java/net/minecraft/server/Container.java
++++ b/src/main/java/net/minecraft/server/Container.java
+@@ -45,7 +45,12 @@ public abstract class Container {
+     }
+     private IChatBaseComponent title;
+     public final IChatBaseComponent getTitle() {
+-        Preconditions.checkState(this.title != null, "Title not set");
++        // Paper start - return chat component with empty text instead of throwing error
++        // Preconditions.checkState(this.title != null, "Title not set");
++        if(this.title == null){
++            return new ChatComponentText("");
++        }
++        // Paper end
+         return this.title;
+     }
+     public final void setTitle(IChatBaseComponent title) {


### PR DESCRIPTION
…Fixes #3328

https://github.com/PaperMC/Paper/pull/3843