### PR TITLE
Add BellRevealRaiderEvent

### DIFF
--- a/Spigot-API-Patches/0314-Add-BellRevealRaiderEvent.patch
+++ b/Spigot-API-Patches/0314-Add-BellRevealRaiderEvent.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 26 May 2021 17:08:57 -0400
+Subject: [PATCH] Add BellRevealRaiderEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..03dae5be7dba8ab550d03f365c05af4ba73e4224
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/BellRevealRaiderEvent.java
+@@ -0,0 +1,58 @@
++package io.papermc.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Raider;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a {@link org.bukkit.entity.Raider} is revealed by a bell.
++ */
++public class BellRevealRaiderEvent extends BlockEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++
++    private boolean cancelled = false;
++    private final Raider raider;
++
++    public BellRevealRaiderEvent(@NotNull Block theBlock, @NotNull Entity raider) {
++        super(theBlock);
++        this.raider = (Raider) raider;
++    }
++
++    /**
++     * Gets the raider that the bell revealed.
++     *
++     * @return The raider
++     */
++    @NotNull
++    public Raider getEntity() {
++        return raider;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    /**
++     * {@inheritDoc}
++     * <p>
++     * This does not cancel the particle effects shown on the bell, only the entity.
++     */
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    public static @NotNull HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/Spigot-Server-Patches/0752-Add-BellRevealRaiderEvent.patch
+++ b/Spigot-Server-Patches/0752-Add-BellRevealRaiderEvent.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Wed, 26 May 2021 17:09:07 -0400
+Subject: [PATCH] Add BellRevealRaiderEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBell.java b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBell.java
+index 84f9f52c5b632621b509448ac1c760f64de6b062..83626417aa9a00096680851a9a14f52f84fc7887 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/TileEntityBell.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/TileEntityBell.java
+@@ -6,6 +6,7 @@ import net.minecraft.core.BlockPosition;
+ import net.minecraft.core.EnumDirection;
+ import net.minecraft.core.IPosition;
+ import net.minecraft.core.particles.Particles;
++import net.minecraft.server.MCUtil;
+ import net.minecraft.sounds.SoundCategory;
+ import net.minecraft.sounds.SoundEffects;
+ import net.minecraft.tags.Tag;
+@@ -181,6 +182,7 @@ public class TileEntityBell extends TileEntity implements ITickable {
+     }
+ 
+     private void b(EntityLiving entityliving) {
++        if (!new io.papermc.paper.event.block.BellRevealRaiderEvent(world.getWorld().getBlockAt(MCUtil.toLocation(world, position)), entityliving.getBukkitEntity()).callEvent()) return; // Paper - BellRevealRaiderEvent
+         entityliving.addEffect(new MobEffect(MobEffects.GLOWING, 60));
+     }
+ }


### PR DESCRIPTION
This is triggered for each entity effected, similar to my GuardianAppearenceEvent pull request.

Cancelled for each entity (the particle effect is client side)
![image](https://user-images.githubusercontent.com/23108066/119732179-de81c700-be45-11eb-83c9-56ed538fc192.png)

Normal behavior (not cancelled)
![image](https://user-images.githubusercontent.com/23108066/119732536-4e904d00-be46-11eb-8f1d-e401daffc881.png)
