### PR TITLE
Skip POI finding when stuck inside a vehicle

### DIFF
--- a/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
+++ b/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
@@ -5,23 +5,22 @@ Subject: [PATCH] Skip POI finding if stuck in vehicle
 
 
 diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-index 63a761ebef80d4af09cdc2682e496d78492c4a3a..b1cd9d9f263f1525138c35ab818c6cd8117ae57d 100644
+index 63a761ebef80d4af09cdc2682e496d78492c4a3a..86349bea3ddb931ed56da7b02b611b45b5aa1a1d 100644
 --- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 +++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-@@ -45,6 +45,12 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -45,6 +45,11 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
      }
  
      protected boolean a(WorldServer worldserver, EntityCreature entitycreature) {
 +        // Paper start - don't calculate POI if they're trapped in a vehicle
-+        Entity vehicle = entitycreature.getVehicle();
-+        if (vehicle instanceof EntityBoat || vehicle instanceof EntityMinecartRideable) {
++        if (entitycreature.getVehicle() != null) {
 +            return false;
 +        }
 +        // Paper end
          if (this.d && entitycreature.isBaby()) {
              return false;
          } else if (this.f == 0L) {
-@@ -84,7 +90,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -84,7 +89,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
                  villageplace.a(this.b.c(), (blockposition1) -> {
                      return blockposition1.equals(blockposition);
                  }, blockposition, 1);

--- a/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
+++ b/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Paul Sauve <paul@technove.co>
+Date: Sat, 20 Feb 2021 16:43:07 +0000
+Subject: [PATCH] Skip POI finding if stuck in vehicle
+
+
+diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
+index 63a761ebef80d4af09cdc2682e496d78492c4a3a..a153ca82abd559f318177332ce4a52fdb50d8bd1 100644
+--- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
++++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
+@@ -45,6 +45,12 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+     }
+ 
+     protected boolean a(WorldServer worldserver, EntityCreature entitycreature) {
++        // Paper start - don't calculate POI if they're trapped in a vehicle
++        Entity vehicle = entitycreature.getVehicle();
++        if (vehicle instanceof EntityBoat || vehicle instanceof EntityMinecartRideable) {
++            return false;
++        }
++        // Paper end
+         if (this.d && entitycreature.isBaby()) {
+             return false;
+         } else if (this.f == 0L) {

--- a/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
+++ b/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
@@ -5,22 +5,23 @@ Subject: [PATCH] Skip POI finding if stuck in vehicle
 
 
 diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-index 63a761ebef80d4af09cdc2682e496d78492c4a3a..86349bea3ddb931ed56da7b02b611b45b5aa1a1d 100644
+index 63a761ebef80d4af09cdc2682e496d78492c4a3a..b1cd9d9f263f1525138c35ab818c6cd8117ae57d 100644
 --- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 +++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-@@ -45,6 +45,11 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -45,6 +45,12 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
      }
  
      protected boolean a(WorldServer worldserver, EntityCreature entitycreature) {
 +        // Paper start - don't calculate POI if they're trapped in a vehicle
-+        if (entitycreature.getVehicle() != null) {
++        Entity vehicle = entitycreature.getVehicle();
++        if (vehicle instanceof EntityBoat || vehicle instanceof EntityMinecartRideable) {
 +            return false;
 +        }
 +        // Paper end
          if (this.d && entitycreature.isBaby()) {
              return false;
          } else if (this.f == 0L) {
-@@ -84,7 +89,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+@@ -84,7 +90,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
                  villageplace.a(this.b.c(), (blockposition1) -> {
                      return blockposition1.equals(blockposition);
                  }, blockposition, 1);

--- a/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
+++ b/Spigot-Server-Patches/0675-Skip-POI-finding-if-stuck-in-vehicle.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Skip POI finding if stuck in vehicle
 
 
 diff --git a/src/main/java/net/minecraft/server/BehaviorFindPosition.java b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
-index 63a761ebef80d4af09cdc2682e496d78492c4a3a..a153ca82abd559f318177332ce4a52fdb50d8bd1 100644
+index 63a761ebef80d4af09cdc2682e496d78492c4a3a..b1cd9d9f263f1525138c35ab818c6cd8117ae57d 100644
 --- a/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 +++ b/src/main/java/net/minecraft/server/BehaviorFindPosition.java
 @@ -45,6 +45,12 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
@@ -21,3 +21,12 @@ index 63a761ebef80d4af09cdc2682e496d78492c4a3a..a153ca82abd559f318177332ce4a52fd
          if (this.d && entitycreature.isBaby()) {
              return false;
          } else if (this.f == 0L) {
+@@ -84,7 +90,7 @@ public class BehaviorFindPosition extends Behavior<EntityCreature> {
+                 villageplace.a(this.b.c(), (blockposition1) -> {
+                     return blockposition1.equals(blockposition);
+                 }, blockposition, 1);
+-                entitycreature.getBehaviorController().setMemory(this.c, (Object) GlobalPos.create(worldserver.getDimensionKey(), blockposition));
++                entitycreature.getBehaviorController().setMemory(this.c, GlobalPos.create(worldserver.getDimensionKey(), blockposition)); // Paper - decompile fix
+                 this.e.ifPresent((obyte) -> {
+                     worldserver.broadcastEntityEffect(entitycreature, obyte);
+                 });


### PR DESCRIPTION
This ports the Airplane patch (https://github.com/TECHNOVE/Airplane/blob/master/patches/server/0019-Skip-POI-finding-if-stuck-in-vehicle.patch) keeping the author with an added decompile fix.

A simple patch to maintain with high benefit.