### PR TITLE
Add ElderGuardianAppearanceEvent

### DIFF
--- a/Spigot-API-Patches/0269-Add-ElderGuardianAppearanceEvent.patch
+++ b/Spigot-API-Patches/0269-Add-ElderGuardianAppearanceEvent.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Mon, 1 Feb 2021 20:32:30 -0500
+Subject: [PATCH] Add ElderGuardianAppearanceEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..484fbe642227697f208c382715f0931153225549
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
+@@ -0,0 +1,63 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.ElderGuardian;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++
++import java.util.Collections;
++import java.util.List;
++
++/**
++ * Is called when an {@link org.bukkit.entity.ElderGuardian} appears in front of a {@link org.bukkit.entity.Player}.
++ */
++public class ElderGuardianAppearanceEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++    private final List<Player> affectedPlayers;
++
++    public ElderGuardianAppearanceEvent(@NotNull Entity what, List<Player> affectedPlayers) {
++        super(what);
++        this.affectedPlayers = affectedPlayers;
++    }
++
++    /**
++     * Get an immutable list of players affected by the guardian appearance.
++     *
++     * @return Players affected by the appearance
++     */
++    @NotNull
++    public List<Player> getAffectedPlayers() {
++        return Collections.unmodifiableList(affectedPlayers);
++    }
++
++    /**
++     * The elder guardian playing the effect.
++     *
++     * @return The elder guardian
++     */
++    @NotNull
++    public ElderGuardian getEntity() {
++        return (ElderGuardian) entity;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++}

--- a/Spigot-API-Patches/0269-Add-ElderGuardianAppearanceEvent.patch
+++ b/Spigot-API-Patches/0269-Add-ElderGuardianAppearanceEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add ElderGuardianAppearanceEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..484fbe642227697f208c382715f0931153225549
+index 0000000000000000000000000000000000000000..d2475dfd04cef2ee6b5407ddfdef374dc2537d72
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/ElderGuardianAppearanceEvent.java
 @@ -0,0 +1,63 @@
@@ -32,7 +32,7 @@ index 0000000000000000000000000000000000000000..484fbe642227697f208c382715f09311
 +    private boolean cancelled;
 +    private final List<Player> affectedPlayers;
 +
