### PR TITLE
Add Tick TemporalUnit

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -52,4 +52,5 @@ Doc <nachito94@msn.com>
 Nick Hensel <nickhensel25@icloud.com>
 vytskalt <vytskalt@protonmail.com>
 TheFruxz <cedricspitzer@outlook.de>
+Kieran Wallbanks <kieran.wallbanks@gmail.com>
 ```

--- a/Spigot-API-Patches/0284-Add-Tick-TemporalUnit.patch
+++ b/Spigot-API-Patches/0284-Add-Tick-TemporalUnit.patch
@@ -6,15 +6,18 @@ Subject: [PATCH] Add Tick TemporalUnit
 
 diff --git a/src/main/java/io/papermc/paper/util/Tick.java b/src/main/java/io/papermc/paper/util/Tick.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a5621e8d00c9f6bf5a416ab6f4e1ba19cef3ee23
+index 0000000000000000000000000000000000000000..05d26bfe37258ab398d386ae80fa252cdbcd0c8a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Tick.java
-@@ -0,0 +1,87 @@
+@@ -0,0 +1,94 @@
 +package io.papermc.paper.util;
++
++import org.jetbrains.annotations.NotNull;
 +
 +import java.time.Duration;
 +import java.time.temporal.Temporal;
 +import java.time.temporal.TemporalUnit;
++import java.util.Objects;
 +
 +/**
 + * A TemporalUnit that represents one server tick.
@@ -29,7 +32,7 @@ index 0000000000000000000000000000000000000000..a5621e8d00c9f6bf5a416ab6f4e1ba19
 +     * Gets the instance of the tick temporal unit.
 +     * @return the tick instance
 +     */
-+    public static Tick tick() {
++    public static @NotNull Tick tick() {
 +        return INSTANCE;
 +    }
 +
@@ -46,34 +49,38 @@ index 0000000000000000000000000000000000000000..a5621e8d00c9f6bf5a416ab6f4e1ba19
 +     * Creates a duration from an amount of ticks. This is shorthand for
 +     * {@link Duration#of(long, TemporalUnit)} called with the amount of ticks and
 +     * {@link #tick()}.
-+     *
 +     * @param ticks the amount of ticks
 +     * @return the duration
 +     */
-+    public static Duration of(long ticks) {
++    public static @NotNull Duration of(long ticks) {
 +        return Duration.of(ticks, INSTANCE);
 +    }
 +
 +    /**
 +     * Gets the number of whole ticks that occur in the provided duration. Note that this
 +     * method returns an {@code int} as this is the unit that Minecraft stores ticks in.
-+     *
 +     * @param duration the duration
 +     * @return the number of whole ticks in this duration
 +     * @throws ArithmeticException if the duration is zero or an overflow occurs
 +     */
-+    public int fromDuration(Duration duration) {
++    public int fromDuration(@NotNull Duration duration) {
++        Objects.requireNonNull(duration, "duration cannot be null");
 +        return Math.toIntExact(Math.floorDiv(duration.toMillis(), INSTANCE.milliseconds));
 +    }
 +
 +    @Override
-+    public Duration getDuration() {
++    public @NotNull Duration getDuration() {
 +        return Duration.ofMillis(this.milliseconds);
 +    }
 +
++    /**
++     * As the actual length of a tick can differ from the expected length of a tick, this
++     * method returns {@code true}.
++     * @return {@code true}
++     */
 +    @Override
 +    public boolean isDurationEstimated() {
-+        return false;
++        return true;
 +    }
 +
 +    @Override
@@ -88,12 +95,12 @@ index 0000000000000000000000000000000000000000..a5621e8d00c9f6bf5a416ab6f4e1ba19
 +
 +    @SuppressWarnings("unchecked") // following ChronoUnit#addTo
 +    @Override
-+    public <R extends Temporal> R addTo(R temporal, long amount) {
++    public <R extends Temporal> @NotNull R addTo(@NotNull R temporal, long amount) {
 +        return (R) temporal.plus(amount, this);
 +    }
 +
 +    @Override
-+    public long between(Temporal start, Temporal end) {
++    public long between(@NotNull Temporal start, @NotNull Temporal end) {
 +        return start.until(end, this);
 +    }
 +}

--- a/Spigot-API-Patches/0284-Add-Tick-TemporalUnit.patch
+++ b/Spigot-API-Patches/0284-Add-Tick-TemporalUnit.patch
@@ -1,0 +1,130 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Kieran Wallbanks <kieran.wallbanks@gmail.com>
+Date: Fri, 2 Apr 2021 17:28:58 +0100
+Subject: [PATCH] Add Tick TemporalUnit
+
+
+diff --git a/src/main/java/io/papermc/paper/util/Tick.java b/src/main/java/io/papermc/paper/util/Tick.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..a5621e8d00c9f6bf5a416ab6f4e1ba19cef3ee23
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/util/Tick.java
+@@ -0,0 +1,87 @@
++package io.papermc.paper.util;
++
++import java.time.Duration;
++import java.time.temporal.Temporal;
++import java.time.temporal.TemporalUnit;
++
++/**
++ * A TemporalUnit that represents one server tick.
++ * @see #tick()
++ */
++public final class Tick implements TemporalUnit {
++    private static final Tick INSTANCE = new Tick(50L);
++
++    private final long milliseconds;
++
++    /**
++     * Gets the instance of the tick temporal unit.
++     * @return the tick instance
++     */
++    public static Tick tick() {
++        return INSTANCE;
++    }
++
++    /**
++     * Creates a new tick.
++     * @param length the length of the tick in milliseconds
++     * @see #tick()
++     */
++    private Tick(long length) {
++        this.milliseconds = length;
++    }
++
++    /**
++     * Creates a duration from an amount of ticks. This is shorthand for
++     * {@link Duration#of(long, TemporalUnit)} called with the amount of ticks and
++     * {@link #tick()}.
++     *
++     * @param ticks the amount of ticks
++     * @return the duration
++     */
++    public static Duration of(long ticks) {
++        return Duration.of(ticks, INSTANCE);
++    }
++
++    /**
++     * Gets the number of whole ticks that occur in the provided duration. Note that this
++     * method returns an {@code int} as this is the unit that Minecraft stores ticks in.
++     *
++     * @param duration the duration
++     * @return the number of whole ticks in this duration
++     * @throws ArithmeticException if the duration is zero or an overflow occurs
++     */
++    public int fromDuration(Duration duration) {
++        return Math.toIntExact(Math.floorDiv(duration.toMillis(), INSTANCE.milliseconds));
++    }
++
++    @Override
++    public Duration getDuration() {
++        return Duration.ofMillis(this.milliseconds);
++    }
++
++    @Override
++    public boolean isDurationEstimated() {
++        return false;
++    }
++
++    @Override
++    public boolean isDateBased() {
++        return false;
++    }
++
++    @Override
++    public boolean isTimeBased() {
++        return true;
++    }
++
++    @SuppressWarnings("unchecked") // following ChronoUnit#addTo
++    @Override
++    public <R extends Temporal> R addTo(R temporal, long amount) {
++        return (R) temporal.plus(amount, this);
++    }
++
++    @Override
++    public long between(Temporal start, Temporal end) {
++        return start.until(end, this);
++    }
++}
+diff --git a/src/test/java/io/papermc/paper/TickTest.java b/src/test/java/io/papermc/paper/TickTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4f41afbdccdae4c6b1558ebdebf6cdfc489e3d1f
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/TickTest.java
+@@ -0,0 +1,25 @@
++package io.papermc.paper;
++
++import io.papermc.paper.util.Tick;
++import org.junit.Test;
++
++import java.time.Duration;
++
++import static org.junit.Assert.assertEquals;
++
++public class TickTest {
++
++    @Test
++    public void testTickLength() {
++        assertEquals(50, Duration.of(1, Tick.tick()).toMillis());
++        assertEquals(100, Duration.of(2, Tick.tick()).toMillis());
++    }
++
++    @Test
++    public void testTickFromDuration() {
++        assertEquals(0, Tick.tick().fromDuration(Duration.ofMillis(0)));
++        assertEquals(0, Tick.tick().fromDuration(Duration.ofMillis(10)));
++        assertEquals(1, Tick.tick().fromDuration(Duration.ofMillis(60)));
++        assertEquals(2, Tick.tick().fromDuration(Duration.ofMillis(100)));
++    }
++}

--- a/patches/api/0411-Add-Tick-TemporalUnit.patch
+++ b/patches/api/0411-Add-Tick-TemporalUnit.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Tick TemporalUnit
 
 diff --git a/src/main/java/io/papermc/paper/util/Tick.java b/src/main/java/io/papermc/paper/util/Tick.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..05d26bfe37258ab398d386ae80fa252cdbcd0c8a
+index 0000000000000000000000000000000000000000..42021c8708dc9c932cb497ca31ea4a3e2add22dd
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Tick.java
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,91 @@
 +package io.papermc.paper.util;
 +
 +import org.jetbrains.annotations.NotNull;
@@ -20,7 +20,9 @@ index 0000000000000000000000000000000000000000..05d26bfe37258ab398d386ae80fa252c
 +import java.util.Objects;
 +
 +/**
-+ * A TemporalUnit that represents one server tick.
++ * A TemporalUnit that represents the target length of one server tick. This is defined
++ * as 50 milliseconds. Note that this class is not for measuring the length that a tick
++ * took, rather it is used for simple conversion between times and ticks.
 + * @see #tick()
 + */
 +public final class Tick implements TemporalUnit {
@@ -73,14 +75,9 @@ index 0000000000000000000000000000000000000000..05d26bfe37258ab398d386ae80fa252c
 +        return Duration.ofMillis(this.milliseconds);
 +    }
 +
-+    /**
-+     * As the actual length of a tick can differ from the expected length of a tick, this
-+     * method returns {@code true}.
-+     * @return {@code true}
-+     */
 +    @Override
 +    public boolean isDurationEstimated() {
-+        return true;
++        return false;
 +    }
 +
 +    @Override
@@ -104,18 +101,16 @@ index 0000000000000000000000000000000000000000..05d26bfe37258ab398d386ae80fa252c
 +        return start.until(end, this);
 +    }
 +}
-diff --git a/src/test/java/io/papermc/paper/TickTest.java b/src/test/java/io/papermc/paper/TickTest.java
+diff --git a/src/test/java/io/papermc/paper/util/TickTest.java b/src/test/java/io/papermc/paper/util/TickTest.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4f41afbdccdae4c6b1558ebdebf6cdfc489e3d1f
+index 0000000000000000000000000000000000000000..9a48f7a82636d4047a3f5fefe69bb88c2f5aaaef
 --- /dev/null
-+++ b/src/test/java/io/papermc/paper/TickTest.java
-@@ -0,0 +1,25 @@
-+package io.papermc.paper;
-+
-+import io.papermc.paper.util.Tick;
-+import org.junit.Test;
++++ b/src/test/java/io/papermc/paper/util/TickTest.java
+@@ -0,0 +1,23 @@
++package io.papermc.paper.util;
 +
 +import java.time.Duration;
++import org.junit.Test;
 +
 +import static org.junit.Assert.assertEquals;
 +

--- a/patches/api/0411-Add-Tick-TemporalUnit.patch
+++ b/patches/api/0411-Add-Tick-TemporalUnit.patch
@@ -6,12 +6,13 @@ Subject: [PATCH] Add Tick TemporalUnit
 
 diff --git a/src/main/java/io/papermc/paper/util/Tick.java b/src/main/java/io/papermc/paper/util/Tick.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..66168a285facc2a6e5febe3391741e16a887d641
+index 0000000000000000000000000000000000000000..900f39c0c5c6f4f2c89e0b4dade0d26b367c4f57
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Tick.java
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,94 @@
 +package io.papermc.paper.util;
 +
++import net.kyori.adventure.util.Ticks;
 +import org.jetbrains.annotations.NotNull;
 +
 +import java.time.Duration;
@@ -26,7 +27,7 @@ index 0000000000000000000000000000000000000000..66168a285facc2a6e5febe3391741e16
 + * @see #tick()
 + */
 +public final class Tick implements TemporalUnit {
-+    private static final Tick INSTANCE = new Tick(50L);
++    private static final Tick INSTANCE = new Tick(Ticks.SINGLE_TICK_DURATION_MS);
 +
 +    private final long milliseconds;
 +

--- a/patches/api/0411-Add-Tick-TemporalUnit.patch
+++ b/patches/api/0411-Add-Tick-TemporalUnit.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Tick TemporalUnit
 
 diff --git a/src/main/java/io/papermc/paper/util/Tick.java b/src/main/java/io/papermc/paper/util/Tick.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..42021c8708dc9c932cb497ca31ea4a3e2add22dd
+index 0000000000000000000000000000000000000000..66168a285facc2a6e5febe3391741e16a887d641
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/Tick.java
-@@ -0,0 +1,91 @@
+@@ -0,0 +1,93 @@
 +package io.papermc.paper.util;
 +
 +import org.jetbrains.annotations.NotNull;
@@ -75,6 +75,8 @@ index 0000000000000000000000000000000000000000..42021c8708dc9c932cb497ca31ea4a3e
 +        return Duration.ofMillis(this.milliseconds);
 +    }
 +
++    // Note: This is a workaround in order to allow calculations with this duration.
++    // See: Duration#add
 +    @Override
 +    public boolean isDurationEstimated() {
 +        return false;


### PR DESCRIPTION
This PR adds a new class `Tick` that implements `TemporalUnit` to allow easy handling of ticks as a unit of time. Additionally, some unit tests have been provided just for fun.

For example, to create a new duration from a certain number of ticks you can simply do one of the following:
```java
Duration.of(50, Tick.tick());
Tick.of(50);
```

The inverse is also possible, calculating the whole number of ticks in a given duration:
```java
Tick.fromDuration(Duration.of(100, ChronoUnit.SECONDS));
```

This PR is a more restrictive version of the [equivalent PR in Minestom](https://github.com/Minestom/Minestom/pull/205).