### PR TITLE
Add config option for displayname in quit message

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -6,6 +6,20 @@ Subject: [PATCH] Adventure
 Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 1d03a79e9010bc514b72a81ba0ad4a62aeff1bb7..429b74474ced04d8dd8f038b8590b8dfe178bf4d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -217,4 +217,9 @@ public class PaperConfig {
+                 " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
+                 " - Server Name: " + timingsServerName);
+     }
++
++    public static boolean useDisplayNameInQuit = false;
++    private static void useDisplayNameInQuit() {
++        useDisplayNameInQuit = getBoolean("use-display-name-in-quit-message", useDisplayNameInQuit);
++    }
+ }
 diff --git a/src/main/java/io/papermc/paper/adventure/AdventureComponent.java b/src/main/java/io/papermc/paper/adventure/AdventureComponent.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..a2acd31dce4461338a8baa96e03df36a4b4281b8
@@ -1248,7 +1262,7 @@ index d34e91887cd73009bf852fb849e495a8affed7a9..5fa4afb75d46a32d91402c5ca850d17d
               }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 5b49047b820dbe1f326320b71445ac216bf688b5..7a9901e7ce45dea4e0d61e82de6d8f5de1f836e7 100644
+index 5b49047b820dbe1f326320b71445ac216bf688b5..005ea84b8ebaa66c6a3db428efb0a002d5faf807 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.authlib.GameProfile;
@@ -1315,7 +1329,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..7a9901e7ce45dea4e0d61e82de6d8f5d
          }
  
 -        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, entityplayer.getBukkitEntity().displayName()));
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())));
          cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/Spigot-Server-Patches/0061-Default-loading-permissions.yml-before-plugins.patch
