### PR TITLE
fix beacon activate/deactivate events

### DIFF
--- a/Spigot-API-Patches/0290-Introduce-beacon-activation-deactivation-events.patch
+++ b/Spigot-API-Patches/0290-Introduce-beacon-activation-deactivation-events.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Introduce beacon activation/deactivation events
 
 diff --git a/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java b/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a907015c769c754a1599325068259ca0f109489a
+index 0000000000000000000000000000000000000000..7575ca7dd84dee89528ec2e5e5f99f97d8a10f58
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/block/BeaconActivatedEvent.java
 @@ -0,0 +1,40 @@
@@ -20,7 +20,7 @@ index 0000000000000000000000000000000000000000..a907015c769c754a1599325068259ca0
 +
 +/**
 + * Called when a beacon is activated.
-+ * Activation occurs when the beacon activation sound is played, and the beam becomes visible.
++ * Activation occurs when the beacon beam becomes visible.
 + */
 +public class BeaconActivatedEvent extends BlockEvent {
 +    private static final HandlerList handlers = new HandlerList();

--- a/Spigot-Server-Patches/0719-Introduce-beacon-activation-deactivation-events.patch
+++ b/Spigot-Server-Patches/0719-Introduce-beacon-activation-deactivation-events.patch
@@ -5,47 +5,32 @@ Subject: [PATCH] Introduce beacon activation/deactivation events
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
-index 8dfb9eb12d07c2d4737ecf3de1ae7f6de31891bf..fb2e914599ce024fa151735e8c2ac2eb6bdf05e7 100644
+index 8dfb9eb12d07c2d4737ecf3de1ae7f6de31891bf..c47c8c70b9f156e9a43c4555f3a38df628e4fbdf 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
-@@ -46,6 +46,8 @@ import org.bukkit.potion.PotionEffect;
- import org.bukkit.craftbukkit.event.CraftEventFactory;
- import org.bukkit.entity.Player;
- import com.destroystokyo.paper.event.block.BeaconEffectEvent;
-+import io.papermc.paper.event.block.BeaconActivatedEvent;
-+import io.papermc.paper.event.block.BeaconDeactivatedEvent;
- // Paper end
- 
- public class TileEntityBeacon extends TileEntity implements ITileInventory, ITickable {
-@@ -211,6 +213,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
-                 boolean flag1 = this.levels > 0;
- 
-                 if (!flag && flag1) {
-+                    // Paper start - BeaconActivatedEvent
-+                    org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, position);
-+                    new BeaconActivatedEvent(block).callEvent();
-+                    // Paper end
-                     this.a(SoundEffects.BLOCK_BEACON_ACTIVATE);
-                     Iterator iterator = this.world.a(EntityPlayer.class, (new AxisAlignedBB((double) i, (double) j, (double) k, (double) i, (double) (j - 4), (double) k)).grow(10.0D, 5.0D, 10.0D)).iterator();
- 
-@@ -220,6 +226,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
-                         CriterionTriggers.l.a(entityplayer, this);
-                     }
-                 } else if (flag && !flag1) {
-+                    // Paper start - BeaconDeactivatedEvent
-+                    org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, position);
-+                    new BeaconDeactivatedEvent(block).callEvent();
-+                    // Paper end
-                     this.a(SoundEffects.BLOCK_BEACON_DEACTIVATE);
-                 }
+@@ -201,6 +201,15 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+                 this.a(SoundEffects.BLOCK_BEACON_AMBIENT);
              }
-@@ -257,6 +267,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+         }
++        // Paper start - beacon activation/deactivation events
++        if (!(i1 > 0) && this.levels > 0) {
++            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, position);
++            new io.papermc.paper.event.block.BeaconActivatedEvent(block).callEvent();
++        } else if (i1 > 0 && !(this.levels > 0)) {
++            org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, position);
++            new io.papermc.paper.event.block.BeaconDeactivatedEvent(block).callEvent();
++        }
++        // Paper end
+ 
+         if (this.i >= l) {
+             this.i = -1;
+@@ -257,6 +266,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
  
      @Override
      public void al_() {
 +        // Paper start - BeaconDeactivatedEvent
 +        org.bukkit.block.Block block = org.bukkit.craftbukkit.block.CraftBlock.at(world, position);
-+        new BeaconDeactivatedEvent(block).callEvent();
++        new io.papermc.paper.event.block.BeaconDeactivatedEvent(block).callEvent();
 +        // Paper end
          this.a(SoundEffects.BLOCK_BEACON_DEACTIVATE);
          super.al_();


### PR DESCRIPTION
Fixes #5644

The events were being called in the wrong place, so they weren't being fired some of time.