### PR TITLE
Update Java version warning

### DIFF
--- a/Spigot-Server-Patches/0609-Add-warning-for-servers-not-running-on-Java-16.patch
+++ b/Spigot-Server-Patches/0609-Add-warning-for-servers-not-running-on-Java-16.patch
@@ -1,12 +1,12 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Kyle Wood <demonwav@gmail.com>
 Date: Wed, 2 Dec 2020 21:58:45 -0800
-Subject: [PATCH] Add warning for servers not running on Java 11
+Subject: [PATCH] Add warning for servers not running on Java 16
 
 
 diff --git a/src/main/java/io/papermc/paper/util/PaperJvmChecker.java b/src/main/java/io/papermc/paper/util/PaperJvmChecker.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c6ea429819c07e7f4bc257cad73463a030767825
+index 0000000000000000000000000000000000000000..fdf3ff8894e5e202229d1be52fe3c92ea039ef15
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/PaperJvmChecker.java
 @@ -0,0 +1,48 @@
@@ -38,7 +38,7 @@ index 0000000000000000000000000000000000000000..c6ea429819c07e7f4bc257cad73463a0
 +    }
 +
 +    public static void checkJvm() {
-+        if (getJvmVersion() < 11) {
++        if (getJvmVersion() < 16) {
 +            final Logger logger = LogManager.getLogger();
 +            logger.warn("************************************************************");
 +            logger.warn("* WARNING - YOU ARE RUNNING AN OUTDATED VERSION OF JAVA.");
@@ -46,14 +46,14 @@ index 0000000000000000000000000000000000000000..c6ea429819c07e7f4bc257cad73463a0
 +            logger.warn("* JAVA WHEN MINECRAFT 1.17 IS RELEASED.");
 +            logger.warn("*");
 +            logger.warn("* Please update the version of Java you use to run Paper");
-+            logger.warn("* to at least Java 11. When Paper for Minecraft 1.17 is");
-+            logger.warn("* released support for versions of Java before 11 will");
++            logger.warn("* to at least Java 16. When Paper for Minecraft 1.17 is");
++            logger.warn("* released support for versions of Java before 16 will");
 +            logger.warn("* be dropped.");
 +            logger.warn("*");
 +            logger.warn("* Current Java version: {}", System.getProperty("java.version"));
 +            logger.warn("*");
 +            logger.warn("* Check this forum post for more information: ");
-+            logger.warn("*   https://papermc.io/java11");
++            logger.warn("*   https://papermc.io/java16");
 +            logger.warn("************************************************************");
 +        }
 +    }


### PR DESCRIPTION
Users should be made aware of this as soon as possible, since the jump to Java 16 is not as easy as it is from 8 to 11.
The papermc.io link should be updated accordingly before this is merged.

@proximsy :AlienPls3: