### PR TITLE
Add clear boolean to Block#setType

### DIFF
--- a/Spigot-API-Patches/0311-Add-clear-boolean-to-Block-setType.patch
+++ b/Spigot-API-Patches/0311-Add-clear-boolean-to-Block-setType.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 21 May 2021 21:14:20 -0700
+Subject: [PATCH] Add clear boolean to Block#setType
+
+Fixes SPIGOT-3725: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-3725
+
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 08e6f1741685f54506c8a4ff29bbd30f62cf8e45..bc90c1b47591086f115b63fc102cbb1ad0f576c6 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -313,6 +313,51 @@ public interface Block extends Metadatable {
+      * @param applyPhysics False to cancel physics on the changed block.
+      */
+     void setType(@NotNull Material type, boolean applyPhysics);
++    // Paper start
++    /**
++     * Sets the type of this block
++     *
++     * <br>
++     * Note that applyPhysics = false is not in general safe. It should only be
++     * used when you need to avoid triggering a physics update of neighboring
++     * blocks, for example when creating a {@link Bisected} block. If you are
++     * using a custom populator, then this parameter may also be required to
++     * prevent triggering infinite chunk loads on border blocks. This method
++     * should NOT be used to "hack" physics by placing blocks in impossible
++     * locations. Such blocks are liable to be removed on various events such as
++     * world upgrades. Furthermore setting large amounts of such blocks in close
++     * proximity may overload the server physics engine if an update is
++     * triggered at a later point. If this occurs, the resulting behavior is
++     * undefined.
++     *
++     * @param type Material to change this block to
++     * @param applyPhysics False to cancel physics on the changed block.
++     * @param clear true to clear the inventory (if the block has an inventory)
++     */
++    void setType(@NotNull Material type, boolean applyPhysics, boolean clear);
++
++    /**
++     * Sets the complete data for this block
++     *
++     * <br>
++     * Note that applyPhysics = false is not in general safe. It should only be
++     * used when you need to avoid triggering a physics update of neighboring
++     * blocks, for example when creating a {@link Bisected} block. If you are
++     * using a custom populator, then this parameter may also be required to
++     * prevent triggering infinite chunk loads on border blocks. This method
++     * should NOT be used to "hack" physics by placing blocks in impossible
++     * locations. Such blocks are liable to be removed on various events such as
++     * world upgrades. Furthermore setting large amounts of such blocks in close
++     * proximity may overload the server physics engine if an update is
++     * triggered at a later point. If this occurs, the resulting behavior is
++     * undefined.
++     *
++     * @param data new block specific data
++     * @param applyPhysics false to cancel physics from the changed block
++     * @param clear true to clear the inventory (if the block has an inventory)
++     */
++    void setBlockData(@NotNull BlockData data, boolean applyPhysics, boolean clear);
++    // Paper end
+ 
+     /**
+      * Gets the face relation of this block compared to the given block.

--- a/Spigot-Server-Patches/0745-Add-clear-boolean-to-Block-setType.patch
+++ b/Spigot-Server-Patches/0745-Add-clear-boolean-to-Block-setType.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 21 May 2021 21:14:31 -0700
+Subject: [PATCH] Add clear boolean to Block#setType
+
+Fixes SPIGOT-3725: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-3725
+
+diff --git a/src/main/java/net/minecraft/world/Clearable.java b/src/main/java/net/minecraft/world/Clearable.java
+index e6fd8076161cd85d1965c6f650b5ea84837325ce..090c7d51135a75cf72e17af948716541f34b4dcf 100644
+--- a/src/main/java/net/minecraft/world/Clearable.java
++++ b/src/main/java/net/minecraft/world/Clearable.java
+@@ -6,6 +6,7 @@ public interface Clearable {
+ 
+     void clear();
+ 
++    static void clear(@Nullable Object object) { Clearable.a(object); } // Paper - OBFHELPER
+     static void a(@Nullable Object object) {
+         if (object instanceof Clearable) {
+             ((Clearable) object).clear();
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 0006b3cad5fe46e50b0efeae99102f9d80276d61..abb776db1cffa67ed25d8884b26c5a4ff520c95d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -169,8 +169,14 @@ public class CraftBlock implements Block {
+ 
+     @Override
+     public void setType(Material type, boolean applyPhysics) {
++        // Paper start
++        this.setType(type, applyPhysics, false);
++    }
++    @Override
++    public void setType(Material type, boolean applyPhysics, boolean clear) {
++        // Paper end
+         Preconditions.checkArgument(type != null, "Material cannot be null");
+-        setBlockData(type.createBlockData(), applyPhysics);
++        setBlockData(type.createBlockData(), applyPhysics, clear); // Paper
+     }
+ 
+     @Override
+@@ -180,11 +186,26 @@ public class CraftBlock implements Block {
+ 
+     @Override
+     public void setBlockData(BlockData data, boolean applyPhysics) {
++        // Paper start
++        this.setBlockData(data, applyPhysics, false);
++    }
++    @Override
++    public void setBlockData(BlockData data, boolean applyPhysics, boolean clear) {
++        // Paper end
+         Preconditions.checkArgument(data != null, "BlockData cannot be null");
+-        setTypeAndData(((CraftBlockData) data).getState(), applyPhysics);
++        setTypeAndData(((CraftBlockData) data).getState(), applyPhysics, clear); // Paper
+     }
+ 
+     public boolean setTypeAndData(final IBlockData blockData, final boolean applyPhysics) {
++        // Paper start
++        return this.setTypeAndData(blockData, applyPhysics, false);
++    }
++    public boolean setTypeAndData(final IBlockData blockData, final boolean applyPhysics, final boolean clear) {
++        if (clear) {
++            TileEntity tileEntity = world.getTileEntity(position);
++            net.minecraft.world.Clearable.clear(tileEntity);
++        }
++        // Paper end
+         // SPIGOT-611: need to do this to prevent glitchiness. Easier to handle this here (like /setblock) than to fix weirdness in tile entity cleanup
+         if (!blockData.isAir() && blockData.getBlock() instanceof BlockTileEntity && blockData.getBlock() != getNMSBlock()) {
+             // SPIGOT-4612: faster - just clear tile


### PR DESCRIPTION
So I tested this and didnt run into any issues, but since it's dealing with part of the code base I'm not entirely comfortable with yet, the whole changing block state part, I probably put the clear in the wrong place in CraftBlock#setTypeAndData.

Also, if it is a bug that the existing setType doesn't clear inventories, this can easily be refactored to just fix that instead of adding a new parameter to clear tile entities.

Fixes [SPIGOT-3725](https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-3725)