### PR TITLE
Change Thread#stop() invocation to Thread#interrupt()

### DIFF
--- a/Spigot-Server-Patches/0438-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0438-Improved-Watchdog-Support.patch
@@ -122,7 +122,7 @@ index ed5712cc7c070f44500e5c1a1d41cd26bdd13fec..fe3fe04981a0cc1ddeac2e030ee754ba
 +        if (!isMainThread()) {
 +            MinecraftServer.LOGGER.info("Stopping main thread (Ignore any thread death message you see! - DO NOT REPORT THREAD DEATH TO PAPER)");
 +            while (this.getThread().isAlive()) {
-+                this.getThread().stop();
++                this.getThread().interrupt();
 +                try {
 +                    Thread.sleep(1);
 +                } catch (InterruptedException e) {}


### PR DESCRIPTION
## Changes
This pull changes the force stop of the thread in `MinecraftServer#stop()` to use `Thread#interrupt()` instead of `Thread#stop()`. Although `Thread#stop()` is **effective**, it is still unsafe, and hence deprecated. 


## Reasoning
Oracle notes that:

> Stopping a thread causes it to unlock all the monitors that it has locked. (The monitors are unlocked as the ThreadDeath exception propagates up the stack.) If any of the objects previously protected by these monitors were in an inconsistent state, other threads may now view these objects in an inconsistent state. Such objects are said to be damaged. When threads operate on damaged objects, arbitrary behavior can result. This behavior may be subtle and difficult to detect, or it may be pronounced. Unlike other unchecked exceptions, ThreadDeath kills threads silently; thus, the user has no warning that his program may be corrupted. The corruption can manifest itself at any time after the actual damage occurs, even hours or days in the future.

Even though the server is stopped, taking the safer route is preferred. `Thread#stop()` directly invokes `Thread#stop0(Throwable)`, a native function. Viewing the native function supports the documentation above as it releases those locks during deoptimization, as well as leads to the invocation of a few other unsafe operations. 

Although it is called to force-stop the server, and probably should not matter, there is always the chance that something *that* native does cause future harm and of course, to an extent, enforces bad practices. However, if there is a case where `Thread#stop()` with absolute certainty should be used instead, then this PR would be useless -- but in the less-likely occasion the code finds a way to reach this point, `Thread#interrupt()` works about the same, without of course, the implications of `Thread#stop()` This PR introduces the usage of a safer method call, `Thread#interrupt()`, plus removes the usage of the well deprecated `Thread#stop()`.
