### PR TITLE
Don't print spawn load time when not loading spawn, closes #5438

### DIFF
--- a/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -21,7 +21,7 @@ index 38d25a12c6a52d8a83214e2a0f43a218cf15ceac..ffe9b1a63d78925e1d77b9e730aef42f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5020b1ef1e0fc08a00a40aecfd3eeb74348865d1..4605b26cedbd0478b41e976f4b48ad78f12e37ff 100644
+index 5020b1ef1e0fc08a00a40aecfd3eeb74348865d1..0aa723d9940f4b33cd587aef6e23e238c2c22359 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -717,35 +717,36 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -74,6 +74,15 @@ index 5020b1ef1e0fc08a00a40aecfd3eeb74348865d1..4605b26cedbd0478b41e976f4b48ad78
  
          if (true) {
              WorldServer worldserver1 = worldserver;
+@@ -768,7 +769,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+         // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
+         this.executeModerately();
+         // CraftBukkit end
+-        worldloadlistener.b();
++        if (worldserver.getWorld().getKeepSpawnInMemory()) worldloadlistener.b(); // Paper
+         chunkproviderserver.getLightEngine().a(5);
+         // CraftBukkit start
+         // this.updateSpawnFlags();
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
 index a7fbbb755b2e829022efb0ae63fc1020d5adda4f..a9c0d3fc4aa07d9d580a31106169796b7bde4e63 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java

--- a/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0429-Increase-Light-Queue-Size.patch
@@ -28,13 +28,13 @@ index 6c8e9d498c9a30a1aa88494ba09c3cae012a8fa1..cd248eb6be663e8be33f2c3c6b06b77b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 835f84c2d33e48b2bcdaed822c7a50f3431bc323..31f09291015e805379ee55360bbf262ec371f493 100644
+index b9ce6fe70e9c8223ddad8feb46c90e3178ab5fed..072e17fd3a23406fb8818d0f217ba5f176282580 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -776,7 +776,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.executeModerately();
          // CraftBukkit end
-         worldloadlistener.b();
+         if (worldserver.getWorld().getKeepSpawnInMemory()) worldloadlistener.b(); // Paper
 -        chunkproviderserver.getLightEngine().a(5);
 +        chunkproviderserver.getLightEngine().a(worldserver.paperConfig.lightQueueSize); // Paper - increase light queue size
          // CraftBukkit start


### PR DESCRIPTION
Previously the time for loading the world would be printed even when `keep-spawn-loaded` was set to false. As the timer was never started, this would print insane times. This will check to see that the spawn is being kept in memory before printing load times. Closes #5438 