### PR TITLE
Add Unix domain socket support

### DIFF
--- a/Spigot-Server-Patches/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
+++ b/Spigot-Server-Patches/0088-Add-handshake-event-to-allow-plugins-to-handle-clien.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add handshake event to allow plugins to handle client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/HandshakeListener.java b/src/main/java/net/minecraft/server/network/HandshakeListener.java
-index 9b24afa4f4fe41d2261b16aaecec2144ac7d049f..5047a742d2e6a9749aa7d37e761d023a3425944b 100644
+index 9b24afa4f4fe41d2261b16aaecec2144ac7d049f..1164782be686c91379494b236ebded817a002a6f 100644
 --- a/src/main/java/net/minecraft/server/network/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/network/HandshakeListener.java
 @@ -29,7 +29,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -18,7 +18,7 @@ index 9b24afa4f4fe41d2261b16aaecec2144ac7d049f..5047a742d2e6a9749aa7d37e761d023a
  
      public HandshakeListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
          this.b = minecraftserver;
-@@ -88,8 +88,34 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -88,8 +88,35 @@ public class HandshakeListener implements PacketHandshakingInListener {
                      this.c.close(chatmessage);
                  } else {
                      this.c.setPacketListener(new LoginListener(this.b, this.c));
@@ -27,8 +27,9 @@ index 9b24afa4f4fe41d2261b16aaecec2144ac7d049f..5047a742d2e6a9749aa7d37e761d023a
 +                boolean handledByEvent = false;
 +                // Try and handle the handshake through the event
 +                if (com.destroystokyo.paper.event.player.PlayerHandshakeEvent.getHandlerList().getRegisteredListeners().length != 0) { // Hello? Can you hear me?
-+                    java.net.InetSocketAddress socketAddress = (java.net.InetSocketAddress) this.getNetworkManager().socketAddress;
-+                    com.destroystokyo.paper.event.player.PlayerHandshakeEvent event = new com.destroystokyo.paper.event.player.PlayerHandshakeEvent(packethandshakinginsetprotocol.hostname, socketAddress.getAddress().getHostAddress(), !proxyLogicEnabled);
++                    java.net.SocketAddress socketAddress = this.getNetworkManager().socketAddress;
++                    String hostnameOfRemote = socketAddress instanceof java.net.InetSocketAddress ? ((java.net.InetSocketAddress) socketAddress).getHostString() : InetAddress.getLoopbackAddress().getHostAddress();
++                    com.destroystokyo.paper.event.player.PlayerHandshakeEvent event = new com.destroystokyo.paper.event.player.PlayerHandshakeEvent(packethandshakinginsetprotocol.hostname, hostnameOfRemote, !proxyLogicEnabled);
 +                    if (event.callEvent()) {
 +                        // If we've failed somehow, let the client know so and go no further.
 +                        if (event.isFailed()) {
@@ -39,7 +40,7 @@ index 9b24afa4f4fe41d2261b16aaecec2144ac7d049f..5047a742d2e6a9749aa7d37e761d023a
 +                        }
 +
 +                        if (event.getServerHostname() != null) packethandshakinginsetprotocol.hostname = event.getServerHostname();
-+                        if (event.getSocketAddressHostname() != null) this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), socketAddress.getPort());
++                        if (event.getSocketAddressHostname() != null) this.getNetworkManager().socketAddress = new java.net.InetSocketAddress(event.getSocketAddressHostname(), socketAddress instanceof java.net.InetSocketAddress ? ((java.net.InetSocketAddress) socketAddress).getPort() : 0);
 +                        this.getNetworkManager().spoofedUUID = event.getUniqueId();
 +                        this.getNetworkManager().spoofedProfile = gson.fromJson(event.getPropertiesJson(), com.mojang.authlib.properties.Property[].class);
 +                        handledByEvent = true; // Hooray, we did it!

--- a/Spigot-Server-Patches/0171-Expose-client-protocol-version-and-virtual-host.patch
+++ b/Spigot-Server-Patches/0171-Expose-client-protocol-version-and-virtual-host.patch
@@ -88,10 +88,10 @@ index b290ddfbc19aed3e44169281c3dae5429dac0062..14c002376540d2039fc2fe2ef746e534
          return this.a;
      }
 diff --git a/src/main/java/net/minecraft/server/network/HandshakeListener.java b/src/main/java/net/minecraft/server/network/HandshakeListener.java
