### PR TITLE
Don't annotate type parameters using JetBrains annotations

### DIFF
--- a/Spigot-API-Patches/0295-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
+++ b/Spigot-API-Patches/0295-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow for Component suggestion tooltips in
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java b/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
-index 619ed37169c126a8c75d02699a04728bac49d10d..31c90ab0710020a2ff104b5cb8af604f3d682f31 100644
+index 619ed37169c126a8c75d02699a04728bac49d10d..4cd97cb102e1ec53b3fe1a451b65b4b640fde099 100644
 --- a/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
 +++ b/src/main/java/com/destroystokyo/paper/event/server/AsyncTabCompleteEvent.java
 @@ -24,6 +24,11 @@
@@ -93,7 +93,7 @@ index 619ed37169c126a8c75d02699a04728bac49d10d..31c90ab0710020a2ff104b5cb8af604f
 +     *
 +     * @return a list of offered completions
 +     */
-+    public @NotNull List<@NotNull Completion> completions() {
++    public @NotNull List<Completion> completions() {
 +        return this.completions;
 +    }
 +
@@ -107,7 +107,7 @@ index 619ed37169c126a8c75d02699a04728bac49d10d..31c90ab0710020a2ff104b5cb8af604f
 +     *
 +     * @param newCompletions the new completions
 +     */
-+    public void completions(final @NotNull List<@NotNull Completion> newCompletions) {
++    public void completions(final @NotNull List<Completion> newCompletions) {
 +        Validate.notNull(newCompletions, "new completions");
 +        this.completions.clear();
 +        this.completions.addAll(newCompletions);


### PR DESCRIPTION
Ran into the same issue as before, where JB annotations don't allow properly annotating the nullability of certain things, this time type parameters. Maven doesn't care about the improper use of JB annotations, and compiles anyways, but when compiling with Gradle it errors.

edit: looks like AnnotationTest needs updating...
edit 2: AnnotationTest was more trouble than it was worth to update to allow checker annotations on method parameters, so I've just dropped the type parameter annotations altogether.