### PR TITLE
stop firing pressure plate EntityInteractEvent for ignored entities (fixes #4962)

### DIFF
--- a/Spigot-Server-Patches/0685-stop-firing-pressure-plate-EntityInteractEvent-for-i.patch
+++ b/Spigot-Server-Patches/0685-stop-firing-pressure-plate-EntityInteractEvent-for-i.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trigary <trigary0@gmail.com>
+Date: Tue, 2 Feb 2021 09:17:59 +0100
+Subject: [PATCH] stop firing pressure plate EntityInteractEvent for ignored
+ entities
+
+
+diff --git a/src/main/java/net/minecraft/server/BlockPressurePlateBinary.java b/src/main/java/net/minecraft/server/BlockPressurePlateBinary.java
+index ef79fbb628c4eaffe9d34de6129d6e833aac7c76..2e1dbd4786f77a8822d039206000799b927ff24c 100644
+--- a/src/main/java/net/minecraft/server/BlockPressurePlateBinary.java
++++ b/src/main/java/net/minecraft/server/BlockPressurePlateBinary.java
+@@ -67,6 +67,7 @@ public class BlockPressurePlateBinary extends BlockPressurePlateAbstract {
+ 
+             while (iterator.hasNext()) {
+                 Entity entity = (Entity) iterator.next();
++                if (entity.isIgnoreBlockTrigger()) continue; // Paper - don't call event for ignored entities
+ 
+                 // CraftBukkit start - Call interact event when turning on a pressure plate
+                 if (this.getPower(world.getType(blockposition)) == 0) {


### PR DESCRIPTION
This only affects bats at the moment.

You can't see it in the patch, but the value of `Entity#isIgnoreBlockTrigger()`  is checked after the events have been fired.

Basically, this is how stuff worked before and after Bukkit events were added to the method:
```
for each entity:
//Added by Bukkit: fire PlayerInteractEvent or EntityInteractEvent
//Added by Bukkit: if event not cancelled
if not isIgnoreBlockTrigger
return full power
```

Fixes #4962 