### PR TITLE
fix: legacy component serialisation was wiped out

### DIFF
--- a/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
@@ -16,8 +16,24 @@ index de6bfc27cd38fd6293853d55cf62699aade94212..65aec1dc2fd9ef9c9a9f022f13008505
          @Nullable
          public static IChatMutableComponent a(String s) {
              return (IChatMutableComponent) ChatDeserializer.a(IChatBaseComponent.ChatSerializer.a, s, IChatMutableComponent.class, false);
+diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+index 6c9aed49d5e63d6df608719ed17e813f86e93fcc..391f96e585d80f7921fd96f207b0b60d88961ae7 100644
+--- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
++++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
+@@ -158,6 +158,11 @@ public class PacketDataSerializer extends ByteBuf {
+     public PacketDataSerializer writeComponent(final net.kyori.adventure.text.Component component) {
+         return this.writeUtf(PaperAdventure.asJsonString(component, this.adventure$locale), 262144);
+     }
++
++    @Deprecated
++    public PacketDataSerializer writeComponent(final net.md_5.bungee.api.chat.BaseComponent[] component) {
++        return this.writeUtf(net.md_5.bungee.chat.ComponentSerializer.toString(component), 262144);
++    }
+     // Paper end
+ 
+     public PacketDataSerializer a(IChatBaseComponent ichatbasecomponent) {
 diff --git a/src/main/java/net/minecraft/server/PacketPlayOutTitle.java b/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
-index 772ca6256964692a2b9c12e2edc532d2a8f51f7b..f98a261d825c9ebe284f1e3658ca1df451995b59 100644
+index 772ca6256964692a2b9c12e2edc532d2a8f51f7b..71168d9d0252e93253fa3b3f0bface3ae58757b7 100644
 --- a/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
 +++ b/src/main/java/net/minecraft/server/PacketPlayOutTitle.java
 @@ -44,6 +44,17 @@ public class PacketPlayOutTitle implements Packet<PacketListenerPlayOut> {
@@ -38,6 +54,15 @@ index 772ca6256964692a2b9c12e2edc532d2a8f51f7b..f98a261d825c9ebe284f1e3658ca1df4
  
      @Override
      public void b(PacketDataSerializer packetdataserializer) throws IOException {
+@@ -52,6 +63,8 @@ public class PacketPlayOutTitle implements Packet<PacketListenerPlayOut> {
+             // Paper start
+             if (this.adventure$text != null) {
+                 packetdataserializer.writeComponent(this.adventure$text);
++            } else if (this.components != null) {
++                packetdataserializer.writeComponent(this.components);
+             } else
+             // Paper end
+             packetdataserializer.a(this.b);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index 4c0a6d00b17b5e11c0f2b5d7170701bedd20b87c..2542b3a135dd3f728a5a44c9f9c81ae524734abf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java

--- a/Spigot-Server-Patches/0261-Fix-client-rendering-skulls-from-same-user.patch
+++ b/Spigot-Server-Patches/0261-Fix-client-rendering-skulls-from-same-user.patch
@@ -25,10 +25,10 @@ index bdb6f9bf3477f85859e3f0dd761e2e895f1a8e2b..22568201a292edc8e25396e55cad1572
      private Entity k;
      private ShapeDetectorBlock l;
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 6c9aed49d5e63d6df608719ed17e813f86e93fcc..3d6fbde63d110559b552d052ef9a934318a00682 100644
+index 391f96e585d80f7921fd96f207b0b60d88961ae7..3a257d3b0a6adb4d0a43833b996d70765559eff8 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-@@ -293,9 +293,18 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -298,9 +298,18 @@ public class PacketDataSerializer extends ByteBuf {
              if (item.usesDurability() || item.n()) {
                  // Spigot start - filter
                  itemstack = itemstack.cloneItemStack();
@@ -48,7 +48,7 @@ index 6c9aed49d5e63d6df608719ed17e813f86e93fcc..3d6fbde63d110559b552d052ef9a9343
              }
  
              this.a(nbttagcompound);
-@@ -315,7 +324,16 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -320,7 +329,16 @@ public class PacketDataSerializer extends ByteBuf {
              itemstack.setTag(this.l());
              // CraftBukkit start
              if (itemstack.getTag() != null) {

--- a/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0299-Add-Velocity-IP-Forwarding-Support.patch
@@ -211,10 +211,10 @@ index 066b0dbdbc101a8235fb872c2d1e9d427dfd6bb8..ddad076c7eb6d30f2e0f187e004c9e19
      }
  
 diff --git a/src/main/java/net/minecraft/server/PacketDataSerializer.java b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-index 3d6fbde63d110559b552d052ef9a934318a00682..4be310ada6477b2040f2ea11010f429c3f38c4ac 100644
+index 3a257d3b0a6adb4d0a43833b996d70765559eff8..8865e8e375f7cb437e5a7ff9f42a4156d8edd9e3 100644
 --- a/src/main/java/net/minecraft/server/PacketDataSerializer.java
 +++ b/src/main/java/net/minecraft/server/PacketDataSerializer.java
-@@ -173,6 +173,7 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -178,6 +178,7 @@ public class PacketDataSerializer extends ByteBuf {
          return this.d(oenum.ordinal());
      }
  
@@ -222,7 +222,7 @@ index 3d6fbde63d110559b552d052ef9a934318a00682..4be310ada6477b2040f2ea11010f429c
      public int i() {
          int i = 0;
          int j = 0;
-@@ -213,6 +214,7 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -218,6 +219,7 @@ public class PacketDataSerializer extends ByteBuf {
          return this;
      }
  
@@ -230,7 +230,7 @@ index 3d6fbde63d110559b552d052ef9a934318a00682..4be310ada6477b2040f2ea11010f429c
      public UUID k() {
          return new UUID(this.readLong(), this.readLong());
      }
-@@ -340,6 +342,7 @@ public class PacketDataSerializer extends ByteBuf {
+@@ -345,6 +347,7 @@ public class PacketDataSerializer extends ByteBuf {
          }
      }
  


### PR DESCRIPTION
When merging 4e958e229f9f448a10dbc610bab460dbf222902e, nobody caught the
fact we removed the component serialisation of legacy BungeeCord Chat
API components in the PacketPlayOutTitle class.

Test plugin code:

```kotlin
class LegacyMessageCommand : BaseCommand() {
    override fun register(manager: PaperCommandManager<CommandSender>) {
        manager.command(manager.commandBuilder("legacymsg")
            .sender<Player>()
            .handler {
                val component = ComponentBuilder("Test")
                    .color(ChatColor.DARK_RED)
                    .bold(true)
                    .append(" message")
                    .bold(false)
                    .color(ChatColor.of("#f8a8a8"))
                    .event(
                        HoverEvent(
                            HoverEvent.Action.SHOW_TEXT,
                            Text(
                                ComponentBuilder("Test hover")
                                    .color(ChatColor.AQUA)
                                    .underlined(true)
                                    .create()
                            )
                        )
                    )
                    .event(
                        ClickEvent(
                            ClickEvent.Action.SUGGEST_COMMAND,
                            "/legacymsg"
                        )
                    )
                    .create()
                it.sender.sendMessage(*component)
                it.sender.sendActionBar(*component)
                it.sender.sendTitle(
                    Title.builder()
                        .title(component)
                        .subtitle(component)
                        .fadeIn(40)
                        .stay(60)
                        .fadeOut(40)
                        .build()
                )
            })
    }
}
```

Fixes GH-5271.