### PR TITLE
[ci skip] add vs code files to .gitignore

### DIFF
--- a/patches/api/0001-Convert-project-to-Gradle.patch
+++ b/patches/api/0001-Convert-project-to-Gradle.patch
@@ -8,7 +8,7 @@ apply if there are changes made to it from upstream - thus notifying us
 that changes were made.
 
 diff --git a/.gitignore b/.gitignore
-index e431e3435737e28394d81b56568a08b3c3148b9b..c484aff2c192bf42059b5689327909e4af654401 100644
+index e431e3435737e28394d81b56568a08b3c3148b9b..b23bde3b5e881f146539a307d0a59f2177b6a036 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,5 @@
@@ -17,6 +17,14 @@ index e431e3435737e28394d81b56568a08b3c3148b9b..c484aff2c192bf42059b5689327909e4
  # Eclipse stuff
  /.classpath
  /.project
+@@ -30,3 +32,7 @@
+ *.ipr
+ *.iws
+ .idea/
++
++# vs code
++/.vscode
++/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
 index 0000000000000000000000000000000000000000..6e64a444fb20aabaabfb15a30d645702c11c2da8

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -8,7 +8,7 @@ apply if there are changes made to it from upstream - thus notifying us
 that changes were made.
 
 diff --git a/.gitignore b/.gitignore
-index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a2f617b57 100644
+index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..bb338269c9e3bef4c274157c490d8b8f8c589937 100644
 --- a/.gitignore
 +++ b/.gitignore
 @@ -1,3 +1,6 @@
@@ -18,6 +18,14 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a
  # Eclipse stuff
  /.classpath
  /.project
+@@ -37,3 +40,7 @@ dependency-reduced-pom.xml
+ 
+ /src/main/resources/achievement
+ /src/main/resources/lang
++
++# vs code
++/.vscode
++/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
 index 0000000000000000000000000000000000000000..8d27de2c9da08ca32ff18fc4b8b02ea583edfc1c


### PR DESCRIPTION
Visual Studio Code generates a .vscode directory and a .factorypath file. They are now ignored in the Paper-API and Paper-Server directories.