### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/Spigot-Server-Patches/0002-Paper-config-files.patch
+++ b/Spigot-Server-Patches/0002-Paper-config-files.patch
@@ -689,7 +689,7 @@ index 344b7f52e85af3e543da0bb1dd14b68eb41ebb84..f794113e7cc5809d1da0c85648fb7311
          this.world = new CraftWorld((WorldServer) this, gen, env);
          this.ticksPerAnimalSpawns = this.getServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 20a5e136a8967311026111b4c246c200596cd019..bd62288b6951c6b5962497a3c93989cab5d66ad4 100644
+index b28ce2590d044dede6b9166e168c00d4ed6578f2..7b77bbf15e59c5a993fb1683c27e41425419e138 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -808,6 +808,7 @@ public final class CraftServer implements Server {
@@ -716,7 +716,7 @@ index 20a5e136a8967311026111b4c246c200596cd019..bd62288b6951c6b5962497a3c93989ca
          overrideAllCommandBlockCommands = commandsConfiguration.getStringList("command-block-overrides").contains("*");
          ignoreVanillaPermissions = commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2097,4 +2100,35 @@ public final class CraftServer implements Server {
+@@ -2105,4 +2108,35 @@ public final class CraftServer implements Server {
          return spigot;
      }
      // Spigot end
@@ -753,7 +753,7 @@ index 20a5e136a8967311026111b4c246c200596cd019..bd62288b6951c6b5962497a3c93989ca
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3f52c19b6b797e26b3dcedcec2afd28c478e7091..3a6578170765a472d36b169b999e9dc57bf8070b 100644
+index c6417a0594ffe2d3650ec54d44e575e347a1f724..3b48799d084f14722f815cb35cbd48b618380fca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {

--- a/Spigot-Server-Patches/0009-Timings-v2.patch
+++ b/Spigot-Server-Patches/0009-Timings-v2.patch
@@ -1812,10 +1812,10 @@ index 27703b807735d52313b93f8f606aa263571525d2..f301c7ba4b17b92c6cf2fcee6da1e670
  
      private static NBTTagCompound a(ChunkCoordIntPair chunkcoordintpair, Map<StructureGenerator<?>, StructureStart<?>> map, Map<StructureGenerator<?>, LongSet> map1) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bd62288b6951c6b5962497a3c93989cab5d66ad4..6d68610d8ffdef4357cf61ac2f4cf6bf54157b15 100644
+index 7b77bbf15e59c5a993fb1683c27e41425419e138..ce68a6cf845af640e03819c44860590655f74cb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2069,12 +2069,31 @@ public final class CraftServer implements Server {
+@@ -2077,12 +2077,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1646,7 +1646,7 @@ index 7ec93ddd7e7c9dc54e3e4dcfe0d1654c0b0a8536..3f057f0bd23bc1c693c8f04ee8acd662
              }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e3a4896de 100644
+index ce68a6cf845af640e03819c44860590655f74cb1..cb470baa3533e4502c13982ef4e03041fac91ce5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -563,8 +563,11 @@ public final class CraftServer implements Server {
@@ -1662,7 +1662,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
      }
  
      public Player getPlayer(final EntityPlayer entity) {
-@@ -1302,7 +1305,15 @@ public final class CraftServer implements Server {
+@@ -1310,7 +1313,15 @@ public final class CraftServer implements Server {
          return configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1678,7 +1678,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
      public String getShutdownMessage() {
          return configuration.getString("settings.shutdown-message");
      }
-@@ -1418,7 +1429,15 @@ public final class CraftServer implements Server {
+@@ -1426,7 +1437,15 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1694,7 +1694,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1426,14 +1445,14 @@ public final class CraftServer implements Server {
+@@ -1434,14 +1453,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1711,7 +1711,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1659,6 +1678,14 @@ public final class CraftServer implements Server {
+@@ -1667,6 +1686,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1726,7 +1726,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1671,13 +1698,28 @@ public final class CraftServer implements Server {
+@@ -1679,13 +1706,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1755,7 +1755,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1721,6 +1763,12 @@ public final class CraftServer implements Server {
+@@ -1729,6 +1771,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1768,7 +1768,7 @@ index 6d68610d8ffdef4357cf61ac2f4cf6bf54157b15..2f6b49e3ae7a7407eaec9810af8bf72e
      @Override
      public String getMotd() {
          return console.getMotd();
-@@ -2149,5 +2197,15 @@ public final class CraftServer implements Server {
+@@ -2157,5 +2205,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }

--- a/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
+++ b/Spigot-Server-Patches/0024-Further-improve-server-tick-loop.patch
@@ -140,10 +140,10 @@ index 9ba05ab7ec97896349f4b754f2993cda9ab1bbfd..add4f149fd31d1420d825b646b3e0888
                      GameProfilerTick gameprofilertick = GameProfilerTick.a("Server");
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1818a6af3a55d15be698d5219e0eea63e2077611..f84fe5929cb7bcedff5fc587163380172bc1e8be 100644
+index c66be5b9f304878f9179faba433f2e844bcee72c..eeaf100f73bb10e0a49400795f568438982f7cfa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2113,6 +2113,17 @@ public final class CraftServer implements Server {
+@@ -2121,6 +2121,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/Spigot-Server-Patches/0047-Expose-server-CommandMap.patch
+++ b/Spigot-Server-Patches/0047-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e78182508ccd05bcb934a29eb495ff9c884d3a55..5e97a52222dbccbdde7d478d76363495784facb8 100644
+index 3b29f94dcfb98ba7cdd61c7b398dbc8fc56f5aef..9142a4813414d125ebff32e1521659da525e7337 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1752,6 +1752,7 @@ public final class CraftServer implements Server {
+@@ -1760,6 +1760,7 @@ public final class CraftServer implements Server {
          return helpMap;
      }
  

--- a/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
+++ b/Spigot-Server-Patches/0062-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b16d5f35d2c1c2ac29be2d6457ad83d0fcb98379..991ef9048822e52d1f39467f9b815eb1ba779f4b 100644
+index b75c5571c3f1d7c45ca2dd29ff285cb5a0d27071..9e2b3ef9296cd6bbba99f1b1e3181fff4e537760 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2244,5 +2244,23 @@ public final class CraftServer implements Server {
+@@ -2252,5 +2252,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
+++ b/Spigot-Server-Patches/0108-Add-setting-for-proxy-online-mode-status.patch
@@ -66,10 +66,10 @@ index 4ad084e7cea3b341ca0dbaa6e853cfc685a555ff..b9f94f957dd5372c8b02d785204690e4
  
      public synchronized void a(GameProfile gameprofile) { // Paper - synchronize
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 96abe76ab9d71561740499b4dfcfa94ded1c1b53..f1572f708911d61ae6dc0077475fee8d815e28db 100644
+index a084beced6647d6815e9bd728b2107c03998777c..f6d4e8d008b85bcf52cfeceb6b40fe9d1a2b557b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1507,7 +1507,8 @@ public final class CraftServer implements Server {
+@@ -1515,7 +1515,8 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/Spigot-Server-Patches/0120-Allow-Reloading-of-Command-Aliases.patch
+++ b/Spigot-Server-Patches/0120-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1572f708911d61ae6dc0077475fee8d815e28db..d3621b626799f470329e8f5097fc10016cd48560 100644
+index f6d4e8d008b85bcf52cfeceb6b40fe9d1a2b557b..e5ade7ac2bd059e2d05f2f38d0dae77070c989f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2273,5 +2273,24 @@ public final class CraftServer implements Server {
+@@ -2281,5 +2281,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/Spigot-Server-Patches/0145-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d3621b626799f470329e8f5097fc10016cd48560..1f0021c5374e1af9c9cd29d44e6b0bd9522394d9 100644
+index e5ade7ac2bd059e2d05f2f38d0dae77070c989f7..e2062f2a86cd764c86e69709b370f54b7fb5e15c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2292,5 +2292,10 @@ public final class CraftServer implements Server {
+@@ -2300,5 +2300,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -266,7 +266,7 @@ index 6c80f328016b6cd30c77b5a5b1e2f6be0b3cd2f0..a892bcf08dddac90f01caec81229259e
  
          this.k = new GameProfileBanList(PlayerList.b);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1f0021c5374e1af9c9cd29d44e6b0bd9522394d9..5d357b0f84b5242066dcce203752a0f46e9a249c 100644
+index e2062f2a86cd764c86e69709b370f54b7fb5e15c..268d56859a0de3b2ca39155f882991b5bf3aa5e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,7 +46,6 @@ import java.util.function.Consumer;
@@ -285,7 +285,7 @@ index 1f0021c5374e1af9c9cd29d44e6b0bd9522394d9..5d357b0f84b5242066dcce203752a0f4
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.ServerCommand;
  import net.minecraft.server.bossevents.BossBattleCustom;
-@@ -1201,9 +1201,13 @@ public final class CraftServer implements Server {
+@@ -1209,9 +1209,13 @@ public final class CraftServer implements Server {
          return logger;
      }
  

--- a/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0152-Basic-PlayerProfile-API.patch
@@ -517,7 +517,7 @@ index b9f94f957dd5372c8b02d785204690e4ade36a98..692d95c94df85d752a3ddc66e1f2af76
          private volatile long c;
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4f9c42a4b0256f181263bf5e0492714a01fbec38..7d2fc05ddb18369aed29595e3c0dcbf6db136309 100644
+index 92c68becf45d83dbc18d3a9c1f86f8aa308e0d87..c8ea7b8ad46ce0fab794b897b5f3fe414a679387 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -227,6 +227,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -530,7 +530,7 @@ index 4f9c42a4b0256f181263bf5e0492714a01fbec38..7d2fc05ddb18369aed29595e3c0dcbf6
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2309,5 +2312,24 @@ public final class CraftServer implements Server {
+@@ -2317,5 +2320,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/Spigot-Server-Patches/0180-AsyncTabCompleteEvent.patch
+++ b/Spigot-Server-Patches/0180-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index 3628965d2a18a367c2357b54b65786fb90c38205..fc624315b156f450c1cbc87a81e9eeff
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7d2fc05ddb18369aed29595e3c0dcbf6db136309..f1d4e2ac2823e2246463350b21f28c6d32f4f2c5 100644
+index c8ea7b8ad46ce0fab794b897b5f3fe414a679387..3c019719e6eaf789bd5e20f382b707973f8b39c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1844,7 +1844,7 @@ public final class CraftServer implements Server {
+@@ -1852,7 +1852,7 @@ public final class CraftServer implements Server {
              offers = tabCompleteChat(player, message);
          }
  

--- a/Spigot-Server-Patches/0202-getPlayerUniqueId-API.patch
+++ b/Spigot-Server-Patches/0202-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f1d4e2ac2823e2246463350b21f28c6d32f4f2c5..6b0b55aa2ac4dec4e6005f557b9ba6975a7b58ed 100644
+index 3c019719e6eaf789bd5e20f382b707973f8b39c6..d15314af5ed58c846b97997fdfdf28786873ae01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1511,6 +1511,25 @@ public final class CraftServer implements Server {
+@@ -1519,6 +1519,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
+++ b/Spigot-Server-Patches/0313-Make-the-default-permission-message-configurable.patch
@@ -29,10 +29,10 @@ index 13edb435b3fa65b4980bd7472aa5a5196f4d5b2b..469f78775b03cf363d88e35c69c0dc18
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8f472f34e4839c1c6b02b2464d73635085a78544..c1e563b76271ad84654fe2abf31f86815600dca6 100644
+index 54fa963faab3289d014299a38099eb72ff541065..0cfbe461c9b915c96b27f88f651a296d470b995f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2334,6 +2334,11 @@ public final class CraftServer implements Server {
+@@ -2342,6 +2342,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/Spigot-Server-Patches/0349-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index 7ef01f2f80eea31fa76d22c3a0d5036883dee516..e885e5c4c772a87c0359ed2c56aa71a8
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c1e563b76271ad84654fe2abf31f86815600dca6..841443e8dc9e72296d364fa61f8778d7c24038c9 100644
+index 0cfbe461c9b915c96b27f88f651a296d470b995f..7b2326922415ae55dd930654defb09f736c1f781 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1833,7 +1833,7 @@ public final class CraftServer implements Server {
+@@ -1841,7 +1841,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/Spigot-Server-Patches/0381-Expose-the-internal-current-tick.patch
+++ b/Spigot-Server-Patches/0381-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 841443e8dc9e72296d364fa61f8778d7c24038c9..6a92b46d127d6c3b30123343c3c0e2926174a7f8 100644
+index 7b2326922415ae55dd930654defb09f736c1f781..3cb67cfe8b69da722709ebdde250add88c19fee3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2357,5 +2357,10 @@ public final class CraftServer implements Server {
+@@ -2365,5 +2365,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/Spigot-Server-Patches/0431-Add-tick-times-API-and-mspt-command.patch
+++ b/Spigot-Server-Patches/0431-Add-tick-times-API-and-mspt-command.patch
@@ -147,10 +147,10 @@ index 5ea593ccfedf55140a723f6dc29bebe282e77ab3..795cf9635ab6ac7f001476354813cac9
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6a92b46d127d6c3b30123343c3c0e2926174a7f8..a42650f6353b86a5054d071a4355c6d3b5dc926e 100644
+index 3cb67cfe8b69da722709ebdde250add88c19fee3..35e1739c4c90f4f27ed2b729a2ec2522b3aa0c06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2195,6 +2195,16 @@ public final class CraftServer implements Server {
+@@ -2203,6 +2203,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/Spigot-Server-Patches/0432-Expose-MinecraftServer-isRunning.patch
+++ b/Spigot-Server-Patches/0432-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a42650f6353b86a5054d071a4355c6d3b5dc926e..35d3d3d49fb5231df7ec7820c6c422abfb8165a5 100644
+index 35e1739c4c90f4f27ed2b729a2ec2522b3aa0c06..fbc5d62d1ac2affc5240b114ee88375ff0199ef4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2372,5 +2372,10 @@ public final class CraftServer implements Server {
+@@ -2380,5 +2380,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
+++ b/Spigot-Server-Patches/0437-Improved-Watchdog-Support.patch
@@ -345,10 +345,10 @@ index cc41dcd85760b57bb8076b37e9a907d1cb4e12c7..efcfc8f0f45901d14ac8fdf8ed7b0bd6
              String msg = "Entity threw exception at " + entity.world.getWorld().getName() + ":" + entity.locX() + "," + entity.locY() + "," + entity.locZ();
              System.err.println(msg);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 35d3d3d49fb5231df7ec7820c6c422abfb8165a5..4373cd10711a6250745d93da697e4e11818be8e6 100644
+index fbc5d62d1ac2affc5240b114ee88375ff0199ef4..b55b2a27adba357faee0f260c8d7cc247d8d8238 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1833,7 +1833,7 @@ public final class CraftServer implements Server {
+@@ -1841,7 +1841,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/Spigot-Server-Patches/0465-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0465-Implement-Mob-Goal-API.patch
@@ -1043,10 +1043,10 @@ index 8c8e39d35fb56aa6cf7d456adab01dff5d13a60d..bcf6c924894f49f1c602b83b501f904e
  
      public PathfinderGoalWrapped(int i, PathfinderGoal pathfindergoal) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 352f4caec33de8a4351392859b43caa6b02d51c4..e20e3d69ac1c4cf97afd522340464e53d2497c08 100644
+index 688bf56b331cc4b6b9664365f97a98720ec522a9..3b7a7791a221aaf39b4b6974b2f37efd403e4b25 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2384,5 +2384,11 @@ public final class CraftServer implements Server {
+@@ -2392,5 +2392,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/Spigot-Server-Patches/0524-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/Spigot-Server-Patches/0524-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -27,10 +27,10 @@ index 60ecd3a92af0f1968b10bb8babfb43147ef568d3..9077b70650d70dd294f53a1ef73e86e2
  
                                  for (int l = 0; l < k; ++l) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e95093e1b2d7368a796e3e98e2bd491906164e44..d0eb0509953ddcd8d25bf3a9fd4f2170f7b88037 100644
+index 02de2c985e0dcb43ff10e686b608052e83629064..1e0546a14506a41d1a7b74d306b992cfbdf6e0cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2026,6 +2026,32 @@ public final class CraftServer implements Server {
+@@ -2034,6 +2034,32 @@ public final class CraftServer implements Server {
          return new CraftChunkData(world);
      }
  

--- a/Spigot-Server-Patches/0590-Add-getOfflinePlayerIfCached-String.patch
+++ b/Spigot-Server-Patches/0590-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 21bc20882835243bff5308e6a6a168e9811f5a60..38553aa11224a1621e7a06801a0448a0948ce130 100644
+index 53254ad9e775e9e78da238a54be7d3fc4b8a6ced..49d989545aa1a02ecc811a74f0283e779d2543a0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1606,6 +1606,28 @@ public final class CraftServer implements Server {
+@@ -1614,6 +1614,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/Spigot-Server-Patches/0655-Added-Vanilla-Entity-Tags.patch
+++ b/Spigot-Server-Patches/0655-Added-Vanilla-Entity-Tags.patch
@@ -40,10 +40,10 @@ index 0000000000000000000000000000000000000000..2ca8e1bade5450a14125b77540792e0b
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 38553aa11224a1621e7a06801a0448a0948ce130..bc8cb33d2d41deeeecc7b8740ef49d7f79076fcc 100644
+index 49d989545aa1a02ecc811a74f0283e779d2543a0..19bd420e6bf625f77bb37755ff8364e5955feb2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2215,6 +2215,11 @@ public final class CraftServer implements Server {
+@@ -2223,6 +2223,11 @@ public final class CraftServer implements Server {
                  Preconditions.checkArgument(clazz == org.bukkit.Fluid.class, "Fluid namespace must have fluid type");
  
                  return (org.bukkit.Tag<T>) new CraftFluidTag(console.getTagRegistry().getFluidTags(), key);

--- a/Spigot-Server-Patches/0690-Implement-Keyed-on-World.patch
+++ b/Spigot-Server-Patches/0690-Implement-Keyed-on-World.patch
@@ -64,19 +64,19 @@ index 760579921927b4c8b0f20b2611b95fd626e4b27f..3075700dfa992da81b10246fcf7c7ad1
          return this.c;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cbac3c96c5d3c1551912f5769bfc50d690519495..03b8d67a5f0088c0254b2099f27e8dcae32a6221 100644
+index e8305df0ce11bf7c297bf5f0acc95f07324e4143..6cc8eb04f42592aa12f76bb4a0a863ea509741b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1154,7 +1154,7 @@ public final class CraftServer implements Server {
-             chunkgenerator = worlddimension.c();
+@@ -1161,7 +1161,7 @@ public final class CraftServer implements Server {
+         } else if (name.equals(levelName + "_the_end")) {
+             worldKey = net.minecraft.world.level.World.THE_END;
+         } else {
+-            worldKey = ResourceKey.a(IRegistry.L, new MinecraftKey(name.toLowerCase(java.util.Locale.ENGLISH)));
++            worldKey = ResourceKey.newResourceKey(IRegistry.getWorldRegistry(), new net.minecraft.resources.MinecraftKey(creator.key().getNamespace().toLowerCase(java.util.Locale.ENGLISH), creator.key().getKey().toLowerCase(java.util.Locale.ENGLISH))); // Paper
          }
  
--        ResourceKey<net.minecraft.world.level.World> worldKey = ResourceKey.a(IRegistry.L, new MinecraftKey(name.toLowerCase(java.util.Locale.ENGLISH)));
-+        ResourceKey<net.minecraft.world.level.World> worldKey = ResourceKey.newResourceKey(IRegistry.getWorldRegistry(), new MinecraftKey(creator.key().getNamespace().toLowerCase(java.util.Locale.ENGLISH), creator.key().getKey().toLowerCase(java.util.Locale.ENGLISH))); // Paper
- 
          WorldServer internal = (WorldServer) new WorldServer(console, console.executorService, worldSession, worlddata, worldKey, dimensionmanager, getServer().worldLoadListenerFactory.create(11),
-                 chunkgenerator, worlddata.getGeneratorSettings().isDebugWorld(), j, creator.environment() == Environment.NORMAL ? list : ImmutableList.of(), true, creator.environment(), generator);
-@@ -1245,6 +1245,15 @@ public final class CraftServer implements Server {
+@@ -1253,6 +1253,15 @@ public final class CraftServer implements Server {
          return null;
      }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
51e2981b #831: Reload unloaded main worlds correctly