### PR TITLE
Fix CraftPotionBrewer cache

### DIFF
--- a/Spigot-Server-Patches/0730-Fix-CraftPotionBrewer-cache.patch
+++ b/Spigot-Server-Patches/0730-Fix-CraftPotionBrewer-cache.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Sceri <scerimail@gmail.com>
+Date: Fri, 14 May 2021 19:06:51 +0500
+Subject: [PATCH] Fix CraftPotionBrewer cache
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionBrewer.java b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionBrewer.java
+index 7156bd1c8938a0b111be11d93ed2645a58d75611..4d108ed58a768a5a5e2e33213921f0a89487b6a2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionBrewer.java
++++ b/src/main/java/org/bukkit/craftbukkit/potion/CraftPotionBrewer.java
+@@ -15,12 +15,18 @@ import org.bukkit.potion.PotionEffectType;
+ import org.bukkit.potion.PotionType;
+ 
+ public class CraftPotionBrewer implements PotionBrewer {
+-    private static final Map<PotionType, Collection<PotionEffect>> cache = Maps.newHashMap();
++    private static final Map<Integer, Collection<PotionEffect>> cache = Maps.newHashMap(); // Paper
+ 
+     @Override
+     public Collection<PotionEffect> getEffects(PotionType damage, boolean upgraded, boolean extended) {
+-        if (cache.containsKey(damage))
+-            return cache.get(damage);
++        // Paper start
++        int key = damage.ordinal() << 2;
++        key |= (upgraded ? 1 : 0) << 1;
++        key |= extended ? 1 : 0;
++
++        if (cache.containsKey(key))
++            return cache.get(key);
++        // Paper end
+ 
+         List<MobEffect> mcEffects = PotionRegistry.a(CraftPotionUtil.fromBukkit(new PotionData(damage, extended, upgraded))).a();
+ 
+@@ -29,9 +35,9 @@ public class CraftPotionBrewer implements PotionBrewer {
+             builder.add(CraftPotionUtil.toBukkit(effect));
+         }
+ 
+-        cache.put(damage, builder.build());
++        cache.put(key, builder.build()); // Paper
+ 
+-        return cache.get(damage);
++        return cache.get(key); // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
The cache does not support upgrade and extended flags. Therefore, the getEffects method returns the same list of effects for different flag values, which is wrong.

Note:
At the moment, this method is the only way to get the LIST of effects by type of potion, because PotionType contains only 1 effect (#5366)