### PR TITLE
fix enderman universal anger

### DIFF
--- a/patches/server/0749-fix-enderman-universal-anger.patch
+++ b/patches/server/0749-fix-enderman-universal-anger.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trigary <trigary0@gmail.com>
+Date: Fri, 20 Aug 2021 15:08:56 +0200
+Subject: [PATCH] fix enderman universal anger
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
+index e1e220b3e4967590a2a77370e2a6ab919ad50eaa..ab21911f243200476431f7f80a159720c87e9084 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
++++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
+@@ -95,8 +95,11 @@ public class EnderMan extends Monster implements NeutralMob {
+         this.goalSelector.addGoal(11, new EnderMan.EndermanTakeBlockGoal(this));
+         this.targetSelector.addGoal(1, new EnderMan.EndermanLookForPlayerGoal(this, this::isAngryAt));
+         this.targetSelector.addGoal(2, new HurtByTargetGoal(this, new Class[0]));
+-        this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Endermite.class, true, false));
+-        this.targetSelector.addGoal(4, new ResetUniversalAngerTargetGoal<>(this, false));
++        // Paper start - fix enderman universal anger
++        this.targetSelector.addGoal(3, new NearestAttackableTargetGoal<>(this, Player.class, 10, true, false, this::isAngryAt));
++        this.targetSelector.addGoal(4, new NearestAttackableTargetGoal<>(this, Endermite.class, true, false));
++        this.targetSelector.addGoal(5, new ResetUniversalAngerTargetGoal<>(this, false));
++        // Paper stop - fix enderman universal anger
+     }
+ 
+     public static AttributeSupplier.Builder createAttributes() {


### PR DESCRIPTION
Other entities that had a `PathfinderGoalUniversalAngerReset` also had a `PathfinderGoalNearestAttackableTarget`, so I added it. I did a lot of testing, it seems to work. It's definitely better than not being attacked at all, hopefully it doesn't break something else.

I changed the priority on the selectors. That's all I changed about them. The extra diff is a shame, let me know if there's a better way. :/

Fixes #5155. Oh GitHub, why isn't it enough if I have it in the title?