### PR TITLE
Extend hide/showPlayer API

### DIFF
--- a/Spigot-API-Patches/0276-Extend-hide-showPlayer-API.patch
+++ b/Spigot-API-Patches/0276-Extend-hide-showPlayer-API.patch
@@ -1,0 +1,86 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Fri, 26 Feb 2021 16:36:59 -0600
+Subject: [PATCH] Extend hide/showPlayer API
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8e788e406 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1249,6 +1249,34 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public void hidePlayer(@NotNull Plugin plugin, @NotNull Player player);
+ 
++    // Paper start
++    /**
++     * Hides a player from this player
++     *
++     * @param plugin Plugin that wants to hide the player
++     * @param player Player to hide
++     * @param immediate Immediately untrack the Player. Defaults to true.
++     */
++    public void hidePlayer(@NotNull Plugin plugin, @NotNull Player player, boolean immediate);
++
++    /**
++     * Adds a player UUID to be hidden from this player
++     *
++     * @param plugin Plugin that wants to hide the Player UUID
++     * @param uuid Player UUID to hide
++     */
++    public void hidePlayer(@NotNull Plugin plugin, @NotNull UUID uuid);
++
++    /**
++     * Adds a player UUID to be hidden from this player
++     *
++     * @param plugin Plugin that wants to hide the Player UUID
++     * @param uuid Player UUID to hide
++     * @param immediate If the Player with the given UUID is online, immediately hide them from the player. Defaults to true.
++     */
++    public void hidePlayer(@NotNull Plugin plugin, @NotNull UUID uuid, boolean immediate);
++    // Paper end
++
+     /**
+      * Allows this player to see a player that was previously hidden
+      *
+@@ -1268,6 +1296,40 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public void showPlayer(@NotNull Plugin plugin, @NotNull Player player);
+ 
++    // Paper start
++    /**
++     * Allows this player to see a player that was previously hidden. If
++     * another another plugin had hidden the player too, then the player will
++     * remain hidden until the other plugin calls this method too.
++     *
++     * @param plugin Plugin that wants to show the player
++     * @param player Player to show
++     * @param immediate Immediately track the Player. Defaults to true.
++     */
++    public void showPlayer(@NotNull Plugin plugin, @NotNull Player player, boolean immediate);
++
++    /**
++     * Allows this player to see a player that was previously hidden. If
++     * another another plugin had hidden the player too, then the player will
++     * remain hidden until the other plugin calls this method too.
++     *
++     * @param plugin Plugin that wants to show the player
++     * @param uuid Player UUID to show
++     */
++    public void showPlayer(@NotNull Plugin plugin, @NotNull UUID uuid);
++
++    /**
++     * Allows this player to see a player that was previously hidden. If
++     * another another plugin had hidden the player too, then the player will
++     * remain hidden until the other plugin calls this method too.
++     *
++     * @param plugin Plugin that wants to show the player
++     * @param uuid Player UUID to show
++     * @param immediate If the Player with the given UUID is online, immediately show them to the player. Defaults to true.
++     */
++    public void showPlayer(@NotNull Plugin plugin, @NotNull UUID uuid, boolean immediate);
++    // Paper end
++
+     /**
+      * Checks to see if a player has been hidden from this player
+      *

--- a/Spigot-API-Patches/0276-Extend-hide-showPlayer-API.patch
+++ b/Spigot-API-Patches/0276-Extend-hide-showPlayer-API.patch
@@ -5,13 +5,18 @@ Subject: [PATCH] Extend hide/showPlayer API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8e788e406 100644
+index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..ca4069d0a7fdf8a4f79eac93300a3a5bfe5a7045 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1249,6 +1249,34 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1247,7 +1247,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param plugin Plugin that wants to hide the player
+      * @param player Player to hide
       */
-     public void hidePlayer(@NotNull Plugin plugin, @NotNull Player player);
- 
+-    public void hidePlayer(@NotNull Plugin plugin, @NotNull Player player);
++    default void hidePlayer(@NotNull Plugin plugin, @NotNull Player player) {
++        hidePlayer(plugin, player, true);
++    }
++
 +    // Paper start
 +    /**
 +     * Hides a player from this player
@@ -28,7 +33,9 @@ index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8
 +     * @param plugin Plugin that wants to hide the Player UUID
 +     * @param uuid Player UUID to hide
 +     */
-+    public void hidePlayer(@NotNull Plugin plugin, @NotNull UUID uuid);
++    default void hidePlayer(@NotNull Plugin plugin, @NotNull UUID uuid) {
++        hidePlayer(plugin, uuid, true);
++    }
 +
 +    /**
 +     * Adds a player UUID to be hidden from this player
@@ -39,14 +46,18 @@ index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8
 +     */
 +    public void hidePlayer(@NotNull Plugin plugin, @NotNull UUID uuid, boolean immediate);
 +    // Paper end
