### PR TITLE
Add raw address to AsyncPlayerPreLoginEvent

### DIFF
--- a/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -29,6 +29,8 @@ index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669
 +        return rawAddress;
 +    }
 +
+
++    @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile) {
 +        this(name, ipAddress, ipAddress, uniqueId, profile);
 +    }

--- a/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -1,0 +1,47 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Connor Linfoot <connorlinfoot@me.com>
+Date: Wed, 12 May 2021 08:09:19 +0100
+Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669f1b68c23 100644
+--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+@@ -20,6 +20,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+     private net.kyori.adventure.text.Component message; // Paper
+     //private String name; // Paper - Not used anymore
+     private final InetAddress ipAddress;
++    private final InetAddress rawAddress; // Paper
+     //private UUID uniqueId; // Paper - Not used anymore
+ 
+     @Deprecated
+@@ -49,7 +50,20 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         this.profile = profile;
+     }
+ 
++    /**
++     * Gets the raw address of the player logging in
++     * @return The address
++     */
++    @NotNull
++    public InetAddress getRawAddress() {
++        return rawAddress;
++    }
++
+     public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile) {
++        this(name, ipAddress, ipAddress, uniqueId, profile);
++    }
++
++    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final InetAddress rawAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile) {
+         super(true);
+         this.profile = profile;
+         // Paper end
+@@ -57,6 +71,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         this.message = net.kyori.adventure.text.Component.empty(); // Paper
+         //this.name = name; // Paper - Not used anymore
+         this.ipAddress = ipAddress;
++        this.rawAddress = rawAddress; // Paper
+         //this.uniqueId = uniqueId; // Paper - Not used anymore
+     }
+ 

--- a/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/Spigot-API-Patches/0297-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669f1b68c23 100644
+index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..77aefda5aac4602bf5bf71c29600e7450defdd4e 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -20,6 +20,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
@@ -16,10 +16,11 @@ index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669
      //private UUID uniqueId; // Paper - Not used anymore
  
      @Deprecated
-@@ -49,7 +50,20 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -49,7 +50,23 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.profile = profile;
      }
  
++    // Paper Start
 +    /**
 +     * Gets the raw address of the player logging in
 +     * @return The address
@@ -28,8 +29,8 @@ index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669
 +    public InetAddress getRawAddress() {
 +        return rawAddress;
 +    }
++    // Paper end
 +
-
 +    @Deprecated
      public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile) {
 +        this(name, ipAddress, ipAddress, uniqueId, profile);
@@ -39,7 +40,7 @@ index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..707aaae8e0b1fa90f6ea8e6b7e2b2669
          super(true);
          this.profile = profile;
          // Paper end
-@@ -57,6 +71,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+@@ -57,6 +74,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
          this.message = net.kyori.adventure.text.Component.empty(); // Paper
          //this.name = name; // Paper - Not used anymore
          this.ipAddress = ipAddress;

--- a/Spigot-Server-Patches/0726-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/Spigot-Server-Patches/0726-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
-index c67b94840e4c967baebf6eb351df15f0e4ead4be..933bc5231d7990a6732224092f9bfb9d5f5e7112 100644
+index c67b94840e4c967baebf6eb351df15f0e4ead4be..f54af7cabc6b4e062948dc97e577e7fe04b5add4 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/network/LoginListener.java
 @@ -327,12 +327,13 @@ public class LoginListener implements PacketLoginInListener {
                          // Paper end
                          String playerName = i.getName();
                          java.net.InetAddress address = ((java.net.InetSocketAddress) networkManager.getSocketAddress()).getAddress();
-+                        java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) networkManager.getRawAddress()).getAddress();
++                        java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) networkManager.getRawAddress()).getAddress(); // Paper
                          java.util.UUID uniqueId = i.getId();
                          final org.bukkit.craftbukkit.CraftServer server = LoginListener.this.server.server;
  

--- a/Spigot-Server-Patches/0726-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/Spigot-Server-Patches/0726-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Connor Linfoot <connorlinfoot@me.com>
+Date: Wed, 12 May 2021 08:09:19 +0100
+Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
+index c67b94840e4c967baebf6eb351df15f0e4ead4be..933bc5231d7990a6732224092f9bfb9d5f5e7112 100644
+--- a/src/main/java/net/minecraft/server/network/LoginListener.java
++++ b/src/main/java/net/minecraft/server/network/LoginListener.java
+@@ -327,12 +327,13 @@ public class LoginListener implements PacketLoginInListener {
+                         // Paper end
+                         String playerName = i.getName();
+                         java.net.InetAddress address = ((java.net.InetSocketAddress) networkManager.getSocketAddress()).getAddress();
++                        java.net.InetAddress rawAddress = ((java.net.InetSocketAddress) networkManager.getRawAddress()).getAddress();
+                         java.util.UUID uniqueId = i.getId();
+                         final org.bukkit.craftbukkit.CraftServer server = LoginListener.this.server.server;
+ 
+                             // Paper start
+                             PlayerProfile profile = CraftPlayerProfile.asBukkitMirror(getGameProfile());
+-                            AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, uniqueId, profile);
++                            AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile);
+                         server.getPluginManager().callEvent(asyncEvent);
+                             profile = asyncEvent.getPlayerProfile();
+                             profile.complete(true);


### PR DESCRIPTION
Would be nice to be able to access the raw address during this event instead of having to wait and check on the PlayerLoginEvent, especially if you wish to do something based on that information in AsyncPlayerPreLoginEvent.