### PR TITLE
ci: replace Java 11 with Java 16 in GH Actions build flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                java: [11, 8]
+                java: [16, 11, 8]
             fail-fast: true
         steps:
             - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,7 +13,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                java: [16, 11, 8]
+                java: [16, 8]
             fail-fast: true
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
With our new dependence on Java 16+ as of Minecraft 1.17 (refer to:
https://www.minecraft.net/en-us/article/minecraft-snapshot-21w19a), we
should also ensure everything we merge builds on Java 16.

Signed-off-by: Mariell Hoversholm <proximyst@proximyst.com>