### PR TITLE
Make PlayerList more thread safe

### DIFF
--- a/patches/server/0817-Make-PlayerList-more-thread-safe.patch
+++ b/patches/server/0817-Make-PlayerList-more-thread-safe.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: stonar96 <minecraft.stonar96@gmail.com>
+Date: Mon, 5 Apr 2021 02:30:01 +0200
+Subject: [PATCH] Make PlayerList more thread safe
+
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 40d55cade76d0e8f39f91a322bc8a821877efa2c..4a9842110bb4b23735850014a54a8500bc809b8d 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -131,7 +131,7 @@ public abstract class PlayerList {
+     private static final SimpleDateFormat BAN_DATE_FORMAT = new SimpleDateFormat("yyyy-MM-dd 'at' HH:mm:ss z");
+     private final MinecraftServer server;
+     public final List<ServerPlayer> players = new java.util.concurrent.CopyOnWriteArrayList(); // CraftBukkit - ArrayList -> CopyOnWriteArrayList: Iterator safety
+-    private final Map<UUID, ServerPlayer> playersByUUID = Maps.newHashMap();
++    private final Map<UUID, ServerPlayer> playersByUUID = Maps.newConcurrentMap(); // Paper - newHashMap -> newConcurrentMap
+     private final UserBanList bans;
+     private final IpBanList ipBans;
+     private final ServerOpList ops;
+@@ -153,7 +153,7 @@ public abstract class PlayerList {
+ 
+     // CraftBukkit start
+     private CraftServer cserver;
+-    private final Map<String,ServerPlayer> playersByName = new java.util.HashMap<>();
++    private final Map<String,ServerPlayer> playersByName = new java.util.concurrent.ConcurrentHashMap<>(); // Paper - HashMap -> ConcurrentHashMap
+     public @Nullable String collideRuleTeamName; // Paper - Team name used for collideRule
+ 
+     public PlayerList(MinecraftServer server, RegistryAccess.RegistryHolder registryManager, PlayerDataStorage saveHandler, int maxPlayers) {


### PR DESCRIPTION
This PR makes online player lookups by unique ID and name thread safe, which can be useful for e.g. sending messages in an asynchronous context but it also improves thread safety of various other methods that do player lookups internally, such as some methods of `OfflinePlayer`.

Although visibility is often no issue because of a present happens-before relationship and I have heard several times that concurrent reads are fail-safe in the most `HashMap` implementations nowadays, the docs do not guarantee any behavior regarding this. Therefore I have replaced the `HashMap`s by `ConcurrentHashMap`s.

Note that `HashMap` and `ConcurrentHashMap` have different contracts for `null` keys, which also affects behavior of API methods. However, those are all annotated with `@NotNull` anyway and no `null` keys are used internally as far as I can see.

I don't know if this has any noticeable effects performance wise.