### PR TITLE
Add ItemStack#displayName to get the formatted display name of an ItemStack

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -2852,10 +2852,10 @@ index 14346d83bc99581b18e53d19af03708c0bf22cf7..664de64b020cf9090a2fbee0afe2bfaf
      public abstract String getTitle();
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..3dba4c361993e143e511b4f108ac0b444a84d964 100644
+index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..850134ca5f95a4c6d0e71168b52e15bd824d4a81 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -141,4 +141,15 @@ public interface ItemFactory {
+@@ -141,4 +141,24 @@ public interface ItemFactory {
      @Deprecated
      @NotNull
      Material updateMaterial(@NotNull final ItemMeta meta, @NotNull final Material material) throws IllegalArgumentException;
@@ -2869,10 +2869,19 @@ index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..3dba4c361993e143e511b4f108ac0b44
 +     */
 +    @NotNull
 +    net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull ItemStack item, final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op);
++
++    /**
++     * Get the formatted display name of the {@link ItemStack}.
++     *
++     * @param itemStack the {@link ItemStack}
++     * @return display name of the {@link ItemStack}
++     */
++    @NotNull
++    net.kyori.adventure.text.Component getDisplayName(@NotNull ItemStack itemStack);
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..4b20b557eaa958cf1ad1baf8d6cc17f38b180ff1 100644
+index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..69f87877abd4ddcff1db7d97237d339511b193b8 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
@@ -2884,7 +2893,7 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..4b20b557eaa958cf1ad1baf8d6cc17f3
      private Material type = Material.AIR;
      private int amount = 0;
      private MaterialData data = null;
-@@ -595,4 +595,12 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
+@@ -595,4 +595,21 @@ public class ItemStack implements Cloneable, ConfigurationSerializable {
  
          return true;
      }
@@ -2894,6 +2903,15 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..4b20b557eaa958cf1ad1baf8d6cc17f3
 +    @Override
 +    public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
 +        return org.bukkit.Bukkit.getServer().getItemFactory().asHoverEvent(this, op);
++    }
++
++    /**
++     * Get the formatted display name of the {@link ItemStack}.
++     *
++     * @return display name of the {@link ItemStack}
++     */
++    public @NotNull net.kyori.adventure.text.Component displayName() {
++        return Bukkit.getServer().getItemFactory().getDisplayName(this);
 +    }
 +    // Paper end
  }

--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -2852,7 +2852,7 @@ index 14346d83bc99581b18e53d19af03708c0bf22cf7..664de64b020cf9090a2fbee0afe2bfaf
      public abstract String getTitle();
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..850134ca5f95a4c6d0e71168b52e15bd824d4a81 100644
+index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -141,4 +141,24 @@ public interface ItemFactory {
@@ -2877,11 +2877,11 @@ index 4ff149fd98895dd8ba45939a37c223b1f8d7281f..850134ca5f95a4c6d0e71168b52e15bd
 +     * @return display name of the {@link ItemStack}
 +     */
 +    @NotNull
-+    net.kyori.adventure.text.Component getDisplayName(@NotNull ItemStack itemStack);
++    net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..69f87877abd4ddcff1db7d97237d339511b193b8 100644
+index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..a15abec467bac70116a6fc21a300d4930b909f15 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -22,7 +22,7 @@ import org.jetbrains.annotations.Nullable;
@@ -2911,7 +2911,7 @@ index f70a6a22b85ff0da76e67e9b223ad4e0b020b5c4..69f87877abd4ddcff1db7d97237d3395
 +     * @return display name of the {@link ItemStack}
 +     */
 +    public @NotNull net.kyori.adventure.text.Component displayName() {
-+        return Bukkit.getServer().getItemFactory().getDisplayName(this);
++        return Bukkit.getServer().getItemFactory().displayName(this);
 +    }
 +    // Paper end
  }

