### PR TITLE
Fix various mob drops being captured as death drops

### DIFF
--- a/build-data/mappings-patch.tiny
+++ b/build-data/mappings-patch.tiny
@@ -55,3 +55,11 @@ c	net/minecraft/server/network/PlayerConnection	net/minecraft/server/network/Ser
 # Commands performCommand adds a stripSlash boolean
 c	net/minecraft/commands/CommandDispatcher	net/minecraft/commands/Commands
 	m	(Lnet/minecraft/commands/CommandListenerWrapper;Ljava/lang/String;Ljava/lang/String;Z)I	a	performCommand
+
+# Craftbukkit overloads equipItemIfPossible in Mob adding an ItemEntity parameter
+c	net/minecraft/world/entity/EntityInsentient	net/minecraft/world/entity/Mob
+	m	(Lnet/minecraft/world/item/ItemStack;Lnet/minecraft/world/entity/item/EntityItem;)Z	j	equipItemIfPossible
+
+# Craftbukkit overloads convertTo in Mob adding various API reasons
+c	net/minecraft/world/entity/EntityInsentient	net/minecraft/world/entity/Mob
+	m	(Lnet/minecraft/world/entity/EntityTypes;ZLorg/bukkit/event/entity/EntityTransformEvent$TransformReason;Lorg/bukkit/event/entity/CreatureSpawnEvent$SpawnReason;)Lnet/minecraft/world/entity/EntityInsentient;	a	convertTo

--- a/patches/server/0730-Add-a-bunch-of-missing-forceDrop-toggles.patch
+++ b/patches/server/0730-Add-a-bunch-of-missing-forceDrop-toggles.patch
@@ -1,0 +1,76 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 20 Jul 2021 21:25:35 -0700
+Subject: [PATCH] Add a bunch of missing forceDrop toggles
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index b366c47cc53f195d8ad6ce281fc8145ca588947a..ed5ea221cb273c77848b773924193e06dc30f66f 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -1470,7 +1470,9 @@ public abstract class Mob extends LivingEntity {
+             }
+ 
+             if (this.tickCount > 100) {
++                this.forceDrops = true; // Paper
+                 this.spawnAtLocation((ItemLike) Items.LEAD);
++                this.forceDrops = false; // Paper
+                 this.leashInfoTag = null;
+             }
+         }
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java b/src/main/java/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java
+index 89c53df5a745a5712c3c74030ed942c3102f3725..aba1b220826c7680892a93c1733ad32dc8a0a23f 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/WorkAtComposter.java
+@@ -100,7 +100,9 @@ public class WorkAtComposter extends WorkAtPoi {
+                 ItemStack itemstack = inventorysubcontainer.addItem(new ItemStack(Items.BREAD, j));
+ 
+                 if (!itemstack.isEmpty()) {
++                    entity.forceDrops = true; // Paper
+                     entity.spawnAtLocation(itemstack, 0.5F);
++                    entity.forceDrops = false; // Paper
+                 }
+ 
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Panda.java b/src/main/java/net/minecraft/world/entity/animal/Panda.java
+index 851ee58e52c6003d6ae7b58c9b6b9a9a9795fa85..12ed864bedf2201fad68e2aeba249c3c18a12444 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Panda.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Panda.java
+@@ -521,7 +521,9 @@ public class Panda extends Animal {
+         }
+ 
+         if (!this.level.isClientSide() && this.random.nextInt(700) == 0 && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
++            this.forceDrops = true; // Paper
+             this.spawnAtLocation((ItemLike) Items.SLIME_BALL);
++            this.forceDrops = false; // Paper
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java b/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
+index 2631f08496c8e45874b22760b559a91b7b2bf415..7f3dc582276a00120d4d6a1e829da2e7908e87cf 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
++++ b/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
+@@ -174,7 +174,9 @@ public class SnowGolem extends AbstractGolem implements Shearable, RangedAttackM
+         this.level.playSound((Player) null, (Entity) this, SoundEvents.SNOW_GOLEM_SHEAR, shearedSoundCategory, 1.0F, 1.0F);
+         if (!this.level.isClientSide()) {
+             this.setPumpkin(false);
++            this.forceDrops = true; // Paper
+             this.spawnAtLocation(new ItemStack(Items.CARVED_PUMPKIN), 1.7F);
++            this.forceDrops = false; // Paper
+         }
+ 
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java b/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
+index adc2feafd0c1a38d1b6b65b8aee59d21725b84fe..c7ad0e317c0c74e5ad3e08278c5e7b31c894413e 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/piglin/Piglin.java
+@@ -306,7 +306,9 @@ public class Piglin extends AbstractPiglin implements CrossbowAttackMob, Invento
+     @Override
+     protected void finishConversion(ServerLevel world) {
+         PiglinAi.cancelAdmiring(this);
++        this.forceDrops = true; // Paper
+         this.inventory.removeAllItems().forEach(this::spawnAtLocation);
++        this.forceDrops = false; // Paper
+         super.finishConversion(world);
+     }
+ 


### PR DESCRIPTION
Snow golem drops were being counted as death drops and so were not dropping right away, but if the golem died after being sheared