### PR TITLE
Fix Log4J converter not parsing hex without named colors

### DIFF
--- a/Spigot-Server-Patches/0676-Add-support-for-hex-color-codes-in-console.patch
+++ b/Spigot-Server-Patches/0676-Add-support-for-hex-color-codes-in-console.patch
@@ -7,12 +7,13 @@ Converts upstream's hex color code legacy format into actual hex color codes in 
 
 diff --git a/src/main/java/io/papermc/paper/console/HexFormattingConverter.java b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d51db8864fce4b7eade5f39d84329a3f8591611d
+index 0000000000000000000000000000000000000000..362afb369ed8b00b0682237a6f9ca710391c9df8
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/HexFormattingConverter.java
-@@ -0,0 +1,181 @@
+@@ -0,0 +1,187 @@
 +package io.papermc.paper.console;
 +
++import net.kyori.adventure.text.format.TextColor;
 +import net.minecrell.terminalconsole.TerminalConsoleAppender;
 +import org.apache.logging.log4j.core.LogEvent;
 +import org.apache.logging.log4j.core.config.Configuration;
@@ -22,7 +23,6 @@ index 0000000000000000000000000000000000000000..d51db8864fce4b7eade5f39d84329a3f
 +import org.apache.logging.log4j.util.PerformanceSensitive;
 +import org.apache.logging.log4j.util.PropertiesUtil;
 +
-+import java.awt.*;
 +import java.util.List;
 +import java.util.regex.Matcher;
 +import java.util.regex.Pattern;
@@ -102,7 +102,8 @@ index 0000000000000000000000000000000000000000..d51db8864fce4b7eade5f39d84329a3f
 +        }
 +
 +        boolean useAnsi = ansi && TerminalConsoleAppender.isAnsiSupported();
-+        String content = useAnsi ? convertRGBColors(toAppendTo.substring(start)) : stripRGBColors(toAppendTo.substring(start));
++        String content = toAppendTo.substring(start);
++        content = useAnsi ? convertRGBColors(content) : stripRGBColors(content);
 +        format(content, toAppendTo, start, useAnsi);
 +    }
 +
@@ -111,10 +112,10 @@ index 0000000000000000000000000000000000000000..d51db8864fce4b7eade5f39d84329a3f
 +        StringBuffer buffer = new StringBuffer();
 +        while (matcher.find()) {
 +            String s = matcher.group().replace(String.valueOf(COLOR_CHAR), "").replace('x', '#');
-+            Color color = Color.decode(s);
-+            int red = color.getRed();
-+            int blue = color.getBlue();
-+            int green = color.getGreen();
++            TextColor color = TextColor.fromHexString(s);
++            int red = color.red();
++            int blue = color.blue();
++            int green = color.green();
 +            String replacement = String.format(RGB_ANSI, red, green, blue);
 +            matcher.appendReplacement(buffer, replacement);
 +        }
@@ -136,6 +137,11 @@ index 0000000000000000000000000000000000000000..d51db8864fce4b7eade5f39d84329a3f
 +        int next = s.indexOf(COLOR_CHAR);
 +        int last = s.length() - 1;
 +        if (next == -1 || next == last) {
++            result.setLength(start);
++            result.append(s);
++            if (ansi) {
++                result.append(ANSI_RESET);
++            }
 +            return;
 +        }
 +


### PR DESCRIPTION
also switches to adventure's `TextColor` since `java.awt`'s `Color` sometimes isn't always available/breaks on some OS's