### PR TITLE
Remove unneeded component conversion for kick msg

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1394,7 +1394,7 @@ index 4ed497ee04d9e9116e1f7d90bf975aeadd24aa93..a39f58e0c60b5e3ccc3b725f1f4167d5
               }
              // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c601a5c577e438a3fa8dd4c5f36dbe9494b03d52..15418868c2b92498139e66d913ee1c35b3abf0cf 100644
+index c601a5c577e438a3fa8dd4c5f36dbe9494b03d52..6ebd4ec781aa215c2b941261250c15c87c223cab 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.authlib.GameProfile;
@@ -1513,7 +1513,7 @@ index c601a5c577e438a3fa8dd4c5f36dbe9494b03d52..15418868c2b92498139e66d913ee1c35
          // CraftBukkit start - disconnect safely
          for (EntityPlayer player : this.players) {
 -            player.playerConnection.disconnect(this.server.server.getShutdownMessage()); // CraftBukkit - add custom shutdown message
-+            player.playerConnection.disconnect(PaperAdventure.asVanilla(this.server.server.shutdownMessage())); // CraftBukkit - add custom shutdown message // Paper - Adventure
++            player.playerConnection.disconnect(this.server.server.shutdownMessage()); // CraftBukkit - add custom shutdown message // Paper - Adventure
          }
          // CraftBukkit end
  
@@ -2078,7 +2078,7 @@ index 3a4e2261d0b0cd17df3f96e75f3c509156679c48..105d0388998d1e35e634d2163fe1a44a
          player.activeContainer.addSlotListener(player);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6cb968dec5 100644
+index b51a874e4665f977a154792e6216e03e04525f39..6ab14bccb1fcd108931bf7ec331e60f652e0b42d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -240,14 +240,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2176,7 +2176,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
          getHandle().playerConnection.sendPacket(packet);
      }
  
-@@ -335,6 +360,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -335,6 +360,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getHandle().playerConnection.disconnect(message == null ? "" : message);
      }
  
@@ -2186,9 +2186,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
 +        org.spigotmc.AsyncCatcher.catchOp("player kick");
 +        final PlayerConnection connection = this.getHandle().playerConnection;
 +        if (connection != null) {
-+            connection.disconnect(io.papermc.paper.adventure.PaperAdventure.asVanilla(
-+                message == null ? net.kyori.adventure.text.Component.empty() : message
-+            ));
++            connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
 +        }
 +    }
 +    // Paper end
@@ -2196,7 +2194,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
      @Override
      public void setCompassTarget(Location loc) {
          if (getHandle().playerConnection == null) return;
-@@ -561,6 +599,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -561,6 +597,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getHandle().playerConnection.sendPacket(packet);
      }
  
@@ -2234,7 +2232,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
      @Override
      public void sendSignChange(Location loc, String[] lines) {
         sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -583,12 +652,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -583,12 +650,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          IChatBaseComponent[] components = CraftSign.sanitizeLines(lines);
@@ -2250,7 +2248,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
      }
  
      @Override
-@@ -1688,6 +1758,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1688,6 +1756,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : getHandle().clientViewDistance;
      }
  
