### PR TITLE
Add Material Tag for Buttons

### DIFF
--- a/Spigot-API-Patches/0154-Add-Material-Tags.patch
+++ b/Spigot-API-Patches/0154-Add-Material-Tags.patch
@@ -113,10 +113,10 @@ index 0000000000000000000000000000000000000000..a02a02aa0c87e0f0ed9e509e4dcab015
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/MaterialTags.java b/src/main/java/com/destroystokyo/paper/MaterialTags.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a9b1a046f
+index 0000000000000000000000000000000000000000..3fdd8a71ecee6c2d13556c0936900699782b9517
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/MaterialTags.java
-@@ -0,0 +1,556 @@
+@@ -0,0 +1,565 @@
 +/*
 + * Copyright (c) 2018 Daniel Ennis (Aikar) MIT License
 + *
@@ -285,7 +285,6 @@ index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a
 +    public static final MaterialSetTag TERRACOTTA = new MaterialSetTag(keyFor("terracotta"))
 +        .endsWith("TERRACOTTA")
 +        .ensureSize("TERRACOTTA", 33);
-+
 +
 +    /**
 +     * Covers both golden apples.
@@ -638,6 +637,9 @@ index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a
 +    public static final MaterialSetTag THROWABLE_PROJECTILES = new MaterialSetTag(keyFor("throwable_projectiles"))
 +        .add(Material.EGG, Material.SNOWBALL, Material.SPLASH_POTION, Material.TRIDENT, Material.ENDER_PEARL, Material.EXPERIENCE_BOTTLE, Material.FIREWORK_ROCKET);
 +
++    /**
++     * Covers materials that can be colored, such as wool, shulker boxes, stained glass etc.
++     */
 +    @SuppressWarnings("unchecked")
 +    public static final MaterialSetTag COLORABLE = new MaterialSetTag(keyFor("colorable"))
 +        .add(Tag.WOOL, Tag.CARPETS).add(SHULKER_BOXES, STAINED_GLASS, STAINED_GLASS_PANES, CONCRETES, BEDS);
@@ -657,7 +659,7 @@ index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a
 +        .endsWith("_CORAL_FAN")
 +        .endsWith("_CORAL_WALL_FAN")
 +        .ensureSize("CORAL_FANS", 20);
-+    
++
 +    /**
 +     * Covers the variants of coral blocks.
 +     */
@@ -672,6 +674,13 @@ index 0000000000000000000000000000000000000000..3f36165d89ae4aaa153dcb9ddbb8c58a
 +            .add(PICKAXES, SWORDS, SHOVELS, AXES, HOES, HELMETS, CHEST_EQUIPPABLE, LEGGINGS, BOOTS, BOWS)
 +            .add(Material.TRIDENT, Material.SHIELD, Material.FISHING_ROD, Material.SHEARS, Material.FLINT_AND_STEEL, Material.CARROT_ON_A_STICK, Material.WARPED_FUNGUS_ON_A_STICK)
 +            .ensureSize("ENCHANTABLE", 65);
++
++    /**
++     * Covers the variants of buttons.
++     */
++    public static final MaterialSetTag BUTTONS = new MaterialSetTag(keyFor("buttons"))
++        .endsWith("_BUTTON")
++        .ensureSize("BUTTONS", 10);
 +}
 diff --git a/src/main/java/io/papermc/paper/tag/BaseTag.java b/src/main/java/io/papermc/paper/tag/BaseTag.java
 new file mode 100644


### PR DESCRIPTION
Useful for checking if a player interacted with a button etc.

Also adds an un-added comment for the COLORABLE material tag with a removal of a random empty line and line with spaces when no others do.