### PR TITLE
Fix legacyComposer not using AsyncChatEvent messages

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..89597b4a3064c3c6001c7e927a848ee7
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..84dcca67ccd2e52881b4a97de0f061b396ab5f35
+index 0000000000000000000000000000000000000000..50253e8dfffc84e26f02c6a470a5a8b078d90e12
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 @@ -0,0 +1,215 @@
@@ -171,18 +171,18 @@ index 0000000000000000000000000000000000000000..84dcca67ccd2e52881b4a97de0f061b3
 +            // continuing from AsyncPlayerChatEvent (without PlayerChatEvent)
 +            event -> {
 +                this.processModern(
-+                    legacyComposer(event.getFormat(), legacyDisplayName((CraftPlayer) event.getPlayer()), event.getMessage()),
++                    legacyComposer(event.getFormat()),
 +                    event.getRecipients(),
-+                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()),
++                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()).replaceText(URL_REPLACEMENT_CONFIG),
 +                    event.isCancelled()
 +                );
 +            },
 +            // continuing from AsyncPlayerChatEvent and PlayerChatEvent
 +            event -> {
 +                this.processModern(
-+                    legacyComposer(event.getFormat(), legacyDisplayName((CraftPlayer) event.getPlayer()), event.getMessage()),
++                    legacyComposer(event.getFormat()),
 +                    event.getRecipients(),
-+                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()),
++                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()).replaceText(URL_REPLACEMENT_CONFIG),
 +                    event.isCancelled()
 +                );
 +            },
@@ -297,8 +297,8 @@ index 0000000000000000000000000000000000000000..84dcca67ccd2e52881b4a97de0f061b3
 +        return player.displayName();
 +    }
 +
-+    private static ChatComposer legacyComposer(final String format, final String legacyDisplayName, final String legacyMessage) {
-+        return (player, displayName, message) -> PaperAdventure.LEGACY_SECTION_UXRC.deserialize(String.format(format, legacyDisplayName, legacyMessage)).replaceText(URL_REPLACEMENT_CONFIG);
++    private static ChatComposer legacyComposer(final String format) {
++        return (player, displayName, message) -> PaperAdventure.LEGACY_SECTION_UXRC.deserialize(String.format(format, PaperAdventure.LEGACY_SECTION_UXRC.serialize(displayName), PaperAdventure.LEGACY_SECTION_UXRC.serialize(message))).replaceText(URL_REPLACEMENT_CONFIG);
 +    }
 +
 +    private void queueIfAsyncOrRunImmediately(final Waitable<Void> waitable) {

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -165,7 +165,7 @@ index 0000000000000000000000000000000000000000..50253e8dfffc84e26f02c6a470a5a8b0
 +        this.async = async;
 +    }
 +
-+    @SuppressWarnings("CodeBlock2Expr")
++    @SuppressWarnings({"CodeBlock2Expr", "deprecated"})
 +    public void process() {
 +        this.processingLegacyFirst(
 +            // continuing from AsyncPlayerChatEvent (without PlayerChatEvent)
@@ -173,7 +173,7 @@ index 0000000000000000000000000000000000000000..50253e8dfffc84e26f02c6a470a5a8b0
 +                this.processModern(
 +                    legacyComposer(event.getFormat()),
 +                    event.getRecipients(),
-+                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()).replaceText(URL_REPLACEMENT_CONFIG),
++                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()),
 +                    event.isCancelled()
 +                );
 +            },
@@ -182,7 +182,7 @@ index 0000000000000000000000000000000000000000..50253e8dfffc84e26f02c6a470a5a8b0
 +                this.processModern(
 +                    legacyComposer(event.getFormat()),
 +                    event.getRecipients(),
-+                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()).replaceText(URL_REPLACEMENT_CONFIG),
++                    PaperAdventure.LEGACY_SECTION_UXRC.deserialize(event.getMessage()),
 +                    event.isCancelled()
 +                );
 +            },

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -298,7 +298,7 @@ index 0000000000000000000000000000000000000000..50253e8dfffc84e26f02c6a470a5a8b0
 +    }
 +
 +    private static ChatComposer legacyComposer(final String format) {
-+        return (player, displayName, message) -> PaperAdventure.LEGACY_SECTION_UXRC.deserialize(String.format(format, PaperAdventure.LEGACY_SECTION_UXRC.serialize(displayName), PaperAdventure.LEGACY_SECTION_UXRC.serialize(message))).replaceText(URL_REPLACEMENT_CONFIG);
++        return (player, displayName, message) -> PaperAdventure.LEGACY_SECTION_UXRC.deserialize(String.format(format, legacyDisplayName((CraftPlayer) player), PaperAdventure.LEGACY_SECTION_UXRC.serialize(message))).replaceText(URL_REPLACEMENT_CONFIG);
 +    }
 +
 +    private void queueIfAsyncOrRunImmediately(final Waitable<Void> waitable) {


### PR DESCRIPTION
Fixes AsyncChatEvent essentially not working if AsyncPlayerChatEvent was listened to.

Before this patch, the legacyComposer inputs were ignored, so it broke when plugins like that existed:
```kotlin
import org.bukkit.event.player.AsyncPlayerChatEvent
import io.papermc.paper.event.player.AsyncChatEvent
import net.kyori.adventure.text.Component
import net.kyori.adventure.text.TextComponent
import net.kyori.adventure.text.format.NamedTextColor

class BugListener(private val plugin: ToiletPaper) : Listener {
    @EventHandler
    private fun onAsyncChat(e: AsyncChatEvent) {
        e.getPlayer().sendMessage("You send a message!");
        val component = Component.text("Test");
        e.message(component);
    }
    
    @EventHandler
    private fun onPlayerChat(e: AsyncPlayerChatEvent){ //<--- This break AsyncChatEvent
        //Didn't Do anything here
        return;
    }
}
```

Reported on Discord: https://discord.com/channels/289587909051416579/555462289851940864/833247957990113301