### PR TITLE
Add ItemStack#getTranslationKey()

### DIFF
--- a/Spigot-API-Patches/0223-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-API-Patches/0223-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -27,35 +27,42 @@ index 2b53e68e96ea346a6f2b5cadcf9f81b2c231c408..e453e5eb7245aad3ecbb19652ebb34ab
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index e348034288c74ab80360086d71f0b7f61551df24..a604b7e00e64912a2103d9af845eddff6835e825 100644
+index e348034288c74ab80360086d71f0b7f61551df24..2d9264ffe0fee863f1b814952ef063daa7962d76 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -101,5 +101,27 @@ public interface UnsafeValues {
+@@ -101,5 +101,34 @@ public interface UnsafeValues {
      byte[] serializeItem(ItemStack item);
  
      ItemStack deserializeItem(byte[] data);
 +
 +    /**
 +     * Return the translation key for the Material, so the client can translate it into the active
-+     * locale when using a TranslatableComponent.
++     * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.
 +     * @return the translation key
 +     */
 +    String getTranslationKey(Material mat);
 +
 +    /**
 +     * Return the translation key for the Block, so the client can translate it into the active
-+     * locale when using a TranslatableComponent.
++     * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.
 +     * @return the translation key
 +     */
 +    String getTranslationKey(org.bukkit.block.Block block);
 +
 +    /**
 +     * Return the translation key for the EntityType, so the client can translate it into the active
-+     * locale when using a TranslatableComponent.<br>
++     * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.<br>
 +     * This is <code>null</code>, when the EntityType isn't known to NMS (custom entities)
 +     * @return the translation key
 +     */
 +    String getTranslationKey(org.bukkit.entity.EntityType type);
++
++    /**
++     * Return the translation key for the ItemStack, so the client can translate it into the active
++     * locale when using a {@link net.kyori.adventure.text.TranslatableComponent}.<br>
++     * @return the translation key
++     */
++    String getTranslationKey(ItemStack itemStack);
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
@@ -95,4 +102,26 @@ index 774363a8186b3861f10c0452ac63726cae365169..692b75eb78405874077c850bfc72e247
 +    String getTranslationKey() {
 +        return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
 +    }
+ }
+diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
+index 58f99e3ebac9a01ebffe4d208e16cbee474d4aa3..a3335b8622a70fbf4a55213f1a5010ffdc4783bb 100644
+--- a/src/main/java/org/bukkit/inventory/ItemStack.java
++++ b/src/main/java/org/bukkit/inventory/ItemStack.java
+@@ -842,5 +842,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+         ItemMeta itemMeta = getItemMeta();
+         return itemMeta != null && itemMeta.hasItemFlag(flag);
+     }
++
++    /**
++     * Gets the translation key for this itemstack.
++     * This is not the same as getting the translation key
++     * for the material of this itemstack.
++     *
++     * @return the translation key
++     */
++    @NotNull
++    public String getTranslationKey() {
++        return Bukkit.getUnsafe().getTranslationKey(this);
++    }
+     // Paper end
  }

