### PR TITLE
[CI-SKIP] Add Other textarea to issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -65,9 +65,12 @@ body:
         - label: My version of Minecraft is supported by Paper.
           required: true
 
-  - type: markdown
+  - type: textarea
     attributes:
-      value: |
+      label: Other
+      description: |
         Please include other helpful information below.
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false
 

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -37,6 +37,9 @@ body:
         - label: I have ensured the feature I'm requesting isn't already in the latest supported Paper build.
           required: true
 
-  - type: markdown
+  - type: textarea
     attributes:
-      value: Add any other context or screenshots about the feature request below.
+      label: Other
+      description: Add any other context or screenshots about the feature request below.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/performance-problem.yml
+++ b/.github/ISSUE_TEMPLATE/performance-problem.yml
@@ -70,8 +70,11 @@ body:
         - label: My version of Minecraft is supported by Paper.
           required: true
 
-  - type: markdown
+  - type: textarea
     attributes:
-      value: |
+      label: Other
+      description: |
         Please include other helpful links below.
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
+++ b/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
@@ -67,8 +67,11 @@ body:
         - label: My version of Minecraft is supported by Paper.
           required: true
 
-  - type: markdown
+  - type: textarea
     attributes:
-      value: |
+      label: Other
+      description: |
         Please include other helpful information below, if any.
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
+    validations:
+      required: false


### PR DESCRIPTION
Currently issues have markdown text saying that the reporter should put any additional information below, which is not possible because there's no area to put it in.

This changes all final `markdown` entries to optional `textarea`s, making it possible for reported to put any additional information there.

Not sure what the best label would be - I've chosen `Other`, but `Extra information` and many more come to mind.