### PR TITLE
Call PreCreatureSpawnEvent for more spawn reasons

### DIFF
--- a/Spigot-Server-Patches/0185-PreCreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0185-PreCreatureSpawnEvent.patch
@@ -14,6 +14,57 @@ instead and save a lot of server resources.
 
 See: https://github.com/PaperMC/Paper/issues/917
 
+diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
+index b1fe488e41a2c9f77df091e1d14ed5c87a4358c8..14f47d100c3f44a8263c9b907e9ca74944676687 100644
+--- a/src/main/java/net/minecraft/server/EntityTypes.java
++++ b/src/main/java/net/minecraft/server/EntityTypes.java
+@@ -187,6 +187,20 @@ public class EntityTypes<T extends Entity> {
+ 
+     @Nullable
+     public T spawnCreature(WorldServer worldserver, @Nullable NBTTagCompound nbttagcompound, @Nullable IChatBaseComponent ichatbasecomponent, @Nullable EntityHuman entityhuman, BlockPosition blockposition, EnumMobSpawn enummobspawn, boolean flag, boolean flag1, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason spawnReason) {
++        // Paper start - Call PreCreatureSpawnEvent
++        org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(EntityTypes.getName(this).getKey());
++        if (type != null) {
++            com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
++            event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                MCUtil.toLocation(worldserver, blockposition),
++                type,
++                spawnReason
++            );
++            if (!event.callEvent()) {
++                return null;
++            }
++        }
++        // Paper end
+         T t0 = this.createCreature(worldserver, nbttagcompound, ichatbasecomponent, entityhuman, blockposition, enummobspawn, flag, flag1);
+ 
+         if (t0 != null) {
+diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
+index 732323ee1de01929c73bc5f98444c0f68f908a67..b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971 100644
+--- a/src/main/java/net/minecraft/server/EntityVillager.java
++++ b/src/main/java/net/minecraft/server/EntityVillager.java
+@@ -868,6 +868,21 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+             BlockPosition blockposition1 = this.a(blockposition, d0, d1);
+ 
+             if (blockposition1 != null) {
++                // Paper start - Call PreCreatureSpawnEvent
++                com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent event;
++                event = new com.destroystokyo.paper.event.entity.PreCreatureSpawnEvent(
++                    MCUtil.toLocation(world, blockposition1),
++                    org.bukkit.entity.EntityType.IRON_GOLEM,
++                    org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.VILLAGE_DEFENSE
++                );
++                if (!event.callEvent()) {
++                    if (event.shouldAbortSpawn()) {
++                        SensorGolemLastSeen.b(this); // Set Golem Last Seen to stop it from spawning another one
++                        return null;
++                    }
++                    break;
++                }
++                // Paper end
+                 EntityIronGolem entityirongolem = (EntityIronGolem) EntityTypes.IRON_GOLEM.createCreature(worldserver, (NBTTagCompound) null, (IChatBaseComponent) null, (EntityHuman) null, blockposition1, EnumMobSpawn.MOB_SUMMONED, false, false);
+ 
+                 if (entityirongolem != null) {
 diff --git a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java b/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
 index 34ab03fce7ab5c7702234590ffc9ca7fec72a86a..2827026ba4bdd857f231028393726d6c95610072 100644
 --- a/src/main/java/net/minecraft/server/MobSpawnerAbstract.java
@@ -46,6 +97,27 @@ index 34ab03fce7ab5c7702234590ffc9ca7fec72a86a..2827026ba4bdd857f231028393726d6c
                              Entity entity = EntityTypes.a(nbttagcompound, world, (entity1) -> {
                                  entity1.setPositionRotation(d3, d4, d5, entity1.yaw, entity1.pitch);
                                  return entity1;
+diff --git a/src/main/java/net/minecraft/server/SensorGolemLastSeen.java b/src/main/java/net/minecraft/server/SensorGolemLastSeen.java
+index 008932fafece5a62541b94444d56ab717c4d103f..f8727f7b3f146ae023c64ace4919d150c31a1ac3 100644
+--- a/src/main/java/net/minecraft/server/SensorGolemLastSeen.java
++++ b/src/main/java/net/minecraft/server/SensorGolemLastSeen.java
+@@ -29,7 +29,7 @@ public class SensorGolemLastSeen extends Sensor<EntityLiving> {
+         Optional<List<EntityLiving>> optional = entityliving.getBehaviorController().getMemory(MemoryModuleType.MOBS);
+ 
+         if (optional.isPresent()) {
+-            boolean flag = ((List) optional.get()).stream().anyMatch((entityliving1) -> {
++            boolean flag = optional.get().stream().anyMatch((entityliving1) -> { // Paper - decompile fixes
+                 return entityliving1.getEntityType().equals(EntityTypes.IRON_GOLEM);
+             });
+ 
+@@ -40,6 +40,7 @@ public class SensorGolemLastSeen extends Sensor<EntityLiving> {
+         }
+     }
+ 
++    public static void setDetectedRecently(EntityLiving entityLiving) { b(entityLiving); } // Paper - OBFHELPER
+     public static void b(EntityLiving entityliving) {
+         entityliving.getBehaviorController().a(MemoryModuleType.GOLEM_DETECTED_RECENTLY, true, 600L);
+     }
 diff --git a/src/main/java/net/minecraft/server/SpawnerCreature.java b/src/main/java/net/minecraft/server/SpawnerCreature.java
 index 137ee1b453b80e96c1a8fa3271f6350f9294cafb..0ecdfd45073235b7b01e84f4490f17088c4ee675 100644
 --- a/src/main/java/net/minecraft/server/SpawnerCreature.java

--- a/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0374-implement-optional-per-player-mob-spawns.patch
@@ -605,10 +605,10 @@ index d34cbba632c8847fe40cf68acf4ec204cde8c2bc..e14875420dda139799ceabdddde4ade9
          return this.cj;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index b1fe488e41a2c9f77df091e1d14ed5c87a4358c8..788540ab2b090e9625d35e20d495733ab8f54331 100644
+index 14f47d100c3f44a8263c9b907e9ca74944676687..c49e7ec418eedac45182de67cb673839dc7e27c2 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
-@@ -281,6 +281,7 @@ public class EntityTypes<T extends Entity> {
+@@ -295,6 +295,7 @@ public class EntityTypes<T extends Entity> {
          return this.bl;
      }
  

--- a/Spigot-Server-Patches/0470-Add-villager-reputation-API.patch
+++ b/Spigot-Server-Patches/0470-Add-villager-reputation-API.patch
@@ -20,10 +20,10 @@ index 0000000000000000000000000000000000000000..0f10c333d88f2e1c56a6c7f22d421084
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index a5426eabb4c2458213f54ea66edc06714aa30c1f..039d5cc20a6de46b0812b428e2f6526905ece2bf 100644
+index 1322a8f12484700c3d707b3d18ad90c059703530..eaa84fde9cfa8e2d31e7f85b976393d576545670 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -947,6 +947,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -962,6 +962,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
          this.bD = 0;
      }
  

--- a/Spigot-Server-Patches/0565-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-Server-Patches/0565-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -18,7 +18,7 @@ index a45ceff9ff970b996b2767379a2ecd4693f52d3a..4b4f14711d483089a5d5478b57539911
          if (this.name == null) {
              this.name = SystemUtils.a("block", IRegistry.BLOCK.getKey(this));
 diff --git a/src/main/java/net/minecraft/server/EntityTypes.java b/src/main/java/net/minecraft/server/EntityTypes.java
-index 788540ab2b090e9625d35e20d495733ab8f54331..bf914dc5ee7f2d4a324b6711ea273f5581ec84ad 100644
+index c49e7ec418eedac45182de67cb673839dc7e27c2..93b5a6471cde31739d2bd5f2a9fc0e0d974d0eb0 100644
 --- a/src/main/java/net/minecraft/server/EntityTypes.java
 +++ b/src/main/java/net/minecraft/server/EntityTypes.java
 @@ -147,6 +147,7 @@ public class EntityTypes<T extends Entity> {
@@ -29,7 +29,7 @@ index 788540ab2b090e9625d35e20d495733ab8f54331..bf914dc5ee7f2d4a324b6711ea273f55
      public static Optional<EntityTypes<?>> a(String s) {
          return IRegistry.ENTITY_TYPE.getOptional(MinecraftKey.a(s));
      }
-@@ -286,6 +287,7 @@ public class EntityTypes<T extends Entity> {
+@@ -300,6 +301,7 @@ public class EntityTypes<T extends Entity> {
          return this.bg;
      }
  

--- a/Spigot-Server-Patches/0612-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0612-Fix-curing-zombie-villager-discount-exploit.patch
@@ -22,10 +22,10 @@ index 6262246c4018c660705fbad028f297fc44e7197f..9ebe8771c2d5e843756868824740ef59
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index 0388d1099f2a6d436a5a5e58bbbdae3ddab969e7..de9ea6770b8afc5e1020bef04ac6cca93b6b420c 100644
+index b343ce9df323ebd95d387b35025d8970ae733c44..c8b7ab17d53c302698fa7f9850c18e474832a585 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -923,6 +923,15 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -938,6 +938,15 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
      @Override
      public void a(ReputationEvent reputationevent, Entity entity) {
          if (reputationevent == ReputationEvent.a) {


### PR DESCRIPTION
This makes it so that the PreCreatureSpawnEvent gets called for more spawn reasons, especially Iron Golems from afraid Villagers and Zombified Piglin portal spawns as well as any other cases where the EntityTypes#spawnCreature method is used. (spawn eggs, wandering trader/llama, fish buckets, infested stones, dispensers)