### PR TITLE
Add command line option to load extra plugin jars not in the plugins folder

### DIFF
--- a/Spigot-API-Patches/0304-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/Spigot-API-Patches/0304-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -1,0 +1,142 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 18 May 2021 14:42:26 -0700
+Subject: [PATCH] Add command line option to load extra plugin jars not in the
+ plugins folder
+
+ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 26685f59b235ea5b4c4fb7ae21acb5149edaa2b3..ca866876f2f35a1c41eb009064412423fa09e441 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -60,6 +60,7 @@ public final class SimplePluginManager implements PluginManager {
+     private final Map<String, Map<Permissible, Boolean>> permSubs = new HashMap<String, Map<Permissible, Boolean>>();
+     private final Map<Boolean, Map<Permissible, Boolean>> defSubs = new HashMap<Boolean, Map<Permissible, Boolean>>();
+     private boolean useTimings = false;
++    private File pluginsDirectory; public @Nullable File pluginsDirectory() { return this.pluginsDirectory; } // Paper
+ 
+     public SimplePluginManager(@NotNull Server instance, @NotNull SimpleCommandMap commandMap) {
+         server = instance;
+@@ -115,6 +116,13 @@ public final class SimplePluginManager implements PluginManager {
+     @Override
+     @NotNull
+     public Plugin[] loadPlugins(@NotNull File directory) {
++        // Paper start - extra jars
++        return this.loadPlugins(directory, java.util.Collections.emptyList());
++    }
++    @NotNull
++    public Plugin[] loadPlugins(final @NotNull File directory, final @NotNull List<File> extraPluginJars) {
++        this.pluginsDirectory = directory;
++        // Paper end
+         Validate.notNull(directory, "Directory cannot be null");
+         Validate.isTrue(directory.isDirectory(), "Directory must be a directory");
+ 
+@@ -132,7 +140,11 @@ public final class SimplePluginManager implements PluginManager {
+         Map<String, Collection<String>> softDependencies = new HashMap<String, Collection<String>>();
+ 
+         // This is where it figures out all possible plugins
+-        for (File file : directory.listFiles()) {
++        // Paper start - extra jars
++        final List<File> pluginJars = new ArrayList<>(java.util.Arrays.asList(directory.listFiles()));
++        pluginJars.addAll(extraPluginJars);
++        for (File file : pluginJars) {
++            // Paper end
+             PluginLoader loader = null;
+             for (Pattern filter : filters) {
+                 Matcher match = filter.matcher(file.getName());
+@@ -148,14 +160,14 @@ public final class SimplePluginManager implements PluginManager {
+                 description = loader.getPluginDescription(file);
+                 String name = description.getName();
+                 if (name.equalsIgnoreCase("bukkit") || name.equalsIgnoreCase("minecraft") || name.equalsIgnoreCase("mojang")) {
+-                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': Restricted Name");
++                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "': Restricted Name"); // Paper
+                     continue;
+                 } else if (description.rawName.indexOf(' ') != -1) {
+-                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': uses the space-character (0x20) in its name");
++                    server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "': uses the space-character (0x20) in its name"); // Paper
+                     continue;
+                 }
+             } catch (InvalidDescriptionException ex) {
+-                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "'", ex);
++                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'", ex); // Paper
+                 continue;
+             }
+ 
+@@ -166,7 +178,7 @@ public final class SimplePluginManager implements PluginManager {
+                     description.getName(),
+                     file.getPath(),
+                     replacedFile.getPath(),
+-                    directory.getPath()
++                    file.getParentFile().getPath() // Paper
+                 ));
+             }
+ 
+@@ -187,7 +199,7 @@ public final class SimplePluginManager implements PluginManager {
+                             file.getPath(),
+                             provided,
+                             pluginFile.getPath(),
+-                            directory.getPath()
++                            file.getParentFile().getPath() // Paper
+                     ));
+                 } else {
+                     String replacedPlugin = pluginsProvided.put(provided, description.getName());
+@@ -269,7 +281,7 @@ public final class SimplePluginManager implements PluginManager {
+ 
+                             server.getLogger().log(
+                                 Level.SEVERE,
+-                                "Could not load '" + entry.getValue().getPath() + "' in folder '" + directory.getPath() + "'",
++                                "Could not load '" + entry.getValue().getPath() + "' in folder '" + entry.getValue().getParentFile().getPath() + "'", // Paper
+                                 new UnknownDependencyException("Unknown dependency " + dependency + ". Please download and install " + dependency + " to run this plugin."));
+                             break;
+                         }
+@@ -308,11 +320,11 @@ public final class SimplePluginManager implements PluginManager {
+                             loadedPlugins.add(loadedPlugin.getName());
+                             loadedPlugins.addAll(loadedPlugin.getDescription().getProvides());
+                         } else {
+-                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "'");
++                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'"); // Paper
+                         }
+                         continue;
+                     } catch (InvalidPluginException ex) {
+-                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "'", ex);
++                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'", ex); // Paper
+                     }
+                 }
+             }
+@@ -339,11 +351,11 @@ public final class SimplePluginManager implements PluginManager {
+                                 loadedPlugins.add(loadedPlugin.getName());
+                                 loadedPlugins.addAll(loadedPlugin.getDescription().getProvides());
+                             } else {
+-                                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "'");
++                                server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'"); // Paper
+                             }
+                             break;
+                         } catch (InvalidPluginException ex) {
+-                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "'", ex);
++                            server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "'", ex); // Paper
+                         }
+                     }
+                 }
+@@ -356,7 +368,7 @@ public final class SimplePluginManager implements PluginManager {
+                     while (failedPluginIterator.hasNext()) {
+                         File file = failedPluginIterator.next();
+                         failedPluginIterator.remove();
+-                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + directory.getPath() + "': circular dependency detected");
++                        server.getLogger().log(Level.SEVERE, "Could not load '" + file.getPath() + "' in folder '" + file.getParentFile().getPath() + "': circular dependency detected"); // Paper
+                     }
+                 }
+             }
+diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+index 31793f46e5623729dfb4048e901f274082f57826..d3812d8cd195017841ee08ffbc53a5748fcc74ec 100644
+--- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
+@@ -94,7 +94,7 @@ public final class JavaPluginLoader implements PluginLoader {
+             throw new InvalidPluginException(ex);
+         }
+ 
+-        final File parentFile = file.getParentFile();
++        final File parentFile = ((SimplePluginManager) this.server.getPluginManager()).pluginsDirectory(); // Paper
+         final File dataFolder = new File(parentFile, description.getName());
+         @SuppressWarnings("deprecation")
+         final File oldDataFolder = new File(parentFile, description.getRawName());

