### PR TITLE
ci: update setup-java action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/setup-java@v2
               with:
                   java-version: ${{ matrix.java }}
-                  distribution: 'zulu'
+                  distribution: 'adopt'
             - name: Cache maven
               uses: actions/cache@v2
               with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,9 +18,10 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: JDK ${{ matrix.java }}
-              uses: actions/setup-java@v1
+              uses: actions/setup-java@v2
               with:
                   java-version: ${{ matrix.java }}
+                  distribution: 'zulu'
             - name: Cache maven
               uses: actions/cache@v2
               with:


### PR DESCRIPTION
Updates the setup-java action to v2, and changes our distribution from Zulu to Adoptium.

Will need rebase once #5709 is merged.