### PR TITLE
Fix PlayerBucketEmptyEvent result itemstack

### DIFF
--- a/Spigot-Server-Patches/0749-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
+++ b/Spigot-Server-Patches/0749-Fix-PlayerBucketEmptyEvent-result-itemstack.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 20 May 2021 22:16:37 -0700
+Subject: [PATCH] Fix PlayerBucketEmptyEvent result itemstack
+
+Fixes SPIGOT-2560: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-2560
+
+diff --git a/src/main/java/net/minecraft/world/item/ItemBucket.java b/src/main/java/net/minecraft/world/item/ItemBucket.java
+index d126f668828e0788e369294c0b376ef52b344f2c..f97447d77890cd65b5613899c389483bcf82be01 100644
+--- a/src/main/java/net/minecraft/world/item/ItemBucket.java
++++ b/src/main/java/net/minecraft/world/item/ItemBucket.java
+@@ -118,6 +118,13 @@ public class ItemBucket extends Item {
+     }
+ 
+     protected ItemStack a(ItemStack itemstack, EntityHuman entityhuman) {
++        // Paper
++        if (itemLeftInHandAfterPlayerBucketEmptyEvent != null) {
++            ItemStack itemInHand = itemLeftInHandAfterPlayerBucketEmptyEvent;
++            itemLeftInHandAfterPlayerBucketEmptyEvent = null;
++            return itemInHand;
++        }
++        // Paper
+         return !entityhuman.abilities.canInstantlyBuild ? new ItemStack(Items.BUCKET) : itemstack;
+     }
+ 
+@@ -128,6 +135,7 @@ public class ItemBucket extends Item {
+         return a(entityhuman, world, blockposition, movingobjectpositionblock, null, null, null, null);
+     }
+ 
++    private ItemStack itemLeftInHandAfterPlayerBucketEmptyEvent = null; // Paper
+     public boolean a(EntityHuman entityhuman, World world, BlockPosition blockposition, @Nullable MovingObjectPositionBlock movingobjectpositionblock, EnumDirection enumdirection, BlockPosition clicked, ItemStack itemstack, EnumHand enumhand) {
+         // Paper end
+         // CraftBukkit end
+@@ -148,6 +156,9 @@ public class ItemBucket extends Item {
+                     ((EntityPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                     return false;
+                 }
++                // Paper start
++                itemLeftInHandAfterPlayerBucketEmptyEvent = event.getItemStack().equals(CraftItemStack.asNewCraftStack(net.minecraft.world.item.Items.BUCKET)) ? null : CraftItemStack.asNMSCopy(event.getItemStack());
++                // Paper end
+             }
+             // CraftBukkit end
+             if (!flag1) {


### PR DESCRIPTION
Fixes [SPIGOT-2560](https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-2560)
Not sure if there is a clearer fix here, the result item stack isn't set in the same area as the event is fired.