--- a/Spigot-API-Patches/0061-ensureServerConversions-API.patch
+++ b/Spigot-API-Patches/0061-ensureServerConversions-API.patch
@@ -7,13 +7,13 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 3dba4c361993e143e511b4f108ac0b444a84d964..30ab5d38197bccfc06f6f5554b162f8bdbfe2a45 100644
+index 850134ca5f95a4c6d0e71168b52e15bd824d4a81..44a858490f4db37f979fd487ed7a5b2b8b7f1a3f 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -151,5 +151,17 @@ public interface ItemFactory {
+@@ -160,5 +160,17 @@ public interface ItemFactory {
       */
      @NotNull
-     net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull ItemStack item, final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op);
+     net.kyori.adventure.text.Component getDisplayName(@NotNull ItemStack itemStack);
 +
 +    /**
 +     * Minecart updates are converting simple item stacks into more complex NBT oriented Item Stacks.
@@ -29,7 +29,7 @@ index 3dba4c361993e143e511b4f108ac0b444a84d964..30ab5d38197bccfc06f6f5554b162f8b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 4b20b557eaa958cf1ad1baf8d6cc17f38b180ff1..c31f667c466ba80bd88ae560d14dbd18a84118b4 100644
+index 69f87877abd4ddcff1db7d97237d339511b193b8..47d8611221967d32b654ddac0fbf0e405ef62352 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -536,7 +536,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
@@ -41,9 +41,9 @@ index 4b20b557eaa958cf1ad1baf8d6cc17f38b180ff1..c31f667c466ba80bd88ae560d14dbd18
      }
  
      /**
-@@ -602,5 +602,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
-     public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
-         return org.bukkit.Bukkit.getServer().getItemFactory().asHoverEvent(this, op);
+@@ -611,5 +611,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+     public @NotNull net.kyori.adventure.text.Component displayName() {
+         return Bukkit.getServer().getItemFactory().getDisplayName(this);
      }
 +
 +    /**

--- a/Spigot-API-Patches/0061-ensureServerConversions-API.patch
+++ b/Spigot-API-Patches/0061-ensureServerConversions-API.patch
@@ -7,13 +7,13 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 850134ca5f95a4c6d0e71168b52e15bd824d4a81..44a858490f4db37f979fd487ed7a5b2b8b7f1a3f 100644
+index 6cc4bad2ecd19f44a680ff03cbfb99d48ea5c337..845119c9ba9dc2719dc67b0edb0ff2ad58656bde 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -160,5 +160,17 @@ public interface ItemFactory {
       */
      @NotNull
-     net.kyori.adventure.text.Component getDisplayName(@NotNull ItemStack itemStack);
+     net.kyori.adventure.text.Component displayName(@NotNull ItemStack itemStack);
 +
 +    /**
 +     * Minecart updates are converting simple item stacks into more complex NBT oriented Item Stacks.
@@ -29,7 +29,7 @@ index 850134ca5f95a4c6d0e71168b52e15bd824d4a81..44a858490f4db37f979fd487ed7a5b2b
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 69f87877abd4ddcff1db7d97237d339511b193b8..47d8611221967d32b654ddac0fbf0e405ef62352 100644
+index a15abec467bac70116a6fc21a300d4930b909f15..1c69ca6a6d0e956d796827159236ee3466813d0e 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -536,7 +536,7 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
@@ -43,7 +43,7 @@ index 69f87877abd4ddcff1db7d97237d339511b193b8..47d8611221967d32b654ddac0fbf0e40
      /**
 @@ -611,5 +611,18 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public @NotNull net.kyori.adventure.text.Component displayName() {
-         return Bukkit.getServer().getItemFactory().getDisplayName(this);
+         return Bukkit.getServer().getItemFactory().displayName(this);
      }
 +
 +    /**

--- a/Spigot-API-Patches/0062-Add-getI18NDisplayName-API.patch
+++ b/Spigot-API-Patches/0062-Add-getI18NDisplayName-API.patch
@@ -8,10 +8,10 @@ Currently the server only supports the English language. To override this,
 You must replace the language file embedded in the server jar.
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 30ab5d38197bccfc06f6f5554b162f8bdbfe2a45..3578f491a053154789ad696e93c70fdde74912e6 100644
+index 44a858490f4db37f979fd487ed7a5b2b8b7f1a3f..3fd56a95de7d4cbeaf5d8554fbc7127a627cb977 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -163,5 +163,16 @@ public interface ItemFactory {
+@@ -172,5 +172,16 @@ public interface ItemFactory {
       */
      @NotNull
      ItemStack ensureServerConversions(@NotNull ItemStack item);
@@ -29,10 +29,10 @@ index 30ab5d38197bccfc06f6f5554b162f8bdbfe2a45..3578f491a053154789ad696e93c70fdd
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index c31f667c466ba80bd88ae560d14dbd18a84118b4..77d6b2ed68d8ce30b5cadb156941d2d1f7dcf5b1 100644
+index 47d8611221967d32b654ddac0fbf0e405ef62352..82bd3e6701dbd7df9f0f8c3801c5ae1baba4eec5 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -615,5 +615,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -624,5 +624,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public ItemStack ensureServerConversions() {
          return Bukkit.getServer().getItemFactory().ensureServerConversions(this);
      }

--- a/Spigot-API-Patches/0105-ItemStack-getMaxItemUseDuration.patch
+++ b/Spigot-API-Patches/0105-ItemStack-getMaxItemUseDuration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 77d6b2ed68d8ce30b5cadb156941d2d1f7dcf5b1..cc065602db56c51b87d273a52d9ef82439fcaa7a 100644
+index 82bd3e6701dbd7df9f0f8c3801c5ae1baba4eec5..f41701e6374ca23eca4bdb092e385053a12eb718 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -627,5 +627,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -636,5 +636,13 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public String getI18NDisplayName() {
          return Bukkit.getServer().getItemFactory().getI18NDisplayName(this);
      }

--- a/Spigot-API-Patches/0113-ItemStack-API-additions-for-quantity-flags-lore.patch
+++ b/Spigot-API-Patches/0113-ItemStack-API-additions-for-quantity-flags-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack API additions for quantity/flags/lore
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index cc065602db56c51b87d273a52d9ef82439fcaa7a..c6eca5a69cb8f5b161ff99ecad9475be64dcfed5 100644
+index f41701e6374ca23eca4bdb092e385053a12eb718..07fd8a495828ff79239359c736c425c4902543a4 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -2,7 +2,9 @@ package org.bukkit.inventory;
@@ -18,7 +18,7 @@ index cc065602db56c51b87d273a52d9ef82439fcaa7a..c6eca5a69cb8f5b161ff99ecad9475be
  import org.apache.commons.lang.Validate;
  import org.bukkit.Bukkit;
  import org.bukkit.Material;
-@@ -635,5 +637,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -644,5 +646,185 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          // Requires access to NMS
          return ensureServerConversions().getMaxItemUseDuration();
      }

