### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/Spigot-API-Patches/0115-RangedEntity-API.patch
+++ b/Spigot-API-Patches/0115-RangedEntity-API.patch
@@ -93,19 +93,15 @@ index c43854298548391679c1d280bd42edbeed7759b9..d23226ccb0f6c25028f000ce31346cd0
      /**
       * Represents the base color that the llama has.
 diff --git a/src/main/java/org/bukkit/entity/Piglin.java b/src/main/java/org/bukkit/entity/Piglin.java
-index eefe96c997af7d4547de3e047c2d36f0e09e25e2..6e106e1291370416f53a597b48822d3e839ee73d 100644
+index b96e57552245e2c6d452755d4227c572266fcec7..6fdc0e0bb62189dbf3cf9ce7a87b7fbb995956a3 100644
 --- a/src/main/java/org/bukkit/entity/Piglin.java
 +++ b/src/main/java/org/bukkit/entity/Piglin.java
-@@ -1,9 +1,11 @@
- package org.bukkit.entity;
- 
-+import com.destroystokyo.paper.entity.RangedEntity; // Paper
-+
+@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
  /**
   * Represents a Piglin.
   */
--public interface Piglin extends PiglinAbstract {
-+public interface Piglin extends PiglinAbstract, RangedEntity { // Paper
+-public interface Piglin extends PiglinAbstract, InventoryHolder {
++public interface Piglin extends PiglinAbstract, InventoryHolder, com.destroystokyo.paper.entity.RangedEntity { // Paper
  
      /**
       * Get whether the piglin is able to hunt hoglins.

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2443,10 +2443,10 @@ index b51a874e4665f977a154792e6216e03e04525f39..6ab14bccb1fcd108931bf7ec331e60f6
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8e83eb95ffce62aad10f4d9b259dc5dd076b7640..418becfe2b4fe5ca808f250469bbb46414a5cbc0 100644
+index 5df71cbc9d5b7a481fd087623a0d02c98e5fefc4..8a7511fc1876dc6761826dd2636bce19d177d2e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -785,9 +785,9 @@ public class CraftEventFactory {
+@@ -788,9 +788,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2458,7 +2458,7 @@ index 8e83eb95ffce62aad10f4d9b259dc5dd076b7640..418becfe2b4fe5ca808f250469bbb464
          event.setKeepInventory(keepInventory);
          org.bukkit.World world = entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -811,7 +811,7 @@ public class CraftEventFactory {
+@@ -814,7 +814,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
+++ b/Spigot-Server-Patches/0116-Add-EntityZapEvent.patch
@@ -38,10 +38,10 @@ index 651ee45431c22b944fac640f936608ae587c055d..6df58fe8084d866de1697ef3fdbfe664
              entitywitch.prepare(worldserver, worldserver.getDamageScaler(entitywitch.getChunkCoordinates()), EnumMobSpawn.CONVERSION, (GroupDataEntity) null, (NBTTagCompound) null);
              entitywitch.setNoAI(this.isNoAI());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 418becfe2b4fe5ca808f250469bbb46414a5cbc0..3951ccb8821a1363d9b5f76568f5e7f6dcbc675b 100644
+index 8a7511fc1876dc6761826dd2636bce19d177d2e8..aa484fb733e87c17cc77e56b36f6e1126e8ca4cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1095,6 +1095,14 @@ public class CraftEventFactory {
+@@ -1098,6 +1098,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
+++ b/Spigot-Server-Patches/0121-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index a52cd6d0318e0fee28fc5d252a4b596b92860320..a17812943b5402684c68ddeac5408dc9
  
                  this.die();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 3951ccb8821a1363d9b5f76568f5e7f6dcbc675b..2127455979b25055c38a4e8088419069d948e539 100644
+index aa484fb733e87c17cc77e56b36f6e1126e8ca4cf..6bee8bcd653737748c442b03a8ce3bedc57dff20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -119,6 +119,7 @@ import org.bukkit.entity.ThrownPotion;
+@@ -121,6 +121,7 @@ import org.bukkit.entity.ThrownPotion;
  import org.bukkit.entity.Vehicle;
  import org.bukkit.entity.Villager;
  import org.bukkit.entity.Villager.Profession;
@@ -29,7 +29,7 @@ index 3951ccb8821a1363d9b5f76568f5e7f6dcbc675b..2127455979b25055c38a4e8088419069
  import org.bukkit.event.Cancellable;
  import org.bukkit.event.Event;
  import org.bukkit.event.Event.Result;
-@@ -1054,6 +1055,17 @@ public class CraftEventFactory {
+@@ -1057,6 +1058,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0123-Add-ProjectileCollideEvent.patch
+++ b/Spigot-Server-Patches/0123-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 149588433cd0ea0f71b45267e39b28697ccfd2c0..8bc65e9c0fa5e134a8eb4e03f0da5b2c
  
          this.checkBlockCollisions();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2127455979b25055c38a4e8088419069d948e539..2ca0d109b148321964ac68259df82e4b1d7c57b2 100644
+index 6bee8bcd653737748c442b03a8ce3bedc57dff20..d07c146119980358aeaf8f9dc5f419fd1385ced5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1199,6 +1199,16 @@ public class CraftEventFactory {
+@@ -1202,6 +1202,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/Spigot-Server-Patches/0174-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -20,10 +20,10 @@ index 90ca51dfdbb3045dd528450225cba96f5834166e..6c692e58cde22003ecbf6dc569579914
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2ca0d109b148321964ac68259df82e4b1d7c57b2..d7a0a978411d56c93bec0d510060216eb592fed8 100644
+index d07c146119980358aeaf8f9dc5f419fd1385ced5..aa984540917e363438cc38cdb3004d3fc4987ab4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -596,16 +596,32 @@ public class CraftEventFactory {
+@@ -599,16 +599,32 @@ public class CraftEventFactory {
              EntityExperienceOrb xp = (EntityExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/Spigot-Server-Patches/0182-ExperienceOrbMergeEvent.patch
+++ b/Spigot-Server-Patches/0182-ExperienceOrbMergeEvent.patch
@@ -8,10 +8,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d7a0a978411d56c93bec0d510060216eb592fed8..e068896b1b8aab8bba8acd641bf0479c89ad3321 100644
+index aa984540917e363438cc38cdb3004d3fc4987ab4..69b5c76b312d055603ce62ad7b0c88cd01272ba9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -606,7 +606,7 @@ public class CraftEventFactory {
+@@ -609,7 +609,7 @@ public class CraftEventFactory {
                      if (e instanceof EntityExperienceOrb) {
                          EntityExperienceOrb loopItem = (EntityExperienceOrb) e;
                          // Paper start

--- a/Spigot-Server-Patches/0230-RangedEntity-API.patch
+++ b/Spigot-Server-Patches/0230-RangedEntity-API.patch
@@ -92,12 +92,12 @@ index 6dcf196fd83f2175a5d34c8d138d923c32ddb899..818034c62893a71808e3af0aa3339360
      public CraftLlama(CraftServer server, EntityLlama entity) {
          super(server, entity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
-index a224ebf16834fa10e169fa3239d89b1e60673dbb..b3b5d3a7f8ed522680f764cfd20d1e5c69627804 100644
+index 0327f3d9e1f4f9078ad7838bc03c63d2cff35f9b..45239f1b0c654a7b8450d03189b5b935771598ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPiglin.java
-@@ -5,7 +5,7 @@ import org.bukkit.craftbukkit.CraftServer;
- import org.bukkit.entity.EntityType;
+@@ -14,7 +14,7 @@ import org.bukkit.entity.EntityType;
  import org.bukkit.entity.Piglin;
+ import org.bukkit.inventory.Inventory;
  
 -public class CraftPiglin extends CraftPiglinAbstract implements Piglin {
 +public class CraftPiglin extends CraftPiglinAbstract implements Piglin, com.destroystokyo.paper.entity.CraftRangedEntity<EntityPiglin> { // Paper

--- a/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
@@ -193,10 +193,10 @@ index 2abd5157b0964fc02994ca7a9317d2fb5539dc1c..ee3fbf0789b4841a113727397ba6809b
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e068896b1b8aab8bba8acd641bf0479c89ad3321..69bcd6dcfc62ab7b5666b8e185efa07a9adbc179 100644
+index 69b5c76b312d055603ce62ad7b0c88cd01272ba9..7a245a0bc67ba7aaa986d20443d23e1a8a831dce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1184,7 +1184,7 @@ public class CraftEventFactory {
+@@ -1187,7 +1187,7 @@ public class CraftEventFactory {
  
      public static Container callInventoryOpenEvent(EntityPlayer player, Container container, boolean cancelled) {
          if (player.activeContainer != player.defaultContainer) { // fire INVENTORY_CLOSE if one already open
@@ -205,7 +205,7 @@ index e068896b1b8aab8bba8acd641bf0479c89ad3321..69bcd6dcfc62ab7b5666b8e185efa07a
          }
  
          CraftServer server = player.world.getServer();
-@@ -1350,8 +1350,18 @@ public class CraftEventFactory {
+@@ -1353,8 +1353,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
+++ b/Spigot-Server-Patches/0247-Vanished-players-don-t-have-rights.patch
@@ -174,10 +174,10 @@ index fdd9e37a8c90fc3311e515355af0a0593efbdacc..cf32a4f63e8e59535c02a3f9c57f9883
          if (operatorboolean.apply(false, false)) {
              throw (IllegalArgumentException) SystemUtils.c((Throwable) (new IllegalArgumentException()));
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 69bcd6dcfc62ab7b5666b8e185efa07a9adbc179..6d08487ff25b474b2372de37ea77aa0eb997d89a 100644
+index 7a245a0bc67ba7aaa986d20443d23e1a8a831dce..31358b90784a6e983ff8b687021c721ed5d43eab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1220,6 +1220,14 @@ public class CraftEventFactory {
+@@ -1223,6 +1223,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/Spigot-Server-Patches/0258-Add-hand-to-bucket-events.patch
+++ b/Spigot-Server-Patches/0258-Add-hand-to-bucket-events.patch
@@ -126,10 +126,10 @@ index 07c5cdd00930a55fd412ef95f71f55ee908189a1..88b1a0235bfc0b41ae1855f8900632e4
      public boolean s_() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6d08487ff25b474b2372de37ea77aa0eb997d89a..877a0ea25f3cea970fa3827b12efc1a44bdcdf9c 100644
+index 31358b90784a6e983ff8b687021c721ed5d43eab..338b319910d12cf62ab9c5977257ad1ccec5544a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -231,7 +231,7 @@ public class CraftEventFactory {
+@@ -234,7 +234,7 @@ public class CraftEventFactory {
      public static Entity entityDamage; // For use in EntityDamageByEntityEvent
  
      // helper methods
@@ -138,7 +138,7 @@ index 6d08487ff25b474b2372de37ea77aa0eb997d89a..877a0ea25f3cea970fa3827b12efc1a4
          int spawnSize = Bukkit.getServer().getSpawnRadius();
  
          if (world.getDimensionKey() != World.OVERWORLD) return true;
-@@ -421,6 +421,20 @@ public class CraftEventFactory {
+@@ -424,6 +424,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, WorldServer world, EntityHuman who, BlockPosition changed, BlockPosition clicked, EnumDirection clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
@@ -159,7 +159,7 @@ index 6d08487ff25b474b2372de37ea77aa0eb997d89a..877a0ea25f3cea970fa3827b12efc1a4
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -433,10 +447,10 @@ public class CraftEventFactory {
+@@ -436,10 +450,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/Spigot-Server-Patches/0279-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0279-Improve-death-events.patch
@@ -98,7 +98,7 @@ index 046b191e771ed9be337e095214a67febd768e5f6..b6b4eb9ac883cfdfab5f114767fb5cfb
  
      protected void l(double d0, double d1, double d2) {
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index a64b2953c43138491cdab3e3e24e2e7ed969e171..b3c2976a48c2349e5c22d58dd1ac64a02cd969d5 100644
+index bfbfdeffe668ac3363ffdab2c5cb7b19217f55ea..e20acbd904f12e9036cb0565d6aa9a3f63008d43 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -189,7 +189,7 @@ public abstract class EntityLiving extends Entity {
@@ -346,7 +346,7 @@ index a13867ff6d188e7633a91f1e1600116286ac0cd4..6c5075ef2420131aa21b403623a5dfa4
  
      public void injectScaledMaxHealth(Collection<AttributeModifiable> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 877a0ea25f3cea970fa3827b12efc1a44bdcdf9c..fbd24e10b1b966898e7e1556c5f9bd607497d970 100644
+index 338b319910d12cf62ab9c5977257ad1ccec5544a..b7ebd2e3e919d09ee99997f2358cc0c399d5041b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -18,6 +18,8 @@ import net.minecraft.network.protocol.game.PacketPlayInCloseWindow;
@@ -358,7 +358,7 @@ index 877a0ea25f3cea970fa3827b12efc1a44bdcdf9c..fbd24e10b1b966898e7e1556c5f9bd60
  import net.minecraft.util.Unit;
  import net.minecraft.world.EnumHand;
  import net.minecraft.world.IInventory;
-@@ -802,9 +804,16 @@ public class CraftEventFactory {
+@@ -805,9 +807,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(EntityLiving victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -375,7 +375,7 @@ index 877a0ea25f3cea970fa3827b12efc1a44bdcdf9c..fbd24e10b1b966898e7e1556c5f9bd60
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -820,8 +829,15 @@ public class CraftEventFactory {
+@@ -823,8 +832,15 @@ public class CraftEventFactory {
          CraftPlayer entity = victim.getBukkitEntity();
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
@@ -391,7 +391,7 @@ index 877a0ea25f3cea970fa3827b12efc1a44bdcdf9c..fbd24e10b1b966898e7e1556c5f9bd60
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -838,6 +854,31 @@ public class CraftEventFactory {
+@@ -841,6 +857,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0410-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/Spigot-Server-Patches/0410-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index fbd24e10b1b966898e7e1556c5f9bd607497d970..dbfd500ad18262e4c1af40308229802fa0cb2e5d 100644
+index b7ebd2e3e919d09ee99997f2358cc0c399d5041b..0b27d68dce9537c17701bd4944c807414564170b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -346,13 +346,18 @@ public class CraftEventFactory {
+@@ -349,13 +349,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -102,10 +102,10 @@ index 69361caebf0d3caa5195b519a16691705ac5e16a..5eb900619951083b9a777b1645cb5495
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index dbfd500ad18262e4c1af40308229802fa0cb2e5d..ce02da607d07d22cb0b71e032efa0a8f45148d0c 100644
+index 0b27d68dce9537c17701bd4944c807414564170b..d620d3e7c023786d1b7411399a05a75028a404cc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -824,7 +824,8 @@ public class CraftEventFactory {
+@@ -827,7 +827,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/Spigot-Server-Patches/0522-Add-PrepareResultEvent.patch
+++ b/Spigot-Server-Patches/0522-Add-PrepareResultEvent.patch
@@ -106,10 +106,10 @@ index cfcb2469569edd51bbb74ca8d7a35a1ec0ecb434..1589d9ca201d386d11d9fd57fa8ba684
  
      private void a(IInventory iinventory, ItemStack itemstack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ce02da607d07d22cb0b71e032efa0a8f45148d0c..703f2648dde7ad1620e83f88ac4184e5803ed9b4 100644
+index d620d3e7c023786d1b7411399a05a75028a404cc..55619fbc3fdb9393d7c47a23dc337b06ce4495d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1531,19 +1531,44 @@ public class CraftEventFactory {
+@@ -1534,19 +1534,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/Spigot-Server-Patches/0617-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/Spigot-Server-Patches/0617-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 703f2648dde7ad1620e83f88ac4184e5803ed9b4..62fcf390e5cf5b76e1f7b34fea856911d9494044 100644
+index 55619fbc3fdb9393d7c47a23dc337b06ce4495d6..94476dfc0178f924fdad51b15f131ed266268776 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -268,6 +268,10 @@ public class CraftEventFactory {
+@@ -271,6 +271,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/Spigot-Server-Patches/0636-Implemented-BlockFailedDispenseEvent.patch
+++ b/Spigot-Server-Patches/0636-Implemented-BlockFailedDispenseEvent.patch
@@ -29,7 +29,7 @@ index ccab4714bf5a6be8afd92430874fd6f881d4f92f..223cc0ba06cf4b007049880daad881e5
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 62fcf390e5cf5b76e1f7b34fea856911d9494044..d4b288e127cbd03ded93977fac0c40359525b92d 100644
+index 94476dfc0178f924fdad51b15f131ed266268776..a7f8e08dcbc102041891e51cbe9c984d6f43747b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -4,6 +4,7 @@ import com.google.common.base.Function;
@@ -40,7 +40,7 @@ index 62fcf390e5cf5b76e1f7b34fea856911d9494044..d4b288e127cbd03ded93977fac0c4035
  import java.net.InetAddress;
  import java.util.ArrayList;
  import java.util.Collections;
-@@ -121,7 +122,6 @@ import org.bukkit.entity.ThrownPotion;
+@@ -123,7 +124,6 @@ import org.bukkit.entity.ThrownPotion;
  import org.bukkit.entity.Vehicle;
  import org.bukkit.entity.Villager;
  import org.bukkit.entity.Villager.Profession;
@@ -48,8 +48,8 @@ index 62fcf390e5cf5b76e1f7b34fea856911d9494044..d4b288e127cbd03ded93977fac0c4035
  import org.bukkit.event.Cancellable;
  import org.bukkit.event.Event;
  import org.bukkit.event.Event.Result;
-@@ -1787,4 +1787,12 @@ public class CraftEventFactory {
- 
+@@ -1796,4 +1796,12 @@ public class CraftEventFactory {
+         Bukkit.getPluginManager().callEvent(event);
          return event;
      }
 +

--- a/Spigot-Server-Patches/0642-Implement-API-to-expose-exact-interaction-point.patch
+++ b/Spigot-Server-Patches/0642-Implement-API-to-expose-exact-interaction-point.patch
@@ -18,10 +18,10 @@ index 31012963815a5c7355753b8cd2749976282ef0d2..87722285690d9d3370610e2a2eb809e0
          interactResult = event.useItemInHand() == Event.Result.DENY;
          interactPosition = blockposition.immutableCopy();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d4b288e127cbd03ded93977fac0c40359525b92d..d2f471b8af997cfedaba8e6b5932f8f6079f3392 100644
+index a7f8e08dcbc102041891e51cbe9c984d6f43747b..365d186c5a6d985ed08e09112b74f44b7cfad688 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -69,7 +69,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParameters;
+@@ -70,7 +70,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParameters;
  import net.minecraft.world.phys.MovingObjectPosition;
  import net.minecraft.world.phys.MovingObjectPositionBlock;
  import net.minecraft.world.phys.MovingObjectPositionEntity;
@@ -31,7 +31,7 @@ index d4b288e127cbd03ded93977fac0c40359525b92d..d2f471b8af997cfedaba8e6b5932f8f6
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -484,7 +486,13 @@ public class CraftEventFactory {
+@@ -487,7 +489,13 @@ public class CraftEventFactory {
          return callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index d4b288e127cbd03ded93977fac0c40359525b92d..d2f471b8af997cfedaba8e6b5932f8f6
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -510,7 +518,10 @@ public class CraftEventFactory {
+@@ -513,7 +521,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/Spigot-Server-Patches/0653-Implement-BlockPreDispenseEvent.patch
+++ b/Spigot-Server-Patches/0653-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 966051ab3e720e5b3f0fb9ab852c8908c5f23f3b..9b92824f1c2797e321ced953d33d2c2f
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d2f471b8af997cfedaba8e6b5932f8f6079f3392..f0ab3d42bc34bf8c1b81642e600360110a88115b 100644
+index 365d186c5a6d985ed08e09112b74f44b7cfad688..c109bbec67bd683077f0ab7331116a240a475827 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -70,6 +70,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
+@@ -71,6 +71,7 @@ import net.minecraft.world.phys.MovingObjectPosition;
  import net.minecraft.world.phys.MovingObjectPositionBlock;
  import net.minecraft.world.phys.MovingObjectPositionEntity;
  import net.minecraft.world.phys.Vec3D;
@@ -28,7 +28,7 @@ index d2f471b8af997cfedaba8e6b5932f8f6079f3392..f0ab3d42bc34bf8c1b81642e60036011
  import org.bukkit.Bukkit;
  import org.bukkit.Location; // Paper
  import org.bukkit.Material;
-@@ -1805,5 +1806,11 @@ public class CraftEventFactory {
+@@ -1814,5 +1815,11 @@ public class CraftEventFactory {
          BlockFailedDispenseEvent event = new BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/Spigot-Server-Patches/0660-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/Spigot-Server-Patches/0660-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -138,10 +138,10 @@ index 8f6d2a6a388021f437ac5554e9ece8eca89e1f46..519f0cabadcf97a44a112fd963a8d3ab
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f0ab3d42bc34bf8c1b81642e600360110a88115b..bbc7f97748f5b61047a9b01a2ecb8c2d0a7b677c 100644
+index c109bbec67bd683077f0ab7331116a240a475827..e45a635b9d0948c71d5d3fcb317d2c8a228148ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1469,8 +1469,10 @@ public class CraftEventFactory {
+@@ -1472,8 +1472,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/Spigot-Server-Patches/0667-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/Spigot-Server-Patches/0667-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bbc7f97748f5b61047a9b01a2ecb8c2d0a7b677c..b14cec316b16e46d54d389650372c5c9ce1e5a4d 100644
+index e45a635b9d0948c71d5d3fcb317d2c8a228148ea..a678277416cd71e01cd6980bcfaf9a9803e7ea17 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -398,13 +398,30 @@ public class CraftEventFactory {
+@@ -401,13 +401,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, EntityPlayer player, List<EntityItem> items) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
0e11bc1f #522: Add piglin bartering API
a16a309d #613: Add PlayerBucketEntityEvent and make PlayerBucketFishEvent deprecated in favor of the newer, more generic event

CraftBukkit Changes:
fd905ab5 #703: Add piglin bartering API