### PR TITLE
Add fast alternative constructor for Vector3f

### DIFF
--- a/Spigot-Server-Patches/0694-Add-fast-alternative-constructor-for-Vector3f.patch
+++ b/Spigot-Server-Patches/0694-Add-fast-alternative-constructor-for-Vector3f.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Irmo van den Berge <irmo.vandenberge@ziggo.nl>
+Date: Wed, 10 Mar 2021 21:26:31 +0100
+Subject: [PATCH] Add fast alternative constructor for Vector3f
+
+Signed-off-by: Irmo van den Berge <irmo.vandenberge@ziggo.nl>
+
+diff --git a/src/main/java/net/minecraft/server/Vector3f.java b/src/main/java/net/minecraft/server/Vector3f.java
+index fa25e5d1530e099f73355c2779e0d57a51ad4b6e..c8de8056e60c159d85d14e80bdbf12f1dac9a621 100644
+--- a/src/main/java/net/minecraft/server/Vector3f.java
++++ b/src/main/java/net/minecraft/server/Vector3f.java
+@@ -16,6 +16,18 @@ public class Vector3f {
+         this(nbttaglist.i(0), nbttaglist.i(1), nbttaglist.i(2));
+     }
+ 
++    // Paper start - faster alternative constructor
++    private Vector3f(float x, float y, float z, Void dummy_var) {
++        this.x = x;
++        this.y = y;
++        this.z = z;
++    }
++
++    public static Vector3f createWithoutValidityChecks(float x, float y, float z) {
++        return new Vector3f(x, y, z, null);
++    }
++    // Paper end
++
+     public NBTTagList a() {
+         NBTTagList nbttaglist = new NBTTagList();
+ 


### PR DESCRIPTION
The Vector3f constructor does a bunch of checks to validate the float values, and to ensure they stay within the angle range 0 - 360. When you calculate these angles yourself from a plugin, this guarantee is implicit to the code and all these checks are, are overhead.

It showed up in timings, so instead I opted to null-construct the Vector3f using Objenesis and set the fields using reflection. Now objenesis shows up in performance timings.

This patch adds a static factory method to construct this vector to improve performance on paper servers.

This is a hot item when it comes to updating armorstand pose, which uses these vectors. This is called a lot by animatronic plugins, and plugins that use armorstands for moving 3d item models.