### PR TITLE
Add EntityPortalReadyEvent

### DIFF
--- a/patches/api/0387-Add-EntityPortalReadyEvent.patch
+++ b/patches/api/0387-Add-EntityPortalReadyEvent.patch
@@ -1,0 +1,101 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 12 May 2021 04:30:53 -0700
+Subject: [PATCH] Add EntityPortalReadyEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3c6c1d7e97a0c9813bbc585fd209cc63f498e0d4
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityPortalReadyEvent.java
+@@ -0,0 +1,89 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.PortalType;
++import org.bukkit.World;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Called when an entity is ready to be teleported by a plugin.
++ * Currently this is only called after the required
++ * ticks have passed for a Nether Portal.
++ * <p>
++ * Cancelling this event resets the entity's readiness
++ * regarding the current portal.
++ */
++public class EntityPortalReadyEvent extends EntityEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private World targetWorld;
++    private final PortalType portalType;
++    private boolean cancelled;
++
++    public EntityPortalReadyEvent(final @NotNull Entity entity, final @Nullable World targetWorld, final @NotNull PortalType portalType) {
++        super(entity);
++        this.targetWorld = targetWorld;
++        this.portalType = portalType;
++    }
++
++    /**
++     * Gets the world this portal will teleport to.
++     * Can be null if "allow-nether" is false in server.properties
++     * or if there is another situation where there is no world to teleport to.
++     * <p>
++     * This world may be modified by later events such as {@link org.bukkit.event.player.PlayerPortalEvent}
++     * or {@link org.bukkit.event.entity.EntityPortalEvent}.
++     *
++     * @return the world the portal will teleport the entity to.
++     */
++    public @Nullable World getTargetWorld() {
++        return targetWorld;
++    }
++
++    /**
++     * Sets the world this portal will teleport to. A null value
++     * will essentially cancel the teleport and prevent further events
++     * such as {@link org.bukkit.event.player.PlayerPortalEvent} from firing.
++     * <p>
++     * This world may be modified by later events such as {@link org.bukkit.event.player.PlayerPortalEvent}
++     * or {@link org.bukkit.event.entity.EntityPortalEvent}.
++     *
++     * @param targetWorld the world
++     */
++    public void setTargetWorld(final @Nullable World targetWorld) {
++        this.targetWorld = targetWorld;
++    }
++
++    /**
++     * Gets the portal type for this event.
++     *
++     * @return the portal type
++     */
++    public @NotNull PortalType getPortalType() {
++        return portalType;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(final boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++}

--- a/patches/server/0926-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0926-Add-EntityPortalReadyEvent.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 12 May 2021 04:30:42 -0700
+Subject: [PATCH] Add EntityPortalReadyEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 19a64b582bc042e426220e080d9c21b3a82cf3f7..cff8490a2f08215fdd8c5d819ec76cafd8a8cb90 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -2856,6 +2856,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+                 if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
+                     this.level.getProfiler().push("portal");
+                     this.portalTime = i;
++                    // Paper start
++                    io.papermc.paper.event.entity.EntityPortalReadyEvent event = new io.papermc.paper.event.entity.EntityPortalReadyEvent(this.getBukkitEntity(), worldserver1 == null ? null : worldserver.getWorld(), org.bukkit.PortalType.NETHER);
++                    if (!event.callEvent()) {
++                        this.portalTime = 0;
++                    } else {
++                        worldserver1 = event.getTargetWorld() == null ? null : ((CraftWorld) event.getTargetWorld()).getHandle();
++                    // Paper end
+                     this.setPortalCooldown();
+                     // CraftBukkit start
+                     if (this instanceof ServerPlayer) {
+@@ -2863,6 +2870,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+                     } else {
+                         this.changeDimension(worldserver1);
+                     }
++                    } // Paper
+                     // CraftBukkit end
+                     this.level.getProfiler().pop();
+                 }


### PR DESCRIPTION
Fixes #4632

It doesn't look feasible to have Entity/PlayerPortalEvents called if there isn't a world to teleport to, this should function as an alternative to those looking to listen to when a player has waited long enough in a nether portal.