### PR TITLE
Fix broadcast event and add Adventure broadcast

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -757,28 +757,40 @@ index 0000000000000000000000000000000000000000..77db592d05b754f879f8d1790642e9d9
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac4376b06d 100644
+index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..f3b07f0f1b3be14c8ecd059e1f3594cc90f84442 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -278,7 +278,9 @@ public final class Bukkit {
       *
       * @param message the message
       * @return the number of players
-+     * @deprecated in favour of {@link Server#sendMessage(net.kyori.adventure.text.Component)}
++     * @deprecated in favour of {@link Server#broadcast(net.kyori.adventure.text.Component)}
       */
 +    @Deprecated // Paper
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -836,6 +838,7 @@ public final class Bukkit {
+@@ -836,6 +838,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
 +    // Paper start
++    /**
++     * Broadcast a message to all players.
++     * <p>
++     * This is the same as calling {@link #broadcast(net.kyori.adventure.text.Component,
++     * java.lang.String)} with the {@link Server#BROADCAST_CHANNEL_USERS} permission.
++     *
++     * @param message the message
++     * @return the number of players
++     */
++    public static int broadcast(@NotNull net.kyori.adventure.text.Component message) {
++        return server.broadcast(message);
++    }
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -845,6 +848,21 @@ public final class Bukkit {
+@@ -845,6 +860,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -800,7 +812,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1044,6 +1062,7 @@ public final class Bukkit {
+@@ -1044,6 +1074,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -808,7 +820,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1069,6 +1088,38 @@ public final class Bukkit {
+@@ -1069,6 +1100,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -847,7 +859,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1087,6 +1138,7 @@ public final class Bukkit {
+@@ -1087,6 +1150,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -855,7 +867,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1099,10 +1151,30 @@ public final class Bukkit {
+@@ -1099,10 +1163,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -886,7 +898,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      /**
       * Creates an empty merchant.
       *
-@@ -1110,7 +1182,20 @@ public final class Bukkit {
+@@ -1110,7 +1194,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -907,7 +919,7 @@ index 7c715fdc11ab7837552b1fe3ffd08b31cec0a63b..426b1e83226e674ee4bf3ec05ddcd3ac
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1181,22 +1266,47 @@ public final class Bukkit {
+@@ -1181,22 +1278,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -1029,10 +1041,10 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c108f206f3c 100644
+index a6b9e4f158583e5932bf8ca210d531857e9f5360..7abdbf43e2f52e8e9e0f7bd7c7a58baf347e3929 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -55,7 +55,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -55,13 +55,13 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a server implementation.
   */
@@ -1041,17 +1053,33 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
  
      /**
       * Used for all administrative messages, such as an operator using a
+      * command.
+      * <p>
+-     * For use in {@link #broadcast(java.lang.String, java.lang.String)}.
++     * For use in {@link #broadcast(net.kyori.adventure.text.Component, java.lang.String)}.
+      */
+     public static final String BROADCAST_CHANNEL_ADMINISTRATIVE = "bukkit.broadcast.admin";
+ 
+@@ -69,7 +69,7 @@ public interface Server extends PluginMessageRecipient {
+      * Used for all announcement messages, such as informing users that a
+      * player has joined.
+      * <p>
+-     * For use in {@link #broadcast(java.lang.String, java.lang.String)}.
++     * For use in {@link #broadcast(net.kyori.adventure.text.Component, java.lang.String)}.
+      */
+     public static final String BROADCAST_CHANNEL_USERS = "bukkit.broadcast.user";
+ 
 @@ -229,7 +229,9 @@ public interface Server extends PluginMessageRecipient {
       *
       * @param message the message
       * @return the number of players
-+     * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
++     * @deprecated use {@link #broadcast(net.kyori.adventure.text.Component)}
       */
 +    @Deprecated // Paper
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -703,8 +705,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -703,8 +705,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -1060,6 +1088,17 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
 +    @Deprecated // Paper
      public int broadcast(@NotNull String message, @NotNull String permission);
 +    // Paper start
++    /**
++     * Broadcast a message to all players.
++     * <p>
++     * This is the same as calling {@link #broadcast(net.kyori.adventure.text.Component,
++     * java.lang.String)} with the {@link #BROADCAST_CHANNEL_USERS} permission.
++     *
++     * @param message the message
++     * @return the number of players
++     */
++    int broadcast(@NotNull net.kyori.adventure.text.Component message);
++
 +    /**
 +     * Broadcasts the specified message to every user with the given
 +     * permission name.
@@ -1074,7 +1113,7 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -869,6 +885,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -869,6 +896,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -1082,7 +1121,7 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -894,6 +911,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -894,6 +922,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -1119,7 +1158,7 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -908,6 +955,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -908,6 +966,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -1142,7 +1181,7 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -918,18 +981,32 @@ public interface Server extends PluginMessageRecipient {
+@@ -918,10 +992,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -1153,29 +1192,29 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
      Inventory createInventory(@Nullable InventoryHolder owner, int size, @NotNull String title) throws IllegalArgumentException;
  
 +    // Paper start
+     /**
+      * Creates an empty merchant.
+      *
+@@ -929,7 +1006,18 @@ public interface Server extends PluginMessageRecipient {
+      * when the merchant inventory is viewed
+      * @return a new merchant
+      */
++    @NotNull Merchant createMerchant(@Nullable net.kyori.adventure.text.Component title);
++    // Paper start
 +    /**
 +     * Creates an empty merchant.
 +     *
 +     * @param title the title of the corresponding merchant inventory, displayed
 +     * when the merchant inventory is viewed
 +     * @return a new merchant
-+     */
-+    @NotNull Merchant createMerchant(@Nullable net.kyori.adventure.text.Component title);
-+    // Paper start
-     /**
-      * Creates an empty merchant.
-      *
-      * @param title the title of the corresponding merchant inventory, displayed
-      * when the merchant inventory is viewed
-      * @return a new merchant
 +     * @deprecated in favour of {@link #createMerchant(net.kyori.adventure.text.Component)}
-      */
++     */
      @NotNull
 +    @Deprecated // Paper
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -986,20 +1063,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -986,20 +1074,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -1217,21 +1256,21 @@ index a6b9e4f158583e5932bf8ca210d531857e9f5360..d9515a79dc7ed60c66960cd6c6bb4c10
      String getShutdownMessage();
  
      /**
-@@ -1368,7 +1466,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1368,7 +1477,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
-+         * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
++         * @deprecated use {@link #broadcast(net.kyori.adventure.text.Component)}
           */
 +        @Deprecated // Paper
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1377,7 +1477,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1377,7 +1488,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
-+         * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
++         * @deprecated use {@link #broadcast(net.kyori.adventure.text.Component)}
           */
 +        @Deprecated // Paper
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {

--- a/Spigot-API-Patches/0007-Add-getTPS-method.patch
+++ b/Spigot-API-Patches/0007-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 426b1e83226e674ee4bf3ec05ddcd3ac4376b06d..cd1b4be422a3a4290579d5daed9466084f18ed60 100644
+index ab4d5aca6251b620ef5d654fa4ea3fc31783c2f2..0636edd8d9121eabfa60957c8c224261d228a16b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1531,6 +1531,17 @@ public final class Bukkit {
+@@ -1543,6 +1543,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index 426b1e83226e674ee4bf3ec05ddcd3ac4376b06d..cd1b4be422a3a4290579d5daed946608
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d9515a79dc7ed60c66960cd6c6bb4c108f206f3c..9ec374570e135a4ba14db7efdbb5c1bd213226eb 100644
+index b862f22d5f31934eb46b50ecf04f8c1bf23c5044..5c638e0d45e8896382bdbf9b9c10474b05a97df5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1290,6 +1290,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1301,6 +1301,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/Spigot-API-Patches/0015-Expose-server-CommandMap.patch
+++ b/Spigot-API-Patches/0015-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cd1b4be422a3a4290579d5daed9466084f18ed60..10274053320f1ec690a65d3794abb44b58658059 100644
+index 0636edd8d9121eabfa60957c8c224261d228a16b..8d707e117035d5bc0d8c9a5fd386ee8355359259 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1705,6 +1705,19 @@ public final class Bukkit {
+@@ -1717,6 +1717,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index cd1b4be422a3a4290579d5daed9466084f18ed60..10274053320f1ec690a65d3794abb44b
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9ec374570e135a4ba14db7efdbb5c1bd213226eb..7e4a728ceb943b6a32b9ba9b84bada34e71c0980 100644
+index 5c638e0d45e8896382bdbf9b9c10474b05a97df5..24bcc63afbda5f27aad385dc707f262d1a3a3399 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1300,6 +1300,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1311,6 +1311,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/Spigot-API-Patches/0026-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/Spigot-API-Patches/0026-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 22b83b142de97dcba28fa9a49730de7880d0b5d2..945d75525465739dd30610dff985ea0fb0f1c8df 100644
+index c546ab363d80a8263d140b2b4d81b840370d3436..1380a26f34a9d2b162e88fbea14b17118945643c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1740,6 +1740,13 @@ public final class Bukkit {
+@@ -1752,6 +1752,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 22b83b142de97dcba28fa9a49730de7880d0b5d2..945d75525465739dd30610dff985ea0f
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9ce9b4ce2da6c57c62607502ae2042e30fc26d88..f69c30ebea9c9e9add0b6c97994be0ce64a80ad3 100644
+index 22ad961b2d080f3160e37c521003143e76d144e9..4c201097ef98f545acb604fa72d56413553e4d4f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1538,4 +1538,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1549,4 +1549,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/Spigot-API-Patches/0039-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-API-Patches/0039-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 945d75525465739dd30610dff985ea0fb0f1c8df..555ef4c187ce0c83cc29af145694ec9c448d452e 100644
+index 1380a26f34a9d2b162e88fbea14b17118945643c..7b3a0c958b4b4bffb6c19a0e4d3bf4824f8db237 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1747,6 +1747,15 @@ public final class Bukkit {
+@@ -1759,6 +1759,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 945d75525465739dd30610dff985ea0fb0f1c8df..555ef4c187ce0c83cc29af145694ec9c
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f69c30ebea9c9e9add0b6c97994be0ce64a80ad3..9d81f25e39d345b797f73855a802b186d77f6d12 100644
+index 4c201097ef98f545acb604fa72d56413553e4d4f..6f4817af249e258905c97f4dac3d2f33804bdfc5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1540,4 +1540,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1551,4 +1551,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/Spigot-API-Patches/0050-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-API-Patches/0050-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 555ef4c187ce0c83cc29af145694ec9c448d452e..2527e896a4409326ea2612723b829696d44fc199 100644
+index 7b3a0c958b4b4bffb6c19a0e4d3bf4824f8db237..e2052baa65ed3525a89b26c065b3e2a58916ab99 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1756,6 +1756,16 @@ public final class Bukkit {
+@@ -1768,6 +1768,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 555ef4c187ce0c83cc29af145694ec9c448d452e..2527e896a4409326ea2612723b829696
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9d81f25e39d345b797f73855a802b186d77f6d12..7d94242b2f8ecb537b3140f9d6f706d3e266c456 100644
+index 6f4817af249e258905c97f4dac3d2f33804bdfc5..8fd026e4ffcdf009365ae04b87f7559bed32c7d3 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1542,4 +1542,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1553,4 +1553,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/Spigot-API-Patches/0056-Basic-PlayerProfile-API.patch
+++ b/Spigot-API-Patches/0056-Basic-PlayerProfile-API.patch
@@ -267,10 +267,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2527e896a4409326ea2612723b829696d44fc199..f5d3a7370390871d1b6075f32846d1a942b05b7f 100644
+index e2052baa65ed3525a89b26c065b3e2a58916ab99..39942b4c5683f2dcc40be5a23af36a3bb32badb1 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1766,6 +1766,40 @@ public final class Bukkit {
+@@ -1778,6 +1778,40 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -312,10 +312,10 @@ index 2527e896a4409326ea2612723b829696d44fc199..f5d3a7370390871d1b6075f32846d1a9
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7d94242b2f8ecb537b3140f9d6f706d3e266c456..38d138b217734e598581ed14065ff2015135ee9a 100644
+index 8fd026e4ffcdf009365ae04b87f7559bed32c7d3..0c1fbaee08cb614dfdd1de0200dfa7fa351fc52d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1551,5 +1551,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1562,5 +1562,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/Spigot-API-Patches/0162-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-API-Patches/0162-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 2d7f8e128e23934a8fe26baf19198b7ffc8447bb..908b75f0b9897ce830ed7c0a2c1dd0a458a872f1 100644
+index 6b619b85fee86ccc599cb46d789e39b81af3201c..dcaefdaf5a0de8486f59115c8c4d4c211b7d64cd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1781,6 +1781,15 @@ public final class Bukkit {
+@@ -1793,6 +1793,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index 2d7f8e128e23934a8fe26baf19198b7ffc8447bb..908b75f0b9897ce830ed7c0a2c1dd0a4
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 01657abaff86cf7bb3ffb857024c5032781b8660..a68b973e7574cae3ee7be7cfc51786589280408a 100644
+index c642fe9cfae6407404f5cf17264f42ef83a01280..9b8e6b7bbbed44e2659379c8046acaa35aaa8910 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1564,6 +1564,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1575,6 +1575,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/Spigot-API-Patches/0176-Flip-some-Spigot-API-null-annotations.patch
+++ b/Spigot-API-Patches/0176-Flip-some-Spigot-API-null-annotations.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 908b75f0b9897ce830ed7c0a2c1dd0a458a872f1..1f5bcda86990d7c336db21d9c927bbf6b1b6d74d 100644
+index dcaefdaf5a0de8486f59115c8c4d4c211b7d64cd..e3304fcc8c4fd176abd3fb7d4b47e5ccb7bdd37f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1377,7 +1377,7 @@ public final class Bukkit {
+@@ -1389,7 +1389,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 908b75f0b9897ce830ed7c0a2c1dd0a458a872f1..1f5bcda86990d7c336db21d9c927bbf6
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1674,7 +1674,7 @@ public final class Bukkit {
+@@ -1686,7 +1686,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -62,10 +62,10 @@ index 9c91c49ed7302c12fcb1d8e9bc58712efc199954..d5d67b3d84cd88ed0f858497e68535ec
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index a68b973e7574cae3ee7be7cfc51786589280408a..39188fcf95beff906c68a822f6aa5e19ad3ad08c 100644
+index 9b8e6b7bbbed44e2659379c8046acaa35aaa8910..989a732e5ef2053deede245d65fbf99cdf117c5e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1160,7 +1160,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1171,7 +1171,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -74,7 +74,7 @@ index a68b973e7574cae3ee7be7cfc51786589280408a..39188fcf95beff906c68a822f6aa5e19
      ScoreboardManager getScoreboardManager();
  
      /**
-@@ -1430,7 +1430,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1441,7 +1441,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -84,7 +84,7 @@ index a68b973e7574cae3ee7be7cfc51786589280408a..39188fcf95beff906c68a822f6aa5e19
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 3578f491a053154789ad696e93c70fdde74912e6..0654873eef22d1e35c7430f098ff9e8f00b870e3 100644
+index 591e095dabd4cb72881abf206b1d7f0c8818cef3..ecf509a970ed4f0052d5d2c756406bf96052a680 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -3,6 +3,7 @@ package org.bukkit.inventory;
@@ -105,7 +105,7 @@ index 3578f491a053154789ad696e93c70fdde74912e6..0654873eef22d1e35c7430f098ff9e8f
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index ce9ee2d6d72069af518fc8d7d48a35c03b5f9f1f..3d63514729ddc30ff559a65815612be81e777892 100644
+index 686e2a0b9fe061816b41435ef2337870dbdca8e5..290c3f0fd6e8c3407d421b697e0ee01584f4cebd 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -8,6 +8,7 @@ import java.util.Set; // Paper

--- a/Spigot-API-Patches/0184-Expose-the-internal-current-tick.patch
+++ b/Spigot-API-Patches/0184-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1f5bcda86990d7c336db21d9c927bbf6b1b6d74d..3e2d644806233bb72f2f6637ec6edde4e3bcfdc9 100644
+index e3304fcc8c4fd176abd3fb7d4b47e5ccb7bdd37f..49bf621a2c0e5e9641b334a42b2769944c991d5d 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1823,6 +1823,10 @@ public final class Bukkit {
+@@ -1835,6 +1835,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index 1f5bcda86990d7c336db21d9c927bbf6b1b6d74d..3e2d644806233bb72f2f6637ec6edde4
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 39188fcf95beff906c68a822f6aa5e19ad3ad08c..f107b5658b60e59e9d98bc86a0313f4da201c190 100644
+index 989a732e5ef2053deede245d65fbf99cdf117c5e..e448ae78304974f7664b7ef18568a547833ece9f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1598,5 +1598,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1609,5 +1609,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/Spigot-API-Patches/0190-Add-tick-times-API.patch
+++ b/Spigot-API-Patches/0190-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 3e2d644806233bb72f2f6637ec6edde4e3bcfdc9..296c8fbb9239ab28f5ebbd4c322a3b9226a3ce11 100644
+index 49bf621a2c0e5e9641b334a42b2769944c991d5d..4bae8a4387b86c868149f06b490ef6dfced2ff41 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1578,6 +1578,25 @@ public final class Bukkit {
+@@ -1590,6 +1590,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 3e2d644806233bb72f2f6637ec6edde4e3bcfdc9..296c8fbb9239ab28f5ebbd4c322a3b92
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f107b5658b60e59e9d98bc86a0313f4da201c190..7195b480a16aa67f8e06fd3064b1072eafbb27b2 100644
+index e448ae78304974f7664b7ef18568a547833ece9f..bea7ffdb00e6de1391e9143901c62f0aceaaf727 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1334,6 +1334,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1345,6 +1345,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/Spigot-API-Patches/0191-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-API-Patches/0191-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 296c8fbb9239ab28f5ebbd4c322a3b9226a3ce11..86ac6702b3aeab1126b2b2879b87ef3883793d44 100644
+index 4bae8a4387b86c868149f06b490ef6dfced2ff41..4dadea432c8d79b15fa126b4f0c810e9a72b4029 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1846,6 +1846,15 @@ public final class Bukkit {
+@@ -1858,6 +1858,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 296c8fbb9239ab28f5ebbd4c322a3b9226a3ce11..86ac6702b3aeab1126b2b2879b87ef38
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7195b480a16aa67f8e06fd3064b1072eafbb27b2..16a74b834c4d4b907f9b11ccf9ef9804514df224 100644
+index bea7ffdb00e6de1391e9143901c62f0aceaaf727..b92261e09790e89788560bf7c9784c8399504810 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1620,5 +1620,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1631,5 +1631,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/Spigot-API-Patches/0200-Add-Mob-Goal-API.patch
+++ b/Spigot-API-Patches/0200-Add-Mob-Goal-API.patch
@@ -441,10 +441,10 @@ index 0000000000000000000000000000000000000000..b42091752981a1f309ab350e9a394092
 +    GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 12214ce2af7363d40cf44652e46f05c5c1f2fe5a..77d352450f6bc5293efec3b75e08b857e2626fe7 100644
+index bbf15311a48ba96e14ffa2ab9d59613e79f06618..4cffbc4f665e267371e99094e8b7de975fffc223 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1867,6 +1867,16 @@ public final class Bukkit {
+@@ -1879,6 +1879,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -462,10 +462,10 @@ index 12214ce2af7363d40cf44652e46f05c5c1f2fe5a..77d352450f6bc5293efec3b75e08b857
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 360decea2eb6de4c567fa4cceea8f19bceff6823..4b1f515f2228f16c1ce793bd45510243d758236f 100644
+index 21ebe1e70a4b9df54a5c730cee6d024cc1358b88..969cba46ba2790dde32724111ad77332c5872e0b 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1637,5 +1637,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1648,5 +1648,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/Spigot-API-Patches/0215-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-API-Patches/0215-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 77d352450f6bc5293efec3b75e08b857e2626fe7..1eaf6aae1e13c48a7f911e523015cb9b8cca8638 100644
+index 4cffbc4f665e267371e99094e8b7de975fffc223..a1e211653e05f3c9bc2ddf5aa1b69dea1c4bb61b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1478,6 +1478,22 @@ public final class Bukkit {
+@@ -1490,6 +1490,22 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -32,10 +32,10 @@ index 77d352450f6bc5293efec3b75e08b857e2626fe7..1eaf6aae1e13c48a7f911e523015cb9b
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 4b1f515f2228f16c1ce793bd45510243d758236f..8ee02c3d6cc8751704e5993fecd05293714e492f 100644
+index 969cba46ba2790dde32724111ad77332c5872e0b..71538dfce294776b8f98046cbddde21dc9ae89e7 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1245,6 +1245,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1256,6 +1256,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/Spigot-API-Patches/0231-Add-getOfflinePlayerIfCached-String.patch
+++ b/Spigot-API-Patches/0231-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 6228d7eca85fba52296c8d63d32804f32af1b421..68101a322ffab8ec28843386b79b8079576fa720 100644
+index 3a930ee1b1dce3639d590a8646f68b4ab92207fb..a498c5267458767e1f7802ab3d3b7a22f987d985 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -950,6 +950,27 @@ public final class Bukkit {
+@@ -962,6 +962,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index 6228d7eca85fba52296c8d63d32804f32af1b421..68101a322ffab8ec28843386b79b8079
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 6237578b373002c009efde4fb4c1864f0bf4f19e..a79fa08b9e6fb924b2da933eb6e4b365d14d938d 100644
+index 9d8886526ae0cd31ec5771462f3cd57692b1cb53..bbc7a1a35da6c8c66c18779ba4fb1aca1a567e6f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -797,6 +797,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -808,6 +808,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/Spigot-API-Patches/0300-Add-basic-Datapack-API.patch
+++ b/Spigot-API-Patches/0300-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5f7208196684d9c8373df28b7cfb5f9e21baa41e..33f04d57b7df3a6f9743246ba9af6d67f4fa4b54 100644
+index 050ee6a6fd0b74d9bfdd9dfe88cd4cd3d17da868..a8b6cc350e85d4f1a31f30dee42feafd0edb6009 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1937,6 +1937,14 @@ public final class Bukkit {
+@@ -1949,6 +1949,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 5f7208196684d9c8373df28b7cfb5f9e21baa41e..33f04d57b7df3a6f9743246ba9af6d67
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f3e27d2d02a9407bb1b091b8c1125ad5abf99e55..35ec8a060c2a2d2d48477b1bb940db51d18bf38e 100644
+index eb7f604600839618eaf27e0e5444b4830716eb07..2b400079559abd6b847782ae8480f2ae1948e22a 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1698,5 +1698,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1709,5 +1709,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1683,23 +1683,22 @@ index 7ec93ddd7e7c9dc54e3e4dcfe0d1654c0b0a8536..3f057f0bd23bc1c693c8f04ee8acd662
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153bca9fcd3 100644
+index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2ad09749f3005c3eff143d83580e25910341aa6b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -562,8 +562,11 @@ public final class CraftServer implements Server {
+@@ -562,8 +562,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
 +    @Deprecated // Paper start
      public int broadcastMessage(String message) {
 -        return broadcast(message, BROADCAST_CHANNEL_USERS);
-+        this.sendMessage(io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.deserialize(message));
-+        return this.getOnlinePlayers().size() + 1;
++        return this.broadcast(message, BROADCAST_CHANNEL_USERS);
 +        // Paper end
      }
  
      public Player getPlayer(final EntityPlayer entity) {
-@@ -1307,7 +1310,15 @@ public final class CraftServer implements Server {
+@@ -1307,7 +1309,15 @@ public final class CraftServer implements Server {
          return configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1715,7 +1714,7 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
      public String getShutdownMessage() {
          return configuration.getString("settings.shutdown-message");
      }
-@@ -1423,7 +1434,15 @@ public final class CraftServer implements Server {
+@@ -1423,7 +1433,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1726,12 +1725,17 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
 +    }
 +
 +    @Override
++    public int broadcast(net.kyori.adventure.text.Component message) {
++        return this.broadcast(message, BROADCAST_CHANNEL_USERS);
++    }
++
++    @Override
 +    public int broadcast(net.kyori.adventure.text.Component message, String permission) {
 +        // Paper end
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1431,14 +1450,14 @@ public final class CraftServer implements Server {
+@@ -1431,14 +1454,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1748,7 +1752,7 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1664,6 +1683,14 @@ public final class CraftServer implements Server {
+@@ -1664,6 +1687,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1763,7 +1767,7 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1676,13 +1703,28 @@ public final class CraftServer implements Server {
+@@ -1676,13 +1707,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1782,17 +1786,17 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
      }
  
 +    // Paper start
-     @Override
++    @Override
 +    public Merchant createMerchant(net.kyori.adventure.text.Component title) {
 +        return new org.bukkit.craftbukkit.inventory.CraftMerchantCustom(title == null ? InventoryType.MERCHANT.defaultTitle() : title);
 +    }
 +    // Paper end
-+    @Override
+     @Override
 +    @Deprecated // Paper
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1726,6 +1768,12 @@ public final class CraftServer implements Server {
+@@ -1726,6 +1772,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1805,7 +1809,7 @@ index 0c1e12b0b43f949d4ace600b2ccdffe52faab1e6..2c2e87d96f61e7ef88847df70e1c6153
      @Override
      public String getMotd() {
          return console.getMotd();
-@@ -2154,5 +2202,15 @@ public final class CraftServer implements Server {
+@@ -2154,5 +2206,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }

--- a/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
+++ b/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
@@ -140,10 +140,10 @@ index c21790b4de698aa6f7fc4dadab64d791cd0562b6..fb0d985b5c977a7c63701484678b7592
                      GameProfilerTick gameprofilertick = GameProfilerTick.a("Server");
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a9449a62f678ec6dc5e923c64e89140bb96fb697..d9672aeae53119d2fbc1456cd3071d5c9eb8a730 100644
+index 462633df2af43959fddf5b7a8ec43063abf7b14b..b4b592faaa699b6e62f77ddf57b239c5e15948ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2118,6 +2118,17 @@ public final class CraftServer implements Server {
+@@ -2122,6 +2122,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/Spigot-Server-Patches/0045-Ensure-commands-are-not-ran-async.patch
+++ b/Spigot-Server-Patches/0045-Ensure-commands-are-not-ran-async.patch
@@ -48,10 +48,10 @@ index 5db09e60c2ac1f4cb0da3190e57896ccae7c58a3..865d8efa2d480ae7edc286e3e79f2997
          } else if (this.player.getChatFlags() == EnumChatVisibility.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d9672aeae53119d2fbc1456cd3071d5c9eb8a730..69f2ccef0f88d8407ee00d41ac32ebb071b6803f 100644
+index b4b592faaa699b6e62f77ddf57b239c5e15948ff..b7de5049dfd6807de1c84a9454b9097141399660 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -761,6 +761,29 @@ public final class CraftServer implements Server {
+@@ -760,6 +760,29 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/Spigot-Server-Patches/0047-Expose-server-CommandMap.patch
+++ b/Spigot-Server-Patches/0047-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 69f2ccef0f88d8407ee00d41ac32ebb071b6803f..bfd78c41757c73736371811aab97ca05a01667c9 100644
+index b7de5049dfd6807de1c84a9454b9097141399660..f78f5e4f2c04b64dff1d2229a137c600f18e7051 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1757,6 +1757,7 @@ public final class CraftServer implements Server {
+@@ -1761,6 +1761,7 @@ public final class CraftServer implements Server {
          return helpMap;
      }
  

--- a/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ac10067e924cfbfe0a528cad62293686c0c24562..3f300a4fd661707e386090e5ba3be3ddb9af2d00 100644
+index 6eec60b5739edb8f7278608e525b38bdac15bba8..6d66a899912bfab2ce610fb6fb2dbec87cbb5790 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2249,5 +2249,23 @@ public final class CraftServer implements Server {
+@@ -2253,5 +2253,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/Spigot-Server-Patches/0063-Remove-Metadata-on-reload.patch
+++ b/Spigot-Server-Patches/0063-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3f300a4fd661707e386090e5ba3be3ddb9af2d00..16a2c614d58f3604613138210a7ac1be0b00a15c 100644
+index 6d66a899912bfab2ce610fb6fb2dbec87cbb5790..e670f484d454f7c706a0ec92c98087fa1373c492 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -872,8 +872,18 @@ public final class CraftServer implements Server {
+@@ -871,8 +871,18 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
@@ -66,10 +66,10 @@ index 4ad084e7cea3b341ca0dbaa6e853cfc685a555ff..b9f94f957dd5372c8b02d785204690e4
  
      public synchronized void a(GameProfile gameprofile) { // Paper - synchronize
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 16a2c614d58f3604613138210a7ac1be0b00a15c..e07d5e54e0d606113337913f940e8659ab6e98e7 100644
+index e670f484d454f7c706a0ec92c98087fa1373c492..b392f7703222dbba30cdd81ac83e93da36ec043f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1512,7 +1512,8 @@ public final class CraftServer implements Server {
+@@ -1516,7 +1516,8 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/Spigot-Server-Patches/0120-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-Server-Patches/0120-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e07d5e54e0d606113337913f940e8659ab6e98e7..8c8d3c4f8818552843ee93ae39af06d51404af9f 100644
+index b392f7703222dbba30cdd81ac83e93da36ec043f..539577a0378754cbe0942a79140f6d137eb825ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2278,5 +2278,24 @@ public final class CraftServer implements Server {
+@@ -2282,5 +2282,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8c8d3c4f8818552843ee93ae39af06d51404af9f..c029cf4d930c5bc412b55a567b03bbce41b61bbd 100644
+index 539577a0378754cbe0942a79140f6d137eb825ed..0ed8e95d464cf17dc0355056775a9a375a4e7a86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2297,5 +2297,10 @@ public final class CraftServer implements Server {
+@@ -2301,5 +2301,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -266,7 +266,7 @@ index 67814e3e54ec2be02c4d592c56b60e66d15bedb2..8348dfa43c1f6e07c01024b40f4b3ebc
  
          this.k = new GameProfileBanList(PlayerList.b);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c029cf4d930c5bc412b55a567b03bbce41b61bbd..86d069819b97b7fe60acd7f4bdb0c4a67565a31e 100644
+index 0ed8e95d464cf17dc0355056775a9a375a4e7a86..2a05ef7553e3b05d5757e69e69c247e24ba29249 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,7 +46,6 @@ import java.util.function.Consumer;
@@ -285,7 +285,7 @@ index c029cf4d930c5bc412b55a567b03bbce41b61bbd..86d069819b97b7fe60acd7f4bdb0c4a6
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.ServerCommand;
  import net.minecraft.server.bossevents.BossBattleCustom;
-@@ -1206,9 +1206,13 @@ public final class CraftServer implements Server {
+@@ -1205,9 +1205,13 @@ public final class CraftServer implements Server {
          return logger;
      }
  

--- a/Spigot-Server-Patches/0151-Add-UnknownCommandEvent.patch
+++ b/Spigot-Server-Patches/0151-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 86d069819b97b7fe60acd7f4bdb0c4a67565a31e..3194bb89c6bd97d780c3a4789a23ad5a4c43f85d 100644
+index 2a05ef7553e3b05d5757e69e69c247e24ba29249..9e974159476e7a359f59c0cdf5aae1be4422d1c0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -792,7 +792,13 @@ public final class CraftServer implements Server {
+@@ -791,7 +791,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
@@ -517,7 +517,7 @@ index b9f94f957dd5372c8b02d785204690e4ade36a98..692d95c94df85d752a3ddc66e1f2af76
          private volatile long c;
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3194bb89c6bd97d780c3a4789a23ad5a4c43f85d..1ca2900e675c8198f0fa9f5bd98161dec057aa85 100644
+index 9e974159476e7a359f59c0cdf5aae1be4422d1c0..bda96a2f64ae27d53e5a5c6d36ffb5441fee112f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -224,6 +224,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -530,7 +530,7 @@ index 3194bb89c6bd97d780c3a4789a23ad5a4c43f85d..1ca2900e675c8198f0fa9f5bd98161de
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2312,5 +2315,24 @@ public final class CraftServer implements Server {
+@@ -2316,5 +2319,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/Spigot-Server-Patches/0179-AsyncTabCompleteEvent.patch
+++ b/Spigot-Server-Patches/0179-AsyncTabCompleteEvent.patch
@@ -14,7 +14,7 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index 3628965d2a18a367c2357b54b65786fb90c38205..fc624315b156f450c1cbc87a81e9eeff5d31b4c2 100644
+index 301b63db3abc348441c3580a6606b65f550d8a78..1860def3971d1e17429bdde51c2bc336887da233 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -713,10 +713,10 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -72,10 +72,10 @@ index 3628965d2a18a367c2357b54b65786fb90c38205..fc624315b156f450c1cbc87a81e9eeff
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1ca2900e675c8198f0fa9f5bd98161dec057aa85..b37f4e87b9f6461b575ab36cd75943b553c4b0f4 100644
+index bda96a2f64ae27d53e5a5c6d36ffb5441fee112f..3aed540b6359df9940a26901c55f0306743ad085 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1847,7 +1847,7 @@ public final class CraftServer implements Server {
+@@ -1851,7 +1851,7 @@ public final class CraftServer implements Server {
              offers = tabCompleteChat(player, message);
          }
  

--- a/Spigot-Server-Patches/0201-getPlayerUniqueId-API.patch
+++ b/Spigot-Server-Patches/0201-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b37f4e87b9f6461b575ab36cd75943b553c4b0f4..2bdee3fe7ad763a3b15259534796a9f457db7ee6 100644
+index 3aed540b6359df9940a26901c55f0306743ad085..47443fae011fb8cdf18c38e6c4b443b874bd26e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1514,6 +1514,25 @@ public final class CraftServer implements Server {
+@@ -1518,6 +1518,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/Spigot-Server-Patches/0261-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0261-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -48,10 +48,10 @@ index 5bbd3bb52b76b8b6cdf90c94bcb29f122f31c543..52c0dd4f2779125116d9dcccc2aef7a1
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2bdee3fe7ad763a3b15259534796a9f457db7ee6..04e20cb1efb7dd4be13e7c01f86f671bc9924314 100644
+index 47443fae011fb8cdf18c38e6c4b443b874bd26e4..ba982907b97faace89b73365aef1c91dab692ff1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -810,6 +810,7 @@ public final class CraftServer implements Server {
+@@ -809,6 +809,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index 2bdee3fe7ad763a3b15259534796a9f457db7ee6..04e20cb1efb7dd4be13e7c01f86f671b
          reloadCount++;
          configuration = YamlConfiguration.loadConfiguration(getConfigFile());
          commandsConfiguration = YamlConfiguration.loadConfiguration(getCommandsConfigFile());
-@@ -928,6 +929,7 @@ public final class CraftServer implements Server {
+@@ -927,6 +928,7 @@ public final class CraftServer implements Server {
          enablePlugins(PluginLoadOrder.STARTUP);
          enablePlugins(PluginLoadOrder.POSTWORLD);
          getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/Spigot-Server-Patches/0298-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0298-Add-Velocity-IP-Forwarding-Support.patch
@@ -293,10 +293,10 @@ index 21e70a133278d85ecd65fec36a273ed4faabf6cc..b89a8ee2ea03d00a3d6af63d6e3e0fd6
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d2e8d50adc49cc00d95f928a65a3c23fff0c4c80..8f472f34e4839c1c6b02b2464d73635085a78544 100644
+index ba982907b97faace89b73365aef1c91dab692ff1..22f9d8c0189293b88353bbe1bcc40dd1d431d458 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -682,7 +682,7 @@ public final class CraftServer implements Server {
+@@ -681,7 +681,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/Spigot-Server-Patches/0312-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0312-Make-the-default-permission-message-configurable.patch
@@ -29,10 +29,10 @@ index 13edb435b3fa65b4980bd7472aa5a5196f4d5b2b..469f78775b03cf363d88e35c69c0dc18
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 63f24b977d11fc2658f8ec23c65029f3baf551f5..d44ff2830b6c74f301108f31432627426ca41b9a 100644
+index 22f9d8c0189293b88353bbe1bcc40dd1d431d458..aff20bc4a4d9834b2555f5fe4fa9c46751eae2ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2337,6 +2337,11 @@ public final class CraftServer implements Server {
+@@ -2341,6 +2341,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/Spigot-Server-Patches/0348-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/Spigot-Server-Patches/0348-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index fa7935cccb450ae5f782fec5ebe27275fe6dd510..5a5e097b131500d7cb9f61ea0f96f900
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d44ff2830b6c74f301108f31432627426ca41b9a..4b9fa3d5133839e3bd26bb28d485928e6f1d6de3 100644
+index aff20bc4a4d9834b2555f5fe4fa9c46751eae2ba..40ed419457982e1dae1605915aeccd10703df57b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1836,7 +1836,7 @@ public final class CraftServer implements Server {
+@@ -1840,7 +1840,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/Spigot-Server-Patches/0380-Expose-the-internal-current-tick.patch
+++ b/Spigot-Server-Patches/0380-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4b9fa3d5133839e3bd26bb28d485928e6f1d6de3..363a0b60e65e0edbc7b73c956af56b4607051a41 100644
+index 40ed419457982e1dae1605915aeccd10703df57b..b76da976d8710d9e91b8b00fa3b888adfc791dc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2360,5 +2360,10 @@ public final class CraftServer implements Server {
+@@ -2364,5 +2364,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/Spigot-Server-Patches/0430-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0430-Add-tick-times-API-and-mspt-command.patch
@@ -147,10 +147,10 @@ index 5e6ca8690c5cb312e805798e8483ac701439227b..506edef56ef6012424556f058996dbf6
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 363a0b60e65e0edbc7b73c956af56b4607051a41..eddd35b6976eefe56c04803932ae6951d1d120c2 100644
+index b76da976d8710d9e91b8b00fa3b888adfc791dc3..8577451ed4dcba901ca9f74e0ff198ab0336d689 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2198,6 +2198,16 @@ public final class CraftServer implements Server {
+@@ -2202,6 +2202,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/Spigot-Server-Patches/0431-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0431-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index eddd35b6976eefe56c04803932ae6951d1d120c2..d697b1c5e62dce806335f45100bd9d766d12fd19 100644
+index 8577451ed4dcba901ca9f74e0ff198ab0336d689..e11649b838b6c6e8745d3a0c6d093b3cfff0acda 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2375,5 +2375,10 @@ public final class CraftServer implements Server {
+@@ -2379,5 +2379,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/Spigot-Server-Patches/0436-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0436-Improved-Watchdog-Support.patch
@@ -348,10 +348,10 @@ index cc41dcd85760b57bb8076b37e9a907d1cb4e12c7..efcfc8f0f45901d14ac8fdf8ed7b0bd6
              String msg = "Entity threw exception at " + entity.world.getWorld().getName() + ":" + entity.locX() + "," + entity.locY() + "," + entity.locZ();
              System.err.println(msg);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d697b1c5e62dce806335f45100bd9d766d12fd19..1ec08b8d1f8104dcdfa00bc0c53c26b7796c514d 100644
+index e11649b838b6c6e8745d3a0c6d093b3cfff0acda..63f89916d9982caa99525e01bd0e3f153af74d0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1836,7 +1836,7 @@ public final class CraftServer implements Server {
+@@ -1840,7 +1840,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/Spigot-Server-Patches/0464-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0464-Implement-Mob-Goal-API.patch
@@ -1043,10 +1043,10 @@ index 8c8e39d35fb56aa6cf7d456adab01dff5d13a60d..bcf6c924894f49f1c602b83b501f904e
  
      public PathfinderGoalWrapped(int i, PathfinderGoal pathfindergoal) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7d19942373523f18eb9420d0873f2309895b34d7..cc1316825b639e4b95407922dfa246763db36a9a 100644
+index f6e2e54b5a1b8c2df41a0593fa15112c5195c49c..aa5efc9225bb58f9290b9aefcb5ef171c7a88e7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2387,5 +2387,11 @@ public final class CraftServer implements Server {
+@@ -2391,5 +2391,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/Spigot-Server-Patches/0474-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/Spigot-Server-Patches/0474-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index 1d77d6254b024c286781be8dc74680bc1e8f1238..bc45d15091282f30f7d147aed4e72b4e
          // CraftBukkit end
          if (this.getServerConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cc1316825b639e4b95407922dfa246763db36a9a..870c3fb58971da94dcf4d91c3077bca305f15b2b 100644
+index aa5efc9225bb58f9290b9aefcb5ef171c7a88e7d..5f03ec59588fd975ca2fb62961b10212d8a9cbec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -939,6 +939,35 @@ public final class CraftServer implements Server {
+@@ -938,6 +938,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/Spigot-Server-Patches/0493-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/Spigot-Server-Patches/0493-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 870c3fb58971da94dcf4d91c3077bca305f15b2b..e08d43ae76e9e1d32fe86520f1380b927933f1e7 100644
+index 5f03ec59588fd975ca2fb62961b10212d8a9cbec..a295ab6a7ec79775224381e94e288069f5d311fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -343,7 +343,7 @@ public final class CraftServer implements Server {
@@ -34,7 +34,7 @@ index 870c3fb58971da94dcf4d91c3077bca305f15b2b..e08d43ae76e9e1d32fe86520f1380b92
          minimumAPI = configuration.getString("settings.minimum-api");
          loadIcon();
      }
-@@ -834,7 +834,7 @@ public final class CraftServer implements Server {
+@@ -833,7 +833,7 @@ public final class CraftServer implements Server {
          waterAmbientSpawn = configuration.getInt("spawn-limits.water-ambient");
          ambientSpawn = configuration.getInt("spawn-limits.ambient");
          warningState = WarningState.value(configuration.getString("settings.deprecated-verbose"));

--- a/Spigot-Server-Patches/0523-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-Server-Patches/0523-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -27,10 +27,10 @@ index 60ecd3a92af0f1968b10bb8babfb43147ef568d3..9077b70650d70dd294f53a1ef73e86e2
  
                                  for (int l = 0; l < k; ++l) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e08d43ae76e9e1d32fe86520f1380b927933f1e7..cd85c77ae032d15c4bf64a1e93c851aaee53cc02 100644
+index a295ab6a7ec79775224381e94e288069f5d311fe..8f44857e9f61c72fa210c16c8bd6b8a6bbdac239 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2029,6 +2029,32 @@ public final class CraftServer implements Server {
+@@ -2033,6 +2033,32 @@ public final class CraftServer implements Server {
          return new CraftChunkData(world);
      }
  

--- a/Spigot-Server-Patches/0549-Add-setMaxPlayers-API.patch
+++ b/Spigot-Server-Patches/0549-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index d3f3dc4ad2c758482b7a8d5c07caa526ce1e3424..8bd55e3d2b5142081a7dfe1dbbd36f2f
      private EnumGamemode u;
      private boolean v;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cd85c77ae032d15c4bf64a1e93c851aaee53cc02..a44e50c31163d6930ae7ac580b0e8eda31ece9ac 100644
+index 8f44857e9f61c72fa210c16c8bd6b8a6bbdac239..4dceb2d0beb6f91526b101d4947556049a0f3251 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -615,6 +615,13 @@ public final class CraftServer implements Server {
+@@ -614,6 +614,13 @@ public final class CraftServer implements Server {
          return playerList.getMaxPlayers();
      }
  

--- a/Spigot-Server-Patches/0589-Add-getOfflinePlayerIfCached-String.patch
+++ b/Spigot-Server-Patches/0589-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a44e50c31163d6930ae7ac580b0e8eda31ece9ac..f94a0e397e4ff331da7640591ed9644ba5b28ced 100644
+index 4dceb2d0beb6f91526b101d4947556049a0f3251..7277fd5807254020054cdbfb97fbd334e05da832 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1609,6 +1609,28 @@ public final class CraftServer implements Server {
+@@ -1613,6 +1613,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/Spigot-Server-Patches/0654-Added-Vanilla-Entity-Tags.patch
+++ b/Spigot-Server-Patches/0654-Added-Vanilla-Entity-Tags.patch
@@ -40,10 +40,10 @@ index 0000000000000000000000000000000000000000..2ca8e1bade5450a14125b77540792e0b
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f94a0e397e4ff331da7640591ed9644ba5b28ced..4608612583064d9d06365718a7dca864159e38f5 100644
+index 7277fd5807254020054cdbfb97fbd334e05da832..0f04ba41df95986b71524995738831223080cb88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2218,6 +2218,11 @@ public final class CraftServer implements Server {
+@@ -2222,6 +2222,11 @@ public final class CraftServer implements Server {
                  Preconditions.checkArgument(clazz == org.bukkit.Fluid.class, "Fluid namespace must have fluid type");
  
                  return (org.bukkit.Tag<T>) new CraftFluidTag(console.getTagRegistry().getFluidTags(), key);

--- a/Spigot-Server-Patches/0672-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0672-misc-debugging-dumps.patch
@@ -66,7 +66,7 @@ index f8446fd716a891a0b71675ccee6a6eac55fba87c..176a17582cb3b29a2ed430914ba8c058
              try {
                  this.serverThread.join();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4608612583064d9d06365718a7dca864159e38f5..ab4ddd62d6361ca99a7ec24c5b83f74314d1494a 100644
+index 0f04ba41df95986b71524995738831223080cb88..e5c78b4e7537c8a042dcc41ca6b77c000c4317de 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
@@ -77,7 +77,7 @@ index 4608612583064d9d06365718a7dca864159e38f5..ab4ddd62d6361ca99a7ec24c5b83f743
  import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
  import java.awt.image.BufferedImage;
  import java.io.File;
-@@ -938,6 +939,7 @@ public final class CraftServer implements Server {
+@@ -937,6 +938,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/Spigot-Server-Patches/0689-Implement-Keyed-on-World.patch
+++ b/Spigot-Server-Patches/0689-Implement-Keyed-on-World.patch
@@ -64,10 +64,10 @@ index 760579921927b4c8b0f20b2611b95fd626e4b27f..3075700dfa992da81b10246fcf7c7ad1
          return this.c;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ab4ddd62d6361ca99a7ec24c5b83f74314d1494a..16ed4a59fa70b94a80c94c99af74fdce9b44768d 100644
+index e5c78b4e7537c8a042dcc41ca6b77c000c4317de..706dad235de3b7ffe014f564e1c68f18e1edeefc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1158,7 +1158,7 @@ public final class CraftServer implements Server {
+@@ -1157,7 +1157,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.World.THE_END;
          } else {
@@ -76,7 +76,7 @@ index ab4ddd62d6361ca99a7ec24c5b83f74314d1494a..16ed4a59fa70b94a80c94c99af74fdce
          }
  
          WorldServer internal = (WorldServer) new WorldServer(console, console.executorService, worldSession, worlddata, worldKey, dimensionmanager, getServer().worldLoadListenerFactory.create(11),
-@@ -1248,6 +1248,15 @@ public final class CraftServer implements Server {
+@@ -1247,6 +1247,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/Spigot-Server-Patches/0730-Add-basic-Datapack-API.patch
+++ b/Spigot-Server-Patches/0730-Add-basic-Datapack-API.patch
@@ -134,7 +134,7 @@ index e87523612d0423d71eab7b9af851c1c268cdf84f..568da9686c41a41e43ede3fe15e0ca53
          return this.c;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 16ed4a59fa70b94a80c94c99af74fdce9b44768d..033a0f1852afd6c1fd136ef07b611a9132adfa0c 100644
+index 706dad235de3b7ffe014f564e1c68f18e1edeefc..89244c152665c97cb539bea07fedd1774ed626f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
@@ -161,7 +161,7 @@ index 16ed4a59fa70b94a80c94c99af74fdce9b44768d..033a0f1852afd6c1fd136ef07b611a91
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2493,5 +2496,11 @@ public final class CraftServer implements Server {
+@@ -2497,5 +2500,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/Spigot-Server-Patches/0738-Fix-and-optimise-world-force-upgrading.patch
+++ b/Spigot-Server-Patches/0738-Fix-and-optimise-world-force-upgrading.patch
@@ -375,10 +375,10 @@ index ebb0d6988f87013ea5d523ab4a1b31cb669ccc43..74d826853389b8e01ffe2b076cf2b179
          return this.cache.getAndMoveToFirst(ChunkCoordIntPair.pair(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c51e9b50323f5e33bad5fd25d74c572241377059..ff79c13bc7717eb9529e802b8e31a1f756b02f97 100644
+index 8209f188dbc932114268486a2ebd77df989a86ec..cebecee640ed5a7fc2b978e00ff7eb012228267d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1147,14 +1147,7 @@ public final class CraftServer implements Server {
+@@ -1146,14 +1146,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.a(console.getServerModName(), console.getModded().isPresent());
@@ -394,7 +394,7 @@ index c51e9b50323f5e33bad5fd25d74c572241377059..ff79c13bc7717eb9529e802b8e31a1f7
  
          long j = BiomeManager.a(creator.seed());
          List<MobSpawner> list = ImmutableList.of(new MobSpawnerPhantom(), new MobSpawnerPatrol(), new MobSpawnerCat(), new VillageSiege(), new MobSpawnerTrader(worlddata));
-@@ -1171,6 +1164,14 @@ public final class CraftServer implements Server {
+@@ -1170,6 +1163,14 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.c();
          }
  


### PR DESCRIPTION
This PR fixes the fact that the `BroadcastMessageEvent` was broken for the `broadcastMessage(String)` method in the Adventure update. Additionally, it also adds a `broadcast(Component)` method to mimic the functionality of the `broadcastMessage(String)` method but with Adventure components.

I believe that this also addresses the issue that `sendMessage` on `Server` does not fire the `BroadcastMessageEvent` by distinguishing between "a message sent to all forwarded audience members" and "a server broadcast" for Adventure components, thus mimicking the functionality of the old string methods.