### PR TITLE
Do not load chunks for explosions

### DIFF
--- a/Spigot-Server-Patches/0747-Do-not-load-chunks-for-explosions.patch
+++ b/Spigot-Server-Patches/0747-Do-not-load-chunks-for-explosions.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Shane Freeder <theboyetronic@gmail.com>
+Date: Wed, 26 May 2021 00:48:39 +0100
+Subject: [PATCH] Do not load chunks for explosions
+
+
+diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
+index 79008bda42558ea7d28ccf51b66405a3bdb52da7..1041b887b233495f80bb0de9c9ce7293b6896379 100644
+--- a/src/main/java/net/minecraft/world/level/Explosion.java
++++ b/src/main/java/net/minecraft/world/level/Explosion.java
+@@ -155,7 +155,8 @@ public class Explosion {
+ 
+                         for (float f1 = 0.3F; f > 0.0F; f -= 0.22500001F) {
+                             BlockPosition blockposition = new BlockPosition(d4, d5, d6);
+-                            IBlockData iblockdata = this.world.getType(blockposition);
++                            IBlockData iblockdata = this.world.getTypeIfLoaded(blockposition); // Paper - Do not load chunks for explosions
++                            if (iblockdata == null) continue; // Paper - Do not load chunks for explosions
+                             if (!iblockdata.isDestroyable()) continue; // Paper
+                             Fluid fluid = iblockdata.getFluid(); // Paper
+                             Optional<Float> optional = this.l.a(this, this.world, blockposition, iblockdata, fluid);


### PR DESCRIPTION
Explosions in the "real world" will only be done in chunks where stuff is
actually ticking, e.g. players igniting TNT, most "out of range" explosions
are generally entities such as fireballs which have gotten into edge chunks
due to vanillas poor handing of entities which fire projectiles

Some considerations are due maybe if we wanna allow some sources to load chunks,
e.g. players creating chains of TNT into unloaded chunks, however, this is a rare
thing and should maybe thrown behind a config option as to if we want to allow this

Creating this as a PR mostly for comments on this, I don't believe that explosions should be loading chunks, but, there are always people out there with oddball setups and am too tired to decide if I wanna force this as-is