### PR TITLE
Allow adding items to BlockDropItemEvent

### DIFF
--- a/Spigot-API-Patches/0271-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/Spigot-API-Patches/0271-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Wed, 20 Jan 2021 14:25:26 -0600
+Subject: [PATCH] Allow adding items to BlockDropItemEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java b/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java
+index a0f6f1af304190b4c5db4b284d460f625eeb7801..3dd4bd38e72c04e74e5787fb38ca9abd10bad06b 100644
+--- a/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java
++++ b/src/main/java/org/bukkit/event/block/BlockDropItemEvent.java
+@@ -64,7 +64,7 @@ public class BlockDropItemEvent extends BlockEvent implements Cancellable {
+      * Gets list of the Item drops caused by the block break.
+      *
+      * This list is mutable - removing an item from it will cause it to not
+-     * drop. It is not legal however to add new items to the list.
++     * drop. Adding to the list is allowed.
+      *
+      * @return The Item the block caused to drop
+      */

--- a/Spigot-Server-Patches/0671-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/Spigot-Server-Patches/0671-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Wed, 20 Jan 2021 14:23:37 -0600
+Subject: [PATCH] Allow adding items to BlockDropItemEvent
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index c9e2d2f0eb1f4075da2b5fa05198de4940ebf354..b66fb60ad3949cebb3ff10878b7490675e703234 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -380,13 +380,30 @@ public class CraftEventFactory {
+     }
+ 
+     public static void handleBlockDropItemEvent(Block block, BlockState state, EntityPlayer player, List<EntityItem> items) {
+-        BlockDropItemEvent event = new BlockDropItemEvent(block, state, player.getBukkitEntity(), Lists.transform(items, (item) -> (org.bukkit.entity.Item) item.getBukkitEntity()));
++        // Paper start
++        List<Item> list = new ArrayList<>();
++        for (EntityItem item : items) {
++            list.add((Item) item.getBukkitEntity());
++        }
++        BlockDropItemEvent event = new BlockDropItemEvent(block, state, player.getBukkitEntity(), list);
++        // Paper end
+         Bukkit.getPluginManager().callEvent(event);
+ 
+         if (!event.isCancelled()) {
+-            for (EntityItem item : items) {
+-                item.world.addEntity(item);
++            // Paper start
++            for (Item bukkit : list) {
++                if (!bukkit.isValid()) {
++                    Entity item = ((org.bukkit.craftbukkit.entity.CraftItem) bukkit).getHandle();
++                    item.world.addEntity(item);
++                }
++            }
++        } else {
++            for (Item bukkit : list) {
++                if (bukkit.isValid()) {
++                    bukkit.remove();
++                }
+             }
++            // Paper end
+         }
+     }
+ 


### PR DESCRIPTION
Seemed like a pointless restriction to not allow this to begin with.