### PR TITLE
Set Pitch/Yaw on AreaEffectCloud spawn

### DIFF
--- a/Spigot-Server-Patches/0705-Set-area-affect-cloud-rotation.patch
+++ b/Spigot-Server-Patches/0705-Set-area-affect-cloud-rotation.patch
@@ -1,0 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Mon, 5 Apr 2021 16:58:20 -0400
+Subject: [PATCH] Set area affect cloud rotation
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 05098332d83b1abfaa0a6d3bd4a9e801ea90d2ad..6c2a4607028c61e4a01ff200d301878e2d63b456 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -1977,6 +1977,7 @@ public class CraftWorld implements World {
+             entity = EntityTypes.LIGHTNING_BOLT.a(world);
+         } else if (AreaEffectCloud.class.isAssignableFrom(clazz)) {
+             entity = new EntityAreaEffectCloud(world, x, y, z);
++            entity.setPositionRotation(x, y, z, yaw, pitch); // Paper - Set area effect cloud Rotation
+         } else if (EvokerFangs.class.isAssignableFrom(clazz)) {
+             entity = new EntityEvokerFangs(world, x, y, z, (float) Math.toRadians(yaw), 0, null);
+         }


### PR DESCRIPTION
Area effect clouds can be used with player spectating to lock the player's view while having a basically "invisible" entity. However, pitch/yaw for spawning is not retained.

This patch now sets an area effect clouds yaw/pitch when spawning them.