### PR TITLE
Future proof auto fix y on login

### DIFF
--- a/Spigot-Server-Patches/0114-Auto-fix-bad-Y-levels-on-player-login.patch
+++ b/Spigot-Server-Patches/0114-Auto-fix-bad-Y-levels-on-player-login.patch
@@ -6,14 +6,14 @@ Subject: [PATCH] Auto fix bad Y levels on player login
 Bring down to a saner Y level if super high, as this can cause the server to crash
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 3d5d1b83094b5ca45fae47055db397630fdd4f04..82085f30e4eefa1867536a8c591210380ebad725 100644
+index 120cad4e7330900fa11d278cf87a6ab4484469c3..68b3aa51e4639df87ad7a3478ae718e3d7616ad8 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -339,6 +339,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      @Override
      public void loadData(NBTTagCompound nbttagcompound) {
          super.loadData(nbttagcompound);
-+        if (this.locY() > 300) this.setPositionRaw(locX(), 257, locZ()); // Paper - bring down to a saner Y level if out of world
++        if (this.locY() > world.getWorld().getMaxHeight()) this.setPositionRaw(locX(), world.getWorld().getMaxHeight(), locZ()); // Paper - bring down to a saner Y level if out of world
          if (nbttagcompound.hasKeyOfType("playerGameType", 99)) {
              if (this.getMinecraftServer().getForceGamemode()) {
                  this.playerInteractManager.a(this.getMinecraftServer().getGamemode(), EnumGamemode.NOT_SET);


### PR DESCRIPTION
Use the world max height to future proof for 1.17+ worlds that have changeable max height. The old +1 to the new location seemed pointless so I removed it.