### PR TITLE
Clear SyncLoadInfo

### DIFF
--- a/Spigot-Server-Patches/0678-Clear-SyncLoadInfo.patch
+++ b/Spigot-Server-Patches/0678-Clear-SyncLoadInfo.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Fri, 26 Feb 2021 16:10:53 -0600
+Subject: [PATCH] Clear SyncLoadInfo
+
+This patch merely adds the extra argument "clear" after /paper syncloadinfo to clear currently stored syncload info.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+index 0abfe19e204d20af0f8dedbeedb0ef98dfe9d3c8..fa385aac361fb73fd974a8a13dc9bc86e2707451 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
++++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+@@ -262,6 +262,13 @@ public class PaperCommand extends Command {
+             sender.sendMessage(ChatColor.RED + "This command requires the server startup flag '-Dpaper.debug-sync-loads=true' to be set.");
+             return;
+         }
++
++        if (args.length > 1 && args[1].equals("clear")) {
++            SyncLoadFinder.clear();
++            sender.sendMessage(ChatColor.GRAY + "Sync load data cleared.");
++            return;
++        }
++
+         File file = new File(new File(new File("."), "debug"),
+             "sync-load-info" + DateTimeFormatter.ofPattern("yyyy-MM-dd_HH.mm.ss").format(LocalDateTime.now()) + ".txt");
+         file.getParentFile().mkdirs();
+diff --git a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
+index 1a68a8012f83bab9e814159c76b8c3710c7b1112..82a1e4386522684876e5febaf90bbe161a2f1ed2 100644
+--- a/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
++++ b/src/main/java/com/destroystokyo/paper/io/SyncLoadFinder.java
+@@ -27,6 +27,10 @@ public class SyncLoadFinder {
+         public final Long2IntOpenHashMap coordinateTimes = new Long2IntOpenHashMap();
+     }
+ 
++    public static void clear() {
++        SYNC_LOADS.clear();
++    }
++
+     public static void logSyncLoad(final World world, final int chunkX, final int chunkZ) {
+         if (!ENABLED) {
+             return;


### PR DESCRIPTION
Simple patch, useful if you wanna clear out a bunch of syncload info to test specific cases.