-index 5047a742d2e6a9749aa7d37e761d023a3425944b..24486bc7290ec6ef1e00a94e289ca35b804ab172 100644
+index ce4573c4cdc6c42aafb966e0e9658b197ab4243d..b08bd632e7e2126aa7aa58a3643e1f59f03fe538 100644
 --- a/src/main/java/net/minecraft/server/network/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/network/HandshakeListener.java
-@@ -149,6 +149,10 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -150,6 +150,10 @@ public class HandshakeListener implements PacketHandshakingInListener {
                  throw new UnsupportedOperationException("Invalid intention " + packethandshakinginsetprotocol.b());
          }
  
@@ -103,7 +103,7 @@ index 5047a742d2e6a9749aa7d37e761d023a3425944b..24486bc7290ec6ef1e00a94e289ca35b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3ab71629699f4978cd2dab36ec7e3b32a1681f91..b9a12d59e0144becc7e9c06d9a3c3079d006b583 100644
+index 2a3a2ea0fb7aee6bee88c4e578d2dd8074be971b..debb2887387e0a873292d32a9e34096494e4b716 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -188,6 +188,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/Spigot-Server-Patches/0298-Add-Velocity-IP-Forwarding-Support.patch
+++ b/Spigot-Server-Patches/0298-Add-Velocity-IP-Forwarding-Support.patch
@@ -189,7 +189,7 @@ index eb970c1e954cb0aa83aa12e83c471778809e69b2..2d8c917509f10a96fc82404908b452cb
      public void a(PacketDataSerializer packetdataserializer) throws IOException {
          this.a = packetdataserializer.i();
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
-index 21e70a133278d85ecd65fec36a273ed4faabf6cc..36f747af18347197bab7c335d5d7dfc01a5aff80 100644
+index 21e70a133278d85ecd65fec36a273ed4faabf6cc..b89a8ee2ea03d00a3d6af63d6e3e0fd62af31130 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/network/LoginListener.java
 @@ -18,12 +18,14 @@ import javax.crypto.Cipher;
@@ -251,7 +251,7 @@ index 21e70a133278d85ecd65fec36a273ed4faabf6cc..36f747af18347197bab7c335d5d7dfc0
                          String playerName = i.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) networkManager.getSocketAddress()).getAddress();
                          java.util.UUID uniqueId = i.getId();
