### PR TITLE
Add checkerframework nullness annotations to accepted list for AnnotationTest

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -3597,3 +3597,38 @@ index da01d2926cc8a2485a3349ac1ebb32cad20e287c..f0af10a5b9ad048be197ed5ec6c8ed26
      void setColor(@NotNull ChatColor color);
  
      /**
+diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
+index 0c7377247ad9251c9e498039511e7220370aba2d..c62919f18f318fec15a6c364d8b6d562c2b04762 100644
+--- a/src/test/java/org/bukkit/AnnotationTest.java
++++ b/src/test/java/org/bukkit/AnnotationTest.java
+@@ -26,6 +26,12 @@ import org.objectweb.asm.tree.ParameterNode;
+ public class AnnotationTest {
+ 
+     private static final String[] ACCEPTED_ANNOTATIONS = {
++        // Paper start
++        "Lorg/checkerframework/checker/nullness/qual/Nullable;",
++        "Lorg/checkerframework/checker/nullness/qual/NonNull;",
++        "Lorg/checkerframework/checker/nullness/qual/PolyNull;",
++        "Lorg/checkerframework/checker/nullness/qual/MonotonicNonNull;",
++        // Paper end
+         "Lorg/jetbrains/annotations/Nullable;",
+         "Lorg/jetbrains/annotations/NotNull;",
+         "Lorg/jetbrains/annotations/Contract;",
+@@ -66,7 +72,7 @@ public class AnnotationTest {
+                     continue;
+                 }
+ 
+-                if (mustBeAnnotated(Type.getReturnType(method.desc)) && !isWellAnnotated(method.invisibleAnnotations)) {
++                if (mustBeAnnotated(Type.getReturnType(method.desc)) && !isWellAnnotated(method.invisibleAnnotations) && !isWellAnnotated(method.visibleTypeAnnotations)) { // Paper - also check visible type annotations
+                     warn(errors, clazz, method, "return value");
+                 }
+ 
+@@ -174,7 +180,7 @@ public class AnnotationTest {
+         return true;
+     }
+ 
+-    private static boolean isWellAnnotated(@Nullable List<AnnotationNode> annotations) {
++    private static boolean isWellAnnotated(@Nullable List<? extends AnnotationNode> annotations) { // Paper - allow children of AnnotationNode
+         if (annotations == null) {
+             return false;
+         }

--- a/Spigot-API-Patches/0171-Annotation-Test-changes.patch
+++ b/Spigot-API-Patches/0171-Annotation-Test-changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Annotation Test changes
 
 
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index 0c7377247ad9251c9e498039511e7220370aba2d..38be576b39526592f324b2675b3db41b18e100cc 100644
+index c62919f18f318fec15a6c364d8b6d562c2b04762..2bb75e967d4250476a151599b68de80011d222b2 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
-@@ -40,7 +40,17 @@ public class AnnotationTest {
+@@ -46,7 +46,17 @@ public class AnnotationTest {
          "org/bukkit/util/io/Wrapper",
          "org/bukkit/plugin/java/PluginClassLoader",
          // Generic functional interface

--- a/Spigot-API-Patches/0175-Ignore-package-private-methods-for-nullability-annot.patch
+++ b/Spigot-API-Patches/0175-Ignore-package-private-methods-for-nullability-annot.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ignore package-private methods for nullability annotations
 This isn't API
 
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index 38be576b39526592f324b2675b3db41b18e100cc..a48be38b159bec27ec398666b28620a9ea625547 100644
+index 2bb75e967d4250476a151599b68de80011d222b2..03229d5f4ec36a82197beb391356d791ff67fb2f 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
-@@ -162,7 +162,7 @@ public class AnnotationTest {
+@@ -168,7 +168,7 @@ public class AnnotationTest {
  
      private static boolean isMethodIncluded(@NotNull ClassNode clazz, @NotNull MethodNode method, @NotNull Map<String, ClassNode> allClasses) {
          // Exclude private, synthetic and deprecated methods

--- a/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
+++ b/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Better AnnotationTest printout
 
 
 diff --git a/pom.xml b/pom.xml
-index e1d1635889d68d1e17dc66f3a65545b44deffa69..bba9d7a8a61018f2fc8b9059ad012d43810599dc 100644
+index de6a5b697535b9532fee1521363432c76c233952..e66661eb84308dc13faa0d39b7487f40c1180443 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -237,6 +237,19 @@
@@ -41,10 +41,10 @@ index 0000000000000000000000000000000000000000..072ac1a96394b8d494f42fca8dfe0811
 +public class JunitEventListener extends RunListener {
 +}
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index a48be38b159bec27ec398666b28620a9ea625547..4c2780c903ec354edac741b673a7174284a9849a 100644
+index 03229d5f4ec36a82197beb391356d791ff67fb2f..19271057cf24329757c9419fa6c97848e008a96c 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
-@@ -101,13 +101,18 @@ public class AnnotationTest {
+@@ -107,13 +107,18 @@ public class AnnotationTest {
  
          Collections.sort(errors);
  

--- a/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
+++ b/Spigot-API-Patches/0282-fix-Inventory-getContents-null-annotations.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix Inventory#getContents null annotations
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 6386206188e820206bb1a9f516b5e194fdc9d952..607eb670b5e6adc2a4dce81b6e56b219c8a4f95f 100644
+index 6386206188e820206bb1a9f516b5e194fdc9d952..7956aebcb390379677dccf7c9561866cf94c024c 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -158,9 +158,8 @@ public interface Inventory extends Iterable<ItemStack> {
@@ -15,7 +15,7 @@ index 6386206188e820206bb1a9f516b5e194fdc9d952..607eb670b5e6adc2a4dce81b6e56b219
 -    @NotNull
 -    public ItemStack[] getContents();
 -
-+    public @Nullable ItemStack @NotNull [] getContents(); // Paper - make array elements nullable instead array
++    public @org.checkerframework.checker.nullness.qual.Nullable ItemStack @org.checkerframework.checker.nullness.qual.NonNull [] getContents(); // Paper - make array elements nullable instead array
 +    
      /**
       * Completely replaces the inventory's contents. Removes all existing


### PR DESCRIPTION
Also use checkerframework annotations instead of jetbrains ones for Inventory#getContents as jetbrains ones do not allow properly annotating the nullability of an array and it's contents.