--- a/Spigot-API-Patches/0226-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-API-Patches/0226-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,13 +6,13 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index a604b7e00e64912a2103d9af845eddff6835e825..fafc4d63b6202b00a133c50cd38dec54db9b3576 100644
+index 2d9264ffe0fee863f1b814952ef063daa7962d76..84eda68281c6c6968d95b1313a33696c3a9980d4 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -123,5 +123,13 @@ public interface UnsafeValues {
+@@ -130,5 +130,12 @@ public interface UnsafeValues {
       * @return the translation key
       */
-     String getTranslationKey(org.bukkit.entity.EntityType type);
+     String getTranslationKey(ItemStack itemStack);
 +
 +    /**
 +     * Creates and returns the next EntityId available.
@@ -20,6 +20,5 @@ index a604b7e00e64912a2103d9af845eddff6835e825..fafc4d63b6202b00a133c50cd38dec54
 +     * Use this when sending custom packets, so that there are no collisions on the client or server.
 +     */
 +    public int nextEntityId();
-+
      // Paper end
  }

--- a/Spigot-API-Patches/0282-Item-Rarity-API.patch
+++ b/Spigot-API-Patches/0282-Item-Rarity-API.patch
@@ -61,13 +61,14 @@ index 112c3f035ec7e7a7cae939264e0af4c6f4450abd..9b1c9e60dba9ea3ef8d8e164f13dd76d
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index fafc4d63b6202b00a133c50cd38dec54db9b3576..6db8c3bae9c9bb10eedf8102b3ac4c6eb288b77b 100644
+index 84eda68281c6c6968d95b1313a33696c3a9980d4..bcd10b2c9255d778b678310febf1937301d01a50 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -131,5 +131,21 @@ public interface UnsafeValues {
+@@ -137,5 +137,22 @@ public interface UnsafeValues {
+      * Use this when sending custom packets, so that there are no collisions on the client or server.
       */
      public int nextEntityId();
- 
++
 +    /**
 +     * Gets the item rarity of a material. The material <b>MUST</b> be an item.
 +     * Use {@link Material#isItem()} before this.
@@ -87,12 +88,12 @@ index fafc4d63b6202b00a133c50cd38dec54db9b3576..6db8c3bae9c9bb10eedf8102b3ac4c6e
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 58f99e3ebac9a01ebffe4d208e16cbee474d4aa3..3c64c6ef397af102a3e085fe6b77a888d5c3de84 100644
+index a3335b8622a70fbf4a55213f1a5010ffdc4783bb..b9694780d824063cf90cd968d3e6b57f49fcbeb3 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -842,5 +842,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
-         ItemMeta itemMeta = getItemMeta();
-         return itemMeta != null && itemMeta.hasItemFlag(flag);
+@@ -854,5 +854,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+     public String getTranslationKey() {
+         return Bukkit.getUnsafe().getTranslationKey(this);
      }
 +
 +    /**

--- a/Spigot-API-Patches/0283-Expose-protocol-version.patch
+++ b/Spigot-API-Patches/0283-Expose-protocol-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index 6db8c3bae9c9bb10eedf8102b3ac4c6eb288b77b..3bf6e58b2351cee935e23abec1cea289e31943dc 100644
+index bcd10b2c9255d778b678310febf1937301d01a50..6dbd520182b1e7713a68baad09b7f613424ef619 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
-@@ -147,5 +147,12 @@ public interface UnsafeValues {
+@@ -154,5 +154,12 @@ public interface UnsafeValues {
       * @return the itemstack rarity
       */
      public io.papermc.paper.inventory.ItemRarity getItemStackRarity(ItemStack itemStack);

--- a/Spigot-Server-Patches/0564-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-Server-Patches/0564-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -26,7 +26,7 @@ index 9d2955f05aadd4bbc6dcfec068a55d7fe6950ba0..f2cf33d42839710a3bbdf0c8ea0be28a
          if (this.bo == null) {
              this.bo = SystemUtils.a("entity", IRegistry.ENTITY_TYPE.getKey(this));
 diff --git a/src/main/java/net/minecraft/world/item/Item.java b/src/main/java/net/minecraft/world/item/Item.java
-index ca513e7b0a416860aba89e41de6a7c5ff42baa69..5d7c44a53fb98532057b09176677ce0d719b055b 100644
+index ca513e7b0a416860aba89e41de6a7c5ff42baa69..467121839b94e09f59c64300de9f26d3c6caf1e5 100644
 --- a/src/main/java/net/minecraft/world/item/Item.java
 +++ b/src/main/java/net/minecraft/world/item/Item.java
 @@ -56,7 +56,7 @@ public class Item implements IMaterial {
@@ -46,15 +46,23 @@ index ca513e7b0a416860aba89e41de6a7c5ff42baa69..5d7c44a53fb98532057b09176677ce0d
      protected String m() {
          if (this.name == null) {
              this.name = SystemUtils.a("item", IRegistry.ITEM.getKey(this));
+@@ -164,6 +165,7 @@ public class Item implements IMaterial {
+         return this.m();
+     }
+ 
++    public String getDescriptionId(ItemStack itemStack) { return f(itemStack); } // Paper - OBFHELPER
+     public String f(ItemStack itemstack) {
+         return this.getName();
+     }
 diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
-index cc512bd2e89382e7fdbc59b41640e95ccafbbfe9..768934fa4158a9773d06f5b23bfb19db75f6d179 100644
+index cc512bd2e89382e7fdbc59b41640e95ccafbbfe9..d4903842aebeff3e32dbf7d3f4b670af4ebad174 100644
 --- a/src/main/java/net/minecraft/world/level/block/Block.java
 +++ b/src/main/java/net/minecraft/world/level/block/Block.java
 @@ -318,6 +318,7 @@ public class Block extends BlockBase implements IMaterial {
          return !this.material.isBuildable() && !this.material.isLiquid();
      }
  
-+    public String getDescriptionId() { return i(); } // Paper - OBFHELPER
++    public String getOrCreateDescriptionId() { return i(); } // Paper - OBFHELPER
      public String i() {
          if (this.name == null) {
              this.name = SystemUtils.a("block", IRegistry.BLOCK.getKey(this));
@@ -74,7 +82,7 @@ index e3ab0b76e5003553b29215a43bc5a762f2663648..ee8977a1e4a83598ba7873c4c482fea8
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 2519dbce9717ff647d50c31aed6aca68b9f4e3af..6c59816bb9246f22d518aa9f87ec382ae3d3a014 100644
+index 2519dbce9717ff647d50c31aed6aca68b9f4e3af..8049063ea37f3e0eac3f3a26703adc80fc99341a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -45,6 +45,7 @@ import org.bukkit.Registry;
@@ -85,7 +93,7 @@ index 2519dbce9717ff647d50c31aed6aca68b9f4e3af..6c59816bb9246f22d518aa9f87ec382a
  import org.bukkit.craftbukkit.block.data.CraftBlockData;
  import org.bukkit.craftbukkit.inventory.CraftItemStack;
  import org.bukkit.craftbukkit.legacy.CraftLegacy;
-@@ -420,6 +421,25 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -420,6 +421,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
              throw new RuntimeException();
          }
      }
@@ -93,14 +101,14 @@ index 2519dbce9717ff647d50c31aed6aca68b9f4e3af..6c59816bb9246f22d518aa9f87ec382a
 +    @Override
 +    public String getTranslationKey(Material mat) {
 +        if (mat.isBlock()) {
-+            return getBlock(mat).getDescriptionId();
++            return getBlock(mat).getOrCreateDescriptionId();
 +        }
-+        return getItem(mat).getOrCreateDescriptionId();
++        return getItem(mat).getName();
 +    }
 +
 +    @Override
 +    public String getTranslationKey(org.bukkit.block.Block block) {
-+        return ((org.bukkit.craftbukkit.block.CraftBlock)block).getNMS().getBlock().getDescriptionId();
++        return ((org.bukkit.craftbukkit.block.CraftBlock)block).getNMS().getBlock().getOrCreateDescriptionId();
 +    }
 +
 +    @Override
@@ -108,6 +116,11 @@ index 2519dbce9717ff647d50c31aed6aca68b9f4e3af..6c59816bb9246f22d518aa9f87ec382a
 +        return net.minecraft.world.entity.EntityTypes.getByName(type.getName()).map(net.minecraft.world.entity.EntityTypes::getDescriptionId).orElse(null);
 +    }
 +
++    @Override
++    public String getTranslationKey(org.bukkit.inventory.ItemStack itemStack) {
++        net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
++        return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
++    }
      // Paper end
  
      /**

--- a/Spigot-Server-Patches/0572-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-Server-Patches/0572-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -21,17 +21,17 @@ index 344862c3f479ae7b6d4f929c9ef7882aba983ffb..e2301dbeb3d76684b2a0ab4262bb76ca
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 6c59816bb9246f22d518aa9f87ec382ae3d3a014..a1c918e84627d79f6665237851f614880a9da6f7 100644
+index 8049063ea37f3e0eac3f3a26703adc80fc99341a..5b03187f4d76e3052ee9abe0ee2774218d41b864 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -440,6 +440,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
-         return net.minecraft.world.entity.EntityTypes.getByName(type.getName()).map(net.minecraft.world.entity.EntityTypes::getDescriptionId).orElse(null);
+@@ -445,6 +445,10 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         net.minecraft.world.item.ItemStack nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
+         return nmsItemStack.getItem().getDescriptionId(nmsItemStack);
      }
- 
++
 +    public int nextEntityId() {
 +        return net.minecraft.world.entity.Entity.nextEntityId();
 +    }
-+
      // Paper end
  
      /**

--- a/Spigot-Server-Patches/0692-Item-Rarity-API.patch
+++ b/Spigot-Server-Patches/0692-Item-Rarity-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Item Rarity API
 
 
 diff --git a/src/main/java/net/minecraft/world/item/Item.java b/src/main/java/net/minecraft/world/item/Item.java
-index 5d7c44a53fb98532057b09176677ce0d719b055b..e6a838430084d64326d1042c7b2089f49a24a789 100644
+index 467121839b94e09f59c64300de9f26d3c6caf1e5..f7758ee4aa8bbb31a80ec2e331b3fd3c55069808 100644
 --- a/src/main/java/net/minecraft/world/item/Item.java
 +++ b/src/main/java/net/minecraft/world/item/Item.java
 @@ -45,7 +45,7 @@ public class Item implements IMaterial {
@@ -17,7 +17,7 @@ index 5d7c44a53fb98532057b09176677ce0d719b055b..e6a838430084d64326d1042c7b2089f4
      private final int maxStackSize;
      private final int durability;
      private final boolean d;
-@@ -208,6 +208,7 @@ public class Item implements IMaterial {
+@@ -209,6 +209,7 @@ public class Item implements IMaterial {
          return itemstack.hasEnchantments();
      }
  
@@ -26,13 +26,14 @@ index 5d7c44a53fb98532057b09176677ce0d719b055b..e6a838430084d64326d1042c7b2089f4
          if (!itemstack.hasEnchantments()) {
              return this.a;
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index f69b4576f05dbf763e99d5d1cbed069c55c793ed..971877c42f7a46696a389ef7d93f44993c360810 100644
+index 848a704fa100c39098a5716bb25b6a9ed85d7a8c..de6a9d795ebaf9c608944415c7dc18c6aee23245 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -467,6 +467,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -472,6 +472,20 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public int nextEntityId() {
          return net.minecraft.world.entity.Entity.nextEntityId();
      }
- 
++
 +    @Override
 +    public io.papermc.paper.inventory.ItemRarity getItemRarity(org.bukkit.Material material) {
 +        Item item = getItem(material);
@@ -46,7 +47,6 @@ index f69b4576f05dbf763e99d5d1cbed069c55c793ed..971877c42f7a46696a389ef7d93f4499
 +    public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
 +        return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getItemStackRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
 +    }
-+
      // Paper end
  
      /**

--- a/Spigot-Server-Patches/0700-Expose-protocol-version.patch
+++ b/Spigot-Server-Patches/0700-Expose-protocol-version.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Expose protocol version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 971877c42f7a46696a389ef7d93f44993c360810..6141e86278d876e42dbed6e8f2275280babcef77 100644
+index de6a9d795ebaf9c608944415c7dc18c6aee23245..697949abbe662a55fc31ad811863717e35b9d1b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-@@ -481,6 +481,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+@@ -486,6 +486,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+     public io.papermc.paper.inventory.ItemRarity getItemStackRarity(org.bukkit.inventory.ItemStack itemStack) {
          return io.papermc.paper.inventory.ItemRarity.values()[getItem(itemStack.getType()).getItemStackRarity(CraftItemStack.asNMSCopy(itemStack)).ordinal()];
      }
- 
++
 +    @Override
 +    public int getProtocolVersion() {
 +        return net.minecraft.SharedConstants.getGameVersion().getProtocolVersion();
 +    }
-+
      // Paper end
  
      /**


### PR DESCRIPTION
Fixes #4600

Uses Item#getName which is overriden in the right places.
Also provides translation api for itemstacks.
