### PR TITLE
[Meta] Exempt more labels from being marked as stale

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -2,6 +2,10 @@ daysUntilStale: 60
 daysUntilClose: 7
 exemptLabels:
   - "status: accepted"
+  - "type: bug"
+  - "status: blocked"
+  - "future"
+  - "we must go deeper"
 staleLabel: "resolution: stale"
 markComment: >
   This issue has been automatically marked as stale because it has not had

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,11 +1,12 @@
 daysUntilStale: 60
 daysUntilClose: 7
 exemptLabels:
-  - "status: accepted"
+  - "for: future"
   - "type: bug"
+  - "status: accepted"
   - "status: blocked"
-  - "future"
-  - "we must go deeper"
+  - "status: in progress"
+  - "status: rebase required"
 staleLabel: "resolution: stale"
 markComment: >
   This issue has been automatically marked as stale because it has not had


### PR DESCRIPTION
In my opinion stale bot is marking too many issues as stale as time to go through all of them and mark them as accepted seems to not be there. While I get that you want to keep stale bot to be easier to filter out actual stale issues I don't agree with creating more work for both devs and reporters by having the stale bot (wrongly) mark issues that have already be touched by devs/triage members.

The easiest (and cleanest) solution in my eyes is to simply exempt more of the labels that have been commonly used  to mark issues and which (imo) clearly mean that the issue will stay open indefinitely.

Even if this doesn't get accepted as is, maybe it could serve as a discussion place about the stale bot behaviour that is less spamy than Discord and actual focused on all developers/contributors.