### PR TITLE
Updated Upstream (Bukkit)

### DIFF
--- a/Spigot-API-Patches/0001-POM-changes.patch
+++ b/Spigot-API-Patches/0001-POM-changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] POM changes
 
 
 diff --git a/pom.xml b/pom.xml
-index 6b1cebc7fb6760a44359d81b029c4d8843125e49..ed19c62e5a2dbc7e660eae61aef21295afdb8aaf 100644
+index 5f3253b9c4a533e746707d602d4a7988519742ef..61b8ee4e3e122dd2671f50ea3b432e4abd4600a2 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -2,34 +2,28 @@
+@@ -2,33 +2,34 @@
  <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
      <modelVersion>4.0.0</modelVersion>
@@ -40,31 +40,23 @@ index 6b1cebc7fb6760a44359d81b029c4d8843125e49..ed19c62e5a2dbc7e660eae61aef21295
      </properties>
  
 -    <distributionManagement>
--        <repository>
++    <repositories>
+         <repository>
 -            <id>spigotmc-releases</id>
 -            <url>https://hub.spigotmc.org/nexus/content/repositories/releases/</url>
--        </repository>
++            <id>sonatype</id>
++            <url>https://oss.sonatype.org/content/groups/public/</url>
+         </repository>
 -        <snapshotRepository>
 -            <id>spigotmc-snapshots</id>
 -            <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
 -        </snapshotRepository>
 -    </distributionManagement>
--
-     <repositories>
-         <!--
-             If you are a plugin developer, please use https://hub.spigotmc.org/nexus/content/repositories/snapshots/
-@@ -41,6 +35,10 @@
-             <id>spigotmc-public</id>
-             <url>https://hub.spigotmc.org/nexus/content/groups/public/</url>
-         </repository>
-+        <repository>
-+            <id>sonatype</id>
-+            <url>https://oss.sonatype.org/content/groups/public/</url>
-+        </repository>
-     </repositories>
++    </repositories>
  
-     <pluginRepositories>
-@@ -57,6 +55,20 @@
+     <dependencies>
+         <dependency>
+@@ -37,6 +38,20 @@
              <version>2.6</version>
              <scope>compile</scope>
          </dependency>
@@ -85,7 +77,7 @@ index 6b1cebc7fb6760a44359d81b029c4d8843125e49..ed19c62e5a2dbc7e660eae61aef21295
          <!-- bundled with Minecraft, should be kept in sync -->
          <dependency>
              <groupId>com.google.guava</groupId>
-@@ -113,6 +125,7 @@
+@@ -93,6 +108,7 @@
      </dependencies>
  
      <build>
@@ -93,7 +85,7 @@ index 6b1cebc7fb6760a44359d81b029c4d8843125e49..ed19c62e5a2dbc7e660eae61aef21295
          <plugins>
              <plugin>
                  <groupId>net.md-5</groupId>
-@@ -131,10 +144,6 @@
+@@ -111,10 +127,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>
@@ -102,9 +94,9 @@ index 6b1cebc7fb6760a44359d81b029c4d8843125e49..ed19c62e5a2dbc7e660eae61aef21295
 -                    <compilerId>eclipse</compilerId>
 -                </configuration>
                  <dependencies>
-                     <!-- we need our custom version as it fixes some bugs on case sensitive file systems -->
                      <dependency>
-@@ -185,6 +194,7 @@
+                         <groupId>org.codehaus.plexus</groupId>
+@@ -164,6 +176,7 @@
                              </excludes>
                          </filter>
                      </filters>

--- a/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
+++ b/Spigot-API-Patches/0002-Add-FastUtil-to-Bukkit.patch
@@ -6,11 +6,11 @@ Subject: [PATCH] Add FastUtil to Bukkit
 Doesn't expose to plugins, just allows Paper-API to use it for optimization
 
 diff --git a/pom.xml b/pom.xml
-index ed19c62e5a2dbc7e660eae61aef21295afdb8aaf..58fc279186e01a4703102227f387e96272fcf0a7 100644
+index 61b8ee4e3e122dd2671f50ea3b432e4abd4600a2..12306d830c6889c2c9b12699abebe0411262aef6 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -49,6 +49,12 @@
-     </pluginRepositories>
+@@ -32,6 +32,12 @@
+     </repositories>
  
      <dependencies>
 +        <dependency>

--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -7,12 +7,12 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/pom.xml b/pom.xml
-index 58fc279186e01a4703102227f387e96272fcf0a7..06f294ca94709b39f9f1e56fe32b44524b651c13 100644
+index 12306d830c6889c2c9b12699abebe0411262aef6..9e9aa8efe9f2d74f32c22dbd3cc5ed6dedf2ad1a 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -48,7 +48,39 @@
-         </pluginRepository>
-     </pluginRepositories>
+@@ -31,7 +31,39 @@
+         </repository>
+     </repositories>
  
 +    <!-- Paper start -->
 +    <dependencyManagement>
@@ -50,7 +50,7 @@ index 58fc279186e01a4703102227f387e96272fcf0a7..06f294ca94709b39f9f1e56fe32b4452
          <dependency>
              <groupId>it.unimi.dsi</groupId>
              <artifactId>fastutil</artifactId>
-@@ -215,6 +247,12 @@
+@@ -197,6 +229,12 @@
                          <link>https://javadoc.io/doc/org.yaml/snakeyaml/1.27/</link>
                          <link>https://javadoc.io/doc/org.jetbrains/annotations-java5/20.1.0/</link>
                          <link>https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/</link>

--- a/Spigot-API-Patches/0023-Use-ASM-for-event-executors.patch
+++ b/Spigot-API-Patches/0023-Use-ASM-for-event-executors.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/pom.xml b/pom.xml
-index 2a73ac313919c671dd6b6eafd3caa5d44ac14dc1..c43d7d6ef8f8e60e027cde33efceeca6ce98d233 100644
+index 9e9aa8efe9f2d74f32c22dbd3cc5ed6dedf2ad1a..89918b5af7fbf42357e96dffb00b8a011a8ef13c 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -160,6 +160,17 @@
+@@ -143,6 +143,17 @@
              <version>9.0</version>
              <scope>test</scope>
          </dependency>

--- a/Spigot-API-Patches/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/Spigot-API-Patches/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,10 +14,10 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/pom.xml b/pom.xml
-index c43d7d6ef8f8e60e027cde33efceeca6ce98d233..1b9b4349e303a17e96ce0a09e8776b6635092e57 100644
+index 89918b5af7fbf42357e96dffb00b8a011a8ef13c..e1d1635889d68d1e17dc66f3a65545b44deffa69 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -141,6 +141,13 @@
+@@ -124,6 +124,13 @@
              <version>20.1.0</version>
              <scope>provided</scope>
          </dependency>

--- a/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
+++ b/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Better AnnotationTest printout
 
 
 diff --git a/pom.xml b/pom.xml
-index 650dbfd69281ada120c9cd9b04934f493c65977c..af17cd24b44c601f300e3ad5d6c57d810768b5e8 100644
+index e1d1635889d68d1e17dc66f3a65545b44deffa69..bba9d7a8a61018f2fc8b9059ad012d43810599dc 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -255,6 +255,19 @@
+@@ -237,6 +237,19 @@
                      <shadedArtifactAttached>true</shadedArtifactAttached>
                  </configuration>
              </plugin>


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
c589f546 Use upstream plexus-compiler-eclipse