### PR TITLE
missing customizations in BeaconEffectEvent

### DIFF
--- a/Spigot-Server-Patches/0039-Add-BeaconEffectEvent.patch
+++ b/Spigot-Server-Patches/0039-Add-BeaconEffectEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add BeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
-index c6914c8d2a3d1057c98537a3538097d3ac6149e0..f9b1ab0e19ff398a16b1452e86f1a165a4b54219 100644
+index c6914c8d2a3d1057c98537a3538097d3ac6149e0..4098357d60165a4c670a7bc5134abf66178124c6 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
 @@ -42,6 +42,11 @@ import net.minecraft.world.phys.AxisAlignedBB;
@@ -20,7 +20,7 @@ index c6914c8d2a3d1057c98537a3538097d3ac6149e0..f9b1ab0e19ff398a16b1452e86f1a165
  
  public class TileEntityBeacon extends TileEntity implements ITileInventory, ITickable {
  
-@@ -268,14 +273,31 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -268,14 +273,30 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
      }
  
      private void applyEffect(List list, MobEffectList effects, int i, int b0) {
@@ -47,13 +47,12 @@ index c6914c8d2a3d1057c98537a3538097d3ac6149e0..f9b1ab0e19ff398a16b1452e86f1a165
 +                // Paper start - BeaconEffectEvent
 +                BeaconEffectEvent event = new BeaconEffectEvent(block, effect, (Player) entityhuman.getBukkitEntity(), isPrimary);
 +                if (CraftEventFactory.callEvent(event).isCancelled()) continue;
-+                PotionEffect eventEffect = event.getEffect();
-+                entityhuman.addEffect(new MobEffect(MobEffectList.fromId(eventEffect.getType().getId()), eventEffect.getDuration(), eventEffect.getAmplifier(), true, true), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);
++                entityhuman.addEffect(new MobEffect(CraftPotionUtil.fromBukkit(event.getEffect())), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.BEACON);
 +                // Paper end
              }
          }
      }
-@@ -298,10 +320,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -298,10 +319,10 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
              int i = getLevel();
              List list = getHumansInRange();
  

--- a/Spigot-Server-Patches/0594-Beacon-API-custom-effect-ranges.patch
+++ b/Spigot-Server-Patches/0594-Beacon-API-custom-effect-ranges.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Beacon API - custom effect ranges
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
-index f9b1ab0e19ff398a16b1452e86f1a165a4b54219..8dfb9eb12d07c2d4737ecf3de1ae7f6de31891bf 100644
+index 4098357d60165a4c670a7bc5134abf66178124c6..cd28a731a56eb7534faae5b120195b62d5d15bd4 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBeacon.java
 @@ -73,6 +73,26 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
@@ -45,7 +45,7 @@ index f9b1ab0e19ff398a16b1452e86f1a165a4b54219..8dfb9eb12d07c2d4737ecf3de1ae7f6d
  
              AxisAlignedBB axisalignedbb = (new AxisAlignedBB(this.position)).g(d0).b(0.0D, (double) this.world.getBuildHeight(), 0.0D);
              List<EntityHuman> list = this.world.a(EntityHuman.class, axisalignedbb);
-@@ -364,6 +385,9 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -363,6 +384,9 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
          this.secondaryEffect = MobEffectList.fromId(nbttagcompound.getInt("Secondary"));
          this.levels = nbttagcompound.getInt("Levels"); // SPIGOT-5053, use where available
          // CraftBukkit end
@@ -55,7 +55,7 @@ index f9b1ab0e19ff398a16b1452e86f1a165a4b54219..8dfb9eb12d07c2d4737ecf3de1ae7f6d
          if (nbttagcompound.hasKeyOfType("CustomName", 8)) {
              this.customName = IChatBaseComponent.ChatSerializer.a(nbttagcompound.getString("CustomName"));
          }
-@@ -380,6 +404,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
+@@ -379,6 +403,8 @@ public class TileEntityBeacon extends TileEntity implements ITileInventory, ITic
          if (this.customName != null) {
              nbttagcompound.setString("CustomName", IChatBaseComponent.ChatSerializer.a(this.customName));
          }


### PR DESCRIPTION
The set effect in BeaconEffectEvent was only transferring some of its configuration, missing the show icon/particles options.