### PR TITLE
fix PlayerItemHeldEvent firing twice

### DIFF
--- a/Spigot-Server-Patches/0711-fix-PlayerItemHeldEvent-firing-twice.patch
+++ b/Spigot-Server-Patches/0711-fix-PlayerItemHeldEvent-firing-twice.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
+Date: Thu, 22 Apr 2021 19:02:07 -0700
+Subject: [PATCH] fix PlayerItemHeldEvent firing twice
+
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/PacketPlayInHeldItemSlot.java b/src/main/java/net/minecraft/network/protocol/game/PacketPlayInHeldItemSlot.java
+index d68f3e6b35f0af846c8a66710c5752508c095179..0e8ee44d0104ca7c666f57bdb54e0957935d5b34 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/PacketPlayInHeldItemSlot.java
++++ b/src/main/java/net/minecraft/network/protocol/game/PacketPlayInHeldItemSlot.java
+@@ -24,6 +24,7 @@ public class PacketPlayInHeldItemSlot implements Packet<PacketListenerPlayIn> {
+         packetlistenerplayin.a(this);
+     }
+ 
++    public int getItemInHandIndex() { return b(); } // Paper - OBFHELPER
+     public int b() {
+         return this.itemInHandIndex;
+     }
+diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
+index 6ad075907d56a8f41ca3a7b82ff90a6d3ad9f1d4..b543776da3b799643893984a8c6f29477ed78d4a 100644
+--- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
++++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
+@@ -1903,6 +1903,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+         PlayerConnectionUtils.ensureMainThread(packetplayinhelditemslot, this, this.player.getWorldServer());
+         if (this.player.isFrozen()) return; // CraftBukkit
+         if (packetplayinhelditemslot.b() >= 0 && packetplayinhelditemslot.b() < PlayerInventory.getHotbarSize()) {
++            if (packetplayinhelditemslot.getItemInHandIndex() == this.player.inventory.itemInHandIndex) { return; } // Paper - don't fire itemheldevent when there wasn't a slot change
+             PlayerItemHeldEvent event = new PlayerItemHeldEvent(this.getPlayer(), this.player.inventory.itemInHandIndex, packetplayinhelditemslot.b());
+             this.server.getPluginManager().callEvent(event);
+             if (event.isCancelled()) {


### PR DESCRIPTION
Fixes #5482 