### PR TITLE
Reset shield blocking on dimension change

### DIFF
--- a/Spigot-Server-Patches/0665-Reset-shield-blocking-on-dimension-change.patch
+++ b/Spigot-Server-Patches/0665-Reset-shield-blocking-on-dimension-change.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yive <admin@yive.me>
+Date: Sun, 24 Jan 2021 08:55:19 -0800
+Subject: [PATCH] Reset shield blocking on dimension change
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
+index 04d505c7a19775d0353c10424a84a1ce8885dc2c..baa82134d1f56a4d370db3012207e0f2b2fcd9ed 100644
+--- a/src/main/java/net/minecraft/server/EntityPlayer.java
++++ b/src/main/java/net/minecraft/server/EntityPlayer.java
+@@ -989,6 +989,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+                 this.world.getServer().getPluginManager().callEvent(changeEvent);
+                 // CraftBukkit end
+             }
++            // Paper start
++            if (this.isBlocking()) {
++                this.clearActiveItem();
++            }
++            // Paper end
+ 
+             return this;
+         }


### PR DESCRIPTION
Fixes a bug that allows players to be infinitely blocking after dimension change (IE through a nether portal) along with allowing them to sprint during said period.