### PR TITLE
fix cancelling block falling causing client desync (fixes #5386)

### DIFF
--- a/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
+++ b/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix cancelling block falling causing client desync
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
-index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..4d47c2d224266e2ae26694a7b80dd2f506017fe8 100644
+index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..91fd2a6efcd524634165cb70c302ee60105ec8c7 100644
 --- a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
 @@ -43,6 +43,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
@@ -31,7 +31,7 @@ index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..4d47c2d224266e2ae26694a7b80dd2f5
 +                        this.die();
 +                        return;
 +                    } else {
-+                        this.world.a(blockposition, false);
++                        this.world.setAir(blockposition, false);
 +                    }
 +                    // Paper end - fix cancelling block falling causing client desync
                  } else if (!this.world.isClientSide) {

--- a/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
+++ b/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
@@ -5,10 +5,18 @@ Subject: [PATCH] fix cancelling block falling causing client desync
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
-index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..91fd2a6efcd524634165cb70c302ee60105ec8c7 100644
+index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..2a61c24dd26edf4c72e977c6024fe233bab08a2f 100644
 --- a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
 +++ b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
-@@ -43,6 +43,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
+@@ -14,6 +14,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutSpawnEntity;
+ import net.minecraft.network.syncher.DataWatcher;
+ import net.minecraft.network.syncher.DataWatcherObject;
+ import net.minecraft.network.syncher.DataWatcherRegistry;
++import net.minecraft.server.level.WorldServer;
+ import net.minecraft.tags.Tag;
+ import net.minecraft.tags.TagsBlock;
+ import net.minecraft.tags.TagsFluid;
+@@ -43,6 +44,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
  import net.minecraft.world.phys.MovingObjectPositionBlock;
  import net.minecraft.world.phys.Vec3D;
  
@@ -16,7 +24,7 @@ index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..91fd2a6efcd524634165cb70c302ee60
  import org.bukkit.craftbukkit.event.CraftEventFactory; // CraftBukkit
  
  public class EntityFallingBlock extends Entity {
-@@ -116,8 +117,18 @@ public class EntityFallingBlock extends Entity {
+@@ -116,8 +118,18 @@ public class EntityFallingBlock extends Entity {
  
              if (this.ticksLived++ == 0) {
                  blockposition = this.getChunkCoordinates();
@@ -26,7 +34,7 @@ index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..91fd2a6efcd524634165cb70c302ee60
 +                if (this.world.getType(blockposition).isSameInstance(block)) {
 +                    if (CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, Blocks.AIR.getBlockData()).isCancelled()) {
 +                        if (this.world.getType(blockposition).isSameInstance(block)) { //if listener didn't update the block
-+                            CraftBlock.at(world, blockposition).getState().update(false, false);
++                            ((WorldServer) world).getChunkProvider().flagDirty(blockposition);
 +                        }
 +                        this.die();
 +                        return;

--- a/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
+++ b/Spigot-Server-Patches/0698-fix-cancelling-block-falling-causing-client-desync.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Trigary <trigary0@gmail.com>
+Date: Sat, 27 Mar 2021 11:13:30 +0100
+Subject: [PATCH] fix cancelling block falling causing client desync
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
+index 62d8b53c024888aa43b8fddf8a475dfb8284a4cc..4d47c2d224266e2ae26694a7b80dd2f506017fe8 100644
+--- a/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
++++ b/src/main/java/net/minecraft/world/entity/item/EntityFallingBlock.java
+@@ -43,6 +43,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
+ import net.minecraft.world.phys.MovingObjectPositionBlock;
+ import net.minecraft.world.phys.Vec3D;
+ 
++import org.bukkit.craftbukkit.block.CraftBlock;
+ import org.bukkit.craftbukkit.event.CraftEventFactory; // CraftBukkit
+ 
+ public class EntityFallingBlock extends Entity {
+@@ -116,8 +117,18 @@ public class EntityFallingBlock extends Entity {
+ 
+             if (this.ticksLived++ == 0) {
+                 blockposition = this.getChunkCoordinates();
+-                if (this.world.getType(blockposition).a(block) && !CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, Blocks.AIR.getBlockData()).isCancelled()) {
+-                    this.world.a(blockposition, false);
++                // Paper start - fix cancelling block falling causing client desync
++                if (this.world.getType(blockposition).isSameInstance(block)) {
++                    if (CraftEventFactory.callEntityChangeBlockEvent(this, blockposition, Blocks.AIR.getBlockData()).isCancelled()) {
++                        if (this.world.getType(blockposition).isSameInstance(block)) { //if listener didn't update the block
++                            CraftBlock.at(world, blockposition).getState().update(false, false);
++                        }
++                        this.die();
++                        return;
++                    } else {
++                        this.world.a(blockposition, false);
++                    }
++                    // Paper end - fix cancelling block falling causing client desync
+                 } else if (!this.world.isClientSide) {
+                     this.die();
+                     return;
+diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBase.java b/src/main/java/net/minecraft/world/level/block/state/BlockBase.java
+index ac3709c8158d42ccafd457cfa44a16dc8c9eb949..d9765da72c614260fdba47e7d1add4145991f97c 100644
+--- a/src/main/java/net/minecraft/world/level/block/state/BlockBase.java
++++ b/src/main/java/net/minecraft/world/level/block/state/BlockBase.java
+@@ -682,6 +682,7 @@ public abstract class BlockBase {
+             return this.getBlock().a(tag) && predicate.test(this);
+         }
+ 
++        public final boolean isSameInstance(Block block) { return a(block); } // Paper - OBFHELPER
+         public boolean a(Block block) {
+             return this.getBlock().a(block);
+         }


### PR DESCRIPTION
Fixes #5386 by mimicking what plugins currently can do to solve the issue: updating the block to notify clients.