### PR TITLE
Add JavaDoc links to Tag class pointing to custom Paper tags

### DIFF
--- a/Spigot-API-Patches/0154-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0154-Add-Material-Tags.patch
@@ -944,17 +944,16 @@ index 0000000000000000000000000000000000000000..9266c9d77e2eef7cd717dc729834a190
 +        .ensureSize("WATER_BASED", 9);
 +}
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index aacbfadc91f580cc667603c8165eacbadee38cca..9be0d33dd6931e998801a19268721372f86f6bf8 100644
+index aacbfadc91f580cc667603c8165eacbadee38cca..3c2a6a2167eab43097f5d6ccf1550e12795fc0b6 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -10,6 +10,11 @@ import org.jetbrains.annotations.NotNull;
+@@ -10,6 +10,10 @@ import org.jetbrains.annotations.NotNull;
   * Note that whilst all tags defined within this interface must be present in
   * implementations, their existence is not guaranteed across future versions.
   *
-+ * <br><br>
-+ * Custom tags defined by Paper are not present (as constants) in this class.
++ * <p>Custom tags defined by Paper are not present (as constants) in this class.
 + * To access them please refer to {@link com.destroystokyo.paper.MaterialTags}
-+ * and {@link io.papermc.paper.tag.EntityTags}.
++ * and {@link io.papermc.paper.tag.EntityTags}.</p>
 + *
   * @param <T> the type of things grouped by this tag
   */

--- a/Spigot-API-Patches/0154-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0154-Add-Material-Tags.patch
@@ -943,6 +943,24 @@ index 0000000000000000000000000000000000000000..9266c9d77e2eef7cd717dc729834a190
 +        .add(DOLPHIN, SQUID, GUARDIAN, ELDER_GUARDIAN, TURTLE, COD, SALMON, PUFFERFISH, TROPICAL_FISH)
 +        .ensureSize("WATER_BASED", 9);
 +}
+diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
+index aacbfadc91f580cc667603c8165eacbadee38cca..ef1b991fda4fbdb93d464b7b77b91fcde09dc0d1 100644
+--- a/src/main/java/org/bukkit/Tag.java
++++ b/src/main/java/org/bukkit/Tag.java
+@@ -10,6 +10,13 @@ import org.jetbrains.annotations.NotNull;
+  * Note that whilst all tags defined within this interface must be present in
+  * implementations, their existence is not guaranteed across future versions.
+  *
++ * <!-- Paper start -->
++ * <br><br>
++ * Custom tags defined by Paper are not present (as constants) in this class.
++ * To access them please refer to {@link com.destroystokyo.paper.MaterialTags}
++ * and {@link io.papermc.paper.tag.EntityTags}.
++ * <!-- Paper end -->
++ *
+  * @param <T> the type of things grouped by this tag
+  */
+ public interface Tag<T extends Keyed> extends Keyed {
 diff --git a/src/test/java/com/destroystokyo/paper/MaterialTagsTest.java b/src/test/java/com/destroystokyo/paper/MaterialTagsTest.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..328c51471dc12e81c1a1b643455337b3fef4d14a

--- a/Spigot-API-Patches/0154-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0154-Add-Material-Tags.patch
@@ -944,19 +944,17 @@ index 0000000000000000000000000000000000000000..9266c9d77e2eef7cd717dc729834a190
 +        .ensureSize("WATER_BASED", 9);
 +}
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index aacbfadc91f580cc667603c8165eacbadee38cca..ef1b991fda4fbdb93d464b7b77b91fcde09dc0d1 100644
+index aacbfadc91f580cc667603c8165eacbadee38cca..9be0d33dd6931e998801a19268721372f86f6bf8 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -10,6 +10,13 @@ import org.jetbrains.annotations.NotNull;
+@@ -10,6 +10,11 @@ import org.jetbrains.annotations.NotNull;
   * Note that whilst all tags defined within this interface must be present in
   * implementations, their existence is not guaranteed across future versions.
   *
-+ * <!-- Paper start -->
 + * <br><br>
 + * Custom tags defined by Paper are not present (as constants) in this class.
 + * To access them please refer to {@link com.destroystokyo.paper.MaterialTags}
 + * and {@link io.papermc.paper.tag.EntityTags}.
-+ * <!-- Paper end -->
 + *
   * @param <T> the type of things grouped by this tag
   */

--- a/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
+++ b/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added Vanilla Entity Tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index ef1b991fda4fbdb93d464b7b77b91fcde09dc0d1..d106510cbedf45091c928169cf0efc8544cb0ce3 100644
+index 9be0d33dd6931e998801a19268721372f86f6bf8..9307cb35b355440d63ff015e35a0c0e6b44c4477 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -428,6 +428,32 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -426,6 +426,32 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla fluid tag representing water and flowing water.
       */
      Tag<Fluid> FLUIDS_WATER = Bukkit.getTag(REGISTRY_FLUIDS, NamespacedKey.minecraft("water"), Fluid.class);

--- a/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
+++ b/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added Vanilla Entity Tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 9be0d33dd6931e998801a19268721372f86f6bf8..9307cb35b355440d63ff015e35a0c0e6b44c4477 100644
+index 3c2a6a2167eab43097f5d6ccf1550e12795fc0b6..c1ec099448d57f2a5f973ac5b4e4a25b79ea2112 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -426,6 +426,32 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -425,6 +425,32 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla fluid tag representing water and flowing water.
       */
      Tag<Fluid> FLUIDS_WATER = Bukkit.getTag(REGISTRY_FLUIDS, NamespacedKey.minecraft("water"), Fluid.class);

--- a/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
+++ b/Spigot-API-Patches/0264-Added-Vanilla-Entity-Tags.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added Vanilla Entity Tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index aacbfadc91f580cc667603c8165eacbadee38cca..cbefdacee2d7b29a705de20935e20380a4632e14 100644
+index ef1b991fda4fbdb93d464b7b77b91fcde09dc0d1..d106510cbedf45091c928169cf0efc8544cb0ce3 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -421,6 +421,32 @@ public interface Tag<T extends Keyed> extends Keyed {
+@@ -428,6 +428,32 @@ public interface Tag<T extends Keyed> extends Keyed {
       * Vanilla fluid tag representing water and flowing water.
       */
      Tag<Fluid> FLUIDS_WATER = Bukkit.getTag(REGISTRY_FLUIDS, NamespacedKey.minecraft("water"), Fluid.class);


### PR DESCRIPTION
Reasoning: by adding JavaDoc links users are able to find the Paper additions.

Let's say someone wants to find a tag for pickaxes. The first place to look would be the `Tag` class. What if the user does not know about these extra classes added by Paper? The user would have to give up the search. But this modification adds links to the `Tag` class, which I assume developers are already familiar with. So developers are now able to discover new tags and, hopefully, the ones they need, through these links.