### PR TITLE
Added option to disable pathfinding updates on block updates

### DIFF
--- a/Spigot-Server-Patches/0669-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/Spigot-Server-Patches/0669-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lukas81298 <lukas81298@gommehd.net>
+Date: Mon, 25 Jan 2021 14:37:57 +0100
+Subject: [PATCH] added option to disable pathfinding updates on block changes
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index ac96011d4e104c99bb37833d91b8121f03b9d349..0776e68340b0510cc99084bea80791d562dfea40 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -799,4 +799,9 @@ public class PaperWorldConfig {
+     private void enderDragonsDeathAlwaysPlacesDragonEgg() {
+         enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
+     }
++
++    public boolean updatePathfindingOnBlockUpdate = true;
++    private void setUpdatePathfindingOnBlockUpdate() {
++        updatePathfindingOnBlockUpdate = getBoolean("update-pathfinding-on-block-update", this.updatePathfindingOnBlockUpdate);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
+index fdf6380bb95fd5d82842f69411ba440b520f82ca..2b94c195db43d8e7fd58301a33377e87daa16e98 100644
+--- a/src/main/java/net/minecraft/server/WorldServer.java
++++ b/src/main/java/net/minecraft/server/WorldServer.java
+@@ -1571,6 +1571,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+     @Override
+     public void notify(BlockPosition blockposition, IBlockData iblockdata, IBlockData iblockdata1, int i) {
+         this.getChunkProvider().flagDirty(blockposition);
++        if(this.paperConfig.updatePathfindingOnBlockUpdate) { // Paper - option to disable pathfinding updates
+         VoxelShape voxelshape = iblockdata.getCollisionShape(this, blockposition);
+         VoxelShape voxelshape1 = iblockdata1.getCollisionShape(this, blockposition);
+ 
+@@ -1588,6 +1589,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {
+ 
+             this.tickingEntities = wasTicking; // Paper
+         }
++        } // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
When a block in a world is changed, the pathfinding of all entities in a specific range is updated to prevent mobs from entering dead ends while navigating to a specific position (i.e. a path on the track is removed or changed and the entity is no langer able to take the path). For this purpose, each entity is checked if it is in a specific range and if this is the case, the pathfinding is re-computed. When there are lots of entities in the world, this leads to a significant performance problem, especially when having automated farms. This is reflected in lots of different timings entries.

This PR adds an option to disable the automatic pathfinding update for specific worlds. So far, no one on my server realized that the behavior changed at all. Mobs still won't enter unsafe places (e.g. jump from a edge).
I actually think that there is semantic issue with the vanilla code, at least the computation of 

` Vec3D vec3d = new Vec3D(((double) pathpoint.a + this.a.locX()) / 2.0D, ((double) pathpoint.b + this.a.locY()) / 2.0D, ((double) pathpoint.c + this.a.locZ()) / 2.0D);` in NavigationAbstract.b(BlockPosition) 

does not make any sense to me. The distance between this vector and the position vector of the modified block is computed. However it would make a lot more sense to compute something like (pathpoint.a + entity.widthX /2,  pathpoint.b + entity.height, pathpoint.c/2 + entity.widthZ/2). So I assume that this feature does not work as expected in vanilla and that there is no particular reason for not disabling this function. Correct me if I'm wrong.

Disabling this function lead to a major performance improvement. In my case: 5 tps to 12 tps

