### PR TITLE
Add new methods of PlayerMoveEvent to EntityMoveEvent

### DIFF
--- a/Spigot-API-Patches/0269-EntityMoveEvent.patch
+++ b/Spigot-API-Patches/0269-EntityMoveEvent.patch
@@ -90,45 +90,45 @@ index 0000000000000000000000000000000000000000..a5c017dc0392a4bbdccf33d9e963f96c
 +    }
 +
 +    /**
-+     * Check if the player has changed position (even within the same block) in the event
++     * Check if the entity has changed position (even within the same block) in the event
 +     *
-+     * @return whether the player has changed position or not
++     * @return whether the entity has changed position or not
 +     */
 +    public boolean hasChangedPosition() {
 +        return hasExplicitlyChangedPosition() || !from.getWorld().equals(to.getWorld());
 +    }
 +
 +    /**
-+     * Check if the player has changed position (even within the same block) in the event, disregarding a possible world change
++     * Check if the entity has changed position (even within the same block) in the event, disregarding a possible world change
 +     *
-+     * @return whether the player has changed position or not
++     * @return whether the entity has changed position or not
 +     */
 +    public boolean hasExplicitlyChangedPosition() {
 +        return from.getX() != to.getX() || from.getY() != to.getY() || from.getZ() != to.getZ();
 +    }
 +
 +    /**
-+     * Check if the player has moved to a new block in the event
++     * Check if the entity has moved to a new block in the event
 +     *
-+     * @return whether the player has moved to a new block or not
++     * @return whether the entity has moved to a new block or not
 +     */
 +    public boolean hasChangedBlock() {
 +        return hasExplicitlyChangedBlock() || !from.getWorld().equals(to.getWorld());
 +    }
 +
 +    /**
-+     * Check if the player has moved to a new block in the event, disregarding a possible world change
++     * Check if the entity has moved to a new block in the event, disregarding a possible world change
 +     *
-+     * @return whether the player has moved to a new block or not
++     * @return whether the entity has moved to a new block or not
 +     */
 +    public boolean hasExplicitlyChangedBlock() {
 +        return from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY() || from.getBlockZ() != to.getBlockZ();
 +    }
 +
 +    /**
-+     * Check if the player has changed orientation in the event
++     * Check if the entity has changed orientation in the event
 +     *
-+     * @return whether the player has changed orientation or not
++     * @return whether the entity has changed orientation or not
 +     */
 +    public boolean hasChangedOrientation() {
 +        return from.getPitch() != to.getPitch() || from.getYaw() != to.getYaw();

--- a/Spigot-API-Patches/0269-EntityMoveEvent.patch
+++ b/Spigot-API-Patches/0269-EntityMoveEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] EntityMoveEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..299ff57b3001b4be41cf2f0eea29ed82b8fb8ec7
+index 0000000000000000000000000000000000000000..a5c017dc0392a4bbdccf33d9e963f96cbfbc0d9a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityMoveEvent.java
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,140 @@
 +package io.papermc.paper.event.entity;
 +
 +import com.google.common.base.Preconditions;
@@ -87,6 +87,51 @@ index 0000000000000000000000000000000000000000..299ff57b3001b4be41cf2f0eea29ed82
 +    public void setTo(@NotNull Location to) {
 +        validateLocation(to);
 +        this.to = to;
++    }
++
++    /**
++     * Check if the player has changed position (even within the same block) in the event
++     *
++     * @return whether the player has changed position or not
++     */
++    public boolean hasChangedPosition() {
++        return hasExplicitlyChangedPosition() || !from.getWorld().equals(to.getWorld());
++    }
++
++    /**
++     * Check if the player has changed position (even within the same block) in the event, disregarding a possible world change
++     *
++     * @return whether the player has changed position or not
++     */
++    public boolean hasExplicitlyChangedPosition() {
++        return from.getX() != to.getX() || from.getY() != to.getY() || from.getZ() != to.getZ();
++    }
++
++    /**
++     * Check if the player has moved to a new block in the event
++     *
++     * @return whether the player has moved to a new block or not
++     */
++    public boolean hasChangedBlock() {
++        return hasExplicitlyChangedBlock() || !from.getWorld().equals(to.getWorld());
++    }
++
++    /**
++     * Check if the player has moved to a new block in the event, disregarding a possible world change
++     *
++     * @return whether the player has moved to a new block or not
++     */
++    public boolean hasExplicitlyChangedBlock() {
++        return from.getBlockX() != to.getBlockX() || from.getBlockY() != to.getBlockY() || from.getBlockZ() != to.getBlockZ();
++    }
++
++    /**
++     * Check if the player has changed orientation in the event
++     *
++     * @return whether the player has changed orientation or not
++     */
++    public boolean hasChangedOrientation() {
++        return from.getPitch() != to.getPitch() || from.getYaw() != to.getYaw();
 +    }
 +
 +    private void validateLocation(@NotNull Location loc) {


### PR DESCRIPTION
First time dealing with patches and really git outside my own repos so sorry if I did something horribly wrong (I probably did).

Given part of the intent of the original PR was to encourage plugins to only do things at the appropriate time in PlayerMoveEvent, I figured this was even more useful in EntityMoveEvent since that one fires much more often.