### PR TITLE
Merchant#getRecipes should return an immutable list

### DIFF
--- a/Spigot-Server-Patches/0674-Merchant-getRecipes-should-return-an-immutable-list.patch
+++ b/Spigot-Server-Patches/0674-Merchant-getRecipes-should-return-an-immutable-list.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Wed, 10 Feb 2021 14:53:36 -0800
+Subject: [PATCH] Merchant#getRecipes should return an immutable list
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchant.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchant.java
+index 50bc720d4268804f53b204091c9e8f0c17d8dd23..7159d73ac5c3ef881d9635d64e82847ac3731e22 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchant.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMerchant.java
+@@ -25,7 +25,7 @@ public class CraftMerchant implements Merchant {
+ 
+     @Override
+     public List<MerchantRecipe> getRecipes() {
+-        return Collections.unmodifiableList(Lists.transform(merchant.getOffers(), new Function<net.minecraft.server.MerchantRecipe, MerchantRecipe>() {
++        return com.google.common.collect.ImmutableList.copyOf(Lists.transform(merchant.getOffers(), new Function<net.minecraft.server.MerchantRecipe, MerchantRecipe>() { // Paper - javadoc says 'an immutable list of trades' - not 'an unmodifiable view of a list of trades'. fixes issue with setRecipes(getRecipes())
+             @Override
+             public MerchantRecipe apply(net.minecraft.server.MerchantRecipe recipe) {
+                 return recipe.asBukkit();


### PR DESCRIPTION
This fixes a confusing issue (#5181) where doing `merchant.setRecipes(merchant.getRecipes());` would clear the merchants recipes, as the implementation of getRecipes is guavas Lists.transform wrapped in Collections.unmodifiableList, and the implementation of setRecipes clears the backing list before adding the elements of the provided list to the backing list.

Also, the javadoc for the getRecipes method says 'an immutable list of trades', so this patch makes the javadoc correct.