### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -3517,7 +3517,7 @@ index 254953c1d8ad80173bcc9ed703bacaf32ca89c9a..7dea5e783ce2a1f8ddd2b3ab7a19e03a
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index b9a0b37ceeeda9f6b1c4c23283e53dcb229f7249..0bf95b97140a67682ec2953ccc773f6faad7b7da 100644
+index 565aa1690d5427f5059ab117c4c15b0754e8830b..19856555793f742abb1178ede72dea5623f0e383 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -54,6 +54,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
@@ -3570,7 +3570,7 @@ index b9a0b37ceeeda9f6b1c4c23283e53dcb229f7249..0bf95b97140a67682ec2953ccc773f6f
      private CompletableFuture<Either<List<IChunkAccess>, PlayerChunk.Failure>> a(ChunkCoordIntPair chunkcoordintpair, int i, IntFunction<ChunkStatus> intfunction) {
          List<CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>>> list = Lists.newArrayList();
          int j = chunkcoordintpair.x;
-@@ -945,6 +974,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -953,6 +982,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (!flag1) {
                  this.chunkDistanceManager.a(SectionPosition.a((Entity) entityplayer), entityplayer);
              }
@@ -3578,7 +3578,7 @@ index b9a0b37ceeeda9f6b1c4c23283e53dcb229f7249..0bf95b97140a67682ec2953ccc773f6f
          } else {
              SectionPosition sectionposition = entityplayer.O();
  
-@@ -952,6 +982,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -960,6 +990,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              if (!flag2) {
                  this.chunkDistanceManager.b(sectionposition, entityplayer);
              }
@@ -3586,7 +3586,7 @@ index b9a0b37ceeeda9f6b1c4c23283e53dcb229f7249..0bf95b97140a67682ec2953ccc773f6f
          }
  
          for (int k = i - this.viewDistance; k <= i + this.viewDistance; ++k) {
-@@ -1062,6 +1093,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1070,6 +1101,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              }
          }
  

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1154,7 +1154,7 @@ index 0b5bcb60472c778574702a5ac26a6d02d54bfeac..9ed97d5db81e3603ccccca7500420d7e
  
      private void a(long i, Consumer<Chunk> consumer) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 0bf95b97140a67682ec2953ccc773f6faad7b7da..9eae9d7e9d18d73b1050e1d9b8859802cbd286ed 100644
+index 19856555793f742abb1178ede72dea5623f0e383..62245fa420390dc0a70ba9a95505dc46cd8aa64a 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -1,7 +1,9 @@
@@ -1211,7 +1211,7 @@ index 0bf95b97140a67682ec2953ccc773f6faad7b7da..9eae9d7e9d18d73b1050e1d9b8859802
                  ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
                  Chunk chunk;
  
-@@ -711,6 +717,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -719,6 +725,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  }
  
                  return chunk;
@@ -1219,7 +1219,7 @@ index 0bf95b97140a67682ec2953ccc773f6faad7b7da..9eae9d7e9d18d73b1050e1d9b8859802
              });
          }, (runnable) -> {
              Mailbox mailbox = this.mailboxMain;
-@@ -1169,6 +1176,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1177,6 +1184,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
          PlayerChunkMap.EntityTracker playerchunkmap_entitytracker;
          ObjectIterator objectiterator;
@@ -1227,7 +1227,7 @@ index 0bf95b97140a67682ec2953ccc773f6faad7b7da..9eae9d7e9d18d73b1050e1d9b8859802
  
          for (objectiterator = this.trackedEntities.values().iterator(); objectiterator.hasNext(); playerchunkmap_entitytracker.trackerEntry.a()) {
              playerchunkmap_entitytracker = (PlayerChunkMap.EntityTracker) objectiterator.next();
-@@ -1186,16 +1194,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1194,16 +1202,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  playerchunkmap_entitytracker.e = sectionposition1;
              }
          }

--- a/Spigot-Server-Patches/0038-Send-absolute-position-the-first-time-an-entity-is-s.patch
+++ b/Spigot-Server-Patches/0038-Send-absolute-position-the-first-time-an-entity-is-s.patch
@@ -77,10 +77,10 @@ index 9ad74b380a92e3a563e1a891e81401d8b4707bcf..beb0beb716869978be6bc5a78ce3b6cf
  
                  this.c();
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 9eae9d7e9d18d73b1050e1d9b8859802cbd286ed..e9657faf0a24aee8444372e6f1ca0d971339ce5a 100644
+index 62245fa420390dc0a70ba9a95505dc46cd8aa64a..788a45d5426f0752509442aec2d28b1f32f63cb1 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -1295,10 +1295,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1303,10 +1303,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          private final Entity tracker;
          private final int trackingDistance;
          private SectionPosition e;
