### PR TITLE
Fix PotionSplashEvent for water splash potions

### DIFF
--- a/Spigot-Server-Patches/0759-Fix-PotionSplashEvent-for-water-splash-potions.patch
+++ b/Spigot-Server-Patches/0759-Fix-PotionSplashEvent-for-water-splash-potions.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 May 2021 20:40:53 -0700
+Subject: [PATCH] Fix PotionSplashEvent for water splash potions
+
+Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6221
+
+diff --git a/src/main/java/net/minecraft/world/damagesource/DamageSource.java b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+index 53ea8a6d90faf4f7f8fd0819be4499422bdd4cbe..e6bf78f46acc37d9515d58cec3587e236ac0733c 100644
+--- a/src/main/java/net/minecraft/world/damagesource/DamageSource.java
++++ b/src/main/java/net/minecraft/world/damagesource/DamageSource.java
+@@ -99,6 +99,7 @@ public class DamageSource {
+         return (new EntityDamageSourceIndirect("thrown", entity, entity1)).c();
+     }
+ 
++    public static DamageSource indirectMagic(Entity target, Entity cause) { return c(target, cause); } // Paper - OBFHELPER
+     public static DamageSource c(Entity entity, @Nullable Entity entity1) {
+         return (new EntityDamageSourceIndirect("indirectMagic", entity, entity1)).setIgnoreArmor().setMagic();
+     }
+diff --git a/src/main/java/net/minecraft/world/entity/projectile/EntityPotion.java b/src/main/java/net/minecraft/world/entity/projectile/EntityPotion.java
+index dbc0afc5fb9e358a3e6d596692f57fb28303c4da..9348288fb752e758fe7aee8c2a630ea0fb7b9a8c 100644
+--- a/src/main/java/net/minecraft/world/entity/projectile/EntityPotion.java
++++ b/src/main/java/net/minecraft/world/entity/projectile/EntityPotion.java
+@@ -124,6 +124,7 @@ public class EntityPotion extends EntityProjectileThrowable {
+     private void splash() {
+         AxisAlignedBB axisalignedbb = this.getBoundingBox().grow(4.0D, 2.0D, 4.0D);
+         List<EntityLiving> list = this.world.a(EntityLiving.class, axisalignedbb, EntityPotion.b);
++        Map<LivingEntity, Double> affected = new HashMap<>(); // Paper
+ 
+         if (!list.isEmpty()) {
+             Iterator iterator = list.iterator();
+@@ -133,11 +134,22 @@ public class EntityPotion extends EntityProjectileThrowable {
+                 double d0 = this.h(entityliving);
+ 
+                 if (d0 < 16.0D && entityliving.dO()) {
+-                    entityliving.damageEntity(DamageSource.c(entityliving, this.getShooter()), 1.0F);
++                    // Paper start
++                    double intensity = 1.0D - Math.sqrt(d0) / 4.0D;
++                    affected.put(entityliving.getBukkitLivingEntity(), intensity);
++                    // entityliving.damageEntity(DamageSource.c(entityliving, this.getShooter()), 1.0F); // Paper - moved down
+                 }
+             }
+         }
+ 
++        org.bukkit.event.entity.PotionSplashEvent event = CraftEventFactory.callPotionSplashEvent(this, affected);
++        if (!event.isCancelled()) {
++            for (LivingEntity affectedEntity : event.getAffectedEntities()) {
++                EntityLiving entityliving = ((CraftLivingEntity) affectedEntity).getHandle();
++                entityliving.damageEntity(DamageSource.indirectMagic(entityliving, this.getShooter()), 1.0F);
++            }
++        }
++        // Paper end
+     }
+ 
+     private void a(List<MobEffect> list, @Nullable Entity entity) {
+@@ -155,6 +167,7 @@ public class EntityPotion extends EntityProjectileThrowable {
+                     double d0 = this.h(entityliving);
+ 
+                     if (d0 < 16.0D) {
++                        // Paper - diff on change, used when calling the splash event for water splash potions
+                         double d1 = 1.0D - Math.sqrt(d0) / 4.0D;
+ 
+                         if (entityliving == entity) {


### PR DESCRIPTION
Fixes [SPIGOT-6221](https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6221)

Splash water bottles do affect some entities that take damage from water, like enderman, snow golems, blazes, etc.