-+
+ 
      /**
       * Allows this player to see a player that was previously hidden
-      *
-@@ -1268,6 +1296,40 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1266,7 +1298,45 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param plugin Plugin that wants to show the player
+      * @param player Player to show
       */
-     public void showPlayer(@NotNull Plugin plugin, @NotNull Player player);
- 
+-    public void showPlayer(@NotNull Plugin plugin, @NotNull Player player);
++    default void showPlayer(@NotNull Plugin plugin, @NotNull Player player) {
++        showPlayer(plugin, player, true);
++    }
++
 +    // Paper start
 +    /**
 +     * Allows this player to see a player that was previously hidden. If
@@ -67,7 +78,9 @@ index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8
 +     * @param plugin Plugin that wants to show the player
 +     * @param uuid Player UUID to show
 +     */
-+    public void showPlayer(@NotNull Plugin plugin, @NotNull UUID uuid);
++    default void showPlayer(@NotNull Plugin plugin, @NotNull UUID uuid) {
++        showPlayer(plugin, uuid, true);
++    }
 +
 +    /**
 +     * Allows this player to see a player that was previously hidden. If
@@ -80,7 +93,6 @@ index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..8f2869e3dc695fb73bb7edb2390ae6b8
 +     */
 +    public void showPlayer(@NotNull Plugin plugin, @NotNull UUID uuid, boolean immediate);
 +    // Paper end
