### PR TITLE
Make Player#playSound(Sound) follow the player

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2045,7 +2045,7 @@ index 3a4e2261d0b0cd17df3f96e75f3c509156679c48..105d0388998d1e35e634d2163fe1a44a
          player.activeContainer.addSlotListener(player);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 597b3b061c707081e7665d5896f5d73676e691d6..137870c7d18c9ef3ae637e83c5457d42ec40c669 100644
+index 597b3b061c707081e7665d5896f5d73676e691d6..618c3ec76ce57f29ab3dda1c1b7c6f85ec79c24a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -240,14 +240,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2230,7 +2230,7 @@ index 597b3b061c707081e7665d5896f5d73676e691d6..137870c7d18c9ef3ae637e83c5457d42
      @Override
      public String getLocale() {
          return getHandle().locale;
-@@ -1711,6 +1787,138 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1711,6 +1787,143 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2329,8 +2329,13 @@ index 597b3b061c707081e7665d5896f5d73676e691d6..137870c7d18c9ef3ae637e83c5457d42
 +
 +    @Override
 +    public void playSound(final net.kyori.adventure.sound.Sound sound) {
-+        final Vec3D pos = this.getHandle().getPositionVector();
-+        this.playSound(sound, pos.x, pos.y, pos.z);
++        final MinecraftKey name = io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.name());
++        final java.util.Optional<net.minecraft.sounds.SoundEffect> event = net.minecraft.core.IRegistry.SOUND_EVENT.getOptional(name);
++        if (event.isPresent()) {
++            this.getHandle().playerConnection.sendPacket(new net.minecraft.network.protocol.game.PacketPlayOutEntitySound(event.get(), io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.source()), this.getHandle(), sound.volume(), sound.pitch()));
++        } else {
++            this.getHandle().playerConnection.sendPacket(new PacketPlayOutCustomSoundEffect(name, io.papermc.paper.adventure.PaperAdventure.asVanilla(sound.source()), this.getHandle().getPositionVector(), sound.volume(), sound.pitch()));
++        }
 +    }
 +
 +    @Override

--- a/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
@@ -17,10 +17,10 @@ index b6effe1037f3ae59e6faa5f5d039b6ad54bca5d4..87374174dcbf9e7ee448a1cdd9a35285
          return (float) (1.0D / this.b(GenericAttributes.ATTACK_SPEED) * 20.0D);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32228b4eddaadabbae46ebbc5eb3404acf73fb29..9d3e01f7ad743dbe60685e9b111308ed06a0b4b7 100644
+index fe05aba52b85c9b59460e7a9d69eb30a06e9f09b..ae193816e6787c2c157e199b29fcae3d05c12569 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2186,6 +2186,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2191,6 +2191,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          connection.sendPacket(new net.minecraft.network.protocol.game.PacketPlayOutOpenBook(net.minecraft.world.EnumHand.MAIN_HAND));
          connection.sendPacket(new net.minecraft.network.protocol.game.PacketPlayOutSetSlot(0, slot, inventory.getItemInHand()));
      }

--- a/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c2ebf264d9d150541aeb2d89f24853c2f887cde5..e645a3386df6334e99d80ec6961399461c9545a9 100644
+index f0c7f30a737cce9f719c934910707618f13adf00..604ad90f934a7264b23bece5d6c2b8fe5d8a5f2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2231,6 +2231,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2236,6 +2236,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackCooldown();
      }

--- a/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
+++ b/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
@@ -40,10 +40,10 @@ index 145767e8b0fc4105a0afa47af17dcdbb75e952bc..174eb12722872182b2d9b54841e5bb57
                          double deltaZ = this.locZ() - player.locZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e645a3386df6334e99d80ec6961399461c9545a9..43e4ade73619d430be7ee93687e98ef5a27cb329 100644
+index 604ad90f934a7264b23bece5d6c2b8fe5d8a5f2f..17b75c7e6aa231d39f05d2eddd18273aa413d01f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2240,6 +2240,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2245,6 +2245,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              super.remove();
          }
      }

--- a/Spigot-Server-Patches/0448-Implement-Player-Client-Options-API.patch
+++ b/Spigot-Server-Patches/0448-Implement-Player-Client-Options-API.patch
@@ -149,7 +149,7 @@ index 8981dfacd10cae9de052e1b36ce5181cd0e6752d..202fa94d5dc55b549475ae0309bbcfca
      protected static final DataWatcherObject<NBTTagCompound> bk = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
      protected static final DataWatcherObject<NBTTagCompound> bl = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 43e4ade73619d430be7ee93687e98ef5a27cb329..7a240739ac6e043e590b380659d8e6d794954f84 100644
