### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/Spigot-API-Patches/0001-POM-changes.patch
+++ b/Spigot-API-Patches/0001-POM-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] POM changes
 
 
 diff --git a/pom.xml b/pom.xml
-index 5f3253b9c4a533e746707d602d4a7988519742ef..61b8ee4e3e122dd2671f50ea3b432e4abd4600a2 100644
+index 0223e94c1243a58955f858c8bf6d5df4ca8cf0ec..fd663f5471516c3ebbab07c27197e5df48c481e6 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -2,33 +2,34 @@
@@ -77,7 +77,7 @@ index 5f3253b9c4a533e746707d602d4a7988519742ef..61b8ee4e3e122dd2671f50ea3b432e4a
          <!-- bundled with Minecraft, should be kept in sync -->
          <dependency>
              <groupId>com.google.guava</groupId>
-@@ -93,6 +108,7 @@
+@@ -112,6 +127,7 @@
      </dependencies>
  
      <build>
@@ -85,7 +85,7 @@ index 5f3253b9c4a533e746707d602d4a7988519742ef..61b8ee4e3e122dd2671f50ea3b432e4a
          <plugins>
              <plugin>
                  <groupId>net.md-5</groupId>
-@@ -111,10 +127,6 @@
+@@ -130,10 +146,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>
@@ -96,7 +96,7 @@ index 5f3253b9c4a533e746707d602d4a7988519742ef..61b8ee4e3e122dd2671f50ea3b432e4a
                  <dependencies>
                      <dependency>
                          <groupId>org.codehaus.plexus</groupId>
-@@ -164,6 +176,7 @@
+@@ -183,6 +195,7 @@
                              </excludes>
                          </filter>
                      </filters>

--- a/Spigot-API-Patches/0004-Timings-v2.patch
+++ b/Spigot-API-Patches/0004-Timings-v2.patch
@@ -3454,18 +3454,18 @@ index 62d0017362204070465c8ff72e5c2ca07501f558..745eaa8f2f2ff83536301db8ca47a8af
      }
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 7b9ad3834c9c81220c74a16f1e66fb4da512e9f6..b6d739ca8ad8ebd4b1be7ebd129f9a7ae16b2a2a 100644
+index a09c3f71ca563b6f40a118ce1344d0eb273bed40..cf2f517765d8f2a23cc4a17d9ee2dcd81f841b1b 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -53,7 +53,6 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -54,7 +54,6 @@ public final class JavaPluginLoader implements PluginLoader {
      private final Pattern[] fileFilters = new Pattern[]{Pattern.compile("\\.jar$")};
-     private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final List<PluginClassLoader> loaders = new CopyOnWriteArrayList<PluginClassLoader>();
+     private final LibraryLoader libraryLoader;
 -    public static final CustomTimingsHandler pluginParentTimer = new CustomTimingsHandler("** Plugins"); // Spigot
  
      /**
       * This class was not meant to be constructed explicitly
-@@ -301,27 +300,21 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -292,27 +291,21 @@ public final class JavaPluginLoader implements PluginLoader {
                  }
              }
  
@@ -3497,10 +3497,10 @@ index 7b9ad3834c9c81220c74a16f1e66fb4da512e9f6..b6d739ca8ad8ebd4b1be7ebd129f9a7a
                  eventSet.add(new TimedRegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
              } else {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 5830e8b9b74d6107e54b6e19e03ab0e8c0da2f19..36f542a85e0f16e97c65c0ca64ec660ddf75d63e 100644
+index 6843e32438492f380e2e72bb40dd49d45fe675cb..5ffa98bb9c76d802a9d0ea6c572a704a2732c67c 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -28,7 +28,8 @@ import org.jetbrains.annotations.Nullable;
+@@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;
  /**
   * A ClassLoader for plugins, to allow shared classes across multiple plugins
   */

--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/pom.xml b/pom.xml
-index e3744ee042e0426a513c4fdf4abedafe85e31cd2..363c66f7ec247820bd8db7b05f861ed40c48f384 100644
+index 9aafdcc49ed83b403abb96891008103e6d6a69fa..1ced7a212684cee8faf07fa9a083adcd47be7fcb 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -22,6 +22,7 @@
@@ -58,7 +58,7 @@ index e3744ee042e0426a513c4fdf4abedafe85e31cd2..363c66f7ec247820bd8db7b05f861ed4
          <dependency>
              <groupId>it.unimi.dsi</groupId>
              <artifactId>fastutil</artifactId>
-@@ -197,6 +230,12 @@
+@@ -216,6 +249,12 @@
                          <link>https://javadoc.io/doc/org.yaml/snakeyaml/1.27/</link>
                          <link>https://javadoc.io/doc/org.jetbrains/annotations-java5/20.1.0/</link>
                          <link>https://javadoc.io/doc/net.md-5/bungeecord-chat/1.16-R0.4/</link>

--- a/Spigot-API-Patches/0014-Automatically-disable-plugins-that-fail-to-load.patch
+++ b/Spigot-API-Patches/0014-Automatically-disable-plugins-that-fail-to-load.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Automatically disable plugins that fail to load
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index b6d739ca8ad8ebd4b1be7ebd129f9a7ae16b2a2a..c8497cb3021f584a885f4cb21c3be576ce0935a7 100644
+index cf2f517765d8f2a23cc4a17d9ee2dcd81f841b1b..2e306c7b984a02e12a74fac14589bf29ab6488bf 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -344,6 +344,10 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -335,6 +335,10 @@ public final class JavaPluginLoader implements PluginLoader {
                  jPlugin.setEnabled(true);
              } catch (Throwable ex) {
                  server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);

--- a/Spigot-API-Patches/0023-Use-ASM-for-event-executors.patch
+++ b/Spigot-API-Patches/0023-Use-ASM-for-event-executors.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/pom.xml b/pom.xml
-index 363c66f7ec247820bd8db7b05f861ed40c48f384..88d42ef3b615eb93738faaf453db9e3b5dabc2c2 100644
+index 1ced7a212684cee8faf07fa9a083adcd47be7fcb..7ec7e6047193a6b390d24f6d2722e35d1d36830d 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -144,6 +144,17 @@
+@@ -163,6 +163,17 @@
              <version>9.1</version>
              <scope>test</scope>
          </dependency>
@@ -370,10 +370,10 @@ index a850f0780de05463fc0d3f9e15ff7f19d88b2aed..9026e108ccd3a88aee1267ee275137be
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index c8497cb3021f584a885f4cb21c3be576ce0935a7..5be6460e8eb81381c7e305cb7ab6b77c0c7a8fe5 100644
+index 2e306c7b984a02e12a74fac14589bf29ab6488bf..79ac529017aac059d13fe342f279e9c8faeba599 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -300,21 +300,7 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -291,21 +291,7 @@ public final class JavaPluginLoader implements PluginLoader {
                  }
              }
  

--- a/Spigot-API-Patches/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/Spigot-API-Patches/0067-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,10 +14,10 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/pom.xml b/pom.xml
-index 88d42ef3b615eb93738faaf453db9e3b5dabc2c2..9d0b4f6224e055f4e1da87d5e70703798bef5fba 100644
+index 7ec7e6047193a6b390d24f6d2722e35d1d36830d..6b71d9a397dd5b72320402a47b8e7197d24e061c 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -125,6 +125,13 @@
+@@ -144,6 +144,13 @@
              <version>20.1.0</version>
              <scope>provided</scope>
          </dependency>

