### PR TITLE
[CI-SKIP] Ignore gitignore when adding files in automation

### DIFF
--- a/scripts/apatch.sh
+++ b/scripts/apatch.sh
@@ -52,7 +52,7 @@ fi
 		if [ -f "$file" ] && [[ "$filedata" == *"<<<<<"* ]]; then
 			export summaryfail="$summaryfail\nFAILED TO APPLY: $i"
 		else
-			$gitcmd add "$i"
+			$gitcmd add --force "$i"
 			export summarygood="$summarygood\nAPPLIED CLEAN: $i"
 		fi
 	done

--- a/scripts/importmcdev.sh
+++ b/scripts/importmcdev.sh
@@ -121,6 +121,6 @@ importLibrary com.mojang datafixerupper com/mojang/serialization Dynamic.java
 set -e
 cd "$workdir/Spigot/Spigot-Server/"
 rm -rf nms-patches applyPatches.sh makePatches.sh >/dev/null 2>&1
-$gitcmd add . --force -A >/dev/null 2>&1
+$gitcmd add --force . -A >/dev/null 2>&1
 echo -e "mc-dev Imports\n\n$MODLOG" | $gitcmd commit . -F -
 )

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -54,7 +54,7 @@ do
     mkdir -p "$(dirname $cb/"$file")"
     cp "$nms/$file" "$cb/$file"
 done <   <(find nms-patches -type f -print0)
-$gitcmd add src
+$gitcmd add --force src
 $gitcmd commit -m "Minecraft $ $(date)" --author="Vanilla <auto@mated.null>"
 
 # apply patches
@@ -71,7 +71,7 @@ do
     "$patch" -d src/main/java -p 1 < "$patchFile"
 done <   <(find nms-patches -type f -print0)
 
-$gitcmd add src
+$gitcmd add --force src
 $gitcmd commit -m "CraftBukkit $ $(date)" --author="CraftBukkit <auto@mated.null>"
 $gitcmd checkout -f HEAD~2
 )

--- a/scripts/rebuildPatches.sh
+++ b/scripts/rebuildPatches.sh
@@ -52,7 +52,7 @@ function savePatches {
 
     $gitcmd format-patch --zero-commit --full-index --no-signature --no-stat -N -o "$basedir/${what_name}-Patches/" upstream/upstream >/dev/null
     cd "$basedir"
-    $gitcmd add -A "$basedir/${what_name}-Patches"
+    $gitcmd add --force -A "$basedir/${what_name}-Patches"
     if [ "$nofilter" == "0" ]; then
         cleanupPatches "$basedir/${what_name}-Patches"
     fi

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -16,7 +16,7 @@ function update {
     $gitcmd fetch && $gitcmd clean -fd && $gitcmd reset --hard origin/master
     refRemote=$(git rev-parse HEAD)
     cd ../
-    $gitcmd add $1 -f
+    $gitcmd add --force $1
     refHEAD=$(getRef HEAD "$workdir/$1")
     echo "$1 $refHEAD - $refRemote"
     if [ "$refHEAD" != "$refRemote" ]; then


### PR DESCRIPTION
Continuation of #5387
Fixes #5456

Hopefully this helps idiots like me who have global gitignore set. :)

### Alternative solutions considered
#### Override core.excludesfile
I've tried to disable gitignore globally in the scripts using https://git-scm.com/docs/git-config#Documentation/git-config.txt-GITCONFIGCOUNT , but sadly this only creates additional entries instead of overwriting existing ones.
```sh
export GIT_CONFIG_COUNT=1
export GIT_CONFIG_KEY_0=core.excludesfile
export GIT_CONFIG_VAL_0=/dev/null
```

#### Disable non-local configuration files
I've considered doing "fuller" approach of disabling system, user and global configurations, but it became too complex and fragile.
According to: https://git-scm.com/docs/git#Documentation/git.txt-codeGITCONFIGNOSYSTEMcode
> GIT_CONFIG_NOSYSTEM
>
>    Whether to skip reading settings from the system-wide $(prefix)/etc/gitconfig file. This environment variable can be used along with $HOME and $XDG_CONFIG_HOME to create a predictable environment for a picky script [...]

This obviously disables settings like `author.name` and `author.email`. I've tried to retain just these selected settings by doing:
```sh
export GIT_AUTHOR_NAME="$(git config --get user.name)"
export GIT_AUTHOR_EMAIL="$(git config --get user.email)"
```
before overriding the config paths, but git requires them to be set in config, before it'll actually overwrite them with environment variables.