--- a/Spigot-API-Patches/0206-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/Spigot-API-Patches/0206-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -20,10 +20,10 @@ index d6897f43a0692e031bed8a212d9a637ef548cc60..e348034288c74ab80360086d71f0b7f6
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 3d63514729ddc30ff559a65815612be81e777892..58f99e3ebac9a01ebffe4d208e16cbee474d4aa3 100644
+index bf39989dbe08c93120d75bed6281ae75c460afca..15b48ad1ba5bcf7394fb3f52ce2cc6baa6632f66 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -619,6 +619,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -628,6 +628,30 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          return Bukkit.getServer().getItemFactory().ensureServerConversions(this);
      }
  

--- a/Spigot-API-Patches/0223-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/Spigot-API-Patches/0223-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -104,10 +104,10 @@ index 774363a8186b3861f10c0452ac63726cae365169..692b75eb78405874077c850bfc72e247
 +    }
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 58f99e3ebac9a01ebffe4d208e16cbee474d4aa3..a3335b8622a70fbf4a55213f1a5010ffdc4783bb 100644
+index 15b48ad1ba5bcf7394fb3f52ce2cc6baa6632f66..c236cb81b7ec7993b63da929c0492564e75581ee 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -842,5 +842,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -851,5 +851,17 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          ItemMeta itemMeta = getItemMeta();
          return itemMeta != null && itemMeta.hasItemFlag(flag);
      }

