### PR TITLE
Add an event for entity target searches

### DIFF
--- a/Spigot-API-Patches/0283-Add-EntitySearchTargetEvent.patch
+++ b/Spigot-API-Patches/0283-Add-EntitySearchTargetEvent.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Fri, 19 Mar 2021 19:24:32 +1000
+Subject: [PATCH] Add EntitySearchTargetEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntitySearchTargetEvent.java b/src/main/java/io/papermc/paper/event/entity/EntitySearchTargetEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c2cf90f935a30a3a6d81f7e1b5c3de66e53917b9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntitySearchTargetEvent.java
+@@ -0,0 +1,66 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when an entity attempts to find another entity to target.
++ */
++public class EntitySearchTargetEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean canceled;
++    private LivingEntity target;
++
++    public EntitySearchTargetEvent(@NotNull LivingEntity entity, @Nullable LivingEntity target) {
++        super(entity);
++        this.target = target;
++    }
++
++    @Override
++    @NotNull
++    public LivingEntity getEntity() {
++        return (LivingEntity) entity;
++    }
++
++    /**
++     * Get the targeted entity, if any.
++     *
++     * @return The targeted entity
++     */
++    @Nullable
++    public LivingEntity getTarget() {
++        return target;
++    }
++
++    /**
++     * Set the targeted entity, or null for no target.
++     *
++     * @param target The targeted entity
++     */
++    public void setTarget(@Nullable LivingEntity target) {
++        this.target = target;
++    }
++
++    public boolean isCancelled() {
++        return canceled;
++    }
++
++    public void setCancelled(boolean cancel) {
++        canceled = cancel;
++    }
++
++    @Override
++    @NotNull
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0695-Implement-EntitySearchTargetEvent.patch
+++ b/Spigot-Server-Patches/0695-Implement-EntitySearchTargetEvent.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Matthew Miller <mnmiller1@me.com>
+Date: Fri, 19 Mar 2021 19:24:48 +1000
+Subject: [PATCH] Implement EntitySearchTargetEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/target/PathfinderGoalNearestAttackableTarget.java b/src/main/java/net/minecraft/world/entity/ai/goal/target/PathfinderGoalNearestAttackableTarget.java
+index 44f21c3f7af17e9d39777a48c6715a22fc085da6..7252e5629bff8fb42402b75fe389121c45626379 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/target/PathfinderGoalNearestAttackableTarget.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/target/PathfinderGoalNearestAttackableTarget.java
+@@ -10,6 +10,7 @@ import net.minecraft.world.entity.ai.goal.PathfinderGoal;
+ import net.minecraft.world.entity.ai.targeting.PathfinderTargetCondition;
+ import net.minecraft.world.entity.player.EntityHuman;
+ import net.minecraft.world.phys.AxisAlignedBB;
++import io.papermc.paper.event.entity.EntitySearchTargetEvent; // Paper
+ 
+ public class PathfinderGoalNearestAttackableTarget<T extends EntityLiving> extends PathfinderGoalTarget {
+ 
+@@ -50,12 +51,22 @@ public class PathfinderGoalNearestAttackableTarget<T extends EntityLiving> exten
+     }
+ 
+     protected void g() {
++        // Paper start - call EntitySearchTargetEvent
++        EntityLiving lastTarget = this.c;
+         if (this.a != EntityHuman.class && this.a != EntityPlayer.class) {
+             this.c = this.e.world.b(this.a, this.d, this.e, this.e.locX(), this.e.getHeadY(), this.e.locZ(), this.a(this.k()));
+         } else {
+             this.c = this.e.world.a(this.d, this.e, this.e.locX(), this.e.getHeadY(), this.e.locZ());
+         }
+ 
++        EntitySearchTargetEvent event = new EntitySearchTargetEvent(this.e.getBukkitLivingEntity(), this.c == null ? null : this.c.getBukkitLivingEntity());
++        this.e.world.getServer().getPluginManager().callEvent(event);
++        if (event.isCancelled()) {
++            this.c = lastTarget;
++        } else {
++            this.c = event.getTarget() == null ? null : ((org.bukkit.craftbukkit.entity.CraftLivingEntity) event.getTarget()).getHandle();
++        }
++        // Paper end
+     }
+ 
+     @Override


### PR DESCRIPTION
Adds an event that gets called when the initial target search happens for an entity.

This is useful to override the result even when the entity was unable to find or switch targets.

For example, with this event it's possible to reliably make zombies target cows, whereas with EntityTargetEvent it's only possible to make that happen when zomies un-target or target a different entity.