### PR TITLE
Fix incorrect colors in some log messages

### DIFF
--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -143,10 +143,18 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6c036793a 100644
+index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..bad6dfcb9ed558499c39880c44ae514ee2051a3c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -160,7 +160,7 @@ import org.apache.logging.log4j.Logger;
+@@ -12,6 +12,7 @@ import com.mojang.datafixers.DataFixer;
+ import io.netty.buffer.ByteBuf;
+ import io.netty.buffer.ByteBufOutputStream;
+ import io.netty.buffer.Unpooled;
++import io.papermc.paper.adventure.PaperAdventure; // Paper
+ import it.unimi.dsi.fastutil.longs.LongIterator;
+ import java.awt.image.BufferedImage;
+ import java.io.BufferedWriter;
+@@ -160,7 +161,7 @@ import org.apache.logging.log4j.Logger;
  import com.mojang.serialization.DynamicOps;
  import com.mojang.serialization.Lifecycle;
  import com.google.common.collect.ImmutableSet;
@@ -155,7 +163,7 @@ index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6
  import joptsimple.OptionSet;
  import net.minecraft.nbt.DynamicOpsNBT;
  import net.minecraft.nbt.NBTBase;
-@@ -255,7 +255,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -255,7 +256,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public OptionSet options;
      public org.bukkit.command.ConsoleCommandSender console;
      public org.bukkit.command.RemoteConsoleCommandSender remoteConsole;
@@ -164,7 +172,7 @@ index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6
      public static int currentTick = 0; // Paper - Further improve tick loop
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
-@@ -324,7 +324,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -324,7 +325,9 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.options = options;
          this.datapackconfiguration = datapackconfiguration;
          this.vanillaCommandDispatcher = datapackresources.commandDispatcher; // CraftBukkit
@@ -174,7 +182,7 @@ index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6
          if (System.console() == null && System.getProperty("jline.terminal") == null) {
              System.setProperty("jline.terminal", "jline.UnsupportedTerminal");
              Main.useJline = false;
-@@ -345,6 +347,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -345,6 +348,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  LOGGER.warn((String) null, ex);
              }
          }
@@ -183,7 +191,7 @@ index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
      }
      // CraftBukkit end
