### PR TITLE
Add getMainThreadExecutor to BukkitScheduler

### DIFF
--- a/Spigot-API-Patches/0272-Add-getMainThreadExecutor-to-BukkitScheduler.patch
+++ b/Spigot-API-Patches/0272-Add-getMainThreadExecutor-to-BukkitScheduler.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aleksander Jagiello <themolkapl@gmail.com>
+Date: Sun, 24 Jan 2021 22:17:29 +0100
+Subject: [PATCH] Add getMainThreadExecutor to BukkitScheduler
+
+
+diff --git a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+index ac140fc2c638e22e06b2920db3e376ab9e8c3733..f5e3bfd22d4d38182065b5215e5f78d9bb13381e 100644
+--- a/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
++++ b/src/main/java/org/bukkit/scheduler/BukkitScheduler.java
+@@ -458,4 +458,15 @@ public interface BukkitScheduler {
+     @Deprecated
+     @NotNull
+     public BukkitTask runTaskTimerAsynchronously(@NotNull Plugin plugin, @NotNull BukkitRunnable task, long delay, long period) throws IllegalArgumentException;
++
++    // Paper start - add getMainThreadExecutor
++    /**
++     * Returns an executor that will run tasks on the next server tick.
++     *
++     * @param plugin the reference to the plugin scheduling tasks
++     * @return an executor associated with the given plugin
++     */
++    @NotNull
++    public java.util.concurrent.Executor getMainThreadExecutor(@NotNull Plugin plugin);
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0672-Add-getMainThreadExecutor-to-BukkitScheduler.patch
+++ b/Spigot-Server-Patches/0672-Add-getMainThreadExecutor-to-BukkitScheduler.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Aleksander Jagiello <themolkapl@gmail.com>
+Date: Sun, 24 Jan 2021 22:17:54 +0100
+Subject: [PATCH] Add getMainThreadExecutor to BukkitScheduler
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+index 13e461ffb2ee2e7d0440c0f60809ea99629b843c..0be39dac4b9dd69d7d73d86d64cf1e33e4086e81 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
++++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
+@@ -635,4 +635,15 @@ public class CraftScheduler implements BukkitScheduler {
+     public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException {
+         throw new UnsupportedOperationException("Use BukkitRunnable#runTaskTimerAsynchronously(Plugin, long, long)");
+     }
++
++    // Paper start - add getMainThreadExecutor
++    @Override
++    public Executor getMainThreadExecutor(Plugin plugin) {
++        Validate.notNull(plugin, "Plugin cannot be null");
++        return command -> {
++            Validate.notNull(command, "Command cannot be null");
++            this.runTask(plugin, command);
++        };
++    }
++    // Paper end
+ }


### PR DESCRIPTION
This is useful in eg. CompletableFuture.

https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/CompletableFuture.html#thenAcceptAsync-java.util.function.Consumer-java.util.concurrent.Executor-