### PR TITLE
Fix NotePlayEvent

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -295,3 +295,6 @@ public net.minecraft.world.entity.item.ItemEntity health
 
 # Fix riding distance statistics
 public net.minecraft.world.entity.player.Player checkRidingStatistics(DDD)V
+
+# Fix NotePlayEvent
+public org.bukkit.craftbukkit.block.data.CraftBlockData toNMS(Ljava/lang/Enum;Ljava/lang/Class;)Ljava/lang/Enum;

--- a/patches/api/0359-Fix-NotePlayEvent.patch
+++ b/patches/api/0359-Fix-NotePlayEvent.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kieran Wallbanks <kieran.wallbanks@gmail.com>
+Date: Mon, 21 Jun 2021 12:33:45 +0100
+Subject: [PATCH] Fix NotePlayEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/block/NotePlayEvent.java b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
+index a3887067d1b65fb100ac1407a43c455f5d215510..676b31f6f38d4e85cd4bd16ccf42cbc39a5d8423 100644
+--- a/src/main/java/org/bukkit/event/block/NotePlayEvent.java
++++ b/src/main/java/org/bukkit/event/block/NotePlayEvent.java
+@@ -58,9 +58,7 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
+      * Overrides the {@link Instrument} to be used.
+      *
+      * @param instrument the Instrument. Has no effect if null.
+-     * @deprecated no effect on newer Minecraft versions
+      */
+-    @Deprecated
+     public void setInstrument(@NotNull Instrument instrument) {
+         if (instrument != null) {
+             this.instrument = instrument;
+@@ -71,9 +69,7 @@ public class NotePlayEvent extends BlockEvent implements Cancellable {
+      * Overrides the {@link Note} to be played.
+      *
+      * @param note the Note. Has no effect if null.
+-     * @deprecated no effect on newer Minecraft versions
+      */
+-    @Deprecated
+     public void setNote(@NotNull Note note) {
+         if (note != null) {
+             this.note = note;

--- a/patches/server/0855-Fix-NotePlayEvent.patch
+++ b/patches/server/0855-Fix-NotePlayEvent.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kieran Wallbanks <kieran.wallbanks@gmail.com>
+Date: Mon, 21 Jun 2021 14:23:50 +0100
+Subject: [PATCH] Fix NotePlayEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/NoteBlock.java b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
+index 16e11e31077f160198e0b04abdfeabb97ed20c6f..0e106bcc1f882877a5e444a2621466c6e4696d42 100644
+--- a/src/main/java/net/minecraft/world/level/block/NoteBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/NoteBlock.java
+@@ -60,10 +60,9 @@ public class NoteBlock extends Block {
+     private void playNote(Level world, BlockPos blockposition, BlockState data) { // CraftBukkit
+         if (world.getBlockState(blockposition.above()).isAir()) {
+             // CraftBukkit start
+-            org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, blockposition, data.getValue(NoteBlock.INSTRUMENT), data.getValue(NoteBlock.NOTE));
+-            if (!event.isCancelled()) {
++            // Paper start - move NotePlayEvent call to fix instrument/note changes
+                 world.blockEvent(blockposition, this, 0, 0);
+-            }
++            // Paper end
+             // CraftBukkit end
+         }
+ 
+@@ -92,10 +91,14 @@ public class NoteBlock extends Block {
+ 
+     @Override
+     public boolean triggerEvent(BlockState state, Level world, BlockPos pos, int type, int data) {
+-        int k = (Integer) state.getValue(NoteBlock.NOTE);
++        // Paper start - move NotePlayEvent call to fix instrument/note changes
++        org.bukkit.event.block.NotePlayEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callNotePlayEvent(world, pos, state.getValue(INSTRUMENT), state.getValue(NOTE));
++        if (event.isCancelled()) return false;
++        int k = event.getNote().getId();
+         float f = (float) Math.pow(2.0D, (double) (k - 12) / 12.0D);
+ 
+-        world.playSound((Player) null, pos, ((NoteBlockInstrument) state.getValue(NoteBlock.INSTRUMENT)).getSoundEvent(), SoundSource.RECORDS, 3.0F, f);
++        world.playSound(null, pos, org.bukkit.craftbukkit.block.data.CraftBlockData.toNMS(event.getInstrument(), NoteBlockInstrument.class).getSoundEvent(), SoundSource.RECORDS, 3.0F, f);
++        // Paper end
+         world.addParticle(ParticleTypes.NOTE, (double) pos.getX() + 0.5D, (double) pos.getY() + 1.2D, (double) pos.getZ() + 0.5D, (double) k / 24.0D, 0.0D, 0.0D);
+         return true;
+     }


### PR DESCRIPTION
This PR fixes the `NotePlayEvent` to allow the `setInstrument` and `setNote` methods to work again, thus removing the deprecation from these events. This works for all methods of activating noteblocks, both player interaction and redstone activation.

I've also added a new method to the `Instrument` class, `getName`. This method returns the name of the instrument as they differ from the enum values in the API and is used to get the specific note to play in the `CraftNoteBlock` class. This feels a bit messy, and I think that the `getName` bit should either be deprecated or swapped with the classic static map instantiation thing to also add a `getByName` method.

But regardless, this is a good place to start so let me know if you want any changes made!

Here's a plugin to test it btw, it just locks all notes played to lower C flute:
- [noteblock-changes-test-1.0-SNAPSHOT.jar](https://www.mediafire.com/file/glu1tdegbqz4vs2/noteblock-changes-test-1.0-SNAPSHOT.jar/file)
- [Source](https://gist.github.com/kezz/39547324d631638f692eff781cc7bcac)