### PR TITLE
Fix entity equipment on cancellation of EntityDeathEvent

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -75,6 +75,8 @@ public net.minecraft.server.level.ChunkMap getPoiManager()Lnet/minecraft/world/e
 # Improve death events
 public net.minecraft.world.entity.LivingEntity getDeathSound()Lnet/minecraft/sounds/SoundEvent;
 public net.minecraft.world.entity.LivingEntity getSoundVolume()F
+public net.minecraft.world.entity.Mob handItems
+public net.minecraft.world.entity.Mob armorItems
 
 # Add sun related api
 public net.minecraft.world.entity.Mob isSunBurnTick()Z

--- a/patches/server/0261-Improve-death-events.patch
+++ b/patches/server/0261-Improve-death-events.patch
@@ -70,7 +70,7 @@ index fd1937f49312204d38510996a5be43b731f38bde..a2e2b6ea166bf64fe5b49672a6c6f86a
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7224cb5c2 100644
+index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d23941f6d2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -258,6 +258,7 @@ public abstract class LivingEntity extends Entity {
@@ -104,15 +104,15 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7
              Entity entity = source.getEntity();
              LivingEntity entityliving = this.getKillCredit();
 -
-+            /* // Paper - move down to make death event cancellable - this is the runKillTrigger below
++            /* // Paper - move down to make death event cancellable - this is the awardKillScore below
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, source);
              }
-@@ -1608,20 +1608,46 @@ public abstract class LivingEntity extends Entity {
+@@ -1608,20 +1608,52 @@ public abstract class LivingEntity extends Entity {
              if (!this.level.isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
-+             */ // Paper - move down to make death event cancellable - this is the runKillTrigger below
++             */ // Paper - move down to make death event cancellable - this is the awardKillScore below
  
              this.dead = true;
 -            this.getCombatTracker().recheckStatus();
@@ -130,6 +130,12 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7
 +                    if (this.deathScore >= 0 && entityliving != null) {
 +                        entityliving.awardKillScore(this, this.deathScore, source);
 +                    }
++                    // Paper start - clear equipment if event is not cancelled
++                    if (this instanceof Mob mob) {
++                        java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
++                        java.util.Collections.fill(mob.armorItems, ItemStack.EMPTY);
++                    }
++                    // Paper end
 +
 +                    if (this.isSleeping()) {
 +                        this.stopSleeping();
@@ -158,7 +164,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7
          }
      }
  
