### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/Spigot-API-Patches/0004-Timings-v2.patch
+++ b/Spigot-API-Patches/0004-Timings-v2.patch
@@ -3375,10 +3375,10 @@ index 2a145d851ce30360aa39549745bd87590c034584..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index eaf5d55d10f6828b7d0a06ff38c00ddd0b6ec103..0e05b09fc05ccd0a5dabb658dc62e336b204a127 100644
+index 90c8c3eb8bc3285bf7a51da89015304e49e6602c..344aecc097c5e12476d2be53019145812b028914 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1402,7 +1402,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1353,7 +1353,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           */
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -1115,7 +1115,7 @@ index 344c14a5ed86e9ebe401bfb5ba3aedc0c0ed0b04..41a1bc45cc5eb7f19374115ade7f5328
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd8507602502dd0 100644
+index 344aecc097c5e12476d2be53019145812b028914..c5e7e037493ffe1f1764c3ad5d3e12bfac498cb2 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -30,7 +30,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1350,7 +1350,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -1269,6 +1390,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1220,6 +1341,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -1365,7 +1365,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
      /**
       * Gets the player's current locale.
       *
-@@ -1279,8 +1408,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1230,8 +1359,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -1376,7 +1376,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
      public String getLocale();
  
      /**
-@@ -1298,6 +1429,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1249,6 +1380,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void openBook(@NotNull ItemStack book);
  
@@ -1391,7 +1391,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1352,11 +1491,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1303,11 +1442,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -1405,7 +1405,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1367,7 +1508,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1318,7 +1459,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -1415,7 +1415,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1377,7 +1520,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1328,7 +1471,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -1425,7 +1425,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1388,7 +1533,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1339,7 +1484,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -1435,7 +1435,7 @@ index 0e05b09fc05ccd0a5dabb658dc62e336b204a127..e4d1d95dda8cdefb9056aa688bd85076
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1399,7 +1546,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1350,7 +1497,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/Spigot-API-Patches/0006-Player-affects-spawning-API.patch
+++ b/Spigot-API-Patches/0006-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e4d1d95dda8cdefb9056aa688bd8507602502dd0..671f9eff01a46a1cacdb76a87b93e090d78329b3 100644
+index c5e7e037493ffe1f1764c3ad5d3e12bfac498cb2..e3a23cef93df2bbb2f27f87150bc1dbf7fd051b5 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1414,6 +1414,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1365,6 +1365,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/Spigot-API-Patches/0011-Add-player-view-distance-API.patch
+++ b/Spigot-API-Patches/0011-Add-player-view-distance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player view distance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 671f9eff01a46a1cacdb76a87b93e090d78329b3..68795a48cb15d322906ce0569b7701231c1f94c2 100644
+index e3a23cef93df2bbb2f27f87150bc1dbf7fd051b5..1ce07f925acb550c379e4deb1a013bcbe5701a8a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1428,6 +1428,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1379,6 +1379,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/Spigot-API-Patches/0022-Complete-resource-pack-API.patch
+++ b/Spigot-API-Patches/0022-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c9e4cb2d153fc0c6853fe520263a0073e7504e38..d1b7b0d24f15753337e211328771b3cba47bca18 100644
+index a3d3cefb3739f3cb787befb03a5ddc38fb343849..38f47517d5391696c52d8848c21dee40033458e6 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1173,7 +1173,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1124,7 +1124,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index c9e4cb2d153fc0c6853fe520263a0073e7504e38..d1b7b0d24f15753337e211328771b3cb
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -1635,6 +1637,60 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1586,6 +1588,60 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/Spigot-API-Patches/0042-Add-String-based-Action-Bar-API.patch
+++ b/Spigot-API-Patches/0042-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d1b7b0d24f15753337e211328771b3cba47bca18..3f68baef538098d9ce66b91195b6fa17f26f0d78 100644
+index 38f47517d5391696c52d8848c21dee40033458e6..f5d9899ec0788019ba14f15dc0f290abe4b3cfa8 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -68,7 +68,7 @@ index d1b7b0d24f15753337e211328771b3cba47bca18..3f68baef538098d9ce66b91195b6fa17
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1762,6 +1798,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1713,6 +1749,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index d1b7b0d24f15753337e211328771b3cba47bca18..3f68baef538098d9ce66b91195b6fa17
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -1774,6 +1811,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1725,6 +1762,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/Spigot-API-Patches/0088-Player.setPlayerProfile-API.patch
+++ b/Spigot-API-Patches/0088-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9d1ad67b7d220ab425ac9bf6b1c8d8fb8d5f416c..6769330f336afcd5f26c0f7286defa00bead543c 100644
+index 3063f917f34a28e347daac54bc73e000d6771fed..30b97d4e20f5d89533f0aebd2245fa7578c97420 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
@@ -17,7 +17,7 @@ index 9d1ad67b7d220ab425ac9bf6b1c8d8fb8d5f416c..6769330f336afcd5f26c0f7286defa00
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1748,6 +1749,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1699,6 +1700,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/Spigot-API-Patches/0147-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-API-Patches/0147-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 88fd4cdeaad4d27f414c6b268022cdedf73492e7..3506c4640df9cc61b793a4b934fd41066b9f6572 100644
+index fe4b301e96f58cc41fb9789f030e00645c9a7e60..6253b43490cac138edbb59ce0647d3f37314e435 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1923,6 +1923,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1874,6 +1874,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/Spigot-API-Patches/0194-Add-Player-Client-Options-API.patch
+++ b/Spigot-API-Patches/0194-Add-Player-Client-Options-API.patch
@@ -176,7 +176,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 3506c4640df9cc61b793a4b934fd41066b9f6572..ae23c2e2c5f735ea0f8797e4bc9ee7bedb2abf8e 100644
+index 6253b43490cac138edbb59ce0647d3f37314e435..e6b5969df34f096cec84ebb46061cb956eba4bab 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -187,7 +187,7 @@ index 3506c4640df9cc61b793a4b934fd41066b9f6572..ae23c2e2c5f735ea0f8797e4bc9ee7be
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -1943,6 +1944,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1894,6 +1895,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/Spigot-API-Patches/0221-Brand-support.patch
+++ b/Spigot-API-Patches/0221-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ae23c2e2c5f735ea0f8797e4bc9ee7bedb2abf8e..11f0bca3cbc9eac6afb33c2a387ee2f6e2186402 100644
+index e6b5969df34f096cec84ebb46061cb956eba4bab..61c572fe69cf08aaa36a26ebed21127c14309bf4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2078,6 +2078,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2029,6 +2029,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/Spigot-API-Patches/0230-Player-elytra-boost-API.patch
+++ b/Spigot-API-Patches/0230-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 11f0bca3cbc9eac6afb33c2a387ee2f6e2186402..46eb684a23b1b8321a91f1e70b8196706aebd9bc 100644
+index 61c572fe69cf08aaa36a26ebed21127c14309bf4..5bdc48b533833f626a012b675c9c58f8b00b2400 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1950,6 +1950,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1901,6 +1901,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/Spigot-API-Patches/0259-Add-sendOpLevel-API.patch
+++ b/Spigot-API-Patches/0259-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 46eb684a23b1b8321a91f1e70b8196706aebd9bc..5fe48dcc5a3ea492915350cff44d5f112ce11dbf 100644
+index 5bdc48b533833f626a012b675c9c58f8b00b2400..8a1e35952ae84ae1e41a2b7783e88eab52bd274c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1963,6 +1963,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1914,6 +1914,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/Spigot-API-Patches/0275-Expose-Tracked-Players.patch
+++ b/Spigot-API-Patches/0275-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..b391c720b69714cf49f8733cf4440864ac3dcd72 100644
+index 8a1e35952ae84ae1e41a2b7783e88eab52bd274c..2ea531eaef8c455fdd503f0c0258813fe9136085 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1,6 +1,7 @@
@@ -16,7 +16,7 @@ index 5fe48dcc5a3ea492915350cff44d5f112ce11dbf..b391c720b69714cf49f8733cf4440864
  import java.util.UUID;
  import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
-@@ -1976,6 +1977,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1927,6 +1928,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end
  

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -718,7 +718,7 @@ index da922f395f0fff0881ead893c900c5b2623f48f0..1d03a79e9010bc514b72a81ba0ad4a62
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index 871b79cb2c63525c430c257f00b2cf70157aa476..d847326b0099a0c05a085d5d62de630491c9ac56 100644
+index 55b9fe1a79e0feb80dc2932f1267b972900b92b1..428a10fb100d1b4775dab6cfe69f28c29a45cd70 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -22,6 +22,15 @@ public class Block extends BlockBase implements IMaterial {
@@ -1043,7 +1043,7 @@ index b35ffae9f88cc14aec01482c2a3ed2e2428c2012..03933c24ed4d97e16bcebf6b89b1a8d1
  
      protected BlockPosition ap() {
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 8ad1256bcde950bc34aeb7f61ef9598f3b1cd2a3..d41638b97188ba58d2456d2f6c3c71fc79fe572a 100644
+index f49f66e3c128e9ce0f4edc24332f5c52cbb20d02..2150525c7c015bccc8fa4330f2e6c50f9170c55e 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -42,7 +42,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -2014,10 +2014,10 @@ index 66523c21c49b8a019a82fdeb84a187c3b627ab73..e69de29bb2d1d6434b8b29ae775ad8c2
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6c03ce0d86f12886c9d94db2e2a62ededd124bf6..1cbf0fd6c0f2d1fa62f944162cd9320c640d8530 100644
+index 4ffc8442d559c9bef818011667ac091745575b1d..4bfdd900bae4c886360b24fcc8563e1d2e73ebf0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1833,6 +1833,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1803,6 +1803,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              getHandle().playerConnection.sendPacket(packet);
          }

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1944,7 +1944,7 @@ index db7c4011c8b90b6daca2b48a6d9ec447d31f7197..969bf1095bb2a90ad0f1cb1f1e023e05
      public void setCustomName(String name) {
          // sane limit for name length
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 96b55867d8bfbc85cb290da9b320ec74b9dbb179..513d24877c336b6e32f2ef939788d1082342dde8 100644
+index 3ea267a786f8f047767cace4dc59951b28a615a6..19cdff6eebb7c07d75b515dfa0d47bb762626150 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -316,9 +316,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -1978,7 +1978,7 @@ index 96b55867d8bfbc85cb290da9b320ec74b9dbb179..513d24877c336b6e32f2ef939788d108
          player.activeContainer.addSlotListener(player);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1cbf0fd6c0f2d1fa62f944162cd9320c640d8530..32a8a074600519ec2075229bbd02ca1e4123a70f 100644
+index 4bfdd900bae4c886360b24fcc8563e1d2e73ebf0..c0154a14a4da53b933b121fea585d1c1e4d0e87f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -240,14 +240,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2150,7 +2150,7 @@ index 1cbf0fd6c0f2d1fa62f944162cd9320c640d8530..32a8a074600519ec2075229bbd02ca1e
      }
  
      @Override
-@@ -1718,6 +1788,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1688,6 +1758,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : getHandle().clientViewDistance;
      }
  
@@ -2163,7 +2163,7 @@ index 1cbf0fd6c0f2d1fa62f944162cd9320c640d8530..32a8a074600519ec2075229bbd02ca1e
      @Override
      public String getLocale() {
          return getHandle().locale;
-@@ -1741,6 +1817,137 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1711,6 +1787,137 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2302,10 +2302,10 @@ index 1cbf0fd6c0f2d1fa62f944162cd9320c640d8530..32a8a074600519ec2075229bbd02ca1e
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f6688c7151734f4bdb63a71e810996e04b09e22c..9ff3e1e410336a4d76c94cc52343113c3cb0b613 100644
+index de912d8f521acda1f9e5ec39d20ed28abe2bd01f..b4302fe96d4b2ad6db47fc9d350495cc20a26478 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -766,9 +766,9 @@ public class CraftEventFactory {
+@@ -767,9 +767,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2317,7 +2317,7 @@ index f6688c7151734f4bdb63a71e810996e04b09e22c..9ff3e1e410336a4d76c94cc52343113c
          event.setKeepInventory(keepInventory);
          org.bukkit.World world = entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -792,7 +792,7 @@ public class CraftEventFactory {
+@@ -793,7 +793,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/Spigot-Server-Patches/0021-Player-affects-spawning-API.patch
+++ b/Spigot-Server-Patches/0021-Player-affects-spawning-API.patch
@@ -17,10 +17,10 @@ index 09bab3828197e3078a4ed95e7c8a9f34e8bf1b8d..dc996792df6046d442565a7993ec299a
          double d3 = this.locX() - d0;
          double d4 = this.locY() - d1;
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index a85daaef5bb7df5abee9670eddec06156ecd0f65..371648709a63b394fb7577722c18d4b9a1738b2b 100644
+index 1a4f49a019134ecd50542f0099e44f164aa9b690..dcc9984665a1b6458cee317bb79a3343656cea23 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -68,6 +68,9 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -70,6 +70,9 @@ public abstract class EntityHuman extends EntityLiving {
      private final ItemCooldown bM;
      @Nullable
      public EntityFishingHook hookedFish;
@@ -131,10 +131,10 @@ index 90af43930f9141b0c7f51bb3d887d7b9c4d935eb..1741ec5e241f8ae7a3c30a9021d14cb0
  
      public void c() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5f55e3816f1e00be6e4ae573cc09eb19b59adf74..aaf57e9ebf5c46cfde51bbca1a51d51719f51fe3 100644
+index c0154a14a4da53b933b121fea585d1c1e4d0e87f..5d446eb731621e2205b684923a06b932d41ba421 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1797,8 +1797,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1767,8 +1767,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return getHandle().locale;

--- a/Spigot-Server-Patches/0025-Only-refresh-abilities-if-needed.patch
+++ b/Spigot-Server-Patches/0025-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aaf57e9ebf5c46cfde51bbca1a51d51719f51fe3..4c0a6d00b17b5e11c0f2b5d7170701bedd20b87c 100644
+index 5d446eb731621e2205b684923a06b932d41ba421..11304fef16c341f5643683a4c1b662222c9ce5d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1471,12 +1471,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1441,12 +1441,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/Spigot-Server-Patches/0059-Complete-resource-pack-API.patch
+++ b/Spigot-Server-Patches/0059-Complete-resource-pack-API.patch
@@ -22,7 +22,7 @@ index bb74049fb2baffbe67f9e34cc0ee0b83180d02eb..9a9847c217a6f7a2e2bc09b68b3d2821
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 465fd7b4ee8f0a36c2a944c95666979a2d33c248..21952a8fa3eebad70dba5ab8fb900209a81bdb20 100644
+index 928492e9dd30cf75aff891ac098cac653b46d822..15a515535d6c8c71e0de4a7ab4c0a8759ca3537f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -138,6 +138,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -36,7 +36,7 @@ index 465fd7b4ee8f0a36c2a944c95666979a2d33c248..21952a8fa3eebad70dba5ab8fb900209
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
          super(server, entity);
-@@ -1901,6 +1905,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1871,6 +1875,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/Spigot-Server-Patches/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/Spigot-Server-Patches/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index a001629eda462ba34555aed6fe162078c18e0c02..d20f405287fb25fd4b221345b0845a0c6713298e 100644
+index 7c74a13d875d12d4264e394c682ab515a14f8915..1fb7e29b29adef72bd5a49c87d954973f46f9c81 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -609,7 +609,13 @@ public abstract class EntityLiving extends Entity {
@@ -44,10 +44,10 @@ index a001629eda462ba34555aed6fe162078c18e0c02..d20f405287fb25fd4b221345b0845a0c
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 21952a8fa3eebad70dba5ab8fb900209a81bdb20..0a00d043c1fcddcfab8638eab8feb2993060b9b8 100644
+index 15a515535d6c8c71e0de4a7ab4c0a8759ca3537f..0a24eab942354a03d5ddf4899cf7a80401b669a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1712,6 +1712,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1682,6 +1682,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
+++ b/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 74727e9e1d689e4a280fb223db9196fef16103f7..103a7fe192182d92ae21783c728e494b
          this.locale = packetplayinsettings.locale;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ecec8a27009f2296e078fdb9bf1ed2f1df209de8..268bbcb706501e0d321e58b7edda99ef3bc3a370 100644
+index b93e6c6ec058c3cc73c7fec47e081a5295c1ec6b..f2cb1d8d82f07019d79a3b967f999b26270f7c29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1904,8 +1904,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1874,8 +1874,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper end
      @Override
      public String getLocale() {

--- a/Spigot-Server-Patches/0092-EntityRegainHealthEvent-isFastRegen-API.patch
+++ b/Spigot-Server-Patches/0092-EntityRegainHealthEvent-isFastRegen-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] EntityRegainHealthEvent isFastRegen API
 Don't even get me started
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index d20f405287fb25fd4b221345b0845a0c6713298e..cda084e6fe8f4f5dcd8c0b13bd07326db2ca7c59 100644
+index 1fb7e29b29adef72bd5a49c87d954973f46f9c81..f54d05f59342231434a70c3b12b7cf9b73f98508 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1037,10 +1037,16 @@ public abstract class EntityLiving extends Entity {
@@ -28,15 +28,15 @@ index d20f405287fb25fd4b221345b0845a0c6713298e..cda084e6fe8f4f5dcd8c0b13bd07326d
              if (this.valid) {
                  this.world.getServer().getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/FoodMetaData.java b/src/main/java/net/minecraft/server/FoodMetaData.java
-index 2476e48fba4ec511c78c54e48afe328bac1dd30c..a41aa02c432097feb570447bd08757d3dde9fc8b 100644
+index f40b67c8bf3048b24b7c7b16effd3c18646d589c..077ff94ec57278f71ea6afb5d7a0e55ecb0fa5ef 100644
 --- a/src/main/java/net/minecraft/server/FoodMetaData.java
 +++ b/src/main/java/net/minecraft/server/FoodMetaData.java
-@@ -69,7 +69,7 @@ public class FoodMetaData {
-             if (this.foodTickTimer >= 10) {
+@@ -74,7 +74,7 @@ public class FoodMetaData {
+             if (this.foodTickTimer >= this.saturatedRegenRate) { // CraftBukkit
                  float f = Math.min(this.saturationLevel, 6.0F);
  
 -                entityhuman.heal(f / 6.0F, org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.SATIATED); // CraftBukkit - added RegainReason
 +                entityhuman.heal(f / 6.0F, org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason.SATIATED, true); // CraftBukkit - added RegainReason // Paper - This is fast regen
-                 this.a(f);
+                 // this.a(f); CraftBukkit - EntityExhaustionEvent
+                 entityhuman.applyExhaustion(f, org.bukkit.event.entity.EntityExhaustionEvent.ExhaustionReason.REGEN); // CraftBukkit - EntityExhaustionEvent
                  this.foodTickTimer = 0;
-             }

--- a/Spigot-Server-Patches/0095-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/Spigot-Server-Patches/0095-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -13,10 +13,10 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 371648709a63b394fb7577722c18d4b9a1738b2b..bc930015082ad6b2c5d744f823d9ad28a07fa5d4 100644
+index dcc9984665a1b6458cee317bb79a3343656cea23..ed2c39502a123063996c7d36cacf5a7164d75438 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -593,6 +593,12 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -595,6 +595,12 @@ public abstract class EntityHuman extends EntityLiving {
                  return null;
              }
              // CraftBukkit end
@@ -102,7 +102,7 @@ index d11725d61b888ceb08c4ea30f23d563170ce944d..7251793423e5413dacc1e031ed75d41f
              for ( org.bukkit.map.MapCursor cursor : render.cursors) {
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 4be09328cea0808c3a41681aea860cd04f799bbd..a4d666480f0211d39e62b82e43100e3d436f4d90 100644
+index 486ba1efc934c6851d2b570493af6e1079a7abd5..03b81f40e1ad394d7d287825dabe2ad4b905ac60 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1059,6 +1059,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
+++ b/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
@@ -38,10 +38,10 @@ index 824e172f06e57f86010836a1006a14d0a3b0bda3..eedec25373cfc8adec7ac8a99b146770
              entitywitch.prepare(worldserver, worldserver.getDamageScaler(entitywitch.getChunkCoordinates()), EnumMobSpawn.CONVERSION, (GroupDataEntity) null, (NBTTagCompound) null);
              entitywitch.setNoAI(this.isNoAI());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6c153971dd72ff9df9725f889032cfb59bbe31e3..4b8c984a79e276b980dd9aa33d2ef5deee9e13d1 100644
+index b4302fe96d4b2ad6db47fc9d350495cc20a26478..37d9087f90a203753fcd256f70d0768c1249b9e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1076,6 +1076,14 @@ public class CraftEventFactory {
+@@ -1077,6 +1077,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,7 +18,7 @@ index fda68abbdd7c970048ba710d7ef35214f2aaa74c..2c2d44562f732c75532cda910db5ce67
  
                  this.die();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4b8c984a79e276b980dd9aa33d2ef5deee9e13d1..4d90c941f92aaef8dd53b5c31b71a25d19954f40 100644
+index 37d9087f90a203753fcd256f70d0768c1249b9e6..a3b46a3bfe1169c23a9192763da43c4001804782 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -117,6 +117,7 @@ import org.bukkit.entity.ThrownPotion;
@@ -29,7 +29,7 @@ index 4b8c984a79e276b980dd9aa33d2ef5deee9e13d1..4d90c941f92aaef8dd53b5c31b71a25d
  import org.bukkit.event.Cancellable;
  import org.bukkit.event.Event;
  import org.bukkit.event.Event.Result;
-@@ -1035,6 +1036,17 @@ public class CraftEventFactory {
+@@ -1036,6 +1037,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0123-Add-ProjectileCollideEvent.patch
+++ b/Spigot-Server-Patches/0123-Add-ProjectileCollideEvent.patch
@@ -71,10 +71,10 @@ index 7391fd31148dbde60e34955841a296f454ac768e..53a8ea7d1eff84abe6c49464d556aa27
  
          this.checkBlockCollisions();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4d90c941f92aaef8dd53b5c31b71a25d19954f40..62730cbdf46c0cabe71849d3ee3d403ecccab242 100644
+index a3b46a3bfe1169c23a9192763da43c4001804782..c246407f2912f6d5b5947814471155469688baad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1180,6 +1180,16 @@ public class CraftEventFactory {
+@@ -1181,6 +1181,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/Spigot-Server-Patches/0144-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -26,10 +26,10 @@ index c611b5a63498f5ad1f50a75ccd5d7299e27df7e3..9d1cddc6038f0fd0286e4a32013ae98f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index bc930015082ad6b2c5d744f823d9ad28a07fa5d4..63f3743bbf3632badf4e66a5ee4239ccbc5df700 100644
+index ed2c39502a123063996c7d36cacf5a7164d75438..62c914893ffd40c0e88a9d11f04fb5c7dea9063a 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -434,7 +434,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -436,7 +436,7 @@ public abstract class EntityHuman extends EntityLiving {
          this.j(this.getShoulderEntityLeft());
          this.j(this.getShoulderEntityRight());
          if (!this.world.isClientSide && (this.fallDistance > 0.5F || this.isInWater()) || this.abilities.isFlying || this.isSleeping()) {
@@ -39,7 +39,7 @@ index bc930015082ad6b2c5d744f823d9ad28a07fa5d4..63f3743bbf3632badf4e66a5ee4239cc
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 9d4f0a309a2328aff7b036dafa0a21921e36bacd..90a202f040865d9e5fcbbbca25f86a36fa49984d 100644
+index 9c25c0e60d9ebeac7ff93f41d0624961811de164..b6f68a8d1eb523fa0e33fae717249bbba2c0715b 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -1905,6 +1905,13 @@ public class PlayerConnection implements PacketListenerPlayIn {

--- a/Spigot-Server-Patches/0153-Shoulder-Entities-Release-API.patch
+++ b/Spigot-Server-Patches/0153-Shoulder-Entities-Release-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 63f3743bbf3632badf4e66a5ee4239ccbc5df700..502154234632fbf65fada993f9a1e457fe8f41cd 100644
+index 62c914893ffd40c0e88a9d11f04fb5c7dea9063a..14ab88c1a417c9b9a5fee1756006eb6cfcebc996 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1771,20 +1771,44 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1784,20 +1784,44 @@ public abstract class EntityHuman extends EntityLiving {
  
      }
  
@@ -58,7 +58,7 @@ index 63f3743bbf3632badf4e66a5ee4239ccbc5df700..502154234632fbf65fada993f9a1e457
      @Override
      public abstract boolean isSpectator();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index ccfa8243639f487e0f83f012349fcfef94f377cb..f209e6d8fa20ceb7db71a6bb1685fd79b13f0738 100644
+index 19cdff6eebb7c07d75b515dfa0d47bb762626150..4b0d0b1f8de44088b3433f3474757e6bd6519644 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -493,6 +493,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {

--- a/Spigot-Server-Patches/0174-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/Spigot-Server-Patches/0174-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 502154234632fbf65fada993f9a1e457fe8f41cd..cff46a5d962426912a7a857d8a44348d94223428 100644
+index 14ab88c1a417c9b9a5fee1756006eb6cfcebc996..8b2de281fbab8c2ef36cb7c2e3c9195a6abc0a1b 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1028,7 +1028,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1030,7 +1030,7 @@ public abstract class EntityHuman extends EntityLiving {
                      int i = b0 + EnchantmentManager.b((EntityLiving) this);
  
                      if (this.isSprinting() && flag) {
@@ -18,7 +18,7 @@ index 502154234632fbf65fada993f9a1e457fe8f41cd..cff46a5d962426912a7a857d8a44348d
                          ++i;
                          flag1 = true;
                      }
-@@ -1103,7 +1103,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1105,7 +1105,7 @@ public abstract class EntityHuman extends EntityLiving {
                                  }
                              }
  
@@ -27,7 +27,7 @@ index 502154234632fbf65fada993f9a1e457fe8f41cd..cff46a5d962426912a7a857d8a44348d
                              this.ex();
                          }
  
-@@ -1131,15 +1131,15 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1133,15 +1133,15 @@ public abstract class EntityHuman extends EntityLiving {
                          }
  
                          if (flag2) {
@@ -46,16 +46,16 @@ index 502154234632fbf65fada993f9a1e457fe8f41cd..cff46a5d962426912a7a857d8a44348d
                              }
                          }
  
-@@ -1191,7 +1191,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1193,7 +1193,7 @@ public abstract class EntityHuman extends EntityLiving {
  
-                         this.applyExhaustion(world.spigotConfig.combatExhaustion); // Spigot - Change to use configurable value
+                         this.applyExhaustion(world.spigotConfig.combatExhaustion, EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value
                      } else {
 -                        this.world.playSound((EntityHuman) null, this.locX(), this.locY(), this.locZ(), SoundEffects.ENTITY_PLAYER_ATTACK_NODAMAGE, this.getSoundCategory(), 1.0F, 1.0F);
 +                        sendSoundEffect(this, this.locX(), this.locY(), this.locZ(), SoundEffects.ENTITY_PLAYER_ATTACK_NODAMAGE, this.getSoundCategory(), 1.0F, 1.0F); // Paper - send while respecting visibility
                          if (flag4) {
                              entity.extinguish();
                          }
-@@ -1626,6 +1626,14 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1628,6 +1628,14 @@ public abstract class EntityHuman extends EntityLiving {
      public int getExpToLevel() {
          return this.expLevel >= 30 ? 112 + (this.expLevel - 30) * 9 : (this.expLevel >= 15 ? 37 + (this.expLevel - 15) * 5 : 7 + this.expLevel * 2);
      }
@@ -68,5 +68,5 @@ index 502154234632fbf65fada993f9a1e457fe8f41cd..cff46a5d962426912a7a857d8a44348d
 +    }
 +    // Paper end
  
+     // CraftBukkit start
      public void applyExhaustion(float f) {
-         if (!this.abilities.isInvulnerable) {

--- a/Spigot-Server-Patches/0175-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0175-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -20,10 +20,10 @@ index 90ca51dfdbb3045dd528450225cba96f5834166e..6c692e58cde22003ecbf6dc569579914
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 62730cbdf46c0cabe71849d3ee3d403ecccab242..efe3133a8c5a034c5e168e33880a756161b9adb4 100644
+index c246407f2912f6d5b5947814471155469688baad..62f43cc1ba7acb8886dbaf4dd993e52327586fa0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -577,16 +577,32 @@ public class CraftEventFactory {
+@@ -578,16 +578,32 @@ public class CraftEventFactory {
              EntityExperienceOrb xp = (EntityExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/Spigot-Server-Patches/0183-ExperienceOrbMergeEvent.patch
+++ b/Spigot-Server-Patches/0183-ExperienceOrbMergeEvent.patch
@@ -8,10 +8,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index efe3133a8c5a034c5e168e33880a756161b9adb4..e98655a48d3c1edcac0c6f6facd3967018e21e5f 100644
+index 62f43cc1ba7acb8886dbaf4dd993e52327586fa0..94a9ac289d858629684e2b98982c5c54b59efd0b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -587,7 +587,7 @@ public class CraftEventFactory {
+@@ -588,7 +588,7 @@ public class CraftEventFactory {
                      if (e instanceof EntityExperienceOrb) {
                          EntityExperienceOrb loopItem = (EntityExperienceOrb) e;
                          // Paper start

--- a/Spigot-Server-Patches/0194-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/Spigot-Server-Patches/0194-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -21,10 +21,10 @@ index 3c39f1bb3d88baaaed4dd43c51faeef89bb5c6c2..48f0385c7203c7955de5a015f3dc42be
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index cff46a5d962426912a7a857d8a44348d94223428..a4bdedde80eee8bac475854735284826f06fcaef 100644
+index 8b2de281fbab8c2ef36cb7c2e3c9195a6abc0a1b..010bc57772ec24aa3b075b79cab5aa290dfbe22d 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1035,6 +1035,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1037,6 +1037,7 @@ public abstract class EntityHuman extends EntityLiving {
  
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.isClimbing() && !this.isInWater() && !this.hasEffect(MobEffects.BLINDNESS) && !this.isPassenger() && entity instanceof EntityLiving;
  

--- a/Spigot-Server-Patches/0200-Player.setPlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0200-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index a4bdedde80eee8bac475854735284826f06fcaef..3df97e5a4a85efa8a77808e58039afc0c7fe073b 100644
+index 010bc57772ec24aa3b075b79cab5aa290dfbe22d..f7da83b0104f7643ad2af2bca2eeb26ac08386ef 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -63,7 +63,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -65,7 +65,7 @@ public abstract class EntityHuman extends EntityLiving {
      protected int bG;
      protected final float bH = 0.02F;
      private int g;
@@ -48,10 +48,10 @@ index 92f42f17d7f554fca819d63c1f9401239894e0e1..066b0dbdbc101a8235fb872c2d1e9d42
                              uniqueId = i.getId();
                              // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d2f8b4b324b2a9719f409871afde88ad21a94efe..d9d7e5e6f3a5a84db61afefcc80ac723ce9f728a 100644
+index 9a195b3b3524f6c004e651a4dbcab7607006a5ae..cddba4763f11ad51807693a07484511c473ffadf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1338,8 +1338,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1308,8 +1308,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -66,7 +66,7 @@ index d2f8b4b324b2a9719f409871afde88ad21a94efe..d9d7e5e6f3a5a84db61afefcc80ac723
          PlayerChunkMap.EntityTracker entry = tracker.trackedEntities.get(other.getId());
          if (entry != null) {
              entry.clear(getHandle());
-@@ -1380,8 +1385,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1350,8 +1355,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          hiddenPlayers.remove(player.getUniqueId());
  
@@ -81,7 +81,7 @@ index d2f8b4b324b2a9719f409871afde88ad21a94efe..d9d7e5e6f3a5a84db61afefcc80ac723
  
          getHandle().playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, other));
  
-@@ -1390,6 +1400,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1360,6 +1370,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(getHandle());
          }
      }

--- a/Spigot-Server-Patches/0206-Flag-to-disable-the-channel-limit.patch
+++ b/Spigot-Server-Patches/0206-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d9d7e5e6f3a5a84db61afefcc80ac723ce9f728a..0938f7fee97aa220a55da2e4e456d7880aed837d 100644
+index cddba4763f11ad51807693a07484511c473ffadf..785682d7b932693ff0c437563c9f53f32136e75e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -141,6 +141,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index d9d7e5e6f3a5a84db61afefcc80ac723ce9f728a..0938f7fee97aa220a55da2e4e456d788
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1606,7 +1607,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1576,7 +1577,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/Spigot-Server-Patches/0208-Configurable-sprint-interruption-on-attack.patch
+++ b/Spigot-Server-Patches/0208-Configurable-sprint-interruption-on-attack.patch
@@ -20,10 +20,10 @@ index 48f0385c7203c7955de5a015f3dc42be2ab7b681..cebf1a623a9bec72d60fdd23dda01868
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 3df97e5a4a85efa8a77808e58039afc0c7fe073b..e56c9ccee76a43898382f6f39133efac6b3721be 100644
+index f7da83b0104f7643ad2af2bca2eeb26ac08386ef..c0c8373af47d24a8b9c25a3bebb59b13626a3733 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1084,7 +1084,11 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1086,7 +1086,11 @@ public abstract class EntityHuman extends EntityLiving {
                              }
  
                              this.setMot(this.getMot().d(0.6D, 1.0D, 0.6D));

--- a/Spigot-Server-Patches/0227-PlayerReadyArrowEvent.patch
+++ b/Spigot-Server-Patches/0227-PlayerReadyArrowEvent.patch
@@ -7,10 +7,10 @@ Called when a player is firing a bow and the server is choosing an arrow to use.
 Plugins can skip selection of certain arrows and control which is used.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index e56c9ccee76a43898382f6f39133efac6b3721be..a3d9e81eb53aec369c102c1fcf42b50053b4c38e 100644
+index c0c8373af47d24a8b9c25a3bebb59b13626a3733..67df400f80b8bbafecaefa3e8986dd7fe615fd04 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -2032,6 +2032,17 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -2045,6 +2045,17 @@ public abstract class EntityHuman extends EntityLiving {
          return ImmutableList.of(EntityPose.STANDING, EntityPose.CROUCHING, EntityPose.SWIMMING);
      }
  
@@ -28,7 +28,7 @@ index e56c9ccee76a43898382f6f39133efac6b3721be..a3d9e81eb53aec369c102c1fcf42b500
      @Override
      public ItemStack f(ItemStack itemstack) {
          if (!(itemstack.getItem() instanceof ItemProjectileWeapon)) {
-@@ -2048,7 +2059,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -2061,7 +2072,7 @@ public abstract class EntityHuman extends EntityLiving {
                  for (int i = 0; i < this.inventory.getSize(); ++i) {
                      ItemStack itemstack2 = this.inventory.getItem(i);
  

--- a/Spigot-Server-Patches/0228-Implement-EntityKnockbackByEntityEvent.patch
+++ b/Spigot-Server-Patches/0228-Implement-EntityKnockbackByEntityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement EntityKnockbackByEntityEvent
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index a3d9e81eb53aec369c102c1fcf42b50053b4c38e..111ec5443116cbeecc7c9ecee3a585895d8376ec 100644
+index 67df400f80b8bbafecaefa3e8986dd7fe615fd04..f95e46e80f9e572227ee98cc181098c36f1dd5fe 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1078,7 +1078,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1080,7 +1080,7 @@ public abstract class EntityHuman extends EntityLiving {
                      if (flag5) {
                          if (i > 0) {
                              if (entity instanceof EntityLiving) {
@@ -18,7 +18,7 @@ index a3d9e81eb53aec369c102c1fcf42b50053b4c38e..111ec5443116cbeecc7c9ecee3a58589
                              } else {
                                  entity.i((double) (-MathHelper.sin(this.yaw * 0.017453292F) * (float) i * 0.5F), 0.1D, (double) (MathHelper.cos(this.yaw * 0.017453292F) * (float) i * 0.5F));
                              }
-@@ -1102,7 +1102,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -1104,7 +1104,7 @@ public abstract class EntityHuman extends EntityLiving {
                                  if (entityliving != this && entityliving != entity && !this.r(entityliving) && (!(entityliving instanceof EntityArmorStand) || !((EntityArmorStand) entityliving).isMarker()) && this.h((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
                                      if (entityliving.damageEntity(DamageSource.playerAttack(this).sweep(), f4)) {
@@ -41,7 +41,7 @@ index 6274cf1975270fdac8ae4986e1c170bd075d640e..fbecc8ccab47b428c43530ad344e3255
              }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index f8c9c4e41faed2a76ca6ff4105351b09c2193cdd..014f27ab7c183e3b416e96d6bbbbfc776e54ca84 100644
+index 646db2c9c3a05ac024ef43f65e9b8416154d7e90..2ac85eec14479415c0dd56e1aa255324715df23d 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1246,7 +1246,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
@@ -7,10 +7,10 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 111ec5443116cbeecc7c9ecee3a585895d8376ec..4eea9bf6efb875cd7ba77958c9d3814237d8c74d 100644
+index f95e46e80f9e572227ee98cc181098c36f1dd5fe..67e14b606f9eb83e111e76665bd1228034193513 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -153,7 +153,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -155,7 +155,7 @@ public abstract class EntityHuman extends EntityLiving {
          this.et();
          super.tick();
          if (!this.world.isClientSide && this.activeContainer != null && !this.activeContainer.canUse(this)) {
@@ -19,7 +19,7 @@ index 111ec5443116cbeecc7c9ecee3a585895d8376ec..4eea9bf6efb875cd7ba77958c9d38142
              this.activeContainer = this.defaultContainer;
          }
  
-@@ -348,6 +348,13 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -350,6 +350,13 @@ public abstract class EntityHuman extends EntityLiving {
          return 20;
      }
  
@@ -152,7 +152,7 @@ index d192e341f0f6a3d03329dab16de3b19962091d2a..1a2760552cd42b302d4604917daf1fcd
          }
          // Spigot End
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index fcc11b477ab08b474863d3a8b28c2d2cdf976c4d..a0c3600f7523d43e4e4eff7a574bf0fd9350899e 100644
+index b0142be8baeda1dbb921e171d903eea02953b5b2..8b692e93706fc571433df55f01428c846baf01f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -372,7 +372,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
@@ -180,7 +180,7 @@ index fcc11b477ab08b474863d3a8b28c2d2cdf976c4d..a0c3600f7523d43e4e4eff7a574bf0fd
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0938f7fee97aa220a55da2e4e456d7880aed837d..f6e035d60fc840a72d1be9502c96305c6c884520 100644
+index 785682d7b932693ff0c437563c9f53f32136e75e..df5c75aaeb1aef7cbed9e4b500a2a9a1632e049f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -895,7 +895,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -193,10 +193,10 @@ index 0938f7fee97aa220a55da2e4e456d7880aed837d..f6e035d60fc840a72d1be9502c96305c
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7c4208b03b27bb6b4d0f402e978a3ee730ff7ba7..66c284804ecc0c0eaf12ce71629207dc8caa40a9 100644
+index 94a9ac289d858629684e2b98982c5c54b59efd0b..cc785729b522d1588897db870c55274a83c85f4e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1165,7 +1165,7 @@ public class CraftEventFactory {
+@@ -1166,7 +1166,7 @@ public class CraftEventFactory {
  
      public static Container callInventoryOpenEvent(EntityPlayer player, Container container, boolean cancelled) {
          if (player.activeContainer != player.defaultContainer) { // fire INVENTORY_CLOSE if one already open
@@ -205,7 +205,7 @@ index 7c4208b03b27bb6b4d0f402e978a3ee730ff7ba7..66c284804ecc0c0eaf12ce71629207dc
          }
  
          CraftServer server = player.world.getServer();
-@@ -1330,8 +1330,18 @@ public class CraftEventFactory {
+@@ -1331,8 +1331,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0248-Vanished-players-don-t-have-rights.patch
+++ b/Spigot-Server-Patches/0248-Vanished-players-don-t-have-rights.patch
@@ -147,10 +147,10 @@ index 51c57f4752ea49859b9e00045a40899783731f28..26669ded3ec47d13e4e79d65d0f05a58
      public boolean s_() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cf364cd080978602f4782e13bc31420d97a4f1a3..0d0140c1b132a4c569e34781264cdea8b6d555b2 100644
+index cc785729b522d1588897db870c55274a83c85f4e..d67c82b7727d68addc3a0d8ca6ba53fb21694892 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1201,6 +1201,14 @@ public class CraftEventFactory {
+@@ -1202,6 +1202,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/Spigot-Server-Patches/0259-Add-hand-to-bucket-events.patch
+++ b/Spigot-Server-Patches/0259-Add-hand-to-bucket-events.patch
@@ -126,10 +126,10 @@ index e26b1362899a9fad5e0e3a4e49acd98b67a4f03b..f9d2228fb0543c60d2e0848afb4f927b
      public float v() {
          return this.worldData.d();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0d0140c1b132a4c569e34781264cdea8b6d555b2..10e967e15048d4040005a6b6b31cc27c0397e1b9 100644
+index d67c82b7727d68addc3a0d8ca6ba53fb21694892..c70d96f4800b42893ecf46aa820c201e5d9dd0f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -226,7 +226,7 @@ public class CraftEventFactory {
+@@ -227,7 +227,7 @@ public class CraftEventFactory {
      public static Entity entityDamage; // For use in EntityDamageByEntityEvent
  
      // helper methods
@@ -138,7 +138,7 @@ index 0d0140c1b132a4c569e34781264cdea8b6d555b2..10e967e15048d4040005a6b6b31cc27c
          int spawnSize = Bukkit.getServer().getSpawnRadius();
  
          if (world.getDimensionKey() != World.OVERWORLD) return true;
-@@ -405,6 +405,20 @@ public class CraftEventFactory {
+@@ -406,6 +406,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, WorldServer world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, net.minecraft.server.Item item) {
@@ -159,7 +159,7 @@ index 0d0140c1b132a4c569e34781264cdea8b6d555b2..10e967e15048d4040005a6b6b31cc27c
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -417,10 +431,10 @@ public class CraftEventFactory {
+@@ -418,10 +432,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 4eea9bf6efb875cd7ba77958c9d3814237d8c74d..80a254039f3efbab6f0cbcf830ab5168fdceb0cc 100644
+index 67e14b606f9eb83e111e76665bd1228034193513..d9eaa6ed3408d377218d64d75e97c2ed00ab0b08 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -1993,6 +1993,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -2006,6 +2006,7 @@ public abstract class EntityHuman extends EntityLiving {
          this.datawatcher.set(EntityHuman.bl, nbttagcompound);
      }
  
@@ -17,10 +17,10 @@ index 4eea9bf6efb875cd7ba77958c9d3814237d8c74d..80a254039f3efbab6f0cbcf830ab5168
          return (float) (1.0D / this.b(GenericAttributes.ATTACK_SPEED) * 20.0D);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f6e035d60fc840a72d1be9502c96305c6c884520..8bf28027c00efca4af461f1f28e08a545ddf0521 100644
+index df5c75aaeb1aef7cbed9e4b500a2a9a1632e049f..47e6986f1f3b1366cbabb76d16491bc4bba04b36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2210,6 +2210,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2180,6 +2180,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          connection.sendPacket(new net.minecraft.server.PacketPlayOutOpenBook(net.minecraft.server.EnumHand.MAIN_HAND));
          connection.sendPacket(new net.minecraft.server.PacketPlayOutSetSlot(0, slot, inventory.getItemInHand()));
      }

--- a/Spigot-Server-Patches/0280-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0280-Improve-death-events.patch
@@ -119,7 +119,7 @@ index 09d076db37507b17797635df232a568752c97584..3bcebb89c9f9a5243d1d215a47d7d5e6
      public void saveData(NBTTagCompound nbttagcompound) {
          super.saveData(nbttagcompound);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 858db1505aa06d85f4e0b522d221f6543ff40f56..352049363d4b7a0302610f7d7cd54c9cc6c2a9e0 100644
+index f41bfd776a64303104bc38a046a27d076dac5c86..1e65dc73607d5c530efd3ebd61f2bf93ee632a27 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -96,7 +96,7 @@ public abstract class EntityLiving extends Entity {
@@ -325,10 +325,10 @@ index c0b1643dfb4701f0d790bcfae75ede417d5a3522..03d062f9cdf19df32dcc57a247555e5f
          }
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8bf28027c00efca4af461f1f28e08a545ddf0521..b3c7da0417a95b5614e8ed0443e776cf0360eb1d 100644
+index 47e6986f1f3b1366cbabb76d16491bc4bba04b36..3d8b118421364f20f8d7e4ac6c547f62816b3c43 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1866,7 +1866,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1836,7 +1836,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {
@@ -346,10 +346,10 @@ index 8bf28027c00efca4af461f1f28e08a545ddf0521..b3c7da0417a95b5614e8ed0443e776cf
  
      public void injectScaledMaxHealth(Collection<AttributeModifiable> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a7e427415299a84ec3e134fa430bbbac7cba816b..0f83a95220f30e684b9873c84498d63e95050efe 100644
+index c70d96f4800b42893ecf46aa820c201e5d9dd0f4..b0f6ae131082dcccaca13797eb07efc7bb9e738d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -783,9 +783,16 @@ public class CraftEventFactory {
+@@ -784,9 +784,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(EntityLiving victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -366,7 +366,7 @@ index a7e427415299a84ec3e134fa430bbbac7cba816b..0f83a95220f30e684b9873c84498d63e
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -801,8 +808,15 @@ public class CraftEventFactory {
+@@ -802,8 +809,15 @@ public class CraftEventFactory {
          CraftPlayer entity = victim.getBukkitEntity();
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
@@ -382,7 +382,7 @@ index a7e427415299a84ec3e134fa430bbbac7cba816b..0f83a95220f30e684b9873c84498d63e
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -819,6 +833,31 @@ public class CraftEventFactory {
+@@ -820,6 +834,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0316-force-entity-dismount-during-teleportation.patch
+++ b/Spigot-Server-Patches/0316-force-entity-dismount-during-teleportation.patch
@@ -20,7 +20,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 9b8d17aa68bad1a4916681b9eed121011bf3380c..031dcd2092800118d4cb12c8bb92b51ccf1bbd27 100644
+index 00d783a7fd27fb46f5bbca4055be1530efd71534..1db2c51f0c1de27504d3f44070042e5e0dacf9cd 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1954,12 +1954,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -72,10 +72,10 @@ index 9b8d17aa68bad1a4916681b9eed121011bf3380c..031dcd2092800118d4cb12c8bb92b51c
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 80a254039f3efbab6f0cbcf830ab5168fdceb0cc..cad21f17dba336bb201d46dce3c13964ccacf65e 100644
+index d9eaa6ed3408d377218d64d75e97c2ed00ab0b08..eecf72651a1981288eddadfe9ff802cfe2b2e4b6 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -940,9 +940,11 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -942,9 +942,11 @@ public abstract class EntityHuman extends EntityLiving {
          return -0.35D;
      }
  
@@ -91,7 +91,7 @@ index 80a254039f3efbab6f0cbcf830ab5168fdceb0cc..cad21f17dba336bb201d46dce3c13964
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 352049363d4b7a0302610f7d7cd54c9cc6c2a9e0..cade819fe5f7b23b2f4ada721b33ae74516ef8fc 100644
+index 1e65dc73607d5c530efd3ebd61f2bf93ee632a27..c6ef3a0614d85da8b9940e8a8ede7bb49bb4ca9d 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -2922,11 +2922,13 @@ public abstract class EntityLiving extends Entity {
@@ -112,7 +112,7 @@ index 352049363d4b7a0302610f7d7cd54c9cc6c2a9e0..cade819fe5f7b23b2f4ada721b33ae74
              this.a(entity);
          }
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 79a451fb8b19ff35fa935d40d97a53075e6b6e54..32e22f179b525021d80d4e58d04a14947671a725 100644
+index 65c3746b894c94ee58773e0e9d4ab2b7daf01424..27923a54b3ef297ca52707da1c38bebf6d9ab703 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1125,11 +1125,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {

--- a/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -28,7 +28,7 @@ index 27923a54b3ef297ca52707da1c38bebf6d9ab703..e33c751c259fe74d433991a4ac75f1e1
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 54c22ddd4c232769c11f9044d15492daf1d950af..02dbcbd7858676c38b9f6d15b4088cffb4ec265a 100644
+index 435cbeda2c667b9879527ca349a4c4f277f4904e..3f92b4b71649084968ad4daba1ea046a2b9a91e7 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -99,6 +99,7 @@ public abstract class PlayerList {
@@ -106,7 +106,7 @@ index 00333548b470435aa89fb0f4b29047eb1461e992..5770d4183c1b9ab6119a25930283c023
      public Location getBedSpawnLocation() {
          NBTTagCompound data = getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3c7da0417a95b5614e8ed0443e776cf0360eb1d..6127622d7f46b9f4babaf1dd2bb61eb7ab10cb5b 100644
+index 3d8b118421364f20f8d7e4ac6c547f62816b3c43..78b6860a9b786a9ca74e76f1e550b43be369e699 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -142,6 +142,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index b3c7da0417a95b5614e8ed0443e776cf0360eb1d..6127622d7f46b9f4babaf1dd2bb61eb7
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1510,6 +1511,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1480,6 +1481,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index b3c7da0417a95b5614e8ed0443e776cf0360eb1d..6127622d7f46b9f4babaf1dd2bb61eb7
      public void readExtraData(NBTTagCompound nbttagcompound) {
          hasPlayedBefore = true;
          if (nbttagcompound.hasKey("bukkit")) {
-@@ -1532,6 +1545,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1502,6 +1515,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(NBTTagCompound nbttagcompound) {
@@ -145,7 +145,7 @@ index b3c7da0417a95b5614e8ed0443e776cf0360eb1d..6127622d7f46b9f4babaf1dd2bb61eb7
          if (!nbttagcompound.hasKey("bukkit")) {
              nbttagcompound.set("bukkit", new NBTTagCompound());
          }
-@@ -1546,6 +1561,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1516,6 +1531,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.setLong("firstPlayed", getFirstPlayed());
          data.setLong("lastPlayed", System.currentTimeMillis());
          data.setString("lastKnownName", handle.getName());

--- a/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6127622d7f46b9f4babaf1dd2bb61eb7ab10cb5b..1ea83573eff6f49a5c39d1548b58352c976f7d08 100644
+index 78b6860a9b786a9ca74e76f1e550b43be369e699..719e2ce08e780e9d6e2bbfe0e5b1b9d5be5c3e53 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2255,6 +2255,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2225,6 +2225,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackCooldown();
      }

--- a/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
+++ b/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
@@ -40,10 +40,10 @@ index ad5a7cbe83fb61b79203369895e82edca2ffcb72..06cf8ca80c314b7c236984c7f6236533
                          double deltaZ = this.locZ() - player.locZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1ea83573eff6f49a5c39d1548b58352c976f7d08..e655e8e727398e163671583bf7c8aecd37116ff9 100644
+index 719e2ce08e780e9d6e2bbfe0e5b1b9d5be5c3e53..cdfc22f7a5c5e18178c7eeb0c3a799ce3981c4f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2264,6 +2264,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2234,6 +2234,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              super.remove();
          }
      }

--- a/Spigot-Server-Patches/0412-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/Spigot-Server-Patches/0412-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 126f403c18b0ee4af727f325fae307086f289ced..42226525fb61abec501d80251cb4cbe0dfeb5015 100644
+index b0f6ae131082dcccaca13797eb07efc7bb9e738d..9ee00daced670accc379f2b87d930751238172d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -328,13 +328,18 @@ public class CraftEventFactory {
+@@ -329,13 +329,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/Spigot-Server-Patches/0427-Dead-Player-s-shouldn-t-be-able-to-move.patch
+++ b/Spigot-Server-Patches/0427-Dead-Player-s-shouldn-t-be-able-to-move.patch
@@ -7,10 +7,10 @@ This fixes a lot of game state issues where packets were delayed for processing
 due to 1.15's new queue but processed while dead.
 
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index cad21f17dba336bb201d46dce3c13964ccacf65e..5a7475c2ce72f1a77ae757ee5c77ab4983a150f7 100644
+index eecf72651a1981288eddadfe9ff802cfe2b2e4b6..26f78d0acdd1d6a7914799a96346480df6c66034 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -950,7 +950,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -952,7 +952,7 @@ public abstract class EntityHuman extends EntityLiving {
  
      @Override
      protected boolean isFrozen() {

--- a/Spigot-Server-Patches/0448-Implement-Player-Client-Options-API.patch
+++ b/Spigot-Server-Patches/0448-Implement-Player-Client-Options-API.patch
@@ -85,10 +85,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/EntityHuman.java b/src/main/java/net/minecraft/server/EntityHuman.java
-index 5a7475c2ce72f1a77ae757ee5c77ab4983a150f7..59b00c78f8d92bcceca35d0f25e4d94b3ebdc6e2 100644
+index 26f78d0acdd1d6a7914799a96346480df6c66034..cc2127b26e41182c14fa95afde878e9b5100a117 100644
 --- a/src/main/java/net/minecraft/server/EntityHuman.java
 +++ b/src/main/java/net/minecraft/server/EntityHuman.java
-@@ -34,7 +34,7 @@ public abstract class EntityHuman extends EntityLiving {
+@@ -36,7 +36,7 @@ public abstract class EntityHuman extends EntityLiving {
      private static final Map<EntityPose, EntitySize> b = ImmutableMap.<EntityPose, EntitySize>builder().put(EntityPose.STANDING, EntityHuman.bh).put(EntityPose.SLEEPING, EntityHuman.ah).put(EntityPose.FALL_FLYING, EntitySize.b(0.6F, 0.6F)).put(EntityPose.SWIMMING, EntitySize.b(0.6F, 0.6F)).put(EntityPose.SPIN_ATTACK, EntitySize.b(0.6F, 0.6F)).put(EntityPose.CROUCHING, EntitySize.b(0.6F, 1.5F)).put(EntityPose.DYING, EntitySize.c(0.2F, 0.2F)).build();
      private static final DataWatcherObject<Float> c = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.c);
      private static final DataWatcherObject<Integer> d = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.b);
@@ -149,7 +149,7 @@ index dbc3552d50c4129e1844c8a379ab5ba396645f52..87ec3987d4b6de836016e91ef90383e3
          return this.e;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e655e8e727398e163671583bf7c8aecd37116ff9..c219986c8a1a50c3b14da60eb4717edcb1588c38 100644
+index cdfc22f7a5c5e18178c7eeb0c3a799ce3981c4f4..29d0ce54fdc94353e3b2280f1c7cf97a766f31bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,8 @@
@@ -161,7 +161,7 @@ index e655e8e727398e163671583bf7c8aecd37116ff9..c219986c8a1a50c3b14da60eb4717edc
  import com.destroystokyo.paper.Title;
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
-@@ -2274,6 +2277,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2244,6 +2247,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/Spigot-Server-Patches/0459-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0459-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -102,10 +102,10 @@ index cd50fe3616d4b33c7ad76458fb75683541c33ae5..97425f38ac05c24433dc27c5cda74c36
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 42226525fb61abec501d80251cb4cbe0dfeb5015..cdcb20b322fdad0bc90b9f433b5102c9f72da4df 100644
+index 9ee00daced670accc379f2b87d930751238172d6..57ade60b17472832f33286b7332ca273d835b138 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -803,7 +803,8 @@ public class CraftEventFactory {
+@@ -804,7 +804,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
+++ b/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
@@ -106,10 +106,10 @@ index ba3db09763d94d730c3fe8662e4dbb24e0636786..3506473f9b9f4c747f7b737d9bd02bef
  
      private void a(IInventory iinventory, ItemStack itemstack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cdcb20b322fdad0bc90b9f433b5102c9f72da4df..cccba4777b97c67dda79417a75742af2fabbc2ea 100644
+index 57ade60b17472832f33286b7332ca273d835b138..e2dd012c646f25ef83a8b10896acc31611084df4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1509,19 +1509,44 @@ public class CraftEventFactory {
+@@ -1510,19 +1510,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0547-Brand-support.patch
+++ b/Spigot-Server-Patches/0547-Brand-support.patch
@@ -65,10 +65,10 @@ index 01e18079989043c2c8c49ef1dba254122617261d..50fef192bec41070c5dd89ffbc131012
          return (!this.player.joining && !this.networkManager.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9a1201e473ac99408b32864462f04e021c5f0f8c..d7e73a7f54adc0e0b489a954edb2cf3548851c66 100644
+index edae6ed7c80883e4c27c09d9dd3dcc2f93676390..ca8e6bfa3d472b5eef6ba9aca749a207e02f71c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2407,6 +2407,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2377,6 +2377,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/Spigot-Server-Patches/0557-Brand-support.patch
+++ b/Spigot-Server-Patches/0557-Brand-support.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Brand support
 TODO(Proximyst): Fixup this into the other brand support patch
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d7e73a7f54adc0e0b489a954edb2cf3548851c66..3a014712aee6736a2903574d124aff12639d0f88 100644
+index ca8e6bfa3d472b5eef6ba9aca749a207e02f71c7..5dbe8b797ae11fb2d6dfd5e66a1d17d307bec978 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2410,7 +2410,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2380,7 +2380,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start - brand support
      @Override
      public String getClientBrandName() {

--- a/Spigot-Server-Patches/0589-Player-elytra-boost-API.patch
+++ b/Spigot-Server-Patches/0589-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3a014712aee6736a2903574d124aff12639d0f88..2604ec0ae7b2f1d4e0e249137abc137f479cec05 100644
+index 5dbe8b797ae11fb2d6dfd5e66a1d17d307bec978..5cfccc27daa758f36e14fd6526a0ab6532a20aa6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2303,6 +2303,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2273,6 +2273,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/Spigot-Server-Patches/0604-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/Spigot-Server-Patches/0604-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2604ec0ae7b2f1d4e0e249137abc137f479cec05..4cd9bdc16e1bf8f7ad75424ac52c3754fab7d540 100644
+index 5cfccc27daa758f36e14fd6526a0ab6532a20aa6..7d57a21517e6a7c3d3cb75ff1960f682dc7d2f50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2035,7 +2035,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2005,7 +2005,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/Spigot-Server-Patches/0621-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/Spigot-Server-Patches/0621-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index cccba4777b97c67dda79417a75742af2fabbc2ea..3091241f2619827298b2aa768d41c285059b529e 100644
+index e2dd012c646f25ef83a8b10896acc31611084df4..71aead62d776b4241295835510dff17726054ef6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -261,6 +261,10 @@ public class CraftEventFactory {
+@@ -262,6 +262,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/Spigot-Server-Patches/0640-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-Server-Patches/0640-Implemented-BlockFailedDispenseEvent.patch
@@ -29,7 +29,7 @@ index 65c212690d8ba7c8ea55d4d3b6af1ba3d9f4a7f6..22ab5a861920e1902c64301c3b06cf95
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3091241f2619827298b2aa768d41c285059b529e..a3a1a5fcb4e49f92d6ba137ee8d14e84d355187b 100644
+index 71aead62d776b4241295835510dff17726054ef6..1e00be94d745afd499bd03857d85fd1ae0839538 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -4,6 +4,7 @@ import com.google.common.base.Function;
@@ -48,7 +48,7 @@ index 3091241f2619827298b2aa768d41c285059b529e..a3a1a5fcb4e49f92d6ba137ee8d14e84
  import org.bukkit.event.Cancellable;
  import org.bukkit.event.Event;
  import org.bukkit.event.Event.Result;
-@@ -1752,4 +1752,12 @@ public class CraftEventFactory {
+@@ -1760,4 +1760,12 @@ public class CraftEventFactory {
  
          return event;
      }

--- a/Spigot-Server-Patches/0646-Implement-API-to-expose-exact-interaction-point.patch
+++ b/Spigot-Server-Patches/0646-Implement-API-to-expose-exact-interaction-point.patch
@@ -18,7 +18,7 @@ index 485b609bb5387b0f8a46c1201177cdc6d183ad91..114e986e5132e5e4bb42d0f08a067429
          interactResult = event.useItemInHand() == Event.Result.DENY;
          interactPosition = blockposition.immutableCopy();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7721b3ca951054d73b2fbf28c01a7c02b5416451..c25f18d9bf851df8cfb90f065c2d9a857d77f229 100644
+index 1e00be94d745afd499bd03857d85fd1ae0839538..8bbce9b07afb0ba327b399bf8c13b64d6d3c6e16 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -64,9 +64,11 @@ import net.minecraft.server.NPC;
@@ -33,7 +33,7 @@ index 7721b3ca951054d73b2fbf28c01a7c02b5416451..c25f18d9bf851df8cfb90f065c2d9a85
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -466,7 +468,13 @@ public class CraftEventFactory {
+@@ -467,7 +469,13 @@ public class CraftEventFactory {
          return callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -47,7 +47,7 @@ index 7721b3ca951054d73b2fbf28c01a7c02b5416451..c25f18d9bf851df8cfb90f065c2d9a85
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -492,7 +500,10 @@ public class CraftEventFactory {
+@@ -493,7 +501,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
+++ b/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index ec5ad68f77b14a449ff6f9206d1cd95c74c0577c..bbaaafbb9b2299a1f67e336d8b94b02cc5ed2c28 100644
+index f83159157d00a10a8bf93e723faf043706f83570..c970b8bec13741fcd4d5ce71fd77d0f9ed633088 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1059,6 +1059,11 @@ public abstract class PlayerList {
@@ -32,10 +32,10 @@ index ec5ad68f77b14a449ff6f9206d1cd95c74c0577c..bbaaafbb9b2299a1f67e336d8b94b02c
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4cd9bdc16e1bf8f7ad75424ac52c3754fab7d540..8a6340c1eeda638e70d3da6ad30e51b98fd66947 100644
+index 7d57a21517e6a7c3d3cb75ff1960f682dc7d2f50..4b214783ad4fabf5c2dc4c6c45635dc6e75f2113 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2317,6 +2317,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2287,6 +2287,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/Spigot-Server-Patches/0653-Make-ProjectileHitEvent-Cancellable.patch
+++ b/Spigot-Server-Patches/0653-Make-ProjectileHitEvent-Cancellable.patch
@@ -32,10 +32,10 @@ index 9f5ce64a60fe7c312399ee416b11b84213dd3bee..bbc089b41fcbe0141f13591db2cb44b9
  
          if (movingobjectposition_enummovingobjecttype == MovingObjectPosition.EnumMovingObjectType.ENTITY) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c25f18d9bf851df8cfb90f065c2d9a857d77f229..c225822da37b04814fe990d0f7044f74f2987d13 100644
+index 8bbce9b07afb0ba327b399bf8c13b64d6d3c6e16..579e1b3cde06a1138d90cda61a2bcf87aed3be98 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1295,9 +1295,9 @@ public class CraftEventFactory {
+@@ -1296,9 +1296,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -47,7 +47,7 @@ index c25f18d9bf851df8cfb90f065c2d9a857d77f229..c225822da37b04814fe990d0f7044f74
          }
  
          Block hitBlock = null;
-@@ -1314,7 +1314,7 @@ public class CraftEventFactory {
+@@ -1315,7 +1315,7 @@ public class CraftEventFactory {
          }
  
          ProjectileHitEvent event = new ProjectileHitEvent((Projectile) entity.getBukkitEntity(), hitEntity, hitBlock, hitFace);

--- a/Spigot-Server-Patches/0657-Implement-BlockPreDispenseEvent.patch
+++ b/Spigot-Server-Patches/0657-Implement-BlockPreDispenseEvent.patch
@@ -17,7 +17,7 @@ index 063453552b7b6c2395c8f9be27cdb71a15a56ca4..89325af931b5ca43729758e94e971b61
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c225822da37b04814fe990d0f7044f74f2987d13..02a588d83e1ee5091d93fdc3cdec04bdf92d2d05 100644
+index 579e1b3cde06a1138d90cda61a2bcf87aed3be98..a7ac877014853bb2b2e826ad6950da959f56b268 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -13,6 +13,7 @@ import java.util.List;
@@ -28,7 +28,7 @@ index c225822da37b04814fe990d0f7044f74f2987d13..02a588d83e1ee5091d93fdc3cdec04bd
  import net.minecraft.server.BlockPosition;
  import net.minecraft.server.BlockPropertyInstrument;
  import net.minecraft.server.Container;
-@@ -1770,5 +1771,11 @@ public class CraftEventFactory {
+@@ -1778,5 +1779,11 @@ public class CraftEventFactory {
          BlockFailedDispenseEvent event = new BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/Spigot-Server-Patches/0664-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/Spigot-Server-Patches/0664-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -137,10 +137,10 @@ index 6bd25833bc3ff3ca46367a48da001ed9bda8c19d..5e4652e997362e7c3fac05ac8a4fcdd6
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 02a588d83e1ee5091d93fdc3cdec04bdf92d2d05..ab687c8a7f73bebf089880eae728567856a94ec9 100644
+index a7ac877014853bb2b2e826ad6950da959f56b268..479270bae88f10de80c6fe97536ac7d2c198a6f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1447,8 +1447,10 @@ public class CraftEventFactory {
+@@ -1448,8 +1448,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/Spigot-Server-Patches/0671-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/Spigot-Server-Patches/0671-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ab687c8a7f73bebf089880eae728567856a94ec9..689e19924c6690ba187aa6787f1eb34dd5c85f40 100644
+index 479270bae88f10de80c6fe97536ac7d2c198a6f2..82e36ba35c0bd4d5b3e13281bad1a0664c25c6e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -380,13 +380,30 @@ public class CraftEventFactory {
+@@ -381,13 +381,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, EntityPlayer player, List<EntityItem> items) {

--- a/Spigot-Server-Patches/0679-Expose-Tracked-Players.patch
+++ b/Spigot-Server-Patches/0679-Expose-Tracked-Players.patch
@@ -18,7 +18,7 @@ index d8787985ab4c94e9808332c15b3d16d4b52ba195..e87e1b04e13593f1efa4d1c59cb9e433
      Throwable addedToWorldStack; // Paper - entity debug
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..0a7777f97b85842aa7f214479dcc7a9e6a4bee8a 100644
+index 4b214783ad4fabf5c2dc4c6c45635dc6e75f2113..fc761a3bd87004f16ff9b0a3b0add52f7938f566 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
@@ -29,7 +29,7 @@ index 8a6340c1eeda638e70d3da6ad30e51b98fd66947..0a7777f97b85842aa7f214479dcc7a9e
  import java.util.HashMap;
  import java.util.HashSet;
  import java.util.LinkedHashMap;
-@@ -2326,6 +2327,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2296,6 +2297,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
9d0ad318 Fix javadoc errors in previous commits
9501daa2 #578: Add methods to modify the rate of regeneration and starvation
197d8f3d #577: Add EntityExhaustionEvent

CraftBukkit Changes:
a021e334 #795: Add methods to modify the rate of regeneration and starvation
509e523c #792: Add EntityExhaustionEvent

Spigot Changes:
db99f821 Rebuild patches