### PR TITLE
fix calling setSize on dead slimes causing invincibility (fixes #5137)

### DIFF
--- a/Spigot-Server-Patches/0673-fix-dead-slime-setSize-invincibility.patch
+++ b/Spigot-Server-Patches/0673-fix-dead-slime-setSize-invincibility.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trigary <trigary0@gmail.com>
+Date: Fri, 5 Feb 2021 22:12:13 +0100
+Subject: [PATCH] fix dead slime setSize invincibility
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+index 6e9f1b66dfc12491c945f87c51e81aa02424e885..ac28923df49e7ac8c69665454c806dac5186c48c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSlime.java
+@@ -18,7 +18,7 @@ public class CraftSlime extends CraftMob implements Slime {
+ 
+     @Override
+     public void setSize(int size) {
+-        getHandle().setSize(size, true);
++        getHandle().setSize(size, /* true */ getHandle().isAlive()); // Paper - fix dead slime setSize invincibility
+     }
+ 
+     @Override


### PR DESCRIPTION
Changed the `CraftSlime` class instead of the `EntitySlime` class to minimize the problems this patch could cause. Tested and everything seems to work :)

Again, just for you GitHub: fixes #5137.