### PR TITLE
Fix anchor respawn acting as a bed respawn when using the end portal

### DIFF
--- a/Spigot-Server-Patches/0717-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/Spigot-Server-Patches/0717-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Fri, 23 Apr 2021 22:42:42 +0100
+Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
+ portal
+
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 2df8e914f66176e22aeddf8b94a83af5ea921d88..f8f0212497ad4fbb1273820a06a4ae6721053b8e 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -871,6 +871,7 @@ public abstract class PlayerList {
+ 
+         // Paper start
+         boolean isBedSpawn = false;
++        boolean isAnchorSpawn = false;
+         boolean isRespawn = false;
+         boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
+         // Paper end
+@@ -891,6 +892,7 @@ public abstract class PlayerList {
+                 if (optional.isPresent()) {
+                     IBlockData iblockdata = worldserver1.getType(blockposition);
+                     boolean flag3 = iblockdata.a(Blocks.RESPAWN_ANCHOR);
++                    isAnchorSpawn = flag3; // Paper - Fix anchor respawn acting as a bed respawn from the end portal
+                     Vec3D vec3d = (Vec3D) optional.get();
+                     float f1;
+ 
+@@ -918,7 +920,7 @@ public abstract class PlayerList {
+             }
+ 
+             Player respawnPlayer = cserver.getPlayer(entityplayer1);
+-            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !flag2, flag2);
++            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !isAnchorSpawn, isAnchorSpawn); // Paper - Fix anchor respawn acting as a bed respawn from the end portal
+             cserver.getPluginManager().callEvent(respawnEvent);
+             // Spigot Start
+             if (entityplayer.playerConnection.isDisconnected()) {


### PR DESCRIPTION
Following https://github.com/PaperMC/Paper/pull/5465
The PlayerRespawnEvent uses flag2 for deciding if the respawn was from an anchor or not but flag2 is only used for removing a charge from the Anchor which the End Portal & Credits respawn does not, so when you enter the End Portal with an Anchor respawn set, it will fire the event with bed:true and anchor:false which is incorrect, this patch fixes this issue.

I tested with:
```
    @EventHandler(priority = EventPriority.HIGHEST, ignoreCancelled = true)
    public void a(PlayerRespawnEvent event) {
        Bukkit.getLogger().warning("RESPAWN " + event.isBedSpawn() + " " + event.isAnchorSpawn());
    }
```

I tested this with normal /kill deaths and using the End portal with & without bed and anchor respawns. It all lines up correctly.

Test results:
```
[23:34:26] [Async Chat Thread - #0/INFO]: <HexedHero> Normal death
[23:34:29] [Server thread/WARN]: RESPAWN false false
[23:35:15] [Async Chat Thread - #0/INFO]: <HexedHero> Bed - No Anchor
[23:35:19] [Server thread/WARN]: RESPAWN true false
[23:35:35] [Async Chat Thread - #0/INFO]: <HexedHero> Anchor - No Bed
[23:35:40] [Server thread/WARN]: RESPAWN false true
[23:37:05] [Async Chat Thread - #1/INFO]: <HexedHero> End Portal/Credits - No Bed - No Anchor
[23:37:07] [Server thread/WARN]: RESPAWN false false
[23:36:49] [Async Chat Thread - #1/INFO]: <HexedHero> End Portal/Credits - Bed - No Anchor
[23:36:47] [Server thread/WARN]: RESPAWN true false
[23:37:42] [Async Chat Thread - #1/INFO]: <HexedHero> End Portal/Credits - Anchor - No Bed
[23:37:46] [Server thread/WARN]: RESPAWN false true
```