+++ b/Spigot-Server-Patches/0061-Default-loading-permissions.yml-before-plugins.patch
@@ -16,12 +16,12 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1d03a79e9010bc514b72a81ba0ad4a62aeff1bb7..436e555205327afcb8e294370810cf27f8a21dd7 100644
+index 429b74474ced04d8dd8f038b8590b8dfe178bf4d..716f285e67019b8a62922d09c15883c99f9421aa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -217,4 +217,9 @@ public class PaperConfig {
-                 " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
-                 " - Server Name: " + timingsServerName);
+@@ -222,4 +222,9 @@ public class PaperConfig {
+     private static void useDisplayNameInQuit() {
+         useDisplayNameInQuit = getBoolean("use-display-name-in-quit-message", useDisplayNameInQuit);
      }
 +
 +    public static boolean loadPermsBeforePlugins = true;
@@ -30,7 +30,7 @@ index 1d03a79e9010bc514b72a81ba0ad4a62aeff1bb7..436e555205327afcb8e294370810cf27
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1aae33917fc8a61e38b410421c205a7bc5a13dd..a02ec4d765ef54955459a372960fb5b539f912df 100644
+index 2833861b337cdb28ae12d21c6abee84dbcac314a..6df1ef2640cc6c014051bdb4d71d7cd80e978aec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -399,6 +399,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0076-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/Spigot-Server-Patches/0076-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 436e555205327afcb8e294370810cf27f8a21dd7..772f48ca940b235481dd27669d9370e53f5380dd 100644
+index 716f285e67019b8a62922d09c15883c99f9421aa..439dcc6effdc91830d2b7ede9063982998b37120 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -222,4 +222,9 @@ public class PaperConfig {
+@@ -227,4 +227,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }

--- a/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
+++ b/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Player Collision
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 772f48ca940b235481dd27669d9370e53f5380dd..042cb74c9c55366d91e98449bd51ad2b1d071324 100644
+index 439dcc6effdc91830d2b7ede9063982998b37120..504efea7b6f50a0d17f4f353781953dfb18bdeca 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -227,4 +227,9 @@ public class PaperConfig {
+@@ -232,4 +232,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = Math.max(getInt("settings.region-file-cache-size", 256), 4);
      }
@@ -57,7 +57,7 @@ index d1581c9d9838797eb425020d21bd0fba432e5652..99dc43159f240135957aee35f6129f19
              packetdataserializer.a(this.c);
              packetdataserializer.a(this.d);
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 4612e1d7adc6dad32dac7de040e0b8c45340be8d..e8ede86cab0bfcf1164fcdb6b19a60099b50e5eb 100644
+index 37a6861fca3fb22cd4675e1402432e597c9fb307..8b20c92178d78900ed31e25364b6cbb78110bf48 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -77,6 +77,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0097-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/Spigot-Server-Patches/0097-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 042cb74c9c55366d91e98449bd51ad2b1d071324..d614d6771aa97a544d0397234aa922d1e4c535f4 100644
+index 504efea7b6f50a0d17f4f353781953dfb18bdeca..1b8e5671c9dc8c15ce33d351c1bb20f28919b9a2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -232,4 +232,9 @@ public class PaperConfig {
+@@ -237,4 +237,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }

--- a/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add setting for proxy online mode status
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d614d6771aa97a544d0397234aa922d1e4c535f4..91f8d4e2f747f980a597bca533af631bbff6d6bd 100644
+index 1b8e5671c9dc8c15ce33d351c1bb20f28919b9a2..c52dc0346f93527965ef29a0ccdc4bf3debe302e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
@@ -16,7 +16,7 @@ index d614d6771aa97a544d0397234aa922d1e4c535f4..91f8d4e2f747f980a597bca533af631b
  
  public class PaperConfig {
  
-@@ -237,4 +238,13 @@ public class PaperConfig {
+@@ -242,4 +243,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }
@@ -45,7 +45,7 @@ index 060887d765604e4be82913607bb6266a278f5db6..c5957c2d6c54b076ebe7f9a432e30551
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 83ab502d80bbb97204a6f0e4474d1a3b96218448..7a1a24c71999462aa4f8aebd78914d9bf243f5c9 100644
+index 8e25929a7d1294a7cd764cd29e43977c9b2ca826..719e8117f06a14147587626eb03e1778408f2ce3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1507,7 +1507,8 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0110-Configurable-packet-in-spam-threshold.patch
+++ b/Spigot-Server-Patches/0110-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 91f8d4e2f747f980a597bca533af631bbff6d6bd..5452e0f0e9b468ea3b1f832f1a2494d99b2fafcb 100644
+index c52dc0346f93527965ef29a0ccdc4bf3debe302e..64d7c9058ee757a6d3cf3b648596092a810e105c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -247,4 +247,13 @@ public class PaperConfig {
+@@ -252,4 +252,13 @@ public class PaperConfig {
      public static boolean isProxyOnlineMode() {
          return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }

--- a/Spigot-Server-Patches/0111-Configurable-flying-kick-messages.patch
+++ b/Spigot-Server-Patches/0111-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5452e0f0e9b468ea3b1f832f1a2494d99b2fafcb..3449ba199bdb426ad36dc4a281925f91eea3fab3 100644
+index 64d7c9058ee757a6d3cf3b648596092a810e105c..4e2f243faa209925dcb7c3ef89df3ed875c5ff78 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -256,4 +256,11 @@ public class PaperConfig {
+@@ -261,4 +261,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }
@@ -21,7 +21,7 @@ index 5452e0f0e9b468ea3b1f832f1a2494d99b2fafcb..3449ba199bdb426ad36dc4a281925f91
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index fdf1d57670bf62dba7038f91df9dc589247b57ad..3bee1397a00cd5879504c77a761a3112cc73b5c3 100644
+index 29aa35877549abaef40a88c23f4fc44622e31842..52d28a0ce408a58f0068920d2286409e5124b7f6 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -160,7 +160,7 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3449ba199bdb426ad36dc4a281925f91eea3fab3..ed519159c37299595b4eaeaab5131a8ec3d9d27e 100644
+index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d056d4eae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -263,4 +263,9 @@ public class PaperConfig {
+@@ -268,4 +268,9 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }
@@ -20,7 +20,7 @@ index 3449ba199bdb426ad36dc4a281925f91eea3fab3..ed519159c37299595b4eaeaab5131a8e
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c87c5648582132db4e310a3c580eb3045afc32b8..2101695ca111d0bfcec7da5065034b6029687949 100644
+index c87e3189f2c582a22188555332b8d8ad17372c76..6c228e1f884f0023867c691cee9bd45481b5baec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2292,5 +2292,10 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0165-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/Spigot-Server-Patches/0165-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ed519159c37299595b4eaeaab5131a8ec3d9d27e..cedc8c45224fe991a2ec8dd2ed435edadd556be9 100644
+index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace351305790 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index ed519159c37299595b4eaeaab5131a8ec3d9d27e..cedc8c45224fe991a2ec8dd2ed435eda
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -268,4 +269,9 @@ public class PaperConfig {
+@@ -273,4 +274,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }

--- a/Spigot-Server-Patches/0203-Make-player-data-saving-configurable.patch
+++ b/Spigot-Server-Patches/0203-Make-player-data-saving-configurable.patch
@@ -8,10 +8,10 @@ however, we should still migrate our configuration back upstream,
 to prevent unexpected situations
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index cedc8c45224fe991a2ec8dd2ed435edadd556be9..701d84adb75cc3b2ca4d7ee16481e8687fa45cd5 100644
+index 52954fc3bf932cfc9d5ce63e3d3cace351305790..05a5abb951abe37f30a719cb75376d2d43c0d252 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -274,4 +274,13 @@ public class PaperConfig {
+@@ -279,4 +279,13 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }

--- a/Spigot-Server-Patches/0223-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/Spigot-Server-Patches/0223-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 701d84adb75cc3b2ca4d7ee16481e8687fa45cd5..fddc8e25347b2a14ff7e0636ec341fd9c0fa5581 100644
+index 05a5abb951abe37f30a719cb75376d2d43c0d252..77a03abd59db4a43f6f2d59d4c7ef176e782f205 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -283,4 +283,12 @@ public class PaperConfig {
+@@ -288,4 +288,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }

--- a/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
@@ -117,7 +117,7 @@ index cb9257d66a28ddd30c5e54808c044cd1e10b8a4a..fb121524f0505baf65d0ed3cb6db7cbd
          this.player.o();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 30acb3cd9381bab2932a0679dc496e8b1ed65d94..ed3490b00ec03feefa403c757ebe8d889ed5cd63 100644
+index 57955b39fccc9642499445f07c10a55c7f8eacc7..1dfc6476593aeff1d867f8598a843b67f24d5207 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -423,7 +423,7 @@ public abstract class PlayerList {
@@ -128,7 +128,7 @@ index 30acb3cd9381bab2932a0679dc496e8b1ed65d94..ed3490b00ec03feefa403c757ebe8d88
 +            entityplayer.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
-         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, entityplayer.getBukkitEntity().displayName()));
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())));
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
 index d192e341f0f6a3d03329dab16de3b19962091d2a..1a2760552cd42b302d4604917daf1fcd23765e59 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java

