### PR TITLE
Prevent grindstones from overstacking items fixes #5196

### DIFF
--- a/Spigot-Server-Patches/0689-Prevent-grindstones-from-overstacking-items.patch
+++ b/Spigot-Server-Patches/0689-Prevent-grindstones-from-overstacking-items.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
+Date: Tue, 16 Feb 2021 21:37:51 -0600
+Subject: [PATCH] Prevent grindstones from overstacking items
+
+
+diff --git a/src/main/java/net/minecraft/server/ContainerGrindstone.java b/src/main/java/net/minecraft/server/ContainerGrindstone.java
+index 39f809a37b58e008e7ef32c0759eeecbde26bc94..34e98efa04e545047e7b844c098c18b89442bd40 100644
+--- a/src/main/java/net/minecraft/server/ContainerGrindstone.java
++++ b/src/main/java/net/minecraft/server/ContainerGrindstone.java
+@@ -183,13 +183,13 @@ public class ContainerGrindstone extends Container {
+                 i = Math.max(item.getMaxDurability() - l, 0);
+                 itemstack2 = this.b(itemstack, itemstack1);
+                 if (!itemstack2.e()) {
+-                    if (!ItemStack.matches(itemstack, itemstack1)) {
++                    if (!ItemStack.matches(itemstack, itemstack1) || itemstack2.getMaxStackSize() == 1) { // Paper - add max stack size check
+                         this.resultInventory.setItem(0, ItemStack.b);
+                         this.c();
+                         return;
+                     }
+ 
+-                    b0 = 2;
++                    b0 = 2; // Paper - the problem line for above change, causing over-stacking
+                 }
+             } else {
+                 boolean flag3 = !itemstack.isEmpty();


### PR DESCRIPTION
Just out of view of the patch is the line
`b0 = 2;`
which sets the result quantity to two without checking whether that is possible. This explains why my fix only specifically checks for max stack sizes of 1.

Overstacked items are specifically not supported by the server and can result in item loss when the items are not handled carefully. Specifically there exists an 'issue' with shulker chests that they will destack overstacked items and simply delete items which do not fit.