--- a/Spigot-API-Patches/0068-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
+++ b/Spigot-API-Patches/0068-Add-workaround-for-plugins-modifying-the-parent-of-t.patch
@@ -87,10 +87,10 @@ index bb2e55e97bf887a28cac7d4f9a0a23960d22cf56..04fa3991f6ce4e9dad804f28fc6c9476
  
      /**
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 36f542a85e0f16e97c65c0ca64ec660ddf75d63e..3a02dbe9d183bc907dcce081d8338d5716ed5242 100644
+index 5ffa98bb9c76d802a9d0ea6c572a704a2732c67c..22abd85da592c79e312928de596e5d552a45ef12 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -42,6 +42,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+@@ -44,6 +44,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
      private JavaPlugin pluginInit;
      private IllegalStateException pluginState;
      private final Set<String> seenIllegalAccess = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -98,16 +98,16 @@ index 36f542a85e0f16e97c65c0ca64ec660ddf75d63e..3a02dbe9d183bc907dcce081d8338d57
  
      static {
          ClassLoader.registerAsParallelCapable();
-@@ -59,6 +60,8 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
-         this.manifest = jar.getManifest();
+@@ -62,6 +63,8 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
          this.url = file.toURI().toURL();
+         this.libraryLoader = libraryLoader;
  
 +        this.logger = com.destroystokyo.paper.utils.PaperPluginLogger.getLogger(description); // Paper - Register logger early
 +
          try {
              Class<?> jarClass;
              try {
-@@ -203,6 +206,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+@@ -220,6 +223,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
          pluginState = new IllegalStateException("Initial initialization");
          this.pluginInit = javaPlugin;
  

--- a/Spigot-API-Patches/0099-Close-Plugin-Class-Loaders-on-Disable.patch
+++ b/Spigot-API-Patches/0099-Close-Plugin-Class-Loaders-on-Disable.patch
@@ -97,10 +97,10 @@ index 8b33d914d29897c0276f9e2e7ce83bd2c316d5e2..a7393d2830b95d7167121b02066a3f35
              lookupNames.clear();
              dependencyGraph = GraphBuilder.directed().build();
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 5be6460e8eb81381c7e305cb7ab6b77c0c7a8fe5..bef88a6e2e6f7071401a3af0aec31e62aa265566 100644
+index 79ac529017aac059d13fe342f279e9c8faeba599..816c2b1797447ab315ceb6eda89d25f27d2bce98 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -331,7 +331,7 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -322,7 +322,7 @@ public final class JavaPluginLoader implements PluginLoader {
              } catch (Throwable ex) {
                  server.getLogger().log(Level.SEVERE, "Error occurred while enabling " + plugin.getDescription().getFullName() + " (Is it up to date?)", ex);
                  // Paper start - Disable plugins that fail to load
@@ -109,7 +109,7 @@ index 5be6460e8eb81381c7e305cb7ab6b77c0c7a8fe5..bef88a6e2e6f7071401a3af0aec31e62
                  return;
                  // Paper end
              }
-@@ -344,6 +344,12 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -335,6 +335,12 @@ public final class JavaPluginLoader implements PluginLoader {
  
      @Override
      public void disablePlugin(@NotNull Plugin plugin) {
@@ -122,9 +122,9 @@ index 5be6460e8eb81381c7e305cb7ab6b77c0c7a8fe5..bef88a6e2e6f7071401a3af0aec31e62
          Validate.isTrue(plugin instanceof JavaPlugin, "Plugin is not associated with this PluginLoader");
  
          if (plugin.isEnabled()) {
-@@ -370,6 +376,16 @@ public final class JavaPluginLoader implements PluginLoader {
-                 for (String name : names) {
-                     removeClass(name);
+@@ -367,6 +373,16 @@ public final class JavaPluginLoader implements PluginLoader {
+                 } catch (IOException ex) {
+                     //
                  }
 +                // Paper start - close Class Loader on disable
 +                try {

--- a/Spigot-API-Patches/0119-Add-an-asterisk-to-legacy-API-plugins.patch
+++ b/Spigot-API-Patches/0119-Add-an-asterisk-to-legacy-API-plugins.patch
@@ -45,10 +45,10 @@ index 4de959bbd1270d7d6ea8e5e69521bcca6abe2138..1aa58c59e1e8738bbdc77752885ff3b1
              if (plugin.getDescription().getProvides().size() > 0) {
                  pluginList.append(" (").append(String.join(", ", plugin.getDescription().getProvides())).append(")");
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index bef88a6e2e6f7071401a3af0aec31e62aa265566..de44d850d7b3ab3e528eb6f2de375a6c3e0e5cf9 100644
+index 816c2b1797447ab315ceb6eda89d25f27d2bce98..f26303315c9c93356f0b04440136855dd54d32b7 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -315,7 +315,14 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -306,7 +306,14 @@ public final class JavaPluginLoader implements PluginLoader {
          Validate.isTrue(plugin instanceof JavaPlugin, "Plugin is not associated with this PluginLoader");
  
          if (!plugin.isEnabled()) {

--- a/Spigot-API-Patches/0193-Make-JavaPluginLoader-thread-safe.patch
+++ b/Spigot-API-Patches/0193-Make-JavaPluginLoader-thread-safe.patch
@@ -5,40 +5,34 @@ Subject: [PATCH] Make JavaPluginLoader thread-safe
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index de44d850d7b3ab3e528eb6f2de375a6c3e0e5cf9..9d1f7cdf12029c8198792fd299f92be476040222 100644
+index f26303315c9c93356f0b04440136855dd54d32b7..ce751577623eaad0f31e2eb7bf0842d1ab73e845 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -52,6 +52,8 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -52,6 +52,8 @@ import org.yaml.snakeyaml.error.YAMLException;
+ public final class JavaPluginLoader implements PluginLoader {
      final Server server;
      private final Pattern[] fileFilters = new Pattern[]{Pattern.compile("\\.jar$")};
-     private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
 +    private final Map<String, java.util.concurrent.locks.ReentrantReadWriteLock> classLoadLock = new java.util.HashMap<String, java.util.concurrent.locks.ReentrantReadWriteLock>(); // Paper
 +    private final Map<String, Integer> classLoadLockCount = new java.util.HashMap<String, Integer>(); // Paper
      private final List<PluginClassLoader> loaders = new CopyOnWriteArrayList<PluginClassLoader>();
+     private final LibraryLoader libraryLoader;
  
-     /**
-@@ -191,7 +193,19 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -201,12 +203,33 @@ public final class JavaPluginLoader implements PluginLoader {
  
      @Nullable
-     Class<?> getClassByName(final String name) {
+     Class<?> getClassByName(final String name, boolean resolve, PluginDescriptionFile description) {
 +        // Paper start - make MT safe
-         Class<?> cachedClass = classes.get(name);
-+        if (cachedClass != null) {
-+            return cachedClass;
-+        }
 +        java.util.concurrent.locks.ReentrantReadWriteLock lock;
 +        synchronized (classLoadLock) {
 +            lock = classLoadLock.computeIfAbsent(name, (x) -> new java.util.concurrent.locks.ReentrantReadWriteLock());
 +            classLoadLockCount.compute(name, (x, prev) -> prev != null ? prev + 1 : 1);
 +        }
 +        lock.writeLock().lock();try {
-+        cachedClass = classes.get(name);
 +        // Paper end
- 
-         if (cachedClass != null) {
-             return cachedClass;
-@@ -205,6 +219,19 @@ public final class JavaPluginLoader implements PluginLoader {
-                 }
+         for (PluginClassLoader loader : loaders) {
+             try {
+                 return loader.loadClass0(name, resolve, false, ((SimplePluginManager) server.getPluginManager()).isTransitiveDepend(description, loader.plugin.getDescription()));
+             } catch (ClassNotFoundException cnfe) {
              }
          }
 +        // Paper start - make MT safe

--- a/Spigot-API-Patches/0205-Prioritise-own-classes-where-possible.patch
+++ b/Spigot-API-Patches/0205-Prioritise-own-classes-where-possible.patch
@@ -25,56 +25,53 @@ The patch in general terms just loads the class in the plugin's jar
 before it starts looking elsewhere for it.
 
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 9d1f7cdf12029c8198792fd299f92be476040222..384edf9890dfbd1cddfdcac4db1ebe9a4d761f78 100644
+index ce751577623eaad0f31e2eb7bf0842d1ab73e845..a93cdeb7bb2ad3173031799c552b27c4c8ad21ee 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-@@ -50,6 +50,7 @@ import org.yaml.snakeyaml.error.YAMLException;
+@@ -51,6 +51,7 @@ import org.yaml.snakeyaml.error.YAMLException;
   */
  public final class JavaPluginLoader implements PluginLoader {
      final Server server;
 +    private static final boolean DISABLE_CLASS_PRIORITIZATION = Boolean.getBoolean("Paper.DisableClassPrioritization"); // Paper
      private final Pattern[] fileFilters = new Pattern[]{Pattern.compile("\\.jar$")};
-     private final Map<String, Class<?>> classes = new ConcurrentHashMap<String, Class<?>>();
      private final Map<String, java.util.concurrent.locks.ReentrantReadWriteLock> classLoadLock = new java.util.HashMap<String, java.util.concurrent.locks.ReentrantReadWriteLock>(); // Paper
-@@ -193,6 +194,11 @@ public final class JavaPluginLoader implements PluginLoader {
+     private final Map<String, Integer> classLoadLockCount = new java.util.HashMap<String, Integer>(); // Paper
+@@ -203,6 +204,11 @@ public final class JavaPluginLoader implements PluginLoader {
  
      @Nullable
-     Class<?> getClassByName(final String name) {
+     Class<?> getClassByName(final String name, boolean resolve, PluginDescriptionFile description) {
 +        // Paper start - prioritize self
-+        return getClassByName(name, null);
++        return getClassByName(name, resolve, description, null);
 +    }
-+    Class<?> getClassByName(final String name, PluginClassLoader requester) {
++    Class<?> getClassByName(final String name, boolean resolve, PluginDescriptionFile description, PluginClassLoader requester) {
 +        // Paper end
          // Paper start - make MT safe
-         Class<?> cachedClass = classes.get(name);
-         if (cachedClass != null) {
-@@ -204,6 +210,16 @@ public final class JavaPluginLoader implements PluginLoader {
+         java.util.concurrent.locks.ReentrantReadWriteLock lock;
+         synchronized (classLoadLock) {
+@@ -210,6 +216,13 @@ public final class JavaPluginLoader implements PluginLoader {
              classLoadLockCount.compute(name, (x, prev) -> prev != null ? prev + 1 : 1);
          }
          lock.writeLock().lock();try {
 +            // Paper start - prioritize self
 +            if (!DISABLE_CLASS_PRIORITIZATION && requester != null) {
 +                try {
-+                cachedClass = requester.findClass(name, false);
++                return requester.loadClass0(name, false, false, ((SimplePluginManager) server.getPluginManager()).isTransitiveDepend(description, requester.plugin.getDescription()));
 +                } catch (ClassNotFoundException cnfe) {}
-+                if (cachedClass != null) {
-+                    return cachedClass;
-+                }
 +            }
-+            // Paper end-
-         cachedClass = classes.get(name);
++            // Paper end
          // Paper end
- 
+         for (PluginClassLoader loader : loaders) {
+             try {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 3a02dbe9d183bc907dcce081d8338d5716ed5242..28e5c6591fb594ca79ee92480cedc8f549e3fe01 100644
+index 22abd85da592c79e312928de596e5d552a45ef12..e7a8a221a23d2adc497afd21e512eecba4c63a6b 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -108,7 +108,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+@@ -117,7 +117,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+         }
  
-         if (result == null) {
-             if (checkGlobal) {
--                result = loader.getClassByName(name);
-+                result = loader.getClassByName(name, this); // Paper - prioritize self
+         if (checkGlobal) {
+-            Class<?> result = loader.getClassByName(name, resolve, description);
++            Class<?> result = loader.getClassByName(name, resolve, description, this);  // Paper - prioritize self
  
-                 if (result != null) {
-                     PluginDescriptionFile provider = ((PluginClassLoader) result.getClassLoader()).description;
+             if (result != null) {
+                 PluginDescriptionFile provider = ((PluginClassLoader) result.getClassLoader()).description;

--- a/Spigot-API-Patches/0207-Provide-a-useful-PluginClassLoader-toString.patch
+++ b/Spigot-API-Patches/0207-Provide-a-useful-PluginClassLoader-toString.patch
@@ -8,10 +8,10 @@ however, this provides no indication of the owner of the classloader, making
 these messages effectively useless, this patch rectifies this
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 28e5c6591fb594ca79ee92480cedc8f549e3fe01..62f7a6817da079513f471e36cd79739d36a36d86 100644
+index e7a8a221a23d2adc497afd21e512eecba4c63a6b..11e5618ff66385574ba04db0942a75227cf8eb0f 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -209,4 +209,16 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+@@ -226,4 +226,16 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
          javaPlugin.logger = this.logger; // Paper - set logger
          javaPlugin.init(loader, loader.server, description, dataFolder, file, this);
      }

--- a/Spigot-API-Patches/0241-Enable-multi-release-plugin-jars.patch
+++ b/Spigot-API-Patches/0241-Enable-multi-release-plugin-jars.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Enable multi-release plugin jars
 
 
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 62f7a6817da079513f471e36cd79739d36a36d86..7760be3e34fa20825faf145d9fb5b2855c1a4602 100644
+index 11e5618ff66385574ba04db0942a75227cf8eb0f..c833cee9fddd12afdfe6bde1435559819b9ad656 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-@@ -56,7 +56,18 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+@@ -58,7 +58,18 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
          this.description = description;
          this.dataFolder = dataFolder;
          this.file = file;
@@ -27,4 +27,4 @@ index 62f7a6817da079513f471e36cd79739d36a36d86..7760be3e34fa20825faf145d9fb5b285
 +        // Paper end
          this.manifest = jar.getManifest();
          this.url = file.toURI().toURL();
- 
+         this.libraryLoader = libraryLoader;

--- a/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
+++ b/Spigot-API-Patches/0257-Better-AnnotationTest-printout.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Better AnnotationTest printout
 
 
 diff --git a/pom.xml b/pom.xml
-index 9d0b4f6224e055f4e1da87d5e70703798bef5fba..c2e9ca1cc7f14d3a696385edc3cb341f902fa2fd 100644
+index 6b71d9a397dd5b72320402a47b8e7197d24e061c..73fbd5d5a591871a3a386fb5c455cd96a3992e7a 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -238,6 +238,19 @@
+@@ -257,6 +257,19 @@
                      <shadedArtifactAttached>true</shadedArtifactAttached>
                  </configuration>
              </plugin>

--- a/Spigot-Server-Patches/0001-POM-Changes.patch
+++ b/Spigot-Server-Patches/0001-POM-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] POM Changes
 
 
 diff --git a/pom.xml b/pom.xml
-index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21fd0f4318 100644
+index 920da83478057968db0e179954041e5747b41bcd..8ce86529d55c256c745dac2cfa7bd2e3c702bf87 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -1,15 +1,14 @@
@@ -58,17 +58,17 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
 -            <artifactId>spigot-api</artifactId>
 +            <groupId>com.destroystokyo.paper</groupId>
 +            <artifactId>paper-api</artifactId>
++            <version>${project.version}</version>
++            <scope>compile</scope>
++        </dependency>
++        <dependency>
++            <groupId>com.destroystokyo.paper</groupId>
++            <artifactId>paper-mojangapi</artifactId>
              <version>${project.version}</version>
              <scope>compile</scope>
          </dependency>
          <dependency>
 -            <groupId>org.spigotmc</groupId>
-+            <groupId>com.destroystokyo.paper</groupId>
-+            <artifactId>paper-mojangapi</artifactId>
-+            <version>${project.version}</version>
-+            <scope>compile</scope>
-+        </dependency>
-+        <dependency>
 +            <groupId>io.papermc</groupId>
              <artifactId>minecraft-server</artifactId>
              <version>${minecraft.version}-SNAPSHOT</version>
@@ -123,8 +123,8 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
 +            <version>8.0.23</version>
              <scope>runtime</scope>
          </dependency>
-         <!-- testing -->
-@@ -100,34 +125,22 @@
+         <!-- add these back in as they are not exposed by the API -->
+@@ -132,34 +157,22 @@
  
      <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
      <build>
@@ -170,7 +170,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
                          </goals>
                      </execution>
                  </executions>
-@@ -137,6 +150,7 @@
+@@ -169,6 +182,7 @@
                  <artifactId>maven-jar-plugin</artifactId>
                  <version>3.2.0</version>
                  <configuration>
@@ -178,7 +178,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
                      <archive>
                          <manifest>
                              <addDefaultEntries>false</addDefaultEntries>
-@@ -144,11 +158,13 @@
+@@ -176,11 +190,13 @@
                          <manifestEntries>
                              <Main-Class>org.bukkit.craftbukkit.Main</Main-Class>
                              <Implementation-Title>CraftBukkit</Implementation-Title>
@@ -194,7 +194,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
                          </manifestEntries>
                          <manifestSections>
                              <manifestSection>
-@@ -184,14 +200,24 @@
+@@ -216,14 +232,24 @@
                              <goal>shade</goal>
                          </goals>
                          <configuration>
@@ -219,8 +219,8 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
 +                                        <exclude>META-INF/org/apache/logging/log4j/core/config/plugins/Log4j2Plugins.dat</exclude>
                                      </excludes>
                                  </filter>
-                             </filters>
-@@ -207,10 +233,11 @@
+                                 <filter>
+@@ -245,10 +271,11 @@
                                      <pattern>jline</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.jline</shadedPattern>
                                  </relocation>
@@ -236,7 +236,7 @@ index ebce3da9abf550089ead322bc2cef359c803a434..5710dd02c80bc713e5dd289c9aa4bc21
                                  <relocation>
                                      <pattern>org.apache.commons.codec</pattern>
                                      <shadedPattern>org.bukkit.craftbukkit.libs.org.apache.commons.codec</shadedPattern>
-@@ -258,10 +285,6 @@
+@@ -316,10 +343,6 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <version>3.8.1</version>

--- a/Spigot-Server-Patches/0004-MC-Utils.patch
+++ b/Spigot-Server-Patches/0004-MC-Utils.patch
@@ -3269,10 +3269,10 @@ index 7fd6893c30fbb34367181620aa159ed79b803455..0b5bcb60472c778574702a5ac26a6d02
  
                  if (optional.isPresent()) {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index f1459d4d2b2592aea1fc39257255979f0a8c61e5..e818bf022b74cae34a512d8c98b47ec3e5c74b9a 100644
+index 2d297902e3b0f99a3d9f64606f9edcdabecbe83a..3fa2e077912949f6ca7b14da93c2206215ebcc7e 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -223,6 +223,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -224,6 +224,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public Integer clientViewDistance;
      // CraftBukkit end
  
@@ -3281,7 +3281,7 @@ index f1459d4d2b2592aea1fc39257255979f0a8c61e5..e818bf022b74cae34a512d8c98b47ec3
      public EntityPlayer(MinecraftServer minecraftserver, WorldServer worldserver, GameProfile gameprofile, PlayerInteractManager playerinteractmanager) {
          super(worldserver, worldserver.getSpawn(), worldserver.v(), gameprofile);
          this.spawnDimension = World.OVERWORLD;
-@@ -235,6 +237,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -236,6 +238,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.c(worldserver);
          this.co = minecraftserver.a(this);
  

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -1145,7 +1145,7 @@ index 9c44a3d9273afaf4d35f4ff86727386b34d9eb06..fff22c40ba38575951e8e4821ade22b2
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1819d2261 100644
+index 3fa2e077912949f6ca7b14da93c2206215ebcc7e..5ef8b66cf266488df75ce7399596f75273b90761 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -143,6 +143,7 @@ import net.minecraft.world.item.enchantment.EnchantmentManager;
@@ -1156,7 +1156,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
  import org.bukkit.Bukkit;
  import org.bukkit.GameMode;
  import org.bukkit.Location;
-@@ -211,6 +212,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -212,6 +213,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      // CraftBukkit start
      public String displayName;
@@ -1164,7 +1164,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
      public IChatBaseComponent listName;
      public org.bukkit.Location compassTarget;
      public int newExp = 0;
-@@ -241,6 +243,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -242,6 +244,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
          // CraftBukkit start
          this.displayName = this.getName();
@@ -1172,7 +1172,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
          this.canPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
      }
-@@ -694,23 +697,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -695,23 +698,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
          IChatBaseComponent defaultMessage = this.getCombatTracker().getDeathMessage();
  
@@ -1200,7 +1200,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
  
              this.playerConnection.a((Packet) (new PacketPlayOutCombatEvent(this.getCombatTracker(), PacketPlayOutCombatEvent.EnumCombatEventType.ENTITY_DIED, ichatbasecomponent)), (future) -> {
                  if (!future.isSuccess()) {
-@@ -1660,6 +1657,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1669,6 +1666,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.a(ichatbasecomponent, ChatMessageType.SYSTEM, uuid);
      }
  
@@ -1208,7 +1208,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
      public void a(IChatBaseComponent ichatbasecomponent, ChatMessageType chatmessagetype, UUID uuid) {
          this.playerConnection.a((Packet) (new PacketPlayOutChat(ichatbasecomponent, chatmessagetype, uuid)), (future) -> {
              if (!future.isSuccess() && (chatmessagetype == ChatMessageType.GAME_INFO || chatmessagetype == ChatMessageType.SYSTEM)) {
-@@ -1682,6 +1680,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1691,6 +1689,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      }
  
      public String locale = "en_us"; // CraftBukkit - add, lowercase
@@ -1216,7 +1216,7 @@ index e818bf022b74cae34a512d8c98b47ec3e5c74b9a..bb309790dc90aedabb3c48ea21cd87d1
      public void a(PacketPlayInSettings packetplayinsettings) {
          // CraftBukkit start
          if (getMainHand() != packetplayinsettings.getMainHand()) {
-@@ -1693,6 +1692,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1702,6 +1701,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              this.server.server.getPluginManager().callEvent(event);
          }
          this.locale = packetplayinsettings.locale;

--- a/Spigot-Server-Patches/0031-Configurable-end-credits.patch
+++ b/Spigot-Server-Patches/0031-Configurable-end-credits.patch
@@ -20,10 +20,10 @@ index 4bba6977a0287837b8927718c040ac61463f0469..e6e18f309dc09ea9416ea37dcc697ddc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 0ff92d701d6ee5ce56eec624eece11de15195b41..a9eb414843381e7697c46af4b68f61b68755afde 100644
+index 5ef8b66cf266488df75ce7399596f75273b90761..808bb68b3c5115b1219a65d0dd253bd60d543652 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -190,7 +190,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -191,7 +191,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      private long ca = SystemUtils.getMonotonicMillis();
      private Entity spectatedEntity;
      public boolean worldChangeInvuln;
@@ -32,7 +32,7 @@ index 0ff92d701d6ee5ce56eec624eece11de15195b41..a9eb414843381e7697c46af4b68f61b6
      private final RecipeBookServer recipeBook = new RecipeBookServer();
      private Vec3D cf;
      private int cg;
-@@ -895,6 +895,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -896,6 +896,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              this.decouple();
              this.getWorldServer().removePlayer(this);
              if (!this.viewingCredits) {

--- a/Spigot-Server-Patches/0040-Configurable-container-update-tick-rate.patch
+++ b/Spigot-Server-Patches/0040-Configurable-container-update-tick-rate.patch
@@ -19,10 +19,10 @@ index 4de86b09c6bc3c1974ce61b550ccb73d37f6f170..5a4c3a8c511f22c8c3240c9c7cd83a65
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index a9eb414843381e7697c46af4b68f61b68755afde..1f31104a1a350f3b53ce45b034cafe528d406291 100644
+index 808bb68b3c5115b1219a65d0dd253bd60d543652..cda0e7f8f9a9d66ac4e5a3f52609a4271bf0c4b5 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -209,6 +209,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -210,6 +210,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public boolean e;
      public int ping;
      public boolean viewingCredits;
@@ -30,7 +30,7 @@ index a9eb414843381e7697c46af4b68f61b68755afde..1f31104a1a350f3b53ce45b034cafe52
  
      // CraftBukkit start
      public String displayName;
-@@ -533,7 +534,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -534,7 +535,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              --this.noDamageTicks;
          }
  

--- a/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
+++ b/Spigot-Server-Patches/0091-Implement-PlayerLocaleChangeEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerLocaleChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index ad55212370e3d814a397680927a1514ea0fe85b5..120cad4e7330900fa11d278cf87a6ab4484469c3 100644
+index cda0e7f8f9a9d66ac4e5a3f52609a4271bf0c4b5..3f1f8f7fe9452f66b18a08ef480d50ef78ad3351 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1686,7 +1686,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1695,7 +1695,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          return s;
      }
  
@@ -17,7 +17,7 @@ index ad55212370e3d814a397680927a1514ea0fe85b5..120cad4e7330900fa11d278cf87a6ab4
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void a(PacketPlayInSettings packetplayinsettings) {
          // CraftBukkit start
-@@ -1694,9 +1694,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1703,9 +1703,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(getBukkitEntity(), getMainHand() == EnumMainHand.LEFT ? MainHand.LEFT : MainHand.RIGHT);
              this.server.server.getPluginManager().callEvent(event);
          }

--- a/Spigot-Server-Patches/0114-Auto-fix-bad-Y-levels-on-player-login.patch
+++ b/Spigot-Server-Patches/0114-Auto-fix-bad-Y-levels-on-player-login.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Auto fix bad Y levels on player login
 Bring down to a saner Y level if super high, as this can cause the server to crash
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 3d5d1b83094b5ca45fae47055db397630fdd4f04..82085f30e4eefa1867536a8c591210380ebad725 100644
+index 3f1f8f7fe9452f66b18a08ef480d50ef78ad3351..3fca9c3566b5d9a1fafeb0700942d7658cd5a279 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -339,6 +339,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -340,6 +340,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      @Override
      public void loadData(NBTTagCompound nbttagcompound) {
          super.loadData(nbttagcompound);

--- a/Spigot-Server-Patches/0118-Cache-user-authenticator-threads.patch
+++ b/Spigot-Server-Patches/0118-Cache-user-authenticator-threads.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cache user authenticator threads
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 82085f30e4eefa1867536a8c591210380ebad725..fa315f10219dc340da4f51a8d4a78e1f33023bb3 100644
+index 3fca9c3566b5d9a1fafeb0700942d7658cd5a279..e6dacf68cd678d64547dcdc23b1175a4cfd279d1 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -4,7 +4,9 @@ import com.google.common.collect.Lists;
@@ -18,7 +18,7 @@ index 82085f30e4eefa1867536a8c591210380ebad725..fa315f10219dc340da4f51a8d4a78e1f
  import java.util.Iterator;
  import java.util.List;
  import java.util.Optional;
-@@ -171,7 +173,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -172,7 +174,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public PlayerConnection playerConnection;
      public final MinecraftServer server;
      public final PlayerInteractManager playerInteractManager;
@@ -27,7 +27,7 @@ index 82085f30e4eefa1867536a8c591210380ebad725..fa315f10219dc340da4f51a8d4a78e1f
      private final AdvancementDataPlayer advancementDataPlayer;
      private final ServerStatisticManager serverStatisticManager;
      private float lastHealthScored = Float.MIN_VALUE;
-@@ -549,13 +551,20 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -550,13 +552,20 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          while (!this.removeQueue.isEmpty()) {
              int i = Math.min(this.removeQueue.size(), Integer.MAX_VALUE);
              int[] aint = new int[i];
@@ -50,7 +50,7 @@ index 82085f30e4eefa1867536a8c591210380ebad725..fa315f10219dc340da4f51a8d4a78e1f
  
              this.playerConnection.sendPacket(new PacketPlayOutEntityDestroy(aint));
          }
-@@ -1552,7 +1561,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1561,7 +1570,14 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.lastHealthSent = -1.0F;
          this.lastFoodSent = -1;
          // this.recipeBook.a((RecipeBook) entityplayer.recipeBook); // CraftBukkit

--- a/Spigot-Server-Patches/0130-Properly-fix-item-duplication-bug.patch
+++ b/Spigot-Server-Patches/0130-Properly-fix-item-duplication-bug.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Properly fix item duplication bug
 Credit to prplz for figuring out the real issue
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 4b9595f89c75b220fe70840a74e0aaa0276fa122..09385eabefeb7d59de1ce4138648badd123396f9 100644
+index e6dacf68cd678d64547dcdc23b1175a4cfd279d1..5b2ae94ed7d499e401a058691eb6ed413b626150 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -2060,8 +2060,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2069,8 +2069,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      }
  
      @Override

--- a/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/Spigot-Server-Patches/0146-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/pom.xml b/pom.xml
-index 5710dd02c80bc713e5dd289c9aa4bc21fd0f4318..e0fcbe1b13a5ec1244d6d904ca76336a47967c9b 100644
+index 8ce86529d55c256c745dac2cfa7bd2e3c702bf87..d82c43adadc2da44e9018a6be3e594d32d010bef 100644
 --- a/pom.xml
 +++ b/pom.xml
 @@ -57,10 +57,26 @@
@@ -53,7 +53,7 @@ index 5710dd02c80bc713e5dd289c9aa4bc21fd0f4318..e0fcbe1b13a5ec1244d6d904ca76336a
          </dependency>
          <dependency>
              <groupId>org.apache.logging.log4j</groupId>
-@@ -276,10 +292,18 @@
+@@ -334,10 +350,18 @@
                                  <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
                                      <resource>META-INF/services/java.sql.Driver</resource>
                                  </transformer>
@@ -252,7 +252,7 @@ index 8ae72e8c8325d9b03803f29fcdd83a0ce8d34450..a0804c4df6f047cf913ae70970219617
          System.setOut(IoBuilder.forLogger(logger).setLevel(Level.INFO).buildPrintStream());
          System.setErr(IoBuilder.forLogger(logger).setLevel(Level.WARN).buildPrintStream());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6c80f328016b6cd30c77b5a5b1e2f6be0b3cd2f0..a892bcf08dddac90f01caec81229259e1070c3ea 100644
+index 67814e3e54ec2be02c4d592c56b60e66d15bedb2..8348dfa43c1f6e07c01024b40f4b3ebc05c10035 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -150,8 +150,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/Spigot-Server-Patches/0187-PlayerNaturallySpawnCreaturesEvent.patch
@@ -29,7 +29,7 @@ index 9ed97d5db81e3603ccccca7500420d7e401ef2a5..b9bde85a90b429659e1a4ab111253cdd
                  Optional<Chunk> optional = ((Either) playerchunk.a().getNow(PlayerChunk.UNLOADED_CHUNK)).left();
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 09385eabefeb7d59de1ce4138648badd123396f9..3d517ab98da5fd56101e97b5678f7180839269f8 100644
+index 5b2ae94ed7d499e401a058691eb6ed413b626150..de7167ddf7b36ef266e511187789f99244401c21 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -1,5 +1,6 @@
@@ -39,7 +39,7 @@ index 09385eabefeb7d59de1ce4138648badd123396f9..3d517ab98da5fd56101e97b5678f7180
  import com.google.common.collect.Lists;
  import com.mojang.authlib.GameProfile;
  import com.mojang.datafixers.util.Either;
-@@ -227,6 +228,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -228,6 +229,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public boolean sentListPacket = false;
      public Integer clientViewDistance;
      // CraftBukkit end

--- a/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0234-InventoryCloseEvent-Reason-API.patch
@@ -7,10 +7,10 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 3d517ab98da5fd56101e97b5678f7180839269f8..7b07d17f8ae425418ff3cafdfd30d72a5bc0fe16 100644
+index de7167ddf7b36ef266e511187789f99244401c21..b581a6d3ec06498a4c6db92eb50c5d2b28038131 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -546,7 +546,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -547,7 +547,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
          // Paper end
          if (!this.world.isClientSide && !this.activeContainer.canUse(this)) {
@@ -19,7 +19,7 @@ index 3d517ab98da5fd56101e97b5678f7180839269f8..7b07d17f8ae425418ff3cafdfd30d72a
              this.activeContainer = this.defaultContainer;
          }
  
-@@ -719,7 +719,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -720,7 +720,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.activeContainer != this.defaultContainer) {
@@ -28,7 +28,7 @@ index 3d517ab98da5fd56101e97b5678f7180839269f8..7b07d17f8ae425418ff3cafdfd30d72a
          }
  
          net.kyori.adventure.text.Component deathMessage = event.deathMessage() != null ? event.deathMessage() : net.kyori.adventure.text.Component.empty(); // Paper - Adventure
-@@ -1284,7 +1284,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1293,7 +1293,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              return OptionalInt.empty();
          } else {
              if (this.activeContainer != this.defaultContainer) {
@@ -37,7 +37,7 @@ index 3d517ab98da5fd56101e97b5678f7180839269f8..7b07d17f8ae425418ff3cafdfd30d72a
              }
  
              this.nextContainerCounter();
-@@ -1344,7 +1344,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1353,7 +1353,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
          // CraftBukkit end
          if (this.activeContainer != this.defaultContainer) {
@@ -46,7 +46,7 @@ index 3d517ab98da5fd56101e97b5678f7180839269f8..7b07d17f8ae425418ff3cafdfd30d72a
          }
  
          // this.nextContainerCounter(); // CraftBukkit - moved up
-@@ -1408,7 +1408,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1417,7 +1417,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      @Override
      public void closeInventory() {
@@ -112,7 +112,7 @@ index d4862a3a7f523c13c452e7b67072261556162437..5c637fc653482e931fa6d0f5d0394d0b
          this.player.o();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ae877ea38a63ef8d0bd9855e9b9279475bb6c465..95cadb09b5a154d7dfe8144fab6c403547672287 100644
+index bd8bcc3891b29d31742bcfd6080a3972e4a9bee7..80934fc662b33b1c88dd7a3033792d612a7c7930 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -494,7 +494,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0280-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0280-Improve-death-events.patch
@@ -15,10 +15,10 @@ items and experience which is otherwise only properly possible by using
 internal code.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 7b07d17f8ae425418ff3cafdfd30d72a5bc0fe16..1271de75743356090050763ff2fb67d28b48cb23 100644
+index b581a6d3ec06498a4c6db92eb50c5d2b28038131..ae9e0f55ddc194aaef1e57e81863569d9bc7b8f3 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -213,6 +213,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -214,6 +214,10 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public int ping;
      public boolean viewingCredits;
      private int containerUpdateDelay; // Paper
@@ -29,7 +29,7 @@ index 7b07d17f8ae425418ff3cafdfd30d72a5bc0fe16..1271de75743356090050763ff2fb67d2
  
      // CraftBukkit start
      public String displayName;
-@@ -716,6 +720,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -717,6 +721,15 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          IChatBaseComponent defaultMessage = this.getCombatTracker().getDeathMessage();
  
          org.bukkit.event.entity.PlayerDeathEvent event = CraftEventFactory.callPlayerDeathEvent(this, loot, PaperAdventure.asAdventure(defaultMessage), defaultMessage.getString(), keepInventory); // Paper - Adventure
@@ -45,7 +45,7 @@ index 7b07d17f8ae425418ff3cafdfd30d72a5bc0fe16..1271de75743356090050763ff2fb67d2
  
          // SPIGOT-943 - only call if they have an inventory open
          if (this.activeContainer != this.defaultContainer) {
-@@ -862,8 +875,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -863,8 +876,17 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                          }
                      }
                  }

--- a/Spigot-Server-Patches/0298-Call-player-spectator-target-events-and-improve-impl.patch
+++ b/Spigot-Server-Patches/0298-Call-player-spectator-target-events-and-improve-impl.patch
@@ -19,10 +19,10 @@ spectate the target entity.
 Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 1271de75743356090050763ff2fb67d28b48cb23..46d1e766e234bf49d31583e9e59aeb33c719b1ec 100644
+index ae9e0f55ddc194aaef1e57e81863569d9bc7b8f3..f5be9554e1fd01a35b926196b30fd64f1567a799 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1811,15 +1811,59 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1820,15 +1820,59 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          return (Entity) (this.spectatedEntity == null ? this : this.spectatedEntity);
      }
  

--- a/Spigot-Server-Patches/0304-Reset-players-airTicks-on-respawn.patch
+++ b/Spigot-Server-Patches/0304-Reset-players-airTicks-on-respawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset players airTicks on respawn
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 46d1e766e234bf49d31583e9e59aeb33c719b1ec..fbc0c81bb7e87f7820325a9a7bb39123db272845 100644
+index f5be9554e1fd01a35b926196b30fd64f1567a799..3e7ac6699ad1f147220c286e251ce0ec1ca25035 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -2153,6 +2153,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2162,6 +2162,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
  
          this.setHealth(this.getMaxHealth());

--- a/Spigot-Server-Patches/0316-force-entity-dismount-during-teleportation.patch
+++ b/Spigot-Server-Patches/0316-force-entity-dismount-during-teleportation.patch
@@ -20,10 +20,10 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index ae5fe4f71ea1cc231e5d87920c2243f4f4f581f1..bea8dd578cfd5532dd1b679a4ee4e6c74a416bba 100644
+index 3e7ac6699ad1f147220c286e251ce0ec1ca25035..e755191435e74246b309f8fe5a668dae2e499df1 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1252,11 +1252,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1261,11 +1261,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          }
      }
  
@@ -41,7 +41,7 @@ index ae5fe4f71ea1cc231e5d87920c2243f4f4f581f1..bea8dd578cfd5532dd1b679a4ee4e6c7
  
          if (entity1 != entity && this.playerConnection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f102ecb56ac04a5b840fa52e6d1ff9604598d58d..f0c18a55900774ba67eaf094f175a9e37c16e56c 100644
+index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449fb667016f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2040,12 +2040,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -93,7 +93,7 @@ index f102ecb56ac04a5b840fa52e6d1ff9604598d58d..f0c18a55900774ba67eaf094f175a9e3
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index c189a7051240bb357acf5075c98206a258409b0c..58270f45de665b5c1cfd9fc548eadb263ad230e9 100644
+index b3c2976a48c2349e5c22d58dd1ac64a02cd969d5..6ada2fe58966553b52a8a890088c78d5ea0dfd73 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -3015,11 +3015,13 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/Spigot-Server-Patches/0320-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,10 +16,10 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 1bf0e7ca544aa377005dfcc197f136ecef019e3a..97aae1d2a512e6197ca3e491d041efd2def6e37a 100644
+index e755191435e74246b309f8fe5a668dae2e499df1..8d88ed3d68146fbcb090847351945689518e59a9 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -213,6 +213,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -214,6 +214,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public int ping;
      public boolean viewingCredits;
      private int containerUpdateDelay; // Paper
@@ -28,7 +28,7 @@ index 1bf0e7ca544aa377005dfcc197f136ecef019e3a..97aae1d2a512e6197ca3e491d041efd2
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1faae8a451c25cc8e37ef1907206a4f721477b13..e58784539bb1cc66581317c7167ae3326d5622ec 100644
+index 2299581fa889c0e8ddc6b2cc1d3551d02ff8dc2d..7515e9ddbc89de882373469cf3c46046c76af974 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -168,6 +168,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0321-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
+++ b/Spigot-Server-Patches/0321-Workaround-for-vehicle-tracking-issue-on-disconnect.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Workaround for vehicle tracking issue on disconnect
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 66749184ec24d15af3aaa71e79475d2a3f51c843..920e0d7a3339197ad10747266af737753b025ba4 100644
+index 8d88ed3d68146fbcb090847351945689518e59a9..82f49078a91b6ac471d303bc68891d80e201bd1f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1518,6 +1518,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1527,6 +1527,13 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public void p() {
          this.ch = true;
          this.ejectPassengers();

--- a/Spigot-Server-Patches/0342-PlayerDeathEvent-getItemsToKeep.patch
+++ b/Spigot-Server-Patches/0342-PlayerDeathEvent-getItemsToKeep.patch
@@ -8,10 +8,10 @@ Exposes a mutable array on items a player should keep on death
 Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 920e0d7a3339197ad10747266af737753b025ba4..689063b7f1e57d691f130ddb399177566edcad2e 100644
+index 82f49078a91b6ac471d303bc68891d80e201bd1f..a15b119b24090ffc607bfc9003d5b95f3acf3b2f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -694,6 +694,46 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -695,6 +695,46 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          });
      }
  
@@ -58,7 +58,7 @@ index 920e0d7a3339197ad10747266af737753b025ba4..689063b7f1e57d691f130ddb39917756
      @Override
      public void die(DamageSource damagesource) {
          boolean flag = this.world.getGameRules().getBoolean(GameRules.SHOW_DEATH_MESSAGES);
-@@ -777,7 +817,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -778,7 +818,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.dropExperience();
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {

--- a/Spigot-Server-Patches/0348-Fix-sounds-when-item-frames-are-modified-MC-123450.patch
+++ b/Spigot-Server-Patches/0348-Fix-sounds-when-item-frames-are-modified-MC-123450.patch
@@ -18,16 +18,3 @@ index 584f64946821092afab57b9409bc249403bc16e7..43152a6c70c9433d627a58051101530d
              this.playSound(SoundEffects.ENTITY_ITEM_FRAME_ADD_ITEM, 1.0F, 1.0F);
          }
  
-diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
-index 86bb26cd1d327056a64926ed6fc53142ad3756c2..cbdbb89ec28f9b6c3a0eb31be94c440254c6e266 100644
---- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
-+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftItemFrame.java
-@@ -50,7 +50,7 @@ public class CraftItemFrame extends CraftHanging implements ItemFrame {
-         old.die();
- 
-         EntityItemFrame frame = new EntityItemFrame(world, position, direction);
--        frame.setItem(item);
-+        frame.setItem(item, true, false); // Paper - fix itemframe sound
-         world.addEntity(frame);
-         this.entity = frame;
-     }

--- a/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
+++ b/Spigot-Server-Patches/0375-implement-optional-per-player-mob-spawns.patch
@@ -572,7 +572,7 @@ index 662d7f418e8acc9503ebf43e09410e7bd50f6bb3..372e5268783a84effa8f9f06c3f85b18
  
              this.p = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 49e3205dbd94b06b9504039c1a93f830b025a8bb..1e882d9d9b797bb5fb0411f5ecdedf01bcfe5aca 100644
+index a15b119b24090ffc607bfc9003d5b95f3acf3b2f..f0c3bfb0e641b9f1a22fb6873ab3645be6e481c4 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -94,6 +94,7 @@ import net.minecraft.world.effect.MobEffects;
@@ -583,7 +583,7 @@ index 49e3205dbd94b06b9504039c1a93f830b025a8bb..1e882d9d9b797bb5fb0411f5ecdedf01
  import net.minecraft.world.entity.EnumMainHand;
  import net.minecraft.world.entity.IEntityAngerable;
  import net.minecraft.world.entity.animal.horse.EntityHorseAbstract;
-@@ -218,6 +219,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -219,6 +220,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.PacketPlayOutUpdateHealth queuedHealthUpdatePacket;
      // Paper end
@@ -595,7 +595,7 @@ index 49e3205dbd94b06b9504039c1a93f830b025a8bb..1e882d9d9b797bb5fb0411f5ecdedf01
  
      // CraftBukkit start
      public String displayName;
-@@ -256,6 +262,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -257,6 +263,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.adventure$displayName = net.kyori.adventure.text.Component.text(this.getName()); // Paper
          this.canPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
@@ -603,7 +603,7 @@ index 49e3205dbd94b06b9504039c1a93f830b025a8bb..1e882d9d9b797bb5fb0411f5ecdedf01
      }
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
-@@ -2052,6 +2059,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2061,6 +2068,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      }
  
@@ -612,7 +612,7 @@ index 49e3205dbd94b06b9504039c1a93f830b025a8bb..1e882d9d9b797bb5fb0411f5ecdedf01
          return this.cj;
      }
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index a6c3bed5824d112042536a5666098d4d80173c3b..9c5b1dd305567f09a23a3f189d4dadba323b643e 100644
+index 46c91230ab6f12db77b453c312fa7382b76fad34..d00dc8d7933be61f1401f598e5d675f5ae5d7029 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -72,6 +72,7 @@ import net.minecraft.util.thread.ThreadedMailbox;

--- a/Spigot-Server-Patches/0382-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
+++ b/Spigot-Server-Patches/0382-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix stuck in sneak when changing worlds (MC-10657)
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 1e882d9d9b797bb5fb0411f5ecdedf01bcfe5aca..23bb5cd0b10c211019ff0b71128bbf835238e9d8 100644
+index f0c3bfb0e641b9f1a22fb6873ab3645be6e481c4..a0c426afaa7a18f7596d56699f02dcd665f7aa9d 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1072,6 +1072,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1073,6 +1073,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                  this.lastHealthSent = -1.0F;
                  this.lastFoodSent = -1;
  
@@ -18,7 +18,7 @@ index 1e882d9d9b797bb5fb0411f5ecdedf01bcfe5aca..23bb5cd0b10c211019ff0b71128bbf83
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.world.getServer().getPluginManager().callEvent(changeEvent);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 54e49dcc56281d02203fdcdb20906a4ee0e43c05..c5116a9c596074a33c98d29bb1e9cf22a8ad53bf 100644
+index 553b14f7167673938d1bc83d79c730692a4ef105..9af1d81475d2def60a682ed23e88f1afbbc4c7e6 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -846,6 +846,8 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0390-PlayerDeathEvent-shouldDropExperience.patch
+++ b/Spigot-Server-Patches/0390-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 23bb5cd0b10c211019ff0b71128bbf835238e9d8..f242330bcf3d63490b5e7be36f8af6eccfb07820 100644
+index a0c426afaa7a18f7596d56699f02dcd665f7aa9d..f5212a7ec0f2dd27fb1c06e0dfc37f2aff595fde 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -821,7 +821,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -822,7 +822,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              this.eW();
          }
          // SPIGOT-5478 must be called manually now

--- a/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/Spigot-Server-Patches/0418-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -36,10 +36,10 @@ index 525d702d78a609af987ebd2c32169b873e5c05ed..6c8e9d498c9a30a1aa88494ba09c3cae
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index f242330bcf3d63490b5e7be36f8af6eccfb07820..a37c868addc2e4aab8eb28d92b1c9b3e0c0fc4a9 100644
+index f5212a7ec0f2dd27fb1c06e0dfc37f2aff595fde..c0e32b13e79fa6b34ac9448d2f74339bb771274f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -215,6 +215,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -216,6 +216,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public boolean viewingCredits;
      private int containerUpdateDelay; // Paper
      public long loginTime; // Paper

--- a/Spigot-Server-Patches/0425-Don-t-tick-dead-players.patch
+++ b/Spigot-Server-Patches/0425-Don-t-tick-dead-players.patch
@@ -7,10 +7,10 @@ Causes sync chunk loads and who knows what all else.
 This is safe because Spectators are skipped in unloaded chunks too in vanilla.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index a37c868addc2e4aab8eb28d92b1c9b3e0c0fc4a9..e4647849e2fccb68ff9e88ced92c183204b76960 100644
+index c0e32b13e79fa6b34ac9448d2f74339bb771274f..e3721287cc18c8df81d1353084364966eb3f55ab 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -608,7 +608,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -609,7 +609,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      public void playerTick() {
          try {

--- a/Spigot-Server-Patches/0430-Don-t-move-existing-players-to-world-spawn.patch
+++ b/Spigot-Server-Patches/0430-Don-t-move-existing-players-to-world-spawn.patch
@@ -10,10 +10,10 @@ larger than the keep loaded range.
 By skipping this, we avoid potential for a large spike on server start.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index e4647849e2fccb68ff9e88ced92c183204b76960..3cf68af488fdd8492c620e6f3438b35cd4aa7737 100644
+index e3721287cc18c8df81d1353084364966eb3f55ab..79003f43c4f15a7e5dd51587bc8c2f477bedb1b2 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -253,7 +253,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -254,7 +254,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.serverStatisticManager = minecraftserver.getPlayerList().getStatisticManager(this);
          this.advancementDataPlayer = minecraftserver.getPlayerList().f(this);
          this.G = 1.0F;
@@ -22,7 +22,7 @@ index e4647849e2fccb68ff9e88ced92c183204b76960..3cf68af488fdd8492c620e6f3438b35c
          this.co = minecraftserver.a(this);
  
          this.cachedSingleHashSet = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
-@@ -305,6 +305,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -306,6 +306,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      }
      // CraftBukkit end
  
@@ -30,7 +30,7 @@ index e4647849e2fccb68ff9e88ced92c183204b76960..3cf68af488fdd8492c620e6f3438b35c
      private void c(WorldServer worldserver) {
          BlockPosition blockposition = worldserver.getSpawn();
  
-@@ -482,7 +483,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -483,7 +484,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                  position = Vec3D.a(((WorldServer) world).getSpawn());
              }
              this.world = world;
@@ -40,7 +40,7 @@ index e4647849e2fccb68ff9e88ced92c183204b76960..3cf68af488fdd8492c620e6f3438b35c
          this.playerInteractManager.a((WorldServer) world);
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 84c2bc0bac4f388094693859ab7b6ced5e315c27..f35825d4a8574ea75b46be36b9929f8e12405217 100644
+index 0a99ee6221c46043ecdf9e9df7a064aa63ee6951..bd272d6fe86c30c3f22418802f98609410f947f8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -208,6 +208,8 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0442-Prevent-opening-inventories-when-frozen.patch
+++ b/Spigot-Server-Patches/0442-Prevent-opening-inventories-when-frozen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 3cf68af488fdd8492c620e6f3438b35cd4aa7737..3e23bda4c1f379d28b722d21d600627a61a65ff0 100644
+index 79003f43c4f15a7e5dd51587bc8c2f477bedb1b2..5382dfbad7a33670268d5d713cf3bdd425bbe885 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -559,7 +559,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -560,7 +560,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              containerUpdateDelay = world.paperConfig.containerUpdateTickRate;
          }
          // Paper end
@@ -17,7 +17,7 @@ index 3cf68af488fdd8492c620e6f3438b35cd4aa7737..3e23bda4c1f379d28b722d21d600627a
              this.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.activeContainer = this.defaultContainer;
          }
-@@ -1398,7 +1398,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1407,7 +1407,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              } else {
                  // CraftBukkit start
                  this.activeContainer = container;
@@ -26,7 +26,7 @@ index 3cf68af488fdd8492c620e6f3438b35cd4aa7737..3e23bda4c1f379d28b722d21d600627a
                  // CraftBukkit end
                  container.addSlotListener(this);
                  return OptionalInt.of(this.containerCounter);
-@@ -2200,7 +2200,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2209,7 +2209,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      }
  
      @Override

--- a/Spigot-Server-Patches/0447-Implement-Player-Client-Options-API.patch
+++ b/Spigot-Server-Patches/0447-Implement-Player-Client-Options-API.patch
@@ -107,7 +107,7 @@ index 90842b27f64afcdd8eb7d0e52df8cfcb418b5b5a..f47cd43f96f61475bd1d5da11bdbc7c5
          return this.e;
      }
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 3e23bda4c1f379d28b722d21d600627a61a65ff0..d010aed07a1e608897ca5f87afcb7661e295d933 100644
+index 5382dfbad7a33670268d5d713cf3bdd425bbe885..ff0913941a888ab529d7a4dd1b160fe9659b25cb 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -2,6 +2,7 @@ package net.minecraft.server.level;
@@ -118,7 +118,7 @@ index 3e23bda4c1f379d28b722d21d600627a61a65ff0..d010aed07a1e608897ca5f87afcb7661
  import com.mojang.authlib.GameProfile;
  import com.mojang.datafixers.util.Either;
  import com.mojang.serialization.DataResult;
-@@ -190,7 +191,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -191,7 +192,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public int lastSentExp = -99999999;
      public int invulnerableTicks = 60;
      private EnumChatVisibility bY;
@@ -127,7 +127,7 @@ index 3e23bda4c1f379d28b722d21d600627a61a65ff0..d010aed07a1e608897ca5f87afcb7661
      private long ca = SystemUtils.getMonotonicMillis();
      private Entity spectatedEntity;
      public boolean worldChangeInvuln;
-@@ -1801,6 +1802,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1810,6 +1811,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void a(PacketPlayInSettings packetplayinsettings) {

--- a/Spigot-Server-Patches/0451-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/Spigot-Server-Patches/0451-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,10 +28,10 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index d010aed07a1e608897ca5f87afcb7661e295d933..abd2554b6e98c25b59b9989936af8b0624e255a3 100644
+index ff0913941a888ab529d7a4dd1b160fe9659b25cb..505cb0eb74d45906132e78c5cf8741dc5fd4eaf0 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -239,6 +239,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -240,6 +240,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public double maxHealthCache;
      public boolean joining = true;
      public boolean sentListPacket = false;
@@ -40,7 +40,7 @@ index d010aed07a1e608897ca5f87afcb7661e295d933..abd2554b6e98c25b59b9989936af8b06
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index a7efc5c7e4da8f18ecfd6a335a01709db4259367..c90bc462627f71c2ce72a89fe2aa28203df73e52 100644
+index 6279846a92489b5dade21ad55a1bec1157073e27..86cb1f33cd5269ff271129ceedd3a3a8532fa6eb 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -1586,7 +1586,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -61,7 +61,7 @@ index a7efc5c7e4da8f18ecfd6a335a01709db4259367..c90bc462627f71c2ce72a89fe2aa2820
          if (!(entity instanceof EntityComplexPart)) {
              EntityTypes<?> entitytypes = entity.getEntityType();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 599470c2158222be9202a96fc7d9bcf4b0ca0fe1..7305bba223229d9aa5315a8dff5fdc5af8faba6a 100644
+index 7d336c23a57c06c3744ae5b187960da798dd07c8..66c1a9ca392b29fe2191577d32c70b214fa7293d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -276,6 +276,12 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0452-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0452-Load-Chunks-for-Login-Asynchronously.patch
@@ -18,7 +18,7 @@ index 6e5d21af43261dc2f12ceec7b7e3269be635cf7a..ecf4cd6dfea777ab9daea0b40724d247
          boolean flag1 = this.playerChunkMap.b();
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index abd2554b6e98c25b59b9989936af8b0624e255a3..56a4de74d665b5dba97340bb6d9d35ec112c11f9 100644
+index 505cb0eb74d45906132e78c5cf8741dc5fd4eaf0..39fb3a1445338c3ac1642b8e518eb8d1031f9a5c 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -31,6 +31,7 @@ import net.minecraft.core.NonNullList;
@@ -29,7 +29,7 @@ index abd2554b6e98c25b59b9989936af8b0624e255a3..56a4de74d665b5dba97340bb6d9d35ec
  import net.minecraft.network.chat.ChatComponentText;
  import net.minecraft.network.chat.ChatHoverable;
  import net.minecraft.network.chat.ChatMessage;
-@@ -174,6 +175,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -175,6 +176,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      private static final Logger LOGGER = LogManager.getLogger();
      public PlayerConnection playerConnection;
@@ -37,7 +37,7 @@ index abd2554b6e98c25b59b9989936af8b0624e255a3..56a4de74d665b5dba97340bb6d9d35ec
      public final MinecraftServer server;
      public final PlayerInteractManager playerInteractManager;
      public final Deque<Integer> removeQueue = new ArrayDeque<>(); // Paper
-@@ -240,6 +242,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -241,6 +243,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public boolean joining = true;
      public boolean sentListPacket = false;
      public boolean supressTrackerForLogin = false; // Paper
@@ -46,7 +46,7 @@ index abd2554b6e98c25b59b9989936af8b0624e255a3..56a4de74d665b5dba97340bb6d9d35ec
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 94860c06717e8dcf969277562e88687e9a99aaa4..e5d94dedc88e8bbcf8d9517dfb5c6ec6f62de5aa 100644
+index 86cb1f33cd5269ff271129ceedd3a3a8532fa6eb..6e4a47581843be42b77034fec16b1d531a5b5759 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -147,7 +147,7 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {
@@ -130,7 +130,7 @@ index f02ddd53df4674a2b5e0bb142db756d1f153d69b..443247b03b8352c4dd453270dccdbd7e
          this.minecraftServer.getMethodProfiler().enter("keepAlive");
          // Paper Start - give clients a longer time to respond to pings as per pre 1.12.2 timings
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7305bba223229d9aa5315a8dff5fdc5af8faba6a..70b3a7c8c4bd817be9c4dfaee71ec22a42620e11 100644
+index 66c1a9ca392b29fe2191577d32c70b214fa7293d..c7e78d0626fa0dd18021c1a0827a10c08ab10b4a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -41,6 +41,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutEntityStatus;

--- a/Spigot-Server-Patches/0465-Implement-Mob-Goal-API.patch
+++ b/Spigot-Server-Patches/0465-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/pom.xml b/pom.xml
-index 325dc0a46666d5e0cd050fd1fb793c08866c2a43..ab57297272c2d6f3d21067081bcaf8775b8fff09 100644
+index 451aff0bdc4b53bc14cdae7734ac132484b94b4e..c8e74f0fa14df5fe5113779d910c6395b32981ca 100644
 --- a/pom.xml
 +++ b/pom.xml
-@@ -149,6 +149,13 @@
+@@ -181,6 +181,13 @@
              <version>1.3</version>
              <scope>test</scope>
          </dependency>

--- a/Spigot-Server-Patches/0467-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/Spigot-Server-Patches/0467-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -148,10 +148,10 @@ index ecf4cd6dfea777ab9daea0b40724d247df7ddb53..42bb00364375e5cf324b435573853458
                              }
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 56a4de74d665b5dba97340bb6d9d35ec112c11f9..ea62c27302d3ce3234ffa421f8c1a585dab0759b 100644
+index 39fb3a1445338c3ac1642b8e518eb8d1031f9a5c..62ed75ae7ec492d8502776fdf3cf3ee461a38a53 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -249,6 +249,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -250,6 +250,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<EntityPlayer> cachedSingleHashSet; // Paper
  
@@ -192,7 +192,7 @@ index 445dba8ed210407664904b707c36c78a76f25510..25484cac9c62e49de39fbbf506fcb3ed
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 67bea47a2248d228fd070bc0aa66f05b71a76ef5..095d941f33ff297b4573aee5d9ce2233a4b85838 100644
+index 9fc74f08b912ff885c9478167c7ef173c32f1654..a6bb8e3b9e73f81bfa92ac13df27e9c44dd9e311 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -210,6 +210,17 @@ public class PlayerChunkMap extends IChunkLoader implements PlayerChunk.d {

--- a/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
+++ b/Spigot-Server-Patches/0469-No-Tick-view-distance-implementation.patch
@@ -73,10 +73,10 @@ index 335666db1854e8aa4b2ba71d5bdc2658305cb70a..2bbdcedf4856080ea9232effdf3bdae9
                  if (flag1) {
                      ChunkMapDistance.this.j.a(ChunkTaskQueueSorter.a(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index ea62c27302d3ce3234ffa421f8c1a585dab0759b..5b3ccc8e623712cef2afeb16dac001ee4d3423d1 100644
+index 62ed75ae7ec492d8502776fdf3cf3ee461a38a53..89a66078b722f265abd73579545a1f24df9442aa 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -251,6 +251,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -252,6 +252,8 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
  
      double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
  
@@ -179,7 +179,7 @@ index 25484cac9c62e49de39fbbf506fcb3edc4ba6e65..1f6333c2c26ad04e23d2881235ed1dcf
  
      public CompletableFuture<Either<IChunkAccess, PlayerChunk.Failure>> a(ChunkStatus chunkstatus, PlayerChunkMap playerchunkmap) {
 diff --git a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
-index 095d941f33ff297b4573aee5d9ce2233a4b85838..057cc41af7274a6307a07ae6ab0e2e7f2efb5cc5 100644
+index a6bb8e3b9e73f81bfa92ac13df27e9c44dd9e311..e4b5649fbc8cb9662e818581fe2891641de419b6 100644
 --- a/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/PlayerChunkMap.java
 @@ -60,9 +60,11 @@ import net.minecraft.network.protocol.game.PacketPlayOutLightUpdate;
@@ -571,7 +571,7 @@ index 095d941f33ff297b4573aee5d9ce2233a4b85838..057cc41af7274a6307a07ae6ab0e2e7f
                          }
                      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 70b3a7c8c4bd817be9c4dfaee71ec22a42620e11..ee6de0186f6a112d02e1dd4cc73fdaa92ab4d0d9 100644
+index c7e78d0626fa0dd18021c1a0827a10c08ab10b4a..66fcd68f0a0a21b113e8741cc42c841f49009118 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -254,7 +254,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/Spigot-Server-Patches/0485-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -598,7 +598,7 @@ index 42bb00364375e5cf324b43557385345868b37ffe..19e02d12bb0c5a73066f7c57da402779
          boolean flag1 = this.playerChunkMap.b();
  
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 5b3ccc8e623712cef2afeb16dac001ee4d3423d1..21d1b4e0fe93b28cdadac043d081306d32032f81 100644
+index 89a66078b722f265abd73579545a1f24df9442aa..8055172c806f285aa9a9e6de681d03b008fbf785 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -73,6 +73,7 @@ import net.minecraft.network.protocol.game.PacketPlayOutWorldEvent;
@@ -609,7 +609,7 @@ index 5b3ccc8e623712cef2afeb16dac001ee4d3423d1..21d1b4e0fe93b28cdadac043d081306d
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.network.ITextFilter;
  import net.minecraft.server.network.PlayerConnection;
-@@ -187,6 +188,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -188,6 +189,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      private int lastArmorScored = Integer.MIN_VALUE;
      private int lastExpLevelScored = Integer.MIN_VALUE;
      private int lastExpTotalScored = Integer.MIN_VALUE;
@@ -622,7 +622,7 @@ index 5b3ccc8e623712cef2afeb16dac001ee4d3423d1..21d1b4e0fe93b28cdadac043d081306d
      private float lastHealthSent = -1.0E8F;
      private int lastFoodSent = -99999999;
      private boolean lastSentSaturationZero = true;
-@@ -274,6 +281,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -275,6 +282,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
          this.maxHealthCache = this.getMaxHealth();
          this.cachedSingleMobDistanceMap = new com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
      }
@@ -644,7 +644,7 @@ index 5b3ccc8e623712cef2afeb16dac001ee4d3423d1..21d1b4e0fe93b28cdadac043d081306d
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
      // If this is an issue, PRs are welcome
-@@ -621,6 +643,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -622,6 +644,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
              if (valid && !this.isSpectator() || this.world.isLoaded(this.getChunkCoordinates())) { // Paper - don't tick dead players that are not in the world currently (pending respawn)
                  super.tick();
              }
@@ -1232,7 +1232,7 @@ index 6db70005ebc99b19185b8efca550a0783ea05cad..42190a8c6c2eadf05f57df50e3ca9973
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ee6de0186f6a112d02e1dd4cc73fdaa92ab4d0d9..65e01b98c74d2fa9ff6d6db18f9f8c684b7bdac4 100644
+index 66fcd68f0a0a21b113e8741cc42c841f49009118..b4c5915cc68a838259129b8973b3a6a39c1fc963 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -275,8 +275,8 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0539-Incremental-player-saving.patch
+++ b/Spigot-Server-Patches/0539-Incremental-player-saving.patch
@@ -47,10 +47,10 @@ index c3635577b1796e6ca84709469ecf95c815fe53a5..bd6b9c7be8951393e7ba731f4d6a9486
              // Paper start
              for (WorldServer world : getWorlds()) {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 21d1b4e0fe93b28cdadac043d081306d32032f81..1a08be6a490f0b94f86ee87ad06e60b66afc63f9 100644
+index 8055172c806f285aa9a9e6de681d03b008fbf785..3908dc27a5cf127ab3c3630da47318da1bf4e3c9 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -175,6 +175,7 @@ import org.bukkit.inventory.MainHand;
+@@ -176,6 +176,7 @@ import org.bukkit.inventory.MainHand;
  public class EntityPlayer extends EntityHuman implements ICrafting {
  
      private static final Logger LOGGER = LogManager.getLogger();
@@ -59,7 +59,7 @@ index 21d1b4e0fe93b28cdadac043d081306d32032f81..1a08be6a490f0b94f86ee87ad06e60b6
      public NetworkManager networkManager; // Paper
      public final MinecraftServer server;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1b78f53d09cc26fe881933df8aa1a7e77337acf1..939e3721af52069f1abad79d28c0555be3ac2d59 100644
+index 7f5311770f0a461f02039255fbbf1a48df4178f3..d3f3dc4ad2c758482b7a8d5c07caa526ce1e3424 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -563,6 +563,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0596-Add-API-for-quit-reason.patch
+++ b/Spigot-Server-Patches/0596-Add-API-for-quit-reason.patch
@@ -25,10 +25,10 @@ index 878f879f8d410c428ad8a4c49e0c86c559bc47a9..f86f430598026a3a7e27fb8d40cfc5fe
                          NetworkManager.LOGGER.debug("Failed to sent packet", throwable);
                          this.sendPacket(new PacketPlayOutKickDisconnect(chatmessage), (future) -> {
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 1a08be6a490f0b94f86ee87ad06e60b66afc63f9..d850721afc33230890353f16c5bc5579c9efb1bf 100644
+index 3908dc27a5cf127ab3c3630da47318da1bf4e3c9..78fcb90c86700ee6feef0d40753fc8d8a943777f 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -260,6 +260,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -261,6 +261,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
  
      boolean needsChunkCenterUpdate; // Paper - no-tick view distance
@@ -49,7 +49,7 @@ index 8ffc98faecca616005fc56031718a7a10de40102..d00c17210b3c0aff40b37ff11f8e9dc6
              this.networkManager.close(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 272a899c4d599a97201f1c11d829abe40101377d..61513e3c27cf95090e61f7085bb2f0435c774df9 100644
+index 8bd55e3d2b5142081a7dfe1dbbd36f2f995e5856..e0bbb7f3ea7ce4902cd14e64357472087ce6912a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -590,7 +590,7 @@ public abstract class PlayerList {

--- a/Spigot-Server-Patches/0615-Player-Chunk-Load-Unload-Events.patch
+++ b/Spigot-Server-Patches/0615-Player-Chunk-Load-Unload-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index d850721afc33230890353f16c5bc5579c9efb1bf..45c6eb96310146adab802dc3da019f7ee15e0fe5 100644
+index 78fcb90c86700ee6feef0d40753fc8d8a943777f..c0446ed3c7cc24fae2880dfba71228f5edee66d6 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
 @@ -139,6 +139,8 @@ import net.minecraft.world.scores.ScoreboardScore;
@@ -17,7 +17,7 @@ index d850721afc33230890353f16c5bc5579c9efb1bf..45c6eb96310146adab802dc3da019f7e
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
  
-@@ -2089,11 +2091,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -2098,11 +2100,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      public void a(ChunkCoordIntPair chunkcoordintpair, Packet<?> packet, Packet<?> packet1) {
          this.playerConnection.sendPacket(packet1);
          this.playerConnection.sendPacket(packet);

--- a/Spigot-Server-Patches/0663-Reset-shield-blocking-on-dimension-change.patch
+++ b/Spigot-Server-Patches/0663-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 45c6eb96310146adab802dc3da019f7ee15e0fe5..1161605d9f4f9727282ac3677a916a9ebdb1263b 100644
+index c0446ed3c7cc24fae2880dfba71228f5edee66d6..3f44d5b8e3bc4f897a5dda473532004078fe0ebe 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1117,6 +1117,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1118,6 +1118,11 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
                  this.world.getServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/Spigot-Server-Patches/0728-call-PortalCreateEvent-players-and-end-platform.patch
+++ b/Spigot-Server-Patches/0728-call-PortalCreateEvent-players-and-end-platform.patch
@@ -17,10 +17,10 @@ index eb67af795dd716d9f92ac32843accc1ec4efd647..4abc87b7e737bc652e84f76a508ab855
              return this.d(this.getX() + i, this.getY() + j, this.getZ() + k);
          }
 diff --git a/src/main/java/net/minecraft/server/level/EntityPlayer.java b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-index 1161605d9f4f9727282ac3677a916a9ebdb1263b..10e9e5328f783832b957113a8672f45f90ace813 100644
+index 3f44d5b8e3bc4f897a5dda473532004078fe0ebe..8683d6ddc5d8ce4a302fa6e2665b7dcd64f6a00a 100644
 --- a/src/main/java/net/minecraft/server/level/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/EntityPlayer.java
-@@ -1144,15 +1144,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
+@@ -1145,15 +1145,21 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
      private void a(WorldServer worldserver, BlockPosition blockposition) {
          BlockPosition.MutableBlockPosition blockposition_mutableblockposition = blockposition.i();
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
146a7e4b SPIGOT-5345: Add automatic library support

CraftBukkit Changes:
b1064c69 Remove sisu annotation processor from jar
32e40866 SPIGOT-6189: Persistent data disappears when calling setFacingDirection on an item frame
d189f78b #&#x2060;827: Trigger vanilla dimension advancements in non-main worlds
5bbb4a65 Add plumbing for automatic library support

Spigot Changes:
9fb885e8 Rebuild patches