### PR TITLE
Print command usage for /paper entity list at more places

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -7,10 +7,10 @@ Loads each yml file for early init too so it can be used for early options
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b910d7a4fe
+index 0000000000000000000000000000000000000000..5e819f7ac4049d3d2b5ce814263b3276e88fe934
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -0,0 +1,256 @@
+@@ -0,0 +1,259 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Functions;
@@ -164,6 +164,7 @@ index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b9
 +
 +                if (names.isEmpty()) {
 +                    sender.sendMessage(ChatColor.RED + "Invalid filter, does not match any entities. Use /paper entity list for a proper list");
++                    sender.sendMessage(ChatColor.RED + "Usage: /paper entity list [filter] [worldName]");
 +                    return;
 +                }
 +
@@ -175,6 +176,7 @@ index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b9
 +                } else {
 +                    sender.sendMessage(ChatColor.RED + "Please specify the name of a world");
 +                    sender.sendMessage(ChatColor.RED + "To do so without a filter, specify '*' as the filter");
++                    sender.sendMessage(ChatColor.RED + "Usage: /paper entity list [filter] [worldName]");
 +                    return;
 +                }
 +
@@ -182,6 +184,7 @@ index 0000000000000000000000000000000000000000..b8868b86338ce0e89bc74eccccf714b9
 +                World bukkitWorld = Bukkit.getWorld(worldName);
 +                if (bukkitWorld == null) {
 +                    sender.sendMessage(ChatColor.RED + "Could not load world for " + worldName + ". Please select a valid world.");
++                    sender.sendMessage(ChatColor.RED + "Usage: /paper entity list [filter] [worldName]");
 +                    return;
 +                }
 +                WorldServer world = ((CraftWorld) Bukkit.getWorld(worldName)).getHandle();

--- a/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
+++ b/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add MinecraftKey Information to Objects
 Stores the reference to the objects respective MinecraftKey
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index b8868b86338ce0e89bc74eccccf714b910d7a4fe..9cb2f3b31921870ddba044840e99eb04babe26bb 100644
+index 5e819f7ac4049d3d2b5ce814263b3276e88fe934..d37cf906988863840ed99875c7567843cb38a9fc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -178,7 +178,7 @@ public class PaperCommand extends Command {
+@@ -181,7 +181,7 @@ public class PaperCommand extends Command {
  
                  Collection<Entity> entities = world.entitiesById.values();
                  entities.forEach(e -> {

--- a/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -11,10 +11,10 @@ This will ensure that dead entities are skipped from iteration since
 they shouldn't of been in the list in the first place.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 9cb2f3b31921870ddba044840e99eb04babe26bb..f0a836db74ad3e20778d3863223bc9a35ff4ad41 100644
+index d37cf906988863840ed99875c7567843cb38a9fc..600b1a36bb1287af4c0d91e52b7a30e7a3588ce4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-@@ -179,6 +179,7 @@ public class PaperCommand extends Command {
+@@ -182,6 +182,7 @@ public class PaperCommand extends Command {
                  Collection<Entity> entities = world.entitiesById.values();
                  entities.forEach(e -> {
                      MinecraftKey key = e.getMinecraftKey();


### PR DESCRIPTION
These are the QoL changes Paper deserves
I never know if it's /paper entity list * world or /paper entity list world *, this elegant solution fixes it!