### PR TITLE
Use JsonSerializationContext#serialize instead of recursion for AdventureComponents

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1020,7 +1020,7 @@ index dc8cc8d6c00176c8562086282f726dc1b24b2c65..2f6da89d6b25ba5144ec15b1bf0e8ed1
                  packetdataserializer.d(integer);
  
 diff --git a/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java b/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
-index 85140d961722e86abfe7006a0ad752751e73c721..c7c191b0a9889450fdf495f5aa45d59f159f1401 100644
+index 85140d961722e86abfe7006a0ad752751e73c721..e96fa348a37a39c381b6659f612232933686c2a7 100644
 --- a/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
 +++ b/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
 @@ -1,5 +1,6 @@
@@ -1038,7 +1038,15 @@ index 85140d961722e86abfe7006a0ad752751e73c721..c7c191b0a9889450fdf495f5aa45d59f
              gsonbuilder.registerTypeHierarchyAdapter(IChatBaseComponent.class, new IChatBaseComponent.ChatSerializer());
              gsonbuilder.registerTypeHierarchyAdapter(ChatModifier.class, new ChatModifier.ChatModifierSerializer());
              gsonbuilder.registerTypeAdapterFactory(new ChatTypeAdapterFactory());
-@@ -351,10 +353,12 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -263,6 +265,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+         }
+ 
+         public JsonElement serialize(IChatBaseComponent ichatbasecomponent, Type type, JsonSerializationContext jsonserializationcontext) {
++            if (ichatbasecomponent instanceof AdventureComponent) return jsonserializationcontext.serialize(ichatbasecomponent); // Paper
+             JsonObject jsonobject = new JsonObject();
+ 
+             if (!ichatbasecomponent.getChatModifier().g()) {
+@@ -351,10 +354,12 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return jsonobject;
          }
  
@@ -1051,7 +1059,7 @@ index 85140d961722e86abfe7006a0ad752751e73c721..c7c191b0a9889450fdf495f5aa45d59f
          public static JsonElement b(IChatBaseComponent ichatbasecomponent) {
              return IChatBaseComponent.ChatSerializer.a.toJsonTree(ichatbasecomponent);
          }
-@@ -364,6 +368,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -364,6 +369,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return (IChatMutableComponent) ChatDeserializer.a(IChatBaseComponent.ChatSerializer.a, s, IChatMutableComponent.class, false);
          }
  

--- a/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
+++ b/Spigot-Server-Patches/0049-Player-Tab-List-and-Title-APIs.patch
@@ -21,10 +21,10 @@ index 5f1c5dd7902f6cff5acae05e8c6bf58a1ba5bdf1..df459918c14589155a574730205cb35d
  
      public PacketDataSerializer a(IChatBaseComponent ichatbasecomponent) {
 diff --git a/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java b/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
-index c7c191b0a9889450fdf495f5aa45d59f159f1401..e0fe2ba95bd3cb6afcf9c804007438a513c095b7 100644
+index e96fa348a37a39c381b6659f612232933686c2a7..a002125e454f8a86924e9010e0b20a95742fa04b 100644
 --- a/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
 +++ b/src/main/java/net/minecraft/network/chat/IChatBaseComponent.java
-@@ -363,6 +363,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
+@@ -364,6 +364,7 @@ public interface IChatBaseComponent extends Message, IChatFormatted, Iterable<IC
              return IChatBaseComponent.ChatSerializer.a.toJsonTree(ichatbasecomponent);
          }
  


### PR DESCRIPTION
Mojang uses recursion to serialize child components/arguments of translatable components in the ComponentSerializer. This means the registered JsonSerializer for AdventureComponents cannot be used. By instead calling JsonSerializationContext#serialize for AdventureComponents, our serializer will be used.