### PR TITLE
Add ExitPortalCreateEvent

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -46,4 +46,5 @@ Machine_Maker <machine@machinemaker.me>
 Ivan Pekov <ivan@mrivanplays.com>
 Camotoy <20743703+Camotoy@users.noreply.github.com>
 Bjarne Koll <lynxplay101@gmail.com>
+ravkr <rav_kr@interia.pl>
 ```

--- a/Spigot-API-Patches/0295-Add-ExitPortalCreateEvent.patch
+++ b/Spigot-API-Patches/0295-Add-ExitPortalCreateEvent.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ravkr <rav_kr@interia.pl>
+Date: Fri, 26 Mar 2021 03:38:20 +0100
+Subject: [PATCH] Add ExitPortalCreateEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/world/ExitPortalCreateEvent.java b/src/main/java/io/papermc/paper/event/world/ExitPortalCreateEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2b9dc81dca879f2e24712dbeadc91f36ef2545d9
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/world/ExitPortalCreateEvent.java
+@@ -0,0 +1,82 @@
++package io.papermc.paper.event.world;
++
++import org.bukkit.Location;
++import org.bukkit.Material;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.world.WorldEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called <b>before</b> an exit end portal is created.
++ * May be empty (if player visits The End for the first time) or filled with {@link Material#END_PORTAL} (after killing a dragon).
++ */
++public class ExitPortalCreateEvent extends WorldEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private Location portalLocation;
++    private boolean filled;
++    private boolean cancel = false;
++
++    /**
++     * @param portalLocation The middle {@link Material#BEDROCK} block, on the {@link Material#END_PORTAL} level.
++     */
++    public ExitPortalCreateEvent(@NotNull Location portalLocation, boolean filled) {
++        super(portalLocation.getWorld());
++        this.portalLocation = portalLocation;
++        this.filled = filled;
++    }
++
++    /**
++     * Gets the portal location.
++     *
++     * @return The middle {@link Material#BEDROCK} block, on the {@link Material#END_PORTAL} blocks' level.
++     */
++    @NotNull
++    public Location getPortalLocation() {
++        return portalLocation;
++    }
++
++    /**
++     * @param portalLocation The middle portal block, on the bottom. World will be ignored.
++     */
++    public void setPortalLocation(@NotNull Location portalLocation) {
++        this.portalLocation = portalLocation;
++    }
++
++    public boolean isFilled() {
++        return filled;
++    }
++
++    public void setFilled(boolean filled) {
++        this.filled = filled;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancel;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancel = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++    @Override
++    public String toString() {
++        return "ExitPortalCreateEvent{" +
++            "location=" + portalLocation +
++            ", filled=" + filled +
++            ", cancel=" + cancel +
++            '}';
++    }
++}

--- a/Spigot-Server-Patches/0722-Add-ExitPortalCreateEvent.patch
+++ b/Spigot-Server-Patches/0722-Add-ExitPortalCreateEvent.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: ravkr <rav_kr@interia.pl>
+Date: Fri, 26 Mar 2021 02:25:05 +0100
+Subject: [PATCH] Add ExitPortalCreateEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java b/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
+index 0ab6319aa3e4e1f5679f37be36999ca56ca2484c..ba11b39f435e774f97a76971907107dba9f0fccd 100644
+--- a/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
++++ b/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
+@@ -58,6 +58,9 @@ import net.minecraft.world.phys.AxisAlignedBB;
+ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
+ import io.papermc.paper.event.block.DragonEggFormEvent; // Paper - DragonEggFormEvent
++import io.papermc.paper.event.world.ExitPortalCreateEvent; // Paper - ExitPortalCreateEvent
++import org.bukkit.Location; // Paper - ExitPortalCreateEvent
++import net.minecraft.server.MCUtil; // Paper - ExitPortalCreateEvent
+ 
+ public class EnderDragonBattle {
+ 
+@@ -442,14 +445,26 @@ public class EnderDragonBattle {
+     }
+ 
+     public void generateExitPortal(boolean flag) {
+-        WorldGenEndTrophy worldgenendtrophy = new WorldGenEndTrophy(flag);
+-
++        // Paper start - Call ExitPortalCreateEvent and use results
+         if (this.exitPortalLocation == null) {
+             for (this.exitPortalLocation = this.world.getHighestBlockYAt(HeightMap.Type.MOTION_BLOCKING_NO_LEAVES, WorldGenEndTrophy.a).down(); this.world.getType(this.exitPortalLocation).a(Blocks.BEDROCK) && this.exitPortalLocation.getY() > this.world.getSeaLevel(); this.exitPortalLocation = this.exitPortalLocation.down()) {
+                 ;
+             }
+         }
+ 
++        // fix MC-93185
++        if (exitPortalLocation.getY() < this.world.getWorld().getMinHeight() + 1)
++            exitPortalLocation.setY(this.world.getWorld().getMinHeight() + 1);
++        if (exitPortalLocation.getY() > this.world.getWorld().getMaxHeight() - 4)
++            exitPortalLocation.setY(this.world.getWorld().getMaxHeight() - 4);
++
++        Location location = MCUtil.toLocation(world, exitPortalLocation);
++        ExitPortalCreateEvent exitPortalEvent = new ExitPortalCreateEvent(location, flag);
++        if (!exitPortalEvent.callEvent()) return;
++
++        this.exitPortalLocation = MCUtil.toBlockPosition(exitPortalEvent.getPortalLocation());
++        WorldGenEndTrophy worldgenendtrophy = new WorldGenEndTrophy(exitPortalEvent.isFilled());
++        // Paper end
+         worldgenendtrophy.b(WorldGenFeatureConfiguration.k).a(this.world, this.world.getChunkProvider().getChunkGenerator(), new Random(), this.exitPortalLocation); // Paper - decompile fix
+     }
+ 


### PR DESCRIPTION
This event is called just after calculating position of exit portal in The End, so you can modify its position, set/check if it will be filled with portal blocks etc.

Can be used to place portal higher than default on empty worlds (origin: y=-1; blocks from y=-2 to y=2, so portal was cut in the middle). 