### PR TITLE
Ignore NullPointerException when set logo

### DIFF
--- a/Spigot-Server-Patches/0682-Improve-ServerGUI.patch
+++ b/Spigot-Server-Patches/0682-Improve-ServerGUI.patch
@@ -107,7 +107,7 @@ index c2c075b9e3b70f863b6c450e4f31d6fde2935be6..d1d98c2f192514a3f511bebb00c088b0
 +        // Paper start - Add logo as frame image
 +        try {
 +            jframe.setIconImage(ImageIO.read(Objects.requireNonNull(ServerGUI.class.getClassLoader().getResourceAsStream("logo.png"))));
-+        } catch (IOException ignore) {
++        } catch (IOException | NullPointerException ignore) {
 +        }
 +        // Paper end
 +


### PR DESCRIPTION
NullPointerException is thrown if `logo.png` does not exist