### PR TITLE
Fix wrong bucket being returned in PlayerBucketFishEvent

### DIFF
--- a/Spigot-API-Patches/0291-Fix-wrong-bucket-being-returned-in-PlayerBucketFishE.patch
+++ b/Spigot-API-Patches/0291-Fix-wrong-bucket-being-returned-in-PlayerBucketFishE.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: HexedHero <6012891+HexedHero@users.noreply.github.com>
+Date: Thu, 29 Apr 2021 12:00:10 +0100
+Subject: [PATCH] Fix wrong bucket being returned in PlayerBucketFishEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/PlayerBucketFishEvent.java b/src/main/java/org/bukkit/event/player/PlayerBucketFishEvent.java
+index 475b1c1d2b45d98d80059460bce80acabe67ce00..a806f0a3e8c8371fe15e1967bf0e784281477833 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerBucketFishEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerBucketFishEvent.java
+@@ -45,7 +45,7 @@ public class PlayerBucketFishEvent extends PlayerEvent implements Cancellable {
+      */
+     @NotNull
+     public ItemStack getWaterBucket() {
+-        return fishBucket;
++        return waterBucket; // Paper - fix wrong bucket being returned
+     }
+ 
+     /**

--- a/Spigot-API-Patches/0291-Fix-wrong-bucket-being-returned-in-PlayerBucketFishE.patch
+++ b/Spigot-API-Patches/0291-Fix-wrong-bucket-being-returned-in-PlayerBucketFishE.patch
@@ -13,7 +13,7 @@ index 475b1c1d2b45d98d80059460bce80acabe67ce00..a806f0a3e8c8371fe15e1967bf0e7842
      @NotNull
      public ItemStack getWaterBucket() {
 -        return fishBucket;
-+        return waterBucket; // Paper - fix wrong bucket being returned
++        return waterBucket; // Paper - fix wrong bucket being returned SPIGOT-6443
      }
  
      /**


### PR DESCRIPTION
waterBucket was unused prior to this but still set and getWaterBucket and getFishBucket returned the fishBucket.