### PR TITLE
Misc thread dumps

### DIFF
--- a/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..d5e5c6153675855bb8798b11d905b5f2
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ccf2d0b090f0c360dfc7886bb0726e099acec42c..94d41605df60fc7e87f28c723d4b0319d35fa0ff 100644
+index ccf2d0b090f0c360dfc7886bb0726e099acec42c..e658ce4dce7a687cc6ea6d46378b831ca50c291e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -15,6 +15,7 @@ import io.netty.buffer.ByteBuf;
@@ -36,14 +36,31 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..94d41605df60fc7e87f28c723d4b0319
  import it.unimi.dsi.fastutil.longs.LongIterator;
  import java.awt.image.BufferedImage;
  import java.io.BufferedWriter;
-@@ -859,6 +860,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
-         this.safeShutdown(flag, false);
-     }
+@@ -731,6 +732,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+     // CraftBukkit start
+     private boolean hasStopped = false;
+     public volatile boolean hasFullyShutdown = false; // Paper
++    private boolean hasLoggedStop = false; // Paper
+     private final Object stopLock = new Object();
+     public final boolean hasStopped() {
+         synchronized (stopLock) {
+@@ -745,6 +747,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+             if (hasStopped) return;
+             hasStopped = true;
+         }
++        if (!hasLoggedStop && isDebugging()) TraceUtil.dumpTraceForThread(this.getThread(), "Server stopped"); // Paper
+         // Paper start - kill main thread, and kill it hard
+         shutdownThread = Thread.currentThread();
+         org.spigotmc.WatchdogThread.doStop(); // Paper
+@@ -861,6 +864,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public void safeShutdown(boolean flag, boolean isRestarting) {
-+        if (isDebugging()) TraceUtil.dumpTraceForThread(this.getThread(), "Server stopped"); // Paper
          this.isRunning = false;
          this.isRestarting = isRestarting;
++        this.hasLoggedStop = true;
++        if (isDebugging()) TraceUtil.dumpTraceForThread(this.getThread(), "Server stopped"); // Paper
          if (flag) {
+             try {
+                 this.serverThread.join();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index 85023c68a9c85802383cfcf52ec21392abdf3d85..ea1c47ff81d88e1b8d003b66e992727b943b7186 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java

--- a/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
@@ -25,7 +25,7 @@ index 0000000000000000000000000000000000000000..d5e5c6153675855bb8798b11d905b5f2
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ccf2d0b090f0c360dfc7886bb0726e099acec42c..e658ce4dce7a687cc6ea6d46378b831ca50c291e 100644
+index ccf2d0b090f0c360dfc7886bb0726e099acec42c..ccac3589820f244f36dac310d08091f218d5935e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -15,6 +15,7 @@ import io.netty.buffer.ByteBuf;
@@ -56,7 +56,7 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..e658ce4dce7a687cc6ea6d46378b831c
      public void safeShutdown(boolean flag, boolean isRestarting) {
          this.isRunning = false;
          this.isRestarting = isRestarting;
-+        this.hasLoggedStop = true;
++        this.hasLoggedStop = true; // Paper
 +        if (isDebugging()) TraceUtil.dumpTraceForThread(this.getThread(), "Server stopped"); // Paper
          if (flag) {
              try {

--- a/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0675-misc-debugging-dumps.patch
@@ -1,0 +1,66 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Thu, 18 Feb 2021 20:23:28 +0000
+Subject: [PATCH] misc debugging dumps
+
+
+diff --git a/src/main/java/io/papermc/paper/util/TraceUtil.java b/src/main/java/io/papermc/paper/util/TraceUtil.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..d5e5c6153675855bb8798b11d905b5f2d6ea158e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/util/TraceUtil.java
+@@ -0,0 +1,14 @@
++package io.papermc.paper.util;
++
++import org.bukkit.Bukkit;
++
++public final class TraceUtil {
++
++    public static void dumpTraceForThread(Thread thread, String reason) {
++        Bukkit.getLogger().warning(thread.getName() + ": " + reason);
++        StackTraceElement[] trace = thread.getStackTrace();
++        for (StackTraceElement traceElement : trace) {
++            Bukkit.getLogger().warning("\tat " + traceElement);
++        }
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index ccf2d0b090f0c360dfc7886bb0726e099acec42c..94d41605df60fc7e87f28c723d4b0319d35fa0ff 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -15,6 +15,7 @@ import io.netty.buffer.ByteBuf;
+ import io.netty.buffer.ByteBufOutputStream;
+ import io.netty.buffer.Unpooled;
+ import io.papermc.paper.event.entity.EntityMoveEvent;
++import io.papermc.paper.util.TraceUtil;
+ import it.unimi.dsi.fastutil.longs.LongIterator;
+ import java.awt.image.BufferedImage;
+ import java.io.BufferedWriter;
+@@ -859,6 +860,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         this.safeShutdown(flag, false);
+     }
+     public void safeShutdown(boolean flag, boolean isRestarting) {
++        if (isDebugging()) TraceUtil.dumpTraceForThread(this.getThread(), "Server stopped"); // Paper
+         this.isRunning = false;
+         this.isRestarting = isRestarting;
+         if (flag) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 85023c68a9c85802383cfcf52ec21392abdf3d85..ea1c47ff81d88e1b8d003b66e992727b943b7186 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
+ import io.netty.buffer.ByteBuf;
+ import io.netty.buffer.ByteBufOutputStream;
+ import io.netty.buffer.Unpooled;
++import io.papermc.paper.util.TraceUtil;
+ import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
+ import java.awt.image.BufferedImage;
+ import java.io.File;
+@@ -938,6 +939,7 @@ public final class CraftServer implements Server {
+                 plugin.getDescription().getName(),
+                 "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
+             ));
++            if (console.isDebugging()) TraceUtil.dumpTraceForThread(worker.getThread(), "still running"); // Paper
+         }
+         loadPlugins();
+         enablePlugins(PluginLoadOrder.STARTUP);


### PR DESCRIPTION
Adds dumps when the server is in debug mode for one or two maybe more
random situations where having dumps for the odd thing here and there
would be useful for a handful of people but too spammy/useless for
most

"mek stuff pretty" is not my forte, and not sure if other areas are wanted for this type of thing, just two specific ones which I've used personally in the past week and a common "nice to have" for paper-help; if others are wanted, or prettiness applied, somebody feel free too *face keyboards and uses it as a pillow*