### PR TITLE
Update head rotation in missing places

### DIFF
--- a/patches/server/0718-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0718-Update-head-rotation-in-missing-places.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Mon, 21 Jun 2021 21:55:23 -0400
+Subject: [PATCH] Update head rotation in missing places
+
+In certain areas the player's head rotation could be desynced when teleported/moved. This is because bukkit uses a separate head rotation field for yaw. This issue only applies to  players.
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 7e8c3073993cd4b143049882779427d4d104c6f3..ed65515d22db02524f8afa38cee42fe55dc723da 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -1549,6 +1549,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+         this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
+         this.yRotO = this.getYRot();
+         this.xRotO = this.getXRot();
++        this.setYHeadRot(yaw); // Paper - Update head rotation
+     }
+ 
+     public void absMoveTo(double x, double y, double z) {
+@@ -1587,6 +1588,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+         this.setXRot(pitch);
+         this.setOldPosAndRot();
+         this.reapplyPosition();
++        this.setYHeadRot(yaw); // Paper - Update head rotation
+     }
+ 
+     public final void setOldPosAndRot() {

--- a/patches/server/0812-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0812-Update-head-rotation-in-missing-places.patch
@@ -3,13 +3,15 @@ From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Mon, 21 Jun 2021 21:55:23 -0400
 Subject: [PATCH] Update head rotation in missing places
 
-In certain areas the player's head rotation could be desynced when teleported/moved. This is because bukkit uses a separate head rotation field for yaw. This issue only applies to  players.
+In certain areas the player's head rotation could be desynced when teleported/moved.
+This is because bukkit uses a separate head rotation field for yaw.
+This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7e8c3073993cd4b143049882779427d4d104c6f3..ed65515d22db02524f8afa38cee42fe55dc723da 100644
+index 94857a736d2a16e8ade286c6f2ddf8bd798008eb..4f164f238177b5e2b18c76b7cc14596ec93409d1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1549,6 +1549,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1742,6 +1742,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -17,7 +19,7 @@ index 7e8c3073993cd4b143049882779427d4d104c6f3..ed65515d22db02524f8afa38cee42fe5
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1587,6 +1588,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1780,6 +1781,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();


### PR DESCRIPTION
In some instances (like teleporting a player) the head rotation could become desynced with their actual yaw. This is due to the fact that bukkit uses head rotation for yaw (for some reason?) in places like getLocation().

This adds some missing set rotations.

EDIT: This issue only exists for players. This is because they call PlayerConnection#internalTeleport(),
![image](https://user-images.githubusercontent.com/23108066/117552942-7301c200-b01c-11eb-9f2b-7ec83ea8fcf0.png)
 