@@ -2263,7 +2261,7 @@ index b51a874e4665f977a154792e6216e03e04525f39..fd1fd9bfee34b88864187d9004eb9d6c
      @Override
      public int getPing() {
          return getHandle().ping;
-@@ -1716,6 +1792,138 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1716,6 +1790,138 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  

--- a/Spigot-Server-Patches/0021-Player-affects-spawning-API.patch
+++ b/Spigot-Server-Patches/0021-Player-affects-spawning-API.patch
@@ -131,10 +131,10 @@ index 33cba4e475edc0573b901f70c61d3659fd63ad62..8d8b03074df1635946f81bec0feae18d
  
      public void c() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fd1fd9bfee34b88864187d9004eb9d6cb968dec5..cbedfb3525ba34490b84926800bbd61b9997947e 100644
+index 6ab14bccb1fcd108931bf7ec331e60f652e0b42d..cc471418b37a745ecea1af964e81bc0362cf7d94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1772,8 +1772,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1770,8 +1770,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return getHandle().locale;

--- a/Spigot-Server-Patches/0025-Only-refresh-abilities-if-needed.patch
+++ b/Spigot-Server-Patches/0025-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5d446eb731621e2205b684923a06b932d41ba421..11304fef16c341f5643683a4c1b662222c9ce5d8 100644
+index cc471418b37a745ecea1af964e81bc0362cf7d94..fb792de46ff80a6bad77a47954861cddfd17f2d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1441,12 +1441,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1439,12 +1439,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/Spigot-Server-Patches/0054-Configurable-inter-world-teleportation-safety.patch
+++ b/Spigot-Server-Patches/0054-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2542b3a135dd3f728a5a44c9f9c81ae524734abf..465fd7b4ee8f0a36c2a944c95666979a2d33c248 100644
+index 1ad5863dc12b2288a38efed71b7fa4b84296d96d..f2228933719a2325a518be15237fedf56c994d1f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -865,7 +865,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -863,7 +863,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.playerConnection.teleport(to);
          } else {

--- a/Spigot-Server-Patches/0059-Complete-resource-pack-API.patch
+++ b/Spigot-Server-Patches/0059-Complete-resource-pack-API.patch
@@ -22,7 +22,7 @@ index 6a8567c355202560ee523c6dc68cac1ac3e562fd..69dc4431a430461ce242de5c1a1c3023
      // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f473808393b8440f457dfa1b2e1b9e8ccd60ec48..628f34f3855f0c8359b1e916dd3419345f690575 100644
+index f2228933719a2325a518be15237fedf56c994d1f..ed5680e6e0fcfbaf948bdede98d206cff2b26467 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -138,6 +138,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -36,7 +36,7 @@ index f473808393b8440f457dfa1b2e1b9e8ccd60ec48..628f34f3855f0c8359b1e916dd341934
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
          super(server, entity);
-@@ -1876,6 +1880,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1874,6 +1878,32 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/Spigot-Server-Patches/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/Spigot-Server-Patches/0068-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 9b12e15a6c377ae90193596a35114dd452cf6e0c..acbd10432b09172f7541b2f4081d1aa9812194ac 100644
+index 082a3efb8c03e6a0a35411107f3cf3776dee14bf..c7b40800343edb2c2a68786afb828c9dc3e3627f 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -702,7 +702,13 @@ public abstract class EntityLiving extends Entity {
@@ -44,10 +44,10 @@ index 9b12e15a6c377ae90193596a35114dd452cf6e0c..acbd10432b09172f7541b2f4081d1aa9
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 144faef77e69c6c3bf963327179a51bb4c37cc18..b4a2758ee246252d6076e861b45d11dae6e33096 100644
+index ed5680e6e0fcfbaf948bdede98d206cff2b26467..ab7e731cb04a75b829f0cd24d7b94f7ddad166e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1682,6 +1682,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1680,6 +1680,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/Spigot-Server-Patches/0084-Workaround-for-setting-passengers-on-players.patch
+++ b/Spigot-Server-Patches/0084-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b4a2758ee246252d6076e861b45d11dae6e33096..facf2a79144a2d0fbea907c084becaea7bbdc48c 100644
+index ab7e731cb04a75b829f0cd24d7b94f7ddad166e8..4bb57229c045956bab631982e12c0fc420db450e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -874,6 +874,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -872,6 +872,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
+++ b/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index ad55212370e3d814a397680927a1514ea0fe85b5..120cad4e7330900fa11d278cf87a6ab4
          this.locale = packetplayinsettings.locale;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 46af184cd8280822170f28464eb32595733234c3..26396ca131d81b7357c31b3475eea8b2a7fb8638 100644
+index 4bb57229c045956bab631982e12c0fc420db450e..5698ef90bfeceec37eaf7f23361246ef125b3cd1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1879,8 +1879,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1877,8 +1877,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/Spigot-Server-Patches/0142-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/Spigot-Server-Patches/0142-Properly-handle-async-calls-to-restart-the-server.patch
@@ -73,7 +73,7 @@ index 283c1111d99b6ae09b6db0c0079eeb0f1cbb7b2b..d92ca78e483b3f085e3bad1d1250cac2
      // Spigot Start
      private static double calcTps(double avg, double exp, double tps)
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eb5c22d8af3a3cfadd581d641010942caa6bed54..6c80f328016b6cd30c77b5a5b1e2f6be0b3cd2f0 100644
+index f0928684f2bb56b490bea7cd80eb9300d2647f0c..67814e3e54ec2be02c4d592c56b60e66d15bedb2 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1158,9 +1158,15 @@ public abstract class PlayerList {
@@ -89,7 +89,7 @@ index eb5c22d8af3a3cfadd581d641010942caa6bed54..6c80f328016b6cd30c77b5a5b1e2f6be
          // CraftBukkit start - disconnect safely
          for (EntityPlayer player : this.players) {
 +            if (isRestarting) player.playerConnection.disconnect(org.spigotmc.SpigotConfig.restartMessage); else // Paper
-             player.playerConnection.disconnect(PaperAdventure.asVanilla(this.server.server.shutdownMessage())); // CraftBukkit - add custom shutdown message // Paper - Adventure
+             player.playerConnection.disconnect(this.server.server.shutdownMessage()); // CraftBukkit - add custom shutdown message // Paper - Adventure
          }
          // CraftBukkit end
 @@ -1173,6 +1179,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0184-Ability-to-apply-mending-to-XP-API.patch
+++ b/Spigot-Server-Patches/0184-Ability-to-apply-mending-to-XP-API.patch
@@ -42,7 +42,7 @@ index d313b02f41e4f4a90676cbb37afce4e92dd4d664..72afbf8f537770540e90a2880ea81de1
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cf9ae60db30ef09bb4c89935a42632e562b6d61e..4766a78a0562e5ae6e7d4850bd7b5d71425c3a0c 100644
+index b9a12d59e0144becc7e9c06d9a3c3079d006b583..e00b33493208865c0bd1bd11a96dd2ed1348da7c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -58,13 +58,17 @@ import net.minecraft.server.level.WorldServer;
@@ -63,7 +63,7 @@ index cf9ae60db30ef09bb4c89935a42632e562b6d61e..4766a78a0562e5ae6e7d4850bd7b5d71
  import net.minecraft.world.level.EnumGamemode;
  import net.minecraft.world.level.block.entity.TileEntitySign;
  import net.minecraft.world.level.saveddata.maps.MapIcon;
-@@ -1180,8 +1184,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1178,8 +1182,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(getHandle().playerInteractManager.getGameMode().getId());
      }
  

--- a/Spigot-Server-Patches/0200-Player.setPlayerProfile-API.patch
+++ b/Spigot-Server-Patches/0200-Player.setPlayerProfile-API.patch
@@ -48,7 +48,7 @@ index 18b0020d184e46c8957e82100681c8c66b1c3b62..41dd46c6ef95f7dc41d9ca36a5f0b85f
      private final ItemCooldown bM;
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4766a78a0562e5ae6e7d4850bd7b5d71425c3a0c..e6adf5ab609076bf1c25061429ed9aba1df1d9cb 100644
+index e00b33493208865c0bd1bd11a96dd2ed1348da7c..e1d1aaa278287214e2edac5f690d4f5257696ed0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -70,6 +70,7 @@ import net.minecraft.world.item.EnumColor;
@@ -59,7 +59,7 @@ index 4766a78a0562e5ae6e7d4850bd7b5d71425c3a0c..e6adf5ab609076bf1c25061429ed9aba
  import net.minecraft.world.level.block.entity.TileEntitySign;
  import net.minecraft.world.level.saveddata.maps.MapIcon;
  import net.minecraft.world.phys.Vec3D;
-@@ -1312,8 +1313,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1310,8 +1311,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -74,7 +74,7 @@ index 4766a78a0562e5ae6e7d4850bd7b5d71425c3a0c..e6adf5ab609076bf1c25061429ed9aba
          PlayerChunkMap.EntityTracker entry = tracker.trackedEntities.get(other.getId());
          if (entry != null) {
              entry.clear(getHandle());
-@@ -1354,8 +1360,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1352,8 +1358,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          hiddenPlayers.remove(player.getUniqueId());
  
@@ -89,7 +89,7 @@ index 4766a78a0562e5ae6e7d4850bd7b5d71425c3a0c..e6adf5ab609076bf1c25061429ed9aba
  
          getHandle().playerConnection.sendPacket(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, other));
  
-@@ -1364,6 +1375,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1362,6 +1373,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(getHandle());
          }
      }