--- a/Spigot-Server-Patches/0258-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/Spigot-Server-Patches/0258-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index fddc8e25347b2a14ff7e0636ec341fd9c0fa5581..89f1eb215a585eccd8498cb337e5894369e41867 100644
+index 77a03abd59db4a43f6f2d59d4c7ef176e782f205..bd508025b771424c942fd856c31d520b6f548082 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -291,4 +291,18 @@ public class PaperConfig {
+@@ -296,4 +296,18 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }

--- a/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 89f1eb215a585eccd8498cb337e5894369e41867..f1c1c9c09c6bfe288a239d53953e55bb0c113c79 100644
+index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2786328e5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -20,7 +20,7 @@ index 89f1eb215a585eccd8498cb337e5894369e41867..f1c1c9c09c6bfe288a239d53953e55bb
  
  public class PaperConfig {
  
-@@ -292,6 +293,14 @@ public class PaperConfig {
+@@ -297,6 +298,14 @@ public class PaperConfig {
          }
      }
  
@@ -48,7 +48,7 @@ index 88b45c8b4f58ee83d625408eae08aa329c87a6d4..d6d93c76f047573b3e7ea91409fb85e0
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ece800d6f7d156be97e3069f76df5d667b9ce94d..760c5d3b1e9aba0946937f7a9263dbd0c4e295a7 100644
+index be7c2153b3c712f3e5c1ebd3e8526b65bd2f5174..82fe3ab9c5e05bd372f6c5721758742f866f3605 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -813,6 +813,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0292-Configurable-connection-throttle-kick-message.patch
+++ b/Spigot-Server-Patches/0292-Configurable-connection-throttle-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f1c1c9c09c6bfe288a239d53953e55bb0c113c79..20524795840a06cfe60de6ffd0a77b6814132af4 100644
+index 62621562137cba4804f0465c58d25ca2786328e5..7178b37f7978c7e9031a22726005c5099fd78fe0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -276,6 +276,11 @@ public class PaperConfig {
+@@ -281,6 +281,11 @@ public class PaperConfig {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
  

--- a/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 20524795840a06cfe60de6ffd0a77b6814132af4..1697687405392198d2df653220465671675362c2 100644
+index 7178b37f7978c7e9031a22726005c5099fd78fe0..3139c194f9b1bc3510d51a81f13ae43d00a3dc29 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -8,6 +8,7 @@ import java.io.IOException;
@@ -25,7 +25,7 @@ index 20524795840a06cfe60de6ffd0a77b6814132af4..1697687405392198d2df653220465671
  import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
-@@ -247,7 +248,7 @@ public class PaperConfig {
+@@ -252,7 +253,7 @@ public class PaperConfig {
      }
  
      public static boolean isProxyOnlineMode() {
@@ -34,7 +34,7 @@ index 20524795840a06cfe60de6ffd0a77b6814132af4..1697687405392198d2df653220465671
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -319,4 +320,18 @@ public class PaperConfig {
+@@ -324,4 +325,18 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
@@ -273,7 +273,7 @@ index b52e8b72eaee87e227b7cc2fd66101550262cb7e..990cfea6c2339cd3cf688e4645de76dc
      public void a(PacketDataSerializer packetdataserializer) throws IOException {
          this.a = packetdataserializer.i();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 760c5d3b1e9aba0946937f7a9263dbd0c4e295a7..0463e546fba266df3984022e3e1122750fc9bb06 100644
+index 82fe3ab9c5e05bd372f6c5721758742f866f3605..04d53310998fdb21636810b8e7dd9c359691090c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -685,7 +685,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0312-Book-Size-Limits.patch
+++ b/Spigot-Server-Patches/0312-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1697687405392198d2df653220465671675362c2..e8bade581ed391b25c592dbafb3fb3ccf72be616 100644
+index 3139c194f9b1bc3510d51a81f13ae43d00a3dc29..13edb435b3fa65b4980bd7472aa5a5196f4d5b2b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -334,4 +334,11 @@ public class PaperConfig {
+@@ -339,4 +339,11 @@ public class PaperConfig {
              velocitySecretKey = secret.getBytes(StandardCharsets.UTF_8);
          }
      }

--- a/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e8bade581ed391b25c592dbafb3fb3ccf72be616..053ba1023b6d1393c0ade589ae53feb22218f413 100644
+index 13edb435b3fa65b4980bd7472aa5a5196f4d5b2b..469f78775b03cf363d88e35c69c0dc185c22547c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -19,6 +19,7 @@ import java.util.regex.Pattern;
@@ -16,7 +16,7 @@ index e8bade581ed391b25c592dbafb3fb3ccf72be616..053ba1023b6d1393c0ade589ae53feb2
  import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
-@@ -282,6 +283,11 @@ public class PaperConfig {
+@@ -287,6 +288,11 @@ public class PaperConfig {
          connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
      }
  
@@ -29,7 +29,7 @@ index e8bade581ed391b25c592dbafb3fb3ccf72be616..053ba1023b6d1393c0ade589ae53feb2
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0463e546fba266df3984022e3e1122750fc9bb06..c9ce183a8acfda1c639e6d808e90936f5a8d35a8 100644
+index 04d53310998fdb21636810b8e7dd9c359691090c..b4267ce12c0c952b8dd048c0a6a199ebff148377 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2335,6 +2335,11 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
@@ -199,7 +199,7 @@ index e4719a5e7e5ebd91257a9c9b83fa1adad70fd585..9ad822715c9358e5ac2a0e0a0800786a
                  doChunkInfo(sender, args);
                  break;
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 053ba1023b6d1393c0ade589ae53feb22218f413..dbabff7efb887b78545a12ae6bec42b02a3a39e2 100644
+index 469f78775b03cf363d88e35c69c0dc185c22547c..8bf4d2b8c38c02d6a5b2fea37113689a252f1571 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -209,7 +209,7 @@ index 053ba1023b6d1393c0ade589ae53feb22218f413..dbabff7efb887b78545a12ae6bec42b0
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -347,4 +348,54 @@ public class PaperConfig {
+@@ -352,4 +353,54 @@ public class PaperConfig {
          maxBookPageSize = getInt("settings.book-size.page-max", maxBookPageSize);
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }

--- a/Spigot-Server-Patches/0418-Optimise-TickListServer-by-rewriting-it.patch
+++ b/Spigot-Server-Patches/0418-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,10 +42,10 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index dbabff7efb887b78545a12ae6bec42b02a3a39e2..519b43154993ec01eb13a58336ddcc745362892f 100644
+index 8bf4d2b8c38c02d6a5b2fea37113689a252f1571..da93d38fe63035e4ff198ada84a4431f52d97c01 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -349,6 +349,13 @@ public class PaperConfig {
+@@ -354,6 +354,13 @@ public class PaperConfig {
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
  

--- a/Spigot-Server-Patches/0430-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/Spigot-Server-Patches/0430-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -42,10 +42,10 @@ index 11fe3524f38f7756ebd0e3807678e8848fd2217d..884b59d478aa7de49906520e77866a79
      public static final Timing commandFunctionsTimer = Timings.ofSafe("Command Functions");
      public static final Timing connectionTimer = Timings.ofSafe("Connection Handler");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 519b43154993ec01eb13a58336ddcc745362892f..63b3726bfdd22900e7bc577c34db58ddba1084ee 100644
+index da93d38fe63035e4ff198ada84a4431f52d97c01..ddbc8cb712c50038922eded75dd6ca85fe851078 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -405,4 +405,9 @@ public class PaperConfig {
+@@ -410,4 +410,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }

--- a/Spigot-Server-Patches/0453-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0453-Load-Chunks-for-Login-Asynchronously.patch
@@ -31,7 +31,7 @@ index 7da08dd7c2396ae1048d857bfae4fee2a9f3b4d9..1ed26fa55b149e3717cf190abde8f865
  
      public void d(Vec3D vec3d) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 03f13cc10de79137c1e186a4207ad6cc7d68c843..e364576955ce033f732bc9348ab653c5db71487f 100644
+index 50ffd62534793596017368423b11cd5a94950009..05483a9c5b8f77959fb44532f506e268b1676acd 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -46,6 +46,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -73,7 +73,7 @@ index e5790c2aeaa380a3acc26434f5de78ac746c6d57..bdd4766976902e11411728e6faa93b7e
              if (entityplayer != null) {
                  this.g = LoginListener.EnumProtocolState.DELAY_ACCEPT;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7dda59329fe7cd3c675bdb433ff5a49a47cefa8d..d0d7225e6ec16c2e69c66a8f2f8702a82ed070cd 100644
+index b6d31a9e64377de0f9ecfc5f5f24d92b8fe11caf..ce25ed932bc2f49c78c4693806b7f405bc0d6e9d 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -76,6 +76,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -110,7 +110,7 @@ index 7dda59329fe7cd3c675bdb433ff5a49a47cefa8d..d0d7225e6ec16c2e69c66a8f2f8702a8
          this.minecraftServer.getMethodProfiler().enter("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 659efe4e9523e7d213a92ab616ce0594a55a3a9d..326be15831791a950c71ce8e0736ca67341b734c 100644
+index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8f8d9ffcd 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -56,11 +56,12 @@ public abstract class PlayerList {
@@ -211,7 +211,7 @@ index 659efe4e9523e7d213a92ab616ce0594a55a3a9d..326be15831791a950c71ce8e0736ca67
 @@ -449,7 +501,7 @@ public abstract class PlayerList {
          }
  
-         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, entityplayer.getBukkitEntity().displayName()));
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())));
 -        cserver.getPluginManager().callEvent(playerQuitEvent);
 +        if (entityplayer.didPlayerJoinEvent) cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());

--- a/Spigot-Server-Patches/0478-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/Spigot-Server-Patches/0478-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2f9398f7bb90e8ae0a1cb81b162dba28706d408a..5b5edd2aed9cf76535104df65783bfd1d5bb7c85 100644
+index 78271b400c79578d043b20a5389a37b1bef9a70d..5f3b0d95cc7e6a0434d78ea7305a70689c41c71c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -411,4 +411,17 @@ public class PaperConfig {
+@@ -416,4 +416,17 @@ public class PaperConfig {
      private static void midTickChunkTasks() {
          midTickChunkTasks = getInt("settings.chunk-tasks-per-tick", midTickChunkTasks);
      }
@@ -157,7 +157,7 @@ index a552cc5bebb1a70db2e679a514769d0ad791ad68..72de544c0782e4daff222a0ca04e5bc8
  
                      this.world.getMethodProfiler().enter("explosion_blocks");
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 8198962c05fe83fd2ff0401c35f4976eb6e6680b..14dbedbe879c84d8b0e141d1a4e2e7c1256a6f97 100644
+index b5127f4b2deaa70b411991d78657f0c9e73d9e43..f2944dcf6b83b530124d53743a3d58b68ecec6f8 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -362,6 +362,10 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0483-Add-option-for-console-having-all-permissions.patch
+++ b/Spigot-Server-Patches/0483-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5b5edd2aed9cf76535104df65783bfd1d5bb7c85..456e6363758c41e1d58e178bf839e96aa6df6381 100644
+index 5f3b0d95cc7e6a0434d78ea7305a70689c41c71c..7f140333c2e62012fa572c1a061d84432426997f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -424,4 +424,9 @@ public class PaperConfig {
+@@ -429,4 +429,9 @@ public class PaperConfig {
  
      }
  

--- a/Spigot-Server-Patches/0498-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/Spigot-Server-Patches/0498-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 456e6363758c41e1d58e178bf839e96aa6df6381..fd3b4a01c84da110d41b7224ebb38ae78b389f79 100644
+index 7f140333c2e62012fa572c1a061d84432426997f..b67ba8f75e4a3358d7c2462918b85b0bf9b5a922 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -429,4 +429,10 @@ public class PaperConfig {
+@@ -434,4 +434,10 @@ public class PaperConfig {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }
  

--- a/Spigot-Server-Patches/0540-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0540-Incremental-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index fd3b4a01c84da110d41b7224ebb38ae78b389f79..deb77934dcba8c9209c942a6521dd8486cb5a48d 100644
+index b67ba8f75e4a3358d7c2462918b85b0bf9b5a922..fdbd8b89bb8bf3b61f60b812b90483c98a3d5ccb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -435,4 +435,15 @@ public class PaperConfig {
+@@ -440,4 +440,15 @@ public class PaperConfig {
          allowPistonDuplication = getBoolean("settings.unsupported-settings.allow-piston-duplication", config.getBoolean("settings.unsupported-settings.allow-tnt-duplication", false));
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
@@ -25,7 +25,7 @@ index fd3b4a01c84da110d41b7224ebb38ae78b389f79..deb77934dcba8c9209c942a6521dd848
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index dbc9cc0728d1f9de89e15ecf5ccd6f8b07cd0788..7e5e4acb3c892a5d366e0fbfb76b97884345ec24 100644
+index a7f39878829f1c901934fb2d8b53d906295112e9..8436b7be989bf08c8ec1f0d646b20e777a0ebd55 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -45,6 +45,7 @@ import org.bukkit.inventory.MainHand;
@@ -59,7 +59,7 @@ index ca417825eb0827caad817f65b5132f1de37e3679..69fcfff3f21168f334fd526cb65e63e0
              // Paper start
              for (WorldServer world : getWorlds()) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 5255f3b0209226ee09827a51bb8282a220184975..f04b23b6ccf45701fc98dbbe9757181c94d82192 100644
+index f14fb972029d3125f428fb8244c4078722b52617..f000588b2d8b5bdedc076a8532cbd47a823fe1a5 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -485,6 +485,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0556-Prevent-headless-pistons-from-being-created.patch
+++ b/Spigot-Server-Patches/0556-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index deb77934dcba8c9209c942a6521dd8486cb5a48d..35a6b9b6d0eed316cafced70fe98b7477450c435 100644
+index fdbd8b89bb8bf3b61f60b812b90483c98a3d5ccb..faa1b775e45563b93ac1d5b904938b1f5ad8d80c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -436,6 +436,12 @@ public class PaperConfig {
+@@ -441,6 +441,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/Spigot-Server-Patches/0560-Buffer-joins-to-world.patch
+++ b/Spigot-Server-Patches/0560-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 35a6b9b6d0eed316cafced70fe98b7477450c435..110cee7228b17a2378523883a1a83cc97da7608d 100644
+index faa1b775e45563b93ac1d5b904938b1f5ad8d80c..545948f20efd6c8dd42140b565af94cd6b52b661 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -452,4 +452,9 @@ public class PaperConfig {
+@@ -457,4 +457,9 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/Spigot-Server-Patches/0575-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/Spigot-Server-Patches/0575-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 110cee7228b17a2378523883a1a83cc97da7608d..da48ad0e4725d9a9fcb2d60f82249be97be29033 100644
+index 545948f20efd6c8dd42140b565af94cd6b52b661..7d50aded88f5b7dfebaea1aebc86231f7b5c4e25 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -457,4 +457,9 @@ public class PaperConfig {
+@@ -462,4 +462,9 @@ public class PaperConfig {
      private static void maxJoinsPerTick() {
          maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
      }

--- a/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
+++ b/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add API for quit reason
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 7e5e4acb3c892a5d366e0fbfb76b97884345ec24..d58abb47c1a543eaf238569f27bf189322c22a93 100644
+index 8436b7be989bf08c8ec1f0d646b20e777a0ebd55..3728ff515feea7fd6fe8c62c0e6646e8a8662beb 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -130,6 +130,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -49,15 +49,15 @@ index 2ca65ad26155ee168b51db52568d207c92a5d137..8591cd6636f6c1f9cb4fd66618afe635
              this.networkManager.close(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index b0f432ed5ed47c867947a9285567a816da306797..27f6a9b0711a0e00c8350e45e2d0618b1f735eb8 100644
+index 24b28c547555ece196befb041025ae72b6ee7c81..2837b2c3b72a22da70ca7123715c83b4d6e701be 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -512,7 +512,7 @@ public abstract class PlayerList {
              entityplayer.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, entityplayer.getBukkitEntity().displayName()));
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, entityplayer.getBukkitEntity().displayName()), entityplayer.quitReason); // Paper - quit reason
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())));
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())), entityplayer.quitReason); // Paper - quit reason
          if (entityplayer.didPlayerJoinEvent) cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/Spigot-Server-Patches/0615-Limit-recipe-packets.patch
+++ b/Spigot-Server-Patches/0615-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index da48ad0e4725d9a9fcb2d60f82249be97be29033..6a9f41eafcd48ff029f027eeebfc0dc956564d2c 100644
+index 7d50aded88f5b7dfebaea1aebc86231f7b5c4e25..652d87fc5d566dba8018c81676329f0e0bca471b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -329,6 +329,13 @@ public class PaperConfig {
+@@ -334,6 +334,13 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/Spigot-Server-Patches/0617-MC-4-Fix-item-position-desync.patch
+++ b/Spigot-Server-Patches/0617-MC-4-Fix-item-position-desync.patch
@@ -9,10 +9,10 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6a9f41eafcd48ff029f027eeebfc0dc956564d2c..673c40d952bae6ae9e92aac9742e58ffb6a8b1bb 100644
+index 652d87fc5d566dba8018c81676329f0e0bca471b..c56e7fb18f9a56c8025eb70a524f028b5942da37 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -469,4 +469,9 @@ public class PaperConfig {
+@@ -474,4 +474,9 @@ public class PaperConfig {
      private static void trackPluginScoreboards() {
          trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
      }


### PR DESCRIPTION
This restores the behaviour to vanilla by default, but may be changed if
one wants to.

Fixes #5259.