--- a/Spigot-API-Patches/0224-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/Spigot-API-Patches/0224-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 0654873eef22d1e35c7430f098ff9e8f00b870e3..eab52f8615b329a795b3fe3a3719e5687e105061 100644
+index e2bcc96ad067e2abfe9108b3a2235fe5da7ab3eb..3cbe5afc3548d4b7d0c6e625d9029506133676ff 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
-@@ -175,5 +175,62 @@ public interface ItemFactory {
+@@ -184,5 +184,62 @@ public interface ItemFactory {
       */
      @Nullable
      String getI18NDisplayName(@Nullable ItemStack item);

--- a/Spigot-API-Patches/0282-Item-Rarity-API.patch
+++ b/Spigot-API-Patches/0282-Item-Rarity-API.patch
@@ -88,10 +88,10 @@ index 84eda68281c6c6968d95b1313a33696c3a9980d4..bcd10b2c9255d778b678310febf19373
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index a3335b8622a70fbf4a55213f1a5010ffdc4783bb..b9694780d824063cf90cd968d3e6b57f49fcbeb3 100644
+index c236cb81b7ec7993b63da929c0492564e75581ee..7929a00a3e93e0b6a4df99013e0da5bcfecd678b 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -854,5 +854,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -863,5 +863,15 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
      public String getTranslationKey() {
          return Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2600,10 +2600,10 @@ index 04073ed45f8068d80e58d3927b5ebc3160c6a8c6..9949bb8cac73b2f1f02b51079c0e244f
      public String getTitle() {
          return CraftChatMessage.fromComponent(container.getTitle());
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 89a3617068421bb86baf4e8bfd9df2d0626adff7..954791fda47f1017f99a5fca3ef072d47d35596f 100644
+index 89a3617068421bb86baf4e8bfd9df2d0626adff7..ccd27aa93b4ab1dc09a8d684b43b5ecb69100ed8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -334,4 +334,28 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -334,4 +334,17 @@ public final class CraftItemFactory implements ItemFactory {
      public Material updateMaterial(ItemMeta meta, Material material) throws IllegalArgumentException {
          return ((CraftMetaItem) meta).updateMaterial(material);
      }
@@ -2616,19 +2616,8 @@ index 89a3617068421bb86baf4e8bfd9df2d0626adff7..954791fda47f1017f99a5fca3ef072d4
 +    }
 +
 +    @Override
-+    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component getDisplayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
-+        if (itemStack.getType() == Material.WRITTEN_BOOK && itemStack.hasItemMeta()) {
-+            final org.bukkit.inventory.meta.BookMeta bookMeta = (org.bukkit.inventory.meta.BookMeta) itemStack.getItemMeta();
-+            if (bookMeta.hasDisplayName()) {
-+                final net.kyori.adventure.text.Component displayName = bookMeta.displayName();
-+                if (displayName != null) {
-+                    return net.kyori.adventure.text.Component.translatable("chat.square_brackets", displayName)
-+                        .hoverEvent(itemStack);
-+                }
-+            }
-+        }
-+        final net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
-+        return io.papermc.paper.adventure.PaperAdventure.asAdventure(nms.displayName());
++    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).displayName());
 +    }
 +    // Paper end
  }

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1612,6 +1612,18 @@ index f9154b306379c45f15fe55406aaa00351b0471e8..1fb9fea7683075f427edfa411c7747d6
          return this.g;
      }
  
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index 4010152dccc93019f2e7f284d80b92bae0d91c34..f1a780768e3f4bdb43a7ca6d7850befefb71bf57 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -867,6 +867,7 @@ public final class ItemStack {
+     }
+     // CraftBukkit end
+ 
++    public IChatBaseComponent displayName() { return this.C(); } // Paper - OBFHELPER
+     public IChatBaseComponent C() {
+         IChatMutableComponent ichatmutablecomponent = (new ChatComponentText("")).addSibling(this.getName());
+ 
 diff --git a/src/main/java/net/minecraft/world/item/enchantment/Enchantment.java b/src/main/java/net/minecraft/world/item/enchantment/Enchantment.java
 index 0134bbda9e6fc900b7eefa05442e25539bab3431..b76ef55145336cc8dc4857b79767f5a738ad5144 100644
 --- a/src/main/java/net/minecraft/world/item/enchantment/Enchantment.java
@@ -2588,10 +2600,10 @@ index 04073ed45f8068d80e58d3927b5ebc3160c6a8c6..9949bb8cac73b2f1f02b51079c0e244f
      public String getTitle() {
          return CraftChatMessage.fromComponent(container.getTitle());
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 89a3617068421bb86baf4e8bfd9df2d0626adff7..6d320bbe0c75cc0df504faacf0f7d24804b90d5f 100644
+index 89a3617068421bb86baf4e8bfd9df2d0626adff7..954791fda47f1017f99a5fca3ef072d47d35596f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -334,4 +334,12 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -334,4 +334,28 @@ public final class CraftItemFactory implements ItemFactory {
      public Material updateMaterial(ItemMeta meta, Material material) throws IllegalArgumentException {
          return ((CraftMetaItem) meta).updateMaterial(material);
      }
@@ -2601,6 +2613,22 @@ index 89a3617068421bb86baf4e8bfd9df2d0626adff7..6d320bbe0c75cc0df504faacf0f7d248
 +    public net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowItem> asHoverEvent(final ItemStack item, final java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowItem> op) {
 +        final net.minecraft.nbt.NBTTagCompound tag = CraftItemStack.asNMSCopy(item).getTag();
 +        return net.kyori.adventure.text.event.HoverEvent.showItem(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowItem.of(item.getType().getKey(), item.getAmount(), io.papermc.paper.adventure.PaperAdventure.asBinaryTagHolder(tag))));
++    }
++
++    @Override
++    public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component getDisplayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
++        if (itemStack.getType() == Material.WRITTEN_BOOK && itemStack.hasItemMeta()) {
++            final org.bukkit.inventory.meta.BookMeta bookMeta = (org.bukkit.inventory.meta.BookMeta) itemStack.getItemMeta();
++            if (bookMeta.hasDisplayName()) {
++                final net.kyori.adventure.text.Component displayName = bookMeta.displayName();
++                if (displayName != null) {
++                    return net.kyori.adventure.text.Component.translatable("chat.square_brackets", displayName)
++                        .hoverEvent(itemStack);
++                }
++            }
++        }
++        final net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
++        return io.papermc.paper.adventure.PaperAdventure.asAdventure(nms.displayName());
 +    }
 +    // Paper end
  }