--- a/Spigot-Server-Patches/0206-Flag-to-disable-the-channel-limit.patch
+++ b/Spigot-Server-Patches/0206-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e6adf5ab609076bf1c25061429ed9aba1df1d9cb..871c0e0b0c6df68c0f8c87828a01fe006d0646fb 100644
+index e1d1aaa278287214e2edac5f690d4f5257696ed0..2abd5157b0964fc02994ca7a9317d2fb5539dc1c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -146,6 +146,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index e6adf5ab609076bf1c25061429ed9aba1df1d9cb..871c0e0b0c6df68c0f8c87828a01fe00
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1581,7 +1582,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1579,7 +1580,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
@@ -180,10 +180,10 @@ index db7ad5a94d449f58a5749115776e61f448ff2f52..e8f8a07f256e01c5792199bf47f3cc1f
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 871c0e0b0c6df68c0f8c87828a01fe006d0646fb..32228b4eddaadabbae46ebbc5eb3404acf73fb29 100644
+index 2abd5157b0964fc02994ca7a9317d2fb5539dc1c..ee3fbf0789b4841a113727397ba6809b2600ff83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -900,7 +900,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -898,7 +898,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (getHandle().activeContainer != getHandle().defaultContainer) {

--- a/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
+++ b/Spigot-Server-Patches/0279-Expose-attack-cooldown-methods-for-Player.patch
@@ -17,10 +17,10 @@ index b6effe1037f3ae59e6faa5f5d039b6ad54bca5d4..87374174dcbf9e7ee448a1cdd9a35285
          return (float) (1.0D / this.b(GenericAttributes.ATTACK_SPEED) * 20.0D);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5d75a1f838b8ef21c3eaa6dca6e0d82b0ab5e825..577fa407e436fd3b65eb8a40a7f2ec0a7b2abfac 100644
+index ee3fbf0789b4841a113727397ba6809b2600ff83..a13867ff6d188e7633a91f1e1600116286ac0cd4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2191,6 +2191,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2189,6 +2189,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          connection.sendPacket(new net.minecraft.network.protocol.game.PacketPlayOutOpenBook(net.minecraft.world.EnumHand.MAIN_HAND));
          connection.sendPacket(new net.minecraft.network.protocol.game.PacketPlayOutSetSlot(0, slot, inventory.getItemInHand()));
      }

