### PR TITLE
Add corner getter to WorldBorder

### DIFF
--- a/patches/api/0322-Add-corner-getter-to-WorldBorder.patch
+++ b/patches/api/0322-Add-corner-getter-to-WorldBorder.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TwoLeggedCat <80929284+TwoLeggedCat@users.noreply.github.com>
+Date: Wed, 23 Jun 2021 15:44:10 -0500
+Subject: [PATCH] Add corner getter to WorldBorder
+
+
+diff --git a/src/main/java/org/bukkit/WorldBorder.java b/src/main/java/org/bukkit/WorldBorder.java
+index afb7b136b461202026290624836446cff9f9e45d..f1743cca7a87835a425d643cca2d02e4b82a64be 100644
+--- a/src/main/java/org/bukkit/WorldBorder.java
++++ b/src/main/java/org/bukkit/WorldBorder.java
+@@ -47,6 +47,16 @@ public interface WorldBorder {
+      */
+     public void setCenter(double x, double z);
+ 
++    // Paper start
++    /**
++     * Returns the specified corner of the WorldBorder
++     *
++     * @param corner Which corner to return
++     * @return Location of corner where y is always the minimum height of the world
++     */
++    public @NotNull Location getCornerLocation(@NotNull Corner corner);
++    // Paper end
++
+     /**
+      * Sets the new border center.
+      *
+@@ -130,5 +140,32 @@ public interface WorldBorder {
+     public default boolean isInBounds(@NotNull Location location) {
+         return this.isInside(location);
+     }
++
++    public enum Corner {
++        NORTH_EAST,
++        NORTH_WEST,
++        SOUTH_EAST,
++        SOUTH_WEST;
++
++        public boolean isNorth() {
++            switch (this) {
++                case NORTH_EAST:
++                case NORTH_WEST:
++                    return true;
++                default:
++                    return false;
++            }
++        }
++
++        public boolean isEast() {
++            switch (this) {
++                case NORTH_EAST:
++                case SOUTH_EAST:
++                    return true;
++                default:
++                    return false;
++            }
++        }
++    }
+     // Paper end
+ }

--- a/patches/server/0721-Add-corner-getter-to-WorldBorder.patch
+++ b/patches/server/0721-Add-corner-getter-to-WorldBorder.patch
@@ -1,0 +1,39 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: TwoLeggedCat <80929284+TwoLeggedCat@users.noreply.github.com>
+Date: Wed, 23 Jun 2021 15:44:04 -0500
+Subject: [PATCH] Add corner getter to WorldBorder
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java b/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+index 15e0a57e2cb5b9a67f776ff71902e33e47c93fd8..fcb48e7d759a060802ce8e37eb9aa8a0eccd87bb 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorldBorder.java
+@@ -71,6 +71,17 @@ public class CraftWorldBorder implements WorldBorder {
+         this.setCenter(location.getX(), location.getZ());
+     }
+ 
++    // Paper start
++    @Override
++    public @org.jetbrains.annotations.NotNull Location getCornerLocation(@org.jetbrains.annotations.NotNull Corner corner) {
++        org.apache.commons.lang.Validate.notNull(corner, "Corner cannot be null");
++        double halfSize = this.getHalfLength();
++        double x = this.handle.getCenterX() + (corner.isEast() ? halfSize : -halfSize);
++        double z = this.handle.getCenterZ() + (corner.isNorth() ? -halfSize : halfSize);
++        return new Location(world, x, world.getMinHeight(), z);
++    }
++    // Paper end
++
+     @Override
+     public double getDamageBuffer() {
+         return this.handle.getDamageSafeZone();
+@@ -117,4 +128,10 @@ public class CraftWorldBorder implements WorldBorder {
+ 
+         return location.getWorld().equals(this.world) && this.handle.isWithinBounds(new BlockPos(location.getX(), location.getY(), location.getZ()));
+     }
++
++    // Paper start
++    private double getHalfLength() {
++        return this.handle.getSize() / 2;
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Adds methods to get the corners from a WorldBorder.

Couple of questions (which don't need to be answered if the answer is no):

1. Should the new Enum (Corner) be placed under io.papermc? If so, what package?

2. Is 'Validate.notNull(corner, "Corner cannot be null");' unnecessary? Previous discussion came down to "depends on how it's compiled, but unnecessary with Paper's Maven setup," but this is done in other places in Paper, so I did it here as well.

3. Anything else I broke?