+index 17b75c7e6aa231d39f05d2eddd18273aa413d01f..1c76108ea0a4f675fb40fe356531c733dd462ed4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,8 @@
@@ -161,7 +161,7 @@ index 43e4ade73619d430be7ee93687e98ef5a27cb329..7a240739ac6e043e590b380659d8e6d7
  import com.destroystokyo.paper.Title;
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
-@@ -2250,6 +2253,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2255,6 +2258,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/Spigot-Server-Patches/0547-Brand-support.patch
+++ b/Spigot-Server-Patches/0547-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index bd6f3e9d321abcf039875dd5c9f7ccc59afd2dd2..0d65ffcad016a5f3fa9ddf616bc549087bf1335b 100644
+index 1a7d863e3ca320a5b3e768e378693fcd1f45d27b..a0c3283f6ce6b9e4036f131d416a064d5a46a8b8 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -5,6 +5,7 @@ import com.google.common.primitives.Doubles;
@@ -73,10 +73,10 @@ index bd6f3e9d321abcf039875dd5c9f7ccc59afd2dd2..0d65ffcad016a5f3fa9ddf616bc54908
          return (!this.player.joining && !this.networkManager.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ba8c36c9fa7a1fdc3047b14042da8703802f9275..a4726747c066d623f37162e2637403efee7f5708 100644
+index 72591e61861214c4f524379dbaa42dcdd1ac5732..91f590bc2bb6e53d3de270b98bd81beec6b08dd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2385,6 +2385,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2390,6 +2390,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/Spigot-Server-Patches/0588-Player-elytra-boost-API.patch
+++ b/Spigot-Server-Patches/0588-Player-elytra-boost-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a4726747c066d623f37162e2637403efee7f5708..204d3e879c736f44e01f9246af26f6cccf8d72a7 100644
+index 91f590bc2bb6e53d3de270b98bd81beec6b08dd2..fffd847b32bb15d16ef1a3678b43c354e079677a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -69,12 +69,14 @@ import net.minecraft.world.entity.ai.attributes.AttributeMapBase;
@@ -23,7 +23,7 @@ index a4726747c066d623f37162e2637403efee7f5708..204d3e879c736f44e01f9246af26f6cc
  import net.minecraft.world.level.biome.BiomeManager;
  import net.minecraft.world.level.block.entity.TileEntitySign;
  import net.minecraft.world.level.saveddata.maps.MapIcon;
-@@ -2281,6 +2283,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2286,6 +2288,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/Spigot-Server-Patches/0649-Add-sendOpLevel-API.patch
+++ b/Spigot-Server-Patches/0649-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index 0757cfcb96778258ba2593756e4ca9cbb16e2f87..24b3a893a2b76a4ecfbc6b2cc1eac242
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5a245184d6290a58bb9aed139cc4c7b5511ce491..e97ad53eb8bdc4c71d8014d060710cb3a29ab7f8 100644
+index 23b216bc193750a24583748c73341be578a70f37..92ec5c1c2e2284a5db2794a0bcdb992cf88e1f64 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2297,6 +2297,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2302,6 +2302,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/Spigot-Server-Patches/0678-Expose-Tracked-Players.patch
+++ b/Spigot-Server-Patches/0678-Expose-Tracked-Players.patch
@@ -18,7 +18,7 @@ index f7223f214f911dd25abcf3a52745588ec630241d..7abeeefeb579a43bc9ee85fd4150afac
      public Throwable addedToWorldStack; // Paper - entity debug
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e97ad53eb8bdc4c71d8014d060710cb3a29ab7f8..e5549439b3d4d608cf37dd33b6c8c9e10dfe9328 100644
+index 92ec5c1c2e2284a5db2794a0bcdb992cf88e1f64..071e29b8c40945583e39228712c0d265a00feec2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
@@ -29,7 +29,7 @@ index e97ad53eb8bdc4c71d8014d060710cb3a29ab7f8..e5549439b3d4d608cf37dd33b6c8c9e1
  import java.util.HashMap;
  import java.util.HashSet;
  import java.util.LinkedHashMap;
-@@ -2306,6 +2307,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2311,6 +2312,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  


### PR DESCRIPTION
Currently, if you play a sound using the Adventure `Player#playSound(Sound)` method it delegates to the `playSound(Sound, double, double, double)` method. This means that if you use this method to play, say, a record, and the player moves about the sound will not follow it, instead sticking at the location the player was at when the sound was played.

Although this could be considered correct behaviour, I believe it should be the case that if you're playing a sound on an audience member you would expect the sound to come from the audience member, following them if their location changes.

At the moment, this method falls back to sending using the custom sound effect packet using the players location, as the entity sound effect packet does not support custom sounds.

It's worth noting that a potential alternative to this is https://github.com/KyoriPowered/adventure/pull/316 which would mimic this functionality with `player.playSound(sound, player)`.