### PR TITLE
[CI-SKIP] Fix makemcdevsrc.sh for nms relocations

### DIFF
--- a/scripts/makemcdevsrc.sh
+++ b/scripts/makemcdevsrc.sh
@@ -5,25 +5,23 @@ set -e
 PS1="$"
 
 basedir="$(cd "$1" && pwd -P)"
-cd "$basedir"
 workdir="$basedir/work"
 minecraftversion=$(cat "$workdir/BuildData/info.json"  | grep minecraftVersion | cut -d '"' -f 4)
 decompiledir="$workdir/Minecraft/$minecraftversion"
-nms="$decompiledir/spigot/net/minecraft/server"
-papernms="Paper-Server/src/main/java/net/minecraft/server"
-mcdevsrc="${decompiledir}/src/net/minecraft/server"
+nms="$decompiledir/spigot/net/minecraft"
+papernms="$basedir/Paper-Server/src/main/java/net/minecraft"
+mcdevsrc="${decompiledir}/src/net/minecraft"
 rm -rf "${mcdevsrc}"
 mkdir -p "${mcdevsrc}"
-find ${nms} -name *.java -print0 | xargs -I\{} -0 cp \{} "${mcdevsrc}/"
+cd "${nms}"
 
-for file in "${nms}/"*
+for file in $(find . -name '*.java')
 do
-    file=${file##*/}
-    # test if in Paper folder - already imported
-    if [ -f "${papernms}/${file}" ]; then
-        # remove from mcdevsrc folder
-        rm -f "${mcdevsrc}/${file}"
+    if [ ! -f "${papernms}/${file}" ]; then
+		cp --parents "${file}" "${mcdevsrc}"
     fi
 done
+
+cd "$basedir"
 echo "Built $decompiledir/src to be included in your project for src access";
 )

--- a/scripts/makemcdevsrc.sh
+++ b/scripts/makemcdevsrc.sh
@@ -18,7 +18,9 @@ cd "${nms}"
 for file in $(find . -name '*.java')
 do
     if [ ! -f "${papernms}/${file}" ]; then
-		cp --parents "${file}" "${mcdevsrc}"
+		destdir="${mcdevsrc}"/$(dirname "${file}")
+		mkdir -p "${destdir}"
+		cp "${file}" "${destdir}"
     fi
 done
 


### PR DESCRIPTION
After the recent relocations for classes in nms this script needs to be updated to support all source files in net.minecraft and subfolders.
As a side effect only the needed files are copied to the src folder instead of copying all and removing the unneeded files.