### PR TITLE
Fix NPE for shulker box color

### DIFF
--- a/Spigot-API-Patches/0305-Fix-NPE-for-shulker-box-color.patch
+++ b/Spigot-API-Patches/0305-Fix-NPE-for-shulker-box-color.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 May 2021 16:53:46 -0700
+Subject: [PATCH] Fix NPE for shulker box color
+
+
+diff --git a/src/main/java/org/bukkit/block/ShulkerBox.java b/src/main/java/org/bukkit/block/ShulkerBox.java
+index 172f383fea619127324fec2b043639fd0683f135..68d882c834b8df37e35e5f3f95da6c2e73ea32a9 100644
+--- a/src/main/java/org/bukkit/block/ShulkerBox.java
++++ b/src/main/java/org/bukkit/block/ShulkerBox.java
+@@ -3,7 +3,7 @@ package org.bukkit.block;
+ import com.destroystokyo.paper.loottable.LootableBlockInventory;
+ import org.bukkit.DyeColor;
+ import org.bukkit.loot.Lootable;
+-import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
+ 
+ /**
+  * Represents a captured state of a ShulkerBox.
+@@ -15,6 +15,6 @@ public interface ShulkerBox extends Container, LootableBlockInventory, Lidded {
+      *
+      * @return the {@link DyeColor} of this ShulkerBox
+      */
+-    @NotNull
++    @Nullable // Paper
+     public DyeColor getColor();
+ }

--- a/Spigot-Server-Patches/0736-Fix-NPE-for-shulker-box-color.patch
+++ b/Spigot-Server-Patches/0736-Fix-NPE-for-shulker-box-color.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 May 2021 16:53:39 -0700
+Subject: [PATCH] Fix NPE for shulker box color
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
+index e9c8ce7a1e721d4b387c4d14910786cdf7c70a69..ae5d6607bbfb737f454e31062ec7218ac226d0cd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
+@@ -41,7 +41,7 @@ public class CraftShulkerBox extends CraftLootable<TileEntityShulkerBox> impleme
+     public DyeColor getColor() {
+         net.minecraft.world.level.block.Block block = CraftMagicNumbers.getBlock(this.getType());
+ 
+-        return DyeColor.getByWoolData((byte) ((BlockShulkerBox) block).color.getColorIndex());
++        return ((BlockShulkerBox) block).color == null ? null : DyeColor.getByWoolData((byte) ((BlockShulkerBox) block).color.getColorIndex()); // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
So, there are 17 shulker box colors, not just the 16 dye colors, and if the shulkerbox was uncolored, it threw an NPE because it was expecting a color. This does break the behavior of ShulkerBox#getColor, but I really hope an NPE doesn't count as something that can't change because it would break compat.