### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -822,7 +822,7 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index b8a33ac504da73ec990550bdd23e4548f6ccba95..27faaf8d1101f8522b728e3d73833e4dddbf1715 100644
+index fd2af5fded9335602e263a2098760da0e64a87a3..44f01a3d8a461acab187367fc8876e0b73c92386 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
@@ -834,7 +834,7 @@ index b8a33ac504da73ec990550bdd23e4548f6ccba95..27faaf8d1101f8522b728e3d73833e4d
  
      /**
       * Gets the {@link Block} at the given coordinates
-@@ -616,6 +616,14 @@ public interface World extends PluginMessageRecipient, Metadatable {
+@@ -640,6 +640,14 @@ public interface World extends PluginMessageRecipient, Metadatable {
      @NotNull
      public List<Player> getPlayers();
  

--- a/Spigot-API-Patches/0095-Additional-world.getNearbyEntities-API-s.patch
+++ b/Spigot-API-Patches/0095-Additional-world.getNearbyEntities-API-s.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Additional world.getNearbyEntities API's
 Provides more methods to get nearby entities, and filter by types and predicates
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 789e070f6aee83e4b6426def784e05df98e1bc65..96e985eb98ab620e315aec13222b8f0334e5fe0a 100644
+index 0f86a9c67797fd662cbbfdb808789bcab95caba4..cae848ce698337d0b254bd48938abfc1e68ad561 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,9 @@
@@ -19,7 +19,7 @@ index 789e070f6aee83e4b6426def784e05df98e1bc65..96e985eb98ab620e315aec13222b8f03
  import java.util.Collection;
  import java.util.HashMap;
  import java.util.List;
-@@ -635,6 +638,256 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -659,6 +662,256 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
      @NotNull
      public Collection<Entity> getEntitiesByClasses(@NotNull Class<?>... classes);
  

--- a/Spigot-API-Patches/0097-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-API-Patches/0097-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -515,10 +515,10 @@ index b32de827cf8d1780861c271b4215276fdaab7165..1020002ff7127877db2d7e096f2c5217
       * Options which can be applied to redstone dust particles - a particle
       * color and size.
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ed7d484416f127467c2898411564937f256d8861..7a96670447fde144e2263d107771e01cd642aaf4 100644
+index cae848ce698337d0b254bd48938abfc1e68ad561..05643d0f2bf2cb2dedb0a2ad693b2121565d3f1f 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -2559,7 +2559,57 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -2583,7 +2583,57 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       * @param data the data to use for the particle or null,
       *             the type of this depends on {@link Particle#getDataType()}
       */

--- a/Spigot-API-Patches/0112-Expand-Explosions-API.patch
+++ b/Spigot-API-Patches/0112-Expand-Explosions-API.patch
@@ -106,10 +106,10 @@ index 4cf22afc3c1f1cc19b6e5350043431215908a612..af2ee43f2c5133668c18710f526a107d
       * Returns a list of entities within a bounding box centered around a Location.
       *
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 7a96670447fde144e2263d107771e01cd642aaf4..608e57d92d93aef163bcb91c7fb63339b1672945 100644
+index 05643d0f2bf2cb2dedb0a2ad693b2121565d3f1f..c7cdbc36f96a8ee9eaac2a2145afbfc76bc38cc9 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1418,6 +1418,88 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -1442,6 +1442,88 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       */
      public boolean createExplosion(@NotNull Location loc, float power, boolean setFire);
  

--- a/Spigot-API-Patches/0116-Add-World.getEntity-UUID-API.patch
+++ b/Spigot-API-Patches/0116-Add-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 432367560c572e3fa77c4c36cde5bf7d7e157846..9c4f2d9e1a4011e3a9860d913e1a718030696bed 100644
+index c7cdbc36f96a8ee9eaac2a2145afbfc76bc38cc9..edf136ef50c9cdd8ccea2e35508e4464c3de99bd 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -922,6 +922,17 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -946,6 +946,17 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
      @NotNull
      public Collection<Entity> getNearbyEntities(@NotNull Location location, double x, double y, double z);
  

--- a/Spigot-API-Patches/0157-Add-sun-related-API.patch
+++ b/Spigot-API-Patches/0157-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index ce2d4629ff39847cb21a34cc1a0868c9a4d3cdb9..cac7a083b439414ae269edc9df4dc242dfaf5b59 100644
+index ec8e3a949a869545a8e0cb8c2f59f1a6dd8f5485..ce1a3de1d03e10b18c0098ee2778361cc9a4cb01 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -1788,6 +1788,16 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -1812,6 +1812,16 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       */
      public void setFullTime(long time);
  

--- a/Spigot-API-Patches/0201-World-view-distance-api.patch
+++ b/Spigot-API-Patches/0201-World-view-distance-api.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] World view distance api
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 5c004fddaaeb41f966ace1e169103ecfb082a197..eb2b5ae9b66f8ce8adc548f0913c54729a822018 100644
+index daa8e7a3eacfe4583166313727ac550c9775ebb8..476184db904d8a2e1347e1219e8ba196bf4da5cb 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3414,6 +3414,34 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -3438,6 +3438,34 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
      int getViewDistance();
      // Spigot end
  

--- a/Spigot-API-Patches/0203-Spawn-Reason-API.patch
+++ b/Spigot-API-Patches/0203-Spawn-Reason-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Spawn Reason API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index eb2b5ae9b66f8ce8adc548f0913c54729a822018..6441d4e45e5d5f008f95233cdc34048b8be38592 100644
+index 476184db904d8a2e1347e1219e8ba196bf4da5cb..c1010e314144a65e12eaf5514d639a87f45891a9 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index eb2b5ae9b66f8ce8adc548f0913c54729a822018..6441d4e45e5d5f008f95233cdc34048b
  import org.bukkit.generator.ChunkGenerator;
  
  import java.util.ArrayList;
-@@ -2225,6 +2227,12 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -2249,6 +2251,12 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
      @NotNull
      public <T extends Entity> T spawn(@NotNull Location location, @NotNull Class<T> clazz) throws IllegalArgumentException;
  
@@ -30,7 +30,7 @@ index eb2b5ae9b66f8ce8adc548f0913c54729a822018..6441d4e45e5d5f008f95233cdc34048b
      /**
       * Spawn an entity of a specific class at the given {@link Location}, with
       * the supplied function run before the entity is added to the world.
-@@ -2242,7 +2250,28 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -2266,7 +2274,28 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
       *     {@link Entity} requested cannot be spawned
       */
      @NotNull

--- a/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
+++ b/Spigot-Server-Patches/0003-MC-Dev-fixes.patch
@@ -485,10 +485,10 @@ index 998101592723abb26c91d1f92e98be1cf24c954d..ee9069c744df63cbb7f21dd9d28d6d55
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f7e1d35b69906f165adbf346e28047d2b44862c0..cd260f0cbde31b5127bf3a73b9c946746defc348 100644
+index 5ead0146ca3c11c53875d323ffd22fe8e055fa7f..2c8674fbdb76a03e87f94779c30e871962de1f4c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1556,9 +1556,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1558,9 +1558,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              ResourcePackRepository resourcepackrepository = this.resourcePackRepository;
  
              this.resourcePackRepository.getClass();

--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -3101,7 +3101,7 @@ index e01bc3cdbf382cf61add297b871ba8308720508d..03bfd29c12e7dd6e359481ffb56fddad
          // CraftBukkit start - fire event
          setGoalTarget(entityliving, EntityTargetEvent.TargetReason.UNKNOWN, true);
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index c611a6e7178ec3fe3af29943b9fddc9fb154835d..8ad1256bcde950bc34aeb7f61ef9598f3b1cd2a3 100644
+index 9038b28881dea326fb712528b3417a6a12dd5751..f49f66e3c128e9ce0f4edc24332f5c52cbb20d02 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -138,6 +138,7 @@ public abstract class EntityLiving extends Entity {
@@ -3802,10 +3802,10 @@ index 0000000000000000000000000000000000000000..17d73ebbe51a83f79f338bdb1b366cec
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cd260f0cbde31b5127bf3a73b9c946746defc348..472803c2d9292379a36fca681c2ab92ffb01184f 100644
+index 2c8674fbdb76a03e87f94779c30e871962de1f4c..7678f69b9b9a28e6b1ac837fb9e499d8e0db1b13 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -765,6 +765,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -767,6 +767,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              MinecraftServer.LOGGER.error("Failed to unlock level {}", this.convertable.getLevelName(), ioexception1);
          }
          // Spigot start
@@ -4160,10 +4160,10 @@ index f645d3dfb57e99757e233ee2bbb51be5094203cb..985fc002fa5afc71ecd242aa8101684b
          }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 43168f3836eb8823f3b2046882664ba45f1be678..127c03c321e1414e0d174c8d81a7851c9da03574 100644
+index 8ec2eac3646263634c1c763b7d827d25134e2938..e641f4b89b39525686bba4d1e91c4ec26a9bd681 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -101,6 +101,26 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -102,6 +102,26 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      };
      // CraftBukkit end
  
@@ -4190,7 +4190,7 @@ index 43168f3836eb8823f3b2046882664ba45f1be678..127c03c321e1414e0d174c8d81a7851c
      public PlayerChunkMap(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i, boolean flag) {
          super(new File(convertable_conversionsession.a(worldserver.getDimensionKey()), "region"), datafixer, flag);
          this.visibleChunks = this.updatingChunks.clone();
-@@ -190,6 +210,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -191,6 +211,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          };
      }
  
@@ -4205,7 +4205,7 @@ index 43168f3836eb8823f3b2046882664ba45f1be678..127c03c321e1414e0d174c8d81a7851c
      private CompletableFuture<Either<List<IChunkAccess>, PlayerChunk.Failure>> a(ChunkCoordIntPair chunkcoordintpair, int i, IntFunction<ChunkStatus> intfunction) {
          List<CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>>> list = Lists.newArrayList();
          int j = chunkcoordintpair.x;
-@@ -900,6 +928,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -901,6 +929,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (!flag1) {
                  this.chunkDistanceManager.a(SectionPosition.a((Entity) entityplayer), entityplayer);
              }
@@ -4213,7 +4213,7 @@ index 43168f3836eb8823f3b2046882664ba45f1be678..127c03c321e1414e0d174c8d81a7851c
          } else {
              SectionPosition sectionposition = entityplayer.O();
  
-@@ -907,6 +936,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -908,6 +937,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (!flag2) {
                  this.chunkDistanceManager.b(sectionposition, entityplayer);
              }
@@ -4221,7 +4221,7 @@ index 43168f3836eb8823f3b2046882664ba45f1be678..127c03c321e1414e0d174c8d81a7851c
          }
  
          for (int k = i - this.viewDistance; k <= i + this.viewDistance; ++k) {
-@@ -1017,6 +1047,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1018,6 +1048,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
          }
  
@@ -4594,7 +4594,7 @@ index 9ad17c560c8d99a396543ab9f97c34de648f6544..4bf48f77f3f7cd62a91590543f5af441
                      currentTask = null;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index a8ce875f801edc424b5277abf7471e73ce91e3e6..f5f70c1fe31e5c533991e2c857fe8c10a83b94fc 100644
+index 3c7066192ea4c05c101404bb56cbc839771f4200..09aa6809c5400ce8548ac902908b750ce7c964ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -39,6 +39,21 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot

--- a/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
+++ b/Spigot-Server-Patches/0006-Add-MinecraftKey-Information-to-Objects.patch
@@ -92,11 +92,11 @@ index 0000000000000000000000000000000000000000..743142d0303fa25fe48a2abb07040d12
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index f002bafbf0ab5a240dd404416db87470f40e0296..b8f0653e3e82824a62dfe64348a33ab6432b4e17 100644
+index 134c7a9567c97ecf206b272a0e0a28a8a7534009..c80f964aef02ac6edd0dcf9f4af9f849e8ac3da9 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -11,7 +11,7 @@ import org.bukkit.inventory.InventoryHolder;
- // CraftBukkit end
+@@ -13,7 +13,7 @@ import org.bukkit.inventory.InventoryHolder;
+ 
  import org.spigotmc.CustomTimingsHandler; // Spigot
  
 -public abstract class TileEntity {
@@ -104,7 +104,7 @@ index f002bafbf0ab5a240dd404416db87470f40e0296..b8f0653e3e82824a62dfe64348a33ab6
  
      public CustomTimingsHandler tickTimer = org.bukkit.craftbukkit.SpigotTimings.getTileEntityTimings(this); // Spigot
      // CraftBukkit start - data containers
-@@ -19,7 +19,7 @@ public abstract class TileEntity {
+@@ -21,7 +21,7 @@ public abstract class TileEntity {
      public CraftPersistentDataContainer persistentDataContainer;
      // CraftBukkit end
      private static final Logger LOGGER = LogManager.getLogger();
@@ -113,7 +113,7 @@ index f002bafbf0ab5a240dd404416db87470f40e0296..b8f0653e3e82824a62dfe64348a33ab6
      @Nullable
      protected World world;
      protected BlockPosition position;
-@@ -33,6 +33,26 @@ public abstract class TileEntity {
+@@ -35,6 +35,26 @@ public abstract class TileEntity {
          this.tileType = tileentitytypes;
      }
  

--- a/Spigot-Server-Patches/0007-Store-reference-to-current-Chunk-for-Entity-and-Bloc.patch
+++ b/Spigot-Server-Patches/0007-Store-reference-to-current-Chunk-for-Entity-and-Bloc.patch
@@ -117,10 +117,10 @@ index b8267cf23f795fd7e586b0e567037eae5048d08e..b35ffae9f88cc14aec01482c2a3ed2e2
      private String entityKeyString;
  
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index b8f0653e3e82824a62dfe64348a33ab6432b4e17..b9ffd000c97111678d45fd55dc9c207ebadc140e 100644
+index c80f964aef02ac6edd0dcf9f4af9f849e8ac3da9..43757f60d091414befe7daa192b17e2fe1ddbef9 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -51,6 +51,15 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -53,6 +53,15 @@ public abstract class TileEntity implements KeyedObject { // Paper
          getMinecraftKey(); // Try to load if it doesn't exists.
          return tileEntityKeyString;
      }
@@ -137,7 +137,7 @@ index b8f0653e3e82824a62dfe64348a33ab6432b4e17..b9ffd000c97111678d45fd55dc9c207e
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 2770441b13cb993b222c6bf31c11711f001b74c0..db7c4011c8b90b6daca2b48a6d9ec447d31f7197 100644
+index 48747fada4f982ada8c8598fb8ba756d901b40f1..a2048d2dd71381ee5e878c87e0d727ab62756b20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -145,6 +145,7 @@ import net.minecraft.server.EntityZombieVillager;

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1173,19 +1173,19 @@ index 9946985407561596c6c364526d2fe7477771303a..b1fe488e41a2c9f77df091e1d14ed5c8
      }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145f0a7d07e 100644
+index 7678f69b9b9a28e6b1ac837fb9e499d8e0db1b13..c1a651a1c2d5ffed80e4517e465901bb39274548 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -65,7 +65,7 @@ import org.bukkit.craftbukkit.CraftServer;
- import org.bukkit.craftbukkit.Main;
+@@ -67,7 +67,7 @@ import org.bukkit.craftbukkit.Main;
  import org.bukkit.event.server.ServerLoadEvent;
  // CraftBukkit end
+ 
 -import org.bukkit.craftbukkit.SpigotTimings; // Spigot
 +import co.aikar.timings.MinecraftTimings; // Paper
  import org.spigotmc.SlackActivityAccountant; // Spigot
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
-@@ -119,8 +119,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -121,8 +121,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private long T;
      public final Thread serverThread;
      private long nextTick;
@@ -1196,7 +1196,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
      private final ResourcePackRepository resourcePackRepository;
      private final ScoreboardServer scoreboardServer;
      @Nullable
-@@ -711,6 +711,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -713,6 +713,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
          // CraftBukkit end
          MinecraftServer.LOGGER.info("Stopping server");
@@ -1204,7 +1204,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
-@@ -908,9 +909,21 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -910,9 +911,21 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      private boolean canSleepForTick() {
          // CraftBukkit start
@@ -1226,7 +1226,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
      private void executeModerately() {
          this.executeAll();
          java.util.concurrent.locks.LockSupport.parkNanos("executing tasks", 1000L);
-@@ -918,9 +931,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -920,9 +933,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // CraftBukkit end
  
      protected void sleepForTick() {
@@ -1238,7 +1238,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          });
      }
  
-@@ -1003,10 +1016,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1005,10 +1018,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      protected void exit() {}
  
      protected void a(BooleanSupplier booleansupplier) {
@@ -1258,7 +1258,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          ++this.ticks;
          this.b(booleansupplier);
          if (i - this.T >= 5000000000L) {
-@@ -1024,14 +1045,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1026,14 +1047,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
  
          if (autosavePeriod > 0 && this.ticks % autosavePeriod == 0) { // CraftBukkit
@@ -1273,7 +1273,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          }
  
          this.methodProfiler.enter("snooper");
-@@ -1044,6 +1063,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1046,6 +1065,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
  
          this.methodProfiler.exit();
@@ -1287,7 +1287,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          this.methodProfiler.enter("tallying");
          long l = this.h[this.ticks % 100] = SystemUtils.getMonotonicNanos() - i;
  
-@@ -1054,30 +1080,29 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1056,30 +1082,29 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.methodProfiler.exit();
          org.spigotmc.WatchdogThread.tick(); // Spigot
          this.slackActivityAccountant.tickEnded(l); // Spigot
@@ -1326,7 +1326,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          // Send time updates to everyone, it will get the right time from the world the player is in.
          if (this.ticks % 20 == 0) {
              for (int i = 0; i < this.getPlayerList().players.size(); ++i) {
-@@ -1085,7 +1110,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1087,7 +1112,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  entityplayer.playerConnection.sendPacket(new PacketPlayOutUpdateTime(entityplayer.world.getTime(), entityplayer.getPlayerTime(), entityplayer.world.getGameRules().getBoolean(GameRules.DO_DAYLIGHT_CYCLE))); // Add support for per player time
              }
          }
@@ -1335,7 +1335,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
  
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
-@@ -1126,24 +1151,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1128,24 +1153,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
  
          this.methodProfiler.exitEnter("connection");
@@ -1367,7 +1367,7 @@ index 472803c2d9292379a36fca681c2ab92ffb01184f..89d3ff83f0e152e9747c554693af4145
          this.methodProfiler.exit();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654fec23b673 100644
+index e641f4b89b39525686bba4d1e91c4ec26a9bd681..5ca081e8be411aee98efce3e41876efe3bb2e327 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,7 +1,9 @@
@@ -1380,7 +1380,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
  import com.google.common.collect.Lists;
  import com.google.common.collect.Queues;
  import com.google.common.collect.Sets;
-@@ -508,11 +510,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -509,11 +511,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      private CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> f(ChunkCoordIntPair chunkcoordintpair) {
          return CompletableFuture.supplyAsync(() -> {
@@ -1398,7 +1398,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
                      boolean flag = nbttagcompound.hasKeyOfType("Level", 10) && nbttagcompound.getCompound("Level").hasKeyOfType("Status", 8);
  
                      if (flag) {
-@@ -524,7 +529,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -525,7 +530,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      }
  
                      PlayerChunkMap.LOGGER.error("Chunk file at {} is missing level data, skipping", chunkcoordintpair);
@@ -1407,7 +1407,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
              } catch (ReportedException reportedexception) {
                  Throwable throwable = reportedexception.getCause();
  
-@@ -561,7 +566,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -562,7 +567,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              return "chunkGenerate " + chunkstatus.d();
          });
          return completablefuture.thenComposeAsync((either) -> {
@@ -1416,7 +1416,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
                  try {
                      CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture1 = chunkstatus.a(this.world, this.chunkGenerator, this.definedStructureManager, this.lightEngine, (ichunkaccess) -> {
                          return this.c(playerchunk);
-@@ -614,6 +619,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -615,6 +620,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              ChunkStatus chunkstatus = PlayerChunk.getChunkStatus(playerchunk.getTicketLevel());
  
              return !chunkstatus.b(ChunkStatus.FULL) ? PlayerChunk.UNLOADED_CHUNK_ACCESS : either.mapLeft((ichunkaccess) -> {
@@ -1424,7 +1424,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
                  ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
                  Chunk chunk;
  
-@@ -665,6 +671,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -666,6 +672,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
  
                  return chunk;
@@ -1432,7 +1432,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
              });
          }, (runnable) -> {
              Mailbox mailbox = this.mailboxMain;
-@@ -1123,6 +1130,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1124,6 +1131,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          PlayerChunkMap.EntityTracker playerchunkmap_entitytracker;
          ObjectIterator objectiterator;
@@ -1440,7 +1440,7 @@ index 127c03c321e1414e0d174c8d81a7851c9da03574..d98b6ef44e1836920956754dfcb6654f
  
          for (objectiterator = this.trackedEntities.values().iterator(); objectiterator.hasNext(); playerchunkmap_entitytracker.trackerEntry.a()) {
              playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
-@@ -1140,16 +1148,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1141,16 +1149,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  playerchunkmap_entitytracker.e = sectionposition1;
              }
          }
@@ -1544,7 +1544,7 @@ index 8c534c2f06fe72287364536b8767bd774b94c027..9c810b5aa21ca714ccf355d5648b7612
                      PlayerConnectionUtils.LOGGER.debug("Ignoring packet due to disconnection: " + packet);
                  }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 8206523e78176f485605c35d5ff9ae63ab363a65..5b49047b820dbe1f326320b71445ac216bf688b5 100644
+index 1ccc54af2feaec241b36304986e474cea5db564f..e712f33fe733b805098174558bb9319aa33572f0 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1554,7 +1554,7 @@ index 8206523e78176f485605c35d5ff9ae63ab363a65..5b49047b820dbe1f326320b71445ac21
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -955,10 +956,11 @@ public abstract class PlayerList {
+@@ -950,10 +951,11 @@ public abstract class PlayerList {
      }
  
      public void savePlayers() {
@@ -1617,14 +1617,13 @@ index e8ff43662b8397229cb19ea26342b66c88807379..3b8f56c0f0507ebdd9ac20be70688b4c
              this.g.clear();
              this.f.clear();
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index b9ffd000c97111678d45fd55dc9c207ebadc140e..f1d0e2faffb3ef27f5a41d06d0ff7d787f1098f5 100644
+index 43757f60d091414befe7daa192b17e2fe1ddbef9..c8aa347baf100b25694ed9172590b073db810fe9 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -9,11 +9,12 @@ import org.bukkit.craftbukkit.persistence.CraftPersistentDataContainer;
- import org.bukkit.craftbukkit.persistence.CraftPersistentDataTypeRegistry;
- import org.bukkit.inventory.InventoryHolder;
+@@ -12,10 +12,12 @@ import org.bukkit.inventory.InventoryHolder;
  // CraftBukkit end
--import org.spigotmc.CustomTimingsHandler; // Spigot
+ 
+ import org.spigotmc.CustomTimingsHandler; // Spigot
 +import co.aikar.timings.MinecraftTimings; // Paper
 +import co.aikar.timings.Timing; // Paper
  
@@ -1810,11 +1809,11 @@ index 592af06de1fc02d94273363c2ede1175a39997f0..3d915105b277a7cbf330ba2cb3c2f145
  
          // CraftBukkit start - moved from MinecraftServer.saveChunks
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a19242d717f7f9c254e6127fb2cb2f202be2d78a..351440f534653c9d315ccaf1e923e03ca6ba01f6 100644
+index 9b3f9b11abe89cabb3044766dda60a8842c149f4..0e8de6b3a6acd37064209b6890270ae7f64e7f28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2069,12 +2069,31 @@ public final class CraftServer implements Server {
-     private final Spigot spigot = new Spigot()
+     private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
 +        @Deprecated
@@ -2109,10 +2108,10 @@ index 4bf48f77f3f7cd62a91590543f5af441c8268029..ffe9cc1011226d604dc5499e7692e9a9
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad49c62088 100644
+index 09aa6809c5400ce8548ac902908b750ce7c964ec..3c96807e97657502849093e4371e9fef3584a346 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-@@ -1,11 +1,13 @@
+@@ -1,12 +1,15 @@
  package org.bukkit.craftbukkit.scheduler;
  
  import java.util.function.Consumer;
@@ -2121,14 +2120,15 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
  import org.bukkit.Bukkit;
  import org.bukkit.plugin.Plugin;
  import org.bukkit.scheduler.BukkitTask;
+ 
 -import org.bukkit.craftbukkit.SpigotTimings; // Spigot
--import org.spigotmc.CustomTimingsHandler; // Spigot
+ import org.spigotmc.CustomTimingsHandler; // Spigot
 +import co.aikar.timings.MinecraftTimings; // Paper
 +import co.aikar.timings.Timing; // Paper
  
- 
  public class CraftTask implements BukkitTask, Runnable { // Spigot
-@@ -26,12 +28,12 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+ 
+@@ -26,12 +29,12 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
       */
      private volatile long period;
      private long nextRun;
@@ -2144,7 +2144,7 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
      CraftTask() {
          this(null, null, CraftTask.NO_REPEATING, CraftTask.NO_REPEATING);
      }
-@@ -51,7 +53,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -51,7 +54,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          this.id = id;
          this.period = CraftTask.NO_REPEATING;
          this.taskName = taskName;
@@ -2153,7 +2153,7 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
      }
      // Paper end
  
-@@ -72,7 +74,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -72,7 +75,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          }
          this.id = id;
          this.period = period;
@@ -2162,7 +2162,7 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
      }
  
      @Override
-@@ -92,11 +94,13 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -92,11 +95,13 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
  
      @Override
      public void run() {
@@ -2176,7 +2176,7 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
      }
  
      long getPeriod() {
-@@ -123,7 +127,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -123,7 +128,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          this.next = next;
      }
  
@@ -2185,7 +2185,7 @@ index f5f70c1fe31e5c533991e2c857fe8c10a83b94fc..90ba08993fefd975b1095dafa6304aad
          return (rTask != null) ? rTask.getClass() : ((cTask != null) ? cTask.getClass() : null);
      }
  
-@@ -147,9 +151,4 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -147,9 +152,4 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          return true;
      }
  

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1037,7 +1037,7 @@ index 68a5a0cbe88795f59ce96035da45371a5a366f5a..c186af518ef43e9efaf086233e1da8a1
      public static EnumChatFormat a(int i) {
          if (i < 0) {
 diff --git a/src/main/java/net/minecraft/server/IChatBaseComponent.java b/src/main/java/net/minecraft/server/IChatBaseComponent.java
-index 7441beeaa4ee83467dac4d68176132efc6247337..de6bfc27cd38fd6293853d55cf62699aade94212 100644
+index e312078162c7132635995aa47237df0b495d9320..921fe6399745318c18570360fb438c45762b1b8e 100644
 --- a/src/main/java/net/minecraft/server/IChatBaseComponent.java
 +++ b/src/main/java/net/minecraft/server/IChatBaseComponent.java
 @@ -1,5 +1,6 @@
@@ -1047,7 +1047,7 @@ index 7441beeaa4ee83467dac4d68176132efc6247337..de6bfc27cd38fd6293853d55cf62699a
  import com.google.gson.Gson;
  import com.google.gson.GsonBuilder;
  import com.google.gson.JsonArray;
-@@ -104,6 +105,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -107,6 +108,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              GsonBuilder gsonbuilder = new GsonBuilder();
  
              gsonbuilder.disableHtmlEscaping();
@@ -1055,7 +1055,7 @@ index 7441beeaa4ee83467dac4d68176132efc6247337..de6bfc27cd38fd6293853d55cf62699a
              gsonbuilder.registerTypeHierarchyAdapter(IChatBaseComponent.class, new IChatBaseComponent.ChatSerializer());
              gsonbuilder.registerTypeHierarchyAdapter(ChatModifier.class, new ChatModifier.ChatModifierSerializer());
              gsonbuilder.registerTypeAdapterFactory(new ChatTypeAdapterFactory());
-@@ -344,10 +346,12 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -347,10 +349,12 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return jsonobject;
          }
  
@@ -1068,7 +1068,7 @@ index 7441beeaa4ee83467dac4d68176132efc6247337..de6bfc27cd38fd6293853d55cf62699a
          public static JsonElement b(IChatBaseComponent ichatbasecomponent) {
              return IChatBaseComponent.ChatSerializer.a.toJsonTree(ichatbasecomponent);
          }
-@@ -357,6 +361,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -360,6 +364,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return (IChatMutableComponent) ChatDeserializer.a(IChatBaseComponent.ChatSerializer.a, s, IChatMutableComponent.class, false);
          }
  
@@ -1397,7 +1397,7 @@ index d34e91887cd73009bf852fb849e495a8affed7a9..5636a76f1a893dc0609f16a240ae5593
               }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254ebb31fe1f 100644
+index e712f33fe733b805098174558bb9319aa33572f0..d1b26d753774ef89638a1c5130b10f16a6c743d8 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.authlib.GameProfile;
@@ -1416,7 +1416,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
  import com.google.common.base.Predicate;
  import com.google.common.collect.Iterables;
  
-@@ -188,7 +190,7 @@ public abstract class PlayerList {
+@@ -183,7 +185,7 @@ public abstract class PlayerList {
          }
          // CraftBukkit start
          chatmessage.a(EnumChatFormat.YELLOW);
@@ -1425,7 +1425,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
  
          playerconnection.a(entityplayer.locX(), entityplayer.locY(), entityplayer.locZ(), entityplayer.yaw, entityplayer.pitch);
          this.players.add(entityplayer);
-@@ -197,19 +199,18 @@ public abstract class PlayerList {
+@@ -192,19 +194,18 @@ public abstract class PlayerList {
          // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, new EntityPlayer[]{entityplayer})); // CraftBukkit - replaced with loop below
  
          // CraftBukkit start
@@ -1450,7 +1450,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
          }
          // CraftBukkit end
  
-@@ -406,7 +407,7 @@ public abstract class PlayerList {
+@@ -401,7 +402,7 @@ public abstract class PlayerList {
  
      }
  
@@ -1459,7 +1459,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
          WorldServer worldserver = entityplayer.getWorldServer();
  
          entityplayer.a(StatisticList.LEAVE_GAME);
-@@ -417,7 +418,7 @@ public abstract class PlayerList {
+@@ -412,7 +413,7 @@ public abstract class PlayerList {
              entityplayer.closeInventory();
          }
  
@@ -1468,7 +1468,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
          cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
-@@ -478,7 +479,7 @@ public abstract class PlayerList {
+@@ -473,7 +474,7 @@ public abstract class PlayerList {
          cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -1477,7 +1477,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -524,10 +525,10 @@ public abstract class PlayerList {
+@@ -519,10 +520,10 @@ public abstract class PlayerList {
              }
  
              // return chatmessage;
@@ -1490,7 +1490,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
          } else if (getIPBans().isBanned(socketaddress) && !getIPBans().get(socketaddress).hasExpired()) {
              IpBanEntry ipbanentry = this.l.get(socketaddress);
  
-@@ -537,17 +538,17 @@ public abstract class PlayerList {
+@@ -532,17 +533,17 @@ public abstract class PlayerList {
              }
  
              // return chatmessage;
@@ -1511,7 +1511,7 @@ index 5b49047b820dbe1f326320b71445ac216bf688b5..614477b047579afafb88b2ca2a03254e
              return null;
          }
          return entity;
-@@ -1068,7 +1069,7 @@ public abstract class PlayerList {
+@@ -1063,7 +1064,7 @@ public abstract class PlayerList {
      public void shutdown() {
          // CraftBukkit start - disconnect safely
          for (EntityPlayer player : this.players) {
@@ -1542,7 +1542,7 @@ index e6d97e7ffae3eadac586bad078123cd4aaa69916..d11725d61b888ceb08c4ea30f23d5631
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 351440f534653c9d315ccaf1e923e03ca6ba01f6..0dc17debe0c2c01de0d69e944eeafe9d6136490a 100644
+index 0e8de6b3a6acd37064209b6890270ae7f64e7f28..17f4e5a6fcf58ba74678f8a004fc3d5f4a81ae50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -563,8 +563,11 @@ public final class CraftServer implements Server {
@@ -1912,7 +1912,7 @@ index 34ceee4a81ef4ed05eb9007ca17c223f75f4ff50..11acf5f725a7f2e350a05268a00906ba
      public net.minecraft.server.Enchantment getHandle() {
          return target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index db7c4011c8b90b6daca2b48a6d9ec447d31f7197..969bf1095bb2a90ad0f1cb1f1e023e056e3855c0 100644
+index a2048d2dd71381ee5e878c87e0d727ab62756b20..d46ba8d0e3b02a76c02dcc39c87a8bb6c9073149 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -145,6 +145,7 @@ import net.minecraft.server.EntityZombieVillager;
@@ -2556,7 +2556,7 @@ index 9f6e797d34e5ad21a496c89f5a45ddb0638d3adc..115ee3785b4e0ba6a235bbb31b643aa5
          @Override
          public CraftMerchant getCraftMerchant() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index a0cc04cb6d1f02df3018320b4147bd0b156dd81c..1cc49b9d8c784f96cfc54159c1139af501264de6 100644
+index 422c61215601a5f4014b490bd608ec97f3ef3572..123616ed018fbc4d69f46e65d5ff15734008a00d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 @@ -1,8 +1,9 @@
@@ -2570,7 +2570,7 @@ index a0cc04cb6d1f02df3018320b4147bd0b156dd81c..1cc49b9d8c784f96cfc54159c1139af5
  import java.util.ArrayList;
  import java.util.Arrays;
  import java.util.List;
-@@ -267,6 +268,135 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -269,6 +270,135 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          this.generation = (generation == null) ? null : generation.ordinal();
      }
  
@@ -2706,7 +2706,7 @@ index a0cc04cb6d1f02df3018320b4147bd0b156dd81c..1cc49b9d8c784f96cfc54159c1139af5
      @Override
      public String getPage(final int page) {
          Validate.isTrue(isValidPage(page), "Invalid page number");
-@@ -411,7 +541,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -413,7 +543,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      }
  
      @Override
@@ -2991,10 +2991,10 @@ index e3036fe23fa2be100044332c432d1ad5b4872823..543792033497ff416396e8d6bee6b9e8
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
-index 0fba3d2a8d3bd7ec615d137e4625a7f357729d8d..b900aaf66f25e41956e7a4370b887fd4ed530570 100644
+index 6c24db0d2583c5f348d1d96c39139cc44af828d8..d641a9cd493ff7039db592d90d7cad1b5cf459bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
-@@ -27,6 +27,55 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
+@@ -29,6 +29,55 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
  
          return team.getName();
      }

--- a/Spigot-Server-Patches/0012-Configurable-baby-zombie-movement-speed.patch
+++ b/Spigot-Server-Patches/0012-Configurable-baby-zombie-movement-speed.patch
@@ -25,10 +25,10 @@ index 3618cc017feb60e257a28f67cbddca3f792a9833..796c17e0941922a9716212c6eae91643
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index a3f608e3a06abfa4268278b6f1298ece36264a02..d07847876e22971b4a90f67d8281bf08361424e0 100644
+index 3533df35b9fc942b0e34f162a0524a65857370a7..f8b969b203cec7341382abf884a084cb4adbd7f9 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -21,7 +21,7 @@ import org.bukkit.event.entity.EntityTransformEvent;
+@@ -20,7 +20,7 @@ import org.bukkit.event.entity.EntityTransformEvent;
  public class EntityZombie extends EntityMonster {
  
      private static final UUID b = UUID.fromString("B9766B59-9566-4402-BC1F-2EE2A276D836");
@@ -37,7 +37,7 @@ index a3f608e3a06abfa4268278b6f1298ece36264a02..d07847876e22971b4a90f67d8281bf08
      private static final DataWatcherObject<Boolean> d = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.i);
      private static final DataWatcherObject<Integer> bo = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.b);
      public static final DataWatcherObject<Boolean> DROWN_CONVERTING = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.i);
-@@ -124,9 +124,9 @@ public class EntityZombie extends EntityMonster {
+@@ -123,9 +123,9 @@ public class EntityZombie extends EntityMonster {
          if (this.world != null && !this.world.isClientSide) {
              AttributeModifiable attributemodifiable = this.getAttributeInstance(GenericAttributes.MOVEMENT_SPEED);
  

--- a/Spigot-Server-Patches/0013-Configurable-fishing-time-ranges.patch
+++ b/Spigot-Server-Patches/0013-Configurable-fishing-time-ranges.patch
@@ -22,10 +22,10 @@ index 796c17e0941922a9716212c6eae91643d8360418..78948c42b13194005bdbbbc69c2b7ae0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index 96e5246b6e6f285f3c1029147a6566f00b576a27..ad2ec3472a164bdf3a1ff2c42ec18c74ad58a13c 100644
+index 99a18a6c4d42b05cdcfd154c4ff24d9764e73057..b9243b0a2d429828f2a2b68c221129e23c6212ca 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
-@@ -46,6 +46,10 @@ public class EntityFishingHook extends IProjectile {
+@@ -47,6 +47,10 @@ public class EntityFishingHook extends IProjectile {
          entityhuman.hookedFish = this;
          this.an = Math.max(0, i);
          this.lureLevel = Math.max(0, j);

--- a/Spigot-Server-Patches/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/Spigot-Server-Patches/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -25,7 +25,7 @@ index 89e76dd73811fd0f6f8c8e7e5af804d5a4bb5a75..d16ae924bcbe31c964f7fb448757c748
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index b6ca0c88fbfec5cc0a3d06a33f1ab7cddd52cbe3..0f47b10c9c3357f7a462680e2f26d7808a5f8afc 100644
+index ae96ff73f78a514328862de86d3ecdb29fa9c145..09bab3828197e3078a4ed95e7c8a9f34e8bf1b8d 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1765,6 +1765,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -76,10 +76,10 @@ index 50d7c2899deb707dbbe333242e049b963d9b549c..3dfe3d13ac713c963256a662b52f5471
              this.world.addParticle(Particles.SMOKE, this.locX(), this.locY() + 0.5D, this.locZ(), 0.0D, 0.0D, 0.0D);
          } else if (this.b == 0) {
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index b448467a92650e1bd3d5fac7de685550b7e891df..2b8ed9d14bd6dd9330712741859eb77ba0194153 100644
+index 7064fd8e8318797a94b5292d675992a902b681ab..914ff5b7a9787ae5e8d5b8829e6888ba2637cc26 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-@@ -54,6 +54,12 @@ public class EntityTNTPrimed extends Entity {
+@@ -55,6 +55,12 @@ public class EntityTNTPrimed extends Entity {
          }
  
          this.move(EnumMoveType.SELF, this.getMot());

--- a/Spigot-Server-Patches/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/Spigot-Server-Patches/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,10 +19,10 @@ index aab33df7a36eb69300fedfce733985d6c239ca01..550232cb3819138b3bae0fa1c5142948
                      throwable = throwable1;
                      throw throwable1;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 89d3ff83f0e152e9747c554693af4145f0a7d07e..dd104b1cd544983024ac60888940a1c0917d05a1 100644
+index c1a651a1c2d5ffed80e4517e465901bb39274548..82768ab4663b6dc220212581f92bf8c5188c73b5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1223,7 +1223,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1225,7 +1225,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      public String getServerModName() {
@@ -32,7 +32,7 @@ index 89d3ff83f0e152e9747c554693af4145f0a7d07e..dd104b1cd544983024ac60888940a1c0
  
      public CrashReport b(CrashReport crashreport) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 99a242956a56121ab4f108fc58563e1df1537577..7a2409b78a044c37de1ee4fc772e4ac120ae657c 100644
+index 17f4e5a6fcf58ba74678f8a004fc3d5f4a81ae50..6352c45db0053ce75356494ffa3b31b42d6e6414 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -226,7 +226,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;

--- a/Spigot-Server-Patches/0023-Optimize-TileEntity-Ticking.patch
+++ b/Spigot-Server-Patches/0023-Optimize-TileEntity-Ticking.patch
@@ -56,10 +56,10 @@ index 98616f0db75d0e2b2e960dbf88289c87ba426ab6..b19c694cf01bc868dd7c4ec6432b613d
          return this.b.containsKey(iblockstate);
      }
 diff --git a/src/main/java/net/minecraft/server/TileEntityChest.java b/src/main/java/net/minecraft/server/TileEntityChest.java
-index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f34de9e39d 100644
+index 8e5ceacf7f6ed0d639d7850334d8a01a74aef6e3..54cad33750efd80b104664723e1115d107c7a72d 100644
 --- a/src/main/java/net/minecraft/server/TileEntityChest.java
 +++ b/src/main/java/net/minecraft/server/TileEntityChest.java
-@@ -7,7 +7,7 @@ import org.bukkit.craftbukkit.entity.CraftHumanEntity;
+@@ -8,7 +8,7 @@ import org.bukkit.craftbukkit.entity.CraftHumanEntity;
  import org.bukkit.entity.HumanEntity;
  // CraftBukkit end
  
@@ -68,7 +68,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
  
      private NonNullList<ItemStack> items;
      protected float a;
-@@ -85,14 +85,20 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -86,14 +86,20 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
          return nbttagcompound;
      }
  
@@ -91,7 +91,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
          this.b = this.a;
          float f = 0.1F;
  
-@@ -106,8 +112,11 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -107,8 +113,11 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
          if (this.viewingCount > 0 && this.a == 0.0F) {
              this.playOpenSound(SoundEffects.BLOCK_CHEST_OPEN);
          }
@@ -104,7 +104,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
              float f1 = this.a;
  
              if (this.viewingCount > 0) {
-@@ -123,8 +132,11 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -124,8 +133,11 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
              float f2 = 0.5F;
  
              if (this.a < 0.5F && f1 >= 0.5F) {
@@ -117,7 +117,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
  
              if (this.a < 0.0F) {
                  this.a = 0.0F;
-@@ -163,6 +175,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -164,6 +176,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
      }
  
      public void playOpenSound(SoundEffect soundeffect) {
@@ -125,7 +125,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
          BlockPropertyChestType blockpropertychesttype = (BlockPropertyChestType) this.getBlock().get(BlockChest.c);
  
          if (blockpropertychesttype != BlockPropertyChestType.LEFT) {
-@@ -201,6 +214,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -202,6 +215,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
  
              ++this.viewingCount;
              if (this.world == null) return; // CraftBukkit
@@ -133,7 +133,7 @@ index d4b8daf1f064bff25ef5566b0288dad0087e379e..52f64460ba1bfb298f343f71a923c8f3
  
              // CraftBukkit start - Call redstone event
              if (this.getBlock().getBlock() == Blocks.TRAPPED_CHEST) {
-@@ -223,6 +237,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
+@@ -224,6 +238,7 @@ public class TileEntityChest extends TileEntityLootable implements ITickable {
              --this.viewingCount;
  
              // CraftBukkit start - Call redstone event

--- a/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
+++ b/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
@@ -12,10 +12,10 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dd104b1cd544983024ac60888940a1c0917d05a1..478dfe231720324e995dc4123fbf19b9ce26c16e 100644
+index 82768ab4663b6dc220212581f92bf8c5188c73b5..f54300a107477e6b6aa79114212f0088dc4f5be5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -144,7 +144,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -146,7 +146,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public org.bukkit.command.ConsoleCommandSender console;
      public org.bukkit.command.RemoteConsoleCommandSender remoteConsole;
      public ConsoleReader reader;
@@ -24,7 +24,7 @@ index dd104b1cd544983024ac60888940a1c0917d05a1..478dfe231720324e995dc4123fbf19b9
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
      public CommandDispatcher vanillaCommandDispatcher;
-@@ -153,7 +153,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -155,7 +155,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // Spigot start
      public static final int TPS = 20;
      public static final int TICK_TIME = 1000000000 / TPS;
@@ -33,7 +33,7 @@ index dd104b1cd544983024ac60888940a1c0917d05a1..478dfe231720324e995dc4123fbf19b9
      public final double[] recentTps = new double[ 3 ];
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
-@@ -806,6 +806,57 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -808,6 +808,57 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      {
          return ( avg * exp ) + ( tps * ( 1 - exp ) );
      }
@@ -91,7 +91,7 @@ index dd104b1cd544983024ac60888940a1c0917d05a1..478dfe231720324e995dc4123fbf19b9
      // Spigot End
  
      protected void w() {
-@@ -818,30 +869,38 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -820,30 +871,38 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
                  // Spigot start
                  Arrays.fill( recentTps, 20 );
@@ -140,7 +140,7 @@ index dd104b1cd544983024ac60888940a1c0917d05a1..478dfe231720324e995dc4123fbf19b9
                      GameProfilerTick gameprofilertick = GameProfilerTick.a("Server");
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7a2409b78a044c37de1ee4fc772e4ac120ae657c..390714fa5822a61f64f6b3b8731397e9dae77cfd 100644
+index 6352c45db0053ce75356494ffa3b31b42d6e6414..2832610d080db4d8a6c26d946c441306404f6aba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2113,6 +2113,17 @@ public final class CraftServer implements Server {
@@ -159,7 +159,7 @@ index 7a2409b78a044c37de1ee4fc772e4ac120ae657c..390714fa5822a61f64f6b3b8731397e9
 +    // Paper end
 +
      // Spigot start
-     private final Spigot spigot = new Spigot()
+     private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
 diff --git a/src/main/java/org/spigotmc/TicksPerSecondCommand.java b/src/main/java/org/spigotmc/TicksPerSecondCommand.java
 index f5b6dec1cbe7501ce2ee9125920e810bc94670cc..e62890433ffbe0b4e48942fe6c38b599a19e58fd 100644

--- a/Spigot-Server-Patches/0026-Entity-Origin-API.patch
+++ b/Spigot-Server-Patches/0026-Entity-Origin-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 14646561f8fe661ba2b815c1abfb81af61f027d4..48ebaa4cdb5d5f52334e7bd4f80309a10ecedfa9 100644
+index dc996792df6046d442565a7993ec299af6605d92..c6b91de58c0190aca0455aacc04994f8ea5d81b7 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -162,6 +162,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -70,10 +70,10 @@ index 6b226c04d40adff8b0f1d28c0cc79439df002b3d..bdeabfaeb17778a12ab4ad72689a72b0
  
      public void a(boolean flag) {
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index 2b8ed9d14bd6dd9330712741859eb77ba0194153..e25404fd89ad6317c2656c68c2e32aa05e5f0e73 100644
+index 914ff5b7a9787ae5e8d5b8829e6888ba2637cc26..f71e82c365947de822be7b87083b46bd7ce4b902 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-@@ -104,6 +104,14 @@ public class EntityTNTPrimed extends Entity {
+@@ -105,6 +105,14 @@ public class EntityTNTPrimed extends Entity {
      @Override
      protected void loadData(NBTTagCompound nbttagcompound) {
          this.setFuseTicks(nbttagcompound.getShort("Fuse"));
@@ -101,7 +101,7 @@ index ad8a506bb430b26fe147a657a2f826daf9bf4d45..ad4807e0bdd6409bd798f995da8f43ce
          if (i >= 0 && i < this.list.size()) {
              NBTBase nbtbase = (NBTBase) this.list.get(i);
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 21e4088cfdb7218e78fb771fe4c9bd2027594663..89c22be536a45199a29d328b125bdcb9c2848d65 100644
+index 3d915105b277a7cbf330ba2cb3c2f1451ee868e4..02dac635cce43edea05ed4961711ea5394613971 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1135,6 +1135,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -117,7 +117,7 @@ index 21e4088cfdb7218e78fb771fe4c9bd2027594663..89c22be536a45199a29d328b125bdcb9
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 969bf1095bb2a90ad0f1cb1f1e023e056e3855c0..0582d15e14d4fde7630759849b573cb2e08fabe6 100644
+index d46ba8d0e3b02a76c02dcc39c87a8bb6c9073149..2ed97dc772535f2364406c298d06fada8167fb74 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1063,4 +1063,12 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/Spigot-Server-Patches/0027-Prevent-tile-entity-and-entity-crashes.patch
+++ b/Spigot-Server-Patches/0027-Prevent-tile-entity-and-entity-crashes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent tile entity and entity crashes
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index f1d0e2faffb3ef27f5a41d06d0ff7d787f1098f5..da96a91c6b4cc03ad2e4539053bd30e7dc62dfe8 100644
+index c8aa347baf100b25694ed9172590b073db810fe9..5414858ba241c13d4e568191d11111d3d3ec3fc4 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -194,7 +194,12 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -197,7 +197,12 @@ public abstract class TileEntity implements KeyedObject { // Paper
              return IRegistry.BLOCK_ENTITY_TYPE.getKey(this.getTileType()) + " // " + this.getClass().getCanonicalName();
          });
          if (this.world != null) {

--- a/Spigot-Server-Patches/0033-Optimize-explosions.patch
+++ b/Spigot-Server-Patches/0033-Optimize-explosions.patch
@@ -123,10 +123,10 @@ index afe61a1ddc75f155836411b6749198f71ed09919..ac39b02ec5f02f6f2db9f293513686d2
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 478dfe231720324e995dc4123fbf19b9ce26c16e..5b4b6810586761072a790b7bbe3368d26cd5bb13 100644
+index f54300a107477e6b6aa79114212f0088dc4f5be5..38b0863bf470682b9afaab016c5c41af65800e5d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1207,6 +1207,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1209,6 +1209,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
              this.methodProfiler.exit();
              this.methodProfiler.exit();
@@ -135,7 +135,7 @@ index 478dfe231720324e995dc4123fbf19b9ce26c16e..5b4b6810586761072a790b7bbe3368d2
  
          this.methodProfiler.exitEnter("connection");
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 21868a246d01c0f8c8642e42f82f66632b3bcadd..ca874ef00a925095c01767f5b41737302645f149 100644
+index bc1946ea3060220f4598aae2e1aed3d84ab18387..e062f68b87bd70b128f46394881c09ad63278fdc 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -84,6 +84,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {

--- a/Spigot-Server-Patches/0038-Send-absolute-position-the-first-time-an-entity-is-s.patch
+++ b/Spigot-Server-Patches/0038-Send-absolute-position-the-first-time-an-entity-is-s.patch
@@ -77,10 +77,10 @@ index 62a7db8c7d2604d248ec5c1efb3c43356c3d513c..dec48226d713ef0198ef3c679daf553a
  
                  this.c();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index d98b6ef44e1836920956754dfcb6654fec23b673..b40f6b7d45028b5bc58a222e2d54cb8693273325 100644
+index 5ca081e8be411aee98efce3e41876efe3bb2e327..2ba10ed683788219c734a565a163ba553ec72c75 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1249,10 +1249,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1250,10 +1250,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          private final Entity tracker;
          private final int trackingDistance;
          private SectionPosition e;
@@ -97,7 +97,7 @@ index d98b6ef44e1836920956754dfcb6654fec23b673..b40f6b7d45028b5bc58a222e2d54cb86
              this.tracker = entity;
              this.trackingDistance = i;
              this.e = SectionPosition.a(entity);
-@@ -1334,7 +1338,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1335,7 +1339,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      entityplayer.removeQueue.remove(Integer.valueOf(this.tracker.getId()));
                      // CraftBukkit end
  

--- a/Spigot-Server-Patches/0039-Add-BeaconEffectEvent.patch
+++ b/Spigot-Server-Patches/0039-Add-BeaconEffectEvent.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add BeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityBeacon.java b/src/main/java/net/minecraft/server/TileEntityBeacon.java
-index 79774d8dabd46eb91940db934bb58f8b082ff9e2..c6b7bc3dc1445269c1562c308b386ce480d70ef3 100644
+index 1305506d27010e4be03032c9863bed186e2bff06..fdf73eca821bab5ec7a742645893793679b5d42c 100644
 --- a/src/main/java/net/minecraft/server/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/server/TileEntityBeacon.java
-@@ -14,6 +14,11 @@ import org.bukkit.craftbukkit.potion.CraftPotionUtil;
- import org.bukkit.entity.HumanEntity;
+@@ -12,6 +12,11 @@ import javax.annotation.Nullable;
+ import org.bukkit.craftbukkit.potion.CraftPotionUtil;
  import org.bukkit.potion.PotionEffect;
  // CraftBukkit end
 +// Paper start
@@ -20,7 +20,7 @@ index 79774d8dabd46eb91940db934bb58f8b082ff9e2..c6b7bc3dc1445269c1562c308b386ce4
  
  public class TileEntityBeacon extends TileEntity implements ITileInventory, ITickable {
  
-@@ -240,14 +245,31 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -238,14 +243,31 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
      }
  
      private void applyEffect(List list, MobEffectList effects, int i, int b0) {
@@ -53,7 +53,7 @@ index 79774d8dabd46eb91940db934bb58f8b082ff9e2..c6b7bc3dc1445269c1562c308b386ce4
              }
          }
      }
-@@ -270,10 +292,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -268,10 +290,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
              int i = getLevel();
              List list = getHumansInRange();
  

--- a/Spigot-Server-Patches/0041-Use-UserCache-for-player-heads.patch
+++ b/Spigot-Server-Patches/0041-Use-UserCache-for-player-heads.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use UserCache for player heads
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index e950b1957133fef20c464284807df262a7684238..c57634317b661e05ddd085d04f7338045445069f 100644
+index 1a686e603feede34236dc43136ade71cfdc88214..42de897596ada4044df683dc5e8d5d750ee9c207 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -165,7 +165,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -166,7 +166,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          if (name == null) {
              setProfile(null);
          } else {

--- a/Spigot-Server-Patches/0043-Add-PlayerInitialSpawnEvent.patch
+++ b/Spigot-Server-Patches/0043-Add-PlayerInitialSpawnEvent.patch
@@ -9,19 +9,19 @@ This is a duplicate API from spigot, so use our duplicate subclass and
 improve setPosition to use raw
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 1b0fe4f27a7346a1466db97e796c4a65b11e1ab8..fedc9e453cdf17c1b69c87de9fa32a145d4b6f70 100644
+index d1b26d753774ef89638a1c5130b10f16a6c743d8..c71dea3e51c93cf1ad60b8a76408774d67552de8 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -145,7 +145,7 @@ public abstract class PlayerList {
+@@ -140,7 +140,7 @@ public abstract class PlayerList {
  
          // Spigot start - spawn location event
          Player bukkitPlayer = entityplayer.getBukkitEntity();
--        PlayerSpawnLocationEvent ev = new PlayerSpawnLocationEvent(bukkitPlayer, bukkitPlayer.getLocation());
-+        PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(bukkitPlayer, bukkitPlayer.getLocation()); // Paper use our duplicate event
-         Bukkit.getPluginManager().callEvent(ev);
+-        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new org.spigotmc.event.player.PlayerSpawnLocationEvent(bukkitPlayer, bukkitPlayer.getLocation());
++        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(bukkitPlayer, bukkitPlayer.getLocation()); // Paper use our duplicate event
+         cserver.getPluginManager().callEvent(ev);
  
          Location loc = ev.getSpawnLocation();
-@@ -153,7 +153,7 @@ public abstract class PlayerList {
+@@ -148,7 +148,7 @@ public abstract class PlayerList {
  
          entityplayer.spawnIn(worldserver1);
          entityplayer.playerInteractManager.a((WorldServer) entityplayer.world);

--- a/Spigot-Server-Patches/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/Spigot-Server-Patches/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -19,10 +19,10 @@ index 70e074cdf2087e638af8e0f3878d0ef8eb7305cc..416a6760883cb40367535c7c5acd7797
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
-index a737b9cae678a5a3006ee6a00a1f1ddf7bb4e07c..563340d410f76ec1df90403879b835ebd9e6b533 100644
+index d6ecdbfcebeda8e9f599d7ac28e7cdaa8dc852a8..d774a0893b2e6599bade3a9edf22668a30587503 100644
 --- a/src/main/java/net/minecraft/server/EntitySlime.java
 +++ b/src/main/java/net/minecraft/server/EntitySlime.java
-@@ -285,7 +285,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -286,7 +286,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
              }
  
              ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(blockposition);

--- a/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Tab List and Title APIs
 
 
 diff --git a/src/main/java/net/minecraft/server/IChatBaseComponent.java b/src/main/java/net/minecraft/server/IChatBaseComponent.java
-index de6bfc27cd38fd6293853d55cf62699aade94212..65aec1dc2fd9ef9c9a9f022f13008505383a0af4 100644
+index 921fe6399745318c18570360fb438c45762b1b8e..2b8916e3b3ecfd3917b5acf3ea6dfc2793e242c8 100644
 --- a/src/main/java/net/minecraft/server/IChatBaseComponent.java
 +++ b/src/main/java/net/minecraft/server/IChatBaseComponent.java
-@@ -356,6 +356,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -359,6 +359,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return IChatBaseComponent.ChatSerializer.a.toJsonTree(ichatbasecomponent);
          }
  
@@ -64,7 +64,7 @@ index 772ca6256964692a2b9c12e2edc532d2a8f51f7b..71168d9d0252e93253fa3b3f0bface3a
              // Paper end
              packetdataserializer.a(this.b);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4c0a6d00b17b5e11c0f2b5d7170701bedd20b87c..2542b3a135dd3f728a5a44c9f9c81ae524734abf 100644
+index e0805f4e295ff3866e7689214cfd922267a98008..4f3511447473f50336a1deea62958834cb3d4af1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@

--- a/Spigot-Server-Patches/0055-Add-exception-reporting-event.patch
+++ b/Spigot-Server-Patches/0055-Add-exception-reporting-event.patch
@@ -107,10 +107,10 @@ index bf0ccfb9bf20422b90ef26370d113b49be7d730b..060887d765604e4be82913607bb6266a
                         }
                          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index b40f6b7d45028b5bc58a222e2d54cb8693273325..0542dde09d288488b88e17a044cc508d5d39782f 100644
+index 2ba10ed683788219c734a565a163ba553ec72c75..612eb16bce1bce1cad40ea0f279d2b8397263dea 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -761,6 +761,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -762,6 +762,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return true;
              } catch (Exception exception) {
                  PlayerChunkMap.LOGGER.error("Failed to save chunk {},{}", chunkcoordintpair.x, chunkcoordintpair.z, exception);

--- a/Spigot-Server-Patches/0072-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/Spigot-Server-Patches/0072-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -32,10 +32,10 @@ index 48eb9c8a68d45c88c7a42e8e400446a374fb4fc9..2c8d49501664862559ed8974b4821bdd
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5b4b6810586761072a790b7bbe3368d26cd5bb13..a3913ee0756f79159ea0671c9041ab68db0aa121 100644
+index 38b0863bf470682b9afaab016c5c41af65800e5d..575b4e670810b0be51067ba3e4c838e547a1f1dc 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1173,6 +1173,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1175,6 +1175,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
@@ -44,7 +44,7 @@ index 5b4b6810586761072a790b7bbe3368d26cd5bb13..a3913ee0756f79159ea0671c9041ab68
              this.methodProfiler.a(() -> {
                  return worldserver + " " + worldserver.getDimensionKey().a();
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 096a1d3bf0e9c51244ecd9ad2fbd240f3e01f461..e04d2182915ca3ac69353ef967ae3f703ab9fc30 100644
+index 7c6127739f1d88ee0dc411db5fcaa37d7fff36f7..5ce86030a71c181c4c28b8934be4fa8c7eafc299 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -406,7 +406,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -66,7 +66,7 @@ index 096a1d3bf0e9c51244ecd9ad2fbd240f3e01f461..e04d2182915ca3ac69353ef967ae3f70
                      this.getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 4029f090d7b01c10b4f3f99004ab92f04653e884..7e44af3e933f16fc00cd2b43e913f87380fb1cae 100644
+index a7b78b317dc70816fb0b23989bebe30a300ed561..7a1f6d446fb62b0aa72212b44899606c8ec99b55 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -87,6 +87,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0079-Fix-reducedDebugInfo-not-initialized-on-client.patch
+++ b/Spigot-Server-Patches/0079-Fix-reducedDebugInfo-not-initialized-on-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix reducedDebugInfo not initialized on client
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index fedc9e453cdf17c1b69c87de9fa32a145d4b6f70..430d86aba42de6de057a78d78e9d8c41bc6fd680 100644
+index c71dea3e51c93cf1ad60b8a76408774d67552de8..acbdc4736c2f6f181e25b776a2c025bd2af85af2 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -176,6 +176,7 @@ public abstract class PlayerList {
+@@ -171,6 +171,7 @@ public abstract class PlayerList {
          playerconnection.sendPacket(new PacketPlayOutHeldItemSlot(entityplayer.inventory.itemInHandIndex));
          playerconnection.sendPacket(new PacketPlayOutRecipeUpdate(this.server.getCraftingManager().b()));
          playerconnection.sendPacket(new PacketPlayOutTags(this.server.getTagRegistry()));

--- a/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
+++ b/Spigot-Server-Patches/0087-Configurable-Player-Collision.patch
@@ -19,10 +19,10 @@ index 439dcc6effdc91830d2b7ede9063982998b37120..504efea7b6f50a0d17f4f353781953df
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a3913ee0756f79159ea0671c9041ab68db0aa121..31cc60dcf998cf07ca8db14dba37145ed5b3601c 100644
+index 575b4e670810b0be51067ba3e4c838e547a1f1dc..5fd43537ced63947cab0e179f88109d63d1c87e7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -432,6 +432,20 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -434,6 +434,20 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
          }
  
@@ -57,10 +57,10 @@ index d1581c9d9838797eb425020d21bd0fba432e5652..99dc43159f240135957aee35f6129f19
              packetdataserializer.a(this.c);
              packetdataserializer.a(this.d);
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 37a6861fca3fb22cd4675e1402432e597c9fb307..8b20c92178d78900ed31e25364b6cbb78110bf48 100644
+index acbdc4736c2f6f181e25b776a2c025bd2af85af2..5652462008dd857f2dc36b80e3fe5d3d83867ce5 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -77,6 +77,7 @@ public abstract class PlayerList {
+@@ -72,6 +72,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      private CraftServer cserver;
      private final Map<String,EntityPlayer> playersByName = new java.util.HashMap<>();
@@ -68,7 +68,7 @@ index 37a6861fca3fb22cd4675e1402432e597c9fb307..8b20c92178d78900ed31e25364b6cbb7
  
      public PlayerList(MinecraftServer minecraftserver, IRegistryCustom.Dimension iregistrycustom_dimension, WorldNBTStorage worldnbtstorage, int i) {
          this.cserver = minecraftserver.server = new CraftServer((DedicatedServer) minecraftserver, this);
-@@ -306,6 +307,13 @@ public abstract class PlayerList {
+@@ -301,6 +302,13 @@ public abstract class PlayerList {
          }
  
          entityplayer.syncInventory();
@@ -82,7 +82,7 @@ index 37a6861fca3fb22cd4675e1402432e597c9fb307..8b20c92178d78900ed31e25364b6cbb7
          // CraftBukkit - Moved from above, added world
          PlayerList.LOGGER.info("{}[{}] logged in with entity id {} at ([{}]{}, {}, {})", entityplayer.getDisplayName().getString(), s1, entityplayer.getId(), worldserver1.worldDataServer.getName(), entityplayer.locX(), entityplayer.locY(), entityplayer.locZ());
      }
-@@ -426,6 +434,16 @@ public abstract class PlayerList {
+@@ -421,6 +429,16 @@ public abstract class PlayerList {
          entityplayer.playerTick(); // SPIGOT-924
          // CraftBukkit end
  
@@ -99,7 +99,7 @@ index 37a6861fca3fb22cd4675e1402432e597c9fb307..8b20c92178d78900ed31e25364b6cbb7
          this.savePlayerFile(entityplayer);
          if (entityplayer.isPassenger()) {
              Entity entity = entityplayer.getRootVehicle();
-@@ -1074,6 +1092,13 @@ public abstract class PlayerList {
+@@ -1069,6 +1087,13 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  

--- a/Spigot-Server-Patches/0089-Configurable-RCON-IP-address.patch
+++ b/Spigot-Server-Patches/0089-Configurable-RCON-IP-address.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable RCON IP address
 For servers with multiple IP's, ability to bind to a specific interface.
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServerProperties.java b/src/main/java/net/minecraft/server/DedicatedServerProperties.java
-index bec3a69b0f68a29ecff71f10c7b195adc91d16b3..3ecfb193be1d83d2b2c90ca9e264388dabb88c05 100644
+index ebeea0df593bc82e7740203bec6b45e16318ab35..205d56f88440789df8a028b3827dd388fea56f63 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServerProperties.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServerProperties.java
-@@ -57,6 +57,8 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
+@@ -61,6 +61,8 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
      public final PropertyManager<DedicatedServerProperties>.EditableProperty<Boolean> whiteList;
      public final GeneratorSettings generatorSettings;
  
@@ -18,7 +18,7 @@ index bec3a69b0f68a29ecff71f10c7b195adc91d16b3..3ecfb193be1d83d2b2c90ca9e264388d
      // CraftBukkit start
      public DedicatedServerProperties(Properties properties, IRegistryCustom iregistrycustom, OptionSet optionset) {
          super(properties, optionset);
-@@ -108,6 +110,10 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
+@@ -112,6 +114,10 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
          this.textFilteringConfig = this.getString("text-filtering-config", "");
          this.playerIdleTimeout = this.b("player-idle-timeout", 0);
          this.whiteList = this.b("white-list", false);

--- a/Spigot-Server-Patches/0094-remove-null-possibility-for-getServer-singleton.patch
+++ b/Spigot-Server-Patches/0094-remove-null-possibility-for-getServer-singleton.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] remove null possibility for getServer singleton
 to stop IDE complaining about potential NPE
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 31cc60dcf998cf07ca8db14dba37145ed5b3601c..68c6ccf0576752b836079a3c5352102182a6127e 100644
+index 5fd43537ced63947cab0e179f88109d63d1c87e7..5c84033df42b2cba1719010e75aeeb00c817eb61 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -70,6 +70,7 @@ import org.spigotmc.SlackActivityAccountant; // Spigot
+@@ -72,6 +72,7 @@ import org.spigotmc.SlackActivityAccountant; // Spigot
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
  
@@ -17,7 +17,7 @@ index 31cc60dcf998cf07ca8db14dba37145ed5b3601c..68c6ccf0576752b836079a3c53521021
      public static final Logger LOGGER = LogManager.getLogger();
      public static final File b = new File("usercache.json");
      public static final WorldSettings c = new WorldSettings("Demo World", EnumGamemode.SURVIVAL, false, EnumDifficulty.NORMAL, false, new GameRules(), DataPackConfiguration.a);
-@@ -176,6 +177,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -178,6 +179,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      public MinecraftServer(OptionSet options, DataPackConfiguration datapackconfiguration, Thread thread, IRegistryCustom.Dimension iregistrycustom_dimension, Convertable.ConversionSession convertable_conversionsession, SaveData savedata, ResourcePackRepository resourcepackrepository, Proxy proxy, DataFixer datafixer, DataPackResources datapackresources, MinecraftSessionService minecraftsessionservice, GameProfileRepository gameprofilerepository, UserCache usercache, WorldLoadListenerFactory worldloadlistenerfactory) {
          super("Server");
@@ -25,7 +25,7 @@ index 31cc60dcf998cf07ca8db14dba37145ed5b3601c..68c6ccf0576752b836079a3c53521021
          this.m = new GameProfilerSwitcher(SystemUtils.a, this::ai);
          this.methodProfiler = GameProfilerDisabled.a;
          this.serverPing = new ServerPing();
-@@ -2043,7 +2045,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2045,7 +2047,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      @Deprecated
      public static MinecraftServer getServer() {

--- a/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/Spigot-Server-Patches/0096-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -518,7 +518,7 @@ index 0000000000000000000000000000000000000000..a1923aff2b5e2e867670a5a064a76791
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index dba28796a921beda2e5d15ba1565c55f54e36435..df6377b5849aab20246a29b312744604b4cbf6bf 100644
+index 487d041999fd1edc4b48790dbc975cf8cea8ba54..0dd63d2e0ed16eb08cf97dbf8c293e24a5a1bda9 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -73,6 +73,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -530,10 +530,10 @@ index dba28796a921beda2e5d15ba1565c55f54e36435..df6377b5849aab20246a29b312744604
  
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/net/minecraft/server/EntityMinecartContainer.java b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
-index 75e9c1538b3d8ef5186986ab3c8ca8b60f63ee6e..574838bd33a46e464ff7d801345613a3351f487f 100644
+index 3258bf53761dbed2bfe9fd92e011161b914796d0..8e13aebb7043ddfb4b1c02bac46081eb15e906bf 100644
 --- a/src/main/java/net/minecraft/server/EntityMinecartContainer.java
 +++ b/src/main/java/net/minecraft/server/EntityMinecartContainer.java
-@@ -19,6 +19,7 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+@@ -20,6 +20,7 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
      public long lootTableSeed;
  
      // CraftBukkit start
@@ -541,7 +541,7 @@ index 75e9c1538b3d8ef5186986ab3c8ca8b60f63ee6e..574838bd33a46e464ff7d801345613a3
      public List<HumanEntity> transaction = new java.util.ArrayList<HumanEntity>();
      private int maxStack = MAX_STACK;
  
-@@ -176,12 +177,13 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+@@ -177,12 +178,13 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
      @Override
      protected void saveData(NBTTagCompound nbttagcompound) {
          super.saveData(nbttagcompound);
@@ -556,7 +556,7 @@ index 75e9c1538b3d8ef5186986ab3c8ca8b60f63ee6e..574838bd33a46e464ff7d801345613a3
              ContainerUtil.a(nbttagcompound, this.items);
          }
  
-@@ -190,11 +192,12 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+@@ -191,11 +193,12 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
      @Override
      protected void loadData(NBTTagCompound nbttagcompound) {
          super.loadData(nbttagcompound);
@@ -570,7 +570,7 @@ index 75e9c1538b3d8ef5186986ab3c8ca8b60f63ee6e..574838bd33a46e464ff7d801345613a3
              ContainerUtil.b(nbttagcompound, this.items);
          }
  
-@@ -225,14 +228,15 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
+@@ -226,14 +229,15 @@ public abstract class EntityMinecartContainer extends EntityMinecartAbstract imp
      }
  
      public void d(@Nullable EntityHuman entityhuman) {
@@ -646,7 +646,7 @@ index 9265bc7331f5d3cb43394a7457ab89140b731c8b..d9be182a574daaedcc7a106c759c2bde
  
              if (entityhuman != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index da5a80267b189d75374375211a574ca5f18d96be..26cc40e57f5b73b9c32859bff37c4a3d94904c56 100644
+index df71eb9672ecc69ac92c773925d9b692ad343fee..8a7e9302b4b6be086144add8df610b76b58e00d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 @@ -64,7 +64,7 @@ public class CraftBlockEntityState<T extends TileEntity> extends CraftBlockState

--- a/Spigot-Server-Patches/0099-Optimize-UserCache-Thread-Safe.patch
+++ b/Spigot-Server-Patches/0099-Optimize-UserCache-Thread-Safe.patch
@@ -23,10 +23,10 @@ index 7b52bf335e60a700b4c4e25cab1b0261f32775bc..dc0cb79525adf0d5afee1f677e1fde54
  
          if (!NameReferencingFileConverter.e(this)) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 68c6ccf0576752b836079a3c5352102182a6127e..7e4a966b5748417223243344bf7c4483e997a237 100644
+index 5c84033df42b2cba1719010e75aeeb00c817eb61..110184bd18f689cff1f37ceefe97416b5dcfd405 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -787,7 +787,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -789,7 +789,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          } catch (java.lang.InterruptedException ignored) {} // Paper
          if (org.spigotmc.SpigotConfig.saveUserCacheOnStopOnly) {
              LOGGER.info("Saving usercache.json");

--- a/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
@@ -32,7 +32,7 @@ index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..6eca3f300020006f02dd36253b522db4
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index df6377b5849aab20246a29b312744604b4cbf6bf..7abe7bcddd3c60bfb0f290e2475d28396d5319cf 100644
+index 0dd63d2e0ed16eb08cf97dbf8c293e24a5a1bda9..6aa29495802b7d52c4c0f283495c7d1762f657fa 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -2681,6 +2681,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -48,10 +48,10 @@ index df6377b5849aab20246a29b312744604b4cbf6bf..7abe7bcddd3c60bfb0f290e2475d2839
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityTNTPrimed.java b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-index e25404fd89ad6317c2656c68c2e32aa05e5f0e73..b108874d977a4fb1a7c0d52f66bc08390decb4d0 100644
+index f71e82c365947de822be7b87083b46bd7ce4b902..6e77dc89f5441f0f483571fee9aa9f34b6d1dd1c 100644
 --- a/src/main/java/net/minecraft/server/EntityTNTPrimed.java
 +++ b/src/main/java/net/minecraft/server/EntityTNTPrimed.java
-@@ -80,7 +80,27 @@ public class EntityTNTPrimed extends Entity {
+@@ -81,7 +81,27 @@ public class EntityTNTPrimed extends Entity {
                  this.world.addParticle(Particles.SMOKE, this.locX(), this.locY() + 0.5D, this.locZ(), 0.0D, 0.0D, 0.0D);
              }
          }
@@ -80,7 +80,7 @@ index e25404fd89ad6317c2656c68c2e32aa05e5f0e73..b108874d977a4fb1a7c0d52f66bc0839
      }
  
      private void explode() {
-@@ -149,4 +169,11 @@ public class EntityTNTPrimed extends Entity {
+@@ -150,4 +170,11 @@ public class EntityTNTPrimed extends Entity {
      public Packet<?> P() {
          return new PacketPlayOutSpawnEntity(this);
      }

--- a/Spigot-Server-Patches/0106-Fix-Old-Sign-Conversion.patch
+++ b/Spigot-Server-Patches/0106-Fix-Old-Sign-Conversion.patch
@@ -25,10 +25,10 @@ index 58e9c99b44fd8e77e62c4098d9872d5378d4f5e5..8974d7944f159b9346680c639daf0f8c
                              }
  
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index da96a91c6b4cc03ad2e4539053bd30e7dc62dfe8..cea42d98aa6e1f96df0fa70234086dceb124fbbf 100644
+index 5414858ba241c13d4e568191d11111d3d3ec3fc4..524f84ad2c50f8b837eefd0465901b1e22359410 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -20,6 +20,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -23,6 +23,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
      public CraftPersistentDataContainer persistentDataContainer;
      // CraftBukkit end
      private static final Logger LOGGER = LogManager.getLogger();
@@ -37,10 +37,10 @@ index da96a91c6b4cc03ad2e4539053bd30e7dc62dfe8..cea42d98aa6e1f96df0fa70234086dce
      @Nullable
      protected World world;
 diff --git a/src/main/java/net/minecraft/server/TileEntitySign.java b/src/main/java/net/minecraft/server/TileEntitySign.java
-index b7c9b356e24a8269ade76738335a63ef18890d4d..2b249e7e2018a283b80b9462fbc129420e47ec06 100644
+index 810603bc03950580aa4d81233a9dd1c2f51d8a0b..5d0c5d856a66ce6c0594b618e8f6e892585ce665 100644
 --- a/src/main/java/net/minecraft/server/TileEntitySign.java
 +++ b/src/main/java/net/minecraft/server/TileEntitySign.java
-@@ -59,13 +59,14 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
+@@ -58,13 +58,14 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
              }
  
              try {

--- a/Spigot-Server-Patches/0113-Remove-FishingHook-reference-on-Craft-Entity-removal.patch
+++ b/Spigot-Server-Patches/0113-Remove-FishingHook-reference-on-Craft-Entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove FishingHook reference on Craft Entity removal
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
-index 42b306f1a341672996843a5e3dfa57ef32be48e9..385fa768cda07a61079476a7344d492f890e59e9 100644
+index f8e897f0bc4e5d0a432d20983fd37998bb00ae0f..b480ca876687991685b5e070181721da8192a5b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftFishHook.java
-@@ -118,4 +118,14 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
+@@ -119,4 +119,14 @@ public class CraftFishHook extends CraftProjectile implements FishHook {
      public HookState getState() {
          return HookState.values()[getHandle().hookState.ordinal()];
      }

--- a/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
+++ b/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
@@ -21,10 +21,10 @@ index 5bdde99d7143ee1bac5830b042bba5485a95f120..ee94c2827cfc53f7a37e61d8c1c0c30a
              if (CraftEventFactory.callPigZapEvent(this, entitylightning, entitypigzombie).isCancelled()) {
                  return;
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index 824e172f06e57f86010836a1006a14d0a3b0bda3..eedec25373cfc8adec7ac8a99b146770dc15c70e 100644
+index d9f9694cb2677102269294043822fb3773de9b35..8b5901396a7f1dc554a5e237200a8193e9096a18 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -719,6 +719,12 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -717,6 +717,12 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
              EntityVillager.LOGGER.info("Villager {} was struck by lightning {}.", this, entitylightning);
              EntityWitch entitywitch = (EntityWitch) EntityTypes.WITCH.a((World) worldserver);
  

--- a/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add source to PlayerExpChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-index fda68abbdd7c970048ba710d7ef35214f2aaa74c..2c2d44562f732c75532cda910db5ce67d6a534ab 100644
+index 41f54158fe3312188d2a938ca882ece68cf3c08e..cc65c57637e07b82f5efcfa9f73f0e7abe9be6f5 100644
 --- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
 +++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-@@ -188,7 +188,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -189,7 +189,7 @@ public class EntityExperienceOrb extends Entity {
                  }
  
                  if (this.value > 0) {

--- a/Spigot-Server-Patches/0122-Don-t-let-fishinghooks-use-portals.patch
+++ b/Spigot-Server-Patches/0122-Don-t-let-fishinghooks-use-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't let fishinghooks use portals
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index ad2ec3472a164bdf3a1ff2c42ec18c74ad58a13c..0e5bbe285bcbb410cc442eba1738aeb2a117ce62 100644
+index b9243b0a2d429828f2a2b68c221129e23c6212ca..65b9eebcd59d1d95a77780f41862d8c984dee03c 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
-@@ -201,6 +201,11 @@ public class EntityFishingHook extends IProjectile {
+@@ -202,6 +202,11 @@ public class EntityFishingHook extends IProjectile {
  
              this.setMot(this.getMot().a(0.92D));
              this.af();

--- a/Spigot-Server-Patches/0129-Add-API-methods-to-control-if-armour-stands-can-move.patch
+++ b/Spigot-Server-Patches/0129-Add-API-methods-to-control-if-armour-stands-can-move.patch
@@ -31,10 +31,10 @@ index ad3c2f4b448fe8a49c1c43374cd5cf14114c9b16..4870a6f9f894b2c9d0fea83dad0808ac
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index 7d07f95e669a9da9f2d6f663a75c907e6c829a98..bf2749fd724ac7b67fc0d5887aa307745c5f1835 100644
+index 8f38500965a70fb713050321f71c97510703402a..6ff7a59cc7052e900516a89db8daf0720c64a1ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-@@ -228,4 +228,15 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
+@@ -229,4 +229,15 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
      public boolean hasEquipmentLock(EquipmentSlot equipmentSlot, LockType lockType) {
          return (getHandle().disabledSlots & (1 << CraftEquipmentSlot.getNMS(equipmentSlot).getSlotFlag() + lockType.ordinal() * 8)) != 0;
      }

--- a/Spigot-Server-Patches/0132-Firework-API-s.patch
+++ b/Spigot-Server-Patches/0132-Firework-API-s.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Firework API's
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityFireworks.java b/src/main/java/net/minecraft/server/EntityFireworks.java
-index 46b315036bbe576b2bf9938db73d9c5931003cc1..a646dc9f030ad1f76ba2b7bb1bc7897cd34b648c 100644
+index 5306f1d4bdf18a5dbf92b222b892b4accf21f92c..9bc4d3dbd4c64a6fbf33dcf28afde59ace9171ba 100644
 --- a/src/main/java/net/minecraft/server/EntityFireworks.java
 +++ b/src/main/java/net/minecraft/server/EntityFireworks.java
-@@ -13,7 +13,8 @@ public class EntityFireworks extends IProjectile {
+@@ -14,7 +14,8 @@ public class EntityFireworks extends IProjectile {
      public static final DataWatcherObject<Boolean> SHOT_AT_ANGLE = DataWatcher.a(EntityFireworks.class, DataWatcherRegistry.i);
      private int ticksFlown;
      public int expectedLifespan;
@@ -18,7 +18,7 @@ index 46b315036bbe576b2bf9938db73d9c5931003cc1..a646dc9f030ad1f76ba2b7bb1bc7897c
  
      public EntityFireworks(EntityTypes<? extends EntityFireworks> entitytypes, World world) {
          super(entitytypes, world);
-@@ -260,6 +261,11 @@ public class EntityFireworks extends IProjectile {
+@@ -261,6 +262,11 @@ public class EntityFireworks extends IProjectile {
          }
  
          nbttagcompound.setBoolean("ShotAtAngle", (Boolean) this.datawatcher.get(EntityFireworks.SHOT_AT_ANGLE));
@@ -30,7 +30,7 @@ index 46b315036bbe576b2bf9938db73d9c5931003cc1..a646dc9f030ad1f76ba2b7bb1bc7897c
      }
  
      @Override
-@@ -276,7 +282,11 @@ public class EntityFireworks extends IProjectile {
+@@ -277,7 +283,11 @@ public class EntityFireworks extends IProjectile {
          if (nbttagcompound.hasKey("ShotAtAngle")) {
              this.datawatcher.set(EntityFireworks.SHOT_AT_ANGLE, nbttagcompound.getBoolean("ShotAtAngle"));
          }

--- a/Spigot-Server-Patches/0133-PlayerTeleportEndGatewayEvent.patch
+++ b/Spigot-Server-Patches/0133-PlayerTeleportEndGatewayEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerTeleportEndGatewayEvent
 Allows you to access the Gateway being used in a teleport event
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityEndGateway.java b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-index 3284143799db25f66d5311a9635e2890f63dcbe3..6a0f7b02c5a2663bb7304a1f8c6cbf1603507d45 100644
+index b168fdd4df63c90eea1be4f06fb3aa36ff62deb6..91dacc5de8d695b2ea9b2f8b4547f6dbba0451ad 100644
 --- a/src/main/java/net/minecraft/server/TileEntityEndGateway.java
 +++ b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-@@ -155,7 +155,7 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
+@@ -156,7 +156,7 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
                      location.setPitch(player.getLocation().getPitch());
                      location.setYaw(player.getLocation().getYaw());
  

--- a/Spigot-Server-Patches/0134-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/Spigot-Server-Patches/0134-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,10 +7,10 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f7c5df44eda98ee965ccd38568403617bbde8fdc..3f35e1290beaab1fa2ca93ec64ab0dd42d68d71c 100644
+index 8b68c1b680e0b7ecb21b9de782dbc2864e7b5dfe..af8593d117359c75ff8c635a93499d84e25eb854 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -281,6 +281,48 @@ public class CraftWorld implements World {
+@@ -282,6 +282,48 @@ public class CraftWorld implements World {
      private int waterAmbientSpawn = -1;
      private int ambientSpawn = -1;
  

--- a/Spigot-Server-Patches/0135-Enforce-Sync-Player-Saves.patch
+++ b/Spigot-Server-Patches/0135-Enforce-Sync-Player-Saves.patch
@@ -7,10 +7,10 @@ Saving players async is extremely dangerous. This will force it to main
 the same way we handle async chunk loads.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index e8ede86cab0bfcf1164fcdb6b19a60099b50e5eb..fbb7424306d25b0c6dd69229e00c13c4c1a92fec 100644
+index 5652462008dd857f2dc36b80e3fe5d3d83867ce5..1d137602b40e467020b89aa73dd67b661d3dedb7 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -976,11 +976,13 @@ public abstract class PlayerList {
+@@ -971,11 +971,13 @@ public abstract class PlayerList {
      }
  
      public void savePlayers() {

--- a/Spigot-Server-Patches/0137-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/Spigot-Server-Patches/0137-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -8,7 +8,7 @@ Adds lots of information about why this orb exists.
 Replaces isFromBottle() with logic that persists entity reloads too.
 
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index d847326b0099a0c05a085d5d62de630491c9ac56..b537385d12463adc82751e40b479b047b32fa5bd 100644
+index 428a10fb100d1b4775dab6cfe69f28c29a45cd70..cee4e952c96b9f55c57186ac96aa730e656e1f16 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -228,13 +228,13 @@ public class Block extends BlockBase implements IMaterial {
@@ -28,10 +28,10 @@ index d847326b0099a0c05a085d5d62de630491c9ac56..b537385d12463adc82751e40b479b047
          }
  
 diff --git a/src/main/java/net/minecraft/server/ContainerGrindstone.java b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-index 5bdb0c3a7a04a55cd5ddff8e375497e402408811..fe9a083b724a8657cac8462b3f44d3cc12a4db58 100644
+index 9e02e60060adbe4679a4ad2e848bf34b58a523aa..b69adda272f6bfb7f1570c282a16b343c9a552e2 100644
 --- a/src/main/java/net/minecraft/server/ContainerGrindstone.java
 +++ b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-@@ -81,7 +81,7 @@ public class ContainerGrindstone extends Container {
+@@ -82,7 +82,7 @@ public class ContainerGrindstone extends Container {
                          int k = EntityExperienceOrb.getOrbValue(j);
  
                          j -= k;
@@ -41,10 +41,10 @@ index 5bdb0c3a7a04a55cd5ddff8e375497e402408811..fe9a083b724a8657cac8462b3f44d3cc
  
                      world.triggerEffect(1042, blockposition, 0);
 diff --git a/src/main/java/net/minecraft/server/EntityAnimal.java b/src/main/java/net/minecraft/server/EntityAnimal.java
-index b2de91eebbc214cff34a3833541559b934c071f7..bba343542e7e6fa83ec802d97b4c139bb210ab28 100644
+index 1f79975f47be069cddc15bf3b902ed8105bde8ac..b290218e506d5e4ddd1af17f91de19a588bbcfbd 100644
 --- a/src/main/java/net/minecraft/server/EntityAnimal.java
 +++ b/src/main/java/net/minecraft/server/EntityAnimal.java
-@@ -237,7 +237,7 @@ public abstract class EntityAnimal extends EntityAgeable {
+@@ -238,7 +238,7 @@ public abstract class EntityAnimal extends EntityAgeable {
              if (worldserver.getGameRules().getBoolean(GameRules.DO_MOB_LOOT)) {
                  // CraftBukkit start - use event experience
                  if (experience > 0) {
@@ -54,7 +54,7 @@ index b2de91eebbc214cff34a3833541559b934c071f7..bba343542e7e6fa83ec802d97b4c139b
                  // CraftBukkit end
              }
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index 81c926e506c1b6e5c0d909b71f1db81beb645699..ef9df3c7c7c455373641f7a7c701f82a23ffef36 100644
+index 676b23616a0ef09cea62d3a8d2e3a5fe69f209f1..348d3575115ed6c95b4aee56f0fd930103651489 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
 @@ -612,7 +612,7 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
@@ -67,10 +67,10 @@ index 81c926e506c1b6e5c0d909b71f1db81beb645699..ef9df3c7c7c455373641f7a7c701f82a
  
      }
 diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-index 2c2d44562f732c75532cda910db5ce67d6a534ab..a9fff75882217b1fd680fd8fd47110f85d88df28 100644
+index cc65c57637e07b82f5efcfa9f73f0e7abe9be6f5..701d015baf03eba07b319baf447b5ae06ab8accd 100644
 --- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
 +++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-@@ -16,9 +16,59 @@ public class EntityExperienceOrb extends Entity {
+@@ -17,9 +17,59 @@ public class EntityExperienceOrb extends Entity {
      public int value;
      private EntityHuman targetPlayer;
      private int targetTime;
@@ -130,7 +130,7 @@ index 2c2d44562f732c75532cda910db5ce67d6a534ab..a9fff75882217b1fd680fd8fd47110f8
          this.setPosition(d0, d1, d2);
          this.yaw = (float) (this.random.nextDouble() * 360.0D);
          this.setMot((this.random.nextDouble() * 0.20000000298023224D - 0.10000000149011612D) * 2.0D, this.random.nextDouble() * 0.2D * 2.0D, (this.random.nextDouble() * 0.20000000298023224D - 0.10000000149011612D) * 2.0D);
-@@ -153,6 +203,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -154,6 +204,7 @@ public class EntityExperienceOrb extends Entity {
          nbttagcompound.setShort("Health", (short) this.e);
          nbttagcompound.setShort("Age", (short) this.c);
          nbttagcompound.setShort("Value", (short) this.value);
@@ -138,7 +138,7 @@ index 2c2d44562f732c75532cda910db5ce67d6a534ab..a9fff75882217b1fd680fd8fd47110f8
      }
  
      @Override
-@@ -160,6 +211,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -161,6 +212,7 @@ public class EntityExperienceOrb extends Entity {
          this.e = nbttagcompound.getShort("Health");
          this.c = nbttagcompound.getShort("Age");
          this.value = nbttagcompound.getShort("Value");
@@ -147,10 +147,10 @@ index 2c2d44562f732c75532cda910db5ce67d6a534ab..a9fff75882217b1fd680fd8fd47110f8
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index 0e5bbe285bcbb410cc442eba1738aeb2a117ce62..723cd60254111579b157684dc82311af5cf9fd13 100644
+index 65b9eebcd59d1d95a77780f41862d8c984dee03c..fac695125da50bb33b68f317339832a26f7625a6 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
-@@ -464,7 +464,7 @@ public class EntityFishingHook extends IProjectile {
+@@ -465,7 +465,7 @@ public class EntityFishingHook extends IProjectile {
                      this.world.addEntity(entityitem);
                      // CraftBukkit start - this.random.nextInt(6) + 1 -> playerFishEvent.getExpToDrop()
                      if (playerFishEvent.getExpToDrop() > 0) {
@@ -173,7 +173,7 @@ index fef00b46e7cf3690044059f9ee527f799d535b81..a7bbf21e9736a0da38f95d93b013097b
                      // CraftBukkit end
                  }
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index cda084e6fe8f4f5dcd8c0b13bd07326db2ca7c59..abc300a54100b42e30705185ec60da6624db4c91 100644
+index f54d05f59342231434a70c3b12b7cf9b73f98508..6c2370978443e02f2f39d4ef2ceffe559837bc69 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -1501,7 +1501,8 @@ public abstract class EntityLiving extends Entity {
@@ -213,10 +213,10 @@ index 61e24c2897a2cb93881caaa6fff86f44461765ac..19c92bea21ddcc3917eb011dcfe41006
  
          }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index eedec25373cfc8adec7ac8a99b146770dc15c70e..732323ee1de01929c73bc5f98444c0f68f908a67 100644
+index 8b5901396a7f1dc554a5e237200a8193e9096a18..768dfbc58510e8599f05a5bba25558141124e531 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -532,7 +532,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -530,7 +530,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
          }
  
          if (merchantrecipe.isRewardExp()) {
@@ -226,10 +226,10 @@ index eedec25373cfc8adec7ac8a99b146770dc15c70e..732323ee1de01929c73bc5f98444c0f6
  
      }
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerTrader.java b/src/main/java/net/minecraft/server/EntityVillagerTrader.java
-index 86e9c9ec35153d4d6248512e2e3406ca2f3dac46..fa3e786cd6ef67da378a5d51583ca84a82677d8c 100644
+index cce5663d2d6f9658f92c5819b323fee5349ed6bb..250a4e5ddd626794482678a64023f0f5459520e1 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerTrader.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerTrader.java
-@@ -145,7 +145,7 @@ public class EntityVillagerTrader extends EntityVillagerAbstract {
+@@ -146,7 +146,7 @@ public class EntityVillagerTrader extends EntityVillagerAbstract {
          if (merchantrecipe.isRewardExp()) {
              int i = 3 + this.random.nextInt(4);
  
@@ -239,10 +239,10 @@ index 86e9c9ec35153d4d6248512e2e3406ca2f3dac46..fa3e786cd6ef67da378a5d51583ca84a
  
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 862b17e6226f1488167caf08afe7a37b942f7674..8e5975a4871b99329c78379153ad64575d08d123 100644
+index b5c464f34789889e71a9fed3cc600f7f9cb8828a..aae5feb77402d721c23f7e781b53864f6778c1dd 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -377,7 +377,7 @@ public class PlayerInteractManager {
+@@ -378,7 +378,7 @@ public class PlayerInteractManager {
  
                  // Drop event experience
                  if (flag && event != null) {
@@ -265,10 +265,10 @@ index d2698e847cfcbc4d2f91b4f5d66b38b47f86c10e..edc4a5c34e8064d900668d132b3496e3
  
      public SlotFurnaceResult(EntityHuman entityhuman, IInventory iinventory, int i, int j, int k) {
 diff --git a/src/main/java/net/minecraft/server/TileEntityFurnace.java b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-index a3ddf7be4c7ea588098381b8f05b2bad5b388853..99b20fa5feff0f766124d4ec9474852e33e329f2 100644
+index 45bc958667776a4f62c8e625eb8fccdc3dfb0f21..af4db22cf87433fcd4f59be207257a8d7c255883 100644
 --- a/src/main/java/net/minecraft/server/TileEntityFurnace.java
 +++ b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-@@ -573,7 +573,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -574,7 +574,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
              int k = EntityExperienceOrb.getOrbValue(j);
  
              j -= k;
@@ -278,10 +278,10 @@ index a3ddf7be4c7ea588098381b8f05b2bad5b388853..99b20fa5feff0f766124d4ec9474852e
  
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e42f27bb10b6ee279555cfee3c90a88fccad9d65..5bf5a815653b0556d9d2bcaf5f69026b77bd28a6 100644
+index af8593d117359c75ff8c635a93499d84e25eb854..4058484c256343a71d1392ae0aa54bf07fd0d26e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1827,7 +1827,7 @@ public class CraftWorld implements World {
+@@ -1841,7 +1841,7 @@ public class CraftWorld implements World {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new EntityTNTPrimed(world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/Spigot-Server-Patches/0140-Make-targetSize-more-aggressive-in-the-chunk-unload-.patch
+++ b/Spigot-Server-Patches/0140-Make-targetSize-more-aggressive-in-the-chunk-unload-.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make targetSize more aggressive in the chunk unload queue
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 0542dde09d288488b88e17a044cc508d5d39782f..9c520643f415d5952a59c99da2a7726aae8d7ce3 100644
+index 612eb16bce1bce1cad40ea0f279d2b8397263dea..02a516ddabda08db33c94cce2d19d9e77666e074 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -75,7 +75,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -76,7 +76,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private final PlayerMap playerMap;
      public final Int2ObjectMap<PlayerChunkMap.EntityTracker> trackedEntities;
      private final Long2ByteMap z;
@@ -17,7 +17,7 @@ index 0542dde09d288488b88e17a044cc508d5d39782f..9c520643f415d5952a59c99da2a7726a
      private int viewDistance;
  
      // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
-@@ -133,7 +133,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -134,7 +134,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.playerMap = new PlayerMap();
          this.trackedEntities = new Int2ObjectOpenHashMap();
          this.z = new Long2ByteOpenHashMap();
@@ -26,7 +26,7 @@ index 0542dde09d288488b88e17a044cc508d5d39782f..9c520643f415d5952a59c99da2a7726a
          this.definedStructureManager = definedstructuremanager;
          this.w = convertable_conversionsession.a(worldserver.getDimensionKey());
          this.world = worldserver;
-@@ -391,7 +391,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -392,7 +392,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          // Spigot start
          org.spigotmc.SlackActivityAccountant activityAccountant = this.world.getMinecraftServer().slackActivityAccountant;
          activityAccountant.startActivity(0.5);
@@ -35,7 +35,7 @@ index 0542dde09d288488b88e17a044cc508d5d39782f..9c520643f415d5952a59c99da2a7726a
          // Spigot end
          while (longiterator.hasNext()) { // Spigot
              long j = longiterator.nextLong();
-@@ -413,7 +413,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -414,7 +414,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          Runnable runnable;
  

--- a/Spigot-Server-Patches/0142-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/Spigot-Server-Patches/0142-Properly-handle-async-calls-to-restart-the-server.patch
@@ -30,10 +30,10 @@ will have plugins and worlds saving to the disk has a high potential to result
 in corruption/dataloss.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7e4a966b5748417223243344bf7c4483e997a237..c6b520f3f8872a0345f76a75f0b48fe113021716 100644
+index 110184bd18f689cff1f37ceefe97416b5dcfd405..3baf1be1b58ea53ab1ee8d388b5f9a4595ca478a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -91,6 +91,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -93,6 +93,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public final Map<ResourceKey<World>, WorldServer> worldServer;
      private PlayerList playerList;
      private volatile boolean isRunning;
@@ -41,7 +41,7 @@ index 7e4a966b5748417223243344bf7c4483e997a237..c6b520f3f8872a0345f76a75f0b48fe1
      private boolean isStopped;
      private int ticks;
      protected final Proxy proxy;
-@@ -740,7 +741,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -742,7 +743,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (this.playerList != null) {
              MinecraftServer.LOGGER.info("Saving players");
              this.playerList.savePlayers();
@@ -50,7 +50,7 @@ index 7e4a966b5748417223243344bf7c4483e997a237..c6b520f3f8872a0345f76a75f0b48fe1
              try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
  
-@@ -805,8 +806,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -807,8 +808,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          return this.isRunning;
      }
  
@@ -64,7 +64,7 @@ index 7e4a966b5748417223243344bf7c4483e997a237..c6b520f3f8872a0345f76a75f0b48fe1
          if (flag) {
              try {
                  this.serverThread.join();
-@@ -816,6 +822,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -818,6 +824,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
  
      }
@@ -73,10 +73,10 @@ index 7e4a966b5748417223243344bf7c4483e997a237..c6b520f3f8872a0345f76a75f0b48fe1
      // Spigot Start
      private static double calcTps(double avg, double exp, double tps)
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index fbb7424306d25b0c6dd69229e00c13c4c1a92fec..97cf3f1f4c19606f099de84745301b52295e2391 100644
+index 1d137602b40e467020b89aa73dd67b661d3dedb7..74e55f85e2b128913015397ddec70322739e39d5 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -1087,9 +1087,15 @@ public abstract class PlayerList {
+@@ -1082,9 +1082,15 @@ public abstract class PlayerList {
          entityplayer.playerInteractManager.b(worldserver.worldDataServer.getGameType()); // CraftBukkit
      }
  
@@ -92,7 +92,7 @@ index fbb7424306d25b0c6dd69229e00c13c4c1a92fec..97cf3f1f4c19606f099de84745301b52
              player.playerConnection.disconnect(PaperAdventure.asVanilla(this.server.server.shutdownMessage())); // CraftBukkit - add custom shutdown message // Paper - Adventure
          }
          // CraftBukkit end
-@@ -1102,6 +1108,7 @@ public abstract class PlayerList {
+@@ -1097,6 +1103,7 @@ public abstract class PlayerList {
          }
          // Paper end
      }

--- a/Spigot-Server-Patches/0143-Add-system-property-to-disable-book-size-limits.patch
+++ b/Spigot-Server-Patches/0143-Add-system-property-to-disable-book-size-limits.patch
@@ -11,10 +11,10 @@ to make books with as much data as they want. Do not use this without
 limiting incoming data from packets in some other way.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-index 1cc49b9d8c784f96cfc54159c1139af501264de6..88a021fa97b3daeeef002d485095f2fb90121827 100644
+index 123616ed018fbc4d69f46e65d5ff15734008a00d..34449ac7899abbc863266da1e6197873f80940b0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
-@@ -38,6 +38,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -40,6 +40,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      static final int MAX_PAGES = 100;
      static final int MAX_PAGE_LENGTH = 320; // 256 limit + 64 characters to allow for psuedo colour codes
      static final int MAX_TITLE_LENGTH = 32;
@@ -22,7 +22,7 @@ index 1cc49b9d8c784f96cfc54159c1139af501264de6..88a021fa97b3daeeef002d485095f2fb
  
      protected String title;
      protected String author;
-@@ -240,7 +241,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -242,7 +243,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          if (title == null) {
              this.title = null;
              return true;
@@ -31,7 +31,7 @@ index 1cc49b9d8c784f96cfc54159c1139af501264de6..88a021fa97b3daeeef002d485095f2fb
              return false;
          }
  
-@@ -431,7 +432,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -433,7 +434,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
      String validatePage(String page) {
          if (page == null) {
              page = "";
@@ -40,7 +40,7 @@ index 1cc49b9d8c784f96cfc54159c1139af501264de6..88a021fa97b3daeeef002d485095f2fb
              page = page.substring(0, MAX_PAGE_LENGTH);
          }
          return page;
-@@ -441,7 +442,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+@@ -443,7 +444,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
          // asserted: page != null
          if (this.pages == null) {
              this.pages = new ArrayList<String>();

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -186,19 +186,19 @@ index dc0cb79525adf0d5afee1f677e1fde546529cf97..750b1dc10ffb7adb9194e6cc8ace8fa9
          System.setOut(IoBuilder.forLogger(logger).setLevel(Level.INFO).buildPrintStream());
          System.setErr(IoBuilder.forLogger(logger).setLevel(Level.WARN).buildPrintStream());
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306adbd8a9995 100644
+index 3baf1be1b58ea53ab1ee8d388b5f9a4595ca478a..5e64853fca8e1baa103dd69c050a4900ef7f7f37 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -58,7 +58,7 @@ import org.apache.logging.log4j.LogManager;
- import org.apache.logging.log4j.Logger;
- // CraftBukkit start
+@@ -59,7 +59,7 @@ import org.apache.logging.log4j.Logger;
+ import com.mojang.serialization.DynamicOps;
+ import com.mojang.serialization.Lifecycle;
  import com.google.common.collect.ImmutableSet;
 -import jline.console.ConsoleReader;
 +// import jline.console.ConsoleReader; // Paper
  import joptsimple.OptionSet;
  import org.bukkit.Bukkit;
  import org.bukkit.craftbukkit.CraftServer;
-@@ -145,7 +145,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -147,7 +147,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public OptionSet options;
      public org.bukkit.command.ConsoleCommandSender console;
      public org.bukkit.command.RemoteConsoleCommandSender remoteConsole;
@@ -207,7 +207,7 @@ index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306ad
      public static int currentTick = 0; // Paper - Further improve tick loop
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
-@@ -214,7 +214,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -216,7 +216,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.options = options;
          this.datapackconfiguration = datapackconfiguration;
          this.vanillaCommandDispatcher = datapackresources.commandDispatcher; // CraftBukkit
@@ -217,7 +217,7 @@ index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306ad
          if (System.console() == null && System.getProperty("jline.terminal") == null) {
              System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
              Main.useJline = false;
-@@ -235,6 +237,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -237,6 +239,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  LOGGER.warn((String) null, ex);
              }
          }
@@ -226,7 +226,7 @@ index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306ad
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
      }
      // CraftBukkit end
-@@ -978,7 +982,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -980,7 +984,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  org.spigotmc.WatchdogThread.doStop(); // Spigot
                  // CraftBukkit start - Restore terminal to original settings
                  try {
@@ -235,7 +235,7 @@ index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306ad
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1349,7 +1353,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1351,7 +1355,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      @Override
      public void sendMessage(IChatBaseComponent ichatbasecomponent, UUID uuid) {
@@ -245,10 +245,10 @@ index c6b520f3f8872a0345f76a75f0b48fe113021716..ee009052eb10125bbaca95b5fda306ad
  
      public KeyPair getKeyPair() {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 7ecd5e3747fd8acbddcdf5b42285d7b6f3ffbac2..07ab0bf135a6903c936606296b6701b970ad48db 100644
+index 74e55f85e2b128913015397ddec70322739e39d5..a56f9a07472e9a56da12a096400e69bd0d0cd17f 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -81,8 +81,7 @@ public abstract class PlayerList {
+@@ -76,8 +76,7 @@ public abstract class PlayerList {
  
      public PlayerList(MinecraftServer minecraftserver, IRegistryCustom.Dimension iregistrycustom_dimension, WorldNBTStorage worldnbtstorage, int i) {
          this.cserver = minecraftserver.server = new CraftServer((DedicatedServer) minecraftserver, this);
@@ -259,7 +259,7 @@ index 7ecd5e3747fd8acbddcdf5b42285d7b6f3ffbac2..07ab0bf135a6903c936606296b6701b9
  
          this.k = new GameProfileBanList(PlayerList.b);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2101695ca111d0bfcec7da5065034b6029687949..38486fb74a29fd8ace2bfa6e74c1b5230ab99a7f 100644
+index 1203780c0b1ac0f79c0a5a7d648e973371159e52..126debf6b1734368a6147e758de039b51867353d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,7 +46,7 @@ import java.util.function.Consumer;

--- a/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/Spigot-Server-Patches/0147-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -21,10 +21,10 @@ index 9d1cddc6038f0fd0286e4a32013ae98ff0b00dd1..90ca51dfdbb3045dd528450225cba96f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 8d7b77e01c5031953ab3a4811c8397503b52a0e3..7b9188a33c079155a7ff5b0e5de854550324f0f1 100644
+index c649e391b0f6d94efb84e408ca4f61ef0eddef0a..78d136eed54b815f5c866d3ab0d96c1d819bc6b2 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
-@@ -226,7 +226,7 @@ public class EntityCreeper extends EntityMonster {
+@@ -227,7 +227,7 @@ public class EntityCreeper extends EntityMonster {
      private void createEffectCloud() {
          Collection<MobEffect> collection = this.getEffects();
  

--- a/Spigot-Server-Patches/0148-Item-canEntityPickup.patch
+++ b/Spigot-Server-Patches/0148-Item-canEntityPickup.patch
@@ -21,10 +21,10 @@ index a819fc46bebc4b1aaae63f822087574e976e2ab8..6274cf1975270fdac8ae4986e1c170bd
                  }
              }
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index b1e953fc5c61abe0aeb667a12fd4491d11f422de..507ad727ce62a30b1120104b16737e21b777d7ae 100644
+index bbaba67d297c3d6a488bdbf6c500658e872772b0..9b400c1f4ea807149862d30154df9b30895176da 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -20,6 +20,7 @@ public class EntityItem extends Entity {
+@@ -21,6 +21,7 @@ public class EntityItem extends Entity {
      private UUID owner;
      public final float b;
      private int lastTick = MinecraftServer.currentTick - 1; // CraftBukkit

--- a/Spigot-Server-Patches/0149-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/Spigot-Server-Patches/0149-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 507ad727ce62a30b1120104b16737e21b777d7ae..57a2fdfbcd04345901f8f596c68932b4942790a1 100644
+index 9b400c1f4ea807149862d30154df9b30895176da..051c97374fdbd6ff6d4eb58a3b6630ece8469967 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -336,6 +336,7 @@ public class EntityItem extends Entity {
+@@ -337,6 +337,7 @@ public class EntityItem extends Entity {
              // CraftBukkit start - fire PlayerPickupItemEvent
              int canHold = entityhuman.inventory.canHold(itemstack);
              int remaining = i - canHold;
@@ -16,7 +16,7 @@ index 507ad727ce62a30b1120104b16737e21b777d7ae..57a2fdfbcd04345901f8f596c68932b4
  
              if (this.pickupDelay <= 0 && canHold > 0) {
                  itemstack.setCount(canHold);
-@@ -343,8 +344,14 @@ public class EntityItem extends Entity {
+@@ -344,8 +345,14 @@ public class EntityItem extends Entity {
                  PlayerPickupItemEvent playerEvent = new PlayerPickupItemEvent((org.bukkit.entity.Player) entityhuman.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
                  playerEvent.setCancelled(!entityhuman.canPickUpLoot);
                  this.world.getServer().getPluginManager().callEvent(playerEvent);
@@ -31,7 +31,7 @@ index 507ad727ce62a30b1120104b16737e21b777d7ae..57a2fdfbcd04345901f8f596c68932b4
                      return;
                  }
  
-@@ -374,7 +381,11 @@ public class EntityItem extends Entity {
+@@ -375,7 +382,11 @@ public class EntityItem extends Entity {
              // CraftBukkit end
  
              if (this.pickupDelay == 0 && (this.owner == null || this.owner.equals(entityhuman.getUniqueID())) && entityhuman.inventory.pickup(itemstack)) {

--- a/Spigot-Server-Patches/0150-PlayerAttemptPickupItemEvent.patch
+++ b/Spigot-Server-Patches/0150-PlayerAttemptPickupItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerAttemptPickupItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 57a2fdfbcd04345901f8f596c68932b4942790a1..7e1cc212e22f21bec1f6b1a2d337ef2ee70dc699 100644
+index 051c97374fdbd6ff6d4eb58a3b6630ece8469967..fac335b3f80e6af3b08544cfd4abe3c77b66b023 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -9,6 +9,7 @@ import javax.annotation.Nullable;
+@@ -10,6 +10,7 @@ import javax.annotation.Nullable;
  import org.bukkit.event.entity.EntityPickupItemEvent;
  import org.bukkit.event.player.PlayerPickupItemEvent;
  // CraftBukkit end
@@ -16,7 +16,7 @@ index 57a2fdfbcd04345901f8f596c68932b4942790a1..7e1cc212e22f21bec1f6b1a2d337ef2e
  
  public class EntityItem extends Entity {
  
-@@ -338,6 +339,22 @@ public class EntityItem extends Entity {
+@@ -339,6 +340,22 @@ public class EntityItem extends Entity {
              int remaining = i - canHold;
              boolean flyAtPlayer = false; // Paper
  

--- a/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
@@ -513,7 +513,7 @@ index e89c92aded564fe689cc1aa8d0c83abb72f7b10c..aa1b18ffa1e2b7f865f63b7df81d8f3b
          private volatile long c;
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ddd97c732fe5ae24075e70f8b8a2b0c3e52a32c..2b6c9dbbbf97386cd9d9b37254640b8585092140 100644
+index 0d52428faa3730cf4f2bf4e16884fdea6ad57c9a..5c9a2efe69bda1453ae9b679a2ee992ae98e965f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -227,6 +227,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -552,10 +552,10 @@ index 3ddd97c732fe5ae24075e70f8b8a2b0c3e52a32c..2b6c9dbbbf97386cd9d9b37254640b85
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index c57634317b661e05ddd085d04f7338045445069f..da9ad92f6c999d87b790852cb3129f9b04f624a9 100644
+index 42de897596ada4044df683dc5e8d5d750ee9c207..58aeeff96a92b5ba0c3435c680885ad3bc4f4ce6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-@@ -79,6 +79,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -80,6 +80,13 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
      }
  
      private void setProfile(GameProfile profile) {

--- a/Spigot-Server-Patches/0160-ProfileWhitelistVerifyEvent.patch
+++ b/Spigot-Server-Patches/0160-ProfileWhitelistVerifyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ProfileWhitelistVerifyEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 9a2441e3567e8315e71ab66844914ae7835623b4..30acb3cd9381bab2932a0679dc496e8b1ed65d94 100644
+index a56f9a07472e9a56da12a096400e69bd0d0cd17f..2411832c96794f3c39a5e9083b20217880f773ff 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -544,9 +544,9 @@ public abstract class PlayerList {
+@@ -539,9 +539,9 @@ public abstract class PlayerList {
  
              // return chatmessage;
              if (!gameprofilebanentry.hasExpired()) event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Spigot // Paper - Adventure
@@ -21,7 +21,7 @@ index 9a2441e3567e8315e71ab66844914ae7835623b4..30acb3cd9381bab2932a0679dc496e8b
          } else if (getIPBans().isBanned(socketaddress) && !getIPBans().get(socketaddress).hasExpired()) {
              IpBanEntry ipbanentry = this.l.get(socketaddress);
  
-@@ -938,9 +938,25 @@ public abstract class PlayerList {
+@@ -933,9 +933,25 @@ public abstract class PlayerList {
          this.server.getCommandDispatcher().a(entityplayer);
      }
  

--- a/Spigot-Server-Patches/0179-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/Spigot-Server-Patches/0179-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -13,10 +13,10 @@ also Avoid NPE during CraftBlockEntityState load if could not get TE
 If Tile Entity was null, correct Sign to return empty lines instead of null
 
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index cea42d98aa6e1f96df0fa70234086dceb124fbbf..34d92491830c99172bec5251fa80300b6315e5ef 100644
+index 524f84ad2c50f8b837eefd0465901b1e22359410..c6ae3d3f9d7957d4bbe0b4e2613558e5cd9dd9ec 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -33,6 +33,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -36,6 +36,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
      public TileEntity(TileEntityTypes<?> tileentitytypes) {
          this.position = BlockPosition.ZERO;
          this.tileType = tileentitytypes;
@@ -24,7 +24,7 @@ index cea42d98aa6e1f96df0fa70234086dceb124fbbf..34d92491830c99172bec5251fa80300b
      }
  
      // Paper start
-@@ -81,7 +82,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -84,7 +85,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
      public void load(IBlockData iblockdata, NBTTagCompound nbttagcompound) {
          this.position = new BlockPosition(nbttagcompound.getInt("x"), nbttagcompound.getInt("y"), nbttagcompound.getInt("z"));
          // CraftBukkit start - read container
@@ -33,7 +33,7 @@ index cea42d98aa6e1f96df0fa70234086dceb124fbbf..34d92491830c99172bec5251fa80300b
  
          NBTBase persistentDataTag = nbttagcompound.get("PublicBukkitValues");
          if (persistentDataTag instanceof NBTTagCompound) {
-@@ -231,7 +232,12 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -234,7 +235,12 @@ public abstract class TileEntity implements KeyedObject { // Paper
      }
  
      // CraftBukkit start - add method
@@ -46,7 +46,7 @@ index cea42d98aa6e1f96df0fa70234086dceb124fbbf..34d92491830c99172bec5251fa80300b
          if (world == null) return null;
          // Spigot start
          org.bukkit.block.Block block = world.getWorld().getBlockAt(position.getX(), position.getY(), position.getZ());
-@@ -240,7 +246,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -243,7 +249,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
              return null;
          }
          // Spigot end

--- a/Spigot-Server-Patches/0181-Avoid-NPE-in-PathfinderGoalTempt.patch
+++ b/Spigot-Server-Patches/0181-Avoid-NPE-in-PathfinderGoalTempt.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Avoid NPE in PathfinderGoalTempt
 
 
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalTempt.java b/src/main/java/net/minecraft/server/PathfinderGoalTempt.java
-index 74a24c2844d3fb5d6ff53b364c0566c007509e76..90738a547be8822e168abd1e8437a202d123229f 100644
+index 87a20538dd1e056d7412154473863628a7fdefe2..582ea29068de07edce73ab1a55d3ae7373650e16 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalTempt.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalTempt.java
-@@ -55,7 +55,7 @@ public class PathfinderGoalTempt extends PathfinderGoal {
+@@ -56,7 +56,7 @@ public class PathfinderGoalTempt extends PathfinderGoal {
                  }
                  this.target = (event.getTarget() == null) ? null : ((CraftLivingEntity) event.getTarget()).getHandle();
              }

--- a/Spigot-Server-Patches/0182-PlayerPickupExperienceEvent.patch
+++ b/Spigot-Server-Patches/0182-PlayerPickupExperienceEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] PlayerPickupExperienceEvent
 Allows plugins to cancel a player picking up an experience orb
 
 diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-index a9fff75882217b1fd680fd8fd47110f85d88df28..8354d18aa03d29202c82227a1891903a64c7921b 100644
+index 701d015baf03eba07b319baf447b5ae06ab8accd..e7b20e2c07426d156fa819ed2e23e29d6a71d499 100644
 --- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
 +++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-@@ -217,7 +217,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -218,7 +218,7 @@ public class EntityExperienceOrb extends Entity {
      @Override
      public void pickup(EntityHuman entityhuman) {
          if (!this.world.isClientSide) {

--- a/Spigot-Server-Patches/0184-Ability-to-apply-mending-to-XP-API.patch
+++ b/Spigot-Server-Patches/0184-Ability-to-apply-mending-to-XP-API.patch
@@ -25,10 +25,10 @@ index ff56d7b045d7d93419a5f2f35df70b3644ac55b0..7b263594304a9b745f583fe7178ac169
              return true;
          });
 diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-index 8354d18aa03d29202c82227a1891903a64c7921b..4df7df781d12e38885ecfbc89dd1d42d9de14248 100644
+index e7b20e2c07426d156fa819ed2e23e29d6a71d499..837a2c8f6af6e51316511e3948869ac059c8fc0d 100644
 --- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
 +++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-@@ -249,10 +249,12 @@ public class EntityExperienceOrb extends Entity {
+@@ -250,10 +250,12 @@ public class EntityExperienceOrb extends Entity {
          }
      }
  
@@ -42,7 +42,7 @@ index 8354d18aa03d29202c82227a1891903a64c7921b..4df7df781d12e38885ecfbc89dd1d42d
          return i * 2;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 69606cf1ac2c8419801af692c19d55d3d56bc0a8..d2f8b4b324b2a9719f409871afde88ad21a94efe 100644
+index 9cd82ca462d4ae88c2cbcd96e6f0660288be5208..1e3794c3e6bf43c3cc2708c4c8c1f816867a3a09 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1180,8 +1180,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0186-PreCreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0186-PreCreatureSpawnEvent.patch
@@ -40,10 +40,10 @@ index b1fe488e41a2c9f77df091e1d14ed5c87a4358c8..14f47d100c3f44a8263c9b907e9ca749
  
          if (t0 != null) {
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index 732323ee1de01929c73bc5f98444c0f68f908a67..b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971 100644
+index 768dfbc58510e8599f05a5bba25558141124e531..3a6992a5763238996847a8e59b650606a384e4ff 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -868,6 +868,21 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -866,6 +866,21 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
              BlockPosition blockposition1 = this.a(blockposition, d0, d1);
  
              if (blockposition1 != null) {

--- a/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
@@ -29,7 +29,7 @@ index a066026bce318683dcc022920dad39d7ec25e485..8017953af1df6c046a47ebe655e5d1af
                  Optional<Chunk> optional = ((Either) playerchunk.a().getNow(PlayerChunk.UNLOADED_CHUNK)).left();
  
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index fd7513008dde790107647f7f5b9670030696e064..3f559918e85b6d5c2ab8ff593b69d40c1db8bb16 100644
+index 7a9e237d23051b43fe0ac3720cd6a36faabc9dd2..42bf31bd9569a8f1c2b36f1c3a2c5c0d805c9b5d 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -1,5 +1,6 @@
@@ -48,10 +48,10 @@ index fd7513008dde790107647f7f5b9670030696e064..3f559918e85b6d5c2ab8ff593b69d40c
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> cachedSingleHashSet; // Paper
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 9c520643f415d5952a59c99da2a7726aae8d7ce3..8862bbd73b627e37709d46e6aeeee70c89cbd821 100644
+index 02a516ddabda08db33c94cce2d19d9e77666e074..8bfa412b0d3f881f694abec89101e15aa2d00bb7 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -912,12 +912,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -913,12 +913,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          chunkRange = (chunkRange > world.spigotConfig.viewDistance) ? (byte) world.spigotConfig.viewDistance : chunkRange;
          chunkRange = (chunkRange > 8) ? 8 : chunkRange;
  

--- a/Spigot-Server-Patches/0188-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/Spigot-Server-Patches/0188-Add-setPlayerProfile-API-for-Skulls.patch
@@ -48,7 +48,7 @@ index 20588598386a4f479e6a58b294149bed789c63ce..ecc32c2fb1e8e1ac03074102b982adb4
      public BlockFace getRotation() {
          BlockData blockData = getBlockData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
-index da9ad92f6c999d87b790852cb3129f9b04f624a9..ca40a5e33f851d560086533382340dd59f783f54 100644
+index 58aeeff96a92b5ba0c3435c680885ad3bc4f4ce6..fba6c1f454fdee3541393e6803d7249cf1fbe6d2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSkull.java
 @@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableMap.Builder;
@@ -60,7 +60,7 @@ index da9ad92f6c999d87b790852cb3129f9b04f624a9..ca40a5e33f851d560086533382340dd5
  import net.minecraft.server.GameProfileSerializer;
  import net.minecraft.server.NBTBase;
  import net.minecraft.server.NBTTagCompound;
-@@ -17,6 +19,7 @@ import org.bukkit.craftbukkit.inventory.CraftMetaItem.SerializableMeta;
+@@ -18,6 +20,7 @@ import org.bukkit.craftbukkit.inventory.CraftMetaItem.SerializableMeta;
  import org.bukkit.craftbukkit.util.CraftMagicNumbers;
  import org.bukkit.inventory.meta.SkullMeta;
  
@@ -68,7 +68,7 @@ index da9ad92f6c999d87b790852cb3129f9b04f624a9..ca40a5e33f851d560086533382340dd5
  @DelegateDeserialization(SerializableMeta.class)
  class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
  
-@@ -148,6 +151,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
+@@ -149,6 +152,19 @@ class CraftMetaSkull extends CraftMetaItem implements SkullMeta {
          return hasOwner() ? profile.getName() : null;
      }
  

--- a/Spigot-Server-Patches/0191-Add-ArmorStand-Item-Meta.patch
+++ b/Spigot-Server-Patches/0191-Add-ArmorStand-Item-Meta.patch
@@ -13,11 +13,11 @@ starting point for future additions in this area.
 Fixes GH-559
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82519250e1 100644
+index 9be4f8d56eaa6dd0d798dc5c1ae7e2bb0ba39d49..2cdabee85fcb377a563951f13386b13431aed1e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaArmorStand.java
-@@ -8,9 +8,22 @@ import org.bukkit.Material;
- import org.bukkit.configuration.serialization.DelegateDeserialization;
+@@ -9,9 +9,22 @@ import org.bukkit.configuration.serialization.DelegateDeserialization;
+ import org.bukkit.craftbukkit.inventory.CraftMetaItem.ItemMetaKey;
  
  @DelegateDeserialization(CraftMetaItem.SerializableMeta.class)
 -public class CraftMetaArmorStand extends CraftMetaItem {
@@ -40,7 +40,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
      NBTTagCompound entityTag;
  
      CraftMetaArmorStand(CraftMetaItem meta) {
-@@ -21,6 +34,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -22,6 +35,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
          }
  
          CraftMetaArmorStand armorStand = (CraftMetaArmorStand) meta;
@@ -54,7 +54,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
          this.entityTag = armorStand.entityTag;
      }
  
-@@ -29,11 +49,47 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -30,11 +50,47 @@ public class CraftMetaArmorStand extends CraftMetaItem {
  
          if (tag.hasKey(ENTITY_TAG.NBT)) {
              entityTag = tag.getCompound(ENTITY_TAG.NBT);
@@ -102,7 +102,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
      }
  
      @Override
-@@ -56,6 +112,32 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -57,6 +113,32 @@ public class CraftMetaArmorStand extends CraftMetaItem {
      void applyToItem(NBTTagCompound tag) {
          super.applyToItem(tag);
  
@@ -135,7 +135,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
          if (entityTag != null) {
              tag.set(ENTITY_TAG.NBT, entityTag);
          }
-@@ -77,7 +159,7 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -78,7 +160,7 @@ public class CraftMetaArmorStand extends CraftMetaItem {
      }
  
      boolean isArmorStandEmpty() {
@@ -144,7 +144,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
      }
  
      @Override
-@@ -88,7 +170,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -89,7 +171,13 @@ public class CraftMetaArmorStand extends CraftMetaItem {
          if (meta instanceof CraftMetaArmorStand) {
              CraftMetaArmorStand that = (CraftMetaArmorStand) meta;
  
@@ -159,7 +159,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
          }
          return true;
      }
-@@ -103,9 +191,14 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -104,9 +192,14 @@ public class CraftMetaArmorStand extends CraftMetaItem {
          final int original;
          int hash = original = super.applyHash();
  
@@ -177,7 +177,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
  
          return original != hash ? CraftMetaArmorStand.class.hashCode() ^ hash : hash;
      }
-@@ -114,6 +207,28 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -115,6 +208,28 @@ public class CraftMetaArmorStand extends CraftMetaItem {
      Builder<String, Object> serialize(Builder<String, Object> builder) {
          super.serialize(builder);
  
@@ -206,7 +206,7 @@ index 1a3549480be056368bd6c9d1a98335b3bb07d1d5..25b310ad3f1bcefd04406b7efd1ffa82
          return builder;
      }
  
-@@ -127,4 +242,56 @@ public class CraftMetaArmorStand extends CraftMetaItem {
+@@ -128,4 +243,56 @@ public class CraftMetaArmorStand extends CraftMetaItem {
  
          return clone;
      }

--- a/Spigot-Server-Patches/0192-Extend-Player-Interact-cancellation.patch
+++ b/Spigot-Server-Patches/0192-Extend-Player-Interact-cancellation.patch
@@ -13,10 +13,10 @@ Update adjacent blocks of doors, double plants, pistons and beds
 when cancelling interaction.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 8e5975a4871b99329c78379153ad64575d08d123..9b282a917e797a652b5ec10f1f9f550b6d82777f 100644
+index aae5feb77402d721c23f7e781b53864f6778c1dd..daeaae8072a12b1d5f0718ba9e5bdd4f9c0e2169 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -148,6 +148,11 @@ public class PlayerInteractManager {
+@@ -149,6 +149,11 @@ public class PlayerInteractManager {
                  PlayerInteractEvent event = CraftEventFactory.callPlayerInteractEvent(this.player, Action.LEFT_CLICK_BLOCK, blockposition, enumdirection, this.player.inventory.getItemInHand(), EnumHand.MAIN_HAND);
                  if (event.isCancelled()) {
                      // Let the client know the block still exists
@@ -28,7 +28,7 @@ index 8e5975a4871b99329c78379153ad64575d08d123..9b282a917e797a652b5ec10f1f9f550b
                      this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition));
                      // Update any tile entity data for this block
                      TileEntity tileentity = this.world.getTileEntity(blockposition);
-@@ -452,13 +457,32 @@ public class PlayerInteractManager {
+@@ -453,13 +458,32 @@ public class PlayerInteractManager {
          interactItemStack = itemstack.cloneItemStack();
  
          if (event.useInteractedBlock() == Event.Result.DENY) {

--- a/Spigot-Server-Patches/0197-Implement-extended-PaperServerListPingEvent.patch
+++ b/Spigot-Server-Patches/0197-Implement-extended-PaperServerListPingEvent.patch
@@ -175,7 +175,7 @@ index 0000000000000000000000000000000000000000..39b236a6319b1f44fbe28bbe43f064be
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ee009052eb10125bbaca95b5fda306adbd8a9995..88b45c8b4f58ee83d625408eae08aa329c87a6d4 100644
+index 5e64853fca8e1baa103dd69c050a4900ef7f7f37..41fbdaa99f2c884371b7922d28551dffd44686ed 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,6 +2,9 @@ package net.minecraft.server;
@@ -188,7 +188,7 @@ index ee009052eb10125bbaca95b5fda306adbd8a9995..88b45c8b4f58ee83d625408eae08aa32
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -1119,7 +1122,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1121,7 +1124,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (i - this.T >= 5000000000L) {
              this.T = i;
              this.serverPing.setPlayerSample(new ServerPing.ServerPingPlayerSample(this.getMaxPlayers(), this.getPlayerCount()));

--- a/Spigot-Server-Patches/0213-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/Spigot-Server-Patches/0213-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -43,10 +43,10 @@ index 885bf43a591492f19bd5a421ea4271854ae8f192..d192e341f0f6a3d03329dab16de3b199
  
              if (this.a(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5bf5a815653b0556d9d2bcaf5f69026b77bd28a6..94fd77595a6bf2ee8deace75e243e5ce4286d82d 100644
+index 4058484c256343a71d1392ae0aa54bf07fd0d26e..6e2f73cac222044256e97bc2c07f5581d63de1a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2339,11 +2339,17 @@ public class CraftWorld implements World {
+@@ -2353,11 +2353,17 @@ public class CraftWorld implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/Spigot-Server-Patches/0217-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/Spigot-Server-Patches/0217-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 94fd77595a6bf2ee8deace75e243e5ce4286d82d..3518505236e1b5c7267bc65756acd60f34873cfc 100644
+index 6e2f73cac222044256e97bc2c07f5581d63de1a2..e2dd76d0bc5db5dd07d8574135b8d64b40e2c34a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1507,6 +1507,10 @@ public class CraftWorld implements World {
+@@ -1521,6 +1521,10 @@ public class CraftWorld implements World {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new EntityBoat(world, x, y, z);
              entity.setPositionRotation(x, y, z, yaw, pitch);

--- a/Spigot-Server-Patches/0220-Implement-EntityTeleportEndGatewayEvent.patch
+++ b/Spigot-Server-Patches/0220-Implement-EntityTeleportEndGatewayEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityEndGateway.java b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-index 6a0f7b02c5a2663bb7304a1f8c6cbf1603507d45..5550fd9ea6bcae07dcdf431322cb0da0b26a6d71 100644
+index 91dacc5de8d695b2ea9b2f8b4547f6dbba0451ad..a242dd1f7ca7f2d93312d630173397a3abd83b1d 100644
 --- a/src/main/java/net/minecraft/server/TileEntityEndGateway.java
 +++ b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-@@ -168,9 +168,20 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
+@@ -169,9 +169,20 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
  
                  }
                  // CraftBukkit end

--- a/Spigot-Server-Patches/0221-Unset-Ignited-flag-on-cancel-of-Explosion-Event.patch
+++ b/Spigot-Server-Patches/0221-Unset-Ignited-flag-on-cancel-of-Explosion-Event.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Unset Ignited flag on cancel of Explosion Event
 Otherwise the creeper infinite explodes
 
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 7b9188a33c079155a7ff5b0e5de854550324f0f1..647795bc7ea68f9dbe9d3f6488eaec82159feb9f 100644
+index 78d136eed54b815f5c866d3ab0d96c1d819bc6b2..b0de5c0705983debd7995c586612a7802f6d8f59 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
-@@ -12,7 +12,7 @@ public class EntityCreeper extends EntityMonster {
+@@ -13,7 +13,7 @@ public class EntityCreeper extends EntityMonster {
  
      private static final DataWatcherObject<Integer> b = DataWatcher.a(EntityCreeper.class, DataWatcherRegistry.b);
      private static final DataWatcherObject<Boolean> POWERED = DataWatcher.a(EntityCreeper.class, DataWatcherRegistry.i);
@@ -18,7 +18,7 @@ index 7b9188a33c079155a7ff5b0e5de854550324f0f1..647795bc7ea68f9dbe9d3f6488eaec82
      private int bo;
      private int fuseTicks;
      public int maxFuseTicks = 30;
-@@ -217,6 +217,7 @@ public class EntityCreeper extends EntityMonster {
+@@ -218,6 +218,7 @@ public class EntityCreeper extends EntityMonster {
                  this.createEffectCloud();
              } else {
                  fuseTicks = 0;

--- a/Spigot-Server-Patches/0229-Expand-Explosions-API.patch
+++ b/Spigot-Server-Patches/0229-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3518505236e1b5c7267bc65756acd60f34873cfc..5059ae88375ca9077f02fa521b9ff35018584417 100644
+index e2dd76d0bc5db5dd07d8574135b8d64b40e2c34a..ad80ebd9d69b4d86078a7c3daa274f115f172794 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -882,6 +882,11 @@ public class CraftWorld implements World {
+@@ -896,6 +896,11 @@ public class CraftWorld implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !world.createExplosion(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.Effect.BREAK : Explosion.Effect.NONE).wasCanceled;
      }

--- a/Spigot-Server-Patches/0231-RangedEntity-API.patch
+++ b/Spigot-Server-Patches/0231-RangedEntity-API.patch
@@ -82,7 +82,7 @@ index 2ec1af8be419d94dfde8fe2cc46bae88751a9d8f..f31d3eed3a53d171596b888351064f6d
      public CraftIllusioner(CraftServer server, EntityIllagerIllusioner entity) {
          super(server, entity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java
-index 23ab78da150cacefbac3e35f860dbd20548e54fa..3f94c5a9206e2da9c852d282e267ab4d9f7324c4 100644
+index 058010b9910a672264f198fcdcd17be42312e571..71faa1b38f613db468ee939a7ffac7aaed733d20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLlama.java
 @@ -1,5 +1,6 @@
@@ -92,8 +92,8 @@ index 23ab78da150cacefbac3e35f860dbd20548e54fa..3f94c5a9206e2da9c852d282e267ab4d
  import com.google.common.base.Preconditions;
  import net.minecraft.server.EntityLlama;
  import org.bukkit.craftbukkit.CraftServer;
-@@ -9,7 +10,7 @@ import org.bukkit.entity.Horse;
- import org.bukkit.entity.Llama;
+@@ -10,7 +11,7 @@ import org.bukkit.entity.Llama;
+ import org.bukkit.entity.Llama.Color;
  import org.bukkit.inventory.LlamaInventory;
  
 -public class CraftLlama extends CraftChestedHorse implements Llama {
@@ -142,10 +142,10 @@ index 9c659d764b57adf7b5dda0dbd7358cf9df1a1065..662caa42ebb51c3a1ecf0fbe21605589
      public CraftPillager(CraftServer server, EntityPillager entity) {
          super(server, entity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
-index b4ae8984019b09ae52d708a48663d9ca7509eb29..02df66ecfe92727e1b8e662bb41faac0dc014a44 100644
+index 1cd359b3d5e8a68edda9cecce30bd9dc4beadee2..cf68b17745e2fbd8769e6b73d54b908e957e4a88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
-@@ -1,11 +1,12 @@
+@@ -1,12 +1,13 @@
  package org.bukkit.craftbukkit.entity;
  
 +import com.destroystokyo.paper.entity.CraftRangedEntity;
@@ -153,6 +153,7 @@ index b4ae8984019b09ae52d708a48663d9ca7509eb29..02df66ecfe92727e1b8e662bb41faac0
  import org.bukkit.craftbukkit.CraftServer;
  import org.bukkit.entity.EntityType;
  import org.bukkit.entity.Skeleton;
+ import org.bukkit.entity.Skeleton.SkeletonType;
  
 -public class CraftSkeleton extends CraftMonster implements Skeleton {
 +public class CraftSkeleton extends CraftMonster implements Skeleton, CraftRangedEntity<EntitySkeletonAbstract> { // Paper

--- a/Spigot-Server-Patches/0233-Implement-World.getEntity-UUID-API.patch
+++ b/Spigot-Server-Patches/0233-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5059ae88375ca9077f02fa521b9ff35018584417..6c58b404807c109bacdf6f3d35fbb05329ea8465 100644
+index ad80ebd9d69b4d86078a7c3daa274f115f172794..d8d8a8e10911424ba6ce8a80c58f172fbe0b44af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1296,6 +1296,15 @@ public class CraftWorld implements World {
+@@ -1310,6 +1310,15 @@ public class CraftWorld implements World {
          return list;
      }
  

--- a/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
@@ -117,10 +117,10 @@ index 6051ceba109350fdb07f476df97a1f27345f20f1..7a52e92de0f0b1fccfc07045701d1b86
          this.player.o();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 57955b39fccc9642499445f07c10a55c7f8eacc7..1dfc6476593aeff1d867f8598a843b67f24d5207 100644
+index 2411832c96794f3c39a5e9083b20217880f773ff..ec175cd90491c3473543daa0b565fdc453888a34 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -423,7 +423,7 @@ public abstract class PlayerList {
+@@ -418,7 +418,7 @@ public abstract class PlayerList {
          // CraftBukkit start - Quitting must be before we do final save of data, in case plugins need to modify it
          // See SPIGOT-5799, SPIGOT-6145
          if (entityplayer.activeContainer != entityplayer.defaultContainer) {
@@ -180,7 +180,7 @@ index b0142be8baeda1dbb921e171d903eea02953b5b2..8b692e93706fc571433df55f01428c84
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 785682d7b932693ff0c437563c9f53f32136e75e..df5c75aaeb1aef7cbed9e4b500a2a9a1632e049f 100644
+index 9a49fb71a55aca88ed43322769bdb3c5605ea4b6..aab2f601bf6196e9a23762346d5e22e917f603ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -895,7 +895,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0235-Vex-getSummoner-API.patch
+++ b/Spigot-Server-Patches/0235-Vex-getSummoner-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Vex#getSummoner API
 Get's the NPC that summoned this Vex
 
 diff --git a/src/main/java/net/minecraft/server/EntityVex.java b/src/main/java/net/minecraft/server/EntityVex.java
-index ffcb0e1bfbb196ddcbc144fa83d1525398970309..b84eb0394ab9a53e32b774682bc42b067625195e 100644
+index b4bda8baff6ee124b0ec7aed155824a278f8ac50..00568a19d7a25189d599fc84afb6ca6d642e2855 100644
 --- a/src/main/java/net/minecraft/server/EntityVex.java
 +++ b/src/main/java/net/minecraft/server/EntityVex.java
-@@ -89,6 +89,7 @@ public class EntityVex extends EntityMonster {
+@@ -88,6 +88,7 @@ public class EntityVex extends EntityMonster {
  
      }
  

--- a/Spigot-Server-Patches/0239-Avoid-item-merge-if-stack-size-above-max-stack-size.patch
+++ b/Spigot-Server-Patches/0239-Avoid-item-merge-if-stack-size-above-max-stack-size.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Avoid item merge if stack size above max stack size
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 7e1cc212e22f21bec1f6b1a2d337ef2ee70dc699..fde34e4c0c95d23a006304f26339a60ea6cf51fa 100644
+index fac335b3f80e6af3b08544cfd4abe3c77b66b023..3ba7bd0461d1c58c235cf0cda8d4eecf36b57407 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -182,6 +182,10 @@ public class EntityItem extends Entity {
+@@ -183,6 +183,10 @@ public class EntityItem extends Entity {
  
      private void mergeNearby() {
          if (this.z()) {

--- a/Spigot-Server-Patches/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/Spigot-Server-Patches/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Debug Entities option to debug dupe uuid issues
 Add -Ddebug.entities=true to your JVM flags to gain more information
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 74b1aa0d52d0e325f8162d78d60c27f855ef0112..64a739d0660098b840e2369f150670691eb9c441 100644
+index 18ec6f553ddea775b279658a280fc2a3e5f96fa9..be5ad564964f26c90440bb30464edbf9882ff1e1 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -76,6 +76,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -19,10 +19,10 @@ index 74b1aa0d52d0e325f8162d78d60c27f855ef0112..64a739d0660098b840e2369f15067069
          if (bukkitEntity == null) {
              bukkitEntity = CraftEntity.getEntity(world.getServer(), this);
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 8862bbd73b627e37709d46e6aeeee70c89cbd821..4bbcd00950405a4bf3ce391b557049a3b1d4aee8 100644
+index 8bfa412b0d3f881f694abec89101e15aa2d00bb7..6d048fbb48444885051efcb83a55d32047ff6517 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1093,6 +1093,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1094,6 +1094,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              } else {
                  PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = new PlayerChunkMap.EntityTracker(entity, i, j, entitytypes.isDeltaTracking());
  
@@ -30,7 +30,7 @@ index 8862bbd73b627e37709d46e6aeeee70c89cbd821..4bbcd00950405a4bf3ce391b557049a3
                  this.trackedEntities.put(entity.getId(), playerchunkmap_entitytracker);
                  playerchunkmap_entitytracker.track(this.world.getPlayers());
                  if (entity instanceof EntityPlayer) {
-@@ -1134,7 +1135,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1135,7 +1136,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          if (playerchunkmap_entitytracker1 != null) {
              playerchunkmap_entitytracker1.a();
          }
@@ -40,7 +40,7 @@ index 8862bbd73b627e37709d46e6aeeee70c89cbd821..4bbcd00950405a4bf3ce391b557049a3
  
      protected void g() {
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 33444cd8aec8ce39fb4fef232909cd42ef036d54..3bad056cf3c9a4322dbbf3486ea4510117a8d95b 100644
+index d3c282eb5253351ec4288bffaeca715547089cec..cb1330ef117224aea07208cebff544c714ae313a 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -68,6 +68,7 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -52,7 +52,7 @@ index 33444cd8aec8ce39fb4fef232909cd42ef036d54..3bad056cf3c9a4322dbbf3486ea45101
      public boolean captureBlockStates = false;
      public boolean captureTreeGeneration = false;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 0156e97e736998ed63200d73f4244846050d8354..041dfa08066667501f18e043e8b894c660b949a7 100644
+index 89cd1348ab609555d7c49536fa56ba7dcde2d601..f0c088c4c3283725e515e468faab1dee6a04a853 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -88,6 +88,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0248-Vanished-players-don-t-have-rights.patch
+++ b/Spigot-Server-Patches/0248-Vanished-players-don-t-have-rights.patch
@@ -50,10 +50,10 @@ index 0b62041f6dc9cb0151ea55407f6706cac134f1b5..97aed437adb98bc468ec757df8b6d375
              return false;
          }
 diff --git a/src/main/java/net/minecraft/server/ItemBlock.java b/src/main/java/net/minecraft/server/ItemBlock.java
-index f4be1584b5d09b6c5d01b29cecbc96849b6e90fc..9d62bc6d600526881dccb44d158e30f565078cec 100644
+index 6fb62f75fef4651986c8314c22a465304e7aa97a..ae2ad70699347e169d941266ec3ad1af4c9b3786 100644
 --- a/src/main/java/net/minecraft/server/ItemBlock.java
 +++ b/src/main/java/net/minecraft/server/ItemBlock.java
-@@ -154,7 +154,8 @@ public class ItemBlock extends Item {
+@@ -155,7 +155,8 @@ public class ItemBlock extends Item {
          EntityHuman entityhuman = blockactioncontext.getEntity();
          VoxelShapeCollision voxelshapecollision = entityhuman == null ? VoxelShapeCollision.a() : VoxelShapeCollision.a((Entity) entityhuman);
          // CraftBukkit start - store default return

--- a/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0254-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -83,10 +83,10 @@ index f649b6cc5840a79c80217427abdadd889bf2738c..e26b1362899a9fad5e0e3a4e49acd98b
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6c58b404807c109bacdf6f3d35fbb05329ea8465..47d407af1a770404284c591978978b229cbf7541 100644
+index d8d8a8e10911424ba6ce8a80c58f172fbe0b44af..be028a80247dfb3bf7c726b1868c6e5c5bd99264 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1032,6 +1032,7 @@ public class CraftWorld implements World {
+@@ -1046,6 +1046,7 @@ public class CraftWorld implements World {
          for (Object o : world.entitiesById.values()) {
              if (o instanceof net.minecraft.server.Entity) {
                  net.minecraft.server.Entity mcEnt = (net.minecraft.server.Entity) o;
@@ -94,7 +94,7 @@ index 6c58b404807c109bacdf6f3d35fbb05329ea8465..47d407af1a770404284c591978978b22
                  Entity bukkitEntity = mcEnt.getBukkitEntity();
  
                  // Assuming that bukkitEntity isn't null
-@@ -1051,6 +1052,7 @@ public class CraftWorld implements World {
+@@ -1065,6 +1066,7 @@ public class CraftWorld implements World {
          for (Object o : world.entitiesById.values()) {
              if (o instanceof net.minecraft.server.Entity) {
                  net.minecraft.server.Entity mcEnt = (net.minecraft.server.Entity) o;
@@ -102,7 +102,7 @@ index 6c58b404807c109bacdf6f3d35fbb05329ea8465..47d407af1a770404284c591978978b22
                  Entity bukkitEntity = mcEnt.getBukkitEntity();
  
                  // Assuming that bukkitEntity isn't null
-@@ -1077,6 +1079,7 @@ public class CraftWorld implements World {
+@@ -1091,6 +1093,7 @@ public class CraftWorld implements World {
  
          for (Object entity: world.entitiesById.values()) {
              if (entity instanceof net.minecraft.server.Entity) {
@@ -110,7 +110,7 @@ index 6c58b404807c109bacdf6f3d35fbb05329ea8465..47d407af1a770404284c591978978b22
                  Entity bukkitEntity = ((net.minecraft.server.Entity) entity).getBukkitEntity();
  
                  if (bukkitEntity == null) {
-@@ -1100,6 +1103,7 @@ public class CraftWorld implements World {
+@@ -1114,6 +1117,7 @@ public class CraftWorld implements World {
  
          for (Object entity: world.entitiesById.values()) {
              if (entity instanceof net.minecraft.server.Entity) {

--- a/Spigot-Server-Patches/0255-Implement-Expanded-ArmorStand-API.patch
+++ b/Spigot-Server-Patches/0255-Implement-Expanded-ArmorStand-API.patch
@@ -20,10 +20,10 @@ index 9a3183e55fcb6809d2b324ad52e27f3e77d8fcb2..abcf3ab8bab2ca98ab0f7e852b8185e2
          return (this.disabledSlots & 1 << enumitemslot.getSlotFlag()) != 0 || enumitemslot.a() == EnumItemSlot.Function.HAND && !this.hasArms();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index bf2749fd724ac7b67fc0d5887aa307745c5f1835..c19f0b0dd3fe988a30049297355445fd73cae630 100644
+index 6ff7a59cc7052e900516a89db8daf0720c64a1ac..557cdb6ca007c617278e8cf723a2a11eae67d57d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-@@ -238,5 +238,78 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
+@@ -239,5 +239,78 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
      public void setCanMove(boolean move) {
          getHandle().canMove = move;
      }

--- a/Spigot-Server-Patches/0257-Add-TNTPrimeEvent.patch
+++ b/Spigot-Server-Patches/0257-Add-TNTPrimeEvent.patch
@@ -115,17 +115,17 @@ index c6fe9c1f7ef06c4524533130b493ca5e72bd1693..7b601955f3fd36f06c838b896b455a60
                  world.a(blockposition, false);
              }
 diff --git a/src/main/java/net/minecraft/server/EntityEnderDragon.java b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-index ef9df3c7c7c455373641f7a7c701f82a23ffef36..6bd55433fafcfd8079b8e7b1ce6b65daa13b83c1 100644
+index 348d3575115ed6c95b4aee56f0fd930103651489..90a3d3711f71209b7db89d2515377ed1818c3c83 100644
 --- a/src/main/java/net/minecraft/server/EntityEnderDragon.java
 +++ b/src/main/java/net/minecraft/server/EntityEnderDragon.java
-@@ -11,6 +11,7 @@ import org.bukkit.craftbukkit.block.CraftBlock;
+@@ -12,6 +12,7 @@ import org.bukkit.craftbukkit.block.CraftBlock;
  import org.bukkit.event.entity.EntityExplodeEvent;
  import org.bukkit.event.entity.EntityRegainHealthEvent;
  // CraftBukkit end
 +import com.destroystokyo.paper.event.block.TNTPrimeEvent; // Paper - TNTPrimeEvent
  
- // PAIL: Fixme
  public class EntityEnderDragon extends EntityInsentient implements IMonster {
+ 
 @@ -466,6 +467,11 @@ public class EntityEnderDragon extends EntityInsentient implements IMonster {
                      });
                      craftBlock.getNMS().dropNaturally((WorldServer) world, blockposition, ItemStack.b);

--- a/Spigot-Server-Patches/0259-Add-hand-to-bucket-events.patch
+++ b/Spigot-Server-Patches/0259-Add-hand-to-bucket-events.patch
@@ -18,10 +18,10 @@ index c20484220edc849e43a1067d169d4d36f0059836..42e6761c8b18b79ffd3f4d5e853ea87a
              if (event.isCancelled()) {
                  return EnumInteractionResult.PASS;
 diff --git a/src/main/java/net/minecraft/server/ItemBucket.java b/src/main/java/net/minecraft/server/ItemBucket.java
-index 48958308a89cbe39e1b4dddcdd8d1d0b5ece6339..120bf8436fd82294c339add2e7bff1cda8311aea 100644
+index 70a0efac7a549fa0e9895813335f034ec98d3d2b..223361a1a8b41ebe91e0db39f40cf12a4968b1b4 100644
 --- a/src/main/java/net/minecraft/server/ItemBucket.java
 +++ b/src/main/java/net/minecraft/server/ItemBucket.java
-@@ -41,7 +41,7 @@ public class ItemBucket extends Item {
+@@ -42,7 +42,7 @@ public class ItemBucket extends Item {
                      if (iblockdata.getBlock() instanceof IFluidSource) {
                          // CraftBukkit start
                          FluidType dummyFluid = ((IFluidSource) iblockdata.getBlock()).removeFluid(DummyGeneratorAccess.INSTANCE, blockposition, iblockdata);
@@ -30,7 +30,7 @@ index 48958308a89cbe39e1b4dddcdd8d1d0b5ece6339..120bf8436fd82294c339add2e7bff1cd
  
                          if (event.isCancelled()) {
                              ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, blockposition)); // SPIGOT-5163 (see PlayerInteractManager)
-@@ -69,7 +69,7 @@ public class ItemBucket extends Item {
+@@ -70,7 +70,7 @@ public class ItemBucket extends Item {
                      iblockdata = world.getType(blockposition);
                      BlockPosition blockposition2 = iblockdata.getBlock() instanceof IFluidContainer && this.fluidType == FluidTypes.WATER ? blockposition : blockposition1;
  
@@ -39,7 +39,7 @@ index 48958308a89cbe39e1b4dddcdd8d1d0b5ece6339..120bf8436fd82294c339add2e7bff1cd
                          this.a(world, itemstack, blockposition2);
                          if (entityhuman instanceof EntityPlayer) {
                              CriterionTriggers.y.a((EntityPlayer) entityhuman, blockposition2, itemstack);
-@@ -94,10 +94,12 @@ public class ItemBucket extends Item {
+@@ -95,10 +95,12 @@ public class ItemBucket extends Item {
      public void a(World world, ItemStack itemstack, BlockPosition blockposition) {}
  
      public boolean a(@Nullable EntityHuman entityhuman, World world, BlockPosition blockposition, @Nullable MovingObjectPositionBlock movingobjectpositionblock) {
@@ -54,7 +54,7 @@ index 48958308a89cbe39e1b4dddcdd8d1d0b5ece6339..120bf8436fd82294c339add2e7bff1cd
          // CraftBukkit end
          if (!(this.fluidType instanceof FluidTypeFlowing)) {
              return false;
-@@ -110,7 +112,7 @@ public class ItemBucket extends Item {
+@@ -111,7 +113,7 @@ public class ItemBucket extends Item {
  
              // CraftBukkit start
              if (flag1 && entityhuman != null) {
@@ -63,7 +63,7 @@ index 48958308a89cbe39e1b4dddcdd8d1d0b5ece6339..120bf8436fd82294c339add2e7bff1cd
                  if (event.isCancelled()) {
                      ((EntityPlayer) entityhuman).playerConnection.sendPacket(new PacketPlayOutBlockChange(world, blockposition)); // SPIGOT-4238: needed when looking through entity
                      ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
-@@ -119,7 +121,7 @@ public class ItemBucket extends Item {
+@@ -120,7 +122,7 @@ public class ItemBucket extends Item {
              }
              // CraftBukkit end
              if (!flag1) {

--- a/Spigot-Server-Patches/0260-MC-135506-Experience-should-save-as-Integers.patch
+++ b/Spigot-Server-Patches/0260-MC-135506-Experience-should-save-as-Integers.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-135506: Experience should save as Integers
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityExperienceOrb.java b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-index 4df7df781d12e38885ecfbc89dd1d42d9de14248..c2be0c2bc315876f120cff207e5516dda2bd55d7 100644
+index 837a2c8f6af6e51316511e3948869ac059c8fc0d..4a94ce72d559263ef5fa4fb16dc286f531f51d55 100644
 --- a/src/main/java/net/minecraft/server/EntityExperienceOrb.java
 +++ b/src/main/java/net/minecraft/server/EntityExperienceOrb.java
-@@ -202,7 +202,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -203,7 +203,7 @@ public class EntityExperienceOrb extends Entity {
      public void saveData(NBTTagCompound nbttagcompound) {
          nbttagcompound.setShort("Health", (short) this.e);
          nbttagcompound.setShort("Age", (short) this.c);
@@ -17,7 +17,7 @@ index 4df7df781d12e38885ecfbc89dd1d42d9de14248..c2be0c2bc315876f120cff207e5516dd
          this.savePaperNBT(nbttagcompound); // Paper
      }
  
-@@ -210,7 +210,7 @@ public class EntityExperienceOrb extends Entity {
+@@ -211,7 +211,7 @@ public class EntityExperienceOrb extends Entity {
      public void loadData(NBTTagCompound nbttagcompound) {
          this.e = nbttagcompound.getShort("Health");
          this.c = nbttagcompound.getShort("Age");

--- a/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,10 +36,10 @@ index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 88b45c8b4f58ee83d625408eae08aa329c87a6d4..d6d93c76f047573b3e7ea91409fb85e093666812 100644
+index 41fbdaa99f2c884371b7922d28551dffd44686ed..c24397d2ded7d3ea6f7440035ed64d29602900a6 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -898,6 +898,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -900,6 +900,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a(this.serverPing);
  
                  // Spigot start
@@ -48,7 +48,7 @@ index 88b45c8b4f58ee83d625408eae08aa329c87a6d4..d6d93c76f047573b3e7ea91409fb85e0
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index be7c2153b3c712f3e5c1ebd3e8526b65bd2f5174..82fe3ab9c5e05bd372f6c5721758742f866f3605 100644
+index 08015ffe6268469526fcc01e98012bf3aa073c92..dcf148dc56ee80d6dd454045ffed1cc467f724a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -813,6 +813,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0264-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/Spigot-Server-Patches/0264-Use-ConcurrentHashMap-in-JsonList.patch
@@ -122,10 +122,10 @@ index da21918ce0339a0eb8f65ce7791a04ceb12749b7..1fc0139cb9694ddea41f57d95774c3b4
  
          this.d.values().stream().map((jsonlistentry) -> {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index cb6fa4be113d732ed93d9ccbef99c56f9044e7ee..ee56306b49224b5421b6d2870019c1aa053873d7 100644
+index ec175cd90491c3473543daa0b565fdc453888a34..79f6984a8e5bb73daeae1725a11840556c398de2 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -547,7 +547,7 @@ public abstract class PlayerList {
+@@ -542,7 +542,7 @@ public abstract class PlayerList {
          } else if (!this.isWhitelisted(gameprofile, event)) { // Paper
              //chatmessage = new ChatMessage("multiplayer.disconnect.not_whitelisted"); // Paper
              //event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot // Paper - moved to isWhitelisted

--- a/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
+++ b/Spigot-Server-Patches/0267-Allow-disabling-armour-stand-ticking.patch
@@ -137,10 +137,10 @@ index abcf3ab8bab2ca98ab0f7e852b8185e27949a210..5076dd7e874be76d81b13f53076bc472
          this.datawatcher.set(EntityArmorStand.bh, vector3f);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-index c19f0b0dd3fe988a30049297355445fd73cae630..cb22cbd68a4d310fecad3a87a97bf101216a5f64 100644
+index 557cdb6ca007c617278e8cf723a2a11eae67d57d..40e9005c0f520a26a419beae17705171e61c646a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArmorStand.java
-@@ -311,5 +311,16 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
+@@ -312,5 +312,16 @@ public class CraftArmorStand extends CraftLivingEntity implements ArmorStand {
      public boolean isSlotDisabled(org.bukkit.inventory.EquipmentSlot slot) {
          return getHandle().isSlotDisabled(org.bukkit.craftbukkit.CraftEquipmentSlot.getNMS(slot));
      }

--- a/Spigot-Server-Patches/0270-Slime-Pathfinder-Events.patch
+++ b/Spigot-Server-Patches/0270-Slime-Pathfinder-Events.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Slime Pathfinder Events
 
 
 diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
-index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029bcffd5f10 100644
+index d774a0893b2e6599bade3a9edf22668a30587503..60818e1a7ce9c637bef8dc05de8cba10975ffc79 100644
 --- a/src/main/java/net/minecraft/server/EntitySlime.java
 +++ b/src/main/java/net/minecraft/server/EntitySlime.java
-@@ -5,6 +5,14 @@ import java.util.Objects;
- import java.util.Optional;
+@@ -6,6 +6,14 @@ import java.util.Optional;
  import java.util.Random;
  import javax.annotation.Nullable;
+ 
 +// Paper start
 +import com.destroystokyo.paper.event.entity.SlimeChangeDirectionEvent;
 +import com.destroystokyo.paper.event.entity.SlimeSwimEvent;
@@ -23,7 +23,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
  // CraftBukkit start
  import java.util.ArrayList;
  import java.util.List;
-@@ -65,6 +73,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -66,6 +74,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
      @Override
      public void saveData(NBTTagCompound nbttagcompound) {
          super.saveData(nbttagcompound);
@@ -31,7 +31,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          nbttagcompound.setInt("Size", this.getSize() - 1);
          nbttagcompound.setBoolean("wasOnGround", this.bp);
      }
-@@ -79,6 +88,11 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -80,6 +89,11 @@ public class EntitySlime extends EntityInsentient implements IMonster {
  
          this.setSize(i + 1, false);
          super.loadData(nbttagcompound);
@@ -43,7 +43,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          this.bp = nbttagcompound.getBoolean("wasOnGround");
      }
  
-@@ -358,7 +372,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -359,7 +373,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
  
          @Override
          public boolean a() {
@@ -52,7 +52,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          }
  
          @Override
-@@ -379,7 +393,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -380,7 +394,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
  
          @Override
          public boolean a() {
@@ -61,7 +61,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          }
  
          @Override
-@@ -405,14 +419,18 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -406,14 +420,18 @@ public class EntitySlime extends EntityInsentient implements IMonster {
  
          @Override
          public boolean a() {
@@ -82,7 +82,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
              }
  
              ((EntitySlime.ControllerMoveSlime) this.a.getControllerMove()).a(this.b, false);
-@@ -433,7 +451,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -434,7 +452,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
          public boolean a() {
              EntityLiving entityliving = this.a.getGoalTarget();
  
@@ -99,7 +99,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          }
  
          @Override
-@@ -446,7 +472,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -447,7 +473,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
          public boolean b() {
              EntityLiving entityliving = this.a.getGoalTarget();
  
@@ -116,7 +116,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
          }
  
          @Override
-@@ -454,6 +488,13 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -455,6 +489,13 @@ public class EntitySlime extends EntityInsentient implements IMonster {
              this.a.a((Entity) this.a.getGoalTarget(), 10.0F, 10.0F);
              ((EntitySlime.ControllerMoveSlime) this.a.getControllerMove()).a(this.a.yaw, this.a.eL());
          }
@@ -130,7 +130,7 @@ index 563340d410f76ec1df90403879b835ebd9e6b533..e99fd88118a75f36cb93d02aa7c6029b
      }
  
      static class ControllerMoveSlime extends ControllerMove {
-@@ -512,4 +553,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -513,4 +554,15 @@ public class EntitySlime extends EntityInsentient implements IMonster {
              }
          }
      }

--- a/Spigot-Server-Patches/0275-Add-More-Creeper-API.patch
+++ b/Spigot-Server-Patches/0275-Add-More-Creeper-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add More Creeper API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityCreeper.java b/src/main/java/net/minecraft/server/EntityCreeper.java
-index 647795bc7ea68f9dbe9d3f6488eaec82159feb9f..79ef955070b2982be79cc58e40093624bd088ff0 100644
+index b0de5c0705983debd7995c586612a7802f6d8f59..b2f028422d9a7a84e49e383b78032feb887a85c0 100644
 --- a/src/main/java/net/minecraft/server/EntityCreeper.java
 +++ b/src/main/java/net/minecraft/server/EntityCreeper.java
-@@ -14,7 +14,7 @@ public class EntityCreeper extends EntityMonster {
+@@ -15,7 +15,7 @@ public class EntityCreeper extends EntityMonster {
      private static final DataWatcherObject<Boolean> POWERED = DataWatcher.a(EntityCreeper.class, DataWatcherRegistry.i);
      private static final DataWatcherObject<Boolean> d = DataWatcher.a(EntityCreeper.class, DataWatcherRegistry.i); private static final DataWatcherObject<Boolean> isIgnitedDW = d; // Paper OBFHELPER
      private int bo;
@@ -17,7 +17,7 @@ index 647795bc7ea68f9dbe9d3f6488eaec82159feb9f..79ef955070b2982be79cc58e40093624
      public int maxFuseTicks = 30;
      public int explosionRadius = 3;
      private int bs;
-@@ -254,7 +254,18 @@ public class EntityCreeper extends EntityMonster {
+@@ -255,7 +255,18 @@ public class EntityCreeper extends EntityMonster {
      }
  
      public void ignite() {

--- a/Spigot-Server-Patches/0277-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/Spigot-Server-Patches/0277-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9e9b9b9f81f1e4340b98724ca50fb03f699a03cb..ab05cc8e4188fcdfcd77ee6c1f217d0fa170c941 100644
+index be028a80247dfb3bf7c726b1868c6e5c5bd99264..bf7b572e455dfc9dfdacce9d2b93266ec5eac0b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -507,7 +507,7 @@ public class CraftWorld implements World {
+@@ -508,7 +508,7 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/Spigot-Server-Patches/0281-Allow-chests-to-be-placed-with-NBT-data.patch
+++ b/Spigot-Server-Patches/0281-Allow-chests-to-be-placed-with-NBT-data.patch
@@ -17,10 +17,10 @@ index 22568201a292edc8e25396e55cad1572d419b775..7ad595d5d7e090c523aa45a10d0f84b6
                      for (BlockState blockstate : blocks) {
                          blockstate.update(true, false);
 diff --git a/src/main/java/net/minecraft/server/TileEntityChest.java b/src/main/java/net/minecraft/server/TileEntityChest.java
-index 52f64460ba1bfb298f343f71a923c8f34de9e39d..d429c6a4154497fea813ef98d1a30eef2ca5e5e0 100644
+index 54cad33750efd80b104664723e1115d107c7a72d..28df29649a3e78708564b5ab9dc4d340835db9a3 100644
 --- a/src/main/java/net/minecraft/server/TileEntityChest.java
 +++ b/src/main/java/net/minecraft/server/TileEntityChest.java
-@@ -300,7 +300,7 @@ public class TileEntityChest extends TileEntityLootable { // Paper - Remove ITic
+@@ -301,7 +301,7 @@ public class TileEntityChest extends TileEntityLootable { // Paper - Remove ITic
      // CraftBukkit start
      @Override
      public boolean isFilteredNBT() {

--- a/Spigot-Server-Patches/0283-Prevent-chunk-loading-from-Fluid-Flowing.patch
+++ b/Spigot-Server-Patches/0283-Prevent-chunk-loading-from-Fluid-Flowing.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent chunk loading from Fluid Flowing
 
 
 diff --git a/src/main/java/net/minecraft/server/FluidTypeFlowing.java b/src/main/java/net/minecraft/server/FluidTypeFlowing.java
-index 663731a5e7ad3990d1ffac3e0a3028dba37f2b07..d72a88e9275eb00eed35b6467538a46e5cee32d5 100644
+index 9f99503a7631497fd20edb935cd3bb8b5b3cbdf7..cf9d3faabe8732d27c436f4806c727592e475f81 100644
 --- a/src/main/java/net/minecraft/server/FluidTypeFlowing.java
 +++ b/src/main/java/net/minecraft/server/FluidTypeFlowing.java
-@@ -154,7 +154,8 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -155,7 +155,8 @@ public abstract class FluidTypeFlowing extends FluidType {
                  EnumDirection enumdirection = (EnumDirection) entry.getKey();
                  Fluid fluid1 = (Fluid) entry.getValue();
                  BlockPosition blockposition1 = blockposition.shift(enumdirection);
@@ -18,7 +18,7 @@ index 663731a5e7ad3990d1ffac3e0a3028dba37f2b07..d72a88e9275eb00eed35b6467538a46e
  
                  if (this.a(generatoraccess, blockposition, iblockdata, enumdirection, blockposition1, iblockdata1, generatoraccess.getFluid(blockposition1), fluid1.getType())) {
                      // CraftBukkit start
-@@ -181,7 +182,8 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -182,7 +183,8 @@ public abstract class FluidTypeFlowing extends FluidType {
          while (iterator.hasNext()) {
              EnumDirection enumdirection = (EnumDirection) iterator.next();
              BlockPosition blockposition1 = blockposition.shift(enumdirection);
@@ -28,7 +28,7 @@ index 663731a5e7ad3990d1ffac3e0a3028dba37f2b07..d72a88e9275eb00eed35b6467538a46e
              Fluid fluid = iblockdata1.getFluid();
  
              if (fluid.getType().a((FluidType) this) && this.a(enumdirection, (IBlockAccess) iworldreader, blockposition, iblockdata, blockposition1, iblockdata1)) {
-@@ -298,11 +300,18 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -299,11 +301,18 @@ public abstract class FluidTypeFlowing extends FluidType {
              if (enumdirection1 != enumdirection) {
                  BlockPosition blockposition2 = blockposition.shift(enumdirection1);
                  short short0 = a(blockposition1, blockposition2);
@@ -51,7 +51,7 @@ index 663731a5e7ad3990d1ffac3e0a3028dba37f2b07..d72a88e9275eb00eed35b6467538a46e
                  IBlockData iblockdata1 = (IBlockData) pair.getFirst();
                  Fluid fluid = (Fluid) pair.getSecond();
  
-@@ -374,11 +383,16 @@ public abstract class FluidTypeFlowing extends FluidType {
+@@ -375,11 +384,16 @@ public abstract class FluidTypeFlowing extends FluidType {
              EnumDirection enumdirection = (EnumDirection) iterator.next();
              BlockPosition blockposition1 = blockposition.shift(enumdirection);
              short short0 = a(blockposition, blockposition1);

--- a/Spigot-Server-Patches/0285-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
+++ b/Spigot-Server-Patches/0285-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent Mob AI Rules from Loading Chunks
 
 
 diff --git a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
-index 537e7224b9f9dbbe107537c5d7ef9d3bb4cbb422..c03ebbc933197be3e7097ea3f7b7cd08c90db7bb 100644
+index 127428c400f6de1cb65458346aac6a176b6c1896..6ea402c603b9b54705e79a2fdc61fe5a254479a3 100644
 --- a/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
 +++ b/src/main/java/net/minecraft/server/PathfinderGoalRemoveBlock.java
-@@ -12,11 +12,13 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
+@@ -13,11 +13,13 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
      private final Block g;
      private final EntityInsentient entity;
      private int i;
@@ -22,7 +22,7 @@ index 537e7224b9f9dbbe107537c5d7ef9d3bb4cbb422..c03ebbc933197be3e7097ea3f7b7cd08
      }
  
      @Override
-@@ -114,7 +116,9 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
+@@ -115,7 +117,9 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
  
      @Nullable
      private BlockPosition a(BlockPosition blockposition, IBlockAccess iblockaccess) {
@@ -33,7 +33,7 @@ index 537e7224b9f9dbbe107537c5d7ef9d3bb4cbb422..c03ebbc933197be3e7097ea3f7b7cd08
              return blockposition;
          } else {
              BlockPosition[] ablockposition = new BlockPosition[]{blockposition.down(), blockposition.west(), blockposition.east(), blockposition.north(), blockposition.south(), blockposition.down().down()};
-@@ -124,7 +128,7 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
+@@ -125,7 +129,7 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
              for (int j = 0; j < i; ++j) {
                  BlockPosition blockposition1 = ablockposition1[j];
  
@@ -42,7 +42,7 @@ index 537e7224b9f9dbbe107537c5d7ef9d3bb4cbb422..c03ebbc933197be3e7097ea3f7b7cd08
                      return blockposition1;
                  }
              }
-@@ -135,7 +139,7 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
+@@ -136,7 +140,7 @@ public class PathfinderGoalRemoveBlock extends PathfinderGoalGotoTarget {
  
      @Override
      protected boolean a(IWorldReader iworldreader, BlockPosition blockposition) {

--- a/Spigot-Server-Patches/0288-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/Spigot-Server-Patches/0288-Implement-furnace-cook-speed-multiplier-API.patch
@@ -11,18 +11,18 @@ to the nearest Integer when updating its current cook time.
 Modified by: Eric Su <ericsu@alumni.usc.edu>
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityFurnace.java b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe 100644
+index af4db22cf87433fcd4f59be207257a8d7c255883..abc76807595611d35c86f500ef1ef51159e9406b 100644
 --- a/src/main/java/net/minecraft/server/TileEntityFurnace.java
 +++ b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-@@ -10,6 +10,7 @@ import java.util.List;
- import java.util.Map;
+@@ -11,6 +11,7 @@ import java.util.Map;
  import javax.annotation.Nullable;
+ 
  // CraftBukkit start
 +import java.util.List;
  import org.bukkit.craftbukkit.block.CraftBlock;
  import org.bukkit.craftbukkit.entity.CraftHumanEntity;
  import org.bukkit.craftbukkit.inventory.CraftItemStack;
-@@ -28,6 +29,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -29,6 +30,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
      protected NonNullList<ItemStack> items;
      public int burnTime;
      private int ticksForCurrentFuel;
@@ -30,7 +30,7 @@ index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bc
      public int cookTime;
      public int cookTimeTotal;
      protected final IContainerProperties b;
-@@ -228,6 +230,11 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -229,6 +231,11 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
              this.n.put(new MinecraftKey(s), nbttagcompound1.getInt(s));
          }
  
@@ -42,7 +42,7 @@ index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bc
      }
  
      @Override
-@@ -236,6 +243,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -237,6 +244,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
          nbttagcompound.setShort("BurnTime", (short) this.burnTime);
          nbttagcompound.setShort("CookTime", (short) this.cookTime);
          nbttagcompound.setShort("CookTimeTotal", (short) this.cookTimeTotal);
@@ -50,7 +50,7 @@ index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bc
          ContainerUtil.a(nbttagcompound, this.items);
          NBTTagCompound nbttagcompound1 = new NBTTagCompound();
  
-@@ -296,7 +304,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -297,7 +305,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
  
                  if (this.isBurning() && this.canBurn(irecipe)) {
                      ++this.cookTime;
@@ -59,7 +59,7 @@ index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bc
                          this.cookTime = 0;
                          this.cookTimeTotal = this.getRecipeCookingTime();
                          this.burn(irecipe);
-@@ -396,9 +404,13 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -397,9 +405,13 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
          }
      }
  
@@ -76,7 +76,7 @@ index 99b20fa5feff0f766124d4ec9474852e33e329f2..51db9ea42d49c4c21f30cfeba25e09bc
      public static boolean isFuel(ItemStack itemstack) {
          return f().containsKey(itemstack.getItem());
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-index e0e10feeb1608c46effd6104f64db50977f468fe..693511650a7fa39c7c4eeca50cdf50f4a6f58538 100644
+index 27c8cc130e7466c396b514dd77f1385f967bebdb..298e75d72b889396a15907e713c29430c168b915 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 @@ -63,4 +63,20 @@ public abstract class CraftFurnace<T extends TileEntityFurnace> extends CraftCon

--- a/Spigot-Server-Patches/0290-Catch-JsonParseException-in-Entity-and-TE-names.patch
+++ b/Spigot-Server-Patches/0290-Catch-JsonParseException-in-Entity-and-TE-names.patch
@@ -13,10 +13,10 @@ Shulkers) may need to be changed in order for it to re-save properly
 No more crashing though.
 
 diff --git a/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java b/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
-index 850e79b764513bd68a28b675e075f804f59b75a8..7e13b1cf6d92c3e0f2dab1ba1d42bd4f250e256c 100644
+index e16f975e1babd2f08262cbbb42d7f47740525e97..e78809278b9159728722b2b33ad5dfae77e860ed 100644
 --- a/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
 +++ b/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
-@@ -60,7 +60,7 @@ public abstract class CommandBlockListenerAbstract implements ICommandListener {
+@@ -59,7 +59,7 @@ public abstract class CommandBlockListenerAbstract implements ICommandListener {
          this.command = nbttagcompound.getString("Command");
          this.successCount = nbttagcompound.getInt("SuccessCount");
          if (nbttagcompound.hasKeyOfType("CustomName", 8)) {

--- a/Spigot-Server-Patches/0294-Allow-setting-the-vex-s-summoner.patch
+++ b/Spigot-Server-Patches/0294-Allow-setting-the-vex-s-summoner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow setting the vex's summoner
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVex.java b/src/main/java/net/minecraft/server/EntityVex.java
-index b84eb0394ab9a53e32b774682bc42b067625195e..ed6a47ad2fd973695fbb151d1a44000ec3639e54 100644
+index 00568a19d7a25189d599fc84afb6ca6d642e2855..9a33866e7529e1636c228bab01205737bc678b47 100644
 --- a/src/main/java/net/minecraft/server/EntityVex.java
 +++ b/src/main/java/net/minecraft/server/EntityVex.java
-@@ -130,6 +130,7 @@ public class EntityVex extends EntityMonster {
+@@ -129,6 +129,7 @@ public class EntityVex extends EntityMonster {
          this.a(1, flag);
      }
  

--- a/Spigot-Server-Patches/0295-Add-sun-related-API.patch
+++ b/Spigot-Server-Patches/0295-Add-sun-related-API.patch
@@ -17,10 +17,10 @@ index fbecc8ccab47b428c43530ad344e325538cf242d..800a8dd2543f0b83eec67e7805104274
          if (this.world.isDay() && !this.world.isClientSide) {
              float f = this.aR();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bc10ccd76fcf3f03c23f52064c4db17bcad1c574..46a7e7b2f6079df036d2b73c82d7bf5ea1b07871 100644
+index bf7b572e455dfc9dfdacce9d2b93266ec5eac0b4..523f094b5d4572a04da36d68502fa0a22f239e61 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -858,6 +858,13 @@ public class CraftWorld implements World {
+@@ -872,6 +872,13 @@ public class CraftWorld implements World {
          }
      }
  

--- a/Spigot-Server-Patches/0306-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
+++ b/Spigot-Server-Patches/0306-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
@@ -12,10 +12,10 @@ server threads
 Allow usage of a single thread executor by not using ForkJoin so single core CPU's.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d6d93c76f047573b3e7ea91409fb85e093666812..f1008096ee90b506c322fd1667c6b60faefd545c 100644
+index c24397d2ded7d3ea6f7440035ed64d29602900a6..518e15e6a4b7750e90a958686bcd930c351f5e1c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -175,6 +175,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -177,6 +177,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          S s0 = function.apply(thread); // CraftBukkit - decompile error
  
          atomicreference.set(s0);

--- a/Spigot-Server-Patches/0307-Optimize-World-Time-Updates.patch
+++ b/Spigot-Server-Patches/0307-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f1008096ee90b506c322fd1667c6b60faefd545c..93aa20d82d867fee6df938096b0ad64d061fc61a 100644
+index 518e15e6a4b7750e90a958686bcd930c351f5e1c..cf950c123151cea0f63fbc46c0c1b339c59c02b1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1195,12 +1195,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1197,12 +1197,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.

--- a/Spigot-Server-Patches/0310-Fix-SpongeAbsortEvent-handling.patch
+++ b/Spigot-Server-Patches/0310-Fix-SpongeAbsortEvent-handling.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix SpongeAbsortEvent handling
 Only process drops when the block is actually going to be removed
 
 diff --git a/src/main/java/net/minecraft/server/Block.java b/src/main/java/net/minecraft/server/Block.java
-index b537385d12463adc82751e40b479b047b32fa5bd..b364ceafb4c3412b0d11b3b2e8b4321ed96769bb 100644
+index cee4e952c96b9f55c57186ac96aa730e656e1f16..05d9f842a990243c4ec83e62e177c818b5f94e8c 100644
 --- a/src/main/java/net/minecraft/server/Block.java
 +++ b/src/main/java/net/minecraft/server/Block.java
 @@ -189,6 +189,7 @@ public class Block extends BlockBase implements IMaterial {
@@ -18,10 +18,10 @@ index b537385d12463adc82751e40b479b047b32fa5bd..b364ceafb4c3412b0d11b3b2e8b4321e
          if (generatoraccess instanceof WorldServer) {
              a(iblockdata, (WorldServer) generatoraccess, blockposition, tileentity).forEach((itemstack) -> {
 diff --git a/src/main/java/net/minecraft/server/BlockSponge.java b/src/main/java/net/minecraft/server/BlockSponge.java
-index 7051d9bf19f989a1176c1f12e1114240ab4762c4..db73fe0e51bde67d9238ce3f9f6f008c2d8a9d4d 100644
+index 4666e3aedc3d614eb38a08bd34f402b24bd1d0b6..7a2130d74e787f82b771d4efa8d3f15804f05940 100644
 --- a/src/main/java/net/minecraft/server/BlockSponge.java
 +++ b/src/main/java/net/minecraft/server/BlockSponge.java
-@@ -115,8 +115,11 @@ public class BlockSponge extends Block {
+@@ -116,8 +116,11 @@ public class BlockSponge extends Block {
                          // NOP
                      } else if (material == Material.WATER_PLANT || material == Material.REPLACEABLE_WATER_PLANT) {
                          TileEntity tileentity = iblockdata.getBlock().isTileEntity() ? world.getTileEntity(blockposition2) : null;

--- a/Spigot-Server-Patches/0311-Don-t-allow-digging-into-unloaded-chunks.patch
+++ b/Spigot-Server-Patches/0311-Don-t-allow-digging-into-unloaded-chunks.patch
@@ -21,10 +21,10 @@ index fa74b0266172bf83339f85a4e739bbf2256e4ccf..a448773cc46889df37d563beb227beaa
                  return;
              default:
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 9b282a917e797a652b5ec10f1f9f550b6d82777f..3056468a7e70238228b91be0f103cfbe111fedb5 100644
+index daeaae8072a12b1d5f0718ba9e5bdd4f9c0e2169..21acea46a288348cbc2d4fa312035d6679987399 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -80,8 +80,8 @@ public class PlayerInteractManager {
+@@ -81,8 +81,8 @@ public class PlayerInteractManager {
          IBlockData iblockdata;
  
          if (this.j) {
@@ -35,7 +35,7 @@ index 9b282a917e797a652b5ec10f1f9f550b6d82777f..3056468a7e70238228b91be0f103cfbe
                  this.j = false;
              } else {
                  float f = this.a(iblockdata, this.k, this.l);
-@@ -92,7 +92,13 @@ public class PlayerInteractManager {
+@@ -93,7 +93,13 @@ public class PlayerInteractManager {
                  }
              }
          } else if (this.f) {
@@ -50,7 +50,7 @@ index 9b282a917e797a652b5ec10f1f9f550b6d82777f..3056468a7e70238228b91be0f103cfbe
              if (iblockdata.isAir()) {
                  this.world.a(this.player.getId(), this.h, -1);
                  this.m = -1;
-@@ -256,10 +262,12 @@ public class PlayerInteractManager {
+@@ -257,10 +263,12 @@ public class PlayerInteractManager {
                  this.player.playerConnection.sendPacket(new PacketPlayOutBlockBreak(blockposition, this.world.getType(blockposition), packetplayinblockdig_enumplayerdigtype, true, "stopped destroying"));
              } else if (packetplayinblockdig_enumplayerdigtype == PacketPlayInBlockDig.EnumPlayerDigType.ABORT_DESTROY_BLOCK) {
                  this.f = false;

--- a/Spigot-Server-Patches/0317-Add-more-Zombie-API.patch
+++ b/Spigot-Server-Patches/0317-Add-more-Zombie-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more Zombie API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 422632c9050d0bcc5398ac5d4cf51801cea9cdda..9b1297e564738eb40e6e9329817d8ebab11dce40 100644
+index f8b969b203cec7341382abf884a084cb4adbd7f9..f2776a9f78745f1bdd270d40b00a3123628c7c9b 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -33,6 +33,7 @@ public class EntityZombie extends EntityMonster {
+@@ -32,6 +32,7 @@ public class EntityZombie extends EntityMonster {
      private int bt;
      public int drownedConversionTime;
      private int lastTick = MinecraftServer.currentTick; // CraftBukkit - add field
@@ -16,7 +16,7 @@ index 422632c9050d0bcc5398ac5d4cf51801cea9cdda..9b1297e564738eb40e6e9329817d8eba
  
      public EntityZombie(EntityTypes<? extends EntityZombie> entitytypes, World world) {
          super(entitytypes, world);
-@@ -201,6 +202,12 @@ public class EntityZombie extends EntityMonster {
+@@ -200,6 +201,12 @@ public class EntityZombie extends EntityMonster {
          super.movementTick();
      }
  
@@ -29,7 +29,7 @@ index 422632c9050d0bcc5398ac5d4cf51801cea9cdda..9b1297e564738eb40e6e9329817d8eba
      public void startDrownedConversion(int i) {
          this.lastTick = MinecraftServer.currentTick; // CraftBukkit
          this.drownedConversionTime = i;
-@@ -229,9 +236,16 @@ public class EntityZombie extends EntityMonster {
+@@ -228,9 +235,16 @@ public class EntityZombie extends EntityMonster {
  
      }
  
@@ -47,7 +47,7 @@ index 422632c9050d0bcc5398ac5d4cf51801cea9cdda..9b1297e564738eb40e6e9329817d8eba
  
      @Override
      public boolean damageEntity(DamageSource damagesource, float f) {
-@@ -352,6 +366,7 @@ public class EntityZombie extends EntityMonster {
+@@ -351,6 +365,7 @@ public class EntityZombie extends EntityMonster {
          nbttagcompound.setBoolean("CanBreakDoors", this.eU());
          nbttagcompound.setInt("InWaterTime", this.isInWater() ? this.bt : -1);
          nbttagcompound.setInt("DrownedConversionTime", this.isDrownConverting() ? this.drownedConversionTime : -1);
@@ -55,7 +55,7 @@ index 422632c9050d0bcc5398ac5d4cf51801cea9cdda..9b1297e564738eb40e6e9329817d8eba
      }
  
      @Override
-@@ -363,7 +378,11 @@ public class EntityZombie extends EntityMonster {
+@@ -362,7 +377,11 @@ public class EntityZombie extends EntityMonster {
          if (nbttagcompound.hasKeyOfType("DrownedConversionTime", 99) && nbttagcompound.getInt("DrownedConversionTime") > -1) {
              this.startDrownedConversion(nbttagcompound.getInt("DrownedConversionTime"));
          }

--- a/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -28,10 +28,10 @@ index 27923a54b3ef297ca52707da1c38bebf6d9ab703..e33c751c259fe74d433991a4ac75f1e1
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.server.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 435cbeda2c667b9879527ca349a4c4f277f4904e..3f92b4b71649084968ad4daba1ea046a2b9a91e7 100644
+index 79f6984a8e5bb73daeae1725a11840556c398de2..9271ac8f0f5272f1eef751443dd0e9238b55f54e 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -99,6 +99,7 @@ public abstract class PlayerList {
+@@ -94,6 +94,7 @@ public abstract class PlayerList {
      }
  
      public void a(NetworkManager networkmanager, EntityPlayer entityplayer) {
@@ -106,7 +106,7 @@ index 00333548b470435aa89fb0f4b29047eb1461e992..5770d4183c1b9ab6119a25930283c023
      public Location getBedSpawnLocation() {
          NBTTagCompound data = getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3d8b118421364f20f8d7e4ac6c547f62816b3c43..78b6860a9b786a9ca74e76f1e550b43be369e699 100644
+index 24f53c01d596dac2d41fd23406ebcf455a0661df..42aa3e9c00a7a536a1576841660592e3497d2c49 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -142,6 +142,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0325-Fix-Custom-Shapeless-Custom-Crafting-Recipes.patch
+++ b/Spigot-Server-Patches/0325-Fix-Custom-Shapeless-Custom-Crafting-Recipes.patch
@@ -10,10 +10,10 @@ This made the Bukkit RecipeChoice API not work for Shapeless.
 This reimplements vanilla logic using the same test logic as Shaped
 
 diff --git a/src/main/java/net/minecraft/server/ShapelessRecipes.java b/src/main/java/net/minecraft/server/ShapelessRecipes.java
-index 7ba4196a9e71085c35e732b5440db3109121b195..61d88dbaa1f5c543be610ce0914b2c89d8ad40ee 100644
+index 821e4862429c2cef4144cdad2d7853881f383956..ecd63281912ae0ed93c5eb5ccb4249833cb23ab1 100644
 --- a/src/main/java/net/minecraft/server/ShapelessRecipes.java
 +++ b/src/main/java/net/minecraft/server/ShapelessRecipes.java
-@@ -63,16 +63,49 @@ public class ShapelessRecipes implements RecipeCrafting {
+@@ -64,16 +64,49 @@ public class ShapelessRecipes implements RecipeCrafting {
          AutoRecipeStackManager autorecipestackmanager = new AutoRecipeStackManager();
          int i = 0;
  

--- a/Spigot-Server-Patches/0326-Fix-sign-edit-memory-leak.patch
+++ b/Spigot-Server-Patches/0326-Fix-sign-edit-memory-leak.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix sign edit memory leak
 when a player edits a sign, a reference to their Entity is never cleand up.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index f7c91df1c2cc7ae5045ee3425e21d0b1af35a5cc..c333f492dbe6148776dbffd1e5afa5dc2f9af4a8 100644
+index 188af7af384ca35f2e659dfb1f7518dd06803be3..081077c3e00d424baa8f6a293c3a911da447cb69 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
 @@ -2694,7 +2694,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -19,10 +19,10 @@ index f7c91df1c2cc7ae5045ee3425e21d0b1af35a5cc..c333f492dbe6148776dbffd1e5afa5dc
                  this.sendPacket(tileentity.getUpdatePacket()); // CraftBukkit
                  return;
 diff --git a/src/main/java/net/minecraft/server/TileEntitySign.java b/src/main/java/net/minecraft/server/TileEntitySign.java
-index 2b249e7e2018a283b80b9462fbc129420e47ec06..7bee21d9ae9e8c27fe129605060455b55093afda 100644
+index 5d0c5d856a66ce6c0594b618e8f6e892585ce665..144975889a5a8dd9121b821695f6f35604bcbdb2 100644
 --- a/src/main/java/net/minecraft/server/TileEntitySign.java
 +++ b/src/main/java/net/minecraft/server/TileEntitySign.java
-@@ -11,6 +11,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
+@@ -10,6 +10,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
      private EntityHuman c;
      private final FormattedString[] g;
      private EnumColor color;
@@ -30,7 +30,7 @@ index 2b249e7e2018a283b80b9462fbc129420e47ec06..7bee21d9ae9e8c27fe129605060455b5
  
      public TileEntitySign() {
          super(TileEntityTypes.SIGN);
-@@ -112,7 +113,10 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
+@@ -111,7 +112,10 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
      }
  
      public void a(EntityHuman entityhuman) {

--- a/Spigot-Server-Patches/0328-Don-t-check-ConvertSigns-boolean-every-sign-save.patch
+++ b/Spigot-Server-Patches/0328-Don-t-check-ConvertSigns-boolean-every-sign-save.patch
@@ -7,10 +7,10 @@ property lookups arent super cheap. they synchronize, validate
 and check security managers.
 
 diff --git a/src/main/java/net/minecraft/server/TileEntitySign.java b/src/main/java/net/minecraft/server/TileEntitySign.java
-index 7bee21d9ae9e8c27fe129605060455b55093afda..2b9d5724c1b63f5e55010f9e3450004821c098a4 100644
+index 144975889a5a8dd9121b821695f6f35604bcbdb2..3c7847b1156a486e253a0e9f74a857e841d90619 100644
 --- a/src/main/java/net/minecraft/server/TileEntitySign.java
 +++ b/src/main/java/net/minecraft/server/TileEntitySign.java
-@@ -12,6 +12,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
+@@ -11,6 +11,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
      private final FormattedString[] g;
      private EnumColor color;
      public java.util.UUID signEditor; // Paper
@@ -18,7 +18,7 @@ index 7bee21d9ae9e8c27fe129605060455b55093afda..2b9d5724c1b63f5e55010f9e34500048
  
      public TileEntitySign() {
          super(TileEntityTypes.SIGN);
-@@ -32,7 +33,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
+@@ -31,7 +32,7 @@ public class TileEntitySign extends TileEntity implements ICommandListener { //
          }
  
          // CraftBukkit start

--- a/Spigot-Server-Patches/0331-MC-145260-Fix-Whitelist-On-Off-inconsistency.patch
+++ b/Spigot-Server-Patches/0331-MC-145260-Fix-Whitelist-On-Off-inconsistency.patch
@@ -11,10 +11,10 @@ everything to the Whitelist object.
 https://github.com/PaperMC/Paper/issues/1880
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index cdfa9359bbec27dcb59686019bbbffd5f43959c6..64fbe9f17d297fd71add78e72a8fa40ce52a3346 100644
+index 9271ac8f0f5272f1eef751443dd0e9238b55f54e..5be6a3d2ed8f51cb7490183ebb14ffe41cb0728d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -945,9 +945,9 @@ public abstract class PlayerList {
+@@ -940,9 +940,9 @@ public abstract class PlayerList {
      }
      public boolean isWhitelisted(GameProfile gameprofile, org.bukkit.event.player.PlayerLoginEvent loginEvent) {
          boolean isOp = this.operators.d(gameprofile);

--- a/Spigot-Server-Patches/0332-Set-Zombie-last-tick-at-start-of-drowning-process.patch
+++ b/Spigot-Server-Patches/0332-Set-Zombie-last-tick-at-start-of-drowning-process.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Set Zombie last tick at start of drowning process
 Fixes GH-1887
 
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 8c4a27721b66800c2d9b7bc6c1878b73b76b0df1..05d7b7a67bfc117a91903db5f303587a4f8f8624 100644
+index f2776a9f78745f1bdd270d40b00a3123628c7c9b..ab678bfa024ac3e963d5ca85a01c6df91dd6bc42 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -162,6 +162,7 @@ public class EntityZombie extends EntityMonster {
+@@ -161,6 +161,7 @@ public class EntityZombie extends EntityMonster {
                      ++this.bt;
                      if (this.bt >= 600) {
                          this.startDrownedConversion(300);

--- a/Spigot-Server-Patches/0334-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
+++ b/Spigot-Server-Patches/0334-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call WhitelistToggleEvent when whitelist is toggled
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 64fbe9f17d297fd71add78e72a8fa40ce52a3346..15f62a4e66b1a2f208019507f8adbaa1c316829c 100644
+index 5be6a3d2ed8f51cb7490183ebb14ffe41cb0728d..fbb2ba9c9f3c63a9dfd242a4ae72ec609cbe9609 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -1063,6 +1063,7 @@ public abstract class PlayerList {
+@@ -1058,6 +1058,7 @@ public abstract class PlayerList {
      }
  
      public void setHasWhitelist(boolean flag) {

--- a/Spigot-Server-Patches/0337-Entity-getEntitySpawnReason.patch
+++ b/Spigot-Server-Patches/0337-Entity-getEntitySpawnReason.patch
@@ -71,10 +71,10 @@ index 1aecc84479b00a019a5b68f5e726d1c2965ae0f7..c3a5db97fd85b31c6b4bce93527b9d0e
                              // Spigot Start
                              if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, blockposition).isCancelled()) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 15f62a4e66b1a2f208019507f8adbaa1c316829c..a3b1e4911b247a493e53710883f8ef36328ab68c 100644
+index fbb2ba9c9f3c63a9dfd242a4ae72ec609cbe9609..4d8c2ea8e067b81348d59a6d5c4c6c9ec3fbf929 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -263,7 +263,7 @@ public abstract class PlayerList {
+@@ -258,7 +258,7 @@ public abstract class PlayerList {
              // CraftBukkit start
              WorldServer finalWorldServer = worldserver1;
              Entity entity = EntityTypes.a(nbttagcompound1.getCompound("Entity"), finalWorldServer, (entity1) -> {
@@ -96,7 +96,7 @@ index f9d2228fb0543c60d2e0848afb4f927b6a7bce51..47229f73ede76176f884deb9ec623a68
          if (entity.valid) {
              MinecraftServer.LOGGER.error("Attempted Double World add on " + entity, new Throwable());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 8eff62bcdc424cd8c040fd95124d11009f27a0d6..1b722b5598043378c3a94856fa00a8bdf2b64718 100644
+index 91b9d82ec83876438d5c8c199313027bf942e89f..d3d0f432da363414f8bbe5c62ac4ecadaf2ad0e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1107,5 +1107,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/Spigot-Server-Patches/0339-Implement-PlayerPostRespawnEvent.patch
+++ b/Spigot-Server-Patches/0339-Implement-PlayerPostRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index a3b1e4911b247a493e53710883f8ef36328ab68c..ec9d1c98ec58ec6e938a18a1ec86ecc830f12d36 100644
+index 4d8c2ea8e067b81348d59a6d5c4c6c9ec3fbf929..10d03c4d2c31b47d2964bd9c6af7ce8e5aa74393 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -669,9 +669,14 @@ public abstract class PlayerList {
+@@ -664,9 +664,14 @@ public abstract class PlayerList {
          // this.a(entityplayer1, entityplayer, worldserver1); // CraftBukkit - removed
          boolean flag2 = false;
  
@@ -24,7 +24,7 @@ index a3b1e4911b247a493e53710883f8ef36328ab68c..ec9d1c98ec58ec6e938a18a1ec86ecc8
              WorldServer worldserver1 = this.server.getWorldServer(entityplayer.getSpawnDimension());
              if (worldserver1 != null) {
                  Optional optional;
-@@ -722,6 +727,7 @@ public abstract class PlayerList {
+@@ -717,6 +722,7 @@ public abstract class PlayerList {
  
              location = respawnEvent.getRespawnLocation();
              if (!flag) entityplayer.reset(); // SPIGOT-4785
@@ -32,7 +32,7 @@ index a3b1e4911b247a493e53710883f8ef36328ab68c..ec9d1c98ec58ec6e938a18a1ec86ecc8
          } else {
              location.setWorld(worldserver.getWorld());
          }
-@@ -779,6 +785,13 @@ public abstract class PlayerList {
+@@ -774,6 +780,13 @@ public abstract class PlayerList {
          if (entityplayer.playerConnection.isDisconnected()) {
              this.savePlayerFile(entityplayer);
          }

--- a/Spigot-Server-Patches/0340-don-t-go-below-0-for-pickupDelay-breaks-picking-up-i.patch
+++ b/Spigot-Server-Patches/0340-don-t-go-below-0-for-pickupDelay-breaks-picking-up-i.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] don't go below 0 for pickupDelay, breaks picking up items
 vanilla checks for == 0
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index fde34e4c0c95d23a006304f26339a60ea6cf51fa..765eb57ae017acf6cc800f86d0160ca5e3b7b230 100644
+index 3ba7bd0461d1c58c235cf0cda8d4eecf36b57407..001ddbe669c8c1a534a4e023386c00085ee1af95 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -60,6 +60,7 @@ public class EntityItem extends Entity {
+@@ -61,6 +61,7 @@ public class EntityItem extends Entity {
              // CraftBukkit start - Use wall time for pickup and despawn timers
              int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
              if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
@@ -17,7 +17,7 @@ index fde34e4c0c95d23a006304f26339a60ea6cf51fa..765eb57ae017acf6cc800f86d0160ca5
              if (this.age != -32768) this.age += elapsedTicks;
              this.lastTick = MinecraftServer.currentTick;
              // CraftBukkit end
-@@ -152,6 +153,7 @@ public class EntityItem extends Entity {
+@@ -153,6 +154,7 @@ public class EntityItem extends Entity {
          // CraftBukkit start - Use wall time for pickup and despawn timers
          int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
          if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;

--- a/Spigot-Server-Patches/0341-Server-Tick-Events.patch
+++ b/Spigot-Server-Patches/0341-Server-Tick-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Server Tick Events
 Fires event at start and end of a server tick
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 93aa20d82d867fee6df938096b0ad64d061fc61a..c4f1fa6bd54a1928d163d83807f2823029db54e6 100644
+index cf950c123151cea0f63fbc46c0c1b339c59c02b1..57f05599e64cb819e03c68e764934c9c306dabfb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1118,6 +1118,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1120,6 +1120,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
          // Paper end
@@ -17,7 +17,7 @@ index 93aa20d82d867fee6df938096b0ad64d061fc61a..c4f1fa6bd54a1928d163d83807f28230
  
          ++this.ticks;
          this.b(booleansupplier);
-@@ -1161,6 +1162,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1163,6 +1164,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
          // Paper end
  

--- a/Spigot-Server-Patches/0344-Add-Heightmap-API.patch
+++ b/Spigot-Server-Patches/0344-Add-Heightmap-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index f96ddcba26155bf179489b9d856305b90d1ae014..66aeb56325a5dab4ffe4879bf9c4a7414a184397 100644
+index 4c36abfa48b7f4fee2d118ff1d218f8ee5fbe007..342374450382fea241659f5b63a9cc9a17dcb7b8 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -610,8 +610,8 @@ public abstract class World implements GeneratorAccess, AutoCloseable {
@@ -20,10 +20,10 @@ index f96ddcba26155bf179489b9d856305b90d1ae014..66aeb56325a5dab4ffe4879bf9c4a741
  
          if (i >= -30000000 && j >= -30000000 && i < 30000000 && j < 30000000) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7e08032c968bb8405591082193b03badbe872436..e59a86d18de8ea1eff6afca6fed088df74ce5f2c 100644
+index 523f094b5d4572a04da36d68502fa0a22f239e61..3757ab5a2a0c6282d822c22415cc2861eba2f236 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -342,6 +342,29 @@ public class CraftWorld implements World {
+@@ -343,6 +343,29 @@ public class CraftWorld implements World {
          return getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,10 +16,10 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c4f1fa6bd54a1928d163d83807f2823029db54e6..83a0dc052683ad2de6843d49d2e2a861d94e8de2 100644
+index 57f05599e64cb819e03c68e764934c9c306dabfb..6d87fa38c5a84d5befcadf536413b1212bd1b604 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2071,7 +2071,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2073,7 +2073,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // CraftBukkit start
      @Override
      public boolean isMainThread() {
@@ -29,7 +29,7 @@ index c4f1fa6bd54a1928d163d83807f2823029db54e6..83a0dc052683ad2de6843d49d2e2a861
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c9ce183a8acfda1c639e6d808e90936f5a8d35a8..f420f41742efbd4f7bf02067768178bd8288848f 100644
+index aef36d33b4296769a02e9803be5e81b62931f45d..9550a5041e38937e381a2a4067b83434887f331d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1834,7 +1834,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
@@ -105,7 +105,7 @@ index 1dbeda9fb385be29b3bb20c33a0487334c6e7c16..595adbeb253529720e72f695667d5bf9
          this.uniqueID = uuid;
          this.ae = this.uniqueID.toString();
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 4bbcd00950405a4bf3ce391b557049a3b1d4aee8..2db0f3e060850ae65033f878ed46b678686a03f9 100644
+index 6d048fbb48444885051efcb83a55d32047ff6517..8370bb32f9ca5c88cea52b90a6f361ad5333bbb2 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -1,6 +1,7 @@
@@ -134,7 +134,7 @@ index 4bbcd00950405a4bf3ce391b557049a3b1d4aee8..2db0f3e060850ae65033f878ed46b678
  import java.util.concurrent.CompletableFuture;
  import java.util.concurrent.CompletionException;
  import java.util.concurrent.Executor;
-@@ -651,12 +655,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -652,12 +656,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                              // CraftBukkit start - these are spawned serialized (DefinedStructure) and we don't call an add event below at the moment due to ordering complexities
                              boolean needsRemoval = false;
                              if (chunk.needsDecoration && !this.world.getServer().getServer().getSpawnNPCs() && entity instanceof NPC) {
@@ -151,7 +151,7 @@ index 4bbcd00950405a4bf3ce391b557049a3b1d4aee8..2db0f3e060850ae65033f878ed46b678
                                  if (list == null) {
                                      list = Lists.newArrayList(new Entity[]{entity});
                                  } else {
-@@ -683,6 +687,44 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -684,6 +688,44 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          });
      }
  

--- a/Spigot-Server-Patches/0352-improve-CraftWorld-isChunkLoaded.patch
+++ b/Spigot-Server-Patches/0352-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e59a86d18de8ea1eff6afca6fed088df74ce5f2c..91eaa1964666607ec628d857ae4be8f94d2f89aa 100644
+index 3757ab5a2a0c6282d822c22415cc2861eba2f236..1a198ad238fb92c22a971e6fe540e9834eb65056 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -413,13 +413,13 @@ public class CraftWorld implements World {
+@@ -414,13 +414,13 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -21,10 +21,10 @@ index 38d25a12c6a52d8a83214e2a0f43a218cf15ceac..ffe9b1a63d78925e1d77b9e730aef42f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 83a0dc052683ad2de6843d49d2e2a861d94e8de2..816ab7ac0485f3eb80d461711800e84129f50d64 100644
+index 6d87fa38c5a84d5befcadf536413b1212bd1b604..ac512c5a1bd10b119a07c11dc6f8569005348ac8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -597,35 +597,36 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -599,35 +599,36 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      // CraftBukkit start
      public void loadSpawn(WorldLoadListener worldloadlistener, WorldServer worldserver) {
@@ -213,10 +213,10 @@ index 628d1a5555ec70571c0467900c884cc419cbab37..3a95b98b77171b4b18a1d939eb14953d
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index af411ac8fb378f7ead19b4f82f9709680e321dfd..d1fa8ebc9137e0d4917dc6b933b21588257d343e 100644
+index 1a198ad238fb92c22a971e6fe540e9834eb65056..0db39ef48c3f1a4c055185e70a09e5268115bd15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1959,15 +1959,21 @@ public class CraftWorld implements World {
+@@ -1973,15 +1973,21 @@ public class CraftWorld implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/Spigot-Server-Patches/0354-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
+++ b/Spigot-Server-Patches/0354-MC-114618-Fix-EntityAreaEffectCloud-from-going-negat.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] MC-114618 - Fix EntityAreaEffectCloud from going negative
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
-index f04204b8722a061a09e2b3cad6c67ab5fdd8f071..5b0ee830b45a677bf354b02cf4fd311d842e7678 100644
+index 6955fe7f7728987553d2a86fe3966deb5eea077d..35fb12c23bf46d3211ae5756fd604196bdc16da5 100644
 --- a/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
 +++ b/src/main/java/net/minecraft/server/EntityAreaEffectCloud.java
-@@ -175,6 +175,12 @@ public class EntityAreaEffectCloud extends Entity {
+@@ -176,6 +176,12 @@ public class EntityAreaEffectCloud extends Entity {
          super.tick();
          boolean flag = this.k();
          float f = this.getRadius();

--- a/Spigot-Server-Patches/0357-Chunk-debug-command.patch
+++ b/Spigot-Server-Patches/0357-Chunk-debug-command.patch
@@ -32,7 +32,7 @@ https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528273&page=com.atlass
 https://bugs.mojang.com/browse/MC-141484?focusedCommentId=528577&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-528577
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index f0a836db74ad3e20778d3863223bc9a35ff4ad41..e4719a5e7e5ebd91257a9c9b83fa1adad70fd585 100644
+index 600b1a36bb1287af4c0d91e52b7a30e7a3588ce4..2522ec624c53ca0718a8abbcb9c96d104f2f67fa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -28,14 +28,14 @@ public class PaperCommand extends Command {
@@ -203,7 +203,7 @@ index f0a836db74ad3e20778d3863223bc9a35ff4ad41..e4719a5e7e5ebd91257a9c9b83fa1ada
       * Ported from MinecraftForge - author: LexManos <LexManos@gmail.com> - License: LGPLv2.1
       */
 diff --git a/src/main/java/net/minecraft/server/ChunkProviderServer.java b/src/main/java/net/minecraft/server/ChunkProviderServer.java
-index b6ec5d0f281bac483f210fd8c45a8965cd97cc02..534bcc215b0efb8561f7489f01fe49d34cba4c4f 100644
+index 8017953af1df6c046a47ebe655e5d1afa68d50f8..af597b8b3157ac76456f8575a8f85a48fb0f45cd 100644
 --- a/src/main/java/net/minecraft/server/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/ChunkProviderServer.java
 @@ -24,7 +24,7 @@ import org.apache.logging.log4j.Logger;
@@ -417,7 +417,7 @@ index 816d55b17ea531bc2f25b92c003b127fe6e04112..2507bdf7bfa65f1bc728a46322d2a570
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index f6b83ced48aa649bbd58a9b8a8dfe460b961bc22..2c73bc1151d5d87ce6eac3f778ebff9c555b0212 100644
+index eefd94ef237657625f2e7b19099d802e7680b50a..b7af53dbf3139d7d51069e11388b945785cb47f6 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -29,7 +29,7 @@ public class PlayerChunk {
@@ -430,10 +430,10 @@ index f6b83ced48aa649bbd58a9b8a8dfe460b961bc22..2c73bc1151d5d87ce6eac3f778ebff9c
      private final ShortSet[] dirtyBlocks;
      private int r;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 2db0f3e060850ae65033f878ed46b678686a03f9..2e41af4f945f942c9a8f4b29464522ae07b12982 100644
+index 8370bb32f9ca5c88cea52b90a6f361ad5333bbb2..21c261e3cb4d82e358a8e5c1151f59e68b483fd5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -59,7 +59,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -60,7 +60,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final Long2ObjectLinkedOpenHashMap<PlayerChunk> updatingChunks = new Long2ObjectLinkedOpenHashMap();
      public volatile Long2ObjectLinkedOpenHashMap<PlayerChunk> visibleChunks;
      private final Long2ObjectLinkedOpenHashMap<PlayerChunk> pendingUnload;

--- a/Spigot-Server-Patches/0359-Fix-World-isChunkGenerated-calls.patch
+++ b/Spigot-Server-Patches/0359-Fix-World-isChunkGenerated-calls.patch
@@ -132,10 +132,10 @@ index b7af53dbf3139d7d51069e11388b945785cb47f6..2d749c07b159604e1ab904e026adf326
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 2e41af4f945f942c9a8f4b29464522ae07b12982..d8bedba819fa9ee0a4d3bdfbf0b010da7144dd68 100644
+index 21c261e3cb4d82e358a8e5c1151f59e68b483fd5..14288d7beaa9aea531b7eee16a4be4101d0380fa 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -938,12 +938,61 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -939,12 +939,61 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      @Nullable
@@ -277,7 +277,7 @@ index de926992e20da3ec433f9c7b4bc73805fd9d36ab..7a15944926427eb6cad976daabe5e710
          } catch (Throwable throwable1) {
              throwable = throwable1;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d1fa8ebc9137e0d4917dc6b933b21588257d343e..32c4b0089bc4ab1351e74e04b4e07c79beb9e328 100644
+index 0db39ef48c3f1a4c055185e70a09e5268115bd15..f750973175f15c782bd384c09a176e72979068d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -19,6 +19,7 @@ import java.util.Objects;
@@ -288,7 +288,7 @@ index d1fa8ebc9137e0d4917dc6b933b21588257d343e..32c4b0089bc4ab1351e74e04b4e07c79
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.server.ArraySetSorted;
-@@ -418,8 +419,22 @@ public class CraftWorld implements World {
+@@ -419,8 +420,22 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -312,7 +312,7 @@ index d1fa8ebc9137e0d4917dc6b933b21588257d343e..32c4b0089bc4ab1351e74e04b4e07c79
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -530,20 +545,49 @@ public class CraftWorld implements World {
+@@ -531,20 +546,49 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
@@ -62,10 +62,10 @@ index d340990000144d9500069824e7e6609400a54ece..71c7bf2fd4fdb0ad880ca81c198a7cf2
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 816ab7ac0485f3eb80d461711800e84129f50d64..cb551b24a103ff81459483d61050948840c27064 100644
+index ac512c5a1bd10b119a07c11dc6f8569005348ac8..7f63e60caac65a24909566e3f9a0f5ba5aa1575a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -152,6 +152,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -154,6 +154,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public static int currentTick = 0; // Paper - Further improve tick loop
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
@@ -73,7 +73,7 @@ index 816ab7ac0485f3eb80d461711800e84129f50d64..cb551b24a103ff81459483d610509488
      public CommandDispatcher vanillaCommandDispatcher;
      private boolean forceTicks;
      // CraftBukkit end
-@@ -1137,14 +1138,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1139,14 +1140,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.serverPing.b().a(agameprofile);
          }
  
@@ -171,7 +171,7 @@ index 2d749c07b159604e1ab904e026adf326eb9a732e..ad01b9333e73c8e4a7c848edc4ce252a
      public void a(ProtoChunkExtension protochunkextension) {
          for (int i = 0; i < this.statusFutures.length(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index d8bedba819fa9ee0a4d3bdfbf0b010da7144dd68..c4ed4d58f7b344626acb13baeb14288970a7bb90 100644
+index 14288d7beaa9aea531b7eee16a4be4101d0380fa..abe94c9b7262a67de1a93914d94550f5d0abed28 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -47,6 +47,7 @@ import java.util.function.Supplier;
@@ -182,7 +182,7 @@ index d8bedba819fa9ee0a4d3bdfbf0b010da7144dd68..c4ed4d58f7b344626acb13baeb142889
  import org.apache.commons.lang3.mutable.MutableBoolean;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -333,6 +334,64 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -334,6 +335,64 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -247,7 +247,7 @@ index d8bedba819fa9ee0a4d3bdfbf0b010da7144dd68..c4ed4d58f7b344626acb13baeb142889
      protected void save(boolean flag) {
          if (flag) {
              List<PlayerChunk> list = (List) this.visibleChunks.values().stream().filter(PlayerChunk::hasBeenLoaded).peek(PlayerChunk::m).collect(Collectors.toList());
-@@ -443,6 +502,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -444,6 +503,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                          this.world.unloadChunk(chunk);
                      }
@@ -255,7 +255,7 @@ index d8bedba819fa9ee0a4d3bdfbf0b010da7144dd68..c4ed4d58f7b344626acb13baeb142889
  
                      this.lightEngine.a(ichunkaccess.getPos());
                      this.lightEngine.queueUpdate();
-@@ -635,6 +695,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -636,6 +696,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      playerchunk.a(new ProtoChunkExtension(chunk));
                  }
  

--- a/Spigot-Server-Patches/0363-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0363-Anti-Xray.patch
@@ -1007,7 +1007,7 @@ index 0000000000000000000000000000000000000000..333763936897befda5bb6c077944d266
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 6b561332e89476dbecc0b2a044e8556c7fa70626..68a6e8e3425291eb28f1759ecdd54eb80612f3a4 100644
+index fa549cd2ab9d0665dc042f3d4e79e205eaf4da54..6763ecaf5f814302c310f29e3a5a42fc1312a990 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -427,7 +427,7 @@ public class Chunk implements IChunkAccess {
@@ -1330,10 +1330,10 @@ index 5fae0ec8933cef2b87d2f465c8019af0af2e130d..b9276928a58d56ca9aac95d262d85555
          }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index c4ed4d58f7b344626acb13baeb14288970a7bb90..325532e1585beefe1cb341580e0bb3e95020b6fe 100644
+index abe94c9b7262a67de1a93914d94550f5d0abed28..8f0590c2d5965b76083cb39f99f5ab4f33b01ed1 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -609,7 +609,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -610,7 +610,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
  
              this.g(chunkcoordintpair);
@@ -1342,7 +1342,7 @@ index c4ed4d58f7b344626acb13baeb14288970a7bb90..325532e1585beefe1cb341580e0bb3e9
          }, this.executor);
      }
  
-@@ -1349,9 +1349,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1350,9 +1350,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -1355,10 +1355,10 @@ index c4ed4d58f7b344626acb13baeb14288970a7bb90..325532e1585beefe1cb341580e0bb3e9
          }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 3056468a7e70238228b91be0f103cfbe111fedb5..cdaeeb8b01f084ae7a91f9681850a737af8a74be 100644
+index 21acea46a288348cbc2d4fa312035d6679987399..6ea691d81ea62bf05225baa303d974a6df0b822b 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -275,6 +275,8 @@ public class PlayerInteractManager {
+@@ -276,6 +276,8 @@ public class PlayerInteractManager {
              }
  
          }
@@ -1422,7 +1422,7 @@ index 420bf7116def909d3dd7dc9a799723446ddf8f7f..300cbb8b01d94e7eb0cded0c8e118103
      }
  
 diff --git a/src/main/java/net/minecraft/server/World.java b/src/main/java/net/minecraft/server/World.java
-index 66aeb56325a5dab4ffe4879bf9c4a7414a184397..5bb9cd2a9b00e908af700fa44944b2dd218b9653 100644
+index 342374450382fea241659f5b63a9cc9a17dcb7b8..16bc226dfef36b5f96d95f2de4c6bc2e6e606332 100644
 --- a/src/main/java/net/minecraft/server/World.java
 +++ b/src/main/java/net/minecraft/server/World.java
 @@ -2,6 +2,8 @@ package net.minecraft.server;
@@ -1463,7 +1463,7 @@ index 66aeb56325a5dab4ffe4879bf9c4a7414a184397..5bb9cd2a9b00e908af700fa44944b2dd
              if (iblockdata1 == null) {
                  // CraftBukkit start - remove blockstate if failed (or the same)
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index d43fe3564be139a935303a62047a8d74fd3b8d1f..b3af14ed0364e1b2e68656884dff678309498f03 100644
+index 3f97befa2742a575b103b68b19fc6415bfbd8c04..5ce589e38f924c1a60597589ea12d15dbc2a479c 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -100,7 +100,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
@@ -2950,10 +2950,10 @@ index 85f7cfa1fade8d574e7f85d857ab071c66ec4a95..e79ed0b5702688aaa5a86dc5a511c326
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataConverterRegistry.a(), minecraftsessionservice, gameprofilerepository, usercache, WorldLoadListenerLogger::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cb551b24a103ff81459483d61050948840c27064..04a149a4902790c6b6d3c54a1738fb0cf2d462f9 100644
+index 7f63e60caac65a24909566e3f9a0f5ba5aa1575a..3b2fd34a797089c191d397c3e39551c395f7cfce 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -801,7 +801,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -803,7 +803,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getUserCache().b(false); // Paper
          }
          // Spigot end
@@ -3055,10 +3055,10 @@ index ad01b9333e73c8e4a7c848edc4ce252a51ea52b6..25f8febe63167349460e32c831088bb8
                  completablefuture = (CompletableFuture) this.statusFutures.get(i);
                  if (completablefuture != null) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d43769215303d1f139e 100644
+index 8f0590c2d5965b76083cb39f99f5ab4f33b01ed1..fff3604936365cab07ca9f94a2aaf1dd41911eef 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -65,7 +65,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -66,7 +66,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private final LightEngineThreaded lightEngine;
      private final IAsyncTaskHandler<Runnable> executor;
      public final ChunkGenerator chunkGenerator;
@@ -3067,7 +3067,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      private final VillagePlace m;
      public final LongSet unloadQueue;
      private boolean updatingChunksModified;
-@@ -75,7 +75,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -76,7 +76,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final WorldLoadListener worldLoadListener;
      public final PlayerChunkMap.a chunkDistanceManager;
      private final AtomicInteger u;
@@ -3076,7 +3076,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      private final File w;
      private final PlayerMap playerMap;
      public final Int2ObjectMap<PlayerChunkMap.EntityTracker> trackedEntities;
-@@ -158,7 +158,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -159,7 +159,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.lightEngine = new LightEngineThreaded(ilightaccess, this, this.world.getDimensionManager().hasSkyLight(), threadedmailbox1, this.p.a(threadedmailbox1, false));
          this.chunkDistanceManager = new PlayerChunkMap.a(executor, iasynctaskhandler);
          this.l = supplier;
@@ -3085,7 +3085,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
          this.setViewDistance(i);
      }
  
-@@ -200,12 +200,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -201,12 +201,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      @Nullable
@@ -3100,7 +3100,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
          return (PlayerChunk) this.visibleChunks.get(i);
      }
  
-@@ -327,6 +327,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -328,6 +328,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public void close() throws IOException {
          try {
              this.p.close();
@@ -3108,7 +3108,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
              this.m.close();
          } finally {
              super.close();
-@@ -418,7 +419,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -419,7 +420,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.b(() -> {
                  return true;
              });
@@ -3118,7 +3118,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
              PlayerChunkMap.LOGGER.info("ThreadedAnvilChunkStorage ({}): All chunks are saved", this.w.getName());
          } else {
              this.visibleChunks.values().stream().filter(PlayerChunk::hasBeenLoaded).forEach((playerchunk) -> {
-@@ -434,16 +436,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -435,16 +437,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -3140,7 +3140,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
          }
  
          gameprofilerfiller.exit();
-@@ -464,12 +470,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -465,12 +471,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (playerchunk != null) {
                  this.pendingUnload.put(j, playerchunk);
                  this.updatingChunksModified = true;
@@ -3155,7 +3155,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
              }
          }
          activityAccountant.endActivity(); // Spigot
-@@ -483,6 +490,60 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -484,6 +491,60 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -3216,7 +3216,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      private void a(long i, PlayerChunk playerchunk) {
          CompletableFuture<IChunkAccess> completablefuture = playerchunk.getChunkSave();
          Consumer<IChunkAccess> consumer = (ichunkaccess) -> { // CraftBukkit - decompile error
-@@ -496,7 +557,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -497,7 +558,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ((Chunk) ichunkaccess).setLoaded(false);
                      }
  
@@ -3225,7 +3225,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
                      if (this.loadedChunks.remove(i) && ichunkaccess instanceof Chunk) {
                          Chunk chunk = (Chunk) ichunkaccess;
  
-@@ -504,6 +565,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -505,6 +566,13 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      }
                      this.autoSaveQueue.remove(playerchunk); // Paper
  
@@ -3239,7 +3239,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
                      this.lightEngine.a(ichunkaccess.getPos());
                      this.lightEngine.queueUpdate();
                      this.worldLoadListener.a(ichunkaccess.getPos(), (ChunkStatus) null);
-@@ -574,19 +642,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -575,19 +643,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      private CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> f(ChunkCoordIntPair chunkcoordintpair) {
@@ -3272,7 +3272,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
  
                          protochunk.setLastSaved(this.world.getTime());
                          this.a(chunkcoordintpair, protochunk.getChunkStatus().getType());
-@@ -610,7 +682,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -611,7 +683,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
              this.g(chunkcoordintpair);
              return Either.left(new ProtoChunk(chunkcoordintpair, ChunkConverter.a, this.world)); // Paper - Anti-Xray - Add parameter
@@ -3306,7 +3306,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      }
  
      private void g(ChunkCoordIntPair chunkcoordintpair) {
-@@ -837,6 +934,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -838,6 +935,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public boolean saveChunk(IChunkAccess ichunkaccess) {
@@ -3314,7 +3314,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
          this.m.a(ichunkaccess.getPos());
          if (!ichunkaccess.isNeedsSaving()) {
              return false;
-@@ -849,6 +947,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -850,6 +948,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  ChunkStatus chunkstatus = ichunkaccess.getChunkStatus();
  
                  if (chunkstatus.getType() != ChunkStatus.Type.LEVELCHUNK) {
@@ -3322,7 +3322,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
                      if (this.h(chunkcoordintpair)) {
                          return false;
                      }
-@@ -856,12 +955,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -857,12 +956,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      if (chunkstatus == ChunkStatus.EMPTY && ichunkaccess.h().values().stream().noneMatch(StructureStart::e)) {
                          return false;
                      }
@@ -3345,7 +3345,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
                  this.a(chunkcoordintpair, chunkstatus.getType());
                  return true;
              } catch (Exception exception) {
-@@ -870,6 +977,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -871,6 +978,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return false;
              }
          }
@@ -3353,7 +3353,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      }
  
      private boolean h(ChunkCoordIntPair chunkcoordintpair) {
-@@ -999,6 +1107,35 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1000,6 +1108,35 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
      }
  
@@ -3389,7 +3389,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      @Nullable
      public NBTTagCompound readChunkData(ChunkCoordIntPair chunkcoordintpair) throws IOException { // Paper - private -> public
          NBTTagCompound nbttagcompound = this.read(chunkcoordintpair);
-@@ -1020,33 +1157,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1021,33 +1158,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      // Paper start - chunk status cache "api"
      public ChunkStatus getChunkStatusOnDiskIfCached(ChunkCoordIntPair chunkPos) {
@@ -3456,7 +3456,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      }
  
      public IChunkAccess getUnloadingChunk(int chunkX, int chunkZ) {
-@@ -1055,6 +1214,39 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1056,6 +1215,39 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end
  
@@ -3496,7 +3496,7 @@ index 325532e1585beefe1cb341580e0bb3e95020b6fe..7f72d13bb39182666a741d4376921530
      boolean isOutsideOfRange(ChunkCoordIntPair chunkcoordintpair) {
          // Spigot start
          return isOutsideOfRange(chunkcoordintpair, false);
-@@ -1401,6 +1593,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1402,6 +1594,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -4015,7 +4015,7 @@ index 6f9c3f913b2afbde3b5e285ffb9ee49017fa5464..85c9943a32f21e338daa295d5034af37
      }
      public void removeTicketsForSpawn(int radiusInBlocks, BlockPosition spawn) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 32c4b0089bc4ab1351e74e04b4e07c79beb9e328..83d1c748c0dd3004c4a479ca58f634d6a9b6faf4 100644
+index f750973175f15c782bd384c09a176e72979068d9..dbfc080be333dfd165da5bf300282b17fd35b9b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -75,6 +75,7 @@ import net.minecraft.server.IBlockData;
@@ -4026,7 +4026,7 @@ index 32c4b0089bc4ab1351e74e04b4e07c79beb9e328..83d1c748c0dd3004c4a479ca58f634d6
  import net.minecraft.server.MovingObjectPosition;
  import net.minecraft.server.PacketPlayOutCustomSoundEffect;
  import net.minecraft.server.PacketPlayOutUpdateTime;
-@@ -563,22 +564,23 @@ public class CraftWorld implements World {
+@@ -564,22 +565,23 @@ public class CraftWorld implements World {
                  return true;
              }
  
@@ -4058,7 +4058,7 @@ index 32c4b0089bc4ab1351e74e04b4e07c79beb9e328..83d1c748c0dd3004c4a479ca58f634d6
  
              // fall through to load
              // we do this so we do not re-read the chunk data on disk
-@@ -2489,6 +2491,34 @@ public class CraftWorld implements World {
+@@ -2503,6 +2505,34 @@ public class CraftWorld implements World {
      public DragonBattle getEnderDragonBattle() {
          return (getHandle().getDragonBattle() == null) ? null : new CraftDragonBattle(getHandle().getDragonBattle());
      }
@@ -4094,7 +4094,7 @@ index 32c4b0089bc4ab1351e74e04b4e07c79beb9e328..83d1c748c0dd3004c4a479ca58f634d6
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 1b722b5598043378c3a94856fa00a8bdf2b64718..017410819a628c1b373f45ac5a0e9f00dd56639e 100644
+index d3d0f432da363414f8bbe5c62ac4ecadaf2ad0e4..84a39736a131338c27ffe202d45ac1f74409d4b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -509,6 +509,28 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/Spigot-Server-Patches/0372-Implement-alternative-item-despawn-rate.patch
+++ b/Spigot-Server-Patches/0372-Implement-alternative-item-despawn-rate.patch
@@ -78,18 +78,18 @@ index 1ee2cced100626e48eb36ee14f84b9257c79a2f8..b913cd2dd0cd1b369b3f7b5a9d8b1be7
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index 765eb57ae017acf6cc800f86d0160ca5e3b7b230..b832c8df8ee08d7e00c5d7763baa51ff37259880 100644
+index 001ddbe669c8c1a534a4e023386c00085ee1af95..4a20ceaf649f91860047017028809cd8040c9e58 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -6,6 +6,7 @@ import java.util.Objects;
- import java.util.UUID;
+@@ -7,6 +7,7 @@ import java.util.UUID;
  import javax.annotation.Nullable;
+ 
  // CraftBukkit start
 +import org.bukkit.Material; // Paper
  import org.bukkit.event.entity.EntityPickupItemEvent;
  import org.bukkit.event.player.PlayerPickupItemEvent;
  // CraftBukkit end
-@@ -134,7 +135,7 @@ public class EntityItem extends Entity {
+@@ -135,7 +136,7 @@ public class EntityItem extends Entity {
                  }
              }
  
@@ -98,7 +98,7 @@ index 765eb57ae017acf6cc800f86d0160ca5e3b7b230..b832c8df8ee08d7e00c5d7763baa51ff
                  // CraftBukkit start - fire ItemDespawnEvent
                  if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
                      this.age = 0;
-@@ -158,7 +159,7 @@ public class EntityItem extends Entity {
+@@ -159,7 +160,7 @@ public class EntityItem extends Entity {
          this.lastTick = MinecraftServer.currentTick;
          // CraftBukkit end
  
@@ -107,7 +107,7 @@ index 765eb57ae017acf6cc800f86d0160ca5e3b7b230..b832c8df8ee08d7e00c5d7763baa51ff
              // CraftBukkit start - fire ItemDespawnEvent
              if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
                  this.age = 0;
-@@ -508,9 +509,16 @@ public class EntityItem extends Entity {
+@@ -509,9 +510,16 @@ public class EntityItem extends Entity {
  
      public void s() {
          this.o();

--- a/Spigot-Server-Patches/0373-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/Spigot-Server-Patches/0373-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -7,10 +7,10 @@ If the Bukkit generator already has a spawn, use it immediately instead
 of spending time generating one that we won't use
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 04a149a4902790c6b6d3c54a1738fb0cf2d462f9..410e63e4d15fa6ba85683694444cd49c53446574 100644
+index 3b2fd34a797089c191d397c3e39551c395f7cfce..5c1f4ceb02908893b44e9e6120d3b278847141d4 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -509,12 +509,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -511,12 +511,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          } else if (flag1) {
              iworlddataserver.setSpawn(BlockPosition.ZERO.up(), 0.0F);
          } else {
@@ -24,7 +24,7 @@ index 04a149a4902790c6b6d3c54a1738fb0cf2d462f9..410e63e4d15fa6ba85683694444cd49c
              // CraftBukkit start
              if (worldserver.generator != null) {
                  Random rand = new Random(worldserver.getSeed());
-@@ -530,6 +525,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -532,6 +527,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  }
              }
              // CraftBukkit end

--- a/Spigot-Server-Patches/0374-Fix-MC-158900.patch
+++ b/Spigot-Server-Patches/0374-Fix-MC-158900.patch
@@ -7,10 +7,10 @@ The problem was we were checking isExpired() on the entry, but if it
 was expired at that point, then it would be null.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index ec9d1c98ec58ec6e938a18a1ec86ecc830f12d36..1b9781cc301aa09190cceaf9165500d044db5de4 100644
+index 10d03c4d2c31b47d2964bd9c6af7ce8e5aa74393..e0f075aade555ad3129ec0de47ee0ef0263953fe 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -535,8 +535,10 @@ public abstract class PlayerList {
+@@ -530,8 +530,10 @@ public abstract class PlayerList {
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.networkManager.getRawAddress()).getAddress());
  

--- a/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
@@ -573,7 +573,7 @@ index 070c3a842ebd9fa03e5daaee8355775718df6fb2..1eb201695cd118616fb404a0c7ed8ced
  
              this.p = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 763edf6a18401f9f7a84ae99a7ee2eb114a5791c..bf68562b08b8d8fecb25a469b4fb4dbc868b0f28 100644
+index 12f6d9a1cf64a182e94bfe6cfade8a861acfd6a2..92d0ccb9eddae6041e39a6dc06ad0c277bca3d1d 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -91,6 +91,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -617,10 +617,10 @@ index 14f47d100c3f44a8263c9b907e9ca74944676687..c49e7ec418eedac45182de67cb673839
          return this.bg;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 7f72d13bb39182666a741d43769215303d1f139e..a167696d2fc3cb69b9eaa720c5904762e073008b 100644
+index fff3604936365cab07ca9f94a2aaf1dd41911eef..938439d22f47fb18b36c145c4f4ea355f8405673 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -81,7 +81,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -82,7 +82,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final Int2ObjectMap<PlayerChunkMap.EntityTracker> trackedEntities;
      private final Long2ByteMap z;
      private final Queue<Runnable> A; private final Queue<Runnable> getUnloadQueueTasks() { return this.A; } // Paper - OBFHELPER
@@ -630,7 +630,7 @@ index 7f72d13bb39182666a741d43769215303d1f139e..a167696d2fc3cb69b9eaa720c5904762
  
      // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
      public final CallbackExecutor callbackExecutor = new CallbackExecutor();
-@@ -160,6 +161,24 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -161,6 +162,24 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.l = supplier;
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, flag, this.world); // Paper
          this.setViewDistance(i);

--- a/Spigot-Server-Patches/0381-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
+++ b/Spigot-Server-Patches/0381-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix spawning of hanging entities that are not ItemFrames and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 83d1c748c0dd3004c4a479ca58f634d6a9b6faf4..6ddfeea46997907f1dd666000c7cc2eb27cd4398 100644
+index dbfc080be333dfd165da5bf300282b17fd35b9b6..1d76bf1045cd27e70c115ba490ceb5854b996604 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1880,7 +1880,12 @@ public class CraftWorld implements World {
+@@ -1894,7 +1894,12 @@ public class CraftWorld implements World {
                  height = 9;
              }
  

--- a/Spigot-Server-Patches/0383-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
+++ b/Spigot-Server-Patches/0383-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix stuck in sneak when changing worlds (MC-10657)
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index bf68562b08b8d8fecb25a469b4fb4dbc868b0f28..c71a2264438317d1d36ddf56813ccd1cabd32c79 100644
+index 92d0ccb9eddae6041e39a6dc06ad0c277bca3d1d..03730ae7a3e1464a406ddc8ea606a6046fb93d8a 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -944,6 +944,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -18,10 +18,10 @@ index bf68562b08b8d8fecb25a469b4fb4dbc868b0f28..c71a2264438317d1d36ddf56813ccd1c
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.world.getServer().getPluginManager().callEvent(changeEvent);
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 1b9781cc301aa09190cceaf9165500d044db5de4..7534c8d31f08b80d77aff29ca4822bc07b1ad8eb 100644
+index e0f075aade555ad3129ec0de47ee0ef0263953fe..bd8d2e60a1d0609d03978328b44516a18a0d2553 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -774,6 +774,8 @@ public abstract class PlayerList {
+@@ -769,6 +769,8 @@ public abstract class PlayerList {
              entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityEffect(entityplayer.getId(), mobEffect));
          }
  

--- a/Spigot-Server-Patches/0390-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0390-Optimize-Hoppers.patch
@@ -73,10 +73,10 @@ index 7ad595d5d7e090c523aa45a10d0f84b609ea86df..e3e2ecfcc6dabf02844551d94138e6c6
              itemstack.d(this.D());
              if (this.tag != null) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 410e63e4d15fa6ba85683694444cd49c53446574..a4913a0836f1c223af42e6fbbf7bb314332eef23 100644
+index 5c1f4ceb02908893b44e9e6120d3b278847141d4..0176fdd76ad1f3c281319d07c3ff463bde0e8b47 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1241,6 +1241,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1243,6 +1243,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
@@ -85,10 +85,10 @@ index 410e63e4d15fa6ba85683694444cd49c53446574..a4913a0836f1c223af42e6fbbf7bb314
              this.methodProfiler.a(() -> {
                  return worldserver + " " + worldserver.getDimensionKey().a();
 diff --git a/src/main/java/net/minecraft/server/TileEntity.java b/src/main/java/net/minecraft/server/TileEntity.java
-index 34d92491830c99172bec5251fa80300b6315e5ef..58d958a88ac5af5b889d719d9f1ea90ce45cf184 100644
+index c6ae3d3f9d7957d4bbe0b4e2613558e5cd9dd9ec..060c1206e4b5da6be50fff605894fb2a46f57c1b 100644
 --- a/src/main/java/net/minecraft/server/TileEntity.java
 +++ b/src/main/java/net/minecraft/server/TileEntity.java
-@@ -63,6 +63,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -66,6 +66,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
      public void setCurrentChunk(Chunk chunk) {
          this.currentChunk = chunk != null ? new java.lang.ref.WeakReference<>(chunk) : null;
      }
@@ -96,7 +96,7 @@ index 34d92491830c99172bec5251fa80300b6315e5ef..58d958a88ac5af5b889d719d9f1ea90c
      // Paper end
  
      @Nullable
-@@ -141,6 +142,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
+@@ -144,6 +145,7 @@ public abstract class TileEntity implements KeyedObject { // Paper
  
      public void update() {
          if (this.world != null) {

--- a/Spigot-Server-Patches/0396-Fix-items-not-falling-correctly.patch
+++ b/Spigot-Server-Patches/0396-Fix-items-not-falling-correctly.patch
@@ -15,10 +15,10 @@ This patch resolves the conflict by offsetting checking an item's
 move method from Spigot's entity activation range check.
 
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index b832c8df8ee08d7e00c5d7763baa51ff37259880..ba73d14437cfdf07ef0f1f6266131c113c2741fd 100644
+index 4a20ceaf649f91860047017028809cd8040c9e58..0e75d97254c73b2525380024b41a42f56d87b3a5 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -89,7 +89,7 @@ public class EntityItem extends Entity {
+@@ -90,7 +90,7 @@ public class EntityItem extends Entity {
                  }
              }
  

--- a/Spigot-Server-Patches/0401-Tracking-Range-Improvements.patch
+++ b/Spigot-Server-Patches/0401-Tracking-Range-Improvements.patch
@@ -8,10 +8,10 @@ Sets tracking range of watermobs to animals instead of misc and simplifies code
 Also ignores Enderdragon, defaulting it to Mojang's setting
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index a167696d2fc3cb69b9eaa720c5904762e073008b..74df45e6c3f86736f7d136cf6fd911d5b574221d 100644
+index 938439d22f47fb18b36c145c4f4ea355f8405673..08eaaabb712c7a6c9b6631d62874a72e96bf73d5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1740,6 +1740,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1741,6 +1741,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              while (iterator.hasNext()) {
                  Entity entity = (Entity) iterator.next();
                  int j = entity.getEntityType().getChunkRange() * 16;

--- a/Spigot-Server-Patches/0402-Entity-Activation-Range-2.0.patch
+++ b/Spigot-Server-Patches/0402-Entity-Activation-Range-2.0.patch
@@ -118,7 +118,7 @@ index 800a8dd2543f0b83eec67e780510427467649d5d..73ceb0f14610fe1d4d55542dad957b1f
          if (this.isPassenger() && this.getVehicle() instanceof EntityInsentient) {
              EntityInsentient entityinsentient = (EntityInsentient) this.getVehicle();
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index cfc4422aaaf79a7b198f7991d422f887574f59e0..5d8c2f2b002945f5d6c26d61d2c3cffe4c84ec81 100644
+index 9bb211e8cf32e8741566a8d7580d559a112c3d76..fe02b3c02bb6ad47646e6abd4b35d0a6d7510952 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -98,7 +98,7 @@ public abstract class EntityLiving extends Entity {
@@ -143,10 +143,10 @@ index 65cbe073da6a035f1ac539908a3fa8dbf0f42808..d9e1b43283bee15c659dd3a99e45d941
          return this.bB != null;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971..bb096fd5fa20aead7df0188ae294da9c813abace 100644
+index 3a6992a5763238996847a8e59b650606a384e4ff..ee9b1736be7c8fa3324871faa0007fb4781082b8 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -144,17 +144,29 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -142,17 +142,29 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
      @Override
      public void inactiveTick() {
          // SPIGOT-3874, SPIGOT-3894, SPIGOT-3846, SPIGOT-5286 :(
@@ -180,7 +180,7 @@ index b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971..bb096fd5fa20aead7df0188ae294da9c
          this.world.getMethodProfiler().exit();
          if (this.bF) {
              this.bF = false;
-@@ -178,7 +190,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -176,7 +188,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
              this.bv = null;
          }
  
@@ -189,7 +189,7 @@ index b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971..bb096fd5fa20aead7df0188ae294da9c
              Raid raid = ((WorldServer) this.world).b_(this.getChunkCoordinates());
  
              if (raid != null && raid.v() && !raid.a()) {
-@@ -189,6 +201,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -187,6 +199,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
          if (this.getVillagerData().getProfession() == VillagerProfession.NONE && this.eN()) {
              this.eT();
          }
@@ -197,7 +197,7 @@ index b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971..bb096fd5fa20aead7df0188ae294da9c
  
          super.mobTick();
      }
-@@ -825,6 +838,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -823,6 +836,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
          }
      }
  
@@ -206,10 +206,10 @@ index b6ad33b3bfc1a71d3e4495c803cba12ee3c2a971..bb096fd5fa20aead7df0188ae294da9c
          long i = this.world.getTime();
  
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-index ed73f74e4de4b9d737819d7fda213421801e9c54..74ca39067e7538eac5d70031564d0508846204a5 100644
+index d4f43127f02fc67dde4522199ceac45e42b2b25f..f5865052261cb49c3f853e4d65e21831c83c2ea0 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-@@ -44,10 +44,12 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -45,10 +45,12 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
          return super.prepare(worldaccess, difficultydamagescaler, enummobspawn, (GroupDataEntity) groupdataentity, nbttagcompound);
      }
  

--- a/Spigot-Server-Patches/0410-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0410-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -19,10 +19,10 @@ index 7fbd501d70dccf869a4454e2789a5d68f2e15754..9e4591ddc4b755f4ff5a6f1078b51cb1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/BlockPortal.java b/src/main/java/net/minecraft/server/BlockPortal.java
-index a224a04ee1bb9705166913ef1c66aa031d87c270..4132cd4c6f13cfa1c0cda43daaa908ff3c07f32b 100644
+index 17e5961e4a1f41f7ad07a4bf2cdfa796758046e0..bd78d55ee94f1359739a9d790092d07c613eac0f 100644
 --- a/src/main/java/net/minecraft/server/BlockPortal.java
 +++ b/src/main/java/net/minecraft/server/BlockPortal.java
-@@ -44,6 +44,8 @@ public class BlockPortal extends Block {
+@@ -41,6 +41,8 @@ public class BlockPortal extends Block {
  
                  if (entity != null) {
                      entity.resetPortalCooldown();
@@ -32,7 +32,7 @@ index a224a04ee1bb9705166913ef1c66aa031d87c270..4132cd4c6f13cfa1c0cda43daaa908ff
              }
          }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 2a12dd777d881a9231f8e241aee65db60792a110..cabbc9019d6b6fe174b0be61b7f18a2db4702987 100644
+index 1f23d9d1e0054e55f410c1d901c33db708c0b621..f124527c4f727383c6da4eaa503b69112b583e32 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -189,6 +189,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke

--- a/Spigot-Server-Patches/0411-Make-the-GUI-graph-fancier.patch
+++ b/Spigot-Server-Patches/0411-Make-the-GUI-graph-fancier.patch
@@ -398,10 +398,10 @@ index d4d5bc19e167a5271f8eb8d010f8a52b23b942df..859e31c63f94bdc7729c6d475990750b
      });
      private final int[] b = new int[256];
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a4913a0836f1c223af42e6fbbf7bb314332eef23..272f05ac46f9fc2d430f70535a7a44cebea2dbda 100644
+index 0176fdd76ad1f3c281319d07c3ff463bde0e8b47..f625ed0ac4a1740c2b0fdf2a7e6b92fdcfdb1dce 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -106,7 +106,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -108,7 +108,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private String motd;
      private int F;
      private int G;

--- a/Spigot-Server-Patches/0416-Configurable-chance-of-villager-zombie-infection.patch
+++ b/Spigot-Server-Patches/0416-Configurable-chance-of-villager-zombie-infection.patch
@@ -22,10 +22,10 @@ index fe1c9dd8258ec8c3fdf343d4a44de2be2ae3d35f..525d702d78a609af987ebd2c32169b87
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index b7dc265ea684b71cc94e9a0542dad484864c0e30..360f14a3128f9a4c31fadb5a6f245d15845c8ae0 100644
+index ab678bfa024ac3e963d5ca85a01c6df91dd6bc42..555c74feb0d678d8f05d89e274f4736fc35ffebf 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -389,10 +389,14 @@ public class EntityZombie extends EntityMonster {
+@@ -388,10 +388,14 @@ public class EntityZombie extends EntityMonster {
      @Override
      public void a(WorldServer worldserver, EntityLiving entityliving) {
          super.a(worldserver, entityliving);

--- a/Spigot-Server-Patches/0424-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/Spigot-Server-Patches/0424-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,10 +7,10 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 74df45e6c3f86736f7d136cf6fd911d5b574221d..21dfbbdbe72a7562601e23384e2fec8f9393ef29 100644
+index 08eaaabb712c7a6c9b6631d62874a72e96bf73d5..9600ded94f127da50e05129aa00e5b0979b973a3 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1446,6 +1446,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1447,6 +1447,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      protected void addEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
@@ -26,7 +26,7 @@ index 74df45e6c3f86736f7d136cf6fd911d5b574221d..21dfbbdbe72a7562601e23384e2fec8f
              EntityTypes<?> entitytypes = entity.getEntityType();
              int i = entitytypes.getChunkRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 0543f5f30340e367511ec282ea67b611168c6000..d018cbee11356110aace897b1dd4516dd3ca5b61 100644
+index cd04994ed38c7f5d4db6b1ef1796f95ef2c490e1..cbfe3cc34922c4dffb3dea5a279970072de1daae 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1417,7 +1417,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0425-Optimize-Collision-to-not-load-chunks.patch
+++ b/Spigot-Server-Patches/0425-Optimize-Collision-to-not-load-chunks.patch
@@ -40,10 +40,10 @@ index 7bb0843d76864fc10575532745eb63f9ca478354..25e54a1fadc5d31fb250a3f47524b4f3
  
      Stream<VoxelShape> c(@Nullable Entity entity, AxisAlignedBB axisalignedbb, Predicate<Entity> predicate);
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 7534c8d31f08b80d77aff29ca4822bc07b1ad8eb..d4bf928ccfb31903b2fe69e2c5d78127d7f77721 100644
+index bd8d2e60a1d0609d03978328b44516a18a0d2553..73a29023767e6452cd263564c9bce3fb52e93312 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -737,6 +737,7 @@ public abstract class PlayerList {
+@@ -732,6 +732,7 @@ public abstract class PlayerList {
          entityplayer1.forceSetPositionRotation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
          // CraftBukkit end
  

--- a/Spigot-Server-Patches/0428-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/Spigot-Server-Patches/0428-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -83,10 +83,10 @@ index c470c6527b214026c230feaae0c0875c86dea673..df3150072fd36dac28d83309e50342c9
              List<PlayerChunk> allChunks = new ArrayList<>(visibleChunks.values());
              List<EntityPlayer> players = world.players;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa6fdb4d5e 100644
+index 9600ded94f127da50e05129aa00e5b0979b973a3..2622e418cde9f70e38e8d28d7dfde5c3879f520f 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -57,8 +57,33 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -58,8 +58,33 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      private static final Logger LOGGER = LogManager.getLogger();
      public static final int GOLDEN_TICKET = 33 + ChunkStatus.b();
@@ -122,7 +122,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
      private final Long2ObjectLinkedOpenHashMap<PlayerChunk> pendingUnload;
      final LongSet loadedChunks; // Paper - private -> package
      public final WorldServer world;
-@@ -131,7 +156,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -132,7 +157,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      public PlayerChunkMap(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i, boolean flag) {
          super(new File(convertable_conversionsession.a(worldserver.getDimensionKey()), "region"), datafixer, flag);
@@ -131,7 +131,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
          this.pendingUnload = new Long2ObjectLinkedOpenHashMap();
          this.loadedChunks = new LongOpenHashSet();
          this.unloadQueue = new LongOpenHashSet();
-@@ -223,9 +248,52 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -224,9 +249,52 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return (PlayerChunk) this.updatingChunks.get(i);
      }
  
@@ -185,7 +185,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
      }
  
      protected IntSupplier c(long i) {
-@@ -413,8 +481,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -414,8 +482,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      // Paper end
  
      protected void save(boolean flag) {
@@ -196,7 +196,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
              MutableBoolean mutableboolean = new MutableBoolean();
  
              do {
-@@ -442,7 +511,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -443,7 +512,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  //            this.i(); // Paper - nuke IOWorker
              PlayerChunkMap.LOGGER.info("ThreadedAnvilChunkStorage ({}): All chunks are saved", this.w.getName());
          } else {
@@ -205,7 +205,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
                  IChunkAccess ichunkaccess = (IChunkAccess) playerchunk.getChunkSave().getNow(null); // CraftBukkit - decompile error
  
                  if (ichunkaccess instanceof ProtoChunkExtension || ichunkaccess instanceof Chunk) {
-@@ -613,7 +682,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -614,7 +683,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          if (!this.updatingChunksModified) {
              return false;
          } else {
@@ -227,7 +227,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
              this.updatingChunksModified = false;
              return true;
          }
-@@ -1084,12 +1166,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1085,12 +1167,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      protected Iterable<PlayerChunk> f() {
@@ -243,7 +243,7 @@ index 21dfbbdbe72a7562601e23384e2fec8f9393ef29..87de764f74e8174da4c1a28238375caa
          while (objectbidirectionaliterator.hasNext()) {
              Entry<PlayerChunk> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6ddfeea46997907f1dd666000c7cc2eb27cd4398..756c675939c5f5835736e6b8c42ae20941712c49 100644
+index 1d76bf1045cd27e70c115ba490ceb5854b996604..c11f6e647957c353e78f6331de74264079566e1b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -74,6 +74,7 @@ import net.minecraft.server.GroupDataEntity;
@@ -254,7 +254,7 @@ index 6ddfeea46997907f1dd666000c7cc2eb27cd4398..756c675939c5f5835736e6b8c42ae209
  import net.minecraft.server.MinecraftKey;
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.MovingObjectPosition;
-@@ -294,6 +295,7 @@ public class CraftWorld implements World {
+@@ -295,6 +296,7 @@ public class CraftWorld implements World {
          return ret;
      }
      public int getTileEntityCount() {
@@ -262,7 +262,7 @@ index 6ddfeea46997907f1dd666000c7cc2eb27cd4398..756c675939c5f5835736e6b8c42ae209
          // We don't use the full world tile entity list, so we must iterate chunks
          Long2ObjectLinkedOpenHashMap<PlayerChunk> chunks = world.getChunkProvider().playerChunkMap.visibleChunks;
          int size = 0;
-@@ -305,11 +307,13 @@ public class CraftWorld implements World {
+@@ -306,11 +308,13 @@ public class CraftWorld implements World {
              size += chunk.tileEntities.size();
          }
          return size;
@@ -276,7 +276,7 @@ index 6ddfeea46997907f1dd666000c7cc2eb27cd4398..756c675939c5f5835736e6b8c42ae209
          int ret = 0;
  
          for (PlayerChunk chunkHolder : world.getChunkProvider().playerChunkMap.visibleChunks.values()) {
-@@ -318,7 +322,7 @@ public class CraftWorld implements World {
+@@ -319,7 +323,7 @@ public class CraftWorld implements World {
              }
          }
  
@@ -285,7 +285,7 @@ index 6ddfeea46997907f1dd666000c7cc2eb27cd4398..756c675939c5f5835736e6b8c42ae209
      }
      public int getPlayerCount() {
          return world.players.size();
-@@ -443,6 +447,14 @@ public class CraftWorld implements World {
+@@ -444,6 +448,14 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {

--- a/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
@@ -28,10 +28,10 @@ index 6c8e9d498c9a30a1aa88494ba09c3cae012a8fa1..cd248eb6be663e8be33f2c3c6b06b77b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 272f05ac46f9fc2d430f70535a7a44cebea2dbda..96a784744110e7dd4939eb2c1b57346a2d60f983 100644
+index f625ed0ac4a1740c2b0fdf2a7e6b92fdcfdb1dce..0f38b3acb8d40bc4753275045db5861945865b35 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -655,7 +655,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -657,7 +657,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.executeModerately();
          // CraftBukkit end
          worldloadlistener.b();

--- a/Spigot-Server-Patches/0430-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/Spigot-Server-Patches/0430-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -135,10 +135,10 @@ index 475e35a5d3f25929e60ef34d7f41e2db193443ef..1f63cdd9588a8dda1f04154f4d9de21f
          protected boolean executeNext() {
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a258821e7b 100644
+index 0f38b3acb8d40bc4753275045db5861945865b35..2438a50ca1923b028c4848c80248bac61b80d1af 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -935,6 +935,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -937,6 +937,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                          // Paper end
                          tickSection = curTime;
                      }
@@ -146,7 +146,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
                      // Spigot end
  
                      //MinecraftServer.currentTick = (int) (System.currentTimeMillis() / 50); // CraftBukkit // Paper - don't overwrite current tick time
-@@ -1004,7 +1005,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1006,7 +1007,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      }
  
@@ -155,7 +155,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
          // CraftBukkit start
          if (isOversleep) return canOversleep();// Paper - because of our changes, this logic is broken
          return this.forceTicks || this.isEntered() || SystemUtils.getMonotonicMillis() < (this.X ? this.W : this.nextTick);
-@@ -1034,6 +1035,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1036,6 +1037,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          });
      }
  
@@ -179,7 +179,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
      @Override
      protected TickTask postToMainThread(Runnable runnable) {
          return new TickTask(this.ticks, runnable);
-@@ -1120,6 +1138,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1122,6 +1140,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // Paper start - move oversleep into full server tick
          isOversleep = true;MinecraftTimings.serverOversleep.startTiming();
          this.awaitTasks(() -> {
@@ -187,7 +187,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
              return !this.canOversleep();
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
-@@ -1198,13 +1217,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1200,13 +1219,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      protected void b(BooleanSupplier booleansupplier) {
@@ -204,7 +204,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
          this.methodProfiler.exitEnter("levels");
          Iterator iterator = this.getWorlds().iterator();
  
-@@ -1215,7 +1237,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1217,7 +1239,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              processQueue.remove().run();
          }
          MinecraftTimings.processQueueTimer.stopTiming(); // Spigot
@@ -213,7 +213,7 @@ index 96a784744110e7dd4939eb2c1b57346a2d60f983..77a91fa0549d5db12e8a9fa9b51a34a2
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.
          // Paper start - optimize time updates
-@@ -1257,9 +1279,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1259,9 +1281,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.methodProfiler.enter("tick");
  
              try {

--- a/Spigot-Server-Patches/0431-Don-t-move-existing-players-to-world-spawn.patch
+++ b/Spigot-Server-Patches/0431-Don-t-move-existing-players-to-world-spawn.patch
@@ -10,7 +10,7 @@ larger than the keep loaded range.
 By skipping this, we avoid potential for a large spike on server start.
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index cfccab0b33dfa387fdab09ad51d518d42b1b5775..950a16e8aafe71b54b4ba46b61b5d71f8aa3cf94 100644
+index cb9009aecb76abcf6442fa3b5fc6c3d6e776dfa0..a2f364fb61c4a0a691e1617446c1dfcf997753fb 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -125,7 +125,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -40,10 +40,10 @@ index cfccab0b33dfa387fdab09ad51d518d42b1b5775..950a16e8aafe71b54b4ba46b61b5d71f
          this.playerInteractManager.a((WorldServer) world);
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index c52c6cc6ab0bed4fbd088f6d32455e1a58a70c16..ce097978a072dd5499169277aa1143be97c3b4e1 100644
+index 73a29023767e6452cd263564c9bce3fb52e93312..118d50997a31c2b5182d7ba1015f73d739def2f3 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -136,6 +136,8 @@ public abstract class PlayerList {
+@@ -131,6 +131,8 @@ public abstract class PlayerList {
              worldserver1 = worldserver;
          }
  

--- a/Spigot-Server-Patches/0432-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0432-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 63b3726bfdd22900e7bc577c34db58ddba1084ee..2f9398f7bb90e8ae0a1cb81b162dba28706d408a 100644
+index ddbc8cb712c50038922eded75dd6ca85fe851078..78271b400c79578d043b20a5389a37b1bef9a70d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -87,10 +87,10 @@ index 63b3726bfdd22900e7bc577c34db58ddba1084ee..2f9398f7bb90e8ae0a1cb81b162dba28
          version = getInt("config-version", 20);
          set("config-version", 20);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 77a91fa0549d5db12e8a9fa9b51a34a258821e7b..a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534 100644
+index 2438a50ca1923b028c4848c80248bac61b80d1af..2285612851d28c8cae31fc5f99584e6434450d80 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -107,6 +107,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -109,6 +109,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private int F;
      private int G;
      public final long[] h; public long[] getTickTimes() { return h; } // Paper - OBFHELPER
@@ -102,7 +102,7 @@ index 77a91fa0549d5db12e8a9fa9b51a34a258821e7b..a8fe6c5f99c2be9dc7fedb8dfa8b12e4
      @Nullable
      private KeyPair H;
      @Nullable
-@@ -1209,6 +1214,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1211,6 +1216,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.ag = this.ag * 0.8F + (float) l / 1000000.0F * 0.19999999F;
          long i1 = SystemUtils.getMonotonicNanos();
  
@@ -115,7 +115,7 @@ index 77a91fa0549d5db12e8a9fa9b51a34a258821e7b..a8fe6c5f99c2be9dc7fedb8dfa8b12e4
          this.circularTimer.a(i1 - i);
          this.methodProfiler.exit();
          org.spigotmc.WatchdogThread.tick(); // Spigot
-@@ -2181,4 +2192,30 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2183,4 +2194,30 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public ITextFilter a(EntityPlayer entityplayer) {
          return null;
      }
@@ -147,7 +147,7 @@ index 77a91fa0549d5db12e8a9fa9b51a34a258821e7b..a8fe6c5f99c2be9dc7fedb8dfa8b12e4
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80e917d7154ed8cafd308440c66ae16fb782dd35..255ab2909440a7daeae756fc2e3d21ff71f7a551 100644
+index cb8008e2336b220289ba9bea442e5e734dbfac26..b9f685f39f943701889b55b02330bb9e834941ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2196,6 +2196,16 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0438-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0438-Improved-Watchdog-Support.patch
@@ -113,10 +113,10 @@ index bc15da4640a4a6107c9c186a01ce76df87511b41..27db247aa40e0516302c74b9bf00c631
          }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae31058b2f 100644
+index 2285612851d28c8cae31fc5f99584e6434450d80..6d7928dc45e373ecd95756b061615255265f03fa 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -159,7 +159,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -161,7 +161,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public int autosavePeriod;
      public boolean serverAutoSave = false; // Paper
      public CommandDispatcher vanillaCommandDispatcher;
@@ -125,7 +125,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
      // CraftBukkit end
      // Spigot start
      public static final int TPS = 20;
-@@ -169,6 +169,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -171,6 +171,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
  
@@ -134,7 +134,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
      public static <S extends MinecraftServer> S a(Function<Thread, S> function) {
          AtomicReference<S> atomicreference = new AtomicReference();
          Thread thread = new Thread(() -> {
-@@ -731,6 +733,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -733,6 +735,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      // CraftBukkit start
      private boolean hasStopped = false;
@@ -142,7 +142,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (stopLock) {
-@@ -745,6 +748,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -747,6 +750,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              if (hasStopped) return;
              hasStopped = true;
          }
@@ -166,7 +166,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
          // CraftBukkit end
          MinecraftServer.LOGGER.info("Stopping server");
          MinecraftTimings.stopServer(); // Paper
-@@ -810,7 +830,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -812,7 +832,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getUserCache().b(false); // Paper
          }
          // Spigot end
@@ -185,7 +185,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
      }
  
      public String getServerIp() {
-@@ -903,6 +934,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -905,6 +936,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      protected void w() {
          try {
@@ -193,7 +193,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
              if (this.init()) {
                  this.nextTick = SystemUtils.getMonotonicMillis();
                  this.serverPing.setMOTD(new ChatComponentText(this.motd));
-@@ -910,6 +942,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -912,6 +944,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a(this.serverPing);
  
                  // Spigot start
@@ -212,7 +212,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
                  org.spigotmc.WatchdogThread.hasStarted = true; // Paper
                  Arrays.fill( recentTps, 20 );
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
-@@ -965,6 +1009,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -967,6 +1011,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a((CrashReport) null);
              }
          } catch (Throwable throwable) {
@@ -225,7 +225,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              // Spigot Start
              if ( throwable.getCause() != null )
-@@ -996,14 +1046,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -998,14 +1048,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              } catch (Throwable throwable1) {
                  MinecraftServer.LOGGER.error("Exception stopping the server", throwable1);
              } finally {
@@ -243,7 +243,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
              }
  
          }
-@@ -1059,6 +1109,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1061,6 +1111,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      @Override
      protected TickTask postToMainThread(Runnable runnable) {
@@ -256,7 +256,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
          return new TickTask(this.ticks, runnable);
      }
  
-@@ -1301,6 +1357,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1303,6 +1359,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  try {
                      crashreport = CrashReport.a(throwable, "Exception ticking world");
                  } catch (Throwable t) {
@@ -264,7 +264,7 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
                      throw new RuntimeException("Error generating crash report", t);
                  }
                  // Spigot End
-@@ -1758,7 +1815,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1760,7 +1817,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.resourcePackRepository.a(collection);
              this.saveData.a(a(this.resourcePackRepository));
              datapackresources.i();
@@ -275,10 +275,10 @@ index a8fe6c5f99c2be9dc7fedb8dfa8b12e4d0852534..2f5de20ea4e235d6f4664d7b3d0ac9ae
              this.customFunctionData.a(this.dataPackResources.a());
              this.ak.a(this.dataPackResources.h());
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 87de764f74e8174da4c1a28238375caa6fdb4d5e..1b5c97c74b7224a8ac4d6e834925c0509a57d308 100644
+index 2622e418cde9f70e38e8d28d7dfde5c3879f520f..feb0c8f3dec62cd4cdfeede6047ef40bc69ce240 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -487,6 +487,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -488,6 +488,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              MutableBoolean mutableboolean = new MutableBoolean();
  
              do {
@@ -287,10 +287,10 @@ index 87de764f74e8174da4c1a28238375caa6fdb4d5e..1b5c97c74b7224a8ac4d6e834925c050
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 1f1a63a0a9b04aada2f4c66973c69beb9bb93e9d..ef7af4c6b9290ef18977e1aebd57621838685a5a 100644
+index 118d50997a31c2b5182d7ba1015f73d739def2f3..c7d44b1242943f2d0a78614c7bae4840fb41e8f4 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -433,7 +433,7 @@ public abstract class PlayerList {
+@@ -428,7 +428,7 @@ public abstract class PlayerList {
          cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
@@ -345,7 +345,7 @@ index 3c72c156ca488e14604cb0db5f1ac4e068776066..e0f66718f3700f5f4bdb77178e05ca3f
      List<java.lang.Runnable> afterEntityTickingTasks = Lists.newArrayList();
      public void doIfNotEntityTicking(java.lang.Runnable run) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fafe6354fa73d1f11d30be88bd4ff4354bbbb016..7630a7fc347f6add6e628093c1f149ee01d05264 100644
+index 9c05f950a83abd6bbe641c735f8ab7fb279f2853..f52d443eb19e2e37258c455c1afd02d1b3f2006b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1834,7 +1834,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0447-Restrict-vanilla-teleport-command-to-valid-locations.patch
+++ b/Spigot-Server-Patches/0447-Restrict-vanilla-teleport-command-to-valid-locations.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Restrict vanilla teleport command to valid locations
 Fixes GH-3165, GH-3575
 
 diff --git a/src/main/java/net/minecraft/server/CommandTeleport.java b/src/main/java/net/minecraft/server/CommandTeleport.java
-index db9c28b51ff46729f8d7ac5c05905b16f61fcc59..ddc978279f9436617bec222cef8e552c5cdad77b 100644
+index 660704394da82c56b11958664d938ebcc6e23be4..57a23dd7a1196402ddc58e7491ac9ada97f402a4 100644
 --- a/src/main/java/net/minecraft/server/CommandTeleport.java
 +++ b/src/main/java/net/minecraft/server/CommandTeleport.java
-@@ -119,6 +119,12 @@ public class CommandTeleport {
+@@ -120,6 +120,12 @@ public class CommandTeleport {
  
      private static void a(CommandListenerWrapper commandlistenerwrapper, Entity entity, WorldServer worldserver, double d0, double d1, double d2, Set<PacketPlayOutPosition.EnumPlayerTeleportFlags> set, float f, float f1, @Nullable CommandTeleport.a commandteleport_a) throws CommandSyntaxException {
          BlockPosition blockposition = new BlockPosition(d0, d1, d2);

--- a/Spigot-Server-Patches/0449-Fix-Chunk-Post-Processing-deadlock-risk.patch
+++ b/Spigot-Server-Patches/0449-Fix-Chunk-Post-Processing-deadlock-risk.patch
@@ -37,10 +37,10 @@ index 174fc04e8cf5bd481b2f3d4e07031dab9ae66d86..75500aaae0dc44f0da3b4d5ed94da6fe
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 1b5c97c74b7224a8ac4d6e834925c0509a57d308..33e0a93917e67860704e08e639cca1dbdf3b2708 100644
+index feb0c8f3dec62cd4cdfeede6047ef40bc69ce240..356147a09c4aa027480804d9edcca21dc3d85b78 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -134,6 +134,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -135,6 +135,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      };
      // CraftBukkit end
  
@@ -49,7 +49,7 @@ index 1b5c97c74b7224a8ac4d6e834925c0509a57d308..33e0a93917e67860704e08e639cca1db
      // Paper start - distance maps
      private final com.destroystokyo.paper.util.misc.PooledLinkedHashSets<EntityPlayer> pooledLinkedPlayerHashSets = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets<>();
  
-@@ -999,7 +1001,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1000,7 +1002,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return Either.left(chunk);
              });
          }, (runnable) -> {

--- a/Spigot-Server-Patches/0451-Broadcast-join-message-to-console.patch
+++ b/Spigot-Server-Patches/0451-Broadcast-join-message-to-console.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Broadcast join message to console
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index d6c2fe9a339db4c241950f43fb4ee51abb0b9420..786f18d49da29ab96d1810072ff90072a2c12d82 100644
+index c7d44b1242943f2d0a78614c7bae4840fb41e8f4..34246ba0f8a50f732f2ff863f8a824f8573fee83 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -214,7 +214,9 @@ public abstract class PlayerList {
+@@ -209,7 +209,9 @@ public abstract class PlayerList {
  
          if (jm != null && !jm.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
              joinMessage = PaperAdventure.asVanilla(jm); // Paper - Adventure

--- a/Spigot-Server-Patches/0452-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/Spigot-Server-Patches/0452-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,7 +28,7 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index f83a0855b7b26b3a804c15afdd69fc3d76f414c9..03f13cc10de79137c1e186a4207ad6cc7d68c843 100644
+index 9030b76ca6b9dd2bf3f6baa003f68d8b43f3741e..50ffd62534793596017368423b11cd5a94950009 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -111,6 +111,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -40,10 +40,10 @@ index f83a0855b7b26b3a804c15afdd69fc3d76f414c9..03f13cc10de79137c1e186a4207ad6cc
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 33e0a93917e67860704e08e639cca1dbdf3b2708..de9355914ec1dd4f2e5c3a9d9de881c9df9002ce 100644
+index 356147a09c4aa027480804d9edcca21dc3d85b78..429355e5790148e2e061f67e44f0c8f96855f7c5 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1538,6 +1538,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1539,6 +1539,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  .printStackTrace();
              return;
          }
@@ -52,10 +52,10 @@ index 33e0a93917e67860704e08e639cca1dbdf3b2708..de9355914ec1dd4f2e5c3a9d9de881c9
          if (!(entity instanceof EntityComplexPart)) {
              EntityTypes<?> entitytypes = entity.getEntityType();
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 80f549ab92e244478aa12e7113e8f6bf28729f7d..a45390e8a8782dc4295515aab033ba93a3a5a34b 100644
+index 34246ba0f8a50f732f2ff863f8a824f8573fee83..5222382bc572ffa5a9e3274c522f1f956a27e732 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -202,6 +202,12 @@ public abstract class PlayerList {
+@@ -197,6 +197,12 @@ public abstract class PlayerList {
          this.j.put(entityplayer.getUniqueID(), entityplayer);
          // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, new EntityPlayer[]{entityplayer})); // CraftBukkit - replaced with loop below
  
@@ -68,7 +68,7 @@ index 80f549ab92e244478aa12e7113e8f6bf28729f7d..a45390e8a8782dc4295515aab033ba93
          // CraftBukkit start
          PlayerJoinEvent playerJoinEvent = new org.bukkit.event.player.PlayerJoinEvent(cserver.getPlayer(entityplayer), PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
          cserver.getPluginManager().callEvent(playerJoinEvent);
-@@ -237,6 +243,8 @@ public abstract class PlayerList {
+@@ -232,6 +238,8 @@ public abstract class PlayerList {
              entityplayer.playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, new EntityPlayer[] { entityplayer1}));
          }
          entityplayer.sentListPacket = true;
@@ -77,7 +77,7 @@ index 80f549ab92e244478aa12e7113e8f6bf28729f7d..a45390e8a8782dc4295515aab033ba93
          // CraftBukkit end
  
          entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityMetadata(entityplayer.getId(), entityplayer.datawatcher, true)); // CraftBukkit - BungeeCord#2321, send complete data to self on spawn
-@@ -262,6 +270,11 @@ public abstract class PlayerList {
+@@ -257,6 +265,11 @@ public abstract class PlayerList {
              playerconnection.sendPacket(new PacketPlayOutEntityEffect(entityplayer.getId(), mobeffect));
          }
  
@@ -89,7 +89,7 @@ index 80f549ab92e244478aa12e7113e8f6bf28729f7d..a45390e8a8782dc4295515aab033ba93
          if (nbttagcompound != null && nbttagcompound.hasKeyOfType("RootVehicle", 10)) {
              NBTTagCompound nbttagcompound1 = nbttagcompound.getCompound("RootVehicle");
              // CraftBukkit start
-@@ -310,6 +323,10 @@ public abstract class PlayerList {
+@@ -305,6 +318,10 @@ public abstract class PlayerList {
              }
          }
  

--- a/Spigot-Server-Patches/0453-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0453-Load-Chunks-for-Login-Asynchronously.patch
@@ -110,10 +110,10 @@ index 8fbafc6057a6062cbc222239e542a1bffc4fc09e..d525f4b783bc3bff180c9dbc31750f5b
          this.minecraftServer.getMethodProfiler().enter("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8f8d9ffcd 100644
+index 5222382bc572ffa5a9e3274c522f1f956a27e732..f1cd31c4ccc1566327041b9b8469f24db542ae91 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -56,11 +56,12 @@ public abstract class PlayerList {
+@@ -51,11 +51,12 @@ public abstract class PlayerList {
      private static final SimpleDateFormat g = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
      private final MinecraftServer server;
      public final List<EntityPlayer> players = new java.util.concurrent.CopyOnWriteArrayList(); // CraftBukkit - ArrayList -> CopyOnWriteArrayList: Iterator safety
@@ -127,7 +127,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
      // CraftBukkit start
      // private final Map<UUID, ServerStatisticManager> o;
      // private final Map<UUID, AdvancementDataPlayer> p;
-@@ -99,6 +100,11 @@ public abstract class PlayerList {
+@@ -94,6 +95,11 @@ public abstract class PlayerList {
      }
  
      public void a(NetworkManager networkmanager, EntityPlayer entityplayer) {
@@ -139,7 +139,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
          entityplayer.loginTime = System.currentTimeMillis(); // Paper
          GameProfile gameprofile = entityplayer.getProfile();
          UserCache usercache = this.server.getUserCache();
-@@ -112,7 +118,7 @@ public abstract class PlayerList {
+@@ -107,7 +113,7 @@ public abstract class PlayerList {
          if (nbttagcompound != null && nbttagcompound.hasKey("bukkit")) {
              NBTTagCompound bukkit = nbttagcompound.getCompound("bukkit");
              s = bukkit.hasKeyOfType("lastKnownName", 8) ? bukkit.getString("lastKnownName") : s;
@@ -148,7 +148,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
          // CraftBukkit end
  
          if (nbttagcompound != null) {
-@@ -185,6 +191,51 @@ public abstract class PlayerList {
+@@ -180,6 +186,51 @@ public abstract class PlayerList {
          entityplayer.getRecipeBook().a(entityplayer);
          this.sendScoreboard(worldserver1.getScoreboard(), entityplayer);
          this.server.invalidatePingSample();
@@ -200,7 +200,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
          ChatMessage chatmessage;
  
          if (entityplayer.getProfile().getName().equalsIgnoreCase(s)) {
-@@ -422,6 +473,7 @@ public abstract class PlayerList {
+@@ -417,6 +468,7 @@ public abstract class PlayerList {
  
      protected void savePlayerFile(EntityPlayer entityplayer) {
          if (!entityplayer.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -208,7 +208,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
          this.playerFileData.save(entityplayer);
          ServerStatisticManager serverstatisticmanager = (ServerStatisticManager) entityplayer.getStatisticManager(); // CraftBukkit
  
-@@ -449,7 +501,7 @@ public abstract class PlayerList {
+@@ -444,7 +496,7 @@ public abstract class PlayerList {
          }
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getName())));
@@ -217,7 +217,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
          if (server.isMainThread()) entityplayer.playerTick(); // SPIGOT-924 // Paper - don't tick during emergency shutdowns (Watchdog)
-@@ -502,6 +554,13 @@ public abstract class PlayerList {
+@@ -497,6 +549,13 @@ public abstract class PlayerList {
              // this.p.remove(uuid);
              // CraftBukkit end
          }
@@ -231,7 +231,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
  
          // CraftBukkit start
          // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, new EntityPlayer[]{entityplayer}));
-@@ -519,7 +578,7 @@ public abstract class PlayerList {
+@@ -514,7 +573,7 @@ public abstract class PlayerList {
          cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -240,7 +240,7 @@ index 6e89eca0dde4e4ca4ff77e48ec3a4cc2aefec482..6447c6951614d50f391f3cebbd9129a8
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -538,6 +597,13 @@ public abstract class PlayerList {
+@@ -533,6 +592,13 @@ public abstract class PlayerList {
                  list.add(entityplayer);
              }
          }

--- a/Spigot-Server-Patches/0456-Allow-multiple-callbacks-to-schedule-for-Callback-Ex.patch
+++ b/Spigot-Server-Patches/0456-Allow-multiple-callbacks-to-schedule-for-Callback-Ex.patch
@@ -14,10 +14,10 @@ Use an ArrayDeque to store this Queue
 We make sure to also implement a pattern that is recursion safe too.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index de9355914ec1dd4f2e5c3a9d9de881c9df9002ce..bb6712093d3d39968c4ef7daa8466962f0cf30b1 100644
+index 429355e5790148e2e061f67e44f0c8f96855f7c5..06124c8799846fd236f7ac1cad04e79bd30fc44c 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -113,24 +113,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -114,24 +114,32 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final CallbackExecutor callbackExecutor = new CallbackExecutor();
      public static final class CallbackExecutor implements java.util.concurrent.Executor, Runnable {
  

--- a/Spigot-Server-Patches/0460-Implement-Brigadier-Mojang-API.patch
+++ b/Spigot-Server-Patches/0460-Implement-Brigadier-Mojang-API.patch
@@ -30,19 +30,19 @@ index 4b1ea9bc39191e01f83577c7bad128cf1ab9612f..22d748008d24fd6ed7cd8c4914e2ceb3
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/CommandListenerWrapper.java b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
-index 54a1988341a4a6e80ab40624280b7c92532d5db6..7073d697a5d35b9b72ea05d5608438ac3e54c20d 100644
+index 1a5463080bc40b8c9ff67374d03c4eb443682288..efe2391f1648f4f83e9b77fdc6d9d81653cf65b3 100644
 --- a/src/main/java/net/minecraft/server/CommandListenerWrapper.java
 +++ b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
-@@ -16,7 +16,7 @@ import java.util.function.BinaryOperator;
- import java.util.stream.Stream;
- import javax.annotation.Nullable;
+@@ -17,7 +17,7 @@ import javax.annotation.Nullable;
+ 
+ import com.mojang.brigadier.tree.CommandNode; // CraftBukkit
  
 -public class CommandListenerWrapper implements ICompletionProvider {
 +public class CommandListenerWrapper implements ICompletionProvider, com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource { // Paper
  
      public static final SimpleCommandExceptionType a = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.player"));
      public static final SimpleCommandExceptionType b = new SimpleCommandExceptionType(new ChatMessage("permissions.requires.entity"));
-@@ -128,6 +128,25 @@ public class CommandListenerWrapper implements ICompletionProvider {
+@@ -129,6 +129,25 @@ public class CommandListenerWrapper implements ICompletionProvider {
          return this.g;
      }
  

--- a/Spigot-Server-Patches/0461-Villager-Restocks-API.patch
+++ b/Spigot-Server-Patches/0461-Villager-Restocks-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Villager Restocks API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index bb096fd5fa20aead7df0188ae294da9c813abace..1322a8f12484700c3d707b3d18ad90c059703530 100644
+index ee9b1736be7c8fa3324871faa0007fb4781082b8..419de8176a03acc061436d1f92079b6fafcb0ed6 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -44,7 +44,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -42,7 +42,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
      private long bA;
      private int bB;
      private long bC;
@@ -18,10 +18,10 @@ index bb096fd5fa20aead7df0188ae294da9c813abace..1322a8f12484700c3d707b3d18ad90c0
      private boolean bF;
      private static final ImmutableList<MemoryModuleType<?>> bG = ImmutableList.of(MemoryModuleType.HOME, MemoryModuleType.JOB_SITE, MemoryModuleType.POTENTIAL_JOB_SITE, MemoryModuleType.MEETING_POINT, MemoryModuleType.MOBS, MemoryModuleType.VISIBLE_MOBS, MemoryModuleType.VISIBLE_VILLAGER_BABIES, MemoryModuleType.NEAREST_PLAYERS, MemoryModuleType.NEAREST_VISIBLE_PLAYER, MemoryModuleType.NEAREST_VISIBLE_TARGETABLE_PLAYER, MemoryModuleType.NEAREST_VISIBLE_WANTED_ITEM, MemoryModuleType.WALK_TARGET, new MemoryModuleType[]{MemoryModuleType.LOOK_TARGET, MemoryModuleType.INTERACTION_TARGET, MemoryModuleType.BREED_TARGET, MemoryModuleType.PATH, MemoryModuleType.DOORS_TO_CLOSE, MemoryModuleType.NEAREST_BED, MemoryModuleType.HURT_BY, MemoryModuleType.HURT_BY_ENTITY, MemoryModuleType.NEAREST_HOSTILE, MemoryModuleType.SECONDARY_JOB_SITE, MemoryModuleType.HIDING_PLACE, MemoryModuleType.HEARD_BELL_TIME, MemoryModuleType.CANT_REACH_WALK_TARGET_SINCE, MemoryModuleType.LAST_SLEPT, MemoryModuleType.LAST_WOKEN, MemoryModuleType.LAST_WORKED_AT_POI, MemoryModuleType.GOLEM_DETECTED_RECENTLY});
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index fe726e7884c9f091d73c8f5d2cb58a87a16649f8..a8384081c03884c86578dca677914d77441c1863 100644
+index 25a57d94a8cf7705fffcf9302c503207def35c3b..0273cf7e2ec27b094a06e5ad1131585df9a0ae8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -82,6 +82,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -84,6 +84,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
          getHandle().setExperience(experience);
      }
  

--- a/Spigot-Server-Patches/0467-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0467-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 273f9c19768916a86968e02e653754c55317e663..feeb792e3357c14662a2a2dc5c294befd4bdc7c3 100644
+index 894ef285638acbae9b340bd6e4511e7143c6999d..53be44fad4db829359ee7541a08f438ebcf2bde1 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -206,6 +206,21 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -44,10 +44,10 @@ index d89d53e9990918fb9863a7eed3111ef026c95386..d40d41faae13ee17bbe1c7bd4b64126b
          List<Entity> list = this.tracker.getPassengers();
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2f5de20ea4e235d6f4664d7b3d0ac9ae31058b2f..6fd956cbbb4fddc4294ff03976e66d93c1b086c7 100644
+index 6d7928dc45e373ecd95756b061615255265f03fa..f606ccd7586f6ad70d2426363cfd82d07824008d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1531,6 +1531,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1533,6 +1533,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
      }
  
@@ -56,10 +56,10 @@ index 2f5de20ea4e235d6f4664d7b3d0ac9ae31058b2f..6fd956cbbb4fddc4294ff03976e66d93
          return i;
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a620237a724168 100644
+index 06124c8799846fd236f7ac1cad04e79bd30fc44c..c2bade51ed1d42e3850fc3d0b32790ea40250b64 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -146,21 +146,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -147,21 +147,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      // Paper start - distance maps
      private final com.destroystokyo.paper.util.misc.PooledLinkedHashSets<EntityPlayer> pooledLinkedPlayerHashSets = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets<>();
@@ -116,7 +116,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
      }
      // Paper end
  
-@@ -197,6 +231,45 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -198,6 +232,45 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, flag, this.world); // Paper
          this.setViewDistance(i);
          this.playerMobDistanceMap = this.world.paperConfig.perPlayerMobSpawns ? new com.destroystokyo.paper.util.PlayerMobDistanceMap() : null; // Paper
@@ -162,7 +162,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1435,17 +1508,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1436,17 +1509,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void movePlayer(EntityPlayer entityplayer) {
@@ -181,7 +181,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
  
          int i = MathHelper.floor(entityplayer.locX()) >> 4;
          int j = MathHelper.floor(entityplayer.locZ()) >> 4;
-@@ -1561,7 +1624,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1562,7 +1625,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  entity.tracker = playerchunkmap_entitytracker; // Paper - Fast access to tracker
                  this.trackedEntities.put(entity.getId(), playerchunkmap_entitytracker);
@@ -190,7 +190,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
                  if (entity instanceof EntityPlayer) {
                      EntityPlayer entityplayer = (EntityPlayer) entity;
  
-@@ -1604,7 +1667,37 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1605,7 +1668,37 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -228,7 +228,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
          List<EntityPlayer> list = Lists.newArrayList();
          List<EntityPlayer> list1 = this.world.getPlayers();
  
-@@ -1673,23 +1766,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1674,23 +1767,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          PacketDebug.a(this.world, chunk.getPos());
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
@@ -272,7 +272,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
  
          Iterator iterator;
          Entity entity1;
-@@ -1727,7 +1828,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1728,7 +1829,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      public class EntityTracker {
  
@@ -281,7 +281,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
          private final Entity tracker;
          private final int trackingDistance;
          private SectionPosition e;
-@@ -1744,6 +1845,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1745,6 +1846,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.e = SectionPosition.a(entity);
          }
  
@@ -324,7 +324,7 @@ index bb6712093d3d39968c4ef7daa8466962f0cf30b1..4710e6196362b7a058bc87a263a62023
          public boolean equals(Object object) {
              return object instanceof PlayerChunkMap.EntityTracker ? ((PlayerChunkMap.EntityTracker) object).tracker.getId() == this.tracker.getId() : false;
          }
-@@ -1844,7 +1981,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1845,7 +1982,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  int j = entity.getEntityType().getChunkRange() * 16;
                  j = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, j); // Paper
  

--- a/Spigot-Server-Patches/0468-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/Spigot-Server-Patches/0468-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -148,7 +148,7 @@ index 322d0a7d127878ba49362454808b82172acf1600..5c092243e3e6f069f9ab6799de56dd60
                              }
  
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index e364576955ce033f732bc9348ab653c5db71487f..ba24a1a98eb6082af337bce77ab72245cfc913be 100644
+index 05483a9c5b8f77959fb44532f506e268b1676acd..97049fdce7a8d441c0277f8f296bca0ff057db01 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -120,6 +120,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -192,10 +192,10 @@ index 5305da4c7253c7e259d7b08e9722145188adc513..7413e3dbaacc288a29d9499242cb8563
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b853ab323a 100644
+index c2bade51ed1d42e3850fc3d0b32790ea40250b64..cf83f105c4354fe6fa0c07b8c1bd160d5d2d9e4d 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -160,6 +160,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -161,6 +161,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return MinecraftServer.getServer().applyTrackingRangeScale(vanilla);
      }
      // Paper end - use distance map to optimise tracker
@@ -213,7 +213,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
  
      void addPlayerToDistanceMaps(EntityPlayer player) {
          int chunkX = MCUtil.getChunkCoordinate(player.locX());
-@@ -173,6 +184,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -174,6 +185,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
          }
          // Paper end - use distance map to optimise entity tracker
@@ -223,7 +223,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
      }
  
      void removePlayerFromDistanceMaps(EntityPlayer player) {
-@@ -181,6 +195,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -182,6 +196,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.playerEntityTrackerTrackMaps[i].remove(player);
          }
          // Paper end - use distance map to optimise tracker
@@ -234,7 +234,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
      }
  
      void updateMaps(EntityPlayer player) {
-@@ -195,6 +213,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -196,6 +214,9 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
          }
          // Paper end - use distance map to optimise entity tracker
@@ -244,7 +244,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
      }
      // Paper end
  
-@@ -226,7 +247,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -227,7 +248,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.mailboxWorldGen = this.p.a(threadedmailbox, false);
          this.mailboxMain = this.p.a(mailbox, false);
          this.lightEngine = new LightEngineThreaded(ilightaccess, this, this.world.getDimensionManager().hasSkyLight(), threadedmailbox1, this.p.a(threadedmailbox1, false));
@@ -253,7 +253,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
          this.l = supplier;
          this.m = new VillagePlace(new File(this.w, "poi"), datafixer, flag, this.world); // Paper
          this.setViewDistance(i);
-@@ -270,6 +291,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -271,6 +292,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.playerEntityTrackerTrackMaps[ordinal] = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets);
          }
          // Paper end - use distance map to optimise entity tracker
@@ -292,7 +292,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -289,6 +342,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -290,6 +343,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return entityPlayer.mobCounts[enumCreatureType.ordinal()];
      }
  
@@ -300,7 +300,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
      private static double a(ChunkCoordIntPair chunkcoordintpair, Entity entity) {
          double d0 = (double) (chunkcoordintpair.x * 16 + 8);
          double d1 = (double) (chunkcoordintpair.z * 16 + 8);
-@@ -467,6 +521,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -468,6 +522,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          } else {
              if (playerchunk != null) {
                  playerchunk.a(j);
@@ -308,7 +308,7 @@ index 4710e6196362b7a058bc87a263a620237a724168..ebca5620f0bbd4173ca50f023f8333b8
              }
  
              if (playerchunk != null) {
-@@ -1437,30 +1492,53 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1438,30 +1493,53 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return isOutsideOfRange(chunkcoordintpair, false);
      }
  

--- a/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0470-No-Tick-view-distance-implementation.patch
@@ -124,7 +124,7 @@ index 126eae36dc99c29b0d15be26bd68f00fe7e563fe..6ebc4a4b5c90d8592a017e7b29dec5ca
                  if (flag1) {
                      ChunkMapDistance.this.j.a(ChunkTaskQueueSorter.a(() -> {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index ba24a1a98eb6082af337bce77ab72245cfc913be..cbe088d8fe4cff307c1672bac9be8b1ad3515af3 100644
+index 97049fdce7a8d441c0277f8f296bca0ff057db01..6620f0c104a9a71796940e072653d13e193367aa 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -122,6 +122,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -244,10 +244,10 @@ index 7413e3dbaacc288a29d9499242cb8563b4169fd9..825c3c522b0497499b72cb9f2ff3edb3
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908bc909266 100644
+index cf83f105c4354fe6fa0c07b8c1bd160d5d2d9e4d..b508e8318d0608d9bae34d9551d1cb654e53d24e 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -96,7 +96,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -97,7 +97,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private boolean updatingChunksModified;
      private final ChunkTaskQueueSorter p;
      private final Mailbox<ChunkTaskQueueSorter.a<Runnable>> mailboxWorldGen;
@@ -256,7 +256,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      public final WorldLoadListener worldLoadListener;
      public final PlayerChunkMap.a chunkDistanceManager;
      private final AtomicInteger u;
-@@ -171,6 +171,22 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -172,6 +172,22 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerMobSpawnMap; // this map is absent from updateMaps since it's controlled at the start of the chunkproviderserver tick
      public final com.destroystokyo.paper.util.misc.PlayerAreaMap playerChunkTickRangeMap;
      // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -279,7 +279,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
  
      void addPlayerToDistanceMaps(EntityPlayer player) {
          int chunkX = MCUtil.getChunkCoordinate(player.locX());
-@@ -187,6 +203,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -188,6 +204,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          // Paper start - optimise PlayerChunkMap#isOutsideRange
          this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -299,7 +299,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      }
  
      void removePlayerFromDistanceMaps(EntityPlayer player) {
-@@ -199,6 +228,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -200,6 +229,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.playerMobSpawnMap.remove(player);
          this.playerChunkTickRangeMap.remove(player);
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -311,7 +311,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      }
  
      void updateMaps(EntityPlayer player) {
-@@ -216,6 +250,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -217,6 +251,19 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          // Paper start - optimise PlayerChunkMap#isOutsideRange
          this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, ChunkMapDistance.MOB_SPAWN_RANGE);
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -331,7 +331,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      }
      // Paper end
  
-@@ -323,6 +370,45 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -324,6 +371,45 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
              });
          // Paper end - optimise PlayerChunkMap#isOutsideRange
@@ -377,7 +377,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1143,15 +1229,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1144,15 +1230,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          completablefuture1.thenAcceptAsync((either) -> {
              either.mapLeft((chunk) -> {
                  this.u.getAndIncrement();
@@ -395,7 +395,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
          });
          return completablefuture1;
      }
-@@ -1246,32 +1328,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1247,32 +1329,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
      }
  
@@ -449,7 +449,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
  
      protected void sendChunk(EntityPlayer entityplayer, ChunkCoordIntPair chunkcoordintpair, Packet<?>[] apacket, boolean flag, boolean flag1) {
          if (entityplayer.world == this.world) {
-@@ -1279,7 +1367,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1280,7 +1368,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  PlayerChunk playerchunk = this.getVisibleChunk(chunkcoordintpair.pair());
  
                  if (playerchunk != null) {
@@ -458,7 +458,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
  
                      if (chunk != null) {
                          this.a(entityplayer, apacket, chunk);
-@@ -1540,6 +1628,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1541,6 +1629,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end - optimise isOutsideOfRange
  
@@ -466,7 +466,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      private boolean b(EntityPlayer entityplayer) {
          return entityplayer.isSpectator() && !this.world.getGameRules().getBoolean(GameRules.SPECTATORS_GENERATE_CHUNKS);
      }
-@@ -1567,13 +1656,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1568,13 +1657,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.removePlayerFromDistanceMaps(entityplayer); // Paper - distance maps
          }
  
@@ -481,7 +481,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
  
      }
  
-@@ -1581,7 +1664,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1582,7 +1665,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          SectionPosition sectionposition = SectionPosition.a((Entity) entityplayer);
  
          entityplayer.a(sectionposition);
@@ -490,7 +490,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
          return sectionposition;
      }
  
-@@ -1626,6 +1709,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1627,6 +1710,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          int k1;
          int l1;
  
@@ -498,7 +498,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
          if (Math.abs(i1 - i) <= this.viewDistance * 2 && Math.abs(j1 - j) <= this.viewDistance * 2) {
              k1 = Math.min(i, i1) - this.viewDistance;
              l1 = Math.min(j, j1) - this.viewDistance;
-@@ -1663,7 +1747,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1664,7 +1748,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      this.sendChunk(entityplayer, chunkcoordintpair1, new Packet[2], false, true);
                  }
              }
@@ -507,7 +507,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
  
          this.updateMaps(entityplayer); // Paper - distance maps
  
-@@ -1671,11 +1755,46 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1672,11 +1756,46 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      @Override
      public Stream<EntityPlayer> a(ChunkCoordIntPair chunkcoordintpair, boolean flag) {
@@ -558,7 +558,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      }
  
      protected void addEntity(Entity entity) {
-@@ -1833,7 +1952,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1834,7 +1953,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -567,7 +567,7 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {
              apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
-@@ -2019,7 +2138,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2020,7 +2139,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
  
@@ -577,10 +577,10 @@ index ebca5620f0bbd4173ca50f023f8333b853ab323a..025a5b24e259df04ee88cb251477c908
                          }
                      }
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 992e3e932133c60b448ec62a322e74ef8deb7599..1dfd884d9b2dfb3b8c44afb8363019681ae49d84 100644
+index f1cd31c4ccc1566327041b9b8469f24db542ae91..6c96a7123fb28cfadf129c4ba8688f13539583d6 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -177,7 +177,7 @@ public abstract class PlayerList {
+@@ -172,7 +172,7 @@ public abstract class PlayerList {
          boolean flag1 = gamerules.getBoolean(GameRules.REDUCED_DEBUG_INFO);
  
          // Spigot - view distance
@@ -589,7 +589,7 @@ index 992e3e932133c60b448ec62a322e74ef8deb7599..1dfd884d9b2dfb3b8c44afb836301968
          entityplayer.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.sendPacket(new PacketPlayOutCustomPayload(PacketPlayOutCustomPayload.a, (new PacketDataSerializer(Unpooled.buffer())).a(this.getServer().getServerModName())));
          playerconnection.sendPacket(new PacketPlayOutServerDifficulty(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -831,7 +831,7 @@ public abstract class PlayerList {
+@@ -826,7 +826,7 @@ public abstract class PlayerList {
          // CraftBukkit start
          WorldData worlddata = worldserver1.getWorldData();
          entityplayer1.playerConnection.sendPacket(new PacketPlayOutRespawn(worldserver1.getDimensionManager(), worldserver1.getDimensionKey(), BiomeManager.a(worldserver1.getSeed()), entityplayer1.playerInteractManager.getGameMode(), entityplayer1.playerInteractManager.c(), worldserver1.isDebugWorld(), worldserver1.isFlatWorld(), flag));
@@ -598,7 +598,7 @@ index 992e3e932133c60b448ec62a322e74ef8deb7599..1dfd884d9b2dfb3b8c44afb836301968
          entityplayer1.spawnIn(worldserver1);
          entityplayer1.dead = false;
          entityplayer1.playerConnection.teleport(new Location(worldserver1.getWorld(), entityplayer1.locX(), entityplayer1.locY(), entityplayer1.locZ(), entityplayer1.yaw, entityplayer1.pitch));
-@@ -1299,7 +1299,7 @@ public abstract class PlayerList {
+@@ -1294,7 +1294,7 @@ public abstract class PlayerList {
  
      public void a(int i) {
          this.viewDistance = i;
@@ -627,10 +627,10 @@ index d26fd68b2abd4907138ce77a6e6bb45c9af4af02..b5127f4b2deaa70b411991d78657f0c9
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 756c675939c5f5835736e6b8c42ae20941712c49..b55523c573d1d44e84a7a63502473dc33eb1538c 100644
+index c11f6e647957c353e78f6331de74264079566e1b..6fc4b59a750572b6d3b9d23fe490d7e5dc5271a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2540,10 +2540,39 @@ public class CraftWorld implements World {
+@@ -2554,10 +2554,39 @@ public class CraftWorld implements World {
      // Spigot start
      @Override
      public int getViewDistance() {
@@ -669,7 +669,7 @@ index 756c675939c5f5835736e6b8c42ae20941712c49..b55523c573d1d44e84a7a63502473dc3
 +    // Paper end - per player view distance
 +
      // Spigot start
-     private final Spigot spigot = new Spigot()
+     private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
      {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
 index a87cec0b391dfe54f70be9e27723f04f149cfadd..18295dceeacefd2586f3e3fe8bd58790740ba14d 100644

--- a/Spigot-Server-Patches/0471-Add-villager-reputation-API.patch
+++ b/Spigot-Server-Patches/0471-Add-villager-reputation-API.patch
@@ -20,10 +20,10 @@ index 0000000000000000000000000000000000000000..0f10c333d88f2e1c56a6c7f22d421084
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index 1322a8f12484700c3d707b3d18ad90c059703530..eaa84fde9cfa8e2d31e7f85b976393d576545670 100644
+index 419de8176a03acc061436d1f92079b6fafcb0ed6..650e373a925296f14150de5cbecc6b083679ba54 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -962,6 +962,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -960,6 +960,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
          this.bD = 0;
      }
  
@@ -88,7 +88,7 @@ index 3c6d6be4485cad4f2e9a395425b5837590853eee..09d2fc5769089f6d29971d10de5b8209
  
      static class b {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index a8384081c03884c86578dca677914d77441c1863..d24a892c498d7ee58741c9358748a117f01d8a8d 100644
+index 0273cf7e2ec27b094a06e5ad1131585df9a0ae8b..a705e988e3379f1ab50c2d0be3ee559dd3d9d17f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 @@ -1,9 +1,13 @@
@@ -105,7 +105,7 @@ index a8384081c03884c86578dca677914d77441c1863..d24a892c498d7ee58741c9358748a117
  import net.minecraft.server.EntityVillager;
  import net.minecraft.server.IBlockData;
  import net.minecraft.server.IRegistry;
-@@ -124,4 +128,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -126,4 +130,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
      public static VillagerProfession bukkitToNmsProfession(Profession bukkit) {
          return IRegistry.VILLAGER_PROFESSION.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
      }

--- a/Spigot-Server-Patches/0472-Fix-Light-Command.patch
+++ b/Spigot-Server-Patches/0472-Fix-Light-Command.patch
@@ -7,7 +7,7 @@ This lets you run /paper fixlight <chunkRadius> (max 5) to automatically
 fix all light data in the chunks.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index c80af89b4ad0223577ed9513dcab0a784cc964e4..f60800c3bc06a38493e17b00b815f18cb87cc8bf 100644
+index 2079bb001ea2678f6181f913262a9b7731fae778..7367781d360a8eb3a1b22de5c0b57dd98e6763d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -20,6 +20,7 @@ import org.bukkit.command.Command;
@@ -136,10 +136,10 @@ index 825c3c522b0497499b72cb9f2ff3edb39d8fea08..f3d5ea4672f950bd5c52b718f2e1e028
          // Paper start - per player view distance
          // there can be potential desync with player's last mapped section and the view distance map, so use the
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 025a5b24e259df04ee88cb251477c908bc909266..c507e71cef1da50e3709e358def6548cc69546e9 100644
+index b508e8318d0608d9bae34d9551d1cb654e53d24e..d1ec4de8b64934bb5e9346398bc471dab8457b83 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -97,6 +97,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -98,6 +98,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      private final ChunkTaskQueueSorter p;
      private final Mailbox<ChunkTaskQueueSorter.a<Runnable>> mailboxWorldGen;
      final Mailbox<ChunkTaskQueueSorter.a<Runnable>> mailboxMain; // Paper - private -> package private
@@ -152,7 +152,7 @@ index 025a5b24e259df04ee88cb251477c908bc909266..c507e71cef1da50e3709e358def6548c
      public final WorldLoadListener worldLoadListener;
      public final PlayerChunkMap.a chunkDistanceManager;
      private final AtomicInteger u;
-@@ -288,11 +294,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -289,11 +295,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          Mailbox<Runnable> mailbox = Mailbox.a("main", iasynctaskhandler::a);
  
          this.worldLoadListener = worldloadlistener;

--- a/Spigot-Server-Patches/0476-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/Spigot-Server-Patches/0476-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,10 +10,10 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6fd956cbbb4fddc4294ff03976e66d93c1b086c7..d0ce4b96174f85c545a457fe864c7ebadc727ade 100644
+index f606ccd7586f6ad70d2426363cfd82d07824008d..89de6c1a2463b2ea3aefb31c22e277fe707555a3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -771,6 +771,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -773,6 +773,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
@@ -22,7 +22,7 @@ index 6fd956cbbb4fddc4294ff03976e66d93c1b086c7..d0ce4b96174f85c545a457fe864c7eba
          // CraftBukkit end
          if (this.getServerConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e466dd5077fbae6963783774cb7a32b0bbca41ac..6744d56a99d2187fcb742820c9d23158507a4dce 100644
+index 6728a0f753a457fea485265739ca85ebebbf40bb..9b6d081f7db0ed389776c68dc4771e7cbaebea7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -942,6 +942,35 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0481-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/Spigot-Server-Patches/0481-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -39,10 +39,10 @@ index d40d41faae13ee17bbe1c7bd4b64126bcaee5643..3960a975e74ed81c45819fe5e0f01c6c
  
                      if (!flag4 && this.o <= 400 && !this.q && this.r == this.tracker.isOnGround()) {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index c507e71cef1da50e3709e358def6548cc69546e9..1685d6f9f497455636dbcef057db48f9d4039be4 100644
+index d1ec4de8b64934bb5e9346398bc471dab8457b83..2654afa43b8322752267ca71447567e91323922e 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -2134,9 +2134,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2135,9 +2135,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          public void updatePlayer(EntityPlayer entityplayer) {
              org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
              if (entityplayer != this.tracker) {

--- a/Spigot-Server-Patches/0482-Ensure-safe-gateway-teleport.patch
+++ b/Spigot-Server-Patches/0482-Ensure-safe-gateway-teleport.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure safe gateway teleport
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityEndGateway.java b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-index 5550fd9ea6bcae07dcdf431322cb0da0b26a6d71..e0118a971e1ea3c52a1380f519146b8f46a425ea 100644
+index a242dd1f7ca7f2d93312d630173397a3abd83b1d..b740c9b66a77df1ff20fba794c49a1de4292ba88 100644
 --- a/src/main/java/net/minecraft/server/TileEntityEndGateway.java
 +++ b/src/main/java/net/minecraft/server/TileEntityEndGateway.java
-@@ -63,9 +63,14 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
+@@ -64,9 +64,14 @@ public class TileEntityEndGateway extends TileEntityEnderPortal implements ITick
          } else if (!this.world.isClientSide) {
              List<Entity> list = this.world.a(Entity.class, new AxisAlignedBB(this.getPosition()), TileEntityEndGateway::a);
  

--- a/Spigot-Server-Patches/0485-Workaround-for-Client-Lag-Spikes-MC-162253.patch
+++ b/Spigot-Server-Patches/0485-Workaround-for-Client-Lag-Spikes-MC-162253.patch
@@ -12,7 +12,7 @@ to the client, so that it doesn't attempt to calculate them.
 This mitigates the frametime impact to a minimum (but it's still there).
 
 diff --git a/src/main/java/net/minecraft/server/Chunk.java b/src/main/java/net/minecraft/server/Chunk.java
-index 544f4a473d1453e029111bea45483543e3bcbabb..af9d54ef057d5f6977cf77c57cde25b6b0d1f39d 100644
+index 0347dca5d2e40ba078d3f256e17f69ee7f0265cc..3bcd63a754538ccfc5965207a8fc79faa31925c0 100644
 --- a/src/main/java/net/minecraft/server/Chunk.java
 +++ b/src/main/java/net/minecraft/server/Chunk.java
 @@ -234,7 +234,7 @@ public class Chunk implements IChunkAccess {
@@ -37,10 +37,10 @@ index 39572cdce691a459cb9df0cc064fbf7bde83a99e..e52df8096e399c84ff8a2637fdd65ea5
          return chunksection == Chunk.a || chunksection.c();
      }
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 1685d6f9f497455636dbcef057db48f9d4039be4..e38c9a8f4bf017db9f296bffcd029f9603ee82f6 100644
+index 2654afa43b8322752267ca71447567e91323922e..126f94eaf8b328e5ca0133c61f92c52197c498dd 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -1959,12 +1959,112 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1960,12 +1960,112 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  

--- a/Spigot-Server-Patches/0486-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0486-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -889,7 +889,7 @@ index f3d5ea4672f950bd5c52b718f2e1e0280175ccb9..3d95c7cd5d34166a427b45061bce2ac9
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e93401ce62 100644
+index 126f94eaf8b328e5ca0133c61f92c52197c498dd..897496d669eafdbbacebb1d393ee3f6706091bb4 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
 @@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -900,15 +900,15 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
  import it.unimi.dsi.fastutil.longs.Long2ObjectLinkedOpenHashMap;
  import it.unimi.dsi.fastutil.longs.Long2ObjectMap.Entry;
  import it.unimi.dsi.fastutil.longs.LongIterator;
-@@ -52,6 +53,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
- import org.apache.logging.log4j.LogManager;
+@@ -53,6 +54,7 @@ import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
+ 
  import org.bukkit.entity.Player; // CraftBukkit
 +import org.spigotmc.AsyncCatcher;
  
  public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
-@@ -89,6 +91,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -90,6 +92,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      public final WorldServer world;
      private final LightEngineThreaded lightEngine;
      private final IAsyncTaskHandler<Runnable> executor;
@@ -916,7 +916,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
      public final ChunkGenerator chunkGenerator;
      private final Supplier<WorldPersistentData> l; public final Supplier<WorldPersistentData> getWorldPersistentDataSupplier() { return this.l; } // Paper - OBFHELPER
      private final VillagePlace m;
-@@ -126,6 +129,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -127,6 +130,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          @Override
          public void execute(Runnable runnable) {
@@ -924,7 +924,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
              if (queued == null) {
                  queued = new java.util.ArrayDeque<>();
              }
-@@ -134,6 +138,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -135,6 +139,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          @Override
          public void run() {
@@ -932,7 +932,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
              if (queued == null) {
                  return;
              }
-@@ -288,6 +293,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -289,6 +294,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.world = worldserver;
          this.chunkGenerator = chunkgenerator;
          this.executor = iasynctaskhandler;
@@ -948,7 +948,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
          ThreadedMailbox<Runnable> threadedmailbox = ThreadedMailbox.a(executor, "worldgen");
  
          iasynctaskhandler.getClass();
-@@ -382,6 +396,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -383,6 +397,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          this.playerViewDistanceTickMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets,
              (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
               com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> newState) -> {
@@ -956,7 +956,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
                  if (newState.size() != 1) {
                      return;
                  }
-@@ -400,7 +415,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -401,7 +416,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
                  ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(rangeX, rangeZ);
                  PlayerChunkMap.this.world.getChunkProvider().removeTicketAtLevel(TicketType.PLAYER, chunkPos, 31, chunkPos); // entity ticking level, TODO check on update
@@ -969,7 +969,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
          this.playerViewDistanceNoTickMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets);
          this.playerViewDistanceBroadcastMap = new com.destroystokyo.paper.util.misc.PlayerAreaMap(this.pooledLinkedPlayerHashSets,
              (EntityPlayer player, int rangeX, int rangeZ, int currPosX, int currPosZ, int prevPosX, int prevPosZ,
-@@ -417,6 +436,115 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -418,6 +437,115 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              });
          // Paper end - no-tick view distance
      }
@@ -1085,7 +1085,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
  
      public void updatePlayerMobTypeMap(Entity entity) {
          if (!this.world.paperConfig.perPlayerMobSpawns) {
-@@ -546,6 +674,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -547,6 +675,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          List<CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>>> list = Lists.newArrayList();
          int j = chunkcoordintpair.x;
          int k = chunkcoordintpair.z;
@@ -1093,7 +1093,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
  
          for (int l = -i; l <= i; ++l) {
              for (int i1 = -i; i1 <= i; ++i1) {
-@@ -564,6 +693,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -565,6 +694,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  ChunkStatus chunkstatus = (ChunkStatus) intfunction.apply(j1);
                  CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> completablefuture = playerchunk.a(chunkstatus, this);
@@ -1108,7 +1108,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
  
                  list.add(completablefuture);
              }
-@@ -1031,14 +1168,22 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1032,14 +1169,22 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          };
  
          CompletableFuture<NBTTagCompound> chunkSaveFuture = this.world.asyncChunkTaskManager.getChunkSaveFuture(chunkcoordintpair.x, chunkcoordintpair.z);
@@ -1136,7 +1136,7 @@ index e38c9a8f4bf017db9f296bffcd029f9603ee82f6..19a31536d40289cba25120d4cc4788e9
          return ret;
          // Paper end
      }
-@@ -1175,7 +1320,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1176,7 +1321,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              long i = playerchunk.i().pair();
  
              playerchunk.getClass();
@@ -1158,10 +1158,10 @@ index c33d87d9c3ce2c258a5e782768eac491538a2836..99dddcaac05cf6496fdfd3a824b42ff4
      }
  
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 6f5fd83414fd51f7674cf69066b5d5d18327e2bc..5d631dbb426f0e7a2e39c4636cfd5e0c1246c248 100644
+index 6c96a7123fb28cfadf129c4ba8688f13539583d6..6cbb49a728704491ba41fdf9463b8438985e0d1d 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -198,8 +198,8 @@ public abstract class PlayerList {
+@@ -193,8 +193,8 @@ public abstract class PlayerList {
          final ChunkCoordIntPair pos = new ChunkCoordIntPair(chunkX, chunkZ);
          PlayerChunkMap playerChunkMap = worldserver1.getChunkProvider().playerChunkMap;
          playerChunkMap.chunkDistanceManager.addTicketAtLevel(TicketType.LOGIN, pos, 31, pos.pair());
@@ -1172,7 +1172,7 @@ index 6f5fd83414fd51f7674cf69066b5d5d18327e2bc..5d631dbb426f0e7a2e39c4636cfd5e0c
              PlayerChunk updatingChunk = playerChunkMap.getUpdatingChunk(pos.pair());
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingFuture();
-@@ -619,6 +619,7 @@ public abstract class PlayerList {
+@@ -614,6 +614,7 @@ public abstract class PlayerList {
          SocketAddress socketaddress = loginlistener.networkManager.getSocketAddress();
  
          EntityPlayer entity = new EntityPlayer(this.server, this.server.getWorldServer(World.OVERWORLD), gameprofile, new PlayerInteractManager(this.server.getWorldServer(World.OVERWORLD)));
@@ -1180,7 +1180,7 @@ index 6f5fd83414fd51f7674cf69066b5d5d18327e2bc..5d631dbb426f0e7a2e39c4636cfd5e0c
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.networkManager.getRawAddress()).getAddress());
  
-@@ -825,6 +826,7 @@ public abstract class PlayerList {
+@@ -820,6 +821,7 @@ public abstract class PlayerList {
          // CraftBukkit end
  
          worldserver1.getChunkProvider().addTicket(TicketType.POST_TELEPORT, new ChunkCoordIntPair(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper
@@ -1222,10 +1222,10 @@ index d7b9d9fd3a3b607278a3d72b0b306b0be2aa30ad..6fd852db6bcfbfbf84ec2acf6d23b08a
      public static <T> TicketType<T> a(String s, Comparator<T> comparator) {
          return new TicketType<>(s, comparator, 0L);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b55523c573d1d44e84a7a63502473dc33eb1538c..925aa6dddb4f572a05e7b5be5a0a201162b7b1eb 100644
+index 6fc4b59a750572b6d3b9d23fe490d7e5dc5271a5..59a9684d16d702777d834c64ebdcef0ef5a22623 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2530,6 +2530,10 @@ public class CraftWorld implements World {
+@@ -2544,6 +2544,10 @@ public class CraftWorld implements World {
              return future;
          }
  
@@ -1237,7 +1237,7 @@ index b55523c573d1d44e84a7a63502473dc33eb1538c..925aa6dddb4f572a05e7b5be5a0a2011
              net.minecraft.server.Chunk chunk = (net.minecraft.server.Chunk) either.left().orElse(null);
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c219986c8a1a50c3b14da60eb4717edcb1588c38..9a1201e473ac99408b32864462f04e021c5f0f8c 100644
+index 6f20a5b9c96c14ca5fc18c3e4bfe2656c3cb4b63..8a34261c0fdfae3526646ddf14bc9a7b5dedc3b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -848,6 +848,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0487-Optimize-sending-packets-to-nearby-locations-sounds-.patch
+++ b/Spigot-Server-Patches/0487-Optimize-sending-packets-to-nearby-locations-sounds-.patch
@@ -11,10 +11,10 @@ This will drastically cut down on packet sending cost for worlds with
 lots of players in them.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 4bf086ab2ee2514515ab8238a30b766e5c9d3ea9..336e95013d4ff50246d22893d0c89af0245c9109 100644
+index 6cbb49a728704491ba41fdf9463b8438985e0d1d..6d6fb9012b67e1c93c0141eb59bdcfdf65de71db 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -1076,16 +1076,40 @@ public abstract class PlayerList {
+@@ -1071,16 +1071,40 @@ public abstract class PlayerList {
      }
  
      public void sendPacketNearby(@Nullable EntityHuman entityhuman, double d0, double d1, double d2, double d3, ResourceKey<World> resourcekey, Packet<?> packet) {

--- a/Spigot-Server-Patches/0488-Improve-Chunk-Status-Transition-Speed.patch
+++ b/Spigot-Server-Patches/0488-Improve-Chunk-Status-Transition-Speed.patch
@@ -36,7 +36,7 @@ scenario / path:
 Previously would have hopped to SERVER around 12+ times there extra.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerChunk.java b/src/main/java/net/minecraft/server/PlayerChunk.java
-index 371a301f4a295c59ce40fefc6ef07e544414d94b..025ab54dddbf4ef80ce2253f9b6cabcb8e46bfd2 100644
+index 3d95c7cd5d34166a427b45061bce2ac9569784b4..0799970f90527f97d64eb857a0b07990114c7ab2 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunk.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunk.java
 @@ -58,6 +58,13 @@ public class PlayerChunk {
@@ -54,10 +54,10 @@ index 371a301f4a295c59ce40fefc6ef07e544414d94b..025ab54dddbf4ef80ce2253f9b6cabcb
      // Paper start - no-tick view distance
      public final Chunk getSendingChunk() {
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 19a31536d40289cba25120d4cc4788e93401ce62..bb515e4c08bccff2a737aed924c5cf59800ecf47 100644
+index 897496d669eafdbbacebb1d393ee3f6706091bb4..b1c332b79bfa00e89c6d3aca327b88fe94c3bba1 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -741,7 +741,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -742,7 +742,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              return either.mapLeft((list) -> {
                  return (Chunk) list.get(list.size() / 2);
              });
@@ -66,7 +66,7 @@ index 19a31536d40289cba25120d4cc4788e93401ce62..bb515e4c08bccff2a737aed924c5cf59
      }
  
      @Nullable
-@@ -1091,7 +1091,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1092,7 +1092,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      IChunkAccess ichunkaccess = (IChunkAccess) optional.get();
  
                      if (ichunkaccess.getChunkStatus().b(chunkstatus)) {
@@ -75,7 +75,7 @@ index 19a31536d40289cba25120d4cc4788e93401ce62..bb515e4c08bccff2a737aed924c5cf59
  
                          if (chunkstatus == ChunkStatus.LIGHT) {
                              completablefuture1 = this.b(playerchunk, chunkstatus);
-@@ -1107,7 +1107,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1108,7 +1108,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          return this.b(playerchunk, chunkstatus);
                      }
                  }
@@ -84,7 +84,7 @@ index 19a31536d40289cba25120d4cc4788e93401ce62..bb515e4c08bccff2a737aed924c5cf59
          }
      }
  
-@@ -1228,6 +1228,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1229,6 +1229,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return CompletableFuture.completedFuture(Either.right(playerchunk_failure));
              });
          }, (runnable) -> {

--- a/Spigot-Server-Patches/0493-Optimize-Light-Engine.patch
+++ b/Spigot-Server-Patches/0493-Optimize-Light-Engine.patch
@@ -1341,10 +1341,10 @@ index 0799970f90527f97d64eb857a0b07990114c7ab2..afea606641c27e2ea8769455833b96e3
          if (getCurrentPriority() != priority) {
              this.u.a(this.location, this::getCurrentPriority, priority, this::setPriority); // use preferred priority
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index bb515e4c08bccff2a737aed924c5cf59800ecf47..49008cdec739b19409fdaf1b0ed806a6c0e93200 100644
+index b1c332b79bfa00e89c6d3aca327b88fe94c3bba1..4264fab9164b8a59cbbcedfb97272413a6303ac9 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -277,6 +277,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -278,6 +278,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end
  
@@ -1352,7 +1352,7 @@ index bb515e4c08bccff2a737aed924c5cf59800ecf47..49008cdec739b19409fdaf1b0ed806a6
      public PlayerChunkMap(WorldServer worldserver, Convertable.ConversionSession convertable_conversionsession, DataFixer datafixer, DefinedStructureManager definedstructuremanager, Executor executor, IAsyncTaskHandler<Runnable> iasynctaskhandler, ILightAccess ilightaccess, ChunkGenerator chunkgenerator, WorldLoadListener worldloadlistener, Supplier<WorldPersistentData> supplier, int i, boolean flag) {
          super(new File(convertable_conversionsession.a(worldserver.getDimensionKey()), "region"), datafixer, flag);
          //this.visibleChunks = this.updatingChunks.clone(); // Paper - no more cloning
-@@ -308,7 +309,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -309,7 +310,15 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          Mailbox<Runnable> mailbox = Mailbox.a("main", iasynctaskhandler::a);
  
          this.worldLoadListener = worldloadlistener;
@@ -1369,7 +1369,7 @@ index bb515e4c08bccff2a737aed924c5cf59800ecf47..49008cdec739b19409fdaf1b0ed806a6
  
          this.p = new ChunkTaskQueueSorter(ImmutableList.of(threadedmailbox, mailbox, threadedmailbox1), executor, Integer.MAX_VALUE);
          this.mailboxWorldGen = this.p.a(threadedmailbox, false);
-@@ -654,6 +663,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -655,6 +664,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          // Paper end
      }
  
@@ -1377,7 +1377,7 @@ index bb515e4c08bccff2a737aed924c5cf59800ecf47..49008cdec739b19409fdaf1b0ed806a6
      protected IntSupplier c(long i) {
          return () -> {
              PlayerChunk playerchunk = this.getVisibleChunk(i);
-@@ -781,6 +791,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -782,6 +792,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      @Override
      public void close() throws IOException {
          try {

--- a/Spigot-Server-Patches/0495-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/Spigot-Server-Patches/0495-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6744d56a99d2187fcb742820c9d23158507a4dce..64a2ab7a33342c7a60f0bc14dd9256ba1ed62666 100644
+index 9b6d081f7db0ed389776c68dc4771e7cbaebea7d..dfe6b9e680a4b64fd6a664581f0a1db81f04dafa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -346,7 +346,7 @@ public final class CraftServer implements Server {
@@ -44,10 +44,10 @@ index 6744d56a99d2187fcb742820c9d23158507a4dce..64a2ab7a33342c7a60f0bc14dd9256ba
          printSaveWarning = false;
          console.autosavePeriod = configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24eee55682d9 100644
+index 59a9684d16d702777d834c64ebdcef0ef5a22623..602f0aa24adb641933c026aaba7d3245df628bbc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -407,9 +407,22 @@ public class CraftWorld implements World {
+@@ -408,9 +408,22 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -71,7 +71,7 @@ index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24ee
      @Override
      public Chunk getChunkAt(Block block) {
          Preconditions.checkArgument(block != null, "null block");
-@@ -483,7 +496,7 @@ public class CraftWorld implements World {
+@@ -484,7 +497,7 @@ public class CraftWorld implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (isChunkLoaded(x, z)) {
@@ -80,7 +80,7 @@ index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24ee
          }
  
          return true;
-@@ -560,10 +573,12 @@ public class CraftWorld implements World {
+@@ -561,10 +574,12 @@ public class CraftWorld implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkCoordIntPair chunkPos = new ChunkCoordIntPair(x, z);
@@ -94,7 +94,7 @@ index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24ee
              if (immediate == null) {
                  immediate = world.getChunkProvider().playerChunkMap.getUnloadingChunk(x, z);
              }
-@@ -571,7 +586,7 @@ public class CraftWorld implements World {
+@@ -572,7 +587,7 @@ public class CraftWorld implements World {
                  if (!(immediate instanceof ProtoChunkExtension) && !(immediate instanceof net.minecraft.server.Chunk)) {
                      return false; // not full status
                  }
@@ -103,7 +103,7 @@ index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24ee
                  world.getChunkAt(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -598,7 +613,7 @@ public class CraftWorld implements World {
+@@ -599,7 +614,7 @@ public class CraftWorld implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -112,7 +112,7 @@ index 925aa6dddb4f572a05e7b5be5a0a201162b7b1eb..e32e972b00098bf1851b7974218c24ee
          world.getChunkProvider().getChunkAt(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2536,6 +2551,7 @@ public class CraftWorld implements World {
+@@ -2550,6 +2565,7 @@ public class CraftWorld implements World {
          }
          return this.world.getChunkProvider().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.server.Chunk chunk = (net.minecraft.server.Chunk) either.left().orElse(null);

--- a/Spigot-Server-Patches/0503-Expose-Arrow-getItemStack.patch
+++ b/Spigot-Server-Patches/0503-Expose-Arrow-getItemStack.patch
@@ -17,10 +17,10 @@ index 93084633d487684fb598038d148670fe6a00b3ed..402684ee2a42eefc843df663a1f3af9a
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-index cf40d62492dc207815487d6f64e7d11892adc09b..5a0a78d7edead8712090dfb9c53ff904abf5b118 100644
+index ddaa10704188a5a6862bcff783e492c19f4929e5..f310dccff5a11a2694faeabf017b0104362e38f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-@@ -102,6 +102,13 @@ public class CraftArrow extends AbstractProjectile implements AbstractArrow {
+@@ -103,6 +103,13 @@ public class CraftArrow extends AbstractProjectile implements AbstractArrow {
          getHandle().fromPlayer = EntityArrow.PickupStatus.a(status.ordinal());
      }
  

--- a/Spigot-Server-Patches/0505-Hide-sync-chunk-writes-behind-flag.patch
+++ b/Spigot-Server-Patches/0505-Hide-sync-chunk-writes-behind-flag.patch
@@ -9,10 +9,10 @@ on harddrives.
 -DPaper.enable-sync-chunk-writes=true to enable
 
 diff --git a/src/main/java/net/minecraft/server/DedicatedServerProperties.java b/src/main/java/net/minecraft/server/DedicatedServerProperties.java
-index 3ecfb193be1d83d2b2c90ca9e264388dabb88c05..65961a03728852bd75367083a0de6fd0082b17cb 100644
+index 205d56f88440789df8a028b3827dd388fea56f63..15a4f921b1ae2bbc66b7d58238b60151123a7eb3 100644
 --- a/src/main/java/net/minecraft/server/DedicatedServerProperties.java
 +++ b/src/main/java/net/minecraft/server/DedicatedServerProperties.java
-@@ -101,7 +101,7 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
+@@ -105,7 +105,7 @@ public class DedicatedServerProperties extends PropertyManager<DedicatedServerPr
          this.maxWorldSize = this.a("max-world-size", (integer) -> {
              return MathHelper.clamp(integer, 1, 29999984);
          }, 29999984);

--- a/Spigot-Server-Patches/0507-Add-permission-for-command-blocks.patch
+++ b/Spigot-Server-Patches/0507-Add-permission-for-command-blocks.patch
@@ -18,10 +18,10 @@ index dd7066d1a72f5c6f54c1f40a7b694deb827410dc..6b353a99c04e0312f520f8559c05ddaf
              return EnumInteractionResult.a(world.isClientSide);
          } else {
 diff --git a/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java b/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
-index 7e13b1cf6d92c3e0f2dab1ba1d42bd4f250e256c..3820acd65f3cd488dba964e6d9c458852570f4a0 100644
+index e78809278b9159728722b2b33ad5dfae77e860ed..c12d7e1a399b3e4c576a0e32f22b3a439a5df369 100644
 --- a/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
 +++ b/src/main/java/net/minecraft/server/CommandBlockListenerAbstract.java
-@@ -179,7 +179,7 @@ public abstract class CommandBlockListenerAbstract implements ICommandListener {
+@@ -178,7 +178,7 @@ public abstract class CommandBlockListenerAbstract implements ICommandListener {
      }
  
      public EnumInteractionResult a(EntityHuman entityhuman) {
@@ -53,10 +53,10 @@ index 233070b1e169100d62a2dc80dc9d7178ca14ea0e..439b460216c90ff4e269240217d94e52
          } else {
              CommandBlockListenerAbstract commandblocklistenerabstract = packetplayinsetcommandminecart.a(this.player.world);
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index cdaeeb8b01f084ae7a91f9681850a737af8a74be..4b564d36135e9dbdbb57a95791f89aefd180457b 100644
+index 6ea691d81ea62bf05225baa303d974a6df0b822b..942b38aaf1845468852ac41e9fba230837f137e3 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -353,7 +353,7 @@ public class PlayerInteractManager {
+@@ -354,7 +354,7 @@ public class PlayerInteractManager {
              TileEntity tileentity = this.world.getTileEntity(blockposition);
              Block block = iblockdata.getBlock();
  

--- a/Spigot-Server-Patches/0510-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0510-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -39,10 +39,10 @@ index f5792b999ce42acb13ae9a62ceb2ddec39abe209..5504facd2e453238caa71d98743be541
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d0ce4b96174f85c545a457fe864c7ebadc727ade..fc4561e970dfed4ffe5792b7b739e290ae3cadee 100644
+index 89de6c1a2463b2ea3aefb31c22e277fe707555a3..cfe770b7b77bb08407b164b932b898dfbe869b28 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1524,11 +1524,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1526,11 +1526,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
      }
  

--- a/Spigot-Server-Patches/0520-Improve-EntityTargetLivingEntityEvent-for-1.16-mobs.patch
+++ b/Spigot-Server-Patches/0520-Improve-EntityTargetLivingEntityEvent-for-1.16-mobs.patch
@@ -7,10 +7,10 @@ CraftBukkit has a bug in their implementation and is incorrectly handling forget
 Also adds more target reasons for why it forgot target.
 
 diff --git a/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java b/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
-index 7a3a1190b5c09629dbe74adbdebf2756207b9124..51203fd30bfee57ef8d52d0360a64a7e1d6c65a3 100644
+index 2e1b817a639fdd46b07dc70150f246cac3b35232..d98f57d2025c488dc1884132678005b861566869 100644
 --- a/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
 +++ b/src/main/java/net/minecraft/server/BehaviorAttackTargetForget.java
-@@ -26,15 +26,15 @@ public class BehaviorAttackTargetForget<E extends EntityInsentient> extends Beha
+@@ -27,15 +27,15 @@ public class BehaviorAttackTargetForget<E extends EntityInsentient> extends Beha
  
      protected void a(WorldServer worldserver, E e0, long i) {
          if (a((EntityLiving) e0)) {
@@ -31,7 +31,7 @@ index 7a3a1190b5c09629dbe74adbdebf2756207b9124..51203fd30bfee57ef8d52d0360a64a7e
          }
      }
  
-@@ -58,17 +58,20 @@ public class BehaviorAttackTargetForget<E extends EntityInsentient> extends Beha
+@@ -59,17 +59,20 @@ public class BehaviorAttackTargetForget<E extends EntityInsentient> extends Beha
          return optional.isPresent() && !((EntityLiving) optional.get()).isAlive();
      }
  

--- a/Spigot-Server-Patches/0523-Spawn-player-in-correct-world-on-login.patch
+++ b/Spigot-Server-Patches/0523-Spawn-player-in-correct-world-on-login.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Spawn player in correct world on login
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index e7900a3f5ef54108bfe8397d7ee096563a9f9fa1..1da28f6eb3cf7d31e0b491238ec234236afc5b5a 100644
+index 6d6fb9012b67e1c93c0141eb59bdcfdf65de71db..a6ad5daf4118ed45301ed6098d53a94c5690c304 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -121,7 +121,18 @@ public abstract class PlayerList {
+@@ -116,7 +116,18 @@ public abstract class PlayerList {
          }String lastKnownName = s; // Paper
          // CraftBukkit end
  
@@ -16,7 +16,7 @@ index e7900a3f5ef54108bfe8397d7ee096563a9f9fa1..1da28f6eb3cf7d31e0b491238ec23423
 +        // Paper start - move logic in Entity to here, to use bukkit supplied world UUID.
 +        if (nbttagcompound != null && nbttagcompound.hasKey("WorldUUIDMost") && nbttagcompound.hasKey("WorldUUIDLeast")) {
 +            UUID uid = new UUID(nbttagcompound.getLong("WorldUUIDMost"), nbttagcompound.getLong("WorldUUIDLeast"));
-+            org.bukkit.World bWorld = Bukkit.getServer().getWorld(uid);
++            org.bukkit.World bWorld = org.bukkit.Bukkit.getServer().getWorld(uid);
 +            if (bWorld != null) {
 +                resourcekey = ((CraftWorld) bWorld).getHandle().getDimensionKey();
 +            } else {

--- a/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
+++ b/Spigot-Server-Patches/0524-Add-PrepareResultEvent.patch
@@ -56,10 +56,10 @@ index b829a481394167593ccf7521770802531b9ed483..0dd8623591827cd29fdf7916bf9a4b18
  
      private void a(ItemStack itemstack, ItemStack itemstack1, ItemStack itemstack2) {
 diff --git a/src/main/java/net/minecraft/server/ContainerGrindstone.java b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-index fe9a083b724a8657cac8462b3f44d3cc12a4db58..39f809a37b58e008e7ef32c0759eeecbde26bc94 100644
+index b69adda272f6bfb7f1570c282a16b343c9a552e2..57b3c42b6b3fcf791591897fa12d12c2c396191c 100644
 --- a/src/main/java/net/minecraft/server/ContainerGrindstone.java
 +++ b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-@@ -144,6 +144,7 @@ public class ContainerGrindstone extends Container {
+@@ -145,6 +145,7 @@ public class ContainerGrindstone extends Container {
          super.a(iinventory);
          if (iinventory == this.craftInventory) {
              this.e();
@@ -94,10 +94,10 @@ index a6bfc4a49ea0a789cea3706fdd6673837a4b0829..61ef3adcfb021e222042de62ad06a2e7
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/ContainerStonecutter.java b/src/main/java/net/minecraft/server/ContainerStonecutter.java
-index ba3db09763d94d730c3fe8662e4dbb24e0636786..3506473f9b9f4c747f7b737d9bd02bef8ea6d83e 100644
+index 1340520b773caec58d0730311626f2f99425ecfb..232a46021edcaa90d29dfa5e8b6857f4ab4a8eac 100644
 --- a/src/main/java/net/minecraft/server/ContainerStonecutter.java
 +++ b/src/main/java/net/minecraft/server/ContainerStonecutter.java
-@@ -142,6 +142,7 @@ public class ContainerStonecutter extends Container {
+@@ -143,6 +143,7 @@ public class ContainerStonecutter extends Container {
              this.a(iinventory, itemstack);
          }
  

--- a/Spigot-Server-Patches/0531-Thread-Safe-Vanilla-Command-permission-checking.patch
+++ b/Spigot-Server-Patches/0531-Thread-Safe-Vanilla-Command-permission-checking.patch
@@ -26,10 +26,10 @@ index 6976da79b20280fcd72dcfb8b48e2eb73257faf2..d9c47f3fc18266df3be1f564c01dfc3e
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/CommandListenerWrapper.java b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
-index 7073d697a5d35b9b72ea05d5608438ac3e54c20d..86f1cfe454ea0a989775b49a6b88375c766ef647 100644
+index efe2391f1648f4f83e9b77fdc6d9d81653cf65b3..31543b38a7c46d93333c5f96fdb718b0a7a087b2 100644
 --- a/src/main/java/net/minecraft/server/CommandListenerWrapper.java
 +++ b/src/main/java/net/minecraft/server/CommandListenerWrapper.java
-@@ -33,7 +33,7 @@ public class CommandListenerWrapper implements ICompletionProvider, com.destroys
+@@ -34,7 +34,7 @@ public class CommandListenerWrapper implements ICompletionProvider, com.destroys
      private final ResultConsumer<CommandListenerWrapper> l;
      private final ArgumentAnchor.Anchor m;
      private final Vec2F n;
@@ -38,7 +38,7 @@ index 7073d697a5d35b9b72ea05d5608438ac3e54c20d..86f1cfe454ea0a989775b49a6b88375c
  
      public CommandListenerWrapper(ICommandListener icommandlistener, Vec3D vec3d, Vec2F vec2f, WorldServer worldserver, int i, String s, IChatBaseComponent ichatbasecomponent, MinecraftServer minecraftserver, @Nullable Entity entity) {
          this(icommandlistener, vec3d, vec2f, worldserver, i, s, ichatbasecomponent, minecraftserver, entity, false, (commandcontext, flag, j) -> {
-@@ -150,9 +150,11 @@ public class CommandListenerWrapper implements ICompletionProvider, com.destroys
+@@ -151,9 +151,11 @@ public class CommandListenerWrapper implements ICompletionProvider, com.destroys
      @Override
      public boolean hasPermission(int i) {
          // CraftBukkit start

--- a/Spigot-Server-Patches/0533-Fix-SPIGOT-5989.patch
+++ b/Spigot-Server-Patches/0533-Fix-SPIGOT-5989.patch
@@ -10,10 +10,10 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 3f18a8cbea821cb878e0b0d3dde3b3e89b80715f..5255f3b0209226ee09827a51bb8282a220184975 100644
+index 6c3d52cac1918b9f47cd70249f6f020d010ad8b8..faf82af08b00f74d3d835bd54b9c2864aa67ddd4 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -773,6 +773,7 @@ public abstract class PlayerList {
+@@ -768,6 +768,7 @@ public abstract class PlayerList {
          // Paper start
          boolean isBedSpawn = false;
          boolean isRespawn = false;
@@ -21,7 +21,7 @@ index 3f18a8cbea821cb878e0b0d3dde3b3e89b80715f..5255f3b0209226ee09827a51bb8282a2
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -783,7 +784,7 @@ public abstract class PlayerList {
+@@ -778,7 +779,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -30,7 +30,7 @@ index 3f18a8cbea821cb878e0b0d3dde3b3e89b80715f..5255f3b0209226ee09827a51bb8282a2
                  } else {
                      optional = Optional.empty();
                  }
-@@ -826,7 +827,12 @@ public abstract class PlayerList {
+@@ -821,7 +822,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -44,7 +44,7 @@ index 3f18a8cbea821cb878e0b0d3dde3b3e89b80715f..5255f3b0209226ee09827a51bb8282a2
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -864,8 +870,12 @@ public abstract class PlayerList {
+@@ -859,8 +865,12 @@ public abstract class PlayerList {
          }
          // entityplayer1.syncInventory();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/Spigot-Server-Patches/0537-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/Spigot-Server-Patches/0537-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e32e972b00098bf1851b7974218c24eee55682d9..ed55a1e6943fb9cdc763d1b7340e3ec53a46106e 100644
+index 602f0aa24adb641933c026aaba7d3245df628bbc..ceed6ffdb0368e521b5d369d45da0ca83e61ad3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2614,6 +2614,7 @@ public class CraftWorld implements World {
+@@ -2628,6 +2628,7 @@ public class CraftWorld implements World {
              lightning.teleportAndSync( loc.getX(), loc.getY(), loc.getZ() );
              lightning.isEffect = true;
              lightning.isSilent = isSilent;

--- a/Spigot-Server-Patches/0540-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0540-Incremental-player-saving.patch
@@ -37,10 +37,10 @@ index a7f39878829f1c901934fb2d8b53d906295112e9..8436b7be989bf08c8ec1f0d646b20e77
      public NetworkManager networkManager; // Paper
      public final MinecraftServer server;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ca417825eb0827caad817f65b5132f1de37e3679..69fcfff3f21168f334fd526cb65e63e086d32a70 100644
+index cfe770b7b77bb08407b164b932b898dfbe869b28..641c31597cad47c4950d5453e85ce692ab13d2fd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1226,9 +1226,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1228,9 +1228,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          //if (autosavePeriod > 0 && this.ticks % autosavePeriod == 0) { // CraftBukkit // Paper - move down
              //MinecraftServer.LOGGER.debug("Autosave started"); // Paper
              serverAutoSave = (autosavePeriod > 0 && this.ticks % autosavePeriod == 0); // Paper
@@ -59,10 +59,10 @@ index ca417825eb0827caad817f65b5132f1de37e3679..69fcfff3f21168f334fd526cb65e63e0
              // Paper start
              for (WorldServer world : getWorlds()) {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index f14fb972029d3125f428fb8244c4078722b52617..f000588b2d8b5bdedc076a8532cbd47a823fe1a5 100644
+index faf82af08b00f74d3d835bd54b9c2864aa67ddd4..086ada9b6a1d590356919fda078c777bd95f9f44 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -485,6 +485,7 @@ public abstract class PlayerList {
+@@ -480,6 +480,7 @@ public abstract class PlayerList {
      protected void savePlayerFile(EntityPlayer entityplayer) {
          if (!entityplayer.getBukkitEntity().isPersistent()) return; // CraftBukkit
          if (!entityplayer.didPlayerJoinEvent) return; // Paper - If we never fired PJE, we disconnected during login. Data has not changed, and additionally, our saved vehicle is not loaded! If we save now, we will lose our vehicle (CraftBukkit bug)
@@ -70,7 +70,7 @@ index f14fb972029d3125f428fb8244c4078722b52617..f000588b2d8b5bdedc076a8532cbd47a
          this.playerFileData.save(entityplayer);
          ServerStatisticManager serverstatisticmanager = (ServerStatisticManager) entityplayer.getStatisticManager(); // CraftBukkit
  
-@@ -1144,10 +1145,21 @@ public abstract class PlayerList {
+@@ -1139,10 +1140,21 @@ public abstract class PlayerList {
      }
  
      public void savePlayers() {

--- a/Spigot-Server-Patches/0551-Add-setMaxPlayers-API.patch
+++ b/Spigot-Server-Patches/0551-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 0592ee3511d5532440944af45fe5428077c88d7f..9080f28d8c8ce20ea9934384bd14932145c64de0 100644
+index 086ada9b6a1d590356919fda078c777bd95f9f44..f7b17c80480e7d4650fe7210936923c6c3f8b45c 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -69,7 +69,7 @@ public abstract class PlayerList {
+@@ -64,7 +64,7 @@ public abstract class PlayerList {
      public final WorldNBTStorage playerFileData;
      private boolean hasWhitelist;
      private final IRegistryCustom.Dimension s;
@@ -18,7 +18,7 @@ index 0592ee3511d5532440944af45fe5428077c88d7f..9080f28d8c8ce20ea9934384bd149321
      private EnumGamemode u;
      private boolean v;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2535eb4af7f72e46f00c7b6d8c0991e725a01201..93364d6a287282948f6ea9b75e8e56c4fc9482d7 100644
+index 9d973152562bddd3546e875614361eaa8a468b22..f3e787d6cb46854c6e0dae7404dd56d34c9119be 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -618,6 +618,13 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0554-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/Spigot-Server-Patches/0554-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -24,10 +24,10 @@ index d2edfc8053a3db0a8e27f408bd467b193d8f9d9c..dbba898b226d72d3b88695d62c711256
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ed55a1e6943fb9cdc763d1b7340e3ec53a46106e..616732de1b9860b2f9ad990ae1b9c627db369752 100644
+index ceed6ffdb0368e521b5d369d45da0ca83e61ad3b..12c6be2ac4a77428ba7bd3cff2cebea148006692 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -388,11 +388,13 @@ public class CraftWorld implements World {
+@@ -389,11 +389,13 @@ public class CraftWorld implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = getSpawnLocation();

--- a/Spigot-Server-Patches/0555-Add-moon-phase-API.patch
+++ b/Spigot-Server-Patches/0555-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 257d3d9fe97122b5d123509d54916e0c1b16788d..1162bf553ff6e5c5faf688b080a202dc55650ced 100644
+index 12c6be2ac4a77428ba7bd3cff2cebea148006692..d7954f55061e677b00d27be4b8d0890af75a3aad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -327,6 +327,11 @@ public class CraftWorld implements World {
+@@ -328,6 +328,11 @@ public class CraftWorld implements World {
      public int getPlayerCount() {
          return world.players.size();
      }

--- a/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
+++ b/Spigot-Server-Patches/0559-Add-zombie-targets-turtle-egg-config.patch
@@ -19,10 +19,10 @@ index 978062774c1db286bfb9b0ffdef19d880b1f249b..36ecdfce84141ac731b827e469ac842f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index f390abf65d648e1e0697e2d802f3195a0241116e..e3606722cb1b3f6a11d34e1cdef7210280dba677 100644
+index 555c74feb0d678d8f05d89e274f4736fc35ffebf..3e0b12fef4e0aa5bf8a9b905b829e2a305a53d12 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -46,7 +46,7 @@ public class EntityZombie extends EntityMonster {
+@@ -45,7 +45,7 @@ public class EntityZombie extends EntityMonster {
  
      @Override
      protected void initPathfinder() {

--- a/Spigot-Server-Patches/0564-Fix-CraftTeam-null-check.patch
+++ b/Spigot-Server-Patches/0564-Fix-CraftTeam-null-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CraftTeam null check
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
-index b900aaf66f25e41956e7a4370b887fd4ed530570..4d9b5d7cd080f8b2e9d85f2805660c76d7131e66 100644
+index d641a9cd493ff7039db592d90d7cad1b5cf459bb..2b75210cd9b5c5bdc85e24a9cadf6bcfa90b5213 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
-@@ -252,7 +252,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
+@@ -254,7 +254,7 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
  
      @Override
      public boolean hasEntry(String entry) throws IllegalArgumentException, IllegalStateException {

--- a/Spigot-Server-Patches/0568-Cache-block-data-strings.patch
+++ b/Spigot-Server-Patches/0568-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f9900ec85b81249fc302723a426771d8ffd5909d..613abfd8a931e664782e531a7669954022b966a1 100644
+index 641c31597cad47c4950d5453e85ce692ab13d2fd..b2940f0a9b6fba05defe3369b6d2561d054714fe 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1832,6 +1832,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1834,6 +1834,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getPlayerList().reload();
              this.customFunctionData.a(this.dataPackResources.a());
              this.ak.a(this.dataPackResources.h());

--- a/Spigot-Server-Patches/0572-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/Spigot-Server-Patches/0572-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 4b564d36135e9dbdbb57a95791f89aefd180457b..485b609bb5387b0f8a46c1201177cdc6d183ad91 100644
+index 942b38aaf1845468852ac41e9fba230837f137e3..3bae1c39bf122cec88a481b18c01c3d32d6eb747 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -385,10 +385,12 @@ public class PlayerInteractManager {
+@@ -386,10 +386,12 @@ public class PlayerInteractManager {
                      // return true; // CraftBukkit
                  }
                  // CraftBukkit start
@@ -25,7 +25,7 @@ index 4b564d36135e9dbdbb57a95791f89aefd180457b..485b609bb5387b0f8a46c1201177cdc6
                  // Drop event experience
                  if (flag && event != null) {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index 705ce638416e98166a5c659f425be90af1a9a59b..91d759fee68e8b285f912406fb338750c286f6a0 100644
+index dbba898b226d72d3b88695d62c711256d7e3aee2..493e3cd8a3dbc77f73dd1e026c9e580896995675 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -1177,6 +1177,13 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0577-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/Spigot-Server-Patches/0577-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 613abfd8a931e664782e531a7669954022b966a1..bcfe9e0d9abfd54a7338b2cdf9dae1dffebb894d 100644
+index b2940f0a9b6fba05defe3369b6d2561d054714fe..5a1c14eccf58c39aced52011c6e094c0a3c46cd9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1897,6 +1897,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1899,6 +1899,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (this.aN()) {
              PlayerList playerlist = commandlistenerwrapper.getServer().getPlayerList();
              WhiteList whitelist = playerlist.getWhitelist();

--- a/Spigot-Server-Patches/0584-Villager-resetOffers.patch
+++ b/Spigot-Server-Patches/0584-Villager-resetOffers.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Villager#resetOffers
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-index 74ca39067e7538eac5d70031564d0508846204a5..1fddf7c77488a5e53fc48d0db0a7b8acc71e2f42 100644
+index f5865052261cb49c3f853e4d65e21831c83c2ea0..790df2be9cbbc359ba354ed272dbf6dda71951f0 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-@@ -85,6 +85,13 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -86,6 +86,13 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
          return this.tradingPlayer != null;
      }
  
@@ -22,7 +22,7 @@ index 74ca39067e7538eac5d70031564d0508846204a5..1fddf7c77488a5e53fc48d0db0a7b8ac
      @Override
      public MerchantRecipeList getOffers() {
          if (this.trades == null) {
-@@ -207,6 +214,7 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -208,6 +215,7 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
          return this.world;
      }
  

--- a/Spigot-Server-Patches/0588-Fix-item-locations-dropped-from-campfires.patch
+++ b/Spigot-Server-Patches/0588-Fix-item-locations-dropped-from-campfires.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix item locations dropped from campfires
 Fixes #4259 by not flooring the blockposition among other weirdness
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityCampfire.java b/src/main/java/net/minecraft/server/TileEntityCampfire.java
-index 92e70c18d79007fca458bcbb70c05b94f272f731..0a60141b9ef3ac9eca7913d168d73ca5862a9bfa 100644
+index 51e9cba5c9c99f2b73052e8fae499b68e6fae2a2..c56c588f508b51677c599412215f043aa0a35f98 100644
 --- a/src/main/java/net/minecraft/server/TileEntityCampfire.java
 +++ b/src/main/java/net/minecraft/server/TileEntityCampfire.java
-@@ -74,7 +74,11 @@ public class TileEntityCampfire extends TileEntity implements Clearable, ITickab
+@@ -75,7 +75,11 @@ public class TileEntityCampfire extends TileEntity implements Clearable, ITickab
                      result = blockCookEvent.getResult();
                      itemstack1 = CraftItemStack.asNMSCopy(result);
                      // CraftBukkit end

--- a/Spigot-Server-Patches/0591-Avoid-error-bubbling-up-when-item-stack-is-empty-in-.patch
+++ b/Spigot-Server-Patches/0591-Avoid-error-bubbling-up-when-item-stack-is-empty-in-.patch
@@ -8,10 +8,10 @@ This can realistically only happen if there's custom loot active on fishing
 which can return 0 items. This would disconnect the player who's fishing.
 
 diff --git a/src/main/java/net/minecraft/server/EntityFishingHook.java b/src/main/java/net/minecraft/server/EntityFishingHook.java
-index 723cd60254111579b157684dc82311af5cf9fd13..e97c7794e86c0518bcec0a0370bffbeab20e2623 100644
+index fac695125da50bb33b68f317339832a26f7625a6..3580f40b2bb30bceca0ce374edb29608168a00c0 100644
 --- a/src/main/java/net/minecraft/server/EntityFishingHook.java
 +++ b/src/main/java/net/minecraft/server/EntityFishingHook.java
-@@ -445,9 +445,15 @@ public class EntityFishingHook extends IProjectile {
+@@ -446,9 +446,15 @@ public class EntityFishingHook extends IProjectile {
  
                  while (iterator.hasNext()) {
                      ItemStack itemstack1 = (ItemStack) iterator.next();
@@ -29,7 +29,7 @@ index 723cd60254111579b157684dc82311af5cf9fd13..e97c7794e86c0518bcec0a0370bffbea
                      playerFishEvent.setExpToDrop(this.random.nextInt(6) + 1);
                      this.world.getServer().getPluginManager().callEvent(playerFishEvent);
  
-@@ -460,8 +466,12 @@ public class EntityFishingHook extends IProjectile {
+@@ -461,8 +467,12 @@ public class EntityFishingHook extends IProjectile {
                      double d2 = entityhuman.locZ() - this.locZ();
                      double d3 = 0.1D;
  

--- a/Spigot-Server-Patches/0593-Add-ignore-discounts-API.patch
+++ b/Spigot-Server-Patches/0593-Add-ignore-discounts-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ignore discounts API
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index eaa84fde9cfa8e2d31e7f85b976393d576545670..b343ce9df323ebd95d387b35025d8970ae733c44 100644
+index 650e373a925296f14150de5cbecc6b083679ba54..ca9591a1ca07ca0e88212577b7a94990f591f887 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -391,6 +391,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -389,6 +389,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
  
              while (iterator.hasNext()) {
                  MerchantRecipe merchantrecipe = (MerchantRecipe) iterator.next();
@@ -16,7 +16,7 @@ index eaa84fde9cfa8e2d31e7f85b976393d576545670..b343ce9df323ebd95d387b35025d8970
  
                  // CraftBukkit start
                  int bonus = -MathHelper.d((float) i * merchantrecipe.getPriceMultiplier());
-@@ -410,6 +411,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -408,6 +409,7 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
  
              while (iterator1.hasNext()) {
                  MerchantRecipe merchantrecipe1 = (MerchantRecipe) iterator1.next();

--- a/Spigot-Server-Patches/0597-Beacon-API-custom-effect-ranges.patch
+++ b/Spigot-Server-Patches/0597-Beacon-API-custom-effect-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Beacon API - custom effect ranges
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityBeacon.java b/src/main/java/net/minecraft/server/TileEntityBeacon.java
-index c6b7bc3dc1445269c1562c308b386ce480d70ef3..f97b27a4751d1fc3287de8dba384ab5639b832b8 100644
+index fdf73eca821bab5ec7a742645893793679b5d42c..9019db391bc98b55eaa8bef11ab78c9d88fa7a18 100644
 --- a/src/main/java/net/minecraft/server/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/server/TileEntityBeacon.java
-@@ -45,6 +45,26 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -43,6 +43,26 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
          return (hasSecondaryEffect()) ? CraftPotionUtil.toBukkit(new MobEffect(this.secondaryEffect, getLevel(), getAmplification(), true, true)) : null;
      }
      // CraftBukkit end
@@ -35,7 +35,7 @@ index c6b7bc3dc1445269c1562c308b386ce480d70ef3..f97b27a4751d1fc3287de8dba384ab56
  
      public TileEntityBeacon() {
          super(TileEntityTypes.BEACON);
-@@ -235,7 +255,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -233,7 +253,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
  
      public List getHumansInRange() {
          {
@@ -45,7 +45,7 @@ index c6b7bc3dc1445269c1562c308b386ce480d70ef3..f97b27a4751d1fc3287de8dba384ab56
  
              AxisAlignedBB axisalignedbb = (new AxisAlignedBB(this.position)).g(d0).b(0.0D, (double) this.world.getBuildHeight(), 0.0D);
              List<EntityHuman> list = this.world.a(EntityHuman.class, axisalignedbb);
-@@ -336,6 +357,9 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -334,6 +355,9 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
          this.secondaryEffect = MobEffectList.fromId(nbttagcompound.getInt("Secondary"));
          this.levels = nbttagcompound.getInt("Levels"); // SPIGOT-5053, use where available
          // CraftBukkit end
@@ -55,7 +55,7 @@ index c6b7bc3dc1445269c1562c308b386ce480d70ef3..f97b27a4751d1fc3287de8dba384ab56
          if (nbttagcompound.hasKeyOfType("CustomName", 8)) {
              this.customName = IChatBaseComponent.ChatSerializer.a(nbttagcompound.getString("CustomName"));
          }
-@@ -352,6 +376,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -350,6 +374,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
          if (this.customName != null) {
              nbttagcompound.setString("CustomName", IChatBaseComponent.ChatSerializer.a(this.customName));
          }

--- a/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
+++ b/Spigot-Server-Patches/0598-Add-API-for-quit-reason.patch
@@ -49,10 +49,10 @@ index efd66e81492ec4f976b9db66b84f1c5d728c7a13..1f1baaa464459e06ac877ea3dcd1d306
              this.networkManager.close(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 24b28c547555ece196befb041025ae72b6ee7c81..2837b2c3b72a22da70ca7123715c83b4d6e701be 100644
+index f7b17c80480e7d4650fe7210936923c6c3f8b45c..a6a836c936a687d67c67d861c72addf319b44263 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -512,7 +512,7 @@ public abstract class PlayerList {
+@@ -507,7 +507,7 @@ public abstract class PlayerList {
              entityplayer.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  

--- a/Spigot-Server-Patches/0602-Expose-world-spawn-angle.patch
+++ b/Spigot-Server-Patches/0602-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 4378e81421b766219908e4e15ffe4ab774c65f0e..643694ff776986fdbecadff57b9a9b49763dc50c 100644
+index a6a836c936a687d67c67d861c72addf319b44263..c4abe7bdc1a9b725166eff8b77c123dd832b3cf9 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -816,7 +816,7 @@ public abstract class PlayerList {
+@@ -811,7 +811,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getWorldServer(World.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);
@@ -30,10 +30,10 @@ index faf931785ea35df4525d4a429bdb2363e26e491b..14e1762bf8669ef9e8444f5a73952daa
  
      long getTime();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 13614705328e5ae4432b585fe94d04f87b147dae..fe21b612f9bd2cf85670eeffa25998130b543339 100644
+index d7954f55061e677b00d27be4b8d0890af75a3aad..7e4bf999a4ccc798480d2b14559e0004c5c0eea6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -379,7 +379,7 @@ public class CraftWorld implements World {
+@@ -380,7 +380,7 @@ public class CraftWorld implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPosition spawn = world.getSpawn();

--- a/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/Spigot-Server-Patches/0608-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -19,7 +19,7 @@ index b4d76494851601d61a69e2f060727a68f4461267..6262246c4018c660705fbad028f297fc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index e39be18fe6b45a1a53cb484c656872dda00fa274..f9d7419e376268b00db2eb98a3db4116bdb72bd8 100644
+index aa1807502131893f29be5918b533aabe83f87514..8e71f7a8b62d89f2d770b03b4730d3d030717bfd 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1483,6 +1483,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -49,10 +49,10 @@ index 97425f38ac05c24433dc27c5cda74c36871d61a9..0ef9516fbe9283cb1aca71eb9dbdbec0
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityBat.java b/src/main/java/net/minecraft/server/EntityBat.java
-index 38ce3563106b02bfefb54a637713f27262ff258f..0a59e02d762a096cb3de62e0f8105cc5a5fab8d4 100644
+index c1af257c1155d79ceff7211e1c37b4ddb9e1a19a..451ffcfd1fc9fa3091dc2bd697e5d829dcf6443f 100644
 --- a/src/main/java/net/minecraft/server/EntityBat.java
 +++ b/src/main/java/net/minecraft/server/EntityBat.java
-@@ -50,7 +50,7 @@ public class EntityBat extends EntityAmbient {
+@@ -51,7 +51,7 @@ public class EntityBat extends EntityAmbient {
      }
  
      @Override
@@ -75,10 +75,10 @@ index 45fea38933d57e52dea19317c65682d57114a077..fdfdf83c28c3065fa89fba9e44b3da99
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityHorseAbstract.java b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
-index befd863533b84a88ae2f004125428a6fbeedddab..2a91f07ca9c4dc0cb3b5aef5c9c1db7f69773530 100644
+index 9ecad93e6464644fb147f3e2a770f29c0fe762c7..410578d7baf08db330b708a6c5517c4986258f97 100644
 --- a/src/main/java/net/minecraft/server/EntityHorseAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
-@@ -165,7 +165,7 @@ public abstract class EntityHorseAbstract extends EntityAnimal implements IInven
+@@ -166,7 +166,7 @@ public abstract class EntityHorseAbstract extends EntityAnimal implements IInven
      }
  
      @Override
@@ -88,7 +88,7 @@ index befd863533b84a88ae2f004125428a6fbeedddab..2a91f07ca9c4dc0cb3b5aef5c9c1db7f
      }
  
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 91c3d5adb98f0ba004db51ea51942655ba8852c0..2a1b17717b37e5f839e357c2196287a4024852e9 100644
+index cac3138b98ad2df4b63c77edb16c6c0c3951487c..ac800f307dbf18d2fa074a95f1d32bab84cb6cbd 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -43,7 +43,6 @@ import org.bukkit.event.entity.EntityTeleportEvent;

--- a/Spigot-Server-Patches/0611-Add-warning-for-servers-not-running-on-Java-11.patch
+++ b/Spigot-Server-Patches/0611-Add-warning-for-servers-not-running-on-Java-11.patch
@@ -59,18 +59,18 @@ index 0000000000000000000000000000000000000000..c6ea429819c07e7f4bc257cad73463a0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c4b1b18d2e67c71b061d99c9fb71270bdff434d8..242b2924c4b0b163b010a9d771130a6b15160e4c 100644
+index 5a1c14eccf58c39aced52011c6e094c0a3c46cd9..c858e750018dcf5b1c19ee66d4173119b88101a1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -69,6 +69,7 @@ import org.bukkit.craftbukkit.Main;
- import org.bukkit.event.server.ServerLoadEvent;
- // CraftBukkit end
+@@ -72,6 +72,7 @@ import org.bukkit.event.server.ServerLoadEvent;
+ 
  import co.aikar.timings.MinecraftTimings; // Paper
-+import io.papermc.paper.util.PaperJvmChecker; // Paper
  import org.spigotmc.SlackActivityAccountant; // Spigot
++import io.papermc.paper.util.PaperJvmChecker; // Paper
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
-@@ -954,6 +955,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+ 
+@@ -956,6 +957,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  LOGGER.info("Done ({})! For help, type \"help\"", doneTime);
                  // Paper end
  

--- a/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/Spigot-Server-Patches/0613-Fix-curing-zombie-villager-discount-exploit.patch
@@ -22,10 +22,10 @@ index 6262246c4018c660705fbad028f297fc44e7197f..9ebe8771c2d5e843756868824740ef59
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityVillager.java b/src/main/java/net/minecraft/server/EntityVillager.java
-index b343ce9df323ebd95d387b35025d8970ae733c44..c8b7ab17d53c302698fa7f9850c18e474832a585 100644
+index ca9591a1ca07ca0e88212577b7a94990f591f887..bf9732058c7e55e8f1ed38b3b5e8831e6b21706c 100644
 --- a/src/main/java/net/minecraft/server/EntityVillager.java
 +++ b/src/main/java/net/minecraft/server/EntityVillager.java
-@@ -938,6 +938,15 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+@@ -936,6 +936,15 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
      @Override
      public void a(ReputationEvent reputationevent, Entity entity) {
          if (reputationevent == ReputationEvent.a) {

--- a/Spigot-Server-Patches/0617-MC-4-Fix-item-position-desync.patch
+++ b/Spigot-Server-Patches/0617-MC-4-Fix-item-position-desync.patch
@@ -23,10 +23,10 @@ index 652d87fc5d566dba8018c81676329f0e0bca471b..c56e7fb18f9a56c8025eb70a524f028b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/EntityItem.java b/src/main/java/net/minecraft/server/EntityItem.java
-index ba73d14437cfdf07ef0f1f6266131c113c2741fd..f41aaa7623c052b9f4044898d1bdee898c03057a 100644
+index 0e75d97254c73b2525380024b41a42f56d87b3a5..5dfb54e17fcfe6bd30e6b2a449944606e1a0ef17 100644
 --- a/src/main/java/net/minecraft/server/EntityItem.java
 +++ b/src/main/java/net/minecraft/server/EntityItem.java
-@@ -523,4 +523,16 @@ public class EntityItem extends Entity {
+@@ -524,4 +524,16 @@ public class EntityItem extends Entity {
      public Packet<?> P() {
          return new PacketPlayOutSpawnEntity(this);
      }

--- a/Spigot-Server-Patches/0622-Do-not-crash-from-invalid-ingredient-lists-in-Villag.patch
+++ b/Spigot-Server-Patches/0622-Do-not-crash-from-invalid-ingredient-lists-in-Villag.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Do not crash from invalid ingredient lists in
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-index 1fddf7c77488a5e53fc48d0db0a7b8acc71e2f42..8971dd013498e70c4e7a6ac6a218f62e599c86b9 100644
+index 790df2be9cbbc359ba354ed272dbf6dda71951f0..4620c36d568da12092a2f7cb067cbf7fd20bee94 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-@@ -245,7 +245,11 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -246,7 +246,11 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
                      Bukkit.getPluginManager().callEvent(event);
                  }
                  if (!event.isCancelled()) {

--- a/Spigot-Server-Patches/0623-added-PlayerTradeEvent.patch
+++ b/Spigot-Server-Patches/0623-added-PlayerTradeEvent.patch
@@ -26,10 +26,10 @@ index 73ceb0f14610fe1d4d55542dad957b1fdf9f8e04..eb5c3a1f0d9ff665631caf5bf579e83d
          return 80;
      }
 diff --git a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-index 8971dd013498e70c4e7a6ac6a218f62e599c86b9..b2a76db173ae12bff2e8a7de411cb489fdb2e9c7 100644
+index 4620c36d568da12092a2f7cb067cbf7fd20bee94..e0cc45a7494cd6f06169b64ee8ffc16aa1932f8f 100644
 --- a/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityVillagerAbstract.java
-@@ -11,6 +11,9 @@ import org.bukkit.craftbukkit.inventory.CraftMerchantRecipe;
+@@ -12,6 +12,9 @@ import org.bukkit.craftbukkit.inventory.CraftMerchantRecipe;
  import org.bukkit.entity.AbstractVillager;
  import org.bukkit.event.entity.VillagerAcquireTradeEvent;
  // CraftBukkit end
@@ -39,7 +39,7 @@ index 8971dd013498e70c4e7a6ac6a218f62e599c86b9..b2a76db173ae12bff2e8a7de411cb489
  
  public abstract class EntityVillagerAbstract extends EntityAgeable implements NPC, IMerchant {
  
-@@ -107,16 +110,27 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
+@@ -108,16 +111,27 @@ public abstract class EntityVillagerAbstract extends EntityAgeable implements NP
  
      @Override
      public void a(MerchantRecipe merchantrecipe) {

--- a/Spigot-Server-Patches/0629-Cache-burn-durations.patch
+++ b/Spigot-Server-Patches/0629-Cache-burn-durations.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cache burn durations
 
 
 diff --git a/src/main/java/net/minecraft/server/TileEntityFurnace.java b/src/main/java/net/minecraft/server/TileEntityFurnace.java
-index 51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe..bc2fbdda5777b35291490a6eea038f429521a6ab 100644
+index abc76807595611d35c86f500ef1ef51159e9406b..eb6aa82c3c25928070475815288ec215938322c7 100644
 --- a/src/main/java/net/minecraft/server/TileEntityFurnace.java
 +++ b/src/main/java/net/minecraft/server/TileEntityFurnace.java
 @@ -1,5 +1,6 @@
@@ -15,7 +15,7 @@ index 51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe..bc2fbdda5777b35291490a6eea038f42
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import it.unimi.dsi.fastutil.objects.Object2IntMap.Entry;
-@@ -83,7 +84,15 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -84,7 +85,15 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
          this.c = recipes;
      }
  
@@ -31,7 +31,7 @@ index 51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe..bc2fbdda5777b35291490a6eea038f42
          Map<Item, Integer> map = Maps.newLinkedHashMap();
  
          a(map, (IMaterial) Items.LAVA_BUCKET, 20000);
-@@ -146,7 +155,10 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -147,7 +156,10 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
          a(map, (IMaterial) Blocks.FLETCHING_TABLE, 300);
          a(map, (IMaterial) Blocks.SMITHING_TABLE, 300);
          a(map, (IMaterial) Blocks.COMPOSTER, 300);
@@ -43,7 +43,7 @@ index 51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe..bc2fbdda5777b35291490a6eea038f42
      }
  
      // CraftBukkit start - add fields and methods
-@@ -400,7 +412,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -401,7 +413,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
          } else {
              Item item = itemstack.getItem();
  
@@ -52,7 +52,7 @@ index 51db9ea42d49c4c21f30cfeba25e09bce2dcbcbe..bc2fbdda5777b35291490a6eea038f42
          }
      }
  
-@@ -413,7 +425,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
+@@ -414,7 +426,7 @@ public abstract class TileEntityFurnace extends TileEntityContainer implements I
      // Paper end
  
      public static boolean isFuel(ItemStack itemstack) {

--- a/Spigot-Server-Patches/0633-Zombie-API-breaking-doors.patch
+++ b/Spigot-Server-Patches/0633-Zombie-API-breaking-doors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Zombie API - breaking doors
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index e3606722cb1b3f6a11d34e1cdef7210280dba677..096c345da09b273c9e3e30e93759f5901c5e6fb4 100644
+index 3e0b12fef4e0aa5bf8a9b905b829e2a305a53d12..88ccf77e0e124f64391f415a6e26d1187fade59e 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -79,10 +79,12 @@ public class EntityZombie extends EntityMonster {
+@@ -78,10 +78,12 @@ public class EntityZombie extends EntityMonster {
          return (Boolean) this.getDataWatcher().get(EntityZombie.DROWN_CONVERTING);
      }
  

--- a/Spigot-Server-Patches/0634-Fix-nerfed-slime-when-splitting.patch
+++ b/Spigot-Server-Patches/0634-Fix-nerfed-slime-when-splitting.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix nerfed slime when splitting
 
 
 diff --git a/src/main/java/net/minecraft/server/EntitySlime.java b/src/main/java/net/minecraft/server/EntitySlime.java
-index e99fd88118a75f36cb93d02aa7c6029bcffd5f10..8a1ff579ddf2fef191bc370dc51dd2e6404d9a22 100644
+index 60818e1a7ce9c637bef8dc05de8cba10975ffc79..80fab9290479f876fd78997c1bd55fe6b00aac45 100644
 --- a/src/main/java/net/minecraft/server/EntitySlime.java
 +++ b/src/main/java/net/minecraft/server/EntitySlime.java
-@@ -206,6 +206,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
+@@ -207,6 +207,7 @@ public class EntitySlime extends EntityInsentient implements IMonster {
                      entityslime.setPersistent();
                  }
  

--- a/Spigot-Server-Patches/0637-Added-WorldGameRuleChangeEvent.patch
+++ b/Spigot-Server-Patches/0637-Added-WorldGameRuleChangeEvent.patch
@@ -74,10 +74,10 @@ index b245428604e2a432fa3bab4836a5ca1fb35c3f64..53b40f8947c9380ef57ecc7edca203c5
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fe21b612f9bd2cf85670eeffa25998130b543339..22eba9372d334c65d009721e808c958dfc271308 100644
+index 7e4bf999a4ccc798480d2b14559e0004c5c0eea6..d9b683264da17ba65409e2b976c885875fe09c89 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2350,8 +2350,13 @@ public class CraftWorld implements World {
+@@ -2364,8 +2364,13 @@ public class CraftWorld implements World {
  
          if (!isGameRule(rule)) return false;
  
@@ -92,7 +92,7 @@ index fe21b612f9bd2cf85670eeffa25998130b543339..22eba9372d334c65d009721e808c958d
          handle.onChange(getHandle().getMinecraftServer());
          return true;
      }
-@@ -2386,8 +2391,12 @@ public class CraftWorld implements World {
+@@ -2400,8 +2405,12 @@ public class CraftWorld implements World {
  
          if (!isGameRule(rule.getName())) return false;
  

--- a/Spigot-Server-Patches/0638-Added-ServerResourcesReloadedEvent.patch
+++ b/Spigot-Server-Patches/0638-Added-ServerResourcesReloadedEvent.patch
@@ -34,7 +34,7 @@ index 08e472b71cf85b854eaa831881577ce2c3c03b11..4558147a51be6713c11bda6a60fd5ca3
      // CraftBukkit end
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ad19d785768cea627428d77b8f338a9f1530b506..998d5d1472ad330b731f255f13f7327e771d6ca5 100644
+index c858e750018dcf5b1c19ee66d4173119b88101a1..20f44f9952d94aebc64b3ccd9271592bb0890735 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,9 +2,6 @@ package net.minecraft.server;
@@ -47,7 +47,7 @@ index ad19d785768cea627428d77b8f338a9f1530b506..998d5d1472ad330b731f255f13f7327e
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -63,13 +60,11 @@ import org.apache.logging.log4j.Logger;
+@@ -64,15 +61,13 @@ import com.mojang.serialization.Lifecycle;
  import com.google.common.collect.ImmutableSet;
  // import jline.console.ConsoleReader; // Paper
  import joptsimple.OptionSet;
@@ -56,13 +56,15 @@ index ad19d785768cea627428d77b8f338a9f1530b506..998d5d1472ad330b731f255f13f7327e
 -import org.bukkit.craftbukkit.Main;
  import org.bukkit.event.server.ServerLoadEvent;
  // CraftBukkit end
+ 
  import co.aikar.timings.MinecraftTimings; // Paper
+ import org.spigotmc.SlackActivityAccountant; // Spigot
  import io.papermc.paper.util.PaperJvmChecker; // Paper
 +import io.papermc.paper.event.server.ServerResourcesReloadedEvent; // Paper
- import org.spigotmc.SlackActivityAccountant; // Spigot
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
-@@ -1813,7 +1808,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+ 
+@@ -1815,7 +1810,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          return this.customFunctionData;
      }
  
@@ -76,7 +78,7 @@ index ad19d785768cea627428d77b8f338a9f1530b506..998d5d1472ad330b731f255f13f7327e
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
              Stream<String> stream = collection.stream(); // CraftBukkit - decompile error
              ResourcePackRepository resourcepackrepository = this.resourcePackRepository;
-@@ -1829,6 +1830,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1831,6 +1832,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.resourcePackRepository.a(collection);
              this.saveData.a(a(this.resourcePackRepository));
              datapackresources.i();

--- a/Spigot-Server-Patches/0639-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/Spigot-Server-Patches/0639-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -37,10 +37,10 @@ index ced89af70ca791bfe42c4e2d21604997a0cf3e0f..f73304240a626f3f7d9355e6e5f2963a
              LocalDate localdate = LocalDate.now();
              int i = localdate.get(ChronoField.DAY_OF_MONTH);
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 2aaa6aa323e805423a8fd2bd32cc6a1e48edc817..cab4226166c43f11f77be262e0ced1b223764b7d 100644
+index 88ccf77e0e124f64391f415a6e26d1187fade59e..6a1f6a6257546226f3c37d60d98a11ead42615b8 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -436,7 +436,7 @@ public class EntityZombie extends EntityMonster {
+@@ -435,7 +435,7 @@ public class EntityZombie extends EntityMonster {
          Object object = super.prepare(worldaccess, difficultydamagescaler, enummobspawn, groupdataentity, nbttagcompound);
          float f = difficultydamagescaler.d();
  

--- a/Spigot-Server-Patches/0644-Configurable-door-breaking-difficulty.patch
+++ b/Spigot-Server-Patches/0644-Configurable-door-breaking-difficulty.patch
@@ -79,10 +79,10 @@ index c0d26aa9dcd02c44d744b10e18609857ada95889..4761ddfedeed54e79788a6f60f06a805
          }
  
 diff --git a/src/main/java/net/minecraft/server/EntityZombie.java b/src/main/java/net/minecraft/server/EntityZombie.java
-index 62d202ff871cf3f3deea69931fbee84131bdda8b..752e39ad94ea9e8254853a3fda846be2bd436918 100644
+index 6a1f6a6257546226f3c37d60d98a11ead42615b8..c081dfa775dc93afd96eff88953c9a5f21f2adb9 100644
 --- a/src/main/java/net/minecraft/server/EntityZombie.java
 +++ b/src/main/java/net/minecraft/server/EntityZombie.java
-@@ -25,6 +25,7 @@ public class EntityZombie extends EntityMonster {
+@@ -24,6 +24,7 @@ public class EntityZombie extends EntityMonster {
      private static final DataWatcherObject<Boolean> d = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.i);
      private static final DataWatcherObject<Integer> bo = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.b);
      public static final DataWatcherObject<Boolean> DROWN_CONVERTING = DataWatcher.a(EntityZombie.class, DataWatcherRegistry.i);
@@ -90,7 +90,7 @@ index 62d202ff871cf3f3deea69931fbee84131bdda8b..752e39ad94ea9e8254853a3fda846be2
      private static final Predicate<EnumDifficulty> bq = (enumdifficulty) -> {
          return enumdifficulty == EnumDifficulty.HARD;
      };
-@@ -37,7 +38,7 @@ public class EntityZombie extends EntityMonster {
+@@ -36,7 +37,7 @@ public class EntityZombie extends EntityMonster {
  
      public EntityZombie(EntityTypes<? extends EntityZombie> entitytypes, World world) {
          super(entitytypes, world);

--- a/Spigot-Server-Patches/0646-Implement-API-to-expose-exact-interaction-point.patch
+++ b/Spigot-Server-Patches/0646-Implement-API-to-expose-exact-interaction-point.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement API to expose exact interaction point
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerInteractManager.java b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-index 485b609bb5387b0f8a46c1201177cdc6d183ad91..114e986e5132e5e4bb42d0f08a067429bce53ba6 100644
+index 3bae1c39bf122cec88a481b18c01c3d32d6eb747..d57784c5dd44cc110b7c863ffff82263178e7d9a 100644
 --- a/src/main/java/net/minecraft/server/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/PlayerInteractManager.java
-@@ -461,7 +461,7 @@ public class PlayerInteractManager {
+@@ -462,7 +462,7 @@ public class PlayerInteractManager {
              cancelledBlock = true;
          }
  

--- a/Spigot-Server-Patches/0648-Fix-villager-boat-exploit.patch
+++ b/Spigot-Server-Patches/0648-Fix-villager-boat-exploit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix villager boat exploit
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index 643694ff776986fdbecadff57b9a9b49763dc50c..ae2af6bbd62ba3487b82afe4948cb3b2aa16bf2d 100644
+index c4abe7bdc1a9b725166eff8b77c123dd832b3cf9..fbe2b2b3f96232d86efa1bc02c780ec7cc54aa9b 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -543,6 +543,15 @@ public abstract class PlayerList {
+@@ -538,6 +538,15 @@ public abstract class PlayerList {
  
                  for (Iterator iterator = entity.getAllPassengers().iterator(); iterator.hasNext(); entity1.dead = true) {
                      entity1 = (Entity) iterator.next();

--- a/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
+++ b/Spigot-Server-Patches/0650-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index f83159157d00a10a8bf93e723faf043706f83570..c970b8bec13741fcd4d5ce71fd77d0f9ed633088 100644
+index fbe2b2b3f96232d86efa1bc02c780ec7cc54aa9b..568b404e85e6f96cc025ff48bbc9f466c036b841 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -1059,6 +1059,11 @@ public abstract class PlayerList {
+@@ -1054,6 +1054,11 @@ public abstract class PlayerList {
      }
  
      private void a(EntityPlayer entityplayer, int i) {
@@ -20,7 +20,7 @@ index f83159157d00a10a8bf93e723faf043706f83570..c970b8bec13741fcd4d5ce71fd77d0f9
          if (entityplayer.playerConnection != null) {
              byte b0;
  
-@@ -1073,8 +1078,10 @@ public abstract class PlayerList {
+@@ -1068,8 +1073,10 @@ public abstract class PlayerList {
              entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityStatus(entityplayer, b0));
          }
  
@@ -32,7 +32,7 @@ index f83159157d00a10a8bf93e723faf043706f83570..c970b8bec13741fcd4d5ce71fd77d0f9
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7d57a21517e6a7c3d3cb75ff1960f682dc7d2f50..4b214783ad4fabf5c2dc4c6c45635dc6e75f2113 100644
+index 08448756b48db78bb5693995be8806ca43763f2e..a9c1a4ef45f4e85202c8d31c6b7cca58f2aa0df6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2287,6 +2287,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0663-Added-PlayerStonecutterRecipeSelectEvent.patch
+++ b/Spigot-Server-Patches/0663-Added-PlayerStonecutterRecipeSelectEvent.patch
@@ -41,10 +41,10 @@ index e26b8569340fb0240439ff85d481bd3de19c0ae3..7523c77a914d7e78b4ef08c1ef329d2e
          boolean flag = i != this.a;
  
 diff --git a/src/main/java/net/minecraft/server/ContainerStonecutter.java b/src/main/java/net/minecraft/server/ContainerStonecutter.java
-index 3506473f9b9f4c747f7b737d9bd02bef8ea6d83e..5a34796fa0f2a3c250722777b9131fee5e8cf04a 100644
+index 232a46021edcaa90d29dfa5e8b6857f4ab4a8eac..d64c154615f1ff424f5a627f02e3a8fb6136ea8c 100644
 --- a/src/main/java/net/minecraft/server/ContainerStonecutter.java
 +++ b/src/main/java/net/minecraft/server/ContainerStonecutter.java
-@@ -8,13 +8,14 @@ import org.bukkit.craftbukkit.inventory.CraftInventoryStonecutter;
+@@ -9,13 +9,14 @@ import org.bukkit.craftbukkit.inventory.CraftInventoryStonecutter;
  import org.bukkit.craftbukkit.inventory.CraftInventoryView;
  import org.bukkit.entity.Player;
  // CraftBukkit end
@@ -60,7 +60,7 @@ index 3506473f9b9f4c747f7b737d9bd02bef8ea6d83e..5a34796fa0f2a3c250722777b9131fee
      private ItemStack j;
      private long k;
      final Slot c;
-@@ -44,7 +45,7 @@ public class ContainerStonecutter extends Container {
+@@ -45,7 +46,7 @@ public class ContainerStonecutter extends Container {
  
      public ContainerStonecutter(int i, PlayerInventory playerinventory, final ContainerAccess containeraccess) {
          super(Containers.STONECUTTER, i);
@@ -69,7 +69,7 @@ index 3506473f9b9f4c747f7b737d9bd02bef8ea6d83e..5a34796fa0f2a3c250722777b9131fee
          this.i = Lists.newArrayList();
          this.j = ItemStack.b;
          this.l = () -> {
-@@ -122,13 +123,36 @@ public class ContainerStonecutter extends Container {
+@@ -123,13 +124,36 @@ public class ContainerStonecutter extends Container {
      @Override
      public boolean a(EntityHuman entityhuman, int i) {
          if (this.d(i)) {

--- a/Spigot-Server-Patches/0668-EntityMoveEvent.patch
+++ b/Spigot-Server-Patches/0668-EntityMoveEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityLiving.java b/src/main/java/net/minecraft/server/EntityLiving.java
-index 3c23a8ab3fe5e4b58816cf051dbe237530bff4a0..b7a362bd9c5e9dae909b863335bae3a94d404a16 100644
+index b89eba804ab6cb6735bfcc6dd0219b468126e982..9a79371b40803947ed5deef68c50d45683aaae52 100644
 --- a/src/main/java/net/minecraft/server/EntityLiving.java
 +++ b/src/main/java/net/minecraft/server/EntityLiving.java
 @@ -10,6 +10,7 @@ import com.mojang.datafixers.util.Pair;
@@ -38,10 +38,10 @@ index 3c23a8ab3fe5e4b58816cf051dbe237530bff4a0..b7a362bd9c5e9dae909b863335bae3a9
              this.damageEntity(DamageSource.DROWN, 1.0F);
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8c384171ca56a0989ffef1813ad0a9ee3ea31d29..ccf2d0b090f0c360dfc7886bb0726e099acec42c 100644
+index 20f44f9952d94aebc64b3ccd9271592bb0890735..b29705cb25423e2017f5b38cfa7affa738e0e592 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -14,6 +14,7 @@ import com.mojang.serialization.Lifecycle;
+@@ -12,6 +12,7 @@ import com.mojang.datafixers.DataFixer;
  import io.netty.buffer.ByteBuf;
  import io.netty.buffer.ByteBufOutputStream;
  import io.netty.buffer.Unpooled;
@@ -49,7 +49,7 @@ index 8c384171ca56a0989ffef1813ad0a9ee3ea31d29..ccf2d0b090f0c360dfc7886bb0726e09
  import it.unimi.dsi.fastutil.longs.LongIterator;
  import java.awt.image.BufferedImage;
  import java.io.BufferedWriter;
-@@ -1334,6 +1335,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1336,6 +1337,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
@@ -58,7 +58,7 @@ index 8c384171ca56a0989ffef1813ad0a9ee3ea31d29..ccf2d0b090f0c360dfc7886bb0726e09
  
              this.methodProfiler.a(() -> {
 diff --git a/src/main/java/net/minecraft/server/WorldServer.java b/src/main/java/net/minecraft/server/WorldServer.java
-index fbe7f43f6c1010e7a34114f8afb0e64934744335..fdf6380bb95fd5d82842f69411ba440b520f82ca 100644
+index 53d3e1561ea33c38de5dc5dde181439153fa2775..466bb6297bd3bf7bb0ff1f4d0bd1f4ddfe294fa2 100644
 --- a/src/main/java/net/minecraft/server/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/WorldServer.java
 @@ -100,6 +100,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0676-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0676-misc-debugging-dumps.patch
@@ -29,10 +29,10 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ccf2d0b090f0c360dfc7886bb0726e099acec42c..d6ca2ac9a5047b8d6840c8b4985ab75f35bea919 100644
+index b29705cb25423e2017f5b38cfa7affa738e0e592..c572ef2830f2653e2b30622bbac0a3b072bacd7a 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -15,6 +15,7 @@ import io.netty.buffer.ByteBuf;
+@@ -13,6 +13,7 @@ import io.netty.buffer.ByteBuf;
  import io.netty.buffer.ByteBufOutputStream;
  import io.netty.buffer.Unpooled;
  import io.papermc.paper.event.entity.EntityMoveEvent;
@@ -40,7 +40,7 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..d6ca2ac9a5047b8d6840c8b4985ab75f
  import it.unimi.dsi.fastutil.longs.LongIterator;
  import java.awt.image.BufferedImage;
  import java.io.BufferedWriter;
-@@ -731,6 +732,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -733,6 +734,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // CraftBukkit start
      private boolean hasStopped = false;
      public volatile boolean hasFullyShutdown = false; // Paper
@@ -48,7 +48,7 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..d6ca2ac9a5047b8d6840c8b4985ab75f
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (stopLock) {
-@@ -745,6 +747,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -747,6 +749,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              if (hasStopped) return;
              hasStopped = true;
          }
@@ -56,7 +56,7 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..d6ca2ac9a5047b8d6840c8b4985ab75f
          // Paper start - kill main thread, and kill it hard
          shutdownThread = Thread.currentThread();
          org.spigotmc.WatchdogThread.doStop(); // Paper
-@@ -861,6 +864,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -863,6 +866,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public void safeShutdown(boolean flag, boolean isRestarting) {
          this.isRunning = false;
          this.isRestarting = isRestarting;
@@ -66,7 +66,7 @@ index ccf2d0b090f0c360dfc7886bb0726e099acec42c..d6ca2ac9a5047b8d6840c8b4985ab75f
              try {
                  this.serverThread.join();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cd02c294ebbf95bf939a2d19feff0e29bb87edb1..968349163b15cf40dac9717072740ce48231b7c8 100644
+index db0f0550ea011ff8222473de9940e4bfdc7b9e06..f84d879ef982ee4adcaa43e7c3db1f1003961983 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;

--- a/Spigot-Server-Patches/0681-do-not-create-unnecessary-copies-of-passenger-list.patch
+++ b/Spigot-Server-Patches/0681-do-not-create-unnecessary-copies-of-passenger-list.patch
@@ -121,10 +121,10 @@ index baa4a61114e7460c74027e1519332f0dd9582647..15ce9f90306d062f36d1651d7426813e
          return list.isEmpty() ? null : (Entity) list.get(0);
      }
 diff --git a/src/main/java/net/minecraft/server/EntityHorseAbstract.java b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
-index 2a91f07ca9c4dc0cb3b5aef5c9c1db7f69773530..5f9ee870697de306f595120bec05ba98d2fcb534 100644
+index 410578d7baf08db330b708a6c5517c4986258f97..acbdaa097dfd1cba18add0a09ad54ca78d3e0c24 100644
 --- a/src/main/java/net/minecraft/server/EntityHorseAbstract.java
 +++ b/src/main/java/net/minecraft/server/EntityHorseAbstract.java
-@@ -910,7 +910,7 @@ public abstract class EntityHorseAbstract extends EntityAnimal implements IInven
+@@ -911,7 +911,7 @@ public abstract class EntityHorseAbstract extends EntityAnimal implements IInven
      @Nullable
      @Override
      public Entity getRidingPassenger() {
@@ -225,10 +225,10 @@ index fc831dc26eaeab802d5fee456d5c662fe3f8bdfd..8757c6487a433b1fa5c46b50c559aeca
              if (entity == null) {
                  return;
 diff --git a/src/main/java/net/minecraft/server/PlayerChunkMap.java b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-index 49008cdec739b19409fdaf1b0ed806a6c0e93200..e16cd5da219e41f16f9c04fd95b79fe5cf10f6b8 100644
+index 4264fab9164b8a59cbbcedfb97272413a6303ac9..00d0a5fd7c5d2db19756f3c6cfb2381868af51fd 100644
 --- a/src/main/java/net/minecraft/server/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/PlayerChunkMap.java
-@@ -2252,7 +2252,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2253,7 +2253,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  list.add(entity);
              }
  

--- a/Spigot-Server-Patches/0686-fix-converting-txt-to-json-file.patch
+++ b/Spigot-Server-Patches/0686-fix-converting-txt-to-json-file.patch
@@ -49,10 +49,10 @@ index 5504facd2e453238caa71d98743be5416d4dd4fe..d4793a1d476d8d6687ec8782501c3126
              return false;
          } else {
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index c970b8bec13741fcd4d5ce71fd77d0f9ed633088..610613c2dbea18e1064c5f29cc36cf39aece2277 100644
+index 568b404e85e6f96cc025ff48bbc9f466c036b841..1c85ba153a87ae3cf8962034308384ae53f2c730 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
-@@ -98,6 +98,7 @@ public abstract class PlayerList {
+@@ -93,6 +93,7 @@ public abstract class PlayerList {
          this.maxPlayers = i;
          this.playerFileData = worldnbtstorage;
      }

--- a/Spigot-Server-Patches/0689-Prevent-grindstones-from-overstacking-items.patch
+++ b/Spigot-Server-Patches/0689-Prevent-grindstones-from-overstacking-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent grindstones from overstacking items
 
 
 diff --git a/src/main/java/net/minecraft/server/ContainerGrindstone.java b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-index 39f809a37b58e008e7ef32c0759eeecbde26bc94..34e98efa04e545047e7b844c098c18b89442bd40 100644
+index 57b3c42b6b3fcf791591897fa12d12c2c396191c..99e342038172d7e74a45789bd4b58d4660c775d3 100644
 --- a/src/main/java/net/minecraft/server/ContainerGrindstone.java
 +++ b/src/main/java/net/minecraft/server/ContainerGrindstone.java
-@@ -183,13 +183,13 @@ public class ContainerGrindstone extends Container {
+@@ -184,13 +184,13 @@ public class ContainerGrindstone extends Container {
                  i = Math.max(item.getMaxDurability() - l, 0);
                  itemstack2 = this.b(itemstack, itemstack1);
                  if (!itemstack2.e()) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
d264e972 #591: Add option for a consumer before spawning an item
1c537fce #590: Add spawn and transform reasons for piglin zombification.

CraftBukkit Changes:
ee5006d1 #810: Add option for a consumer before spawning an item
f6a39d3c #809: Add spawn and transform reasons for piglin zombification.
0c24068a Organise imports

Spigot Changes:
bff52619 Organise imports