-+    public ElderGuardianAppearanceEvent(@NotNull Entity what, List<Player> affectedPlayers) {
++    public ElderGuardianAppearanceEvent(@NotNull Entity what, @NotNull List<Player> affectedPlayers) {
 +        super(what);
 +        this.affectedPlayers = affectedPlayers;
 +    }

--- a/Spigot-Server-Patches/0667-Add-ElderGuardianAppearanceEvent.patch
+++ b/Spigot-Server-Patches/0667-Add-ElderGuardianAppearanceEvent.patch
@@ -5,39 +5,29 @@ Subject: [PATCH] Add ElderGuardianAppearanceEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityGuardianElder.java b/src/main/java/net/minecraft/server/EntityGuardianElder.java
-index b691e844953bcc2853a806a3bbf9cb7338e98266..6c094da81b86bc491d28622907e5edaecd73de0a 100644
+index b691e844953bcc2853a806a3bbf9cb7338e98266..d37c235900f90593aa6086f3b1f1d0f85bcf2336 100644
 --- a/src/main/java/net/minecraft/server/EntityGuardianElder.java
 +++ b/src/main/java/net/minecraft/server/EntityGuardianElder.java
-@@ -58,16 +58,21 @@ public class EntityGuardianElder extends EntityGuardian {
+@@ -58,6 +58,8 @@ public class EntityGuardianElder extends EntityGuardian {
              boolean flag1 = true;
              boolean flag2 = true;
              boolean flag3 = true;
--            Iterator iterator = list.iterator();
- 
--            while (iterator.hasNext()) {
--                EntityPlayer entityplayer = (EntityPlayer) iterator.next();
 +            // Paper start
 +            if (org.bukkit.craftbukkit.event.CraftEventFactory.handleGuardianAppearanceEvent(this, list)) {
-+                Iterator iterator = list.iterator();
+             Iterator iterator = list.iterator();
  
--                if (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < 2 || entityplayer.getEffect(mobeffectlist).getDuration() < 1200) {
--                    entityplayer.playerConnection.sendPacket(new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.k, this.isSilent() ? 0.0F : 1.0F));
--                    entityplayer.addEffect(new MobEffect(mobeffectlist, 6000, 2), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
-+                while (iterator.hasNext()) {
-+                    EntityPlayer entityplayer = (EntityPlayer) iterator.next();
-+
-+                    if (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < 2 || entityplayer.getEffect(mobeffectlist).getDuration() < 1200) {
-+                        entityplayer.playerConnection.sendPacket(new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.k, this.isSilent() ? 0.0F : 1.0F));
-+                        entityplayer.addEffect(new MobEffect(mobeffectlist, 6000, 2), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
-+                    }
+             while (iterator.hasNext()) {
+@@ -68,6 +70,8 @@ public class EntityGuardianElder extends EntityGuardian {
+                     entityplayer.addEffect(new MobEffect(mobeffectlist, 6000, 2), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
                  }
              }
++            }
 +            // Paper end
          }
  
          if (!this.ez()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 696ded96e6018bc5289cc20f72d6dc9395d3b6a6..ea803d6b27dec0ab6d96e6ad08071ee15c95ce13 100644
+index 696ded96e6018bc5289cc20f72d6dc9395d3b6a6..a4f8c9282aeff22d8480696a67d55ddab2c33528 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -14,6 +14,7 @@ import java.util.Map;

--- a/Spigot-Server-Patches/0667-Add-ElderGuardianAppearanceEvent.patch
+++ b/Spigot-Server-Patches/0667-Add-ElderGuardianAppearanceEvent.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Mon, 1 Feb 2021 20:32:19 -0500
+Subject: [PATCH] Add ElderGuardianAppearanceEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/EntityGuardianElder.java b/src/main/java/net/minecraft/server/EntityGuardianElder.java
+index b691e844953bcc2853a806a3bbf9cb7338e98266..6c094da81b86bc491d28622907e5edaecd73de0a 100644
+--- a/src/main/java/net/minecraft/server/EntityGuardianElder.java
++++ b/src/main/java/net/minecraft/server/EntityGuardianElder.java
+@@ -58,16 +58,21 @@ public class EntityGuardianElder extends EntityGuardian {
+             boolean flag1 = true;
+             boolean flag2 = true;
+             boolean flag3 = true;
+-            Iterator iterator = list.iterator();
+ 
+-            while (iterator.hasNext()) {
+-                EntityPlayer entityplayer = (EntityPlayer) iterator.next();
++            // Paper start
++            if (org.bukkit.craftbukkit.event.CraftEventFactory.handleGuardianAppearanceEvent(this, list)) {
++                Iterator iterator = list.iterator();
+ 
+-                if (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < 2 || entityplayer.getEffect(mobeffectlist).getDuration() < 1200) {
+-                    entityplayer.playerConnection.sendPacket(new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.k, this.isSilent() ? 0.0F : 1.0F));
+-                    entityplayer.addEffect(new MobEffect(mobeffectlist, 6000, 2), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
++                while (iterator.hasNext()) {
++                    EntityPlayer entityplayer = (EntityPlayer) iterator.next();
++
++                    if (!entityplayer.hasEffect(mobeffectlist) || entityplayer.getEffect(mobeffectlist).getAmplifier() < 2 || entityplayer.getEffect(mobeffectlist).getDuration() < 1200) {
++                        entityplayer.playerConnection.sendPacket(new PacketPlayOutGameStateChange(PacketPlayOutGameStateChange.k, this.isSilent() ? 0.0F : 1.0F));
++                        entityplayer.addEffect(new MobEffect(mobeffectlist, 6000, 2), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit
++                    }
+                 }
+             }
++            // Paper end
+         }
+ 
+         if (!this.ez()) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index 696ded96e6018bc5289cc20f72d6dc9395d3b6a6..ea803d6b27dec0ab6d96e6ad08071ee15c95ce13 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -14,6 +14,7 @@ import java.util.Map;
+ import java.util.stream.Collectors;
+ import javax.annotation.Nullable;
+ import io.papermc.paper.event.block.BlockPreDispenseEvent;
++import io.papermc.paper.event.entity.ElderGuardianAppearanceEvent;
+ import net.minecraft.server.BlockPosition;
+ import net.minecraft.server.BlockPropertyInstrument;
+ import net.minecraft.server.Container;
+@@ -1778,4 +1779,16 @@ public class CraftEventFactory {
+         return event.callEvent();
+     }
+     // Paper end
++
++    // Paper start - ElderGuardianAppearanceEvent
++    public static boolean handleGuardianAppearanceEvent(Entity entity, List<EntityPlayer> players) {
++        List<Player> craftPlayers = new ArrayList<>();
++        for (EntityPlayer player : players) {
++            craftPlayers.add(player.getBukkitEntity());
++        }
++
++        ElderGuardianAppearanceEvent event = new ElderGuardianAppearanceEvent(entity.getBukkitEntity(), craftPlayers);
++        return event.callEvent();
++    }
++    // Paper end
+ }


### PR DESCRIPTION
This adds an ElderGuardianAppearanceEvent which allows you to cancel the effects of an elder guardian appearance and get the players that were affected.