-+
+ 
      /**
       * Checks to see if a player has been hidden from this player
-      *

--- a/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
+++ b/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
@@ -1,0 +1,160 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tom <cryptite@gmail.com>
+Date: Fri, 26 Feb 2021 16:36:58 -0600
+Subject: [PATCH] Extend hide/showPlayer API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..f7158a282789013c41089d5ed6573705f1021ed2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1320,26 +1320,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         return (plugin == null) ? null : pluginWeakReferences.computeIfAbsent(plugin, WeakReference::new);
+     }
+ 
++    // Paper start
+     @Override
+     @Deprecated
+     public void hidePlayer(Player player) {
+-        hidePlayer0(null, player);
++        hidePlayer(null, player.getUniqueId());
+     }
+ 
+     @Override
+     public void hidePlayer(Plugin plugin, Player player) {
++        hidePlayer(plugin, player.getUniqueId());
++    }
++
++    @Override
++    public void hidePlayer(Plugin plugin, Player player, boolean immediate) {
++        hidePlayer(plugin, player.getUniqueId(), immediate);
++    }
++
++    @Override
++    public void hidePlayer(Plugin plugin, UUID uuid) {
++        hidePlayer(plugin, uuid, true);
++    }
++
++    @Override
++    public void hidePlayer(Plugin plugin, UUID uuid, boolean immediate) {
+         Validate.notNull(plugin, "Plugin cannot be null");
+         Validate.isTrue(plugin.isEnabled(), "Plugin attempted to hide player while disabled");
++        Validate.notNull(uuid, "hidden player id cannot be null");
+ 
+-        hidePlayer0(plugin, player);
++        hidePlayer0(plugin, uuid, immediate);
+     }
+ 
+-    private void hidePlayer0(@Nullable Plugin plugin, Player player) {
+-        Validate.notNull(player, "hidden player cannot be null");
++    private void hidePlayer0(@Nullable Plugin plugin, UUID uuid, boolean immediate) {
++        Validate.notNull(uuid, "hidden player cannot be null");
+         if (getHandle().playerConnection == null) return;
+-        if (equals(player)) return;
++        if (getUniqueId().equals(uuid)) return;
+ 
+-        Set<WeakReference<Plugin>> hidingPlugins = hiddenPlayers.get(player.getUniqueId());
++        Set<WeakReference<Plugin>> hidingPlugins = hiddenPlayers.get(uuid);
+         if (hidingPlugins != null) {
+             // Some plugins are already hiding the player. Just mark that this
+             // plugin wants the player hidden too and end.
+@@ -1348,13 +1365,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+         hidingPlugins = new HashSet<>();
+         hidingPlugins.add(getPluginWeakReference(plugin));
+-        hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
+-
+-        // Remove this player from the hidden player's EntityTrackerEntry
+-        // Paper start
+-        EntityPlayer other = ((CraftPlayer) player).getHandle();
+-        unregisterPlayer(other);
++        hiddenPlayers.put(uuid, hidingPlugins);
++
++        if (immediate) {
++            org.bukkit.entity.Entity player = server.getEntity(uuid);
++            if (player instanceof CraftPlayer) {
++                // Remove this player from the hidden player's EntityTrackerEntry
++                // Paper start
++                EntityPlayer other = ((CraftPlayer) player).getHandle();
++                unregisterPlayer(other);
++            }
++        }
+     }
++    // Paper end
++
+     private void unregisterPlayer(EntityPlayer other) {
+         PlayerChunkMap tracker = ((WorldServer) entity.world).getChunkProvider().playerChunkMap;
+         // Paper end
+@@ -1369,26 +1393,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         }
+     }
+ 
++    // Paper start
+     @Override
+     @Deprecated
+     public void showPlayer(Player player) {
+-        showPlayer0(null, player);
++        showPlayer(null, player.getUniqueId());
+     }
+ 
+     @Override
+     public void showPlayer(Plugin plugin, Player player) {
++        showPlayer(plugin, player.getUniqueId());
++    }
++
++    @Override
++    public void showPlayer(Plugin plugin, Player player, boolean immediate) {
++        showPlayer(plugin, player.getUniqueId(), immediate);
++    }
++
++    @Override
++    public void showPlayer(Plugin plugin, UUID uuid) {
+         Validate.notNull(plugin, "Plugin cannot be null");
+         // Don't require that plugin be enabled. A plugin must be allowed to call
+         // showPlayer during its onDisable() method.
+-        showPlayer0(plugin, player);
++        showPlayer(plugin, uuid, true);
++    }
++
++    @Override
++    public void showPlayer(Plugin plugin, UUID uuid, boolean immediate) {
++        Validate.notNull(plugin, "Plugin cannot be null");
++        showPlayer0(plugin, uuid, immediate);
+     }
+ 
+-    private void showPlayer0(@Nullable Plugin plugin, Player player) {
+-        Validate.notNull(player, "shown player cannot be null");
++    private void showPlayer0(@Nullable Plugin plugin, UUID uuid, boolean immediate) {
++        Validate.notNull(uuid, "shown player cannot be null");
+         if (getHandle().playerConnection == null) return;
+-        if (equals(player)) return;
++        if (getUniqueId().equals(uuid)) return;
+ 
+-        Set<WeakReference<Plugin>> hidingPlugins = hiddenPlayers.get(player.getUniqueId());
++        Set<WeakReference<Plugin>> hidingPlugins = hiddenPlayers.get(uuid);
+         if (hidingPlugins == null) {
+             return; // Player isn't hidden
+         }
+@@ -1396,12 +1437,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         if (!hidingPlugins.isEmpty()) {
+             return; // Some other plugins still want the player hidden
+         }
+-        hiddenPlayers.remove(player.getUniqueId());
++        hiddenPlayers.remove(uuid);
+ 
+         // Paper start
+-        EntityPlayer other = ((CraftPlayer) player).getHandle();
+-        registerPlayer(other);
++        if (immediate) {
++            org.bukkit.entity.Entity player = server.getEntity(uuid);
++            if (player instanceof CraftPlayer) {
++                EntityPlayer other = ((CraftPlayer) player).getHandle();
++                registerPlayer(other);
++            }
++        }
+     }
++    // Paper end
++
+     private void registerPlayer(EntityPlayer other) {
+         PlayerChunkMap tracker = ((WorldServer) entity.world).getChunkProvider().playerChunkMap;
+         // Paper end

--- a/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
+++ b/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Extend hide/showPlayer API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..651e2e5d694c235197c7299201710e7ff6e20d03 100644
+index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..91142d47ae0c63c5050522791e002810e5dd00f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1320,26 +1320,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -17,7 +17,7 @@ index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..651e2e5d694c235197c7299201710e7f
      @Deprecated
      public void hidePlayer(Player player) {
 -        hidePlayer0(null, player);
-+        hidePlayer(null, player.getUniqueId());
++        hidePlayer0(null, player.getUniqueId(), true);
      }
  
      @Override
@@ -94,7 +94,7 @@ index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..651e2e5d694c235197c7299201710e7f
      @Deprecated
      public void showPlayer(Player player) {
 -        showPlayer0(null, player);
-+        showPlayer(null, player.getUniqueId());
++        showPlayer0(null, player.getUniqueId(), true);
      }
  
      @Override

--- a/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
+++ b/Spigot-Server-Patches/0678-Extend-hide-showPlayer-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Extend hide/showPlayer API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..f7158a282789013c41089d5ed6573705f1021ed2 100644
+index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..651e2e5d694c235197c7299201710e7ff6e20d03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1320,26 +1320,43 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -22,7 +22,7 @@ index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..f7158a282789013c41089d5ed6573705
  
      @Override
      public void hidePlayer(Plugin plugin, Player player) {
-+        hidePlayer(plugin, player.getUniqueId());
++        hidePlayer(plugin, player.getUniqueId(), true);
 +    }
 +
 +    @Override
@@ -99,7 +99,7 @@ index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..f7158a282789013c41089d5ed6573705
  
      @Override
      public void showPlayer(Plugin plugin, Player player) {
-+        showPlayer(plugin, player.getUniqueId());
++        showPlayer(plugin, player.getUniqueId(), true);
 +    }
 +
 +    @Override


### PR DESCRIPTION
This adds the ability to hide/show players by UUID and optionally not immediately. In my use-case, we will sometimes have a cache of players to hide from other players that we send to a player on logon.

Doing this lazily and by UUID allows us to pre-hide players (or Player NPCs sometimes), so that they don't join, see a player for a tick, then hide later.