### PR TITLE
Remove boat interaction event (Fixes #5539)

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -47,4 +47,5 @@ Ivan Pekov <ivan@mrivanplays.com>
 Camotoy <20743703+Camotoy@users.noreply.github.com>
 Bjarne Koll <lynxplay101@gmail.com>
 MeFisto94 <MeFisto94@users.noreply.github.com>
+Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 ```

--- a/Spigot-Server-Patches/0730-Remove-interact-event-from-boat.patch
+++ b/Spigot-Server-Patches/0730-Remove-interact-event-from-boat.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Fri, 23 Apr 2021 16:37:12 -0400
+Subject: [PATCH] Remove interact event from boat
+
+
+diff --git a/src/main/java/net/minecraft/world/item/ItemBoat.java b/src/main/java/net/minecraft/world/item/ItemBoat.java
+index 1d812b3e27f87213afc3e441eb20ca984458ce2a..e24085facbc738c5eecbf85dee1b87072c41537c 100644
+--- a/src/main/java/net/minecraft/world/item/ItemBoat.java
++++ b/src/main/java/net/minecraft/world/item/ItemBoat.java
+@@ -54,6 +54,7 @@ public class ItemBoat extends Item {
+             }
+ 
+             if (movingobjectpositionblock.getType() == MovingObjectPosition.EnumMovingObjectType.BLOCK) {
++               /* Paper - Remove unneeded interaction event trigger
+                 // CraftBukkit start - Boat placement
+                 org.bukkit.event.player.PlayerInteractEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callPlayerInteractEvent(entityhuman, org.bukkit.event.block.Action.RIGHT_CLICK_BLOCK, movingobjectpositionblock.getBlockPosition(), movingobjectpositionblock.getDirection(), itemstack, enumhand);
+ 
+@@ -61,6 +62,7 @@ public class ItemBoat extends Item {
+                     return InteractionResultWrapper.pass(itemstack);
+                 }
+                 // CraftBukkit end
++                */ // Paper - Remove unneeded interaction event trigger
+                 EntityBoat entityboat = new EntityBoat(world, movingobjectpositionblock.getPos().x, movingobjectpositionblock.getPos().y, movingobjectpositionblock.getPos().z);
+ 
+                 entityboat.setType(this.b);


### PR DESCRIPTION
This removes the unneeded interaction event that occurs in ItemBoat. When placing down a boat it would trigger 2 interaction events (1 for placing the boat and 1 for using the item).

This causes placing boats to fire 1 interaction event (from two).