@@ -97,7 +97,7 @@ index 9eae9d7e9d18d73b1050e1d9b8859802cbd286ed..e9657faf0a24aee8444372e6f1ca0d97
              this.tracker = entity;
              this.trackingDistance = i;
              this.e = SectionPosition.a(entity);
-@@ -1380,7 +1384,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1388,7 +1392,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      entityplayer.removeQueue.remove(Integer.valueOf(this.tracker.getId()));
                      // CraftBukkit end
  

--- a/Spigot-Server-Patches/0055-Add-exception-reporting-event.patch
+++ b/Spigot-Server-Patches/0055-Add-exception-reporting-event.patch
@@ -49,10 +49,10 @@ index 0000000000000000000000000000000000000000..f699ce18ca044f813e194ef2786b7ea8
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index e9657faf0a24aee8444372e6f1ca0d971339ce5a..e8150c456efe72a561d6a6a7647eca05fbc8bd94 100644
+index 788a45d5426f0752509442aec2d28b1f32f63cb1..2511fbe7aa5ff1ace71b513d2938975e388295c6 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -807,6 +807,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -815,6 +815,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return true;
              } catch (Exception exception) {
                  PlayerChunkMap.LOGGER.error("Failed to save chunk {},{}", chunkcoordintpair.x, chunkcoordintpair.z, exception);

--- a/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
@@ -9,7 +9,7 @@ from triggering monster spawns on a server.
 Also a highly more effecient way to blanket block spawns in a world
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
-index 95af66ebb7849cbf2bcad6bc52aeb85ab2601b6c..eb576566708d50c002e73aa746d2bc58b9b04c2b 100644
+index 9ed97d5db81e3603ccccca7500420d7e401ef2a5..b9bde85a90b429659e1a4ab111253cddd797368e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 @@ -611,6 +611,15 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -29,7 +29,7 @@ index 95af66ebb7849cbf2bcad6bc52aeb85ab2601b6c..eb576566708d50c002e73aa746d2bc58
                  Optional<Chunk> optional = ((Either) playerchunk.a().getNow(PlayerChunk.UNLOADED_CHUNK)).left();
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index afa87cf70ad978161853771c59f5a4906733cab3..8b79d547a3296f056731cbb66508494d84809e94 100644
+index 09385eabefeb7d59de1ce4138648badd123396f9..3d517ab98da5fd56101e97b5678f7180839269f8 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1,5 +1,6 @@
@@ -48,10 +48,10 @@ index afa87cf70ad978161853771c59f5a4906733cab3..8b79d547a3296f056731cbb66508494d
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> cachedSingleHashSet; // Paper
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 56f83a930c3dad1a1de366bff530131d92b4893c..c6b9b02e6d31bebb3f8c0cadd68e4b5c47fab090 100644
+index 1d71a19a7bbe463f537861531113dd1ed3e5b977..d1e45dfb99074ec027d4f943391a024c726d93b2 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -958,12 +958,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -966,12 +966,23 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          chunkRange = (chunkRange > world.spigotConfig.viewDistance) ? (byte) world.spigotConfig.viewDistance : chunkRange;
          chunkRange = (chunkRange > 8) ? 8 : chunkRange;
  

--- a/Spigot-Server-Patches/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/Spigot-Server-Patches/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Debug Entities option to debug dupe uuid issues
 Add -Ddebug.entities=true to your JVM flags to gain more information
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index c6b9b02e6d31bebb3f8c0cadd68e4b5c47fab090..c4dd2bac48bb93117925b35dcd753d0fbb22e3cf 100644
+index d1e45dfb99074ec027d4f943391a024c726d93b2..66c808244bba70f827d8f15a96814251d352a046 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -1139,6 +1139,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1147,6 +1147,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              } else {
                  PlayerChunkMap.EntityTracker playerchunkmap_entitytracker = new PlayerChunkMap.EntityTracker(entity, i, j, entitytypes.isDeltaTracking());
  
@@ -17,7 +17,7 @@ index c6b9b02e6d31bebb3f8c0cadd68e4b5c47fab090..c4dd2bac48bb93117925b35dcd753d0f
                  this.trackedEntities.put(entity.getId(), playerchunkmap_entitytracker);
                  playerchunkmap_entitytracker.track(this.world.getPlayers());
                  if (entity instanceof EntityPlayer) {
-@@ -1180,7 +1181,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1188,7 +1189,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          if (playerchunkmap_entitytracker1 != null) {
              playerchunkmap_entitytracker1.a();
          }
@@ -27,7 +27,7 @@ index c6b9b02e6d31bebb3f8c0cadd68e4b5c47fab090..c4dd2bac48bb93117925b35dcd753d0f
  
      protected void g() {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 9af581339884d99709242735ad655d90faf7224a..14321bc6ecc5ca70e71c1eef9578091822aa94cd 100644
+index d6a4ec132cadf8134a21f625f4ca978d37c643d0..650015f08ef4defe7510ff2f5cbd25364b733515 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -197,6 +197,9 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0351-Duplicate-UUID-Resolve-Option.patch
@@ -81,7 +81,7 @@ index fbf3ccfb347a5ba6e895339e9576629d940d1aa4..38d25a12c6a52d8a83214e2a0f43a218
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index c4dd2bac48bb93117925b35dcd753d0fbb22e3cf..aeed11cfee42fbde2c2e5731f46ac24de6469e0e 100644
+index 66c808244bba70f827d8f15a96814251d352a046..b736917891afb17e412f94c5d8713aa653b8dc46 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -1,6 +1,7 @@
@@ -118,13 +118,20 @@ index c4dd2bac48bb93117925b35dcd753d0fbb22e3cf..aeed11cfee42fbde2c2e5731f46ac24d
  import net.minecraft.world.level.chunk.Chunk;
  import net.minecraft.world.level.chunk.ChunkConverter;
  import net.minecraft.world.level.chunk.ChunkGenerator;
-@@ -697,12 +702,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
-                             // CraftBukkit start - these are spawned serialized (DefinedStructure) and we don't call an add event below at the moment due to ordering complexities
-                             boolean needsRemoval = false;
-                             if (chunk.needsDecoration && !this.world.getServer().getServer().getSpawnNPCs() && entity instanceof net.minecraft.world.entity.npc.NPC) {
--                                entity.die();
-+                                entity.dead = true; // Paper
-                                 needsRemoval = true;
+@@ -699,18 +704,18 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+                             if (chunk.needsDecoration) {
+                                 net.minecraft.server.dedicated.DedicatedServer server = this.world.getServer().getServer();
+                                 if (!server.getSpawnNPCs() && entity instanceof net.minecraft.world.entity.npc.NPC) {
+-                                    entity.die();
++                                    entity.dead = true; // Paper
+                                     needsRemoval = true;
+                                 }
+ 
+                                 if (!server.getSpawnAnimals() && (entity instanceof net.minecraft.world.entity.animal.EntityAnimal || entity instanceof net.minecraft.world.entity.animal.EntityWaterAnimal)) {
+-                                    entity.die();
++                                    entity.dead = true; // Paper
+                                     needsRemoval = true;
+                                 }
                              }
 -
 -                            if (!(entity instanceof EntityHuman) && (needsRemoval || !this.world.addEntityChunk(entity))) {
@@ -135,7 +142,7 @@ index c4dd2bac48bb93117925b35dcd753d0fbb22e3cf..aeed11cfee42fbde2c2e5731f46ac24d
                                  if (list == null) {
                                      list = Lists.newArrayList(new Entity[]{entity});
                                  } else {
-@@ -729,6 +734,44 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -737,6 +742,44 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          });
      }
  
@@ -181,7 +188,7 @@ index c4dd2bac48bb93117925b35dcd753d0fbb22e3cf..aeed11cfee42fbde2c2e5731f46ac24d
          ChunkCoordIntPair chunkcoordintpair = playerchunk.i();
          CompletableFuture<Either<List<IChunkAccess>, PlayerChunk.Failure>> completablefuture = this.a(chunkcoordintpair, 1, (i) -> {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 61d3524e962b97ed032af1990f8dc6513fbe51d6..a7fbbb755b2e829022efb0ae63fc1020d5adda4f 100644
+index 4e26db120e544d8867d895395241e425f23f575b..fbff779fa581a661cc03850bffa0da346ce15625 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -4,6 +4,8 @@ import com.google.common.annotations.VisibleForTesting;

--- a/Spigot-Server-Patches/0359-Fix-World-isChunkGenerated-calls.patch
+++ b/Spigot-Server-Patches/0359-Fix-World-isChunkGenerated-calls.patch
@@ -76,10 +76,10 @@ index 9891cf98f8c740f84f9135ee8176e67abb648b3a..6bced8533df49d7bfdb32dfa0caad9d7
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> getStatusFutureUnchecked(ChunkStatus chunkstatus) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index a0fcd20d4a7e951437756edb60a44c627612e04c..ccfde274edfe1b611ccf8c583c92b16d52e4518d 100644
+index 27211cb52bf227e2c40313390f49ca18a1d947fb..1272d26124685e19f73e277b5a74108f3363b71a 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -985,12 +985,61 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -993,12 +993,61 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      @Nullable
@@ -294,7 +294,7 @@ index ab9f4d40fd1126a3d7ba5b16fdc6ab09de4a7fdb..55e7e983d2c760a8052d7b3ddbdc8447
          } catch (Throwable throwable1) {
              throwable = throwable1;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c19ac8c28a799bebf68f098171cefd0fc3ec3f0b..57e8b8078aaa92d0869ab2aeb17a5f53c5e7b2bb 100644
+index ec9f9fdf1be4f1e68eea5554a6721efd11a53958..d46c513512c25e55ccdb0be16524f19444c358c5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -19,6 +19,7 @@ import java.util.Objects;

--- a/Spigot-Server-Patches/0363-Anti-Xray.patch
+++ b/Spigot-Server-Patches/0363-Anti-Xray.patch
@@ -1135,7 +1135,7 @@ index a7d10d124021f3427f23fcd533f885367b64515c..3047cf8c4ec1b664d6b790f18d2b1657
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 1f32ab230d650bb5f652efbacdd5e4b90dc4de89..71c2792d7eede35485cc36ac929cf295bcd4646b 100644
+index 0a8447327d2b6719b635b0362f725c0c6233d805..ec3c717cf63848f1d949e932b081a8db65294d65 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -656,7 +656,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -1147,7 +1147,7 @@ index 1f32ab230d650bb5f652efbacdd5e4b90dc4de89..71c2792d7eede35485cc36ac929cf295
          }, this.executor);
      }
  
-@@ -1396,9 +1396,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1404,9 +1404,10 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -1173,7 +1173,7 @@ index d86b1e528b53db809ac993aa2f1d2799d4f1a574..fbd8a6985a261396789c87e4b687140b
  
      public void a(BlockPosition blockposition, PacketPlayInBlockDig.EnumPlayerDigType packetplayinblockdig_enumplayerdigtype, String s) {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 735da5729c16940e3d8877f32a40342b9d1e989d..caf3d4df460d2d6dad6e68a68e1256e3603e3891 100644
+index d7fe6f00b352dad9e9f579f9af86cb8b90ef83ae..e2c0d30c5b25f9c44025f0619ba254c89402d9f9 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -210,7 +210,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
@@ -2601,7 +2601,7 @@ index 75d4a8fc394449ccc006fe67a8842edcd9f36854..6433463938d8bb717840c8f57fe6e707
                  completablefuture = (CompletableFuture) this.statusFutures.get(i);
                  if (completablefuture != null) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d80173c3b 100644
+index ec3c717cf63848f1d949e932b081a8db65294d65..88c9fd204203ba87498948eded57aad678e6d9b6 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -88,6 +88,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
@@ -2860,7 +2860,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
      }
  
      private void g(ChunkCoordIntPair chunkcoordintpair) {
-@@ -884,6 +982,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -892,6 +990,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public boolean saveChunk(IChunkAccess ichunkaccess) {
@@ -2868,7 +2868,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
          this.m.a(ichunkaccess.getPos());
          if (!ichunkaccess.isNeedsSaving()) {
              return false;
-@@ -896,6 +995,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -904,6 +1003,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  ChunkStatus chunkstatus = ichunkaccess.getChunkStatus();
  
                  if (chunkstatus.getType() != ChunkStatus.Type.LEVELCHUNK) {
@@ -2876,7 +2876,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
                      if (this.h(chunkcoordintpair)) {
                          return false;
                      }
-@@ -903,12 +1003,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -911,12 +1011,20 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      if (chunkstatus == ChunkStatus.EMPTY && ichunkaccess.h().values().stream().noneMatch(StructureStart::e)) {
                          return false;
                      }
@@ -2899,7 +2899,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
                  this.a(chunkcoordintpair, chunkstatus.getType());
                  return true;
              } catch (Exception exception) {
-@@ -917,6 +1025,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -925,6 +1033,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return false;
              }
          }
@@ -2907,7 +2907,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
      }
  
      private boolean h(ChunkCoordIntPair chunkcoordintpair) {
-@@ -1046,6 +1155,35 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1054,6 +1163,35 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
      }
  
@@ -2943,7 +2943,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
      @Nullable
      public NBTTagCompound readChunkData(ChunkCoordIntPair chunkcoordintpair) throws IOException { // Paper - private -> public
          NBTTagCompound nbttagcompound = this.read(chunkcoordintpair);
-@@ -1067,33 +1205,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1075,33 +1213,55 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      // Paper start - chunk status cache "api"
      public ChunkStatus getChunkStatusOnDiskIfCached(ChunkCoordIntPair chunkPos) {
@@ -3010,7 +3010,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
      }
  
      public IChunkAccess getUnloadingChunk(int chunkX, int chunkZ) {
-@@ -1102,6 +1262,39 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1110,6 +1270,39 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end
  
@@ -3050,7 +3050,7 @@ index 71c2792d7eede35485cc36ac929cf295bcd4646b..a6c3bed5824d112042536a5666098d4d
      boolean isOutsideOfRange(ChunkCoordIntPair chunkcoordintpair) {
          // Spigot start
          return isOutsideOfRange(chunkcoordintpair, false);
-@@ -1448,6 +1641,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1456,6 +1649,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  

--- a/Spigot-Server-Patches/0400-Tracking-Range-Improvements.patch
+++ b/Spigot-Server-Patches/0400-Tracking-Range-Improvements.patch
@@ -8,10 +8,10 @@ Sets tracking range of watermobs to animals instead of misc and simplifies code
 Also ignores Enderdragon, defaulting it to Mojang's setting
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 9c5b1dd305567f09a23a3f189d4dadba323b643e..4be5f3be285b1944eee66684c1a565ac1eceb024 100644
+index cee5a73c2e5b9eed0ed5b271a9648d8929bb829b..fd1924016518d6edc0508311704763841d8c8493 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -1789,6 +1789,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1797,6 +1797,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              while (iterator.hasNext()) {
                  Entity entity = (Entity) iterator.next();
                  int j = entity.getEntityType().getChunkRange() * 16;

--- a/Spigot-Server-Patches/0423-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/Spigot-Server-Patches/0423-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,10 +7,10 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 4be5f3be285b1944eee66684c1a565ac1eceb024..12cfe9f3c89316557e94c8b944b4f82277fb8877 100644
+index fd1924016518d6edc0508311704763841d8c8493..adc7cd577fe8ea5de5de2ba8b32c4578d27748cc 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -1495,6 +1495,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1503,6 +1503,14 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      protected void addEntity(Entity entity) {
          org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
@@ -26,7 +26,7 @@ index 4be5f3be285b1944eee66684c1a565ac1eceb024..12cfe9f3c89316557e94c8b944b4f822
              EntityTypes<?> entitytypes = entity.getEntityType();
              int i = entitytypes.getChunkRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 49a4c2ab35e00cc30bcfad7c702f9278db7b1155..5d085321414134043e52d8012e12a8891529097c 100644
+index a71531d6d329b11b9ad535786d26c4c2327bcbb9..8159baec6e862580dc340d8fd7c16013ec8f0e66 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1531,7 +1531,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0427-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/Spigot-Server-Patches/0427-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -83,7 +83,7 @@ index a444f6214b90f7707be2265f4b2ab12632986c53..138676e5b03bc80a777a1f4c12f3f4b5
  
                  if (optional.isPresent()) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 12cfe9f3c89316557e94c8b944b4f82277fb8877..8050be2ed04fb0b8141f92595680407bba65dad5 100644
+index adc7cd577fe8ea5de5de2ba8b32c4578d27748cc..c308c5eb0c1ce4b10cef97a9cbb2e2bb79a7ea43 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -106,8 +106,33 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -227,7 +227,7 @@ index 12cfe9f3c89316557e94c8b944b4f82277fb8877..8050be2ed04fb0b8141f92595680407b
              this.updatingChunksModified = false;
              return true;
          }
-@@ -1133,12 +1215,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1141,12 +1223,12 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      protected Iterable<PlayerChunk> f() {

--- a/Spigot-Server-Patches/0448-Fix-Chunk-Post-Processing-deadlock-risk.patch
+++ b/Spigot-Server-Patches/0448-Fix-Chunk-Post-Processing-deadlock-risk.patch
@@ -37,7 +37,7 @@ index 2d7d2e712a7117e6985e3104097a31a5577c1b82..6e5d21af43261dc2f12ceec7b7e3269b
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index bb9c6e9aeb1f30af01338476ba1dd618b14124d5..80c7ff059b78f55ec9c390bd728186a94074e603 100644
+index 21bd5524af246cd19996dc8ec2e969d981cf8ee9..a7efc5c7e4da8f18ecfd6a335a01709db4259367 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -183,6 +183,8 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -49,7 +49,7 @@ index bb9c6e9aeb1f30af01338476ba1dd618b14124d5..80c7ff059b78f55ec9c390bd728186a9
      // Paper start - distance maps
      private final com.destroystokyo.paper.util.misc.PooledLinkedHashSets<EntityPlayer> pooledLinkedPlayerHashSets = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets<>();
  
-@@ -1048,7 +1050,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1056,7 +1058,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  return Either.left(chunk);
              });
          }, (runnable) -> {

--- a/Spigot-Server-Patches/0451-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/Spigot-Server-Patches/0451-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -40,10 +40,10 @@ index d010aed07a1e608897ca5f87afcb7661e295d933..abd2554b6e98c25b59b9989936af8b06
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 80c7ff059b78f55ec9c390bd728186a94074e603..94860c06717e8dcf969277562e88687e9a99aaa4 100644
+index a7efc5c7e4da8f18ecfd6a335a01709db4259367..c90bc462627f71c2ce72a89fe2aa28203df73e52 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -1578,7 +1578,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1586,7 +1586,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          });
      }
  
@@ -52,7 +52,7 @@ index 80c7ff059b78f55ec9c390bd728186a94074e603..94860c06717e8dcf969277562e88687e
          org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
          // Paper start - ignore and warn about illegal addEntity calls instead of crashing server
          if (!entity.valid || entity.world != this.world || this.trackedEntities.containsKey(entity.getId())) {
-@@ -1587,6 +1587,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1595,6 +1595,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  .printStackTrace();
              return;
          }

--- a/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
@@ -30,7 +30,7 @@ index 6110d7723b70df5380338a42b5cbff3446294bac..b64aa6c9ce906b08e43891f8c465fa4e
          List<Entity> list = this.tracker.getPassengers();
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f08c19ab1c 100644
+index 216723730f151a1da73743ad7c6c31bbdb9890f0..67bea47a2248d228fd070bc0aa66f05b71a76ef5 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -61,6 +61,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutMapChunk;
@@ -144,7 +144,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1484,17 +1558,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1492,17 +1566,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
  
      public void movePlayer(EntityPlayer entityplayer) {
@@ -163,7 +163,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
  
          int i = MathHelper.floor(entityplayer.locX()) >> 4;
          int j = MathHelper.floor(entityplayer.locZ()) >> 4;
-@@ -1610,7 +1674,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1618,7 +1682,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
                  entity.tracker = playerchunkmap_entitytracker; // Paper - Fast access to tracker
                  this.trackedEntities.put(entity.getId(), playerchunkmap_entitytracker);
@@ -172,7 +172,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
                  if (entity instanceof EntityPlayer) {
                      EntityPlayer entityplayer = (EntityPlayer) entity;
  
-@@ -1653,7 +1717,37 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1661,7 +1725,37 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          entity.tracker = null; // Paper - We're no longer tracked
      }
  
@@ -210,7 +210,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
          List<EntityPlayer> list = Lists.newArrayList();
          List<EntityPlayer> list1 = this.world.getPlayers();
  
-@@ -1722,23 +1816,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1730,23 +1824,31 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          PacketDebug.a(this.world, chunk.getPos());
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
@@ -254,7 +254,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
  
          Iterator iterator;
          Entity entity1;
-@@ -1776,7 +1878,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1784,7 +1886,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      public class EntityTracker {
  
@@ -263,7 +263,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
          private final Entity tracker;
          private final int trackingDistance;
          private SectionPosition e;
-@@ -1793,6 +1895,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1801,6 +1903,42 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.e = SectionPosition.a(entity);
          }
  
@@ -306,7 +306,7 @@ index 042a6beb8cada116d54bed18181de291bf5ed1bb..c30ec3ad68fc10d01d0b3dd1feea32f0
          public boolean equals(Object object) {
              return object instanceof PlayerChunkMap.EntityTracker ? ((PlayerChunkMap.EntityTracker) object).tracker.getId() == this.tracker.getId() : false;
          }
-@@ -1893,7 +2031,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1901,7 +2039,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  int j = entity.getEntityType().getChunkRange() * 16;
                  j = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, j); // Paper
  

--- a/Spigot-Server-Patches/0467-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/Spigot-Server-Patches/0467-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -192,7 +192,7 @@ index 445dba8ed210407664904b707c36c78a76f25510..25484cac9c62e49de39fbbf506fcb3ed
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index c30ec3ad68fc10d01d0b3dd1feea32f08c19ab1c..3c49ca30959204840a656c1a44de50a60ea1c7df 100644
+index 67bea47a2248d228fd070bc0aa66f05b71a76ef5..095d941f33ff297b4573aee5d9ce2233a4b85838 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -210,6 +210,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -308,7 +308,7 @@ index c30ec3ad68fc10d01d0b3dd1feea32f08c19ab1c..3c49ca30959204840a656c1a44de50a6
              }
  
              if (playerchunk != null) {
-@@ -1487,30 +1542,53 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1495,30 +1550,53 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          return isOutsideOfRange(chunkcoordintpair, false);
      }
  

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -179,7 +179,7 @@ index 25484cac9c62e49de39fbbf506fcb3edc4ba6e65..1f6333c2c26ad04e23d2881235ed1dcf
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a950845eaf 100644
+index 095d941f33ff297b4573aee5d9ce2233a4b85838..057cc41af7274a6307a07ae6ab0e2e7f2efb5cc5 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -60,9 +60,11 @@ import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
@@ -330,7 +330,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      }
  
      public void updatePlayerMobTypeMap(Entity entity) {
-@@ -1193,15 +1287,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1201,15 +1295,11 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          completablefuture1.thenAcceptAsync((either) -> {
              either.mapLeft((chunk) -> {
                  this.u.getAndIncrement();
@@ -348,7 +348,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
          });
          return completablefuture1;
      }
-@@ -1296,32 +1386,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1304,32 +1394,38 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          }
      }
  
@@ -402,7 +402,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
  
      protected void sendChunk(EntityPlayer entityplayer, ChunkCoordIntPair chunkcoordintpair, Packet<?>[] apacket, boolean flag, boolean flag1) {
          if (entityplayer.world == this.world) {
-@@ -1329,7 +1425,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1337,7 +1433,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                  PlayerChunk playerchunk = this.getVisibleChunk(chunkcoordintpair.pair());
  
                  if (playerchunk != null) {
@@ -411,7 +411,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
  
                      if (chunk != null) {
                          this.a(entityplayer, apacket, chunk);
-@@ -1590,6 +1686,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1598,6 +1694,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
      }
      // Paper end - optimise isOutsideOfRange
  
@@ -419,7 +419,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      private boolean b(EntityPlayer entityplayer) {
          return entityplayer.isSpectator() && !this.world.getGameRules().getBoolean(GameRules.SPECTATORS_GENERATE_CHUNKS);
      }
-@@ -1617,13 +1714,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1625,13 +1722,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              this.removePlayerFromDistanceMaps(entityplayer); // Paper - distance maps
          }
  
@@ -434,7 +434,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
  
      }
  
-@@ -1631,7 +1722,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1639,7 +1730,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          SectionPosition sectionposition = SectionPosition.a((Entity) entityplayer);
  
          entityplayer.a(sectionposition);
@@ -443,7 +443,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
          return sectionposition;
      }
  
-@@ -1676,6 +1767,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1684,6 +1775,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
          int k1;
          int l1;
  
@@ -451,7 +451,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
          if (Math.abs(i1 - i) <= this.viewDistance * 2 && Math.abs(j1 - j) <= this.viewDistance * 2) {
              k1 = Math.min(i, i1) - this.viewDistance;
              l1 = Math.min(j, j1) - this.viewDistance;
-@@ -1713,7 +1805,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1721,7 +1813,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                      this.sendChunk(entityplayer, chunkcoordintpair1, new Packet[2], false, true);
                  }
              }
