### PR TITLE
Fix EntityLoadCrossbowEvent Sync Issue

### DIFF
--- a/patches/api/0250-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/api/0250-Add-EntityLoadCrossbowEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 diff --git a/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..287f487b266d5c12fcf6f028452735e314d55636
+index 0000000000000000000000000000000000000000..aa9ccd7c806e864455ecd5f15ddb17c0fa8728c4
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/entity/EntityLoadCrossbowEvent.java
-@@ -0,0 +1,101 @@
+@@ -0,0 +1,97 @@
 +package io.papermc.paper.event.entity;
 +
 +import org.bukkit.entity.LivingEntity;
@@ -88,10 +88,6 @@ index 0000000000000000000000000000000000000000..287f487b266d5c12fcf6f028452735e3
 +    /**
 +     * Set whether or not to cancel the crossbow being loaded. If canceled, the
 +     * projectile that would be loaded into the crossbow will not be consumed.
-+     *
-+     * If set to false, and this event is pertaining to a player entity,
-+     * it's recommended that a call to {@link Player#updateInventory()} is made
-+     * as the client may think the server still loaded an item into the crossbow.
 +     *
 +     * @param cancel true if you wish to cancel this event
 +     */

--- a/patches/server/0566-Add-EntityLoadCrossbowEvent.patch
+++ b/patches/server/0566-Add-EntityLoadCrossbowEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityLoadCrossbowEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/CrossbowItem.java b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-index 1ec3fd560a2b6528040bca68be4a05c9a8435ae9..288776d2c6e4d3f214152910e6c1ccdafa2c3fbd 100644
+index 1ec3fd560a2b6528040bca68be4a05c9a8435ae9..c0c211c7227f4ce5d1e0e433419425e6bb13046f 100644
 --- a/src/main/java/net/minecraft/world/item/CrossbowItem.java
 +++ b/src/main/java/net/minecraft/world/item/CrossbowItem.java
-@@ -90,7 +90,11 @@ public class CrossbowItem extends ProjectileWeaponItem implements Vanishable {
+@@ -90,7 +90,14 @@ public class CrossbowItem extends ProjectileWeaponItem implements Vanishable {
          int j = this.getUseDuration(stack) - remainingUseTicks;
          float f = CrossbowItem.getPowerForTime(j, stack);
  
@@ -16,12 +16,15 @@ index 1ec3fd560a2b6528040bca68be4a05c9a8435ae9..288776d2c6e4d3f214152910e6c1ccda
 +        // Paper start - EntityLoadCrossbowEvent
 +        if (f >= 1.0F && !CrossbowItem.isCharged(stack) /*&& CrossbowItem.tryLoadProjectiles(entityliving, itemstack)*/) {
 +            final io.papermc.paper.event.entity.EntityLoadCrossbowEvent event = new io.papermc.paper.event.entity.EntityLoadCrossbowEvent(user.getBukkitLivingEntity(), stack.asBukkitMirror(), user.getUsedItemHand() == InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND);
-+            if (!event.callEvent() || !tryLoadProjectiles(user, stack, event.shouldConsumeItem())) return;
++            if (!event.callEvent() || !tryLoadProjectiles(user, stack, event.shouldConsumeItem())) {
++                if (user instanceof ServerPlayer player) player.containerMenu.sendAllDataToRemote();
++                return;
++            }
 +            // Paper end
              CrossbowItem.setCharged(stack, true);
              SoundSource soundcategory = user instanceof Player ? SoundSource.PLAYERS : SoundSource.HOSTILE;
  
-@@ -100,9 +104,14 @@ public class CrossbowItem extends ProjectileWeaponItem implements Vanishable {
+@@ -100,9 +107,14 @@ public class CrossbowItem extends ProjectileWeaponItem implements Vanishable {
      }
  
      private static boolean tryLoadProjectiles(LivingEntity shooter, ItemStack projectile) {


### PR DESCRIPTION
Fixes the problem that items are not synchronized when the EntityLoadCrossbowEvent is canceled.

--------

normal (apply PR)
![Normal](https://user-images.githubusercontent.com/45729082/120019524-886a7a80-c023-11eb-97bc-5e321b2d77ef.gif)

abnormal
![Abnormal](https://user-images.githubusercontent.com/45729082/120019593-9ae4b400-c023-11eb-9c79-699a5a17880c.gif)
( + check the crossbow state and amount of arrows )