### PR TITLE
Make discovered maps config work in treasure maps from loot tables too

### DIFF
--- a/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
+++ b/Spigot-Server-Patches/0127-Configurable-Cartographer-Treasure-Maps.patch
@@ -28,13 +28,14 @@ index e83216be5a00d5b927d8c2fc364551bd3077c974..2dc58b9f769ea43b737804456aafab47
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
-index 37ebc9f511479778c131e02b6852b27f63e75bdd..6000c7c2fc68427dea343115183b8faacc985514 100644
+index 37ebc9f511479778c131e02b6852b27f63e75bdd..d071d66fd1215e158130d592ce62165a1f3738f9 100644
 --- a/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
 +++ b/src/main/java/net/minecraft/server/LootItemFunctionExplorationMap.java
-@@ -48,6 +48,15 @@ public class LootItemFunctionExplorationMap extends LootItemFunctionConditional
+@@ -48,7 +48,16 @@ public class LootItemFunctionExplorationMap extends LootItemFunctionConditional
  
              if (vec3d != null) {
                  WorldServer worldserver = loottableinfo.getWorld();
+-                BlockPosition blockposition = worldserver.a(this.e, new BlockPosition(vec3d), this.h, this.i);
 +                // Paper start
 +                if (!worldserver.paperConfig.enableTreasureMaps) {
 +                    /*
@@ -44,9 +45,10 @@ index 37ebc9f511479778c131e02b6852b27f63e75bdd..6000c7c2fc68427dea343115183b8faa
 +                    return itemstack;
 +                }
 +                // Paper end
-                 BlockPosition blockposition = worldserver.a(this.e, new BlockPosition(vec3d), this.h, this.i);
++                BlockPosition blockposition = worldserver.a(this.e, new BlockPosition(vec3d), this.h, !worldserver.paperConfig.treasureMapsAlreadyDiscovered && this.i); // Paper
  
                  if (blockposition != null) {
+                     ItemStack itemstack1 = ItemWorldMap.createFilledMapView(worldserver, blockposition.getX(), blockposition.getZ(), this.g, true, true);
 diff --git a/src/main/java/net/minecraft/server/VillagerTrades.java b/src/main/java/net/minecraft/server/VillagerTrades.java
 index 4f7944d7fdaf02bae40ee71a18bd1c9bb4eb891b..49f9ae86512ad679aaa71992de2284e024591101 100644
 --- a/src/main/java/net/minecraft/server/VillagerTrades.java


### PR DESCRIPTION
This changes applies the `treasure-maps-return-already-discovered` config option to treasure maps generated by loot tables too (e.g. in hidden treasure chests).

If the option is disabled (which is default) it will allow both to work depending on the loot table setup, if the option is enabled then it will force it to also take discovered chunks into consideration ignoring the loot table option.