@@ -460,7 +460,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
  
          this.updateMaps(entityplayer); // Paper - distance maps
  
-@@ -1721,11 +1813,46 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1729,11 +1821,46 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      @Override
      public Stream<EntityPlayer> a(ChunkCoordIntPair chunkcoordintpair, boolean flag) {
@@ -511,7 +511,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      }
  
      public void addEntity(Entity entity) { // Paper - protected -> public
-@@ -1883,7 +2010,48 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1891,7 +2018,48 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
  
      }
  
@@ -561,7 +561,7 @@ index 3c49ca30959204840a656c1a44de50a60ea1c7df..762598b1dc8c6fb4beaad01e5777d0a9
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {
              apacket[0] = new PacketPlayOutMapChunk(chunk, 65535, chunk.world.chunkPacketBlockController.shouldModify(entityplayer, chunk, 65535)); // Paper - Anti-Xray - Bypass
-@@ -2069,7 +2237,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -2077,7 +2245,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
                          ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(this.tracker.chunkX, this.tracker.chunkZ);
                          PlayerChunk playerchunk = PlayerChunkMap.this.getVisibleChunk(chunkcoordintpair.pair());
  

--- a/Spigot-Server-Patches/0480-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
+++ b/Spigot-Server-Patches/0480-Reduce-allocation-of-Vec3D-by-entity-tracker.patch
@@ -39,10 +39,10 @@ index b64aa6c9ce906b08e43891f8c465fa4e8b2a8906..58dd349adf2bc9bac6569464ef7a7aec
  
                      if (!flag4 && this.o <= 400 && !this.q && this.r == this.tracker.isOnGround()) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 5538d97e237e448a7d3eb76a57609980c3a6bddb..ede47aaaace80280756fe4463def1ea26792c9e4 100644
+index 21b43df57fbb65b2f39482d15e8c813403e80de1..b7bf5f7cf7f48be5d7c694de3deddab7a2d889d5 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -2227,9 +2227,14 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2235,9 +2235,14 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
          public void updatePlayer(EntityPlayer entityplayer) {
              org.spigotmc.AsyncCatcher.catchOp("player tracker update"); // Spigot
              if (entityplayer != this.tracker) {

--- a/Spigot-Server-Patches/0484-Workaround-for-Client-Lag-Spikes-MC-162253.patch
+++ b/Spigot-Server-Patches/0484-Workaround-for-Client-Lag-Spikes-MC-162253.patch
@@ -12,7 +12,7 @@ to the client, so that it doesn't attempt to calculate them.
 This mitigates the frametime impact to a minimum (but it's still there).
 
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index ede47aaaace80280756fe4463def1ea26792c9e4..d5c939281df21683efc63937a9146b0dfeb22e2c 100644
+index b7bf5f7cf7f48be5d7c694de3deddab7a2d889d5..1d7891005c7e4ff0c7b817cda987b3bc263f7010 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -85,6 +85,7 @@ import net.minecraft.world.level.World;
@@ -23,7 +23,7 @@ index ede47aaaace80280756fe4463def1ea26792c9e4..d5c939281df21683efc63937a9146b0d
  import net.minecraft.world.level.chunk.ChunkStatus;
  import net.minecraft.world.level.chunk.IChunkAccess;
  import net.minecraft.world.level.chunk.ILightAccess;
-@@ -2055,9 +2056,68 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2063,9 +2064,68 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
      public final void sendChunk(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) { this.a(entityplayer, apacket, chunk); } // Paper - OBFHELPER
      private void a(EntityPlayer entityplayer, Packet<?>[] apacket, Chunk chunk) {
          if (apacket[0] == null) {

--- a/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -922,7 +922,7 @@ index e53054fc46e528f9c713eb4c03add61316e19396..fc79a73c884ceb7e0ce56443c36b135c
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index d5c939281df21683efc63937a9146b0dfeb22e2c..01cce21eeed25b2bb36a0f32b9708afb83690f90 100644
+index 1d7891005c7e4ff0c7b817cda987b3bc263f7010..bcb6821f24a9814a0f213b9b597f1642f9926636 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -1177,7 +1177,7 @@ index d5c939281df21683efc63937a9146b0dfeb22e2c..01cce21eeed25b2bb36a0f32b9708afb
          return ret;
          // Paper end
      }
-@@ -1228,7 +1374,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
+@@ -1236,7 +1382,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
              long i = playerchunk.i().pair();
  
              playerchunk.getClass();
@@ -1290,7 +1290,7 @@ index 2d90ecf04f522a4e16f44c905450a61becaa1ed2..6034ef65ee6030948a5b76fa493addb4
              net.minecraft.world.level.chunk.Chunk chunk = (net.minecraft.world.level.chunk.Chunk) either.left().orElse(null);
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7a240739ac6e043e590b380659d8e6d794954f84..ba8c36c9fa7a1fdc3047b14042da8703802f9275 100644
+index f518fb4cabf53971daf635e3d82967c9baf0d086..54e509091452de26587d16bfd31973cb3909ddd4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -60,6 +60,7 @@ import net.minecraft.server.level.PlayerChunkMap;

--- a/Spigot-Server-Patches/0678-do-not-create-unnecessary-copies-of-passenger-list.patch
+++ b/Spigot-Server-Patches/0678-do-not-create-unnecessary-copies-of-passenger-list.patch
@@ -44,10 +44,10 @@ index 58dd349adf2bc9bac6569464ef7a7aec81729e79..1df8fb8cb3fcf8201e1c5fa8ca13f7a9
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index b47cd2a8fb4920531d80acfcfe40f8211fedc9ae..300884804bf9ac3fba7c30a04d8adf52e3dd2e3e 100644
+index 7fec676b8c944a5599a1694a9fcd5cce87509343..5424bbc7da6a2fa57d6bda222aa82c5e0357b6c3 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-@@ -2307,7 +2307,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+@@ -2315,7 +2315,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
                  list.add(entity);
              }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
e1a6197e SPIGOT-5565: Animals still spawn from chunk gen when spawn-animals=false