-@@ -1629,7 +1655,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1629,7 +1661,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.level.isClientSide) {
              boolean flag = false;
  
@@ -167,17 +173,23 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1658,7 +1684,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1658,7 +1690,8 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
 -    protected void dropAllDeathLoot(DamageSource source) {
++    protected boolean clearEquipmentSlots = true; // Paper
 +    protected org.bukkit.event.entity.EntityDeathEvent dropAllDeathLoot(DamageSource source) { // Paper
          Entity entity = source.getEntity();
          int i;
  
-@@ -1676,15 +1702,18 @@ public abstract class LivingEntity extends Entity {
+@@ -1673,18 +1706,23 @@ public abstract class LivingEntity extends Entity {
+         this.dropEquipment(); // CraftBukkit - from below
+         if (this.shouldDropLoot() && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
+             this.dropFromLootTable(source, flag);
++            this.clearEquipmentSlots = false; // Paper
              this.dropCustomDeathLoot(source, i, flag);
++            this.clearEquipmentSlots = true; // Paper
          }
          // CraftBukkit start - Call death event
 -        CraftEventFactory.callEntityDeathEvent(this, this.drops);
@@ -196,6 +208,20 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..4fbc60ef1e6769bd54b2976935b222f7
  
      // CraftBukkit start
      public int getExpReward() {
+diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
+index 85af49ff909635973ff20ec3e528a4a0a7c19fc4..7db99b4ad89fd5b38a4767d166caedda86a6188a 100644
+--- a/src/main/java/net/minecraft/world/entity/Mob.java
++++ b/src/main/java/net/minecraft/world/entity/Mob.java
+@@ -1002,7 +1002,9 @@ public abstract class Mob extends LivingEntity {
+                 }
+ 
+                 this.spawnAtLocation(itemstack);
++                if (this.clearEquipmentSlots) { // Paper
+                 this.setItemSlot(enumitemslot, ItemStack.EMPTY);
++                } // Paper
+             }
+         }
+ 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Fox.java b/src/main/java/net/minecraft/world/entity/animal/Fox.java
 index 2caf3aa6ca876d59deb98ee917e8228df140b414..63f0ed4c80b7afa091c4a835eefd6d709428f984 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Fox.java

--- a/patches/server/0274-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0274-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4fbc60ef1e6769bd54b2976935b222f7224cb5c2..ea3d289a859e5f093600ae40baa043599ba2d704 100644
+index 28ec62fd75abc04d4dc22204bfd999d23941f6d2..fdf759ee33b591ffce5385c424df7879a4e0a85f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -113,6 +113,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 4fbc60ef1e6769bd54b2976935b222f7224cb5c2..ea3d289a859e5f093600ae40baa04359
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3737,6 +3738,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3746,6 +3747,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0295-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0295-force-entity-dismount-during-teleportation.patch
@@ -93,10 +93,10 @@ index 2981a29b011cb1a08a776abc5ec6a94228061f98..7ec6561722644bfd9dd81d12732eab67
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ea3d289a859e5f093600ae40baa043599ba2d704..8bdaf925580480a9467b5611e77580bb205c0a4a 100644
+index fdf759ee33b591ffce5385c424df7879a4e0a85f..75beea5653d04555b46c4b3a2054405c6aefc421 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3336,9 +3336,15 @@ public abstract class LivingEntity extends Entity {
+@@ -3345,9 +3345,15 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void stopRiding() {

--- a/patches/server/0341-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0341-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8bdaf925580480a9467b5611e77580bb205c0a4a..bb53c547e31ed9d7bcc04b06d774b70607ef927f 100644
+index 75beea5653d04555b46c4b3a2054405c6aefc421..2b2258b8cc35385b857114d0e8a958cd24fa7d26 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3558,9 +3558,14 @@ public abstract class LivingEntity extends Entity {
+@@ -3567,9 +3567,14 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 8bdaf925580480a9467b5611e77580bb205c0a4a..bb53c547e31ed9d7bcc04b06d774b706
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level.isClientSide) {
-@@ -3639,6 +3644,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3648,6 +3653,7 @@ public abstract class LivingEntity extends Entity {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 8bdaf925580480a9467b5611e77580bb205c0a4a..bb53c547e31ed9d7bcc04b06d774b706
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3673,8 +3679,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3682,8 +3688,8 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0356-Lag-compensate-eating.patch
+++ b/patches/server/0356-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index bb53c547e31ed9d7bcc04b06d774b70607ef927f..b8877b52e4ba032fc43d95647d177cd38fb6aaf8 100644
+index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c98f086c1 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3501,6 +3501,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3510,6 +3510,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index bb53c547e31ed9d7bcc04b06d774b70607ef927f..b8877b52e4ba032fc43d95647d177cd3
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3518,8 +3523,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3527,8 +3532,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index bb53c547e31ed9d7bcc04b06d774b70607ef927f..b8877b52e4ba032fc43d95647d177cd3
              this.completeUsingItem();
          }
  
-@@ -3567,7 +3576,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3576,7 +3585,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index bb53c547e31ed9d7bcc04b06d774b70607ef927f..b8877b52e4ba032fc43d95647d177cd3
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3591,7 +3603,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3600,7 +3612,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index bb53c547e31ed9d7bcc04b06d774b70607ef927f..b8877b52e4ba032fc43d95647d177cd3
              }
          }
  
-@@ -3719,7 +3734,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3728,7 +3743,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0374-Entity-Jump-API.patch
+++ b/patches/server/0374-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b8877b52e4ba032fc43d95647d177cd38fb6aaf8..e8501f18f5021678fad09cb5e600c7fc3660fe52 100644
+index 41495db77a242f554fc085b3ac81509c98f086c1..1b9b49caf8d0e2b77064273a4fa1975fa3d5238f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3164,8 +3164,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3173,8 +3173,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {

--- a/patches/server/0402-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0402-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e8501f18f5021678fad09cb5e600c7fc3660fe52..f0af402ec09a1893e9d7ddd6aa355fd262f3b631 100644
+index 1b9b49caf8d0e2b77064273a4fa1975fa3d5238f..d5a70e9fc2a2a85d7262832687770b9693f05f41 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3261,10 +3261,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3270,10 +3270,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0410-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0410-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f0af402ec09a1893e9d7ddd6aa355fd262f3b631..d23b82e5b6168ea618922f46a0e1ee7f46fad8f9 100644
+index d5a70e9fc2a2a85d7262832687770b9693f05f41..0fc95a0ef5ed17b5cefcc72533783857faa2e749 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2039,7 +2039,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2048,7 +2048,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0413-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0413-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -79,6 +79,39 @@ index 12f00a6d3b4335aa8f60646ac129dd481082feec..f2be5a99ea4074a72858ddf8f728f5aa
      }
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 0fc95a0ef5ed17b5cefcc72533783857faa2e749..cd3bad5a767a060a498fa47b539e6e85ba282ca2 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1621,9 +1621,9 @@ public abstract class LivingEntity extends Entity {
+                 // Paper start
+                 org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(source);
+                 if (deathEvent == null || !deathEvent.isCancelled()) {
+-                    if (this.deathScore >= 0 && entityliving != null) {
+-                        entityliving.awardKillScore(this, this.deathScore, source);
+-                    }
++                    // if (this.deathScore >= 0 && entityliving != null) { // Paper moved to be run earlier in #dropAllDeathLoot before destroying the drop items in CraftEventFactory#callEntityDeathEvent
++                    //     entityliving.awardKillScore(this, this.deathScore, source);
++                    // }
+                     // Paper start - clear equipment if event is not cancelled
+                     if (this instanceof Mob mob) {
+                         java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
+@@ -1711,8 +1711,13 @@ public abstract class LivingEntity extends Entity {
+             this.dropCustomDeathLoot(source, i, flag);
+             this.clearEquipmentSlots = true; // Paper
+         }
+-        // CraftBukkit start - Call death event
+-        org.bukkit.event.entity.EntityDeathEvent deathEvent = CraftEventFactory.callEntityDeathEvent(this, this.drops); // Paper
++        // CraftBukkit start - Call death event // Paper start - call advancement triggers with correct entity equipment
++        org.bukkit.event.entity.EntityDeathEvent deathEvent = CraftEventFactory.callEntityDeathEvent(this, this.drops, () -> {
++            final LivingEntity entityliving = this.getKillCredit();
++            if (this.deathScore >= 0 && entityliving != null) {
++                entityliving.awardKillScore(this, this.deathScore, source);
++            }
++        }); // Paper end
+         this.postDeathDropItems(deathEvent); // Paper
+         this.drops = new ArrayList<>();
+         // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java b/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
 index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177ebda892f 100644
 --- a/src/main/java/net/minecraft/world/entity/decoration/ArmorStand.java
@@ -102,10 +135,27 @@ index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aaea18e64db3851f98a7a391d9f9bb265d659d99..5cb2a9da5801ae96ec708e20cdbd0557193236c1 100644
+index aaea18e64db3851f98a7a391d9f9bb265d659d99..d74db5ac46314683b8c8713b8e6f6450ef7eb1b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -827,7 +827,8 @@ public class CraftEventFactory {
+@@ -810,6 +810,11 @@ public class CraftEventFactory {
+     }
+ 
+     public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
++        // Paper start
++        return CraftEventFactory.callEntityDeathEvent(victim, drops, com.google.common.util.concurrent.Runnables.doNothing());
++    }
++    public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops, Runnable lootCheck) {
++        // Paper end
+         CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
+         EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
+         populateFields(victim, event); // Paper - make cancellable
+@@ -823,11 +828,13 @@ public class CraftEventFactory {
+         playDeathSound(victim, event);
+         // Paper end
+         victim.expToDrop = event.getDroppedExp();
++        lootCheck.run(); // Paper - advancement triggers before destroying items
+ 
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/patches/server/0471-Add-PrepareResultEvent.patch
+++ b/patches/server/0471-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..221b6ffb426edc034183dbaf37de29c6
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5fea023590fd1456a4d43c1ebc5b8c243e185631..1c0bf20f19a697e588a1d0210c181d29edbcaba7 100644
+index f49c636a7485a7f41aae7acb584dc1c7c1d2c3a2..dc65191f170954fbc93012bfc02401de36d8d1fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1556,19 +1556,44 @@ public class CraftEventFactory {
+@@ -1562,19 +1562,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0472-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0472-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d23b82e5b6168ea618922f46a0e1ee7f46fad8f9..8fa36430da31346caa0fb1fc0b376d62bd6e247a 100644
+index cd3bad5a767a060a498fa47b539e6e85ba282ca2..5c8fa0f2488b26684ff25459f384e655ce0417c5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3362,7 +3362,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3376,7 +3376,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0543-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0543-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -61,10 +61,10 @@ index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e06
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8fa36430da31346caa0fb1fc0b376d62bd6e247a..81df34945237ccb78fc4e2c97f78ccfeaa947637 100644
+index 5c8fa0f2488b26684ff25459f384e655ce0417c5..bb1645fd1e6242cec7fbd32282062eacc9f9f593 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3276,7 +3276,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3290,7 +3290,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index 8fa36430da31346caa0fb1fc0b376d62bd6e247a..81df34945237ccb78fc4e2c97f78ccfe
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3447,9 +3447,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3461,9 +3461,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0572-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0572-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 4ae21aa6fc91f527d3dca508588d8257961b8d24..b3203049eade7d11602fa2a12a8104a7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 37d99e3a1771feee9edb94f17a649ebb3511a459..fa46a33e34c4ebcf94a54cb597ff6bbb02cfcef9 100644
+index 0bfe25bd5dee6853d624af6988d2b72155aed8c0..d4b772c1df839ad1ec2bfb514432ee1b12099193 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1830,4 +1830,12 @@ public class CraftEventFactory {
+@@ -1836,4 +1836,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0587-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0587-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 07d357b5fcb30ed9ff074a196a19de1481fe3738..83ac86b3c1e7b9233f2db8e5488f97c5
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 419c5bd638230c31dd68ba37174c8057c0229a6a..eda17a60afd6cf03e58e66b2dbfe414b1cfac9d5 100644
+index bfc3442e7952e1ec927f3ebdbefba153e7304e19..da0a74415dcaddc3f692106faf11403e27feee80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1848,5 +1848,11 @@ public class CraftEventFactory {
+@@ -1854,5 +1854,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0592-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0592-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 63b0044a86e6830ccf9d6da8e29989de1402dff4..68da2530db8b0fcdba957ee90c185324a010919f 100644
+index 341614d0f0df4008a443d9cda400d0c0103af90a..0909d3cd41fa8c8fe971e1a6c5a67bab7e0a3dc9 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1228,12 +1228,15 @@ public abstract class Mob extends LivingEntity {
+@@ -1230,12 +1230,15 @@ public abstract class Mob extends LivingEntity {
              return InteractionResult.PASS;
          } else if (this.getLeashHolder() == player) {
              // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index 63b0044a86e6830ccf9d6da8e29989de1402dff4..68da2530db8b0fcdba957ee90c185324
              return InteractionResult.sidedSuccess(this.level.isClientSide);
          } else {
              InteractionResult enuminteractionresult = this.checkAndHandleImportantInteractions(player, hand);
-@@ -1391,8 +1394,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1393,8 +1396,11 @@ public abstract class Mob extends LivingEntity {
  
          if (this.leashHolder != null) {
              if (!this.isAlive() || !this.leashHolder.isAlive()) {
@@ -40,7 +40,7 @@ index 63b0044a86e6830ccf9d6da8e29989de1402dff4..68da2530db8b0fcdba957ee90c185324
              }
  
          }
-@@ -1455,8 +1461,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1457,8 +1463,11 @@ public abstract class Mob extends LivingEntity {
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -54,7 +54,7 @@ index 63b0044a86e6830ccf9d6da8e29989de1402dff4..68da2530db8b0fcdba957ee90c185324
          }
  
          return flag1;
-@@ -1626,8 +1635,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1628,8 +1637,11 @@ public abstract class Mob extends LivingEntity {
      @Override
      protected void removeAfterChangingDimensions() {
          super.removeAfterChangingDimensions();
@@ -122,10 +122,10 @@ index cf932116a0cafd315e44159fbf7c5d25d43782ff..03bda898a5a263053ecd79f74799d370
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index eda17a60afd6cf03e58e66b2dbfe414b1cfac9d5..5931cf0c05ca22f72a465d096dfb60508d84b859 100644
+index da0a74415dcaddc3f692106faf11403e27feee80..afb6eb856d22845716351d5be7eff5991da72dd3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1489,8 +1489,10 @@ public class CraftEventFactory {
+@@ -1495,8 +1495,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0596-EntityMoveEvent.patch
+++ b/patches/server/0596-EntityMoveEvent.patch
@@ -17,7 +17,7 @@ index b5b7bb3c0147f95ac4036e7d2aa8f26ac755f4df..18830fa8e43c70c9da417eb771d55335
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6d635a02a12d3af0639d7afda19d5f71cf81ee44..3a66376145f29e2330daed723ffccf98415b0540 100644
+index f352c7d30a9d493f6d86830414623c2b2b1e2554..7e79aad7950298060e7b71321a0d60c1b29655ce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -205,6 +205,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,10 +29,10 @@ index 6d635a02a12d3af0639d7afda19d5f71cf81ee44..3a66376145f29e2330daed723ffccf98
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 81df34945237ccb78fc4e2c97f78ccfeaa947637..455fd68005262da367b6200713adf0266bdb08b6 100644
+index bb1645fd1e6242cec7fbd32282062eacc9f9f593..5e2052dc1fbf2ee9976190868ed6e431ab56d34c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3222,6 +3222,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3236,6 +3236,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0630-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0630-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 455fd68005262da367b6200713adf0266bdb08b6..7fb05333ffb052373af613f52bafd0684c39c1af 100644
+index 5e2052dc1fbf2ee9976190868ed6e431ab56d34c..f84b897890ca51258cdf6cd04bfba3328096969c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3708,6 +3708,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3722,6 +3722,7 @@ public abstract class LivingEntity extends Entity {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0681-Line-Of-Sight-Changes.patch
+++ b/patches/server/0681-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 7fb05333ffb052373af613f52bafd0684c39c1af..4c0c2bc9fae878304eab1c18b5ef0cae1b780cfd 100644
+index f84b897890ca51258cdf6cd04bfba3328096969c..1879271ef55e07cd93ebab2d01bfeb7e7b247883 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3433,7 +3433,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3447,7 +3447,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0698-Add-a-bunch-of-missing-forceDrop-toggles.patch
+++ b/patches/server/0698-Add-a-bunch-of-missing-forceDrop-toggles.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add a bunch of missing forceDrop toggles
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 68da2530db8b0fcdba957ee90c185324a010919f..4a027c802ffa80f69cf2bc68f737a842fbfb0596 100644
+index 0909d3cd41fa8c8fe971e1a6c5a67bab7e0a3dc9..6604cd4c65abd591a93620a1928e7b2635f0a38e 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1489,7 +1489,9 @@ public abstract class Mob extends LivingEntity {
+@@ -1491,7 +1491,9 @@ public abstract class Mob extends LivingEntity {
              }
  
              if (this.tickCount > 100) {

--- a/patches/server/0704-Improve-boat-collision-performance.patch
+++ b/patches/server/0704-Improve-boat-collision-performance.patch
@@ -17,7 +17,7 @@ index b9775bc4e601fe1be8e514222e56ae782a897395..6288ffdaad147a10f25cce00c1382090
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index bec2507294e266dc16f810d0deb7b790dd0a6df0..3f9e3415db6cfee317da695793d295660ef29b18 100644
+index 2b0ba27fbded68270421f31037f71bb81f98d139..3f210da11885a292e999ede1f894ecf5f4930117 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1316,7 +1316,7 @@ public abstract class LivingEntity extends Entity {
@@ -44,7 +44,7 @@ index bec2507294e266dc16f810d0deb7b790dd0a6df0..3f9e3415db6cfee317da695793d29566
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2085,7 +2086,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2099,7 +2100,7 @@ public abstract class LivingEntity extends Entity {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0715-Make-EntityUnleashEvent-cancellable.patch
+++ b/patches/server/0715-Make-EntityUnleashEvent-cancellable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make EntityUnleashEvent cancellable
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 4a027c802ffa80f69cf2bc68f737a842fbfb0596..697c2663c4deeb8f2ad603c979ab0884ac027930 100644
+index 6604cd4c65abd591a93620a1928e7b2635f0a38e..0a559b658cd52a1cce2895c6d9f96aa665a85c7b 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1463,7 +1463,7 @@ public abstract class Mob extends LivingEntity {
+@@ -1465,7 +1465,7 @@ public abstract class Mob extends LivingEntity {
          if (flag1 && this.isLeashed()) {
              // Paper start - drop leash variable
              EntityUnleashEvent event = new EntityUnleashEvent(this.getBukkitEntity(), UnleashReason.UNKNOWN, true);

--- a/patches/server/0731-Add-critical-damage-API.patch
+++ b/patches/server/0731-Add-critical-damage-API.patch
@@ -72,10 +72,10 @@ index b436103957113bff5e553dacb869c775a3f8b059..3d3dcb47720055f550d17d1f106a2c0e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5013a93f9bdc6d2c52239ca0434c7aa40f0572e1..aaf47d3f58819ead3553973c159c5c6eec4abe43 100644
+index ee0e27500187d695ac6cfaf5fb5d2e844f230b32..c667baa2da8222eb66344c8f1cc0fed416c4df01 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -964,7 +964,7 @@ public class CraftEventFactory {
+@@ -970,7 +970,7 @@ public class CraftEventFactory {
                  } else {
                      damageCause = DamageCause.ENTITY_EXPLOSION;
                  }
@@ -84,7 +84,7 @@ index 5013a93f9bdc6d2c52239ca0434c7aa40f0572e1..aaf47d3f58819ead3553973c159c5c6e
              }
              event.setCancelled(cancelled);
  
-@@ -989,7 +989,7 @@ public class CraftEventFactory {
+@@ -995,7 +995,7 @@ public class CraftEventFactory {
                  cause = DamageCause.THORNS;
              }
  
@@ -93,7 +93,7 @@ index 5013a93f9bdc6d2c52239ca0434c7aa40f0572e1..aaf47d3f58819ead3553973c159c5c6e
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1044,7 +1044,7 @@ public class CraftEventFactory {
+@@ -1050,7 +1050,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index 5013a93f9bdc6d2c52239ca0434c7aa40f0572e1..aaf47d3f58819ead3553973c159c5c6e
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1087,20 +1087,28 @@ public class CraftEventFactory {
+@@ -1093,20 +1093,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0813-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0813-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3f9e3415db6cfee317da695793d295660ef29b18..62daf918d4ab00963041ca869ae718f14f2e3337 100644
+index 3f210da11885a292e999ede1f894ecf5f4930117..0c824a8c44cc9a2c848816450830b91d1199faff 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2570,14 +2570,27 @@ public abstract class LivingEntity extends Entity {
+@@ -2584,14 +2584,27 @@ public abstract class LivingEntity extends Entity {
          return this.hasEffect(MobEffects.JUMP) ? (double) (0.1F * (float) (this.getEffect(MobEffects.JUMP).getAmplifier() + 1)) : 0.0D;
      }
  

--- a/patches/server/0818-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0818-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,10 +34,10 @@ index 703ac671b19636859648f16a5431b2700791e7d5..d8ef6137133716b9ee519e6e4668d2e1
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 62daf918d4ab00963041ca869ae718f14f2e3337..0b8b959e9d51ada4779f88ceceda8c072b083cd5 100644
+index 0c824a8c44cc9a2c848816450830b91d1199faff..430d4e98134dce62d30ddb31fcb125a69571fa5a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3053,7 +3053,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3067,7 +3067,10 @@ public abstract class LivingEntity extends Entity {
          equipmentChanges.forEach((enumitemslot, itemstack) -> {
              ItemStack itemstack1 = itemstack.copy();
  
@@ -49,7 +49,7 @@ index 62daf918d4ab00963041ca869ae718f14f2e3337..0b8b959e9d51ada4779f88ceceda8c07
              switch (enumitemslot.getType()) {
                  case HAND:
                      this.setLastHandItem(enumitemslot, itemstack1);
-@@ -3066,6 +3069,34 @@ public abstract class LivingEntity extends Entity {
+@@ -3080,6 +3083,34 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0819-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0819-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,10 +36,10 @@ index d8ef6137133716b9ee519e6e4668d2e1ae5d9ca3..9a6c67b614944f841813ec2892381c33
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0b8b959e9d51ada4779f88ceceda8c072b083cd5..93b616d1b95e9c112dcd4b6fda9bd467177e6dec 100644
+index 430d4e98134dce62d30ddb31fcb125a69571fa5a..fe7e22d9a69d69dfcce63faa28e90945ea45fc49 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3055,7 +3055,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3069,7 +3069,7 @@ public abstract class LivingEntity extends Entity {
  
              // Paper start - prevent oversized data
              ItemStack toSend = sanitizeItemStack(itemstack1, true);
@@ -48,7 +48,7 @@ index 0b8b959e9d51ada4779f88ceceda8c072b083cd5..93b616d1b95e9c112dcd4b6fda9bd467
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3069,6 +3069,45 @@ public abstract class LivingEntity extends Entity {
+@@ -3083,6 +3083,45 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  


### PR DESCRIPTION
Fixes #3729 - fix advancement triggers having the correct entity equipment
Fixes #4252 - (same as above)
Fixes #6477 - don't reset entity equipment if event is cancelled.

So a much easier way to fix this, would be to just not have the advancement triggers cancellable by the entity death event, suggest that plugins use smth else to cancel those criteria being awarded, but I don't think thats in keeping with what the event is supposed to do, nor with existing behavior.