--- a/Spigot-Server-Patches/0158-Implement-ensureServerConversions-API.patch
+++ b/Spigot-Server-Patches/0158-Implement-ensureServerConversions-API.patch
@@ -7,12 +7,12 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 954791fda47f1017f99a5fca3ef072d47d35596f..65b161e3de32afef84e53da11c8829f7cb4e45e5 100644
+index ccd27aa93b4ab1dc09a8d684b43b5ecb69100ed8..8206e85cefb0b02b1ac9b370808c06019211cdb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -357,5 +357,11 @@ public final class CraftItemFactory implements ItemFactory {
-         final net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
-         return io.papermc.paper.adventure.PaperAdventure.asAdventure(nms.displayName());
+@@ -346,5 +346,11 @@ public final class CraftItemFactory implements ItemFactory {
+     public net.kyori.adventure.text.@org.jetbrains.annotations.NotNull Component displayName(@org.jetbrains.annotations.NotNull ItemStack itemStack) {
+         return io.papermc.paper.adventure.PaperAdventure.asAdventure(CraftItemStack.asNMSCopy(itemStack).displayName());
      }
 +
 +    // Paper start

--- a/Spigot-Server-Patches/0158-Implement-ensureServerConversions-API.patch
+++ b/Spigot-Server-Patches/0158-Implement-ensureServerConversions-API.patch
@@ -7,12 +7,12 @@ This will take a Bukkit ItemStack and run it through any conversions a server pr
 to ensure it meets latest minecraft expectations.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 6d320bbe0c75cc0df504faacf0f7d24804b90d5f..6e748e57c4818e11ac6d4c693bc4f6e1e889f4f8 100644
+index 954791fda47f1017f99a5fca3ef072d47d35596f..65b161e3de32afef84e53da11c8829f7cb4e45e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -341,5 +341,11 @@ public final class CraftItemFactory implements ItemFactory {
-         final net.minecraft.nbt.NBTTagCompound tag = CraftItemStack.asNMSCopy(item).getTag();
-         return net.kyori.adventure.text.event.HoverEvent.showItem(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowItem.of(item.getType().getKey(), item.getAmount(), io.papermc.paper.adventure.PaperAdventure.asBinaryTagHolder(tag))));
+@@ -357,5 +357,11 @@ public final class CraftItemFactory implements ItemFactory {
+         final net.minecraft.world.item.ItemStack nms = CraftItemStack.asNMSCopy(itemStack);
+         return io.papermc.paper.adventure.PaperAdventure.asAdventure(nms.displayName());
      }
 +
 +    // Paper start

--- a/Spigot-Server-Patches/0159-Implement-getI18NDisplayName.patch
+++ b/Spigot-Server-Patches/0159-Implement-getI18NDisplayName.patch
@@ -34,10 +34,10 @@ index 9b8d5e7e4c86a699e26b1b4d0b82e88887a44054..5218214225b50ac4059ab704086a4573
  
      public abstract boolean b(String s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 65b161e3de32afef84e53da11c8829f7cb4e45e5..fe7174b5da88817cb0264aaf008ace3af14ddfdb 100644
+index 8206e85cefb0b02b1ac9b370808c06019211cdb1..910c6109783dfef86e127a0a5b7d7d3865150d89 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -363,5 +363,18 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -352,5 +352,18 @@ public final class CraftItemFactory implements ItemFactory {
      public ItemStack ensureServerConversions(ItemStack item) {
          return CraftItemStack.asCraftMirror(CraftItemStack.asNMSCopy(item));
      }

--- a/Spigot-Server-Patches/0159-Implement-getI18NDisplayName.patch
+++ b/Spigot-Server-Patches/0159-Implement-getI18NDisplayName.patch
@@ -34,10 +34,10 @@ index 9b8d5e7e4c86a699e26b1b4d0b82e88887a44054..5218214225b50ac4059ab704086a4573
  
      public abstract boolean b(String s);
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index 6e748e57c4818e11ac6d4c693bc4f6e1e889f4f8..e6c818d32713d9fb0f02a46696bd8a5dabe2a3ae 100644
+index 65b161e3de32afef84e53da11c8829f7cb4e45e5..fe7174b5da88817cb0264aaf008ace3af14ddfdb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -347,5 +347,18 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -363,5 +363,18 @@ public final class CraftItemFactory implements ItemFactory {
      public ItemStack ensureServerConversions(ItemStack item) {
          return CraftItemStack.asCraftMirror(CraftItemStack.asNMSCopy(item));
      }

--- a/Spigot-Server-Patches/0565-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/Spigot-Server-Patches/0565-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index fe7174b5da88817cb0264aaf008ace3af14ddfdb..150799b13e507e3c6a3d19c30c511dbf774c9ed4 100644
+index 910c6109783dfef86e127a0a5b7d7d3865150d89..347c23d4b7d47198f214c3f95354e8abb660b191 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -376,5 +376,40 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -365,5 +365,40 @@ public final class CraftItemFactory implements ItemFactory {
  
          return nms != null ? net.minecraft.locale.LocaleLanguage.getInstance().translateKey(nms.getItem().getName()) : null;
      }

--- a/Spigot-Server-Patches/0565-Create-HoverEvent-from-ItemStack-Entity.patch
+++ b/Spigot-Server-Patches/0565-Create-HoverEvent-from-ItemStack-Entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Create HoverEvent from ItemStack Entity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-index e6c818d32713d9fb0f02a46696bd8a5dabe2a3ae..6966b9d1ce674232d3f867798fa58bd0933ff69e 100644
+index fe7174b5da88817cb0264aaf008ace3af14ddfdb..150799b13e507e3c6a3d19c30c511dbf774c9ed4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
-@@ -360,5 +360,40 @@ public final class CraftItemFactory implements ItemFactory {
+@@ -376,5 +376,40 @@ public final class CraftItemFactory implements ItemFactory {
  
          return nms != null ? net.minecraft.locale.LocaleLanguage.getInstance().translateKey(nms.getItem().getName()) : null;
      }


### PR DESCRIPTION
The display name includes formatting such as item hover event, display name (in italics if renamed in anvil), and color based on rarity.

This is what vanilla uses for give command feedback, and when an item is shown in a death message.