### PR TITLE
Update log4j to 2.11.2 for JDK 9+ compat

### DIFF
--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c78e2fceb 100644
+index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c82deeb7c 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,15 +1,14 @@
@@ -61,7 +61,33 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
              <artifactId>minecraft-server</artifactId>
              <version>${minecraft.version}-SNAPSHOT</version>
              <scope>compile</scope>
-@@ -64,6 +69,17 @@
+@@ -45,18 +50,17 @@
+             <version>2.12.1</version>
+             <scope>compile</scope>
+         </dependency>
++        <dependency>
++            <groupId>org.apache.logging.log4j</groupId>
++            <artifactId>log4j-api</artifactId>
++            <version>2.11.2</version>
++            <scope>compile</scope>
++        </dependency>
+         <dependency>
+             <groupId>org.apache.logging.log4j</groupId>
+             <artifactId>log4j-iostreams</artifactId>
+-            <version>2.8.1</version>
++            <version>2.11.2</version>
+             <scope>compile</scope>
+-            <exclusions>
+-                <!-- included in minecraft-server -->
+-                <exclusion>
+-                    <groupId>org.apache.logging.log4j</groupId>
+-                    <artifactId>log4j-api</artifactId>
+-                </exclusion>
+-            </exclusions>
+         </dependency>
+         <dependency>
+             <groupId>org.ow2.asm</groupId>
+@@ -64,6 +68,17 @@
              <version>9.1</version>
              <scope>compile</scope>
          </dependency>
@@ -79,7 +105,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
          <!-- deprecated API depend -->
          <dependency>
              <groupId>com.googlecode.json-simple</groupId>
-@@ -100,34 +116,22 @@
+@@ -100,34 +115,22 @@
  
      <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
      <build>
@@ -106,7 +132,8 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
 -                            <descriptionProperty>spigot.desc</descriptionProperty>
 -                        </configuration>
 -                        <phase>initialize</phase>
--                        <goals>
++                        <phase>compile</phase>
+                         <goals>
 -                            <goal>describe</goal>
 -                        </goals>
 -                    </execution>
@@ -118,14 +145,13 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
 -                            <descriptionProperty>craftbukkit.desc</descriptionProperty>
 -                        </configuration>
 -                        <phase>initialize</phase>
-+                        <phase>compile</phase>
-                         <goals>
+-                        <goals>
 -                            <goal>describe</goal>
 +                            <goal>gitdescribe</goal>
                          </goals>
                      </execution>
                  </executions>
-@@ -137,6 +141,7 @@
+@@ -137,6 +140,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>3.2.0</version>
                  <configuration>
@@ -133,7 +159,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
                      <archive>
                          <manifest>
                              <addDefaultEntries>false</addDefaultEntries>
-@@ -144,8 +149,9 @@
+@@ -144,11 +148,13 @@
                          <manifestEntries>
                              <Main-Class>org.bukkit.craftbukkit.Main</Main-Class>
                              <Implementation-Title>CraftBukkit</Implementation-Title>
@@ -145,7 +171,11 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
                              <Specification-Title>Bukkit</Specification-Title>
                              <Specification-Version>${api.version}</Specification-Version>
                              <Specification-Vendor>Bukkit Team</Specification-Vendor>
-@@ -184,14 +190,23 @@
++                            <Multi-Release>true</Multi-Release>
+                         </manifestEntries>
+                         <manifestSections>
+                             <manifestSection>
+@@ -184,14 +190,24 @@
                              <goal>shade</goal>
                          </goals>
                          <configuration>
