### PR TITLE
Make entity tracking range use no-tick instead of ticking view distance

### DIFF
--- a/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
@@ -179,7 +179,7 @@ index 25484cac9c62e49de39fbbf506fcb3edc4ba6e65..1f6333c2c26ad04e23d2881235ed1dcf
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a950845eaf 100644
+index 3c49ca30959204840a656c1a44de50a60ea1c7df..ce42eaa2e6ac7992c435a97af52410127f6eeec6 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -60,9 +60,11 @@ import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
@@ -232,7 +232,14 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
  
      void addPlayerToDistanceMaps(EntityPlayer player) {
          int chunkX = MCUtil.getChunkCoordinate(player.locX());
-@@ -237,6 +261,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -231,12 +255,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveNoTickViewDistance()));
+         }
+         // Paper end - use distance map to optimise entity tracker
          // Paper start - optimise PlayerChunkMap#isOutsideRange
          this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -264,7 +271,14 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      }
  
      void updateMaps(EntityPlayer player) {
-@@ -266,6 +308,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -260,12 +302,25 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveNoTickViewDistance()));
+         }
+         // Paper end - use distance map to optimise entity tracker
          // Paper start - optimise PlayerChunkMap#isOutsideRange
          this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -561,15 +575,26 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {
              apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
-@@ -2069,7 +2237,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2059,7 +2227,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+             org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
+             if (entityplayer != this.tracker) {
+                 Vec3D vec3d = entityplayer.getPositionVector().d(this.tracker.getPositionVector()); // MC-155077, SPIGOT-5113
+-                int i = Math.min(this.b(), (PlayerChunkMap.this.viewDistance - 1) * 16);
++                int i = Math.min(this.b(), (PlayerChunkMap.this.noTickViewDistance - 1) * 16); // Paper - no-tick view distance
+                 boolean flag = vec3d.x >= (double) (-i) && vec3d.x <= (double) i && vec3d.z >= (double) (-i) && vec3d.z <= (double) i && this.tracker.a(entityplayer);
+ 
+                 if (flag) {
+@@ -2069,8 +2237,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
  
 -                        if (playerchunk != null && playerchunk.getChunk() != null) {
+-                            flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
 +                        if (playerchunk != null && playerchunk.getSendingChunk() != null) { // Paper - no-tick view distance
-                             flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= PlayerChunkMap.this.viewDistance;
++                            flag1 = PlayerChunkMap.b(chunkcoordintpair, entityplayer, false) <= Math.max(PlayerChunkMap.this.viewDistance, PlayerChunkMap.this.noTickViewDistance);
                          }
                      }
+ 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
 index 70b3a7c8c4bd817be9c4dfaee71ec22a42620e11..ee6de0186f6a112d02e1dd4cc73fdaa92ab4d0d9 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java

--- a/Spigot-Server-Patches/0472-Fix-Light-Command.patch
+++ b/Spigot-Server-Patches/0472-Fix-Light-Command.patch
@@ -166,7 +166,7 @@ index 1f6333c2c26ad04e23d2881235ed1dcf707be038..e53054fc46e528f9c713eb4c03add613
          // Paper start - per player view distance
          // there can be potential desync with player's last mapped section and the view distance map, so use the
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 762598b1dc8c6fb4beaad01e5777d0a950845eaf..5538d97e237e448a7d3eb76a57609980c3a6bddb 100644
+index ce42eaa2e6ac7992c435a97af52410127f6eeec6..4195ddc976e3dc17cc714c8e172d427c1695dc91 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -346,11 +346,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {

--- a/Spigot-Server-Patches/0481-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/Spigot-Server-Patches/0481-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -39,7 +39,7 @@ index 4c82266656d0a60a166faa082a9aaaaed7f062d3..aa5ba862f18ff706f11b0b26cea55a90
  
                      if (!flag4 && this.o <= 400 && !this.q && this.r == this.tracker.isOnGround()) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 5538d97e237e448a7d3eb76a57609980c3a6bddb..ede47aaaace80280756fe4463def1ea26792c9e4 100644
+index 4195ddc976e3dc17cc714c8e172d427c1695dc91..6850b2f9917b4253baff1973d82d28c0ab7ecf74 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -2227,9 +2227,14 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
@@ -53,7 +53,7 @@ index 5538d97e237e448a7d3eb76a57609980c3a6bddb..ede47aaaace80280756fe4463def1ea2
 +                double vec3d_dy = entityplayer.locY() - this.tracker.locY();
 +                double vec3d_dz = entityplayer.locZ() - this.tracker.locZ();
 +                // Paper end - remove allocation of Vec3D here
-                 int i = Math.min(this.b(), (PlayerChunkMap.this.viewDistance - 1) * 16);
+                 int i = Math.min(this.b(), (PlayerChunkMap.this.noTickViewDistance - 1) * 16); // Paper - no-tick view distance
 -                boolean flag = vec3d.x >= (double) (-i) && vec3d.x <= (double) i && vec3d.z >= (double) (-i) && vec3d.z <= (double) i && this.tracker.a(entityplayer);
 +                boolean flag = vec3d_dx >= (double) (-i) && vec3d_dx <= (double) i && vec3d_dz >= (double) (-i) && vec3d_dz <= (double) i && this.tracker.a(entityplayer); // Paper - remove allocation of Vec3D here
  

--- a/Spigot-Server-Patches/0485-Workaround-for-Client-Lag-Spikes-MC-162253.patch
+++ b/Spigot-Server-Patches/0485-Workaround-for-Client-Lag-Spikes-MC-162253.patch
@@ -12,7 +12,7 @@ to the client, so that it doesn't attempt to calculate them.
 This mitigates the frametime impact to a minimum (but it's still there).
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index ede47aaaace80280756fe4463def1ea26792c9e4..d5c939281df21683efc63937a9146b0dfeb22e2c 100644
+index 50398290c1ef94530826b9409017b6d16854f5c3..327d3dfd6bb3a0a56eeceffec5811f0ac68b038f 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -85,6 +85,7 @@ import net.minecraft.world.level.World;


### PR DESCRIPTION
This PR fixes the entity tracking range being capped by the ticking view distance and uses the no tick view distance instead.

Before:

https://user-images.githubusercontent.com/69646789/110058184-e989f700-7d2f-11eb-9251-1f697e3072f0.mp4

After: 
https://user-images.githubusercontent.com/69646789/110058157-dd059e80-7d2f-11eb-9c70-4d37aa1c8ac1.mp4

Tested using a view distance of 3, a no-tick view distance of 7, and an entity tracking range of 128.
