### PR TITLE
[CI-SKIP] Update version checker to use V2 downloads API

### DIFF
--- a/Spigot-Server-Patches/0019-Implement-Paper-VersionChecker.patch
+++ b/Spigot-Server-Patches/0019-Implement-Paper-VersionChecker.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ccb9961741162d7f8e9445717fa7cc7740f1def5
+index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b24b68898c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -0,0 +1,118 @@
+@@ -0,0 +1,122 @@
 +package com.destroystokyo.paper;
 +
 +import com.destroystokyo.paper.util.VersionFetcher;
@@ -24,6 +24,7 @@ index 0000000000000000000000000000000000000000..ccb9961741162d7f8e9445717fa7cc77
 +import java.io.*;
 +import java.net.HttpURLConnection;
 +import java.net.URL;
++import java.util.stream.StreamSupport;
 +
 +public class PaperVersionFetcher implements VersionFetcher {
 +    private static final java.util.regex.Pattern VER_PATTERN = java.util.regex.Pattern.compile("^([0-9\\.]*)\\-.*R"); // R is an anchor, will always give '-R' at end
@@ -89,7 +90,10 @@ index 0000000000000000000000000000000000000000..ccb9961741162d7f8e9445717fa7cc77
 +            ).openBufferedStream()) {
 +                JsonObject json = new Gson().fromJson(reader, JsonObject.class);
 +                JsonArray builds = json.getAsJsonArray("builds");
-+                int latest = builds.get(builds.size()-1).getAsInt();
++                int latest = StreamSupport.stream(builds.spliterator(), false)
++                    .mapToInt(e -> e.getAsInt())
++                    .max()
++                    .getAsInt();
 +                return latest - jenkinsBuild;
 +            } catch (JsonSyntaxException ex) {
 +                ex.printStackTrace();

--- a/Spigot-Server-Patches/0019-Implement-Paper-VersionChecker.patch
+++ b/Spigot-Server-Patches/0019-Implement-Paper-VersionChecker.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c8b911e5d013525ffc5d2911ee0e421dd916cb00
+index 0000000000000000000000000000000000000000..ccb9961741162d7f8e9445717fa7cc7740f1def5
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -0,0 +1,117 @@
+@@ -0,0 +1,118 @@
 +package com.destroystokyo.paper;
 +
 +import com.destroystokyo.paper.util.VersionFetcher;
@@ -84,11 +84,12 @@ index 0000000000000000000000000000000000000000..c8b911e5d013525ffc5d2911ee0e421d
 +        if (siteApiVersion == null) { return -1; }
 +        try {
 +            try (BufferedReader reader = Resources.asCharSource(
-+                new URL("https://papermc.io/api/v1/paper/" + siteApiVersion + "/latest"),
++                new URL("https://papermc.io/api/v2/projects/paper/versions/" + siteApiVersion),
 +                Charsets.UTF_8
 +            ).openBufferedStream()) {
 +                JsonObject json = new Gson().fromJson(reader, JsonObject.class);
-+                int latest = json.get("build").getAsInt();
++                JsonArray builds = json.getAsJsonArray("builds");
++                int latest = builds.get(builds.size()-1).getAsInt();
 +                return latest - jenkinsBuild;
 +            } catch (JsonSyntaxException ex) {
 +                ex.printStackTrace();

--- a/Spigot-Server-Patches/0020-Add-version-history-to-version-command.patch
+++ b/Spigot-Server-Patches/0020-Add-version-history-to-version-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add version history to version command
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index c8b911e5d013525ffc5d2911ee0e421dd916cb00..dc0ea65ab87255fad0d54dfb509300098a0b4864 100644
+index ccb9961741162d7f8e9445717fa7cc7740f1def5..3bcd024f81b1553156ab130acda6237f363a6565 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -5,7 +5,9 @@ import com.google.common.base.Charsets;
@@ -30,7 +30,7 @@ index c8b911e5d013525ffc5d2911ee0e421dd916cb00..dc0ea65ab87255fad0d54dfb50930009
      }
  
      private static @Nullable String getMinecraftVersion() {
-@@ -114,4 +119,19 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -115,4 +120,19 @@ public class PaperVersionFetcher implements VersionFetcher {
              return -1;
          }
      }

--- a/Spigot-Server-Patches/0020-Add-version-history-to-version-command.patch
+++ b/Spigot-Server-Patches/0020-Add-version-history-to-version-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add version history to version command
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index ccb9961741162d7f8e9445717fa7cc7740f1def5..3bcd024f81b1553156ab130acda6237f363a6565 100644
+index 1a1b50e475b9ede544b2f6d0d36632b24b68898c..580bae0d414d371a07a6bfeefc41fdd989dc0083 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -5,7 +5,9 @@ import com.google.common.base.Charsets;
@@ -18,7 +18,7 @@ index ccb9961741162d7f8e9445717fa7cc7740f1def5..3bcd024f81b1553156ab130acda6237f
  
  import javax.annotation.Nonnull;
  import javax.annotation.Nullable;
-@@ -27,7 +29,10 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -28,7 +30,10 @@ public class PaperVersionFetcher implements VersionFetcher {
      @Override
      public Component getVersionMessage(@Nonnull String serverVersion) {
          String[] parts = serverVersion.substring("git-Paper-".length()).split("[-\\s]");
@@ -30,7 +30,7 @@ index ccb9961741162d7f8e9445717fa7cc7740f1def5..3bcd024f81b1553156ab130acda6237f
      }
  
      private static @Nullable String getMinecraftVersion() {
-@@ -115,4 +120,19 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -119,4 +124,19 @@ public class PaperVersionFetcher implements VersionFetcher {
              return -1;
          }
      }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/46570876/119715891-cec5ab00-be64-11eb-8df1-92bae28c3de9.png)
![image](https://user-images.githubusercontent.com/46570876/119716546-835fcc80-be65-11eb-8c80-1b883011500f.png)


This assumes that builds are listed in ascending order, which isn't mentioned in the API docs, but kashike confirmed that this order is guaranteed: https://discord.com/channels/289587909051416579/289587909051416579/780791361649115156
![image](https://user-images.githubusercontent.com/46570876/119716216-30861500-be65-11eb-9273-a55d18e9b7b5.png)

Not sure if we should handle `builds.size() == 0`?
