### PR TITLE
remove bad null annotation

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -2375,7 +2375,7 @@ index e543b6927280a14e1d1220534758289934e31282..d5bec8b0e155ea5ae5746b6da571754a
          return this.b.size();
      }
 diff --git a/src/main/java/net/minecraft/nbt/NBTTagCompound.java b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
-index b2fb24e9ae19ab6e7039a98fc0c265f801be8a99..44fefe1cdc23667219ce825ba283f84cd3020e14 100644
+index b2fb24e9ae19ab6e7039a98fc0c265f801be8a99..bf4826e90976fed2ae95e84cadc7f29433af1ddf 100644
 --- a/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 @@ -76,7 +76,7 @@ public class NBTTagCompound implements NBTBase {
@@ -2387,7 +2387,7 @@ index b2fb24e9ae19ab6e7039a98fc0c265f801be8a99..44fefe1cdc23667219ce825ba283f84c
  
      protected NBTTagCompound(Map<String, NBTBase> map) {
          this.map = map;
-@@ -139,10 +139,14 @@ public class NBTTagCompound implements NBTBase {
+@@ -139,10 +139,16 @@ public class NBTTagCompound implements NBTBase {
          this.map.put(s, NBTTagLong.a(i));
      }
  
@@ -2397,8 +2397,10 @@ index b2fb24e9ae19ab6e7039a98fc0c265f801be8a99..44fefe1cdc23667219ce825ba283f84c
      }
  
 +
-+    @Nullable public UUID getUUID(String prefix) { return a(prefix); } // Paper - OBFHELPER
-+    @Nullable
++    /**
++     * You must use {@link #hasUUID(String)} before or else it <b>will</b> throw an NPE.
++     */
++    public UUID getUUID(String prefix) { return a(prefix); } // Paper - OBFHELPER
      public UUID a(String s) {
          return GameProfileSerializer.a(this.get(s));
      }

--- a/Spigot-Server-Patches/0132-Firework-API-s.patch
+++ b/Spigot-Server-Patches/0132-Firework-API-s.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Firework API's
 
 
 diff --git a/src/main/java/net/minecraft/nbt/NBTTagCompound.java b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
-index 44fefe1cdc23667219ce825ba283f84cd3020e14..2e862122fd4596c26318aac3b12165970a1660f8 100644
+index bf4826e90976fed2ae95e84cadc7f29433af1ddf..d5508deff819309034554abc7b36aac40fa33503 100644
 --- a/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
-@@ -151,6 +151,7 @@ public class NBTTagCompound implements NBTBase {
+@@ -153,6 +153,7 @@ public class NBTTagCompound implements NBTBase {
          return GameProfileSerializer.a(this.get(s));
      }
  

--- a/Spigot-Server-Patches/0442-Reduce-memory-footprint-of-NBTTagCompound.patch
+++ b/Spigot-Server-Patches/0442-Reduce-memory-footprint-of-NBTTagCompound.patch
@@ -8,7 +8,7 @@ is important because we clone chunk data after reading it for safety.
 So, reduce the impact of the clone on GC.
 
 diff --git a/src/main/java/net/minecraft/nbt/NBTTagCompound.java b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
-index 2e862122fd4596c26318aac3b12165970a1660f8..e37c82c3af7c0fea9c85f7bc8d7a4df648e723ff 100644
+index d5508deff819309034554abc7b36aac40fa33503..77afbaad5b2cb8d912f5404fcbd3a0970490f4f3 100644
 --- a/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 @@ -26,6 +26,7 @@ import net.minecraft.ReportedException;
@@ -37,7 +37,7 @@ index 2e862122fd4596c26318aac3b12165970a1660f8..e37c82c3af7c0fea9c85f7bc8d7a4df6
      }
  
      @Override
-@@ -415,9 +416,17 @@ public class NBTTagCompound implements NBTBase {
+@@ -417,9 +418,17 @@ public class NBTTagCompound implements NBTBase {
  
      @Override
      public NBTTagCompound clone() {

--- a/Spigot-Server-Patches/0514-Support-old-UUID-format-for-NBT.patch
+++ b/Spigot-Server-Patches/0514-Support-old-UUID-format-for-NBT.patch
@@ -24,7 +24,7 @@ index 0560d115288c67e46d921ce529e603f424e601f5..50515cd9287505fcc8ab52e47393fb1d
              uuid = nbttagcompound.a("Id");
          }
 diff --git a/src/main/java/net/minecraft/nbt/NBTTagCompound.java b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
-index e37c82c3af7c0fea9c85f7bc8d7a4df648e723ff..b8a0bbac91c64254f7d4b0661a2365b6ece9bbc7 100644
+index 77afbaad5b2cb8d912f5404fcbd3a0970490f4f3..945df83d4a2170cdcc29cb6d7b9f0f5f3940cb96 100644
 --- a/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 +++ b/src/main/java/net/minecraft/nbt/NBTTagCompound.java
 @@ -142,6 +142,12 @@ public class NBTTagCompound implements NBTBase {
@@ -40,9 +40,9 @@ index e37c82c3af7c0fea9c85f7bc8d7a4df648e723ff..b8a0bbac91c64254f7d4b0661a2365b6
          this.map.put(s, GameProfileSerializer.a(uuid));
      }
  
-@@ -149,11 +155,21 @@ public class NBTTagCompound implements NBTBase {
-     @Nullable public UUID getUUID(String prefix) { return a(prefix); } // Paper - OBFHELPER
-     @Nullable
+@@ -151,11 +157,21 @@ public class NBTTagCompound implements NBTBase {
+      */
+     public UUID getUUID(String prefix) { return a(prefix); } // Paper - OBFHELPER
      public UUID a(String s) {
 +        // Paper start - support old format
 +        if (!hasKeyOfType(s, 11) && this.hasKeyOfType(s + "Most", 99) && this.hasKeyOfType(s + "Least", 99)) {


### PR DESCRIPTION
this method in `NBTTagCompound` will throw an NPE if passed an key that doesn't exist. The Nullable annotation is incorrect here, as the method will only return non null UUID. All places the code that use this, have a hasUUID check before it.