### PR TITLE
Provide translated death message for PlayerDeathEvent

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -1315,34 +1315,34 @@ index 7190db11eff7d48df8a99f405a9dbaefdfa76e3d..1268066e30ddb0cd3792ea4b3de894eb
  
      @Override
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..11cc9da9ff23e4c84f203cb0e62a8624bfcf5260 100644
+index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..d9eddc34a66a77dbd4b18a2cd5d8d218c312bfae 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -11,26 +11,46 @@ import org.jetbrains.annotations.Nullable;
-  */
+@@ -12,25 +12,48 @@ import org.jetbrains.annotations.Nullable;
  public class PlayerDeathEvent extends EntityDeathEvent {
      private int newExp = 0;
--    private String deathMessage = "";
-+    private net.kyori.adventure.text.Component deathMessage; // Paper
+     private String deathMessage = "";
++    private net.kyori.adventure.text.Component adventure$deathMessage; // Paper
      private int newLevel = 0;
      private int newTotalExp = 0;
      private boolean keepLevel = false;
      private boolean keepInventory = false;
 +    // Paper start
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component deathMessage) {
-+        this(player, drops, droppedExp, 0, deathMessage);
++    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage) {
++        this(player, drops, droppedExp, 0, adventure$deathMessage, null);
 +    }
 +
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, @Nullable final net.kyori.adventure.text.Component deathMessage) {
-+        this(player, drops, droppedExp, newExp, 0, 0, deathMessage);
++    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
++        this(player, drops, droppedExp, newExp, 0, 0, adventure$deathMessage, deathMessage);
 +    }
  
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component deathMessage) {
++    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
 +        super(player, drops, droppedExp);
 +        this.newExp = newExp;
 +        this.newTotalExp = newTotalExp;
 +        this.newLevel = newLevel;
 +        this.deathMessage = deathMessage;
++        this.adventure$deathMessage = adventure$deathMessage;
 +    }
 +    // Paper end
 +
@@ -1362,60 +1362,69 @@ index 07a52441a5cdd7e428a14b286d7cb5210e3efa97..11cc9da9ff23e4c84f203cb0e62a8624
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
          this.newLevel = newLevel;
--        this.deathMessage = deathMessage;
-+        this.deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
+         this.deathMessage = deathMessage;
++        this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
      }
  
      @NotNull
-@@ -39,12 +59,13 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -39,25 +62,55 @@ public class PlayerDeathEvent extends EntityDeathEvent {
          return (Player) entity;
      }
  
 +    // Paper start