--- a/Spigot-Server-Patches/0736-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/Spigot-Server-Patches/0736-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -1,0 +1,64 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: jmp <jasonpenilla2@me.com>
+Date: Tue, 18 May 2021 14:39:44 -0700
+Subject: [PATCH] Add command line option to load extra plugin jars not in the
+ plugins folder
+
+ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 033a0f1852afd6c1fd136ef07b611a9132adfa0c..c51e9b50323f5e33bad5fd25d74c572241377059 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -385,8 +385,13 @@ public final class CraftServer implements Server {
+ 
+         File pluginFolder = (File) console.options.valueOf("plugins");
+ 
+-        if (pluginFolder.exists()) {
+-            Plugin[] plugins = pluginManager.loadPlugins(pluginFolder);
++        // Paper start
++        if (true || pluginFolder.exists()) {
++            if (!pluginFolder.exists()) {
++                pluginFolder.mkdirs();
++            }
++            Plugin[] plugins = pluginManager.loadPlugins(pluginFolder, this.extraPluginJars());
++            // Paper end
+             for (Plugin plugin : plugins) {
+                 try {
+                     String message = String.format("Loading %s", plugin.getDescription().getFullName());
+@@ -401,6 +406,18 @@ public final class CraftServer implements Server {
+         }
+     }
+ 
++    // Paper start
++    private List<File> extraPluginJars() {
++        @SuppressWarnings("unchecked")
++        final List<File> jars = (List<File>) this.console.options.valuesOf("add-plugin");
++        return jars.stream()
++            .filter(File::exists)
++            .filter(File::isFile)
++            .filter(file -> file.getName().endsWith(".jar"))
++            .collect(java.util.stream.Collectors.toList());
++    }
++    // Paper end
++
+     public void enablePlugins(PluginLoadOrder type) {
+         if (type == PluginLoadOrder.STARTUP) {
+             helpMap.clear();
+diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
+index 68229f7679f9e974dc7af6c34d6f1d3f8db49353..409fbeeb66fb8f58a72d94686bc9515299927b75 100644
+--- a/src/main/java/org/bukkit/craftbukkit/Main.java
++++ b/src/main/java/org/bukkit/craftbukkit/Main.java
+@@ -153,6 +153,12 @@ public class Main {
+                         .ofType(String.class)
+                         .defaultsTo("Unknown Server")
+                         .describedAs("Name");
++
++                acceptsAll(asList("add-plugin", "add-extra-plugin-jar"))
++                        .withRequiredArg()
++                        .ofType(File.class)
++                        .defaultsTo(new File[] {})
++                        .describedAs("Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.");
+                 // Paper end
+             }
+         };


### PR DESCRIPTION
This is useful for build tool integration, so that it's not necessary to copy plugin jars into the plugins folder in order to load them.

ex: `java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar`