### PR TITLE
Do not add passengers of entities that were above save limit

### DIFF
--- a/Spigot-Server-Patches/0649-Entity-load-save-limit-per-chunk.patch
+++ b/Spigot-Server-Patches/0649-Entity-load-save-limit-per-chunk.patch
@@ -40,7 +40,7 @@ index c5495e02c3fe271b26f62ea2ec64e07957edf37e..234d2daecc5d0bf6a99c0a5f4a87f947
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/ChunkRegionLoader.java b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
-index 8e7da2c5f3852920ec5fbcdd2bff4d299e6aa499..060ef42bc8f22688071fa375bd4dbab8dd2c1e9e 100644
+index 8e7da2c5f3852920ec5fbcdd2bff4d299e6aa499..f51bf71c8d6eef3c054ac64765709794fcfad5ee 100644
 --- a/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 +++ b/src/main/java/net/minecraft/server/ChunkRegionLoader.java
 @@ -495,11 +495,22 @@ public class ChunkRegionLoader {
@@ -80,7 +80,7 @@ index 8e7da2c5f3852920ec5fbcdd2bff4d299e6aa499..060ef42bc8f22688071fa375bd4dbab8
 +                final int saveLimit = world.paperConfig.entityPerChunkSaveLimits.getOrDefault(entityType, -1);
 +                if (saveLimit > -1) {
 +                    if (loadedEntityCounts.getOrDefault(entityType, 0) >= saveLimit) {
-+                        return entity;
++                        return null;
 +                    }
 +                    loadedEntityCounts.merge(entityType, 1, Integer::sum);
 +                }


### PR DESCRIPTION
Thanks to Spottedleaf for finding and fixing this

https://github.com/Spottedleaf/Tuinity/blob/1d169e7a54186194a67e74df76ed907024f5b859/patches/server/0061-Do-not-add-passengers-of-entities-that-were-were-abo.patch