### PR TITLE
Add a "Should Burn in Sunlight" API for Phantoms and Skeletons

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -46,4 +46,5 @@ Machine_Maker <machine@machinemaker.me>
 Ivan Pekov <ivan@mrivanplays.com>
 Camotoy <20743703+Camotoy@users.noreply.github.com>
 Bjarne Koll <lynxplay101@gmail.com>
+MeFisto94 <MeFisto94@users.noreply.github.com>
 ```

--- a/Spigot-API-Patches/0299-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
+++ b/Spigot-API-Patches/0299-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Tue, 11 May 2021 00:48:51 +0200
+Subject: [PATCH] Add a "should burn in sunlight" API for Phantoms and
+ Skeletons
+
+
+diff --git a/src/main/java/org/bukkit/entity/Phantom.java b/src/main/java/org/bukkit/entity/Phantom.java
+index ed4d417c2deefb78807cb61b01df5afcd334d754..a40b045f08b85e22e75459b547e7e7c0b95103ed 100644
+--- a/src/main/java/org/bukkit/entity/Phantom.java
++++ b/src/main/java/org/bukkit/entity/Phantom.java
+@@ -26,5 +26,19 @@ public interface Phantom extends Flying {
+      */
+     @Nullable
+     public java.util.UUID getSpawningEntity();
++
++    /**
++     * Check if this phantom will burn in the sunlight
++     *
++     * @return True if phantom will burn in sunlight
++     */
++    public boolean shouldBurnInDay();
++
++    /**
++     * Set if this phantom should burn in the sunlight
++     *
++     * @param shouldBurnInDay True to burn in sunlight
++     */
++    public void setShouldBurnInDay(boolean shouldBurnInDay);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/entity/Skeleton.java b/src/main/java/org/bukkit/entity/Skeleton.java
+index 1c367f78eadf24850061a84ce63b950b79d3c435..684477b894e52ff33f9fce2edf76e58c292dd75e 100644
+--- a/src/main/java/org/bukkit/entity/Skeleton.java
++++ b/src/main/java/org/bukkit/entity/Skeleton.java
+@@ -46,4 +46,19 @@ public interface Skeleton extends Monster, RangedEntity { // Paper
+          */
+         STRAY;
+     }
++    // Paper start
++    /**
++     * Check if this skeleton will burn in the sunlight
++     *
++     * @return True if skeleton will burn in sunlight
++     */
++    boolean shouldBurnInDay();
++
++    /**
++     * Set if this skeleton should burn in the sunlight
++     *
++     * @param shouldBurnInDay True to burn in sunlight
++     */
++    void setShouldBurnInDay(boolean shouldBurnInDay);
++    // Paper end
+ }

--- a/Spigot-Server-Patches/0729-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
+++ b/Spigot-Server-Patches/0729-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MeFisto94 <MeFisto94@users.noreply.github.com>
+Date: Tue, 11 May 2021 00:48:33 +0200
+Subject: [PATCH] Add a "should burn in sunlight" API for Phantoms and
+ Skeletons
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/EntityPhantom.java b/src/main/java/net/minecraft/world/entity/monster/EntityPhantom.java
+index 42cf3fa42b73739182d26fbb524ee5b304c799b2..16c0c960aa1e4d35093b810c7648b5638175e106 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/EntityPhantom.java
++++ b/src/main/java/net/minecraft/world/entity/monster/EntityPhantom.java
+@@ -134,7 +134,7 @@ public class EntityPhantom extends EntityFlying implements IMonster {
+ 
+     @Override
+     public void movementTick() {
+-        if (this.isAlive() && this.eG()) {
++        if (this.isAlive() && shouldBurnInDay && this.eG()) { // Paper - Configurable Burning
+             this.setOnFire(8);
+         }
+ 
+@@ -165,6 +165,7 @@ public class EntityPhantom extends EntityFlying implements IMonster {
+         if (nbttagcompound.hasUUID("Paper.SpawningEntity")) {
+             this.spawningEntity = nbttagcompound.getUUID("Paper.SpawningEntity");
+         }
++        this.shouldBurnInDay = nbttagcompound.getBoolean("Paper.ShouldBurnInDay");
+         // Paper end
+     }
+ 
+@@ -179,6 +180,7 @@ public class EntityPhantom extends EntityFlying implements IMonster {
+         if (this.spawningEntity != null) {
+             nbttagcompound.setUUID("Paper.SpawningEntity", this.spawningEntity);
+         }
++        nbttagcompound.setBoolean("Paper.ShouldBurnInDay", shouldBurnInDay);
+         // Paper end
+     }
+ 
+@@ -233,6 +235,10 @@ public class EntityPhantom extends EntityFlying implements IMonster {
+         return spawningEntity;
+     }
+     public void setSpawningEntity(java.util.UUID entity) { this.spawningEntity = entity; }
++
++    private boolean shouldBurnInDay = true;
++    public boolean shouldBurnInDay() { return shouldBurnInDay; }
++    public void setShouldBurnInDay(boolean shouldBurnInDay) { this.shouldBurnInDay = shouldBurnInDay; }
+     // Paper end
+ 
+     class b extends PathfinderGoal {
+diff --git a/src/main/java/net/minecraft/world/entity/monster/EntitySkeletonAbstract.java b/src/main/java/net/minecraft/world/entity/monster/EntitySkeletonAbstract.java
+index 06d50b22ede102556fdb3e2a6f1424f7ff13f120..f8358e40c42f219232bf928f4e0073339a5e19d5 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/EntitySkeletonAbstract.java
++++ b/src/main/java/net/minecraft/world/entity/monster/EntitySkeletonAbstract.java
+@@ -98,9 +98,15 @@ public abstract class EntitySkeletonAbstract extends EntityMonster implements IR
+         return EnumMonsterType.UNDEAD;
+     }
+ 
++    // Paper start
++    private boolean shouldBurnInDay = true;
++    public boolean shouldBurnInDay() { return shouldBurnInDay; }
++    public void setShouldBurnInDay(boolean shouldBurnInDay) { this.shouldBurnInDay = shouldBurnInDay; }
++    // Paper end
++
+     @Override
+     public void movementTick() {
+-        boolean flag = this.eG();
++        boolean flag = shouldBurnInDay && this.eG(); // Paper - Configurable Burning
+ 
+         if (flag) {
+             ItemStack itemstack = this.getEquipment(EnumItemSlot.HEAD);
+@@ -224,7 +230,16 @@ public abstract class EntitySkeletonAbstract extends EntityMonster implements IR
+     public void loadData(NBTTagCompound nbttagcompound) {
+         super.loadData(nbttagcompound);
+         this.eL();
++        this.shouldBurnInDay = nbttagcompound.getBoolean("Paper.ShouldBurnInDay"); // Paper
++    }
++
++    // Paper start
++    @Override
++    public void saveData(NBTTagCompound nbttagcompound) {
++        super.saveData(nbttagcompound);
++        nbttagcompound.setBoolean("Paper.ShouldBurnInDay", shouldBurnInDay);
+     }
++    // Paper end
+ 
+     @Override
+     public void setSlot(EnumItemSlot enumitemslot, ItemStack itemstack) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
+index 0cea1d8e23da3a79ef06e43752665a5401b01b4b..476339ef8cafad2d6c78bccb6fd9f3c882b89148 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPhantom.java
+@@ -40,5 +40,15 @@ public class CraftPhantom extends CraftFlying implements Phantom {
+     public java.util.UUID getSpawningEntity() {
+         return getHandle().getSpawningEntity();
+     }
++
++    @Override
++    public boolean shouldBurnInDay() {
++        return getHandle().shouldBurnInDay();
++    }
++
++    @Override
++    public void setShouldBurnInDay(boolean shouldBurnInDay) {
++        getHandle().setShouldBurnInDay(shouldBurnInDay);
++    }
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
+index c2acfa2cc27a187154e17b7f45908682b41b52af..f48c4225dbc3467aaf8d14bc4047430548cc7c78 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
+@@ -36,4 +36,16 @@ public class CraftSkeleton extends CraftMonster implements Skeleton, com.destroy
+     public void setSkeletonType(SkeletonType type) {
+         throw new UnsupportedOperationException("Not supported.");
+     }
++
++    // Paper start
++    @Override
++    public boolean shouldBurnInDay() {
++        return getHandle().shouldBurnInDay();
++    }
++
++    @Override
++    public void setShouldBurnInDay(boolean shouldBurnInDay) {
++        getHandle().setShouldBurnInDay(shouldBurnInDay);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Preventing Mobs (Skeletons and Phantoms) from burning in sunlight is almost impossible with the current API:
While there is `EntityCombustEvent`, there is no `Cause` to distinguish from regular combustions.
The only thing that I could imagine would be listening to both `ECEByBlock` and `ECEByEntity` events and if none of those fire, it _could_ be sunlight.
IIRC, this is technically not possible, because if you listen to the base event, the child events don't call anymore.

Anyway, there is a related PR #1547, which does add this features exclusively to zombies, I extended this for all entities that care for `this.eG()` (which is the sunlight check) at the current time. That way we have a consistent API and editing the Combust Event would be bad in multiple ways, so instead we have this property on the entities.

If there are some issues with the patch in itself (e.g. whitespaces) , please tell me, so that I know that for future patches.
It would be welcomed if you could perform those adjustments upon merge though.