### PR TITLE
Fix NPE for AIR in meta operations in ItemStack

### DIFF
--- a/Spigot-API-Patches/0113-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/Spigot-API-Patches/0113-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8cd9a5aa7 100644
+index cc065602db56c51b87d273a52d9ef82439fcaa7a..db701a709d5fa2d5a6a96846e0ce2342350fb897 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -2,7 +2,9 @@ package org.bukkit.inventory;
@@ -18,7 +18,7 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
  import org.apache.commons.lang.Validate;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
-@@ -635,5 +637,140 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -635,5 +637,152 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }
@@ -110,6 +110,9 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
 +     */
 +    public void setLore(@Nullable List<String> lore) {
 +        ItemMeta itemMeta = getItemMeta();
++        if (itemMeta == null) {
++            throw new IllegalStateException("Cannot set lore on " + getType());
++        }
 +        itemMeta.setLore(lore);
 +        setItemMeta(itemMeta);
 +    }
@@ -121,6 +124,9 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
 +     */
 +    public void addItemFlags(@NotNull ItemFlag... itemFlags) {
 +        ItemMeta itemMeta = getItemMeta();
++        if (itemMeta == null) {
++            throw new IllegalStateException("Cannot add flags on " + getType());
++        }
 +        itemMeta.addItemFlags(itemFlags);
 +        setItemMeta(itemMeta);
 +    }
@@ -132,6 +138,9 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
 +     */
 +    public void removeItemFlags(@NotNull ItemFlag... itemFlags) {
 +        ItemMeta itemMeta = getItemMeta();
++        if (itemMeta == null) {
++            throw new IllegalStateException("Cannot remove flags on " + getType());
++        }
 +        itemMeta.removeItemFlags(itemFlags);
 +        setItemMeta(itemMeta);
 +    }
@@ -144,6 +153,9 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
 +    @NotNull
 +    public Set<ItemFlag> getItemFlags() {
 +        ItemMeta itemMeta = getItemMeta();
++        if (itemMeta == null) {
++            return java.util.Collections.emptySet();
++        }
 +        return itemMeta.getItemFlags();
 +    }
 +
@@ -155,7 +167,7 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..41db4fdbf25d7a2a7b6db373cf2eecc8
 +     */
 +    public boolean hasItemFlag(@NotNull ItemFlag flag) {
 +        ItemMeta itemMeta = getItemMeta();
-+        return itemMeta.hasItemFlag(flag);
++        return itemMeta != null && itemMeta.hasItemFlag(flag);
 +    }
      // Paper end
  }


### PR DESCRIPTION
They will throw `NullPointerException` when the type of `ItemStack` is `Material.AIR`.