### PR TITLE
Add links to the Adventure Javadoc

### DIFF
--- a/Spigot-API-Patches/0276-Javadocs-Add-links-to-the-Adventure-Javadoc.patch
+++ b/Spigot-API-Patches/0276-Javadocs-Add-links-to-the-Adventure-Javadoc.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Tue, 23 Feb 2021 17:53:48 +0100
+Subject: [PATCH] Javadocs: Add links to the Adventure Javadoc
+
+
+diff --git a/pom.xml b/pom.xml
+index 0d922ea17c675d6e3a7106937918d2a818814fba..0ec350553c10809d618179fde39a25789b3c5af9 100644
+--- a/pom.xml
++++ b/pom.xml
+@@ -278,6 +278,12 @@
+                         <link>https://javadoc.io/doc/org.yaml/snakeyaml/1.27/</link>
+                         <link>https://javadoc.io/doc/org.jetbrains/annotations-java5/20.1.0/</link>
+                         <link>https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/</link>
++                        <!-- Paper start, keep in sync with the used adventure version -->
++                        <link>https://jd.adventure.kyori.net/api/4.5.0/</link>
++                        <link>https://jd.adventure.kyori.net/text-serializer-gson/4.5.0/</link>
++                        <link>https://jd.adventure.kyori.net/text-serializer-legacy/4.5.0/</link>
++                        <link>https://jd.adventure.kyori.net/text-serializer-plain/4.5.0/</link>
++                        <!-- Paper end -->
+                     </links>
+                 </configuration>
+             </plugin>


### PR DESCRIPTION
 so they don't appear by their fully qualified name and so that one can jump directly into adventure javadocs, where necessary.

This is as discussed with @MiniDigger on Discord.