### PR TITLE
Add BlockPreDispenseEvent

### DIFF
--- a/Spigot-API-Patches/0263-Add-BlockPreDispenseEvent.patch
+++ b/Spigot-API-Patches/0263-Add-BlockPreDispenseEvent.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Sun, 17 Jan 2021 13:15:54 +1000
+Subject: [PATCH] Add BlockPreDispenseEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java b/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..07aad3f4ff60a6a6de69634b0d31926e9c00e77b
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/BlockPreDispenseEvent.java
+@@ -0,0 +1,60 @@
++package io.papermc.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++public class BlockPreDispenseEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled = false;
++    private final ItemStack itemStack;
++    private final int slot;
++
++    public BlockPreDispenseEvent(@NotNull Block block, @NotNull ItemStack itemStack, int slot) {
++        super(block);
++        this.itemStack = itemStack;
++        this.slot = slot;
++    }
++
++    /**
++     * Gets the {@link ItemStack} to be dispensed.
++     *
++     * @return The item to be dispensed
++     */
++    @NotNull
++    public ItemStack getItemStack() {
++        return itemStack;
++    }
++
++    /**
++     * Gets the inventory slot of the dispenser to dispense from.
++     *
++     * @return The inventory slot
++     */
++    public int getSlot() {
++        return slot;
++    }
++
++    @NotNull
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++}

--- a/Spigot-Server-Patches/0656-Implement-BlockPreDispenseEvent.patch
+++ b/Spigot-Server-Patches/0656-Implement-BlockPreDispenseEvent.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Sun, 17 Jan 2021 13:16:09 +1000
+Subject: [PATCH] Implement BlockPreDispenseEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockDispenser.java b/src/main/java/net/minecraft/server/BlockDispenser.java
+index 063453552b7b6c2395c8f9be27cdb71a15a56ca4..89325af931b5ca43729758e94e971b612f65eea2 100644
+--- a/src/main/java/net/minecraft/server/BlockDispenser.java
++++ b/src/main/java/net/minecraft/server/BlockDispenser.java
+@@ -55,6 +55,7 @@ public class BlockDispenser extends BlockTileEntity {
+             IDispenseBehavior idispensebehavior = this.a(itemstack);
+ 
+             if (idispensebehavior != IDispenseBehavior.NONE) {
++                if (!org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockPreDispenseEvent(worldserver, blockposition, itemstack, i)) return; // Paper - BlockPreDispenseEvent is called here
+                 eventFired = false; // CraftBukkit - reset event status
+                 tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
+             }
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 63d329dca12f902e2fb2a62ee4c86aea6453f1a3..696ded96e6018bc5289cc20f72d6dc9395d3b6a6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -13,6 +13,7 @@ import java.util.List;
+ import java.util.Map;
+ import java.util.stream.Collectors;
+ import javax.annotation.Nullable;
++import io.papermc.paper.event.block.BlockPreDispenseEvent;
+ import net.minecraft.server.BlockPosition;
+ import net.minecraft.server.BlockPropertyInstrument;
+ import net.minecraft.server.Container;
+@@ -1770,5 +1771,11 @@ public class CraftEventFactory {
+         BlockFailedDispenseEvent event = new BlockFailedDispenseEvent(block);
+         return event.callEvent();
+     }
++
++    public static boolean handleBlockPreDispenseEvent(WorldServer worldserver, BlockPosition blockposition, ItemStack itemStack, int slot) {
++        org.bukkit.block.Block block = worldserver.getWorld().getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ());
++        BlockPreDispenseEvent event = new BlockPreDispenseEvent(block, org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(itemStack), slot);
++        return event.callEvent();
++    }
+     // Paper end
+ }


### PR DESCRIPTION
This PR adds an event that is called prior to a Dispenser firing anything. This allows full access to the pre-fire state of the dispenser inventory, and therefore clean cancelling of the event.

Main use case here is for plugins that want to either entirely cancel a dispenser event, or want to perform an action based off the contents of the dispenser. Due to the way the normal dispense event works, neither of these are currently possible.

This also allows working around an old Spigot bug, https://hub.spigotmc.org/jira/browse/SPIGOT-4162