-     /**
-      * Set the death message that will appear to everyone on the server.
-      *
-      * @param deathMessage Message to appear to other players on the server.
-      */
--    public void setDeathMessage(@Nullable String deathMessage) {
-+    public void deathMessage(@Nullable net.kyori.adventure.text.Component deathMessage) {
-         this.deathMessage = deathMessage;
-     }
- 
-@@ -53,9 +74,32 @@ public class PlayerDeathEvent extends EntityDeathEvent {
-      *
-      * @return Message to appear to other players on the server.
-      */
-+    public @Nullable net.kyori.adventure.text.Component deathMessage() {
-+        return this.deathMessage;
-+    }
-+    // Paper end
-+
 +    /**
 +     * Set the death message that will appear to everyone on the server.
 +     *
 +     * @param deathMessage Message to appear to other players on the server.
-+     * @deprecated in favour of {@link #deathMessage(net.kyori.adventure.text.Component)}
 +     */
-+    @Deprecated // Paper
-+    public void setDeathMessage(@Nullable String deathMessage) {
-+        this.deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
++    public void deathMessage(@Nullable net.kyori.adventure.text.Component deathMessage) {
++        this.deathMessage = null;
++        this.adventure$deathMessage = deathMessage;
 +    }
 +
 +    /**
 +     * Get the death message that will appear to everyone on the server.
 +     *
 +     * @return Message to appear to other players on the server.
-+     * @deprecated in favour of {@link #deathMessage()}
 +     */
++    public @Nullable net.kyori.adventure.text.Component deathMessage() {
++        return this.adventure$deathMessage;
++    }
++    // Paper end
++
+     /**
+      * Set the death message that will appear to everyone on the server.
+      *
+      * @param deathMessage Message to appear to other players on the server.
++     * @deprecated in favour of {@link #deathMessage(net.kyori.adventure.text.Component)}
+      */
++    @Deprecated // Paper
+     public void setDeathMessage(@Nullable String deathMessage) {
+         this.deathMessage = deathMessage;
++        this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
+     }
+ 
+     /**
+      * Get the death message that will appear to everyone on the server.
+      *
+      * @return Message to appear to other players on the server.
++     * @deprecated in favour of {@link #deathMessage()}
+      */
      @Nullable
 +    @Deprecated // Paper
      public String getDeathMessage() {
 -        return deathMessage;
-+        return this.deathMessage == null ? null : net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(this.deathMessage); // Paper
++        return this.deathMessage != null ? this.deathMessage : (this.adventure$deathMessage != null ? getDeathMessageString(this.adventure$deathMessage) : null); // Paper
      }
- 
+-
++    // Paper start //TODO: add translation API to drop String deathMessage in favor of just Adventure
++    private static String getDeathMessageString(net.kyori.adventure.text.Component component) {
++        return net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().serialize(component);
++    }
++    // Paper end
      /**
+      * Gets how much EXP the Player should have at respawn.
+      * <p>
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
 index f1e9bc9bc797b7216336d3470e3c696a06f2b21a..090d22bd30f7947103771aaaf09a2398970ac337 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java

--- a/Spigot-API-Patches/0178-PlayerDeathEvent-getItemsToKeep.patch
+++ b/Spigot-API-Patches/0178-PlayerDeathEvent-getItemsToKeep.patch
@@ -8,10 +8,10 @@ Exposes a mutable array on items a player should keep on death
 Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index 11cc9da9ff23e4c84f203cb0e62a8624bfcf5260..cf83b3369d65b5ed3607d09ce5e079dfc847be2c 100644
+index 17deccb858990b09bcb5a063a179e40f1ffc99d1..831c2aeca95f813b675603af8173e2a20b740052 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-@@ -34,7 +34,6 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -36,7 +36,6 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      }
      // Paper end
  
@@ -19,8 +19,8 @@ index 11cc9da9ff23e4c84f203cb0e62a8624bfcf5260..cf83b3369d65b5ed3607d09ce5e079df
      public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final String deathMessage) {
          this(player, drops, droppedExp, 0, deathMessage);
      }
-@@ -53,6 +52,41 @@ public class PlayerDeathEvent extends EntityDeathEvent {
-         this.deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
+@@ -56,6 +55,41 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+         this.adventure$deathMessage = deathMessage != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(deathMessage) : net.kyori.adventure.text.Component.empty(); // Paper
      }
  
 +    @Deprecated // Paper

--- a/Spigot-API-Patches/0186-PlayerDeathEvent-shouldDropExperience.patch
+++ b/Spigot-API-Patches/0186-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
-index cf83b3369d65b5ed3607d09ce5e079dfc847be2c..199d0d2f02833690cbac3db63d3b9504cca7dd27 100644
+index 831c2aeca95f813b675603af8173e2a20b740052..fa30689cc3555020a0989dd0b667644158578754 100644
 --- a/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/PlayerDeathEvent.java
 @@ -1,6 +1,8 @@
@@ -17,33 +17,34 @@ index cf83b3369d65b5ed3607d09ce5e079dfc847be2c..199d0d2f02833690cbac3db63d3b9504
  import org.bukkit.entity.Player;
  import org.bukkit.inventory.ItemStack;
  import org.jetbrains.annotations.NotNull;
-@@ -17,6 +19,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -18,6 +20,8 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      private boolean keepLevel = false;
      private boolean keepInventory = false;
      // Paper start
 +    private boolean doExpDrop;
 +
-     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component deathMessage) {
-         this(player, drops, droppedExp, 0, deathMessage);
+     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage) {
+         this(player, drops, droppedExp, 0, adventure$deathMessage, null);
      }
-@@ -26,11 +30,16 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -27,12 +31,17 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      }
  
-     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component deathMessage) {
-+        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, deathMessage, true);
+     public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage) {
++        this(player, drops, droppedExp, newExp, newTotalExp, newLevel, adventure$deathMessage, deathMessage, true);
 +    }
 +
-+    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component deathMessage, boolean doExpDrop) {
++    public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final net.kyori.adventure.text.Component adventure$deathMessage, @Nullable String deathMessage, boolean doExpDrop) {
          super(player, drops, droppedExp);
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
          this.newLevel = newLevel;
          this.deathMessage = deathMessage;
+         this.adventure$deathMessage = adventure$deathMessage;
 +        this.doExpDrop = doExpDrop;
      }
      // Paper end
  
-@@ -45,6 +54,11 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -47,6 +56,11 @@ public class PlayerDeathEvent extends EntityDeathEvent {
  
      @Deprecated // Paper
      public PlayerDeathEvent(@NotNull final Player player, @NotNull final List<ItemStack> drops, final int droppedExp, final int newExp, final int newTotalExp, final int newLevel, @Nullable final String deathMessage) {
@@ -55,7 +56,7 @@ index cf83b3369d65b5ed3607d09ce5e079dfc847be2c..199d0d2f02833690cbac3db63d3b9504
          super(player, drops, droppedExp);
          this.newExp = newExp;
          this.newTotalExp = newTotalExp;
-@@ -85,6 +99,20 @@ public class PlayerDeathEvent extends EntityDeathEvent {
+@@ -88,6 +102,20 @@ public class PlayerDeathEvent extends EntityDeathEvent {
      public List<ItemStack> getItemsToKeep() {
          return itemsToKeep;
      }

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -749,7 +749,7 @@ index 7e2162fc78168adb96ed20651e1a3e061c29f96d..8e94a62916574bc2e5e93c5cf2e5ea79
          ChatMessage chatmessage = new ChatMessage(this.g());
  
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 37a84b44a46e1490f7b79839b04aef012ddc9fa3..0445bffdd1a6c9548c5c98c1ea4fd2c0c517acf4 100644
+index 37a84b44a46e1490f7b79839b04aef012ddc9fa3..a48b6b292c3472f3ac484eb9fba60a63c3c5625e 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -16,6 +16,7 @@ import org.apache.logging.log4j.LogManager;
@@ -782,7 +782,7 @@ index 37a84b44a46e1490f7b79839b04aef012ddc9fa3..0445bffdd1a6c9548c5c98c1ea4fd2c0
  
 -        String deathmessage = defaultMessage.getString();
 -        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, deathmessage, keepInventory);
-+        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
++        org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.activeContainer != this.defaultContainer) {
@@ -2154,18 +2154,21 @@ index 8428ef53e0408c4a7f74cc03e7e238be9c2f1888..28368aa85e25ad5ee1e35255f093fd3f
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f6688c7151734f4bdb63a71e810996e04b09e22c..6c153971dd72ff9df9725f889032cfb59bbe31e3 100644
+index f6688c7151734f4bdb63a71e810996e04b09e22c..9ff3e1e410336a4d76c94cc52343113c3cb0b613 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -766,7 +766,7 @@ public class CraftEventFactory {
+@@ -766,9 +766,9 @@ public class CraftEventFactory {
          return event;
      }
  
 -    public static PlayerDeathEvent callPlayerDeathEvent(EntityPlayer victim, List<org.bukkit.inventory.ItemStack> drops, String deathMessage, boolean keepInventory) {
-+    public static PlayerDeathEvent callPlayerDeathEvent(EntityPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, boolean keepInventory) { // Paper - Adventure
++    public static PlayerDeathEvent callPlayerDeathEvent(EntityPlayer victim, List<org.bukkit.inventory.ItemStack> drops, net.kyori.adventure.text.Component deathMessage, String stringDeathMessage, boolean keepInventory) { // Paper - Adventure
          CraftPlayer entity = victim.getBukkitEntity();
-         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
+-        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
++        PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
+         org.bukkit.World world = entity.getWorld();
+         Bukkit.getServer().getPluginManager().callEvent(event);
 @@ -792,7 +792,7 @@ public class CraftEventFactory {
       * Server methods
       */

--- a/Spigot-Server-Patches/0280-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0280-Improve-death-events.patch
@@ -274,7 +274,7 @@ index 858db1505aa06d85f4e0b522d221f6543ff40f56..352049363d4b7a0302610f7d7cd54c9c
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index d606e3faaf7c58d89539b6bd997978c066218b9a..273fd5a83790f76f089c2b1308a1e02ac6828683 100644
+index c0b1643dfb4701f0d790bcfae75ede417d5a3522..03d062f9cdf19df32dcc57a247555e5fa21d38b9 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -86,6 +86,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -291,7 +291,7 @@ index d606e3faaf7c58d89539b6bd997978c066218b9a..273fd5a83790f76f089c2b1308a1e02a
 @@ -589,6 +593,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          IChatBaseComponent defaultMessage = this.getCombatTracker().getDeathMessage();
  
-         org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), keepInventory); // Paper - Adventure
+         org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
 +        // Paper start - cancellable death event
 +        if (event.isCancelled()) {
 +            // make compatible with plugins that might have already set the health in an event listener
@@ -346,7 +346,7 @@ index 17ca2f9fbd9f43a9b39637d81e26c92ec00ed4d2..bb88a4a035dc7f56c9b0e81e5c613235
  
      public void injectScaledMaxHealth(Collection<AttributeModifiable> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 10e967e15048d4040005a6b6b31cc27c0397e1b9..126f403c18b0ee4af727f325fae307086f289ced 100644
+index a7e427415299a84ec3e134fa430bbbac7cba816b..0f83a95220f30e684b9873c84498d63e95050efe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -783,9 +783,16 @@ public class CraftEventFactory {
@@ -368,7 +368,7 @@ index 10e967e15048d4040005a6b6b31cc27c0397e1b9..126f403c18b0ee4af727f325fae30708
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
 @@ -801,8 +808,15 @@ public class CraftEventFactory {
          CraftPlayer entity = victim.getBukkitEntity();
-         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage);
+         PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
 +        populateFields(victim, event); // Paper - make cancellable
          org.bukkit.World world = entity.getWorld();


### PR DESCRIPTION
PlayerDeathEvent#getDeathMessage should provide translation for legacy reasons
Should resolve #5227

In investigating said issue, I have observed that there does not seem to be an API method of translating these messages. Usefulness is for when a plugin desires to retrieve the vanilla message so as to modify as they please. Adventure components keep these messages untranslated with no way to get the end string version because, as I understand it, the clients locale can translate these unmodified death messages.

Overall, I feel that this is an incomplete solution in the context of that missing API, but it is the best I can manage with the simple goal of returning to upstream/legacy API behavior.