### PR TITLE
Workaround for visually missing health on join

### DIFF
--- a/Spigot-Server-Patches/0662-Workaround-for-visually-missing-health-on-join.patch
+++ b/Spigot-Server-Patches/0662-Workaround-for-visually-missing-health-on-join.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Fri, 22 Jan 2021 06:36:37 +0000
+Subject: [PATCH] Workaround for visually missing health on join
+
+
+diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
+index 1eb44877e7384ae0a028a12b832684126b8d50ec..17379a863d6cdadbbd7f44ec109719017029b643 100644
+--- a/src/main/java/net/minecraft/server/PlayerList.java
++++ b/src/main/java/net/minecraft/server/PlayerList.java
+@@ -393,6 +393,7 @@ public abstract class PlayerList {
+         if (this.collideRuleTeamName != null && collideRuleTeam != null && entityplayer.getScoreboardTeam() == null) {
+             scoreboard.addPlayerToTeam(entityplayer.getName(), collideRuleTeam);
+         }
++        entityplayer.getBukkitEntity().updateScaledHealth(); // Paper - Fix SPIGOT-6250
+         // Paper end
+         // CraftBukkit - Moved from above, added world
+         PlayerList.LOGGER.info("{}[{}] logged in with entity id {} at ([{}]{}, {}, {})", entityplayer.getDisplayName().getString(), s1, entityplayer.getId(), worldserver1.worldDataServer.getName(), entityplayer.locX(), entityplayer.locY(), entityplayer.locZ());

--- a/Spigot-Server-Patches/0662-Workaround-for-visually-missing-health-on-join.patch
+++ b/Spigot-Server-Patches/0662-Workaround-for-visually-missing-health-on-join.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+From: Doc <nachito94@msn.com>
 Date: Fri, 22 Jan 2021 06:36:37 +0000
 Subject: [PATCH] Workaround for visually missing health on join
 


### PR DESCRIPTION
Force updates the player's health after they join

Fixes #4793 and [SPIGOT-6250](https://hub.spigotmc.org/jira/browse/SPIGOT-6250)
Before: https://i.imgur.com/z16npIM.mp4
After: https://i.imgur.com/b5RBlnN.mp4