-@@ -361,6 +379,35 @@ public class LoginListener implements PacketLoginInListener {
+@@ -361,6 +379,40 @@ public class LoginListener implements PacketLoginInListener {
      // Spigot end
  
      public void a(PacketLoginInCustomPayload packetloginincustompayload) {
@@ -268,7 +268,12 @@ index 21e70a133278d85ecd65fec36a273ed4faabf6cc..36f747af18347197bab7c335d5d7dfc0
 +                return;
 +            }
 +
-+            this.networkManager.socketAddress = new java.net.InetSocketAddress(com.destroystokyo.paper.proxy.VelocityProxy.readAddress(buf), ((java.net.InetSocketAddress) this.networkManager.getSocketAddress()).getPort());
++            java.net.SocketAddress listening = this.networkManager.getSocketAddress();
++            int port = 0;
++            if (listening instanceof java.net.InetSocketAddress) {
++                port = ((java.net.InetSocketAddress) listening).getPort();
++            }
++            this.networkManager.socketAddress = new java.net.InetSocketAddress(com.destroystokyo.paper.proxy.VelocityProxy.readAddress(buf), port);
 +
 +            this.setGameProfile(com.destroystokyo.paper.proxy.VelocityProxy.createProfile(buf));
 +
@@ -288,7 +293,7 @@ index 21e70a133278d85ecd65fec36a273ed4faabf6cc..36f747af18347197bab7c335d5d7dfc0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 04e20cb1efb7dd4be13e7c01f86f671bc9924314..63f24b977d11fc2658f8ec23c65029f3baf551f5 100644
+index d2e8d50adc49cc00d95f928a65a3c23fff0c4c80..8f472f34e4839c1c6b02b2464d73635085a78544 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -682,7 +682,7 @@ public final class CraftServer implements Server {

--- a/Spigot-Server-Patches/0557-Buffer-joins-to-world.patch
+++ b/Spigot-Server-Patches/0557-Buffer-joins-to-world.patch
@@ -57,10 +57,10 @@ index ab70eeaeca222de7de7cab1b3db14b2c4761c3c3..878f879f8d410c428ad8a4c49e0c86c5
  
          if (this.packetListener instanceof PlayerConnection) {
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
-index 06e2b48ed6d6d52d0eb17301254ed07fb69cb8af..e9fc38f69af815f021a08a94dd41b91171dbf2d6 100644
+index 44d20fc4de5c6ab59566efd29e6dfa232e36bff9..e9bc28559efdcccfb142ef8d7c614a5eecfb85a7 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/network/LoginListener.java
-@@ -417,7 +417,7 @@ public class LoginListener implements PacketLoginInListener {
+@@ -422,7 +422,7 @@ public class LoginListener implements PacketLoginInListener {
          return new GameProfile(uuid, gameprofile.getName());
      }
  

--- a/Spigot-Server-Patches/0559-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/Spigot-Server-Patches/0559-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix hex colors not working in some kick messages
 
 
 diff --git a/src/main/java/net/minecraft/server/network/HandshakeListener.java b/src/main/java/net/minecraft/server/network/HandshakeListener.java
-index 3d5381a6737876d3d7de40cacef900ab7ad27e27..97c7914e9826defc3e7167879e387fe697c10f3e 100644
+index ec6a3f57bdfaaa25e9ca350b5a712e644c9c9699..123acee4b06721ede5f2c5f8eaecffb728d63767 100644
 --- a/src/main/java/net/minecraft/server/network/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/network/HandshakeListener.java
 @@ -50,7 +50,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -33,7 +33,7 @@ index 3d5381a6737876d3d7de40cacef900ab7ad27e27..97c7914e9826defc3e7167879e387fe6
                      }
  
                      this.c.sendPacket(new PacketLoginOutDisconnect(chatmessage));
-@@ -98,7 +98,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -99,7 +99,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
                      if (event.callEvent()) {
                          // If we've failed somehow, let the client know so and go no further.
                          if (event.isFailed()) {
@@ -43,7 +43,7 @@ index 3d5381a6737876d3d7de40cacef900ab7ad27e27..97c7914e9826defc3e7167879e387fe6
                              this.getNetworkManager().close(chatmessage);
                              return;
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
-index e9fc38f69af815f021a08a94dd41b91171dbf2d6..c67b94840e4c967baebf6eb351df15f0e4ead4be 100644
+index e9bc28559efdcccfb142ef8d7c614a5eecfb85a7..4b63e84cc5d520a3f532163c5ee39e0f1acf56d8 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/network/LoginListener.java
 @@ -106,14 +106,7 @@ public class LoginListener implements PacketLoginInListener {

--- a/Spigot-Server-Patches/0703-Add-bypass-host-check.patch
+++ b/Spigot-Server-Patches/0703-Add-bypass-host-check.patch
@@ -8,7 +8,7 @@ Paper.bypassHostCheck
 Seriously, fix your firewalls. -.-
 
 diff --git a/src/main/java/net/minecraft/server/network/HandshakeListener.java b/src/main/java/net/minecraft/server/network/HandshakeListener.java
-index 97c7914e9826defc3e7167879e387fe697c10f3e..c30270ab3e822977a87240bbb98289e1d03d3748 100644
+index 123acee4b06721ede5f2c5f8eaecffb728d63767..163dcec66070745e90acce188af2e4d79c679db5 100644
 --- a/src/main/java/net/minecraft/server/network/HandshakeListener.java
 +++ b/src/main/java/net/minecraft/server/network/HandshakeListener.java
 @@ -30,6 +30,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
@@ -19,7 +19,7 @@ index 97c7914e9826defc3e7167879e387fe697c10f3e..c30270ab3e822977a87240bbb98289e1
  
      public HandshakeListener(MinecraftServer minecraftserver, NetworkManager networkmanager) {
          this.b = minecraftserver;
-@@ -117,7 +118,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+@@ -118,7 +119,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
                      // Spigot Start
                  //if (org.spigotmc.SpigotConfig.bungee) { // Paper - comment out, we check above!
                          String[] split = packethandshakinginsetprotocol.hostname.split("\00");

--- a/Spigot-Server-Patches/0740-Add-Unix-domain-socket-support.patch
+++ b/Spigot-Server-Patches/0740-Add-Unix-domain-socket-support.patch
@@ -1,0 +1,141 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Tue, 11 May 2021 17:39:22 -0400
+Subject: [PATCH] Add Unix domain socket support
+
+For Windows and ARM support, JEP-380 is required:
+https://inside.java/2021/02/03/jep380-unix-domain-sockets-channels/
+This will be possible as of the Minecraft 1.17 Java version bump.
+
+Tested-by: Mariell Hoversholm <proximyst@proximyst.com>
+Reviewed-by: Mariell Hoversholm <proximyst@proximyst.com>
+
+diff --git a/src/main/java/net/minecraft/network/NetworkManager.java b/src/main/java/net/minecraft/network/NetworkManager.java
+index f86f430598026a3a7e27fb8d40cfc5fe7b9b845d..bf0c01eaf593972bbb18c22cfdb3abd658ec6498 100644
+--- a/src/main/java/net/minecraft/network/NetworkManager.java
++++ b/src/main/java/net/minecraft/network/NetworkManager.java
+@@ -564,6 +564,11 @@ public class NetworkManager extends SimpleChannelInboundHandler<Packet<?>> {
+     // Spigot Start
+     public SocketAddress getRawAddress()
+     {
++        // Paper start - this can be nullable in the case of a Unix domain socket, so if it is, fake something
++        if (this.channel.remoteAddress() == null) {
++            return new java.net.InetSocketAddress(java.net.InetAddress.getLoopbackAddress(), 0);
++        }
++        // Paper end
+         return this.channel.remoteAddress();
+     }
+     // Spigot End
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index df8270c40ed7ce6f628686ff6f4fa4cf96af6738..b7c637900bf9229069fb618fdda0bf49d36d776e 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -225,6 +225,20 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         this.i(dedicatedserverproperties.enforceWhitelist);
+         // this.saveData.setGameType(dedicatedserverproperties.gamemode); // CraftBukkit - moved to world loading
+         DedicatedServer.LOGGER.info("Default game type: {}", dedicatedserverproperties.gamemode);
++        // Paper start - Unix domain socket support
++        java.net.SocketAddress bindAddress;
++        if (this.getServerIp().startsWith("unix:")) {
++            if (!io.netty.channel.epoll.Epoll.isAvailable()) {
++                DedicatedServer.LOGGER.fatal("**** INVALID CONFIGURATION!");
++                DedicatedServer.LOGGER.fatal("You are trying to use a Unix domain socket but you're not on a supported OS.");
++                return false;
++            } else if (!com.destroystokyo.paper.PaperConfig.velocitySupport && !org.spigotmc.SpigotConfig.bungee) {
++                DedicatedServer.LOGGER.fatal("**** INVALID CONFIGURATION!");
++                DedicatedServer.LOGGER.fatal("Unix domain sockets require IPs to be forwarded from a proxy.");
++                return false;
++            }
++            bindAddress = new io.netty.channel.unix.DomainSocketAddress(this.getServerIp().substring("unix:".length()));
++        } else {
+         InetAddress inetaddress = null;
+ 
+         if (!this.getServerIp().isEmpty()) {
+@@ -234,12 +248,15 @@ public class DedicatedServer extends MinecraftServer implements IMinecraftServer
+         if (this.getPort() < 0) {
+             this.setPort(dedicatedserverproperties.serverPort);
+         }
++        bindAddress = new java.net.InetSocketAddress(inetaddress, this.getPort());
++        }
++        // Paper end
+ 
+         this.P();
+         DedicatedServer.LOGGER.info("Starting Minecraft server on {}:{}", this.getServerIp().isEmpty() ? "*" : this.getServerIp(), this.getPort());
+ 
+         try {
+-            this.getServerConnection().a(inetaddress, this.getPort());
++            this.getServerConnection().bind(bindAddress); // Paper - Unix domain socket support
+         } catch (IOException ioexception) {
+             DedicatedServer.LOGGER.warn("**** FAILED TO BIND TO PORT!");
+             DedicatedServer.LOGGER.warn("The exception was: {}", ioexception.toString());
+diff --git a/src/main/java/net/minecraft/server/network/HandshakeListener.java b/src/main/java/net/minecraft/server/network/HandshakeListener.java
+index 74006c0af831c0e6a2b84b3638e397ab54984dc5..82540af8170f0b8cb52b13061ae8f956f1a6e46f 100644
+--- a/src/main/java/net/minecraft/server/network/HandshakeListener.java
++++ b/src/main/java/net/minecraft/server/network/HandshakeListener.java
+@@ -44,6 +44,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                 this.c.setProtocol(EnumProtocol.LOGIN);
+                 // CraftBukkit start - Connection throttle
+                 try {
++                    if (!(this.c.channel.localAddress() instanceof io.netty.channel.unix.DomainSocketAddress)) { // Paper - the connection throttle is useless when you have a Unix domain socket
+                     long currentTime = System.currentTimeMillis();
+                     long connectionThrottle = this.b.server.getConnectionThrottle();
+                     InetAddress address = ((java.net.InetSocketAddress) this.c.getSocketAddress()).getAddress();
+@@ -72,6 +73,7 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                             }
+                         }
+                     }
++                    } // Paper - add closing bracket for if check above
+                 } catch (Throwable t) {
+                     org.apache.logging.log4j.LogManager.getLogger().debug("Failed to check connection throttle", t);
+                 }
+@@ -120,8 +122,11 @@ public class HandshakeListener implements PacketHandshakingInListener {
+                 //if (org.spigotmc.SpigotConfig.bungee) { // Paper - comment out, we check above!
+                         String[] split = packethandshakinginsetprotocol.hostname.split("\00");
+                         if ( ( split.length == 3 || split.length == 4 ) && ( BYPASS_HOSTCHECK || HOST_PATTERN.matcher( split[1] ).matches() ) ) { // Paper
++                            // Paper start - Unix domain socket support
++                            java.net.SocketAddress socketAddress = c.getSocketAddress();
+                             packethandshakinginsetprotocol.hostname = split[0];
+-                            c.socketAddress = new java.net.InetSocketAddress(split[1], ((java.net.InetSocketAddress) c.getSocketAddress()).getPort());
++                            c.socketAddress = new java.net.InetSocketAddress(split[1], socketAddress instanceof java.net.InetSocketAddress ? ((java.net.InetSocketAddress) socketAddress).getPort() : 0);
++                            // Paper end
+                             c.spoofedUUID = com.mojang.util.UUIDTypeAdapter.fromString( split[2] );
+                         } else
+                         {
+diff --git a/src/main/java/net/minecraft/server/network/ServerConnection.java b/src/main/java/net/minecraft/server/network/ServerConnection.java
+index 69fc2789df88344587b6052f93661ed38f24a503..06b0ed65905b9829564dfddd29012218af0f403d 100644
+--- a/src/main/java/net/minecraft/server/network/ServerConnection.java
++++ b/src/main/java/net/minecraft/server/network/ServerConnection.java
+@@ -70,7 +70,12 @@ public class ServerConnection {
+         this.c = true;
+     }
+ 
++    // Paper start
+     public void a(@Nullable InetAddress inetaddress, int i) throws IOException {
++        bind(new java.net.InetSocketAddress(inetaddress, i));
++    }
++    public void bind(java.net.SocketAddress address) throws IOException {
++    // Paper end
+         List list = this.listeningChannels;
+ 
+         synchronized (this.listeningChannels) {
+@@ -78,7 +83,11 @@ public class ServerConnection {
+             LazyInitVar lazyinitvar;
+ 
+             if (Epoll.isAvailable() && this.e.l()) {
++                if (address instanceof io.netty.channel.unix.DomainSocketAddress) {
++                    oclass = io.netty.channel.epoll.EpollServerDomainSocketChannel.class;
++                } else {
+                 oclass = EpollServerSocketChannel.class;
++                }
+                 lazyinitvar = ServerConnection.b;
+                 ServerConnection.LOGGER.info("Using epoll channel type");
+             } else {
+@@ -106,7 +115,7 @@ public class ServerConnection {
+                     ((NetworkManager) object).setPacketListener(new HandshakeListener(ServerConnection.this.e, (NetworkManager) object));
+                     io.papermc.paper.network.ChannelInitializeListenerHolder.callListeners(channel); // Paper
+                 }
+-            }).group((EventLoopGroup) lazyinitvar.a()).localAddress(inetaddress, i)).option(ChannelOption.AUTO_READ, false).bind().syncUninterruptibly()); // CraftBukkit
++            }).group((EventLoopGroup) lazyinitvar.a()).localAddress(address)).option(ChannelOption.AUTO_READ, false).bind().syncUninterruptibly()); // CraftBukkit // Paper
+         }
+     }
+ 


### PR DESCRIPTION
This PR adds support to Paper so that servers can listen on a Unix domain socket instead of over TCP/IP. A Unix domain socket has several advantages:

* Unix domain sockets feature lower latency and higher throughput, since all of the TCP and IP machinery in the kernel can be skipped. This is especially useful for a proxy connecting to a local server.
* Unix domain sockets are much more secure compared to TCP/IP. Permissions are granted based on file system permissions and are enforced by the kernel. In addition, for proxies, using a Unix domain socket completely eliminates unauthorized connections.

There are some downsides:

* This currently only works on x86_64 Linux with the epoll transport. (Sorry Raspberry Pi and Windows users.)
* The Paper and Bukkit APIs are infested with the implicit knowledge that TCP/IP is the only useful way to connect to a Minecraft server, so I had to implement some hacks to work around that.
* This implementation of Unix domain sockets support requires forwarding player information from a proxy. BungeeCord and Velocity forwarding methods are implemented and known to work.
* Support for this connection method is not widespread - currently the in-development Velocity 2.0.0 is the only proxy with support for this.

I have tested the BungeeCord and Velocity forwarding changes in this PR and confirmed that they work.

## Testing this PR (and using its functionality)

Right now, the easiest way to test this PR is to use the current development builds of [Velocity 2.0.0](https://ci.velocitypowered.com/job/velocity-2.0.0/).

1. Edit `server.properties` and change `server-ip` to `unix:<path>`, for instance `unix:/home/minecraft/servers/lobby/minecraft.sock` and restart the server.
2. Edit the Velocity configuration and set the `lobby` server to point to `unix://<path>`, for instance `unix:///home/minecraft/servers/lobby/minecraft.sock` and reload the proxy with `/velocity reload`.
3. Make sure forwarding is set up on the Paper server and on Velocity.
4. Connect to the proxy. You should be connected to the lobby server over a Unix domain socket now.

## How this PR reconciles TCP/IP anachronisms and Unix domain sockets

This is simple. We assume that connections coming in from an unknown source come from `localhost` and the port is always `0`. This is, strictly speaking, not proper, but in practice is "correct enough". I'm open to any changes to this scheme.