### PR TITLE
Add API to get players in view distance

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -47,4 +47,5 @@ Machine_Maker <machine@machinemaker.me>
 Ivan Pekov <ivan@mrivanplays.com>
 Camotoy <20743703+Camotoy@users.noreply.github.com>
 Bjarne Koll <lynxplay101@gmail.com>
+SirYwell <hannesgreule@outlook.de>
 ```

--- a/Spigot-API-Patches/0284-Add-API-to-get-players-in-view-distance.patch
+++ b/Spigot-API-Patches/0284-Add-API-to-get-players-in-view-distance.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SirYwell <hannesgreule@outlook.de>
+Date: Sat, 10 Apr 2021 18:58:46 +0200
+Subject: [PATCH] Add API to get players in view distance
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index b01cda41fcc14364af6a43165e97a01a5c08d319..5e4086f5e61af685353d57620c4e30e368692e21 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -3517,6 +3517,67 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+      * @param viewDistance view distance in [2, 32]
+      */
+     void setNoTickViewDistance(int viewDistance);
++
++    /**
++     * Returns a collection of players in view distance of the chunk at the given location.
++     * @param location the location in the chunk to get the players in range for.
++     * @return the players in view distance of the chunk.
++     */
++    @NotNull
++    default Collection<Player> getPlayersInViewDistance(@NotNull Location location) {
++        return getPlayersInViewDistance(location.getChunk());
++    }
++
++    /**
++     * Returns a collection of players in view distance of the given chunk.
++     * @param chunk the chunk to get the players in range for.
++     * @return the players in view distance of the chunk.
++     */
++    @NotNull
++    default Collection<Player> getPlayersInViewDistance(@NotNull Chunk chunk) {
++        return getPlayersInViewDistance(chunk.getX(), chunk.getZ());
++    }
++
++    /**
++     * Returns a collection of players in view distance of the chunk at the given
++     * chunk coordinates.
++     * @param chunkX the x-coordinate of the chunk.
++     * @param chunkZ the z-coordinate of the chunk.
++     * @return the players in view distance of the chunk.
++     */
++    @NotNull
++    Collection<Player> getPlayersInViewDistance(int chunkX, int chunkZ);
++
++    /**
++     * Returns a collection of players in the no-tick view distance of the chunk
++     * at the given location.
++     * @param location the location in the chunk to get players in range for.
++     * @return the players in no-tick view distance of the chunk.
++     */
++    @NotNull
++    default Collection<Player> getPlayersInNoTickViewDistance(@NotNull Location location) {
++        return getPlayersInNoTickViewDistance(location.getChunk());
++    }
++
++    /**
++     * Returns a collection of players in the no-tick view distance of the given chunk.
++     * @param chunk the chunk to get the players in range for-
++     * @return the players in no-tick view distance of the chunk.
++     */
++    @NotNull
++    default Collection<Player> getPlayersInNoTickViewDistance(@NotNull Chunk chunk) {
++        return getPlayersInNoTickViewDistance(chunk.getX(), chunk.getZ());
++    }
++
++    /**
++     * Returns a collection of players in the no-tick view distance at the given
++     * chunk coordinates.
++     * @param chunkX the x-coordinate of the chunk.
++     * @param chunkZ the z-coordinate of the chunk.
++     * @return the players in no-tick view distance of the chunk.
++     */
++    @NotNull
++    Collection<Player> getPlayersInNoTickViewDistance(int chunkX, int chunkZ);
+     // Paper end - view distance api
+ 
+     // Spigot start

--- a/Spigot-Server-Patches/0701-Add-API-to-get-players-in-view-distance.patch
+++ b/Spigot-Server-Patches/0701-Add-API-to-get-players-in-view-distance.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SirYwell <hannesgreule@outlook.de>
+Date: Sat, 10 Apr 2021 18:58:57 +0200
+Subject: [PATCH] Add API to get players in view distance
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index e739b4f8a7b8785ceb11c553bd27e2fe0e64a4bb..ca3ca47442cb4a1fc85a0e58b340ad892feb4243 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -2631,6 +2631,28 @@ public class CraftWorld implements World {
+             chunkMap.setNoTickViewDistance(viewDistance);
+         }
+     }
++
++    @Override
++    public Collection<Player> getPlayersInViewDistance(int chunkX, int chunkZ) {
++        return getPlayersInDistance(chunkX, chunkZ, getHandle().getChunkProvider().playerChunkMap.playerViewDistanceTickMap);
++    }
++
++    @Override
++    public Collection<Player> getPlayersInNoTickViewDistance(int chunkX, int chunkZ) {
++        return getPlayersInDistance(chunkX, chunkZ, getHandle().getChunkProvider().playerChunkMap.playerViewDistanceNoTickMap);
++    }
++
++    private Collection<Player> getPlayersInDistance(int chunkX, int chunkZ, com.destroystokyo.paper.util.misc.PlayerAreaMap areaMap) {
++        com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<?> inRange = areaMap.getObjectsInRange(chunkX, chunkZ);
++        Set<Player> players = new HashSet<>();
++        if (inRange == null) return players;
++        for (Object player : inRange.getBackingSet()) {
++            if (player instanceof net.minecraft.server.level.EntityPlayer) {
++                players.add(((net.minecraft.server.level.EntityPlayer) player).getBukkitEntity());
++            }
++        }
++        return players;
++    }
+     // Paper end - per player view distance
+ 
+     // Spigot start


### PR DESCRIPTION
This allows to get a collection of players in the (no-tick) view distance of a chunk