### PR TITLE
Extend PlayerHandshakeEvent to include the IP

### DIFF
--- a/Spigot-API-Patches/0033-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-API-Patches/0033-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d67dade3af3fb0f8b7e5c267087abf6320b433e7
+index 0000000000000000000000000000000000000000..2f9412e0ba177f1e23befd64681a4a5a1994563d
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerHandshakeEvent.java
-@@ -0,0 +1,248 @@
+@@ -0,0 +1,277 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
@@ -37,6 +37,7 @@ index 0000000000000000000000000000000000000000..d67dade3af3fb0f8b7e5c267087abf63
 +
 +    private static final HandlerList HANDLERS = new HandlerList();
 +    @NotNull private final String originalHandshake;
++    @NotNull private final String originalSocketAddressHostname;
 +    private boolean cancelled;
 +    @Nullable private String serverHostname;
 +    @Nullable private String socketAddressHostname;
@@ -50,10 +51,25 @@ index 0000000000000000000000000000000000000000..d67dade3af3fb0f8b7e5c267087abf63
 +     *
 +     * @param originalHandshake the original handshake string
 +     * @param cancelled if this event is enabled
++     *
++     * @deprecated in favour of {@link PlayerHandshakeEvent(String, String, boolean)}
 +     */
++    @Deprecated
 +    public PlayerHandshakeEvent(@NotNull String originalHandshake, boolean cancelled) {
++        this(originalHandshake, "127.0.0.1", cancelled);
++    }
++
++    /**
++     * Creates a new {@link PlayerHandshakeEvent}.
++     *
++     * @param originalHandshake the original handshake string
++     * @param originalSocketAddressHostname the original socket address hostname
++     * @param cancelled if this event is enabled
++     */
++    public PlayerHandshakeEvent(@NotNull String originalHandshake, @NotNull String originalSocketAddressHostname, boolean cancelled) {
 +        super(true);
 +        this.originalHandshake = originalHandshake;
++        this.originalSocketAddressHostname = originalSocketAddressHostname;
 +        this.cancelled = cancelled;
 +    }
 +
