### PR TITLE
Inline shift fields in EnumDirection

### DIFF
--- a/Spigot-Server-Patches/0669-Inline-shift-direction-fields.patch
+++ b/Spigot-Server-Patches/0669-Inline-shift-direction-fields.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Mon, 18 Jan 2021 20:45:25 -0500
+Subject: [PATCH] Inline shift direction fields
+
+Removes a layer of indirection for EnumDirection.getAdjacent(X|Y|Z)(), which is in the
+critical section for much of the server, including the lighting engine.
+
+diff --git a/src/main/java/net/minecraft/server/EnumDirection.java b/src/main/java/net/minecraft/server/EnumDirection.java
+index 1aa070db60f5473576fb5d056cadde5106766489..05b0090ae36cf61f67e26aad478df30c89f31941 100644
+--- a/src/main/java/net/minecraft/server/EnumDirection.java
++++ b/src/main/java/net/minecraft/server/EnumDirection.java
+@@ -49,6 +49,11 @@ public enum EnumDirection implements INamable {
+     }, (enumdirection, enumdirection1) -> {
+         throw new IllegalArgumentException("Duplicate keys");
+     }, Long2ObjectOpenHashMap::new));
++    // Paper start
++    private final int adjX;
++    private final int adjY;
++    private final int adjZ;
++    // Paper end
+ 
+     private EnumDirection(int i, int j, int k, String s, EnumDirection.EnumAxisDirection enumdirection_enumaxisdirection, EnumDirection.EnumAxis enumdirection_enumaxis, BaseBlockPosition baseblockposition) {
+         this.g = i;
+@@ -58,6 +63,11 @@ public enum EnumDirection implements INamable {
+         this.k = enumdirection_enumaxis;
+         this.l = enumdirection_enumaxisdirection;
+         this.m = baseblockposition;
++        // Paper start
++        this.adjX = baseblockposition.getX();
++        this.adjY = baseblockposition.getY();
++        this.adjZ = baseblockposition.getZ();
++        // Paper end
+     }
+ 
+     public static EnumDirection[] a(Entity entity) {
+@@ -133,15 +143,15 @@ public enum EnumDirection implements INamable {
+     }
+ 
+     public int getAdjacentX() {
+-        return this.m.getX();
++        return this.adjX; // Paper
+     }
+ 
+     public int getAdjacentY() {
+-        return this.m.getY();
++        return this.adjY; // Paper
+     }
+ 
+     public int getAdjacentZ() {
+-        return this.m.getZ();
++        return this.adjZ; // Paper
+     }
+ 
+     public String m() {


### PR DESCRIPTION
Removes a layer of indirection for `EnumDirection.getAdjacent(X|Y|Z)()`, which is in the critical section for much of the server, including the lighting engine. This is a small optimization but it does add up.