--- a/Spigot-Server-Patches/0280-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0280-Improve-death-events.patch
@@ -253,7 +253,7 @@ index a64b2953c43138491cdab3e3e24e2e7ed969e171..b3c2976a48c2349e5c22d58dd1ac64a0
          return this.isBaby() ? (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.5F : (this.random.nextFloat() - this.random.nextFloat()) * 0.2F + 1.0F;
      }
 diff --git a/src/main/java/net/minecraft/world/entity/animal/EntityFox.java b/src/main/java/net/minecraft/world/entity/animal/EntityFox.java
-index 459b7727e946679989477f4a7e99c5ca47ac0b30..a3b714a9d63c6bb33a2731fb9293c9d155754b17 100644
+index 77de0706aaa32b565cb1e14754e93a1c4a6e15bd..b7fa24318ef43918b6b10ff4ea8acb960527296e 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/EntityFox.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/EntityFox.java
 @@ -647,15 +647,25 @@ public class EntityFox extends EntityAnimal {
@@ -325,10 +325,10 @@ index 8d35240405d7f7245f3c7b0b611973d58fa4384f..69361caebf0d3caa5195b519a1669170
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9d3e01f7ad743dbe60685e9b111308ed06a0b4b7..2334a9a95ab0e2395744343a5a1e3d26c88b7dc3 100644
+index a13867ff6d188e7633a91f1e1600116286ac0cd4..6c5075ef2420131aa21b403623a5dfa485ee73e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1841,7 +1841,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1839,7 +1839,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index bea8dd578cfd5532dd1b679a4ee4e6c74a416bba..e3cc64e837fa9b9c1f1d95037b1a59f1d1f4e6ef 100644
+index 1bf0e7ca544aa377005dfcc197f136ecef019e3a..97aae1d2a512e6197ca3e491d041efd2def6e37a 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -213,6 +213,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -106,7 +106,7 @@ index 9b8d7b176e288fa715177196e7aff92900d8567a..1e741158bbcc0991259436bec549b32d
      public Location getBedSpawnLocation() {
          NBTTagCompound data = getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2334a9a95ab0e2395744343a5a1e3d26c88b7dc3..c2ebf264d9d150541aeb2d89f24853c2f887cde5 100644
+index 6c5075ef2420131aa21b403623a5dfa485ee73e5..25e0d0dd7b114560896679f0314cea288d7a768c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -147,6 +147,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 2334a9a95ab0e2395744343a5a1e3d26c88b7dc3..c2ebf264d9d150541aeb2d89f24853c2
      // Paper end
  
      public CraftPlayer(CraftServer server, EntityPlayer entity) {
-@@ -1485,6 +1486,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1483,6 +1484,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 2334a9a95ab0e2395744343a5a1e3d26c88b7dc3..c2ebf264d9d150541aeb2d89f24853c2
      public void readExtraData(NBTTagCompound nbttagcompound) {
          hasPlayedBefore = true;
          if (nbttagcompound.hasKey("bukkit")) {
-@@ -1507,6 +1520,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1505,6 +1518,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(NBTTagCompound nbttagcompound) {
@@ -145,7 +145,7 @@ index 2334a9a95ab0e2395744343a5a1e3d26c88b7dc3..c2ebf264d9d150541aeb2d89f24853c2
          if (!nbttagcompound.hasKey("bukkit")) {
              nbttagcompound.set("bukkit", new NBTTagCompound());
          }
-@@ -1521,6 +1536,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1519,6 +1534,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.setLong("firstPlayed", getFirstPlayed());
          data.setLong("lastPlayed", System.currentTimeMillis());
          data.setString("lastKnownName", handle.getName());

--- a/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/Spigot-Server-Patches/0323-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3e07e93a272bb65db9f191ae7c3ed18ccc9d3657..5cdefb8978cdd3d29cc120c35040189c4f86f7bf 100644
+index 25e0d0dd7b114560896679f0314cea288d7a768c..f57ad014fb3d2ce2405bdd63db4c730458aac17a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2236,6 +2236,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2234,6 +2234,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackCooldown();
      }

--- a/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
+++ b/Spigot-Server-Patches/0346-Per-Player-View-Distance-API-placeholders.patch
@@ -40,10 +40,10 @@ index 145767e8b0fc4105a0afa47af17dcdbb75e952bc..174eb12722872182b2d9b54841e5bb57
                          double deltaZ = this.locZ() - player.locZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5cdefb8978cdd3d29cc120c35040189c4f86f7bf..c0d2abd31272e35c0a0a4f8c31cfd89e56552bea 100644
+index f57ad014fb3d2ce2405bdd63db4c730458aac17a..dc8545241ed62f6b654b2559e025c3b34c00575f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2245,6 +2245,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2243,6 +2243,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              super.remove();
          }
      }

--- a/Spigot-Server-Patches/0447-Implement-Player-Client-Options-API.patch
+++ b/Spigot-Server-Patches/0447-Implement-Player-Client-Options-API.patch
@@ -149,7 +149,7 @@ index 8981dfacd10cae9de052e1b36ce5181cd0e6752d..202fa94d5dc55b549475ae0309bbcfca
      protected static final DataWatcherObject<NBTTagCompound> bk = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
      protected static final DataWatcherObject<NBTTagCompound> bl = DataWatcher.a(EntityHuman.class, DataWatcherRegistry.p);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c0d2abd31272e35c0a0a4f8c31cfd89e56552bea..f518fb4cabf53971daf635e3d82967c9baf0d086 100644
+index dc8545241ed62f6b654b2559e025c3b34c00575f..935b5668a81db4d19a08b09c61519114532a23d9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,8 @@
@@ -161,7 +161,7 @@ index c0d2abd31272e35c0a0a4f8c31cfd89e56552bea..f518fb4cabf53971daf635e3d82967c9
  import com.destroystokyo.paper.Title;
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
-@@ -2255,6 +2258,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2253,6 +2256,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -922,7 +922,7 @@ index e53054fc46e528f9c713eb4c03add61316e19396..fc79a73c884ceb7e0ce56443c36b135c
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 1d7891005c7e4ff0c7b817cda987b3bc263f7010..bcb6821f24a9814a0f213b9b597f1642f9926636 100644
+index 6ddbc83a08be4e7aa5cd85cf78f14604d4759f30..5bea15ba1ee3d2c8e8d78ab34ba75723164b7117 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -14,6 +14,7 @@ import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
@@ -1290,7 +1290,7 @@ index 2d90ecf04f522a4e16f44c905450a61becaa1ed2..6034ef65ee6030948a5b76fa493addb4
              net.minecraft.world.level.chunk.Chunk chunk = (net.minecraft.world.level.chunk.Chunk) either.left().orElse(null);
              return CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f518fb4cabf53971daf635e3d82967c9baf0d086..54e509091452de26587d16bfd31973cb3909ddd4 100644
+index 935b5668a81db4d19a08b09c61519114532a23d9..0f8d10c2bc7728b58528096fc0686c3aeee623a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -60,6 +60,7 @@ import net.minecraft.server.level.PlayerChunkMap;
@@ -1309,7 +1309,7 @@ index f518fb4cabf53971daf635e3d82967c9baf0d086..54e509091452de26587d16bfd31973cb
  import net.minecraft.world.level.EnumGamemode;
  import net.minecraft.world.level.biome.BiomeManager;
  import net.minecraft.world.level.block.entity.TileEntitySign;
-@@ -853,6 +855,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -851,6 +853,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/Spigot-Server-Patches/0546-Brand-support.patch
+++ b/Spigot-Server-Patches/0546-Brand-support.patch
@@ -73,10 +73,10 @@ index 92d5a58f7d18aebf06e3cb868abf3f41825f2f84..1d154ef60fd979340cf925748251669e
          return (!this.player.joining && !this.networkManager.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 54e509091452de26587d16bfd31973cb3909ddd4..a632f6ad9c5d4ce0ae73019ac74db8e14b57b61c 100644
+index 0f8d10c2bc7728b58528096fc0686c3aeee623a7..18d7cf6e783843d44715210b7c8db7bf0a5c89ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2390,6 +2390,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2388,6 +2388,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/Spigot-Server-Patches/0587-Player-elytra-boost-API.patch
+++ b/Spigot-Server-Patches/0587-Player-elytra-boost-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a632f6ad9c5d4ce0ae73019ac74db8e14b57b61c..e8512dfde1364c57a6dd263f711d70cf429f9214 100644
+index 18d7cf6e783843d44715210b7c8db7bf0a5c89ae..8337ed8bb20b8d887bcd71ddc5f29bce346c7cff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -69,12 +69,14 @@ import net.minecraft.world.entity.ai.attributes.AttributeMapBase;
@@ -23,7 +23,7 @@ index a632f6ad9c5d4ce0ae73019ac74db8e14b57b61c..e8512dfde1364c57a6dd263f711d70cf
  import net.minecraft.world.level.biome.BiomeManager;
  import net.minecraft.world.level.block.entity.TileEntitySign;
  import net.minecraft.world.level.saveddata.maps.MapIcon;
-@@ -2286,6 +2288,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2284,6 +2286,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/Spigot-Server-Patches/0602-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/Spigot-Server-Patches/0602-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 204d3e879c736f44e01f9246af26f6cccf8d72a7..5a245184d6290a58bb9aed139cc4c7b5511ce491 100644
+index 8337ed8bb20b8d887bcd71ddc5f29bce346c7cff..41987716afa8ec34214868373df97d0e8f8b27c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2014,7 +2014,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2012,7 +2012,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/Spigot-Server-Patches/0647-Add-sendOpLevel-API.patch
+++ b/Spigot-Server-Patches/0647-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index 0757cfcb96778258ba2593756e4ca9cbb16e2f87..24b3a893a2b76a4ecfbc6b2cc1eac242
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aff89527372faeb1e1be0f5cd1618c637a000979..b4d4fac69439c2256ab31f93f94db5b314f76f0e 100644
+index 41987716afa8ec34214868373df97d0e8f8b27c1..e81de526a847c730abf86016354c1dc57780ec8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2302,6 +2302,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2300,6 +2300,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/Spigot-Server-Patches/0676-Expose-Tracked-Players.patch
+++ b/Spigot-Server-Patches/0676-Expose-Tracked-Players.patch
@@ -18,7 +18,7 @@ index f7223f214f911dd25abcf3a52745588ec630241d..7abeeefeb579a43bc9ee85fd4150afac
      public Throwable addedToWorldStack; // Paper - entity debug
      public CraftEntity getBukkitEntity() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b4d4fac69439c2256ab31f93f94db5b314f76f0e..f150ba393bc62e52840e6ebbf3d7696b670ff7e4 100644
+index e81de526a847c730abf86016354c1dc57780ec8b..05248f560d643080a3eac581c01aa89fb3709e6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -16,6 +16,7 @@ import java.net.InetSocketAddress;
@@ -29,7 +29,7 @@ index b4d4fac69439c2256ab31f93f94db5b314f76f0e..f150ba393bc62e52840e6ebbf3d7696b
  import java.util.HashMap;
  import java.util.HashSet;
  import java.util.LinkedHashMap;
-@@ -2311,6 +2312,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2309,6 +2310,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  


### PR DESCRIPTION
Happened to notice that in a couple places, its converting adventure `Component`s to `IChatBaseComponent`s, and then back to an adventure `Component`. 