### PR TITLE
Remove useless check on player interact cancellation

### DIFF
--- a/Spigot-Server-Patches/0192-Extend-Player-Interact-cancellation.patch
+++ b/Spigot-Server-Patches/0192-Extend-Player-Interact-cancellation.patch
@@ -13,7 +13,7 @@ Update adjacent blocks of doors, double plants, pistons and beds
 when cancelling interaction.
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
-index 51157a9223f3da22d1110cfa211a502de59fb8a1..cea19f4aafb3d81bf0dfcdac9103c03786fd5fc2 100644
+index 51157a9223f3da22d1110cfa211a502de59fb8a1..0ead8f1fabcc8debea8e2211d58a83b34acfcf0b 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerInteractManager.java
 @@ -6,6 +6,7 @@ import net.minecraft.core.BlockPosition;
@@ -44,7 +44,7 @@ index 51157a9223f3da22d1110cfa211a502de59fb8a1..cea19f4aafb3d81bf0dfcdac9103c037
                      this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition));
                      // Update any tile entity data for this block
                      TileEntity tileentity = this.world.getTileEntity(blockposition);
-@@ -483,13 +490,32 @@ public class PlayerInteractManager {
+@@ -483,13 +490,20 @@ public class PlayerInteractManager {
          interactItemStack = itemstack.cloneItemStack();
  
          if (event.useInteractedBlock() == Event.Result.DENY) {
@@ -60,18 +60,6 @@ index 51157a9223f3da22d1110cfa211a502de59fb8a1..cea19f4aafb3d81bf0dfcdac9103c037
 +                entityplayer.playerConnection.sendPacket(new PacketPlayOutCloseWindow());
 +            } else if (iblockdata.getBlock() instanceof BlockCommand) {
 +                entityplayer.playerConnection.sendPacket(new PacketPlayOutCloseWindow());
-+            } else if (iblockdata.getBlock() instanceof BlockFlowerPot) {
-+                // Send a block change to air and then send back the correct block, just to make the client happy
-+                PacketPlayOutBlockChange packet = new PacketPlayOutBlockChange(this.world, blockposition);
-+                packet.block = Blocks.AIR.getBlockData();
-+                this.player.playerConnection.sendPacket(packet);
-+
-+                this.player.playerConnection.sendPacket(new PacketPlayOutBlockChange(this.world, blockposition));
-+
-+                TileEntity tileentity = this.world.getTileEntity(blockposition);
-+                if (tileentity != null) {
-+                    player.playerConnection.sendPacket(tileentity.getUpdatePacket());
-+                }
              }
 +            // Paper end - extend Player Interact cancellation
              entityplayer.getBukkitEntity().updateInventory(); // SPIGOT-2867


### PR DESCRIPTION
This removes the BlockFlowerPot check that most likely was used when it was a tile entity. 

This pull request was tested and does not seem to cause any issues.