### PR TITLE
More MemoryKey API

### DIFF
--- a/patches/api/0484-More-MemoryKey-API.patch
+++ b/patches/api/0484-More-MemoryKey-API.patch
@@ -1,0 +1,246 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 9 May 2021 19:35:09 -0700
+Subject: [PATCH] More MemoryKey API
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index fd39ed209b20c927054b8482c400beeeeab460a3..e11054560dd9663667d6f4ae4f03854d986f50de 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -70,6 +70,7 @@ dependencies {
+     compileOnlyApi(checkerQual)
+     testCompileOnly(checkerQual)
+     // Paper end
++    api("io.leangen.geantyref:geantyref:1.3.13") // Paper - more memory key API
+ 
+     testImplementation("org.apache.commons:commons-lang3:3.12.0")
+     testImplementation("org.junit.jupiter:junit-jupiter:5.10.2")
+diff --git a/src/main/java/org/bukkit/entity/LivingEntity.java b/src/main/java/org/bukkit/entity/LivingEntity.java
+index b777e530122549455dcce6fac8d4a151c1c0af42..ba79a2ffdd567ba8396d4101bce11f15a1adfc76 100644
+--- a/src/main/java/org/bukkit/entity/LivingEntity.java
++++ b/src/main/java/org/bukkit/entity/LivingEntity.java
+@@ -942,6 +942,8 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * <p>
+      * Note that the value is null when the specific entity does not have that
+      * value by default.
++     * <p>
++     * Any collection that is returned will be immutable.
+      *
+      * @param memoryKey memory to access
+      * @param <T> the type of the return value
+@@ -961,6 +963,17 @@ public interface LivingEntity extends Attributable, Damageable, ProjectileSource
+      * @param <T> the type of the passed value
+      */
+     <T> void setMemory(@NotNull MemoryKey<T> memoryKey, @Nullable T memoryValue);
++    // Paper start
++    /**
++     * Get the unmodifiable collection of memories that this entity
++     * recognizes. If a {@link MemoryKey} is not in this
++     * collection, {@link #setMemory(MemoryKey, Object)}
++     * will have no effect.
++     *
++     * @return the collection of memories that the entity recognizes
++     */
++    @NotNull Collection<MemoryKey<?>> getRecognizedMemories();
++    // Paper end
+ 
+     /**
+      * Get the {@link Sound} this entity will make when damaged.
+diff --git a/src/main/java/org/bukkit/entity/memory/MemoryKey.java b/src/main/java/org/bukkit/entity/memory/MemoryKey.java
+index d615c006c9153fb65024241604b744fbfc383efc..aba7f6c639d313568c29524e81b2f8f8b86cb2df 100644
+--- a/src/main/java/org/bukkit/entity/memory/MemoryKey.java
++++ b/src/main/java/org/bukkit/entity/memory/MemoryKey.java
+@@ -10,6 +10,27 @@ import org.bukkit.Location;
+ import org.bukkit.NamespacedKey;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
++// Paper start
++import com.destroystokyo.paper.entity.Pathfinder;
++import java.util.Collection;
++import io.papermc.paper.math.BlockPosition;
++import org.bukkit.util.Vector;
++import org.bukkit.entity.Hoglin;
++import org.bukkit.entity.Mob;
++import org.bukkit.entity.PiglinAbstract;
++import java.util.List;
++import java.lang.reflect.Type;
++import io.leangen.geantyref.GenericTypeReflector;
++import io.leangen.geantyref.TypeToken;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Ageable;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.entity.Item;
++import org.bukkit.damage.DamageSource;
++
++import static org.bukkit.NamespacedKey.minecraft;
++// Paper end
+ 
+ /**
+  * Represents a key used for accessing memory values of a
+@@ -17,15 +38,31 @@ import org.jetbrains.annotations.Nullable;
+  *
+  * @param <T> the class type of the memory value
+  */
++@SuppressWarnings("Convert2Diamond") // Paper
+ public final class MemoryKey<T> implements Keyed {
+ 
+     private final NamespacedKey namespacedKey;
+     private final Class<T> tClass;
++    private final TypeToken<T> typeToken; // Paper
++    private final boolean isCollection; // Paper
+ 
+     private MemoryKey(NamespacedKey namespacedKey, Class<T> tClass) {
+         this.namespacedKey = namespacedKey;
+         this.tClass = tClass;
+         MEMORY_KEYS.put(namespacedKey, this);
++        // Paper start
++        this.typeToken = TypeToken.get(tClass);
++        this.isCollection = false;
++    }
++
++    @SuppressWarnings("unchecked")
++    private MemoryKey(NamespacedKey namespacedKey, TypeToken<T> typeToken) {
++        this.namespacedKey = namespacedKey;
++        this.tClass = (Class<T>) GenericTypeReflector.erase(typeToken.getType());
++        MEMORY_KEYS.put(namespacedKey, this);
++        this.typeToken = typeToken;
++        this.isCollection = Collection.class.isAssignableFrom(GenericTypeReflector.erase(this.tClass));
++        // Paper end
+     }
+ 
+     @NotNull
+@@ -69,13 +106,127 @@ public final class MemoryKey<T> implements Keyed {
+     public static final MemoryKey<Location> LIKED_NOTEBLOCK_POSITION = new MemoryKey<>(NamespacedKey.minecraft("liked_noteblock"), Location.class);
+     public static final MemoryKey<Integer> LIKED_NOTEBLOCK_COOLDOWN_TICKS = new MemoryKey<>(NamespacedKey.minecraft("liked_noteblock_cooldown_ticks"), Integer.class);
+     public static final MemoryKey<Integer> ITEM_PICKUP_COOLDOWN_TICKS = new MemoryKey<>(NamespacedKey.minecraft("item_pickup_cooldown_ticks"), Integer.class);
++    // Paper start
++    public static final MemoryKey<List<Location>> SNIFFER_EXPLORED_POSITIONS = new MemoryKey<>(NamespacedKey.minecraft("sniffer_explored_positions"), new TypeToken<List<Location>>() {});
++    public static final MemoryKey<Void> DUMMY = create("dummy", Void.class);
++    public static final MemoryKey<List<Location>> SECONDARY_JOB_SITE = create("secondary_job_site", new TypeToken<List<Location>>() {});
++    public static final MemoryKey<List<LivingEntity>> MOBS = create("mobs", new TypeToken<List<LivingEntity>>() {});
++    public static final MemoryKey<List<LivingEntity>> VISIBLE_MOBS = create("visible_mobs", new TypeToken<List<LivingEntity>>() {});
++    public static final MemoryKey<List<LivingEntity>> VISIBLE_VILLAGER_BABIES = create("visible_villager_babies", new TypeToken<List<LivingEntity>>() {});
++    public static final MemoryKey<List<HumanEntity>> NEAREST_PLAYERS = create("nearest_players", new TypeToken<List<HumanEntity>>() {});
++    public static final MemoryKey<HumanEntity> NEAREST_VISIBLE_PLAYER = create("nearest_visible_player", HumanEntity.class);
++    public static final MemoryKey<HumanEntity> NEAREST_VISIBLE_TARGETABLE_PLAYER = create("nearest_visible_targetable_player", HumanEntity.class);
++    // TODO WalkTarget "walk_target"
++    // TODO PositionTracker "look_target"
++    public static final MemoryKey<LivingEntity> ATTACK_TARGET = create("attack_target", LivingEntity.class);
++    public static final MemoryKey<Boolean> ATTACK_COOLING_DOWN = create("attack_cooling_down", Boolean.class);
++    public static final MemoryKey<LivingEntity> INTERACTION_TARGET = create("interaction_target", LivingEntity.class);
++    public static final MemoryKey<Ageable> BREED_TARGET = create("breed_target", Ageable.class);
++    public static final MemoryKey<Entity> RIDE_TARGET = create("ride_target", Entity.class);
++    public static final MemoryKey<Pathfinder.PathResult> PATH = create("path", Pathfinder.PathResult.class);
++    public static final MemoryKey<List<Location>> INTERACTABLE_DOORS = create("interactable_doors", new TypeToken<List<Location>>() {});
++    public static final MemoryKey<Set<Location>> DOORS_TO_CLOSE = create("doors_to_close", new TypeToken<Set<Location>>() {});
++    public static final MemoryKey<BlockPosition> NEAREST_BED = create("nearest_bed", BlockPosition.class);
++    public static final MemoryKey<DamageSource> HURT_BY = create("hurt_by", DamageSource.class);
++    public static final MemoryKey<LivingEntity> HURT_BY_ENTITY = create("hurt_by_entity", LivingEntity.class);
++    public static final MemoryKey<LivingEntity> AVOID_TARGET = create("avoid_target", LivingEntity.class);
++    public static final MemoryKey<LivingEntity> NEAREST_HOSTILE = create("nearest_hostile", LivingEntity.class);
++    public static final MemoryKey<LivingEntity> NEAREST_ATTACKABLE = create("nearest_attackable", LivingEntity.class);
++    public static final MemoryKey<Location> HIDING_PLACE = create("hiding_place", Location.class);
++    public static final MemoryKey<Long> HEARD_BELL_TIME = create("heard_bell_time", Long.class);
++    public static final MemoryKey<Long> CANT_REACH_WALK_TARGET_SINCE = create("cant_reach_walk_target_since", Long.class);
++    public static final MemoryKey<Ageable> NEAREST_VISIBLE_ADULT = create("nearest_visible_adult", Ageable.class);
++    public static final MemoryKey<Item> NEAREST_VISIBLE_WANTED_ITEM = create("nearest_visible_wanted_item", Item.class);
++    public static final MemoryKey<Mob> NEAREST_VISIBLE_NEMESIS = create("nearest_visible_nemesis", Mob.class);
++    public static final MemoryKey<HumanEntity> TEMPTING_PLAYER = create("tempting_player", HumanEntity.class);
++    public static final MemoryKey<Integer> GAZE_COOLDOWN_TICKS = create("gaze_cooldown_ticks", Integer.class);
++    public static final MemoryKey<Boolean> LONG_JUMP_MID_JUMP = create("long_jump_mid_jump", Boolean.class); // CraftBukkit forgot to add this one themselves
++    public static final MemoryKey<Vector> RAM_TARGET = create("ram_target", Vector.class);
++    public static final MemoryKey<Void> IS_IN_WATER = create("is_in_water", Void.class);
++    public static final MemoryKey<Void> IS_PREGNANT = create("is_pregnant", Void.class);
++    public static final MemoryKey<Boolean> IS_PANICKING = create("is_panicking", Boolean.class);
++    public static final MemoryKey<List<UUID>> UNREACHABLE_TONGUE_TARGETS = create("unreachable_tongue_targets", new TypeToken<List<UUID>>() {});
++    public static final MemoryKey<Integer> TIME_TRYING_TO_REACH_ADMIRE_ITEM = create("time_trying_to_reach_admire_item", Integer.class);
++    public static final MemoryKey<Boolean> DISABLE_WALK_TO_ADMIRE_ITEM = create("disable_walk_to_admire_item", Boolean.class);
++    public static final MemoryKey<BlockPosition> CELEBRATE_LOCATION = create("celebrate_location", BlockPosition.class);
++    public static final MemoryKey<Boolean> DANCING = create("dancing", Boolean.class);
++    public static final MemoryKey<Hoglin> NEAREST_VISIBLE_HUNTABLE_HOGLIN = create("nearest_visible_huntable_hoglin", Hoglin.class);
++    public static final MemoryKey<Hoglin> NEAREST_VISIBLE_BABY_HOGLIN = create("nearest_visible_baby_hoglin", Hoglin.class);
++    public static final MemoryKey<HumanEntity> NEAREST_TARGETABLE_PLAYER_NOT_WEARING_GOLD = create("nearest_targetable_player_not_wearing_gold", HumanEntity.class);
++    public static final MemoryKey<List<PiglinAbstract>> NEARBY_ADULT_PIGLINS = create("nearby_adult_piglins", new TypeToken<List<PiglinAbstract>>() {});
++    public static final MemoryKey<List<PiglinAbstract>> NEAREST_VISIBLE_ADULT_PIGLINS = create("nearest_visible_adult_piglins", new TypeToken<List<PiglinAbstract>>() {});
++    public static final MemoryKey<List<Hoglin>> NEAREST_VISIBLE_ADULT_HOGLINS = create("nearest_visible_adult_hoglins", new TypeToken<List<Hoglin>>() {});
++    public static final MemoryKey<PiglinAbstract> NEAREST_VISIBLE_ADULT_PIGLIN = create("nearest_visible_adult_piglin", new TypeToken<PiglinAbstract>() {});
++    public static final MemoryKey<LivingEntity> NEAREST_VISIBLE_ZOMBIFIED = create("nearest_visible_zombified", LivingEntity.class);
++    public static final MemoryKey<Integer> VISIBLE_ADULT_PIGLIN_COUNT = create("visible_adult_piglin_count", Integer.class);
++    public static final MemoryKey<Integer> VISIBLE_ADULT_HOGLIN_COUNT = create("visible_adult_hoglin_count", Integer.class);
++    public static final MemoryKey<HumanEntity> NEAREST_PLAYER_HOLDING_WANTED_ITEM = create("nearest_player_holding_wanted_item", HumanEntity.class);
++    public static final MemoryKey<Boolean> ATE_RECENTLY = create("ate_recently", Boolean.class);
++    public static final MemoryKey<BlockPosition> NEAREST_REPELLENT = create("nearest_repellent", BlockPosition.class);
++    public static final MemoryKey<Boolean> PACIFIED = create("pacified", Boolean.class);
++    public static final MemoryKey<LivingEntity> ROAR_TARGET = create("roar_target", LivingEntity.class);
++    public static final MemoryKey<BlockPosition> DISTURBANCE_LOCATION = create("disturbance_location", BlockPosition.class);
++    public static final MemoryKey<Void> RECENT_PROJECTILE = create("recent_projectile", Void.class);
++    public static final MemoryKey<Void> IS_SNIFFING = create("is_sniffing", Void.class);
++    public static final MemoryKey<Void> IS_EMERGING = create("is_emerging", Void.class);
++    public static final MemoryKey<Void> ROAR_SOUND_DELAY = create("roar_sound_delay", Void.class);
++    public static final MemoryKey<Void> DIG_COOLDOWN = create("dig_cooldown", Void.class);
++    public static final MemoryKey<Void> ROAR_SOUND_COOLDOWN = create("roar_sound_cooldown", Void.class);
++    public static final MemoryKey<Void> SNIFF_COOLDOWN = create("sniff_cooldown", Void.class);
++    public static final MemoryKey<Void> TOUCH_COOLDOWN = create("touch_cooldown", Void.class);
++    public static final MemoryKey<Void> VIBRATION_COOLDOWN = create("vibration_cooldown", Void.class);
++    public static final MemoryKey<Void> SONIC_BOOM_COOLDOWN = create("sonic_boom_cooldown", Void.class);
++    public static final MemoryKey<Void> SONIC_BOOM_SOUND_COOLDOWN = create("sonic_boom_sound_cooldown", Void.class);
++    public static final MemoryKey<Void> SONIC_BOOM_SOUND_DELAY = create("sonic_boom_sound_delay", Void.class);
++    public static final MemoryKey<Boolean> SNIFFER_DIGGING = create("sniffer_digging", Boolean.class);
++    public static final MemoryKey<BlockPosition> SNIFFER_SNIFFING_TARGET = create("sniffer_sniffing_target", BlockPosition.class);
++    public static final MemoryKey<Void> BREEZE_SHOOT_RECOVER = create("breeze_shoot_recover", Void.class);
++    public static final MemoryKey<Void> BREEZE_LEAVING_WATER = create("breeze_leaving_water", Void.class);
++    public static final MemoryKey<Void> BREEZE_JUMP_COOLDOWN = create("breeze_jump_cooldown", Void.class);
++    public static final MemoryKey<Void> BREEZE_JUMP_INHALING = create("breeze_jump_inhaling", Void.class);
++    public static final MemoryKey<Boolean> DANGER_DETECTED_RECENTLY = create("danger_detected_recently", Boolean.class);
++    public static final MemoryKey<Void> BREEZE_SHOOT = create("breeze_shoot", Void.class);
++    public static final MemoryKey<Void> BREEZE_SHOOT_CHARGING = create("breeze_shoot_charging", Void.class);
++    public static final MemoryKey<BlockPosition> BREEZE_JUMP_TARGET = create("breeze_jump_target", BlockPosition.class);
++    public static final MemoryKey<Boolean> SNIFFER_HAPPY = create("sniffer_happy", Boolean.class);
++    public static final MemoryKey<Void> BREEZE_SHOOT_COOLDOWN = create("breeze_shoot_cooldown", Void.class);
++
++    private static <T> MemoryKey<T> create(final @NotNull String key, final @NotNull Class<T> classOfT) {
++        return new MemoryKey<>(minecraft(key), classOfT);
++    }
++
++    private static <T> MemoryKey<T> create(final @NotNull String key, final @NotNull TypeToken<T> typeOfT) {
++        return new MemoryKey<>(minecraft(key), typeOfT);
++    }
++
+     /**
+-     * @deprecated this constant uses the wrong generic type, the sniffer now stores different positions
+-     * from possibly different worlds. Use the relevant methods in {@link org.bukkit.entity.Sniffer} directly
+-     * for now.
++     * Gets the exact type of this memory key.
++     *
++     * @return the type
++     */
++    public @NotNull Type getType() {
++        return this.typeToken.getType();
++    }
++
++    /**
++     * Gets if this memory key holds a collection.
++     * A class that extends {@link Collection}.
++     *
++     * @return true if a collection
+      */
+-    @Deprecated // Paper
+-    public static final MemoryKey<Location> SNIFFER_EXPLORED_POSITIONS = new MemoryKey<>(NamespacedKey.minecraft("sniffer_explored_positions"), Location.class);
++    public boolean isCollection() {
++        return this.isCollection;
++    }
++
++    @Override
++    public String toString() {
++        return "MemoryKey{" +
++            "namespacedKey=" + this.namespacedKey +
++            ", type=" + this.typeToken.getType() +
++            ", isCollection=" + this.isCollection +
++            '}';
++    }
++    // Paper end
+ 
+     /**
+      * Returns a {@link MemoryKey} by a {@link NamespacedKey}.

--- a/patches/server/0247-Mob-Pathfinding-API.patch
+++ b/patches/server/0247-Mob-Pathfinding-API.patch
@@ -12,12 +12,13 @@ public net.minecraft.world.level.pathfinder.Path nodes
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede02316a3cb
+index 0000000000000000000000000000000000000000..7723e42bea626451689a9c4e76b3d80ff9262603
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/PaperPathfinder.java
-@@ -0,0 +1,148 @@
+@@ -0,0 +1,155 @@
 +package com.destroystokyo.paper.entity;
 +
++import net.minecraft.world.entity.Entity;
 +import org.apache.commons.lang.Validate;
 +import org.bukkit.Location;
 +import org.bukkit.craftbukkit.entity.CraftLivingEntity;
@@ -61,7 +62,7 @@ index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede0
 +    @Override
 +    public PathResult getCurrentPath() {
 +        Path path = entity.getNavigation().getPath();
-+        return path != null && !path.isDone() ? new PaperPathResult(path) : null;
++        return path != null && !path.isDone() ? new PaperPathResult(path, this.entity) : null;
 +    }
 +
 +    @Nullable
@@ -69,7 +70,7 @@ index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede0
 +    public PathResult findPath(Location loc) {
 +        Validate.notNull(loc, "Location can not be null");
 +        Path path = entity.getNavigation().createPath(loc.getX(), loc.getY(), loc.getZ(), 0);
-+        return path != null ? new PaperPathResult(path) : null;
++        return path != null ? new PaperPathResult(path, this.entity) : null;
 +    }
 +
 +    @Nullable
@@ -77,7 +78,7 @@ index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede0
 +    public PathResult findPath(LivingEntity target) {
 +        Validate.notNull(target, "Target can not be null");
 +        Path path = entity.getNavigation().createPath(((CraftLivingEntity) target).getHandle(), 0);
-+        return path != null ? new PaperPathResult(path) : null;
++        return path != null ? new PaperPathResult(path, this.entity) : null;
 +    }
 +
 +    @Override
@@ -117,11 +118,13 @@ index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede0
 +        entity.getNavigation().pathFinder.nodeEvaluator.setCanFloat(canFloat);
 +    }
 +
-+    public class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {
++    public static class PaperPathResult implements com.destroystokyo.paper.entity.PaperPathfinder.PathResult {
 +
 +        private final Path path;
-+        PaperPathResult(Path path) {
++        private final Entity entity;
++        public PaperPathResult(Path path, Entity entity) {
 +            this.path = path;
++            this.entity = entity;
 +        }
 +
 +        @Nullable
@@ -158,10 +161,14 @@ index 0000000000000000000000000000000000000000..3dbe4cf29a7984a1976a60bdeeb3ede0
 +            }
 +            return toLoc(path.nodes.get(path.getNextNodeIndex()));
 +        }
-+    }
 +
-+    private Location toLoc(Node point) {
-+        return new Location(entity.level().getWorld(), point.x, point.y, point.z);
++        public Path getHandle() {
++            return this.path;
++        }
++
++        private Location toLoc(Node point) {
++            return new Location(entity.level().getWorld(), point.x, point.y, point.z);
++        }
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/level/pathfinder/Path.java b/src/main/java/net/minecraft/world/level/pathfinder/Path.java

--- a/patches/server/1052-More-MemoryKey-API.patch
+++ b/patches/server/1052-More-MemoryKey-API.patch
@@ -1,0 +1,603 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 9 May 2021 19:38:00 -0700
+Subject: [PATCH] More MemoryKey API
+
+== AT ==
+public net/minecraft/world/entity/ai/memory/NearestVisibleLivingEntities nearbyEntities
+
+diff --git a/src/main/java/io/papermc/paper/entity/memory/CollectionMemoryConverter.java b/src/main/java/io/papermc/paper/entity/memory/CollectionMemoryConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ff0f3315f10e1f0a40eaf72e3001d09eb5028a2c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/CollectionMemoryConverter.java
+@@ -0,0 +1,45 @@
++package io.papermc.paper.entity.memory;
++
++import com.google.common.collect.Collections2;
++import java.util.ArrayList;
++import java.util.Collection;
++import java.util.Collections;
++import java.util.HashSet;
++import java.util.List;
++import java.util.Set;
++import java.util.function.Function;
++import java.util.function.Supplier;
++import net.minecraft.world.entity.LivingEntity;
++
++@SuppressWarnings({"unchecked", "rawtypes"})
++record CollectionMemoryConverter<C extends Collection, B, M>(
++    Function<Collection<?>, C> bukkitCollectionCreator,
++    Function<Collection<?>, C> nmsCollectionCreator,
++    Supplier<C> emptyCollectionSupplier,
++    MemoryConverter<B, M> converter
++) implements MemoryConverter<Collection<B>, Collection<M>> {
++
++    static <B, M> CollectionMemoryConverter<List, B, M> forList(final MemoryConverter<B, M> elementConverter) {
++        return new CollectionMemoryConverter<>(List::copyOf, ArrayList::new, Collections::emptyList, elementConverter);
++    }
++
++    static <B, M> CollectionMemoryConverter<Set, B, M> forSet(final MemoryConverter<B, M> elementConverter) {
++        return new CollectionMemoryConverter<>(Set::copyOf, HashSet::new, Collections::emptySet, elementConverter);
++    }
++
++    @Override
++    public Collection<B> toBukkit(final Collection<M> nmsCollection, final LivingEntity context) {
++        if (nmsCollection.isEmpty()) {
++            return this.emptyCollectionSupplier.get(); // return Collections#empty<Something>
++        }
++        return this.bukkitCollectionCreator.apply(Collections2.transform(nmsCollection, nmsObject -> this.converter.toBukkit(nmsObject, context)));
++    }
++
++    @Override
++    public Collection<M> toNms(final Collection<B> bukkitCollection, final LivingEntity context) {
++        if (bukkitCollection.isEmpty()) {
++            return this.nmsCollectionCreator.apply(this.emptyCollectionSupplier.get()); // return a mutable empty collection
++        }
++        return this.nmsCollectionCreator.apply(Collections2.transform(bukkitCollection, bukkitObject -> this.converter.toNms(bukkitObject, context)));
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/ContextAwareMemoryConverter.java b/src/main/java/io/papermc/paper/entity/memory/ContextAwareMemoryConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4fc5f5d02898ab2499f4f7bcf34ecb9268d2102f
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/ContextAwareMemoryConverter.java
+@@ -0,0 +1,24 @@
++package io.papermc.paper.entity.memory;
++
++import java.lang.reflect.ParameterizedType;
++import java.lang.reflect.Type;
++import java.util.function.Function;
++import net.minecraft.world.entity.LivingEntity;
++
++abstract class ContextAwareMemoryConverter<B, M> implements MemoryConverter<B, M> {
++
++    private final Function<? super B, ? extends M> toNms;
++
++    ContextAwareMemoryConverter(final Function<? super B, ? extends M> toNms) {
++        this.toNms = toNms;
++        final Type superType = this.getClass().getGenericSuperclass();
++        if (!(superType instanceof ParameterizedType)) {
++            throw new IllegalStateException(superType + " is not an instance of ParameterizedType");
++        }
++    }
++
++    @Override
++    public M toNms(final B bukkitObject, final LivingEntity context) {
++        return this.toNms.apply(bukkitObject);
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/EntityMemoryConverter.java b/src/main/java/io/papermc/paper/entity/memory/EntityMemoryConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..fa79ee410f8fe442546144b7b6f62050b90a8e26
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/EntityMemoryConverter.java
+@@ -0,0 +1,33 @@
++package io.papermc.paper.entity.memory;
++
++import java.lang.reflect.ParameterizedType;
++import java.lang.reflect.Type;
++import net.minecraft.world.entity.Entity;
++import net.minecraft.world.entity.LivingEntity;
++import org.bukkit.craftbukkit.entity.CraftEntity;
++
++abstract class EntityMemoryConverter<CBE extends CraftEntity, ME extends Entity> implements MemoryConverter<CBE, ME> {
++
++    private final Class<CBE> craftBukkitEntityClass;
++    private final Class<ME> nmsEntityClass;
++
++    @SuppressWarnings("unchecked")
++    protected EntityMemoryConverter() {
++        final Type superType = this.getClass().getGenericSuperclass();
++        if (!(superType instanceof final ParameterizedType type)) {
++            throw new IllegalStateException(superType + " is not an instance of ParameterizedType");
++        }
++        this.craftBukkitEntityClass = (Class<CBE>) type.getActualTypeArguments()[0];
++        this.nmsEntityClass = (Class<ME>) type.getActualTypeArguments()[1];
++    }
++
++    @Override
++    public CBE toBukkit(final ME nmsObject, final LivingEntity context) {
++        return this.craftBukkitEntityClass.cast(nmsObject.getBukkitEntity());
++    }
++
++    @Override
++    public ME toNms(final CBE bukkitObject, final LivingEntity context) {
++        return this.nmsEntityClass.cast(bukkitObject.getHandle());
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/MemoryConverter.java b/src/main/java/io/papermc/paper/entity/memory/MemoryConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f0fce7145a652cba9749973502265a051ce70433
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/MemoryConverter.java
+@@ -0,0 +1,32 @@
++package io.papermc.paper.entity.memory;
++
++import net.minecraft.world.entity.LivingEntity;
++import net.minecraft.world.entity.Mob;
++import org.bukkit.entity.memory.MemoryKey;
++import org.checkerframework.checker.nullness.qual.Nullable;
++
++interface MemoryConverter<B, M> {
++
++    B toBukkit(M nmsObject, LivingEntity context);
++
++    M toNms(B bukkitObject, LivingEntity context);
++
++    @FunctionalInterface
++    interface Factory {
++
++        @Nullable MemoryConverter<?, ?> createMemoryConverter(Object toConvert, MemoryKey<?> memoryKey);
++    }
++
++    record Identity<T>(Class<T> typeClass) implements MemoryConverter<T, T> {
++
++        @Override
++        public T toBukkit(final T nmsObject, final LivingEntity context) {
++            return this.typeClass.cast(nmsObject);
++        }
++
++        @Override
++        public T toNms(final T bukkitObject, final LivingEntity context) {
++            return this.typeClass.cast(bukkitObject);
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/PaperMemoryMapper.java b/src/main/java/io/papermc/paper/entity/memory/PaperMemoryMapper.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4c4a24478d2fc64701b1210a21e9f33a6925932c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/PaperMemoryMapper.java
+@@ -0,0 +1,152 @@
++package io.papermc.paper.entity.memory;
++
++import com.destroystokyo.paper.entity.PaperPathfinder;
++import com.destroystokyo.paper.entity.Pathfinder;
++import io.leangen.geantyref.GenericTypeReflector;
++import io.papermc.paper.math.BlockPosition;
++import io.papermc.paper.util.MCUtil;
++import java.lang.reflect.ParameterizedType;
++import java.lang.reflect.Type;
++import java.util.ArrayList;
++import java.util.Collection;
++import java.util.HashMap;
++import java.util.List;
++import java.util.Map;
++import java.util.Set;
++import java.util.UUID;
++import net.minecraft.core.BlockPos;
++import net.minecraft.core.GlobalPos;
++import net.minecraft.world.entity.AgeableMob;
++import net.minecraft.world.entity.Entity;
++import net.minecraft.world.entity.ai.memory.NearestVisibleLivingEntities;
++import net.minecraft.world.entity.item.ItemEntity;
++import net.minecraft.world.entity.monster.piglin.AbstractPiglin;
++import net.minecraft.world.entity.player.Player;
++import net.minecraft.world.level.pathfinder.Path;
++import net.minecraft.world.phys.Vec3;
++import org.bukkit.Location;
++import org.bukkit.craftbukkit.damage.CraftDamageSource;
++import org.bukkit.craftbukkit.entity.CraftAgeable;
++import org.bukkit.craftbukkit.entity.CraftEntity;
++import org.bukkit.craftbukkit.entity.CraftHoglin;
++import org.bukkit.craftbukkit.entity.CraftHumanEntity;
++import org.bukkit.craftbukkit.entity.CraftItem;
++import org.bukkit.craftbukkit.entity.CraftLivingEntity;
++import org.bukkit.craftbukkit.entity.CraftMob;
++import org.bukkit.craftbukkit.entity.CraftPiglinAbstract;
++import org.bukkit.craftbukkit.entity.memory.CraftMemoryMapper;
++import org.bukkit.craftbukkit.util.CraftVector;
++import org.bukkit.damage.DamageSource;
++import org.bukkit.entity.Ageable;
++import org.bukkit.entity.Hoglin;
++import org.bukkit.entity.HumanEntity;
++import org.bukkit.entity.Item;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.Mob;
++import org.bukkit.entity.PiglinAbstract;
++import org.bukkit.entity.memory.MemoryKey;
++import org.bukkit.util.Vector;
++import org.checkerframework.checker.nullness.qual.Nullable;
++
++@SuppressWarnings("Convert2Diamond")
++public final class PaperMemoryMapper {
++
++    static final Map<Type, MemoryConverter<?, ?>> MEMORY_CONVERTER_MAP = new HashMap<>();
++    private static final List<MemoryConverter.Factory> MEMORY_CONVERTER_FACTORIES = new ArrayList<>();
++    private static final Map<MemoryKey<?>, MemoryConverter<?, ?>> CONVERTER_CACHE = new HashMap<>();
++
++    static {
++        register(Void.class, Long.class, Integer.class, Boolean.class, UUID.class);
++
++        register(new SimpleMemoryConverter<Location, GlobalPos>(CraftMemoryMapper::fromNms, CraftMemoryMapper::toNms) {});
++        register(new SimpleMemoryConverter<BlockPosition, BlockPos>(MCUtil::toPosition, MCUtil::toBlockPos) {});
++        register(new SimpleMemoryConverter<Vector, Vec3>(CraftVector::toBukkit, CraftVector::toNMS) {});
++        register(new SimpleMemoryConverter<DamageSource, net.minecraft.world.damagesource.DamageSource>(CraftDamageSource::new, ds -> ((CraftDamageSource) ds).getHandle()) {});
++
++        registerEntity(org.bukkit.entity.Entity.class, new EntityMemoryConverter<CraftEntity, Entity>() {});
++        registerEntity(LivingEntity.class, new EntityMemoryConverter<CraftLivingEntity, net.minecraft.world.entity.LivingEntity>() {});
++        registerEntity(Mob.class, new EntityMemoryConverter<CraftMob, net.minecraft.world.entity.Mob>() {});
++        registerEntity(Ageable.class, new EntityMemoryConverter<CraftAgeable, AgeableMob>() {});
++        registerEntity(HumanEntity.class, new EntityMemoryConverter<CraftHumanEntity, Player>() {});
++
++        registerEntity(PiglinAbstract.class, new EntityMemoryConverter<CraftPiglinAbstract, AbstractPiglin>() {});
++        registerEntity(Item.class, new EntityMemoryConverter<CraftItem, ItemEntity>() {});
++        registerEntity(Hoglin.class, new EntityMemoryConverter<CraftHoglin, net.minecraft.world.entity.monster.hoglin.Hoglin>() {});
++
++        register(new ContextAwareMemoryConverter<Pathfinder.PathResult, Path>(p -> ((PaperPathfinder.PaperPathResult) p).getHandle()) {
++            @Override
++            public Pathfinder.PathResult toBukkit(final Path nmsObject, final net.minecraft.world.entity.LivingEntity context) {
++                return new PaperPathfinder.PaperPathResult(nmsObject, context);
++            }
++        });
++
++        MEMORY_CONVERTER_FACTORIES.add((toConvert, memoryKey) -> {
++            if (memoryKey.getType() instanceof final ParameterizedType type && Collection.class.isAssignableFrom(GenericTypeReflector.erase(type))) {
++                final @Nullable MemoryConverter<?, ?> converter = MEMORY_CONVERTER_MAP.get(type.getActualTypeArguments()[0]);
++                if (converter != null) {
++                    if (toConvert instanceof List<?>) {
++                        return CollectionMemoryConverter.forList(converter);
++                    } else if (toConvert instanceof Set<?>) {
++                        return CollectionMemoryConverter.forSet(converter);
++                    }
++                }
++            }
++            return null;
++        });
++    }
++
++    private PaperMemoryMapper() {
++    }
++
++    static void register(final Class<?>... classes) {
++        for (final Class<?> clazz : classes) {
++            register(clazz, new MemoryConverter.Identity<>(clazz));
++        }
++    }
++
++    static void register(final MemoryConverter<?, ?> memoryConverter) {
++        register(((ParameterizedType) memoryConverter.getClass().getGenericSuperclass()).getActualTypeArguments()[0], memoryConverter);
++    }
++
++    static <BE extends org.bukkit.entity.Entity, CBE extends BE> void registerEntity(final Class<BE> type, final MemoryConverter<CBE, ?> entityMemoryConverter) {
++        register(type, entityMemoryConverter);
++    }
++
++    static void register(final Type type, final MemoryConverter<?, ?> memoryConverter) {
++        MEMORY_CONVERTER_MAP.put(type, memoryConverter);
++    }
++
++    public static <B, M, E extends net.minecraft.world.entity.LivingEntity> M toNms(final B object, final MemoryKey<B> memoryKey, final E context) {
++        final M nms = PaperMemoryMapper.<B, M>getConverter(object, memoryKey).toNms(object, context);
++        if (memoryKey == MemoryKey.VISIBLE_MOBS && nms instanceof List<?>) {
++            // wrap list in special type
++            return (M) new NearestVisibleLivingEntities(context, (List<net.minecraft.world.entity.LivingEntity>) nms);
++        }
++        return nms;
++    }
++
++    public static <B, M, E extends net.minecraft.world.entity.LivingEntity> B fromNms(M object, final MemoryKey<B> memoryKey, final E context) {
++        if (memoryKey == MemoryKey.VISIBLE_MOBS && object instanceof final NearestVisibleLivingEntities visibleMobs) {
++            // unwrap special type into list
++            object = (M) visibleMobs.nearbyEntities;
++        }
++        return getConverter(object, memoryKey).toBukkit(object, context);
++    }
++
++    @SuppressWarnings("unchecked")
++    static <B, M> MemoryConverter<B, M> getConverter(final Object object, final MemoryKey<B> memoryKey) {
++        final MemoryConverter<B, M> converter = (MemoryConverter<B, M>) CONVERTER_CACHE.computeIfAbsent(memoryKey, key -> {
++            for (final MemoryConverter.Factory factory : MEMORY_CONVERTER_FACTORIES) {
++                final @Nullable MemoryConverter<?, ?> fromFactory = factory.createMemoryConverter(object, memoryKey);
++                if (fromFactory != null) {
++                    return fromFactory;
++                }
++            }
++            return MEMORY_CONVERTER_MAP.get(key.getMemoryClass());
++        });
++        if (converter == null) {
++            throw new UnsupportedOperationException("Do not know how to map " + memoryKey);
++        }
++        return converter;
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/SimpleMemoryConverter.java b/src/main/java/io/papermc/paper/entity/memory/SimpleMemoryConverter.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9a0c686e1929a5249d43bd38c5c5bb1bd014f262
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/SimpleMemoryConverter.java
+@@ -0,0 +1,31 @@
++package io.papermc.paper.entity.memory;
++
++import java.lang.reflect.ParameterizedType;
++import java.lang.reflect.Type;
++import java.util.function.Function;
++import net.minecraft.world.entity.LivingEntity;
++
++abstract class SimpleMemoryConverter<B, M> implements MemoryConverter<B, M> {
++
++    private final Function<? super M, ? extends B> toBukkit;
++    private final Function<? super B, ? extends M> toNms;
++
++    SimpleMemoryConverter(final Function<? super M, ? extends B> toBukkit, final Function<? super B, ? extends M> toNms) {
++        this.toBukkit = toBukkit;
++        this.toNms = toNms;
++        final Type superType = this.getClass().getGenericSuperclass();
++        if (!(superType instanceof ParameterizedType)) {
++            throw new IllegalStateException(superType + " is not an instance of ParameterizedType");
++        }
++    }
++
++    @Override
++    public B toBukkit(final M nmsObject, final LivingEntity context) {
++        return this.toBukkit.apply(nmsObject);
++    }
++
++    @Override
++    public M toNms(final B bukkitObject, final LivingEntity context) {
++        return this.toNms.apply(bukkitObject);
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/entity/memory/package-info.java b/src/main/java/io/papermc/paper/entity/memory/package-info.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..be079bbf3aeddcc425d86a1a0aa0de2f2d5ce326
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/entity/memory/package-info.java
+@@ -0,0 +1,5 @@
++@DefaultQualifier(NonNull.class)
++package io.papermc.paper.entity.memory;
++
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index 2d4e49f386be35ee8912c1bca38f74b8d8926f3a..72efa9c7b8267aad1f8c3a5fea8638b464b223bd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -900,13 +900,20 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+ 
+     @Override
+     public <T> T getMemory(MemoryKey<T> memoryKey) {
+-        return (T) this.getHandle().getBrain().getMemory(CraftMemoryKey.bukkitToMinecraft(memoryKey)).map(CraftMemoryMapper::fromNms).orElse(null);
++        if (!this.getHandle().getBrain().hasMemoryValue(CraftMemoryKey.bukkitToMinecraft(memoryKey))) { return null; } // Paper
++        return this.getHandle().getBrain().getMemory(CraftMemoryKey.bukkitToMinecraft(memoryKey)).map(o -> io.papermc.paper.entity.memory.PaperMemoryMapper.fromNms(o, memoryKey, this.getHandle())).orElse(null); // Paper
+     }
+ 
+     @Override
+     public <T> void setMemory(MemoryKey<T> memoryKey, T t) {
+-        this.getHandle().getBrain().setMemory(CraftMemoryKey.bukkitToMinecraft(memoryKey), CraftMemoryMapper.toNms(t));
++        this.getHandle().getBrain().setMemory(CraftMemoryKey.bukkitToMinecraft(memoryKey), (Object) io.papermc.paper.entity.memory.PaperMemoryMapper.toNms(t, memoryKey, this.getHandle())); // Paper
+     }
++    // Paper start
++    @Override
++    public Collection<MemoryKey<?>> getRecognizedMemories() {
++        return java.util.Collections.unmodifiableCollection(com.google.common.collect.Collections2.transform(this.getHandle().getBrain().getMemories().keySet(), CraftMemoryKey::minecraftToBukkit));
++    }
++    // Paper end
+ 
+     @Override
+     public Sound getHurtSound() {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/memory/CraftMemoryMapper.java b/src/main/java/org/bukkit/craftbukkit/entity/memory/CraftMemoryMapper.java
+index ad42f2bf5d2bf2d1e340d1ad34ae912422c2ba5d..3098d38988f9516a4ed181b412f2371c8bea2337 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/memory/CraftMemoryMapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/memory/CraftMemoryMapper.java
+@@ -12,6 +12,7 @@ public final class CraftMemoryMapper {
+ 
+     private CraftMemoryMapper() {}
+ 
++    @Deprecated // Paper
+     public static Object fromNms(Object object) {
+         if (object instanceof GlobalPos) {
+             return CraftMemoryMapper.fromNms((GlobalPos) object);
+@@ -28,6 +29,7 @@ public final class CraftMemoryMapper {
+         throw new UnsupportedOperationException("Do not know how to map " + object);
+     }
+ 
++    @Deprecated // Paper
+     public static Object toNms(Object object) {
+         if (object == null) {
+             return null;
+diff --git a/src/test/java/io/papermc/paper/entity/memory/MemoryKeyTest.java b/src/test/java/io/papermc/paper/entity/memory/MemoryKeyTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..9251335e2af6775ed6262a8f8d9d1d1f42da04d4
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/entity/memory/MemoryKeyTest.java
+@@ -0,0 +1,117 @@
++package io.papermc.paper.entity.memory;
++
++import io.leangen.geantyref.GenericTypeReflector;
++import java.lang.reflect.Field;
++import java.lang.reflect.Modifier;
++import java.lang.reflect.ParameterizedType;
++import java.lang.reflect.Type;
++import java.util.ArrayList;
++import java.util.Collection;
++import java.util.HashMap;
++import java.util.HashSet;
++import java.util.List;
++import java.util.Map;
++import java.util.Set;
++import net.minecraft.core.registries.BuiltInRegistries;
++import net.minecraft.world.entity.ai.memory.MemoryModuleType;
++import org.bukkit.Registry;
++import org.bukkit.craftbukkit.entity.memory.CraftMemoryKey;
++import org.bukkit.entity.LivingEntity;
++import org.bukkit.entity.memory.MemoryKey;
++import org.bukkit.support.AbstractTestingBase;
++import org.junit.jupiter.api.BeforeAll;
++import org.junit.jupiter.api.Test;
++
++import static org.junit.jupiter.api.Assertions.assertFalse;
++import static org.junit.jupiter.api.Assertions.assertNotNull;
++import static org.junit.jupiter.api.Assertions.assertTrue;
++
++class MemoryKeyTest extends AbstractTestingBase {
++
++    static Map<MemoryModuleType<?>, Type> memoryModuleTypes = new HashMap<>();
++    static Set<MemoryModuleType<?>> collections = new HashSet<>();
++
++    @BeforeAll
++    public static void beforeTests() throws IllegalAccessException {
++        for (Field field : MemoryModuleType.class.getFields()) {
++            if (!Modifier.isStatic(field.getModifiers())
++                || !MemoryModuleType.class.isAssignableFrom(field.getType())
++                || !(field.getGenericType() instanceof ParameterizedType paramType
++            ) ) {
++                continue;
++            }
++            if (paramType.getActualTypeArguments().length != 1) {
++                continue;
++            }
++            final MemoryModuleType<?> memoryModuleType = (MemoryModuleType<?>) field.get(null);
++            memoryModuleTypes.put(memoryModuleType, field.getGenericType());
++            if (Collection.class.isAssignableFrom(GenericTypeReflector.erase(paramType.getActualTypeArguments()[0])) || memoryModuleType == MemoryModuleType.NEAREST_VISIBLE_LIVING_ENTITIES) {
++                // special case "NEAREST_VISIBLE_LIVING_ENTITIES" because it's represented as a collection in the API
++                collections.add(memoryModuleType);
++            }
++        }
++    }
++
++    @Test
++    public void testKeysHaveNmsEquivalent() {
++        for (final MemoryKey<?> memoryKey : Registry.MEMORY_MODULE_TYPE) {
++            assertNotNull(CraftMemoryKey.bukkitToMinecraft(memoryKey), memoryKey.getKey() + " does not match an nms memory key");
++        }
++    }
++
++    @Test
++    public void testMemoryTypesHaveBukkitEquivalent() {
++        final Set<String> missing = new HashSet<>();
++        for (final MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
++            if (shouldSkipMemoryModuleType(memoryModuleType)) continue;
++            final MemoryKey<?> key = CraftMemoryKey.minecraftToBukkit(memoryModuleType);
++            if (key == null) {
++                missing.add(memoryModuleType.toString());
++            }
++        }
++        assertTrue(missing.isEmpty(), "Missing MemoryKeys for \n" + String.join("\n", missing));
++    }
++
++
++    @Test
++    public void testIfCollection() {
++        boolean foundCollections = false;
++        for (final MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
++            if (collections.contains(memoryModuleType)) {
++                foundCollections = true;
++                assertTrue(CraftMemoryKey.minecraftToBukkit(memoryModuleType).isCollection(), "Failed to recognize " + memoryModuleType + " as a collection");
++            }
++
++        }
++        assertTrue(foundCollections, "No collection memory types found");
++    }
++
++    @Test
++    public void testGetNonCollectionConverter() {
++        for (final MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
++            if (shouldSkipMemoryModuleType(memoryModuleType)) continue;
++            if (!collections.contains(memoryModuleType)) {
++                final MemoryKey<?> bukkitKey = CraftMemoryKey.minecraftToBukkit(memoryModuleType);
++                assertFalse(bukkitKey.isCollection(), "Should not be a collection, this is just testing non-collections: " + bukkitKey);
++                assertNotNull(PaperMemoryMapper.MEMORY_CONVERTER_MAP.get(bukkitKey.getMemoryClass()), "Could not find a converter for: " + bukkitKey.getMemoryClass());
++                assertNotNull(PaperMemoryMapper.MEMORY_CONVERTER_MAP);
++            }
++        }
++    }
++
++    @Test
++    public void testGetCollectionConverter() {
++        final List<LivingEntity> nmsList = new ArrayList<>();
++        final MemoryConverter<List<LivingEntity>, List<net.minecraft.world.entity.LivingEntity>> listConverter = PaperMemoryMapper.getConverter(nmsList, MemoryKey.MOBS);
++        assertNotNull(listConverter);
++
++        // Throws error if none found
++        PaperMemoryMapper.fromNms(nmsList, MemoryKey.MOBS, null);
++    }
++
++    private static boolean shouldSkipMemoryModuleType(final MemoryModuleType<?> moduleType) {
++        // The following are skipped because of missing API
++        return moduleType == MemoryModuleType.WALK_TARGET
++            || moduleType == MemoryModuleType.LOOK_TARGET;
++    }
++}
+diff --git a/src/test/java/org/bukkit/entity/memory/CraftMemoryKeyTest.java b/src/test/java/org/bukkit/entity/memory/CraftMemoryKeyTest.java
+index fe17d6e580f89a5e784e461601510294651fc74a..629c8eb64e5b179180f4feff795cbe5abae9a02d 100644
+--- a/src/test/java/org/bukkit/entity/memory/CraftMemoryKeyTest.java
++++ b/src/test/java/org/bukkit/entity/memory/CraftMemoryKeyTest.java
+@@ -48,30 +48,30 @@ public class CraftMemoryKeyTest extends AbstractTestingBase {
+         assertEquals(MemoryKey.MEETING_POINT, bukkitHomeKey, "MemoryKey should be MEETING_POINT");
+     }
+ 
+-    @Test
+-    public void shouldReturnNullWhenBukkitRepresentationOfKeyisNotAvailable() {
+-        MemoryKey bukkitNoKey = CraftMemoryKey.minecraftToBukkit(MemoryModuleType.NEAREST_LIVING_ENTITIES);
+-        assertNull(bukkitNoKey, "MemoryModuleType should be null");
+-    }
+-
+-    @Test
+-    public void shouldReturnNullWhenBukkitRepresentationOfKeyisNotAvailableAndSerializerIsNotPresent() {
+-        for (MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
+-            if (!memoryModuleType.getCodec().isPresent()) {
+-                MemoryKey bukkitNoKey = CraftMemoryKey.minecraftToBukkit(memoryModuleType);
+-                assertNull(bukkitNoKey, "MemoryModuleType should be null");
+-            }
+-        }
+-    }
+-
+-    @Test
+-    @Disabled("Unit type not yet implemented")
+-    public void shouldReturnAnInstanceOfMemoryKeyWhenBukkitRepresentationOfKeyisAvailableAndSerializerIsPresent() {
+-        for (MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
+-            if (memoryModuleType.getCodec().isPresent()) {
+-                MemoryKey bukkitNoKey = CraftMemoryKey.minecraftToBukkit(memoryModuleType);
+-                assertNotNull(bukkitNoKey, "MemoryModuleType should not be null " + BuiltInRegistries.MEMORY_MODULE_TYPE.getKey(memoryModuleType));
+-            }
+-        }
+-    }
++    // @Test
++    // public void shouldReturnNullWhenBukkitRepresentationOfKeyisNotAvailable() {
++    //     MemoryKey bukkitNoKey = CraftMemoryKey.minecraftToBukkit(MemoryModuleType.NEAREST_LIVING_ENTITIES);
++    //     Assert.assertNull("MemoryModuleType should be null", bukkitNoKey);
++    // }
++    //
++    // @Test
++    // public void shouldReturnNullWhenBukkitRepresentationOfKeyisNotAvailableAndSerializerIsNotPresent() {
++    //     for (MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
++    //         if (!memoryModuleType.getCodec().isPresent()) {
++    //             MemoryKey bukkitNoKey = CraftMemoryKey.toMemoryKey(memoryModuleType);
++    //             Assert.assertNull("MemoryModuleType should be null", bukkitNoKey);
++    //         }
++    //     }
++    // }
++    //
++    // @Test
++    // @Ignore("Unit type not yet implemented")
++    // public void shouldReturnAnInstanceOfMemoryKeyWhenBukkitRepresentationOfKeyisAvailableAndSerializerIsPresent() {
++    //     for (MemoryModuleType<?> memoryModuleType : BuiltInRegistries.MEMORY_MODULE_TYPE) {
++    //         if (memoryModuleType.getCodec().isPresent()) {
++    //             MemoryKey bukkitNoKey = CraftMemoryKey.toMemoryKey(memoryModuleType);
++    //             Assert.assertNotNull("MemoryModuleType should not be null " + BuiltInRegistries.MEMORY_MODULE_TYPE.getKey(memoryModuleType), bukkitNoKey);
++    //         }
++    //     }
++    // }
+ }


### PR DESCRIPTION
So I added a bunch more of the memory keys. 
Pretty sure I tested one of every type to ensure the conversions were working correctly.

Only ones I **didn't** add keys for, are the ones without a clear bukkit equivalent class to its type. These are the nms classes I didn't know of a bukkit equivalent for:
* PositionTracker
* WalkTarget
* DamageSource (1.19.4 should make adding API for this nicer)
* Path (just needs a slight re-work of paper's path api impl)