### PR TITLE
MC-148809: Fix incorrect structure block data length

### DIFF
--- a/Spigot-Server-Patches/0736-Fix-MC-148809-Increase-structure-block-data-length-t.patch
+++ b/Spigot-Server-Patches/0736-Fix-MC-148809-Increase-structure-block-data-length-t.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SamB440 <sam@islandearth.net>
+Date: Fri, 21 May 2021 00:22:09 +0100
+Subject: [PATCH] Fix MC-148809: Increase structure block data length to 128
+
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/PacketPlayInStruct.java b/src/main/java/net/minecraft/network/protocol/game/PacketPlayInStruct.java
+index 2e19ac6b4e27c5d1bbefd5e99f8298650919d917..de3c33ae24e38471ab34d905f07992cb75dc0789 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/PacketPlayInStruct.java
++++ b/src/main/java/net/minecraft/network/protocol/game/PacketPlayInStruct.java
+@@ -43,7 +43,7 @@ public class PacketPlayInStruct implements Packet<PacketListenerPlayIn> {
+         this.f = new BlockPosition(MathHelper.clamp(packetdataserializer.readByte(), 0, 48), MathHelper.clamp(packetdataserializer.readByte(), 0, 48), MathHelper.clamp(packetdataserializer.readByte(), 0, 48));
+         this.g = (EnumBlockMirror) packetdataserializer.a(EnumBlockMirror.class);
+         this.h = (EnumBlockRotation) packetdataserializer.a(EnumBlockRotation.class);
+-        this.i = packetdataserializer.e(12);
++        this.i = packetdataserializer.e(128); // Paper - Fix MC-148809, increase max character input to 128
+         this.m = MathHelper.a(packetdataserializer.readFloat(), 0.0F, 1.0F);
+         this.n = packetdataserializer.j();
+         byte b0 = packetdataserializer.readByte();


### PR DESCRIPTION
This fixes the fact that a player is kicked from the server when entering a string greater than 12 characters of length into the data marker field of a structure block. Max character length is now 128, as the client expects.

MC-148809: https://bugs.mojang.com/browse/MC-148809

Very minor thing but can be quite annoying.