-@@ -1098,7 +1102,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1098,7 +1103,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  org.spigotmc.WatchdogThread.doStop(); // Spigot
                  // CraftBukkit start - Restore terminal to original settings
                  try {
@@ -192,12 +200,12 @@ index d92ca78e483b3f085e3bad1d1250cac2f9031fa7..62ee4708a3196cfa395317a6312b3ac6
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1469,7 +1473,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1469,7 +1474,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      @Override
      public void sendMessage(IChatBaseComponent ichatbasecomponent, UUID uuid) {
 -        MinecraftServer.LOGGER.info(ichatbasecomponent.getString());
-+        MinecraftServer.LOGGER.info(org.bukkit.craftbukkit.util.CraftChatMessage.fromComponent(ichatbasecomponent));// Paper - Log message with colors
++        MinecraftServer.LOGGER.info(PaperAdventure.LEGACY_SECTION_UXRC.serialize(PaperAdventure.asAdventure(ichatbasecomponent))); // Paper - Log message with colors
      }
  
      public KeyPair getKeyPair() {

--- a/Spigot-Server-Patches/0197-Implement-extended-PaperServerListPingEvent.patch
+++ b/Spigot-Server-Patches/0197-Implement-extended-PaperServerListPingEvent.patch
@@ -223,7 +223,7 @@ index 005ae7a75dfb19152abb606da29acad07c85e499..b9e36a83837913cd3e5abe598f695ba7
              this.c = agameprofile;
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 62ee4708a3196cfa395317a6312b3ac6c036793a..dbf5a849358158324e8a5c87f831236b71f7ec0d 100644
+index bad6dfcb9ed558499c39880c44ae514ee2051a3c..925dd2dc2b4af5596c9dc891f756bad66baadbea 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,6 +2,9 @@ package net.minecraft.server;
@@ -236,7 +236,7 @@ index 62ee4708a3196cfa395317a6312b3ac6c036793a..dbf5a849358158324e8a5c87f831236b
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -1239,7 +1242,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1240,7 +1243,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (i - this.T >= 5000000000L) {
              this.T = i;
              this.serverPing.setPlayerSample(new ServerPing.ServerPingPlayerSample(this.getMaxPlayers(), this.getPlayerCount()));

--- a/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/Spigot-Server-Patches/0262-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,10 +36,10 @@ index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dbf5a849358158324e8a5c87f831236b71f7ec0d..1733717b7cae3e7a805e5275ff89967744c4bc4a 100644
+index 925dd2dc2b4af5596c9dc891f756bad66baadbea..540250a9610e2ee51685b655a7d6c0809bba64fd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1018,6 +1018,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1019,6 +1019,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a(this.serverPing);
  
                  // Spigot start
@@ -48,7 +48,7 @@ index dbf5a849358158324e8a5c87f831236b71f7ec0d..1733717b7cae3e7a805e5275ff899677
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 251427626f4dfdf9f5c4a2e6ef84cff30508fb76..85975c5a1acca101d182dfd01879161e34bfe5c3 100644
+index 6b0b55aa2ac4dec4e6005f557b9ba6975a7b58ed..d2e8d50adc49cc00d95f928a65a3c23fff0c4c80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -813,6 +813,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0306-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
+++ b/Spigot-Server-Patches/0306-Improve-Server-Thread-Pool-and-Thread-Priorities.patch
@@ -75,10 +75,10 @@ index 68ce7605bd63ea280b96db8230463d2afb0a6cb1..46d82c1548088b8305f758699388edf0
          c(throwable);
          if (throwable instanceof CompletionException) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8166ad11642bb1b4b11722a5a09e773a2e749c47..021adb8a6b8c9e05c03391d0f8edfa71b3c0c246 100644
+index 540250a9610e2ee51685b655a7d6c0809bba64fd..67748b3c57766ef297082a7ea6a255b0f42de446 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -285,6 +285,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -286,6 +286,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          S s0 = function.apply(thread); // CraftBukkit - decompile error
  
          atomicreference.set(s0);

--- a/Spigot-Server-Patches/0307-Optimize-World-Time-Updates.patch
+++ b/Spigot-Server-Patches/0307-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4cb57914db19d6024501f2b75361c3d8acdd4149..7dee17e52a5b23ba4d8089482b39215041a64579 100644
+index 67748b3c57766ef297082a7ea6a255b0f42de446..4d44604da7c65df6d8e87b6c6c56371ca307c11f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1315,12 +1315,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1316,12 +1316,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.

--- a/Spigot-Server-Patches/0341-Server-Tick-Events.patch
+++ b/Spigot-Server-Patches/0341-Server-Tick-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Server Tick Events
 Fires event at start and end of a server tick
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7dee17e52a5b23ba4d8089482b39215041a64579..602deb6b456de6cdefc480bf1aab959f9d60007d 100644
+index 4d44604da7c65df6d8e87b6c6c56371ca307c11f..7ef01f2f80eea31fa76d22c3a0d5036883dee516 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1238,6 +1238,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1239,6 +1239,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
          // Paper end
@@ -17,7 +17,7 @@ index 7dee17e52a5b23ba4d8089482b39215041a64579..602deb6b456de6cdefc480bf1aab959f
  
          ++this.ticks;
          this.b(booleansupplier);
-@@ -1281,6 +1282,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1282,6 +1283,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
          // Paper end
  

--- a/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,10 +16,10 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 602deb6b456de6cdefc480bf1aab959f9d60007d..5020b1ef1e0fc08a00a40aecfd3eeb74348865d1 100644
+index 7ef01f2f80eea31fa76d22c3a0d5036883dee516..e885e5c4c772a87c0359ed2c56aa71a856c3be59 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2191,7 +2191,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2192,7 +2192,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // CraftBukkit start
      @Override
      public boolean isMainThread() {

--- a/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/Spigot-Server-Patches/0353-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -21,10 +21,10 @@ index 38d25a12c6a52d8a83214e2a0f43a218cf15ceac..ffe9b1a63d78925e1d77b9e730aef42f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5020b1ef1e0fc08a00a40aecfd3eeb74348865d1..0aa723d9940f4b33cd587aef6e23e238c2c22359 100644
+index e885e5c4c772a87c0359ed2c56aa71a856c3be59..334fe66cf49404c7514b317629b676e52f1841cb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -717,35 +717,36 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -718,35 +718,36 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      // CraftBukkit start
      public void loadSpawn(WorldLoadListener worldloadlistener, WorldServer worldserver) {
@@ -74,7 +74,7 @@ index 5020b1ef1e0fc08a00a40aecfd3eeb74348865d1..0aa723d9940f4b33cd587aef6e23e238
  
          if (true) {
              WorldServer worldserver1 = worldserver;
-@@ -768,7 +769,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -769,7 +770,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
          this.executeModerately();
          // CraftBukkit end

--- a/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
+++ b/Spigot-Server-Patches/0362-incremental-chunk-saving.patch
@@ -29,10 +29,10 @@ index ffe9b1a63d78925e1d77b9e730aef42fed6d58fa..1278d09f70c1e97607ef20d87a178dc2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4605b26cedbd0478b41e976f4b48ad78f12e37ff..4da16809f8f084fc4af4c50b5232914ea8aee04e 100644
+index 334fe66cf49404c7514b317629b676e52f1841cb..571f3860bc31c077c239a32776f6aaf6ff30ce71 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -262,6 +262,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -263,6 +263,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public static int currentTick = 0; // Paper - Further improve tick loop
      public java.util.Queue<Runnable> processQueue = new java.util.concurrent.ConcurrentLinkedQueue<Runnable>();
      public int autosavePeriod;
@@ -40,7 +40,7 @@ index 4605b26cedbd0478b41e976f4b48ad78f12e37ff..4da16809f8f084fc4af4c50b5232914e
      public CommandDispatcher vanillaCommandDispatcher;
      private boolean forceTicks;
      // CraftBukkit end
-@@ -1257,14 +1258,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1258,14 +1259,24 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.serverPing.b().a(agameprofile);
          }
  
@@ -158,7 +158,7 @@ index 6bced8533df49d7bfdb32dfa0caad9d788ffc2c8..75d4a8fc394449ccc006fe67a8842edc
      public void a(ProtoChunkExtension protochunkextension) {
          for (int i = 0; i < this.statusFutures.length(); ++i) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index ccfde274edfe1b611ccf8c583c92b16d52e4518d..1f32ab230d650bb5f652efbacdd5e4b90dc4de89 100644
+index ed454f8dff7b0d94d4bde914a6f26bb019e82296..ca05fe4ed0773b94035c63f8f8db6c034f0b92e2 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -93,6 +93,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.DefinedStruct
@@ -252,7 +252,7 @@ index ccfde274edfe1b611ccf8c583c92b16d52e4518d..1f32ab230d650bb5f652efbacdd5e4b9
                      return PlayerChunk.getChunkState(playerchunk.getTicketLevel());
                  });
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index a9c0d3fc4aa07d9d580a31106169796b7bde4e63..735da5729c16940e3d8877f32a40342b9d1e989d 100644
+index d308197995a92f5be8f5b928fa9ae83dd659545c..d7fe6f00b352dad9e9f579f9af86cb8b90ef83ae 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -888,11 +888,43 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
+++ b/Spigot-Server-Patches/0369-Asynchronous-chunk-IO-and-loading.patch
@@ -2348,10 +2348,10 @@ index 191a74bd9b894f9d64d0a55747cb17e07ceef597..1732fc552c290d294b68d6f92f2a58d9
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataConverterRegistry.a(), minecraftsessionservice, gameprofilerepository, usercache, WorldLoadListenerLogger::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9e6d70bdf4d1cf524e45b55ee51d87a30394ac84..baafdffabf28415da66eccb6e14466cd428f5832 100644
+index 571f3860bc31c077c239a32776f6aaf6ff30ce71..ef13e310a8a452d2ba1d9c8bac72f9baf2693de0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -921,7 +921,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -922,7 +922,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getUserCache().b(false); // Paper
          }
          // Spigot end
@@ -2601,7 +2601,7 @@ index 75d4a8fc394449ccc006fe67a8842edcd9f36854..6433463938d8bb717840c8f57fe6e707
                  completablefuture = (CompletableFuture) this.statusFutures.get(i);
                  if (completablefuture != null) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index ec3c717cf63848f1d949e932b081a8db65294d65..88c9fd204203ba87498948eded57aad678e6d9b6 100644
+index 5a11765c8a7d754ec86d829fa5e85d2809dd937e..46c91230ab6f12db77b453c312fa7382b76fad34 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -88,6 +88,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;

--- a/Spigot-Server-Patches/0373-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/Spigot-Server-Patches/0373-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -7,10 +7,10 @@ If the Bukkit generator already has a spawn, use it immediately instead
 of spending time generating one that we won't use
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 74c4462bc32e966055732944dfb931e75d7fad1f..b3401b59e0b99b32e3a600b3c33163a85f7c3ab2 100644
+index ef13e310a8a452d2ba1d9c8bac72f9baf2693de0..a118187e86238fd4019ba5c25269d5ee80fc56f2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -629,12 +629,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -630,12 +630,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          } else if (flag1) {
              iworlddataserver.setSpawn(BlockPosition.ZERO.up(), 0.0F);
          } else {
@@ -24,7 +24,7 @@ index 74c4462bc32e966055732944dfb931e75d7fad1f..b3401b59e0b99b32e3a600b3c33163a8
              // CraftBukkit start
              if (worldserver.generator != null) {
                  Random rand = new Random(worldserver.getSeed());
-@@ -650,6 +645,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -651,6 +646,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  }
              }
              // CraftBukkit end

--- a/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
+++ b/Spigot-Server-Patches/0389-Optimize-Hoppers.patch
@@ -31,10 +31,10 @@ index edda2121f8c1046478beaa77030ebb36d403b334..7fbd501d70dccf869a4454e2789a5d68
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0a407b7d2c87e2fc745eedf7b3ea794ab0211716..af7bef41d341218f25943eb1e10831cc0be6840a 100644
+index a118187e86238fd4019ba5c25269d5ee80fc56f2..94525c8bd49334fb5aa1b113ed992e857e44ab96 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -128,6 +128,7 @@ import net.minecraft.world.level.WorldSettings;
+@@ -129,6 +129,7 @@ import net.minecraft.world.level.WorldSettings;
  import net.minecraft.world.level.biome.BiomeManager;
  import net.minecraft.world.level.biome.WorldChunkManager;
  import net.minecraft.world.level.block.Block;
@@ -42,7 +42,7 @@ index 0a407b7d2c87e2fc745eedf7b3ea794ab0211716..af7bef41d341218f25943eb1e10831cc
  import net.minecraft.world.level.border.IWorldBorderListener;
  import net.minecraft.world.level.border.WorldBorder;
  import net.minecraft.world.level.chunk.ChunkGenerator;
-@@ -1361,6 +1362,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1362,6 +1363,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper

--- a/Spigot-Server-Patches/0410-Make-the-GUI-graph-fancier.patch
+++ b/Spigot-Server-Patches/0410-Make-the-GUI-graph-fancier.patch
@@ -396,10 +396,10 @@ index 46d82c1548088b8305f758699388edf0d5d4d050..397194b3e90c9df39cfae17b401c7ac8
          consumer.accept(t0);
          return t0;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index af7bef41d341218f25943eb1e10831cc0be6840a..dc817d7c7187de2b37485bef126fb0765a5caf63 100644
+index 94525c8bd49334fb5aa1b113ed992e857e44ab96..c86c3cdea77369e3297548c8d5f10674c1100f76 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -217,7 +217,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -218,7 +218,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private String motd;
      private int F;
      private int G;

--- a/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
+++ b/Spigot-Server-Patches/0428-Increase-Light-Queue-Size.patch
@@ -28,10 +28,10 @@ index 6c8e9d498c9a30a1aa88494ba09c3cae012a8fa1..cd248eb6be663e8be33f2c3c6b06b77b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dc817d7c7187de2b37485bef126fb0765a5caf63..4218dcb90c36bbac35ef292be32972e0fc22e6d2 100644
+index c86c3cdea77369e3297548c8d5f10674c1100f76..54738ef346b1fe4c45ea95db2f236d10f8525a20 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -776,7 +776,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -777,7 +777,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.executeModerately();
          // CraftBukkit end
          if (worldserver.getWorld().getKeepSpawnInMemory()) worldloadlistener.b(); // Paper

--- a/Spigot-Server-Patches/0429-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/Spigot-Server-Patches/0429-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -56,10 +56,10 @@ index da93d38fe63035e4ff198ada84a4431f52d97c01..ddbc8cb712c50038922eded75dd6ca85
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af8f8d8076 100644
+index 54738ef346b1fe4c45ea95db2f236d10f8525a20..5ea593ccfedf55140a723f6dc29bebe282e77ab3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1056,6 +1056,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1057,6 +1057,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                          // Paper end
                          tickSection = curTime;
                      }
@@ -67,7 +67,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
                      // Spigot end
  
                      //MinecraftServer.currentTick = (int) (System.currentTimeMillis() / 50); // CraftBukkit // Paper - don't overwrite current tick time
-@@ -1125,7 +1126,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1126,7 +1127,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      }
  