@@ -91,6 +107,19 @@ index 0000000000000000000000000000000000000000..d67dade3af3fb0f8b7e5c267087abf63
 +    @NotNull
 +    public String getOriginalHandshake() {
 +        return this.originalHandshake;
++    }
++
++    /**
++     * Gets the original socket address hostname.
++     *
++     * <p>This does not include the port.</p>
++     * <p>In cases where this event is manually fired and the plugin wasn't updated yet, the default is {@code "127.0.0.1"}.</p>
++     *
++     * @return the original socket address hostname
++     */
++    @NotNull
++    public String getOriginalSocketAddressHostname() {
++        return this.originalSocketAddressHostname;
 +    }
 +
 +    /**

--- a/Spigot-Server-Patches/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-Server-Patches/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 
 diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
-index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..4de8646811f25b6217cffcd31fc14bcf79151b1a 100644
+index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..bad5d4f165d1e469ed583b036f78e467b94691fd 100644
 --- a/src/main/java/net/minecraft/server/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/HandshakeListener.java
 @@ -14,7 +14,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -18,7 +18,7 @@ index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..4de8646811f25b6217cffcd31fc14bcf
  
      public HandshakeListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
          this.b = minecraftserver;
-@@ -73,8 +73,33 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -73,8 +73,34 @@ public class HandshakeListener implements PacketHandshakingInListener {
                      this.c.close(chatmessage);
                  } else {
                      this.c.setPacketListener(new LoginListener(this.b, this.c));
@@ -27,7 +27,8 @@ index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..4de8646811f25b6217cffcd31fc14bcf
 +                boolean handledByEvent = false;
 +                // Try and handle the handshake through the event
 +                if (com.destroystokyo.paper.event.player.PlayerHandshakeEvent.getHandlerList().getRegisteredListeners().length != 0) { // Hello? Can you hear me?
-+                    com.destroystokyo.paper.event.player.PlayerHandshakeEvent event = new com.destroystokyo.paper.event.player.PlayerHandshakeEvent(packethandshakinginsetprotocol.hostname, !proxyLogicEnabled);
++                    java.net.InetSocketAddress socketAddress = (java.net.InetSocketAddress) this.getNetworkManager().socketAddress;
++                    com.destroystokyo.paper.event.player.PlayerHandshakeEvent event = new com.destroystokyo.paper.event.player.PlayerHandshakeEvent(packethandshakinginsetprotocol.hostname, socketAddress.getAddress().getHostAddress(), !proxyLogicEnabled);
 +                    if (event.callEvent()) {
 +                        // If we've failed somehow, let the client know so and go no further.
 +                        if (event.isFailed()) {
@@ -38,7 +39,7 @@ index 69fd0a7b230c6f6eb46a43477465f77b265cc3c9..4de8646811f25b6217cffcd31fc14bcf
 +                        }
 +
 +                        if (event.getServerHostname() != null) packethandshakinginsetprotocol.hostname = event.getServerHostname();
-+                        if (event.getSocketAddressHostname() != null) this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), ((java.net.InetSocketAddress) this.getNetworkManager().getSocketAddress()).getPort());
++                        if (event.getSocketAddressHostname() != null) this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), socketAddress.getPort());
 +                        this.getNetworkManager().spoofedUUID = event.getUniqueId();
 +                        this.getNetworkManager().spoofedProfile = gson.fromJson(event.getPropertiesJson(), com.mojang.authlib.properties.Property[].class);
 +                        handledByEvent = true; // Hooray, we did it!

--- a/Spigot-Server-Patches/0172-Expose-client-protocol-version-and-virtual-host.patch
+++ b/Spigot-Server-Patches/0172-Expose-client-protocol-version-and-virtual-host.patch
@@ -61,10 +61,10 @@ index 0000000000000000000000000000000000000000..5caca6439d2135e34880d501397fe2ea
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
-index 4de8646811f25b6217cffcd31fc14bcf79151b1a..6d9080abb63a6d13d1184ff6949ba86a470ea390 100644
+index bad5d4f165d1e469ed583b036f78e467b94691fd..89a83253c99c387e1c91c434952c549d598b11aa 100644
 --- a/src/main/java/net/minecraft/server/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/HandshakeListener.java
-@@ -133,6 +133,10 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -134,6 +134,10 @@ public class HandshakeListener implements PacketHandshakingInListener {
                  throw new UnsupportedOperationException("Invalid intention " + packethandshakinginsetprotocol.b());
          }
  

--- a/Spigot-Server-Patches/0562-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/Spigot-Server-Patches/0562-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix hex colors not working in some kick messages
 
 
 diff --git a/src/main/java/net/minecraft/server/HandshakeListener.java b/src/main/java/net/minecraft/server/HandshakeListener.java
-index 471826ee4b32fe73d3c39755005e3287f9673c3c..79f726ef43e70b8882890007146df199824d14e3 100644
+index a9337dc61d6370453a15ad284e44ad071e00572f..5843632fedafbd3e5cafd799cc779c39c9866c76 100644
 --- a/src/main/java/net/minecraft/server/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/HandshakeListener.java
 @@ -35,7 +35,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -33,7 +33,7 @@ index 471826ee4b32fe73d3c39755005e3287f9673c3c..79f726ef43e70b8882890007146df199
                      }
  
                      this.c.sendPacket(new PacketLoginOutDisconnect(chatmessage));
-@@ -82,7 +82,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -83,7 +83,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
                      if (event.callEvent()) {
                          // If we've failed somehow, let the client know so and go no further.
                          if (event.isFailed()) {


### PR DESCRIPTION
# Summary

This PR adds the method `PlayerHandshakeEvent#getOriginalSocketAddressHostname()` which returns the IP literal of the player trying to connect.

# Motivation

Currently, we have no native and easy way to get the IP of the connecting player. There are several use cases for this feature related to IP-based blocking in the earliest state possible.
 We're fully aware that this is definitely not ideal in comparison to kernel-level filtering (e.g. `iptables`) but we have to accomodate for those 1) not experienced in this kind of configuration and 2) not able to add firewall rules (e.g. shared hosting).

A few plugins which could / would probably benefit by this are:
1. Anti-Bot plugins like BotSentry which could drop clients if their IP is on an internal blocklist
2. DDoS mitigation solutions like TCPShield which would be able to run natively on Paper (without ProtocolLib)

Additionally to the possibility to run without extra plugins (ProtocolLib, etc.), this provides TCPShield's plugin the comfort to not use Reflection at all. As we're all aware, the usage of Reflection has several drawbacks, including but not limited to the fragility of the code in regard to future changes. 
Adding further to that, Java 16 will, by default, deny illegal reflective accesses which are currently needed to access the `final` modifier fields to modify the IP without the `PlayerHandshakeEvent`.

# Implementation details

The implementation of this feature is quite straight-forward. We add a new field for this purpose and deprecate the former constructor `PlayerHandshakeEvent(String, boolean)` in favor of `PlayerHandshakeEvent(String, String, boolean)`. The default value for this field is `"127.0.0.1"` which would be a correct IP and is more or less reasonable as there are no occurrences where plugins would manually call this event.

# Alternatives

The alternatives which would come to my mind would be
1.  to keep on using ProtocolLib for this kind of check which adds unnecessary dependencies and would still require the usage of ugly Reflection
2. to use a netty channel adapter which would require NMS or Reflection