### PR TITLE
Check for world change in PlayerMoveEvent API methods

### DIFF
--- a/Spigot-API-Patches/0291-PlayerMoveEvent-Improvements.patch
+++ b/Spigot-API-Patches/0291-PlayerMoveEvent-Improvements.patch
@@ -5,39 +5,57 @@ Subject: [PATCH] PlayerMoveEvent Improvements
 
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
-index 1a58734d919fae247eeb85dd785fd59990856505..a39d4f0e4cd45b20b12809475d6d29613b489503 100644
+index 1a58734d919fae247eeb85dd785fd59990856505..b484abf3b06b1fb3577b43d50d64498dcd7652c9 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerMoveEvent.java
-@@ -93,6 +93,35 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
+@@ -93,6 +93,53 @@ public class PlayerMoveEvent extends PlayerEvent implements Cancellable {
          this.to = to;
      }
  
 +    // Paper start - PlayerMoveEvent improvements
 +    /**
-+     * Check if the player has changed position in the event
-+     * 
++     * Check if the player has changed position (even within the same block) in the event
++     *
 +     * @return whether the player has changed position or not
 +     */
 +    public boolean hasChangedPosition() {
++        return hasExplicitlyChangedPosition() || !from.getWorld().equals(to.getWorld());
++    }
++
++    /**
++     * Check if the player has changed position (even within the same block) in the event, disregarding a possible world change
++     *
++     * @return whether the player has changed position or not
++     */
++    public boolean hasExplicitlyChangedPosition() {
 +        return from.getX() != to.getX() || from.getY() != to.getY() || from.getZ() != to.getZ();
 +    }
 +
 +    /**
++     * Check if the player has moved to a new block in the event
++     *
++     * @return whether the player has moved to a new block or not
++     */
++    public boolean hasChangedBlock() {
++        return hasExplicitlyChangedBlock() || !from.getWorld().equals(to.getWorld());
++    }
++
++    /**
++     * Check if the player has moved to a new block in the event, disregarding a possible world change
++     *
++     * @return whether the player has moved to a new block or not
++     */
++    public boolean hasExplicitlyChangedBlock() {
++        return from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY() || from.getBlockZ() != to.getBlockZ();
++    }
++
++    /**
 +     * Check if the player has changed orientation in the event
-+     * 
++     *
 +     * @return whether the player has changed orientation or not
 +     */
 +    public boolean hasChangedOrientation() {
 +        return from.getPitch() != to.getPitch() || from.getYaw() != to.getYaw();
-+    }
-+
-+    /**
-+     * Check if the player has changed to a new block in the event
-+     * 
-+     * @return whether the player has changed block or not
-+     */
-+    public boolean hasChangedBlock() {
-+        return from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY() || from.getBlockZ() != to.getBlockZ();
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
See https://github.com/PaperMC/Paper/pull/5553#issuecomment-830060990 - with the addition that you *can* actually change the world in the move event, so the check is necessary here as well. Added extra methods without the world check as proximsy suggested.

The only open question would be the rotation method and if it should receive the same treatment (I didn't change it yet, since you don't really "change rotation" as you "change position" in the other ones)