### PR TITLE
editMeta: tighten contract via docs

### DIFF
--- a/Spigot-API-Patches/0307-ItemStack-editMeta.patch
+++ b/Spigot-API-Patches/0307-ItemStack-editMeta.patch
@@ -5,16 +5,23 @@ Subject: [PATCH] ItemStack#editMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 1bd9f7582bb907ff178fd110fdc92834885d1d78..3e2c08641edffcf00b230ad624685aaff30af0e5 100644
+index 1bd9f7582bb907ff178fd110fdc92834885d1d78..a7909406e9d54c1ab4789b984ed6b1da50837fce 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -542,6 +542,24 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -542,6 +542,31 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          return result.ensureServerConversions(); // Paper
      }
  
 +    // Paper start
 +    /**
 +     * Edits the {@link ItemMeta} of this stack.
++     * <p>
++     * The {@link java.util.function.Consumer} must only interact
++     * with this stack's {@link ItemMeta} through the provided {@link ItemMeta} instance.
++     * Calling this method or any other meta-related method of the {@link ItemStack} class
++     * (such as {@link #getItemMeta()}, {@link #addItemFlags(ItemFlag...)}, {@link #lore()}, etc.)
++     * from inside the consumer is disallowed and will produce undefined results or exceptions.
++     * </p>
 +     *
 +     * @param consumer the meta consumer
 +     * @return {@code true} if the edit was successful, {@code false} otherwise


### PR DESCRIPTION
Failing exceptionally vs failing silently:
 - Previously, most of the methods in the `ItemStack` class failed exceptionally if the meta is null. Now with `editMeta` it's kind of 50-50. I believe failing exceptionally is a more logical and more helpful thing to do than to just silently not do the requested modification.
 - Setters/modifiers in `ItemStack` that fail silently: `addUnsafeEnchantment`, `removeEnchantment` (and the deprecated `setDurability`) (and this `editMeta`)
 - Setters/modifiers in `ItemStack` that fail exceptionally: `lore` (and the deprecated `setLore`), `addItemFlags`, `removeItemFlags`
- (Off-topic, but `removeEnchantment` silently fails if the enchantment isn't present, so it's less of an issue that it silently fails for null meta. By the same reasoning, `removeItemFlags` could silently fail for null meta as well, but it doesn't.)

Specifying a more strict contract via JavaDocs:
Currently, there is nothing in the documentation to stop people from calling this `editMeta` method from inside the callback passed to `editMeta` or to call `getItemMeta`, etc. from inside the callback. I believe it's important to specify the behavior in those cases.
By specifying the behavior as undefined/disallowed, we allow the implementation of `editMeta` to change in the future, allowing eg. the use of mutable item metas, should they ever get implemented.
And by adding this documentation snippet we also warn API users not to do "stupid" stuff. These "stupid" stuff might seem stupid to those more familiar with the ItemStack API, a new user might not be familiar with how meta snapshots works just by looking at the `editMeta` documentation.

I'm completely open to feedback and I'm completely open to removing one of these two features from this PR, should exactly one of them be worth merging.