@@ -162,15 +192,16 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
 +                                        <!-- paper -->
 +                                        <exclude>io/netty/**</exclude>
 +                                        <exclude>META-INF/native/libnetty*</exclude>
-+                                        <exclude>com/brigadier/**</exclude>
++                                        <exclude>com/mojang/brigadier/**</exclude>
 +                                        <exclude>META-INF/MANIFEST.MF</exclude>
-+                                        <exclude>com.mojang.authlib.yggdrasil.YggdrasilGameProfileRepository</exclude>
-+                                        <exclude>com.mojang.datafixers.util.Either</exclude>
-+                                        <exclude>org.apache.logging.log4j/**</exclude>
++                                        <exclude>com/mojang/authlib/yggdrasil/YggdrasilGameProfileRepository.class</exclude>
++                                        <exclude>com/mojang/datafixers/util/Either*</exclude>
++                                        <exclude>org/apache/logging/log4j/**</exclude>
++                                        <exclude>META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat</exclude>
                                      </excludes>
                                  </filter>
                              </filters>
-@@ -207,10 +222,11 @@
+@@ -207,10 +223,11 @@
                                      <pattern>jline</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.jline</shadedPattern>
                                  </relocation>
@@ -186,7 +217,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..ce140ae236f97c1a1028e46e562e2c5c
                                  <relocation>
                                      <pattern>org.apache.commons.codec</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.apache.commons.codec</shadedPattern>
-@@ -258,10 +274,6 @@
+@@ -258,10 +275,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>

--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c82deeb7c 100644
+index ebce3da9abf550089ead322bc2cef359c803a434..ab48b2102727d741ab3f0c8daa658593e1305a3b 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,15 +1,14 @@
@@ -28,7 +28,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
          <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
          <api.version>unknown</api.version>
          <bt.name>git</bt.name>
-@@ -20,21 +19,27 @@
+@@ -20,21 +19,39 @@
      </properties>
  
      <parent>
@@ -40,6 +40,18 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
          <relativePath>../pom.xml</relativePath>
      </parent>
  
++    <dependencyManagement>
++        <dependencies>
++            <dependency>
++                <groupId>org.apache.logging.log4j</groupId>
++                <artifactId>log4j-bom</artifactId>
++                <version>2.11.2</version>
++                <type>pom</type>
++                <scope>import</scope>
++            </dependency>
++        </dependencies>
++    </dependencyManagement>
++
      <dependencies>
          <dependency>
 -            <groupId>org.spigotmc</groupId>
@@ -61,21 +73,19 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
              <artifactId>minecraft-server</artifactId>
              <version>${minecraft.version}-SNAPSHOT</version>
              <scope>compile</scope>
-@@ -45,18 +50,17 @@
+@@ -45,18 +62,15 @@
              <version>2.12.1</version>
              <scope>compile</scope>
          </dependency>
 +        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-api</artifactId>
-+            <version>2.11.2</version>
 +            <scope>compile</scope>
 +        </dependency>
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-iostreams</artifactId>
 -            <version>2.8.1</version>
-+            <version>2.11.2</version>
              <scope>compile</scope>
 -            <exclusions>
 -                <!-- included in minecraft-server -->
@@ -87,7 +97,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
          </dependency>
          <dependency>
              <groupId>org.ow2.asm</groupId>
-@@ -64,6 +68,17 @@
+@@ -64,6 +78,17 @@
              <version>9.1</version>
              <scope>compile</scope>
          </dependency>
@@ -105,7 +115,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
          <!-- deprecated API depend -->
          <dependency>
              <groupId>com.googlecode.json-simple</groupId>
-@@ -100,34 +115,22 @@
+@@ -100,34 +125,22 @@
  
      <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
      <build>
@@ -151,7 +161,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
                          </goals>
                      </execution>
                  </executions>
-@@ -137,6 +140,7 @@
+@@ -137,6 +150,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>3.2.0</version>
                  <configuration>
@@ -159,7 +169,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
                      <archive>
                          <manifest>
                              <addDefaultEntries>false</addDefaultEntries>
-@@ -144,11 +148,13 @@
+@@ -144,11 +158,13 @@
                          <manifestEntries>
                              <Main-Class>org.bukkit.craftbukkit.Main</Main-Class>
                              <Implementation-Title>CraftBukkit</Implementation-Title>
@@ -175,7 +185,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
                          </manifestEntries>
                          <manifestSections>
                              <manifestSection>
-@@ -184,14 +190,24 @@
+@@ -184,14 +200,24 @@
                              <goal>shade</goal>
                          </goals>
                          <configuration>
@@ -201,7 +211,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
                                      </excludes>
                                  </filter>
                              </filters>
-@@ -207,10 +223,11 @@
+@@ -207,10 +233,11 @@
                                      <pattern>jline</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.jline</shadedPattern>
                                  </relocation>
@@ -217,7 +227,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..4dc7f94e2bca514b12502f72eb44b93c
                                  <relocation>
                                      <pattern>org.apache.commons.codec</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.apache.commons.codec</shadedPattern>
-@@ -258,10 +275,6 @@
+@@ -258,10 +285,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,10 +19,10 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 4dc7f94e2bca514b12502f72eb44b93c82deeb7c..75c288f2497ad2a6dcdeb6cce420a8bf6a00e93a 100644
+index ab48b2102727d741ab3f0c8daa658593e1305a3b..38e78762528182bbe676ce3ad5a437680b5b7307 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -45,10 +45,27 @@
+@@ -57,10 +57,26 @@
              <scope>compile</scope>
          </dependency>
          <dependency>
@@ -49,12 +49,11 @@ index 4dc7f94e2bca514b12502f72eb44b93c82deeb7c..75c288f2497ad2a6dcdeb6cce420a8bf
 +        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-core</artifactId>
-+            <version>2.11.2</version>
 +            <scope>runtime</scope>
          </dependency>
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
-@@ -266,10 +283,18 @@
+@@ -276,10 +292,18 @@
                                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                      <resource>META-INF/services/java.sql.Driver</resource>
                                  </transformer>

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 2559c83c1b811177ade56537aeab1982ac53ee67..26e59ca76d856cc37222963fd14cb6eaa410c749 100644
+index 4dc7f94e2bca514b12502f72eb44b93c82deeb7c..75c288f2497ad2a6dcdeb6cce420a8bf6a00e93a 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -45,10 +45,27 @@
@@ -49,12 +49,12 @@ index 2559c83c1b811177ade56537aeab1982ac53ee67..26e59ca76d856cc37222963fd14cb6ea
 +        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-core</artifactId>
-+            <version>2.8.1</version>
++            <version>2.11.2</version>
 +            <scope>runtime</scope>
          </dependency>
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
-@@ -265,10 +282,18 @@
+@@ -266,10 +283,18 @@
                                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                      <resource>META-INF/services/java.sql.Driver</resource>
                                  </transformer>
@@ -293,7 +293,7 @@ index 1f0021c5374e1af9c9cd29d44e6b0bd9522394d9..5d357b0f84b5242066dcce203752a0f4
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 78b6d00ea40e8d7c450e08e444c5231e7c99969b..78fad8d06540a0cf41302f12bf25e08e49f589d9 100644
+index 0c069673437d97aff29b3a30caa22fcf62d0d7db..fb49dd66e40e8376e9d6141b97350e16b5d0215e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;

--- a/Spigot-Server-Patches/0167-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/Spigot-Server-Patches/0167-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,20 +15,20 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/pom.xml b/pom.xml
-index 0a6e1782c0eb8aa3aff94c5bfae5c5ea4a24ba56..14d365756efbe2067c049659eb9076ab1e3415ef 100644
+index 75c288f2497ad2a6dcdeb6cce420a8bf6a00e93a..6eed2bce4f01e689ed9d35df16f28a3bbd1d173a 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -65,7 +65,7 @@
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-core</artifactId>
-             <version>2.8.1</version>
+             <version>2.11.2</version>
 -            <scope>runtime</scope>
 +            <scope>compile</scope>
          </dependency>
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index 23c1ba33903f8913a33332d06b2fd1aa3c90f1a1..bf00d6d263b692e8a597694c689768f177835fde 100644
+index 3c93a497a790b8d800852db2ac48feca41f45cef..e8e5e5b568ba53dd006f1461cb4f027ceeae5528 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -290,7 +290,7 @@ public class SpigotConfig

--- a/Spigot-Server-Patches/0167-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/Spigot-Server-Patches/0167-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,13 +15,13 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/pom.xml b/pom.xml
-index 75c288f2497ad2a6dcdeb6cce420a8bf6a00e93a..6eed2bce4f01e689ed9d35df16f28a3bbd1d173a 100644
+index 38e78762528182bbe676ce3ad5a437680b5b7307..6f96ce455f047073c124d13c54e3a77455ddd980 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -65,7 +65,7 @@
+@@ -76,7 +76,7 @@
+         <dependency>
              <groupId>org.apache.logging.log4j</groupId>
              <artifactId>log4j-core</artifactId>
-             <version>2.11.2</version>
 -            <scope>runtime</scope>
 +            <scope>compile</scope>
          </dependency>

--- a/Spigot-Server-Patches/0168-Include-Log4J2-SLF4J-implementation.patch
+++ b/Spigot-Server-Patches/0168-Include-Log4J2-SLF4J-implementation.patch
@@ -5,17 +5,17 @@ Subject: [PATCH] Include Log4J2 SLF4J implementation
 
 
 diff --git a/pom.xml b/pom.xml
-index 14d365756efbe2067c049659eb9076ab1e3415ef..a58e4aa63164aa6ae4e7ecf87ea9c46c73fcb8f4 100644
+index 6eed2bce4f01e689ed9d35df16f28a3bbd1d173a..a894af97db636322fcc3f6a6405bbb1277198195 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -67,6 +67,12 @@
-             <version>2.8.1</version>
+@@ -73,6 +73,12 @@
+             <version>2.11.2</version>
              <scope>compile</scope>
          </dependency>
 +        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-slf4j-impl</artifactId>
-+            <version>2.8.1</version>
++            <version>2.11.2</version>
 +            <scope>runtime</scope>
 +        </dependency>
          <dependency>

--- a/Spigot-Server-Patches/0168-Include-Log4J2-SLF4J-implementation.patch
+++ b/Spigot-Server-Patches/0168-Include-Log4J2-SLF4J-implementation.patch
@@ -5,17 +5,16 @@ Subject: [PATCH] Include Log4J2 SLF4J implementation
 
 
 diff --git a/pom.xml b/pom.xml
-index 6eed2bce4f01e689ed9d35df16f28a3bbd1d173a..a894af97db636322fcc3f6a6405bbb1277198195 100644
+index 6f96ce455f047073c124d13c54e3a77455ddd980..bb15d94f1aadf04439f0b9484f91a81440194c43 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -73,6 +73,12 @@
-             <version>2.11.2</version>
+@@ -83,6 +83,11 @@
+             <artifactId>log4j-api</artifactId>
              <scope>compile</scope>
          </dependency>
 +        <dependency>
 +            <groupId>org.apache.logging.log4j</groupId>
 +            <artifactId>log4j-slf4j-impl</artifactId>
-+            <version>2.11.2</version>
 +            <scope>runtime</scope>
 +        </dependency>
          <dependency>

--- a/Spigot-Server-Patches/0240-Use-asynchronous-Log4j-2-loggers.patch
+++ b/Spigot-Server-Patches/0240-Use-asynchronous-Log4j-2-loggers.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/pom.xml b/pom.xml
-index a58e4aa63164aa6ae4e7ecf87ea9c46c73fcb8f4..ba6e70eb472bda9d0cf51c3b69a5bd41fc24c399 100644
+index fe2d35acadb8cd0fe357b90dc8fa00713d4f87a3..76f123ee8642bcf26c6e59216a96d5f2d6403e4d 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -86,6 +86,13 @@
-                 </exclusion>
-             </exclusions>
+@@ -85,6 +85,13 @@
+             <version>2.11.2</version>
+             <scope>compile</scope>
          </dependency>
 +        <!-- Paper - Async loggers -->
 +        <dependency>

--- a/Spigot-Server-Patches/0240-Use-asynchronous-Log4j-2-loggers.patch
+++ b/Spigot-Server-Patches/0240-Use-asynchronous-Log4j-2-loggers.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/pom.xml b/pom.xml
-index fe2d35acadb8cd0fe357b90dc8fa00713d4f87a3..76f123ee8642bcf26c6e59216a96d5f2d6403e4d 100644
+index bb15d94f1aadf04439f0b9484f91a81440194c43..526a261e93f8be8d2f045d1b8822002b55c11fb9 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -85,6 +85,13 @@
-             <version>2.11.2</version>
+@@ -93,6 +93,13 @@
+             <artifactId>log4j-iostreams</artifactId>
              <scope>compile</scope>
          </dependency>
 +        <!-- Paper - Async loggers -->

--- a/Spigot-Server-Patches/0466-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0466-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/pom.xml b/pom.xml
-index 14e66414d043ce720b8fd7bfa2c476d8369c757b..25ec9c4f8c08551fd80a597a1b39854e70e4f895 100644
+index 76f123ee8642bcf26c6e59216a96d5f2d6403e4d..492a2a40beef7e6cba82e0228fd5bcea2bf3ec27 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -142,6 +142,13 @@
+@@ -141,6 +141,13 @@
              <version>1.3</version>
              <scope>test</scope>
          </dependency>

--- a/Spigot-Server-Patches/0466-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0466-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/pom.xml b/pom.xml
-index 76f123ee8642bcf26c6e59216a96d5f2d6403e4d..492a2a40beef7e6cba82e0228fd5bcea2bf3ec27 100644
+index 526a261e93f8be8d2f045d1b8822002b55c11fb9..eed1dccb481a300b9f4679af157ce512c70cf34a 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -141,6 +141,13 @@
+@@ -149,6 +149,13 @@
              <version>1.3</version>
              <scope>test</scope>
          </dependency>


### PR DESCRIPTION
This allows the calling class lookup to work properly in a plugin context in JDK 9+. It is rare that plugins should be using it rather than the provided `java.util.logging` or SLF4J, but in the event that it is used, this allows it to function properly.

I also introduced a BOM for log4j, so that future version updates need not affect as many patches.