### PR TITLE
Fix annotations so Inventory#getContents returns non-null array with nullable type

### DIFF
--- a/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
+++ b/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: CDFN <codefun@protonmail.com>
+Date: Fri, 12 Mar 2021 18:31:31 +0100
+Subject: [PATCH] fix Inventory#getContents null annotations
+
+
+diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
+index 6386206188e820206bb1a9f516b5e194fdc9d952..0d3572192aa67d75340fd410d6a84e7c23db320d 100644
+--- a/src/main/java/org/bukkit/inventory/Inventory.java
++++ b/src/main/java/org/bukkit/inventory/Inventory.java
+@@ -158,9 +158,8 @@ public interface Inventory extends Iterable<ItemStack> {
+      *
+      * @return An array of ItemStacks from the inventory. Individual items may be null.
+      */
+-    @NotNull
+-    public ItemStack[] getContents();
+-
++    // Paper - make array type nullable instead array
++    public @Nullable ItemStack @NotNull [] getContents();
+     /**
+      * Completely replaces the inventory's contents. Removes all existing
+      * contents and replaces it with the ItemStacks given in the array.

--- a/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
+++ b/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix Inventory#getContents null annotations
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 6386206188e820206bb1a9f516b5e194fdc9d952..0d3572192aa67d75340fd410d6a84e7c23db320d 100644
+index 6386206188e820206bb1a9f516b5e194fdc9d952..607eb670b5e6adc2a4dce81b6e56b219c8a4f95f 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -158,9 +158,8 @@ public interface Inventory extends Iterable<ItemStack> {
@@ -15,8 +15,8 @@ index 6386206188e820206bb1a9f516b5e194fdc9d952..0d3572192aa67d75340fd410d6a84e7c
 -    @NotNull
 -    public ItemStack[] getContents();
 -
-+    // Paper - make array type nullable instead array
-+    public @Nullable ItemStack @NotNull [] getContents();
++    public @Nullable ItemStack @NotNull [] getContents(); // Paper - make array elements nullable instead array
++    
      /**
       * Completely replaces the inventory's contents. Removes all existing
       * contents and replaces it with the ItemStacks given in the array.


### PR DESCRIPTION
Previously IntellIJ was giving following warning:
![image](https://user-images.githubusercontent.com/41289688/110977080-004cd100-8362-11eb-9871-f3e1feee0ecb.png)
which was caused by annotation placed in wrong place. This PR fixes it.