@@ -76,7 +76,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
          // CraftBukkit start
          if (isOversleep) return canOversleep();// Paper - because of our changes, this logic is broken
          return this.forceTicks || this.isEntered() || SystemUtils.getMonotonicMillis() < (this.X ? this.W : this.nextTick);
-@@ -1155,6 +1156,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1156,6 +1157,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          });
      }
  
@@ -100,7 +100,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
      @Override
      public TickTask postToMainThread(Runnable runnable) {
          return new TickTask(this.ticks, runnable);
-@@ -1241,6 +1259,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1242,6 +1260,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // Paper start - move oversleep into full server tick
          isOversleep = true;MinecraftTimings.serverOversleep.startTiming();
          this.awaitTasks(() -> {
@@ -108,7 +108,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
              return !this.canOversleep();
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
-@@ -1319,13 +1338,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1320,13 +1339,16 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      }
  
      protected void b(BooleanSupplier booleansupplier) {
@@ -125,7 +125,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
          this.methodProfiler.exitEnter("levels");
          Iterator iterator = this.getWorlds().iterator();
  
-@@ -1336,7 +1358,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1337,7 +1359,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              processQueue.remove().run();
          }
          MinecraftTimings.processQueueTimer.stopTiming(); // Spigot
@@ -134,7 +134,7 @@ index 4218dcb90c36bbac35ef292be32972e0fc22e6d2..18d078f85acf33e55e77758746f789af
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.
          // Paper start - optimize time updates
-@@ -1378,9 +1400,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1379,9 +1401,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.methodProfiler.enter("tick");
  
              try {
@@ -234,7 +234,7 @@ index 138676e5b03bc80a777a1f4c12f3f4b5316e8dea..99108d2c8145c16943fb29872c55d8e7
          protected boolean executeNext() {
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 5d085321414134043e52d8012e12a8891529097c..c34ec6440b3c081a6e573b213f483c9ccf345c2b 100644
+index 8159baec6e862580dc340d8fd7c16013ec8f0e66..6f15e2d0302108d64b14b3449e81f18f985db7ae 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -571,6 +571,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0431-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0431-Add-tick-times-API-and-mspt-command.patch
@@ -87,10 +87,10 @@ index ddbc8cb712c50038922eded75dd6ca85fe851078..78271b400c79578d043b20a5389a37b1
          version = getInt("config-version", 20);
          set("config-version", 20);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 18d078f85acf33e55e77758746f789af8f8d8076..7ae852296900b0f2ca53311e6884f01e17e9980e 100644
+index 5ea593ccfedf55140a723f6dc29bebe282e77ab3..795cf9635ab6ac7f001476354813cac9d7e025eb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -218,6 +218,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -219,6 +219,11 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      private int F;
      private int G;
      public final long[] h; public long[] getTickTimes() { return h; } // Paper - OBFHELPER
@@ -102,7 +102,7 @@ index 18d078f85acf33e55e77758746f789af8f8d8076..7ae852296900b0f2ca53311e6884f01e
      @Nullable
      private KeyPair H;
      @Nullable
-@@ -1330,6 +1335,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1331,6 +1336,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          this.ag = this.ag * 0.8F + (float) l / 1000000.0F * 0.19999999F;
          long i1 = SystemUtils.getMonotonicNanos();
  
@@ -115,7 +115,7 @@ index 18d078f85acf33e55e77758746f789af8f8d8076..7ae852296900b0f2ca53311e6884f01e
          this.circularTimer.a(i1 - i);
          this.methodProfiler.exit();
          org.spigotmc.WatchdogThread.tick(); // Spigot
-@@ -2302,4 +2313,30 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2303,4 +2314,30 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public ITextFilter a(EntityPlayer entityplayer) {
          return null;
      }

--- a/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
@@ -83,10 +83,10 @@ index 397194b3e90c9df39cfae17b401c7ac891b0dbb7..61b4c42e95994343772a91640b243b8e
          a(SystemUtils.e);
          a(SystemUtils.f);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9cfc45579b 100644
+index 795cf9635ab6ac7f001476354813cac9d7e025eb..6f51409bac9c2907a5be02e4c15319fcc520609f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -270,7 +270,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -271,7 +271,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public int autosavePeriod;
      public boolean serverAutoSave = false; // Paper
      public CommandDispatcher vanillaCommandDispatcher;
@@ -95,7 +95,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
      // CraftBukkit end
      // Spigot start
      public static final int TPS = 20;
-@@ -280,6 +280,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -281,6 +281,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
  
@@ -104,7 +104,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
      public static <S extends MinecraftServer> S a(Function<Thread, S> function) {
          AtomicReference<S> atomicreference = new AtomicReference();
          Thread thread = new Thread(() -> {
-@@ -852,6 +854,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -853,6 +855,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      // CraftBukkit start
      private boolean hasStopped = false;
@@ -112,7 +112,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (stopLock) {
-@@ -866,6 +869,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -867,6 +870,23 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              if (hasStopped) return;
              hasStopped = true;
          }
@@ -136,7 +136,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
          // CraftBukkit end
          MinecraftServer.LOGGER.info("Stopping server");
          MinecraftTimings.stopServer(); // Paper
-@@ -931,7 +951,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -932,7 +952,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getUserCache().b(false); // Paper
          }
          // Spigot end
@@ -155,7 +155,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
      }
  
      public String getServerIp() {
-@@ -1024,6 +1055,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1025,6 +1056,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      protected void w() {
          try {
@@ -163,7 +163,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
              if (this.init()) {
                  this.nextTick = SystemUtils.getMonotonicMillis();
                  this.serverPing.setMOTD(new ChatComponentText(this.motd));
-@@ -1031,6 +1063,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1032,6 +1064,18 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a(this.serverPing);
  
                  // Spigot start
@@ -182,7 +182,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
                  org.spigotmc.WatchdogThread.hasStarted = true; // Paper
                  Arrays.fill( recentTps, 20 );
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
-@@ -1086,6 +1130,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1087,6 +1131,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  this.a((CrashReport) null);
              }
          } catch (Throwable throwable) {
@@ -195,7 +195,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              // Spigot Start
              if ( throwable.getCause() != null )
-@@ -1117,14 +1167,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1118,14 +1168,14 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              } catch (Throwable throwable1) {
                  MinecraftServer.LOGGER.error("Exception stopping the server", throwable1);
              } finally {
@@ -213,7 +213,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
              }
  
          }
-@@ -1180,6 +1230,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1181,6 +1231,12 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
  
      @Override
      public TickTask postToMainThread(Runnable runnable) {
@@ -226,7 +226,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
          return new TickTask(this.ticks, runnable);
      }
  
-@@ -1422,6 +1478,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1423,6 +1479,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  try {
                      crashreport = CrashReport.a(throwable, "Exception ticking world");
                  } catch (Throwable t) {
@@ -234,7 +234,7 @@ index 7ae852296900b0f2ca53311e6884f01e17e9980e..5c7ded8244187d993d8dda4afff95d9c
                      throw new RuntimeException("Error generating crash report", t);
                  }
                  // Spigot End
-@@ -1879,7 +1936,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1880,7 +1937,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.resourcePackRepository.a(collection);
              this.saveData.a(a(this.resourcePackRepository));
              datapackresources.i();
@@ -275,7 +275,7 @@ index 557f80accfa36b495c9a8cffdab2e248c1cbb514..ec1f36736d79d4054ad7ff4da4e3659f
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 8050be2ed04fb0b8141f92595680407bba65dad5..bb9c6e9aeb1f30af01338476ba1dd618b14124d5 100644
+index 5ccc70f36616e1bd8cdb8b23315f7422ec5acc61..b00c5a7eaf456e6d6ce250ee790ce33dfa9bb496 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -536,6 +536,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -287,7 +287,7 @@ index 8050be2ed04fb0b8141f92595680407bba65dad5..bb9c6e9aeb1f30af01338476ba1dd618
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index ae99f3fb3a4b37c737fb276590004b2e10beab5a..06fa9b91cc103a5d5f39ab8fcfb5ccad4cf0e5de 100644
+index cfe784560ea4c368d6e3a0797d09c0a717eb146e..795c4a9e3e33660af888ff80204bfd47a3b327fd 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -177,7 +177,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0466-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5c7ded8244187d993d8dda4afff95d9cfc45579b..25cb877dc3879ff5a1bfaf616ba9942f951eba10 100644
+index 6f51409bac9c2907a5be02e4c15319fcc520609f..e25539dd54956225e8b14d3b8c636130267f226d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1652,6 +1652,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1653,6 +1653,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
      }
  
@@ -30,7 +30,7 @@ index 6110d7723b70df5380338a42b5cbff3446294bac..b64aa6c9ce906b08e43891f8c465fa4e
          List<Entity> list = this.tracker.getPassengers();
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 216723730f151a1da73743ad7c6c31bbdb9890f0..67bea47a2248d228fd070bc0aa66f05b71a76ef5 100644
+index d509cfd2da99233e5142abd176cc50ccea7c32b6..9fc74f08b912ff885c9478167c7ef173c32f1654 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -61,6 +61,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutMapChunk;

--- a/Spigot-Server-Patches/0475-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/Spigot-Server-Patches/0475-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,10 +10,10 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 25cb877dc3879ff5a1bfaf616ba9942f951eba10..5b9f03f3118e6d19ed5c3d41a94b06172d594a81 100644
+index e25539dd54956225e8b14d3b8c636130267f226d..9074646e8111c69c4875b0633a424b250a30bc5c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -892,6 +892,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -893,6 +893,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
@@ -22,7 +22,7 @@ index 25cb877dc3879ff5a1bfaf616ba9942f951eba10..5b9f03f3118e6d19ed5c3d41a94b0617
          // CraftBukkit end
          if (this.getServerConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3014a5d71de98009bdc121ba690c3653c2eef120..32e68e403950be62bd0330b268738225c2e70edd 100644
+index e20e3d69ac1c4cf97afd522340464e53d2497c08..8a8d492bfeb8eb559dbd325978b92878545a9778 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -942,6 +942,35 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0509-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/Spigot-Server-Patches/0509-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,10 +8,10 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5b9f03f3118e6d19ed5c3d41a94b06172d594a81..50c1c6cc53eead25d03ed45427cb9fb80bc2fc36 100644
+index 9074646e8111c69c4875b0633a424b250a30bc5c..c3635577b1796e6ca84709469ecf95c815fe53a5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1645,11 +1645,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1646,11 +1646,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          }
      }
  

--- a/Spigot-Server-Patches/0539-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0539-Incremental-player-saving.patch
@@ -25,10 +25,10 @@ index b67ba8f75e4a3358d7c2462918b85b0bf9b5a922..fdbd8b89bb8bf3b61f60b812b90483c9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 50c1c6cc53eead25d03ed45427cb9fb80bc2fc36..483abe5b3c0c00ebdea405e9bb24509f743bfc2c 100644
+index c3635577b1796e6ca84709469ecf95c815fe53a5..bd6b9c7be8951393e7ba731f4d6a9486f0743be7 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1347,9 +1347,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1348,9 +1348,15 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          //if (autosavePeriod > 0 && this.ticks % autosavePeriod == 0) { // CraftBukkit // Paper - move down
              //MinecraftServer.LOGGER.debug("Autosave started"); // Paper
              serverAutoSave = (autosavePeriod > 0 && this.ticks % autosavePeriod == 0); // Paper

--- a/Spigot-Server-Patches/0566-Cache-block-data-strings.patch
+++ b/Spigot-Server-Patches/0566-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 483abe5b3c0c00ebdea405e9bb24509f743bfc2c..ef980b8cba0e30fc65b119d08a034ced7fdb2bc8 100644
+index bd6b9c7be8951393e7ba731f4d6a9486f0743be7..040933a25f1fa88e86b19ea20f519488af6a2740 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1953,6 +1953,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1954,6 +1954,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.getPlayerList().reload();
              this.customFunctionData.a(this.dataPackResources.a());
              this.ak.a(this.dataPackResources.h());

--- a/Spigot-Server-Patches/0575-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/Spigot-Server-Patches/0575-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ef980b8cba0e30fc65b119d08a034ced7fdb2bc8..43b713476c6f841aafaac9f2a1216b937261efc2 100644
+index 040933a25f1fa88e86b19ea20f519488af6a2740..2834af3e0ff2ae8466fde191a64bf719242f67f3 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2018,6 +2018,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2019,6 +2019,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          if (this.aN()) {
              PlayerList playerlist = commandlistenerwrapper.getServer().getPlayerList();
              WhiteList whitelist = playerlist.getWhitelist();

--- a/Spigot-Server-Patches/0609-Add-warning-for-servers-not-running-on-Java-11.patch
+++ b/Spigot-Server-Patches/0609-Add-warning-for-servers-not-running-on-Java-11.patch
@@ -59,10 +59,10 @@ index 0000000000000000000000000000000000000000..c6ea429819c07e7f4bc257cad73463a0
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 43b713476c6f841aafaac9f2a1216b937261efc2..07021c760b0d734b91240ca96c6480be469a1005 100644
+index 2834af3e0ff2ae8466fde191a64bf719242f67f3..13aac7efac8bfc8ea685621c942c310fdf2496d9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -181,6 +181,7 @@ import org.bukkit.event.server.ServerLoadEvent;
+@@ -182,6 +182,7 @@ import org.bukkit.event.server.ServerLoadEvent;
  
  import co.aikar.timings.MinecraftTimings; // Paper
  import org.spigotmc.SlackActivityAccountant; // Spigot
@@ -70,7 +70,7 @@ index 43b713476c6f841aafaac9f2a1216b937261efc2..07021c760b0d734b91240ca96c6480be
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
  
-@@ -1075,6 +1076,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1076,6 +1077,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  LOGGER.info("Done ({})! For help, type \"help\"", doneTime);
                  // Paper end
  

--- a/Spigot-Server-Patches/0635-Added-ServerResourcesReloadedEvent.patch
+++ b/Spigot-Server-Patches/0635-Added-ServerResourcesReloadedEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added ServerResourcesReloadedEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 07021c760b0d734b91240ca96c6480be469a1005..0ff63eede271b555e9de9b61dc76045d450cd990 100644
+index 13aac7efac8bfc8ea685621c942c310fdf2496d9..1c17db3e9e30d16bc5778bb3220e3e9e8c336258 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,9 +2,6 @@ package net.minecraft.server;
@@ -18,7 +18,7 @@ index 07021c760b0d734b91240ca96c6480be469a1005..0ff63eede271b555e9de9b61dc76045d
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -182,6 +179,7 @@ import org.bukkit.event.server.ServerLoadEvent;
+@@ -183,6 +180,7 @@ import org.bukkit.event.server.ServerLoadEvent;
  import co.aikar.timings.MinecraftTimings; // Paper
  import org.spigotmc.SlackActivityAccountant; // Spigot
  import io.papermc.paper.util.PaperJvmChecker; // Paper
@@ -26,7 +26,7 @@ index 07021c760b0d734b91240ca96c6480be469a1005..0ff63eede271b555e9de9b61dc76045d
  
  public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTask> implements IMojangStatistics, ICommandListener, AutoCloseable {
  
-@@ -1934,7 +1932,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1935,7 +1933,13 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          return this.customFunctionData;
      }
  
@@ -40,7 +40,7 @@ index 07021c760b0d734b91240ca96c6480be469a1005..0ff63eede271b555e9de9b61dc76045d
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
              Stream<String> stream = collection.stream(); // CraftBukkit - decompile error
              ResourcePackRepository resourcepackrepository = this.resourcePackRepository;
-@@ -1950,6 +1954,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1951,6 +1955,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              this.resourcePackRepository.a(collection);
              this.saveData.a(a(this.resourcePackRepository));
              datapackresources.i();

--- a/Spigot-Server-Patches/0665-EntityMoveEvent.patch
+++ b/Spigot-Server-Patches/0665-EntityMoveEvent.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0ff63eede271b555e9de9b61dc76045d450cd990..697ce13c7c32e4badcd171c1e9eefc49620ae525 100644
+index 1c17db3e9e30d16bc5778bb3220e3e9e8c336258..952d5c7c3324377e0036b9d7e524484cb581e5b2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -12,6 +12,7 @@ import com.mojang.datafixers.DataFixer;
- import io.netty.buffer.ByteBuf;
+@@ -13,6 +13,7 @@ import io.netty.buffer.ByteBuf;
  import io.netty.buffer.ByteBufOutputStream;
  import io.netty.buffer.Unpooled;
+ import io.papermc.paper.adventure.PaperAdventure; // Paper
 +import io.papermc.paper.event.entity.EntityMoveEvent;
  import it.unimi.dsi.fastutil.longs.LongIterator;
  import java.awt.image.BufferedImage;
  import java.io.BufferedWriter;
-@@ -1458,6 +1459,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -1459,6 +1460,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
          while (iterator.hasNext()) {
              WorldServer worldserver = (WorldServer) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
@@ -25,7 +25,7 @@ index 0ff63eede271b555e9de9b61dc76045d450cd990..697ce13c7c32e4badcd171c1e9eefc49
  
              this.methodProfiler.a(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index c38ef337f9a662d689994a0d530e8e655b843177..bab75b2232f1fa1def09517610179ca1529d195e 100644
+index 530963c1435985e17d0e3181c2d8affe003f81de..c7a661d4f43fad04ebada1bbebf4e4274fc9c452 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -213,6 +213,7 @@ public class WorldServer extends World implements GeneratorAccessSeed {

--- a/Spigot-Server-Patches/0673-misc-debugging-dumps.patch
+++ b/Spigot-Server-Patches/0673-misc-debugging-dumps.patch
@@ -29,18 +29,18 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 697ce13c7c32e4badcd171c1e9eefc49620ae525..84c3110ea03f9121fc4ab0aaa80ddad5efe28e5c 100644
+index 952d5c7c3324377e0036b9d7e524484cb581e5b2..a116156236caa22d3ee13b5a56f4ed3c8d013f37 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -13,6 +13,7 @@ import io.netty.buffer.ByteBuf;
- import io.netty.buffer.ByteBufOutputStream;
+@@ -14,6 +14,7 @@ import io.netty.buffer.ByteBufOutputStream;
  import io.netty.buffer.Unpooled;
+ import io.papermc.paper.adventure.PaperAdventure; // Paper
  import io.papermc.paper.event.entity.EntityMoveEvent;
 +import io.papermc.paper.util.TraceUtil;
  import it.unimi.dsi.fastutil.longs.LongIterator;
  import java.awt.image.BufferedImage;
  import java.io.BufferedWriter;
-@@ -855,6 +856,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -856,6 +857,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      // CraftBukkit start
      private boolean hasStopped = false;
      public volatile boolean hasFullyShutdown = false; // Paper
@@ -48,7 +48,7 @@ index 697ce13c7c32e4badcd171c1e9eefc49620ae525..84c3110ea03f9121fc4ab0aaa80ddad5
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (stopLock) {
-@@ -869,6 +871,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -870,6 +872,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
              if (hasStopped) return;
              hasStopped = true;
          }
@@ -56,7 +56,7 @@ index 697ce13c7c32e4badcd171c1e9eefc49620ae525..84c3110ea03f9121fc4ab0aaa80ddad5
          // Paper start - kill main thread, and kill it hard
          shutdownThread = Thread.currentThread();
          org.spigotmc.WatchdogThread.doStop(); // Paper
-@@ -985,6 +988,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -986,6 +989,8 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
      public void safeShutdown(boolean flag, boolean isRestarting) {
          this.isRunning = false;
          this.isRestarting = isRestarting;
@@ -66,7 +66,7 @@ index 697ce13c7c32e4badcd171c1e9eefc49620ae525..84c3110ea03f9121fc4ab0aaa80ddad5
              try {
                  this.serverThread.join();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a4755e2cdb40afe6af47435f92963a53d7b719c7..cbac3c96c5d3c1551912f5769bfc50d690519495 100644
+index bc8cb33d2d41deeeecc7b8740ef49d7f79076fcc..41d9f45908d8ef9b7d956aba14973c08832d4f1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;

--- a/Spigot-Server-Patches/0696-forced-whitelist-use-configurable-kick-message.patch
+++ b/Spigot-Server-Patches/0696-forced-whitelist-use-configurable-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] forced whitelist: use configurable kick message
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 84c3110ea03f9121fc4ab0aaa80ddad5efe28e5c..61712ae515b329a6b85dbe2e5960e4e864dc7731 100644
+index a116156236caa22d3ee13b5a56f4ed3c8d013f37..35bb4d0b9ed131e6570cce0b43ae78c5557a0bff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2040,7 +2040,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
+@@ -2041,7 +2041,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
                  EntityPlayer entityplayer = (EntityPlayer) iterator.next();
  
                  if (!whitelist.isWhitelisted(entityplayer.getProfile())) {


### PR DESCRIPTION
CraftChatMessage.fromComponent fails to take into account the style of TranslatableComponent args, causing any styling on args to be completely ignored.

Fixing this is relatively simple, however would cause behavior to deviate from upstream. This commit will fix the coloring in messages logged through MinecraftServer.LOGGER by simply using Adventure's legacy text serializer, which properly serializes TranslatableComponents and their arguments. Note that this doesn't do anything about the underlying issue of CraftChatMessage.fromComponent improperly serializing TranslatableComponents.

I noticed this problem when testing #5030, as log messages for getting advancements had no color compared to in game. Example screenshots:

without fix:
![image](https://user-images.githubusercontent.com/11360596/117754883-12b38180-b1d0-11eb-9521-f5e31cb7ee71.png)



with fix:
![image](https://user-images.githubusercontent.com/11360596/117754834-fd3e5780-b1cf-11eb-9786-75bca8bdccce.png)
