### PR TITLE
[CI-SKIP] Ignore .gitignore

### DIFF
--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -121,6 +121,6 @@ importLibrary com.mojang datafixerupper com/mojang/serialization Dynamic.java
 set -e
 cd "$workdir/Spigot/Spigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1
-$gitcmd add . -A >/dev/null 2>&1
+$gitcmd add . --force -A >/dev/null 2>&1
 echo -e "mc-dev Imports\n\n$MODLOG" | $gitcmd commit . -F -
 )


### PR DESCRIPTION
A `.gitignore` will make packages such as
`net.minecraft.world.entity.ai.goal.**target**` be ignored. This causes
the entire patch to not apply, which is very suspicious. This commit
adds a `--force` parameter to the `git add` command we run, as per `man
git-add`:

```
       -f, --force
           Allow adding otherwise ignored files.
```

The global configuration file was proven problematic, then fixed by
this by commit by Prof_Bloodstone#0123 and thekinrar#0001 on Discord
(`#paper-dev`).

CI-SKIP: This does not apply to the CI, therefore it is not worthy of
its own build.