### PR TITLE
Expose Tracked Players

### DIFF
--- a/Spigot-API-Patches/0276-Expose-Tracked-Players.patch
+++ b/Spigot-API-Patches/0276-Expose-Tracked-Players.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Fri, 26 Feb 2021 16:24:25 -0600
+Subject: [PATCH] Expose Tracked Players
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..b391c720b69714cf49f8733cf4440864ac3dcd72 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1,6 +1,7 @@
+ package org.bukkit.entity;
+ 
+ import java.net.InetSocketAddress;
++import java.util.Set; // Paper
+ import java.util.UUID;
+ import com.destroystokyo.paper.ClientOption; // Paper
+ import com.destroystokyo.paper.Title; // Paper
+@@ -1976,6 +1977,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     void sendOpLevel(byte level);
+     // Paper end
+ 
++    // Paper start
++    /**
++     * @return Returns a set of Players within this player's tracking range (that the player's client can "see")
++     */
++    @NotNull
++    Set<Player> getTrackedPlayers();
++    // Paper end
++
+     // Spigot start
+     public class Spigot extends Entity.Spigot {
+ 

--- a/Spigot-Server-Patches/0679-Expose-Tracked-Players.patch
+++ b/Spigot-Server-Patches/0679-Expose-Tracked-Players.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Fri, 26 Feb 2021 16:24:25 -0600
+Subject: [PATCH] Expose Tracked Players
+
+
+diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
+index d8787985ab4c94e9808332c15b3d16d4b52ba195..e87e1b04e13593f1efa4d1c59cb9e433f2b3c694 100644
+--- a/src/main/java/net/minecraft/server/Entity.java
++++ b/src/main/java/net/minecraft/server/Entity.java
+@@ -80,7 +80,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
+     public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
+     private CraftEntity bukkitEntity;
+ 
+-    PlayerChunkMap.EntityTracker tracker; // Paper
++    public PlayerChunkMap.EntityTracker tracker; // Paper package private -> public
+     boolean collisionLoadChunks = false; // Paper
+     Throwable addedToWorldStack; // Paper - entity debug
+     public CraftEntity getBukkitEntity() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..0a7777f97b85842aa7f214479dcc7a9e6a4bee8a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
+ import java.net.SocketAddress;
+ import java.util.ArrayList;
+ import java.util.Collection;
++import java.util.Collections; // Paper
+ import java.util.HashMap;
+ import java.util.HashSet;
+ import java.util.LinkedHashMap;
+@@ -2326,6 +2327,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // Paper start
++    @Override
++    public Set<Player> getTrackedPlayers() {
++        if (entity.tracker == null) {
++            return Collections.emptySet();
++        }
++
++        Set<Player> set = new HashSet<>(entity.tracker.trackedPlayers.size());
++        for (EntityPlayer entityPlayer : entity.tracker.trackedPlayers) {
++            set.add(entityPlayer.getBukkitEntity().getPlayer());
++        }
++        return set;
++    }
++    // Paper end
++
+     // Spigot start
+     private final Player.Spigot spigot = new Player.Spigot()
+     {


### PR DESCRIPTION
A lot of plugins seem to use reflection to determine this, so this could be a bit of a starter-patch as future PR'ers could also exposed tracked entities as well.

This also seems overly simple, so I feel like I may be missing something; but at the very least it works for me so far.