### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -2086,10 +2086,10 @@ index eea242af23825ad29ada6e997205e87edffb6bb9..3cf81734c8580f4d88ea97b6ac737a37
      public void setCustomName(String name) {
          // sane limit for name length
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 3a4e2261d0b0cd17df3f96e75f3c509156679c48..105d0388998d1e35e634d2163fe1a44aa7037ac8 100644
+index ea41fe964a707b31394e0f4701eb88e7227fa3a7..2e9fd45d52a915a6eab7e75f7d30f4bf3506078b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -316,9 +316,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -315,9 +315,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          container = CraftEventFactory.callInventoryOpenEvent(player, container);
          if (container == null) return;
  
@@ -2104,7 +2104,7 @@ index 3a4e2261d0b0cd17df3f96e75f3c509156679c48..105d0388998d1e35e634d2163fe1a44a
          getHandle().activeContainer = container;
          getHandle().activeContainer.addSlotListener(player);
      }
-@@ -387,8 +390,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -386,8 +389,12 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
  
          // Now open the window
          Containers<?> windowType = CraftContainer.getNotchInventoryType(inventory.getTopInventory());

--- a/Spigot-Server-Patches/0153-Shoulder-Entities-Release-API.patch
+++ b/Spigot-Server-Patches/0153-Shoulder-Entities-Release-API.patch
@@ -58,10 +58,10 @@ index ba26fc2405e17d582da971d03147fb1865e9b546..63e8062ae3f3407b92b72b5fccaa958c
      @Override
      public abstract boolean isSpectator();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 105d0388998d1e35e634d2163fe1a44aa7037ac8..8661f97ac885daca068057c1fcc4eed54c6d7f14 100644
+index 2e9fd45d52a915a6eab7e75f7d30f4bf3506078b..c13f04de0d22ddf51c1f0c26c72da6062c07d8cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -493,6 +493,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -492,6 +492,32 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          getHandle().getCooldownTracker().setCooldown(CraftMagicNumbers.getItem(material), ticks);
      }
  

--- a/Spigot-Server-Patches/0206-Add-method-to-open-already-placed-sign.patch
+++ b/Spigot-Server-Patches/0206-Add-method-to-open-already-placed-sign.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Add method to open already placed sign
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 8661f97ac885daca068057c1fcc4eed54c6d7f14..db7ad5a94d449f58a5749115776e61f448ff2f52 100644
+index c13f04de0d22ddf51c1f0c26c72da6062c07d8cf..16f907df4690098e6c45191963f1f98e2c505f82 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -30,6 +30,7 @@ import net.minecraft.world.level.block.BlockWorkbench;
+@@ -29,6 +29,7 @@ import net.minecraft.world.level.block.BlockEnchantmentTable;
+ import net.minecraft.world.level.block.BlockWorkbench;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.TileEntity;
- import net.minecraft.world.level.block.entity.TileEntityContainer;
 +import net.minecraft.world.level.block.entity.TileEntitySign;
  import net.minecraft.world.level.block.state.IBlockData;
  import org.bukkit.GameMode;
  import org.bukkit.Location;
-@@ -603,6 +604,17 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -602,6 +603,17 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          }
      }
  

--- a/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
+++ b/Spigot-Server-Patches/0233-InventoryCloseEvent-Reason-API.patch
@@ -152,10 +152,10 @@ index 3c49d7acd4ad0717886adf6c469e8a49a58e859b..b6effe1037f3ae59e6faa5f5d039b6ad
          this.activeContainer = this.defaultContainer;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index db7ad5a94d449f58a5749115776e61f448ff2f52..e8f8a07f256e01c5792199bf47f3cc1f0f3d1610 100644
+index 16f907df4690098e6c45191963f1f98e2c505f82..744cd929383ba56cd3435c8c092c8242b4e347e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -373,7 +373,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -372,7 +372,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          if (((EntityPlayer) getHandle()).playerConnection == null) return;
          if (getHandle().activeContainer != getHandle().defaultContainer) {
              // fire INVENTORY_CLOSE if one already open
@@ -164,7 +164,7 @@ index db7ad5a94d449f58a5749115776e61f448ff2f52..e8f8a07f256e01c5792199bf47f3cc1f
          }
          EntityPlayer player = (EntityPlayer) getHandle();
          Container container;
-@@ -443,8 +443,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -442,8 +442,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
  
      @Override
      public void closeInventory() {

--- a/Spigot-Server-Patches/0441-Prevent-opening-inventories-when-frozen.patch
+++ b/Spigot-Server-Patches/0441-Prevent-opening-inventories-when-frozen.patch
@@ -36,10 +36,10 @@ index 79003f43c4f15a7e5dd51587bc8c2f477bedb1b2..5382dfbad7a33670268d5d713cf3bdd4
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index e8f8a07f256e01c5792199bf47f3cc1f0f3d1610..5b142e96248278c6bb6068879bb5ad1578b0f79f 100644
+index 744cd929383ba56cd3435c8c092c8242b4e347e6..5e01ea53306acec8988aaccec62cd33e14156eef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -322,7 +322,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -321,7 +321,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          if (adventure$title == null) adventure$title = io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.deserialize(container.getBukkitView().getTitle()); // Paper
  
          //player.playerConnection.sendPacket(new PacketPlayOutOpenWindow(container.windowId, windowType, CraftChatMessage.fromString(title)[0])); // Paper // Paper - comment
@@ -48,7 +48,7 @@ index e8f8a07f256e01c5792199bf47f3cc1f0f3d1610..5b142e96248278c6bb6068879bb5ad15
          getHandle().activeContainer = container;
          getHandle().activeContainer.addSlotListener(player);
      }
-@@ -396,7 +396,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -395,7 +395,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          net.kyori.adventure.text.Component adventure$title = inventory.title(); // Paper
          if (adventure$title == null) adventure$title = io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.deserialize(inventory.getTitle()); // Paper
          //player.playerConnection.sendPacket(new PacketPlayOutOpenWindow(container.windowId, windowType, CraftChatMessage.fromString(title)[0])); // Paper - comment

--- a/Spigot-Server-Patches/0473-Potential-bed-API.patch
+++ b/Spigot-Server-Patches/0473-Potential-bed-API.patch
@@ -8,7 +8,7 @@ Adds a new method to fetch the location of a player's bed without generating any
 getPotentialBedLocation - Gets the last known location of a player's bed. This does not preform any check if the bed is still valid and does not load any chunks.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 5b142e96248278c6bb6068879bb5ad1578b0f79f..92501a415813b3b0f2be492a4711962320264a76 100644
+index 5e01ea53306acec8988aaccec62cd33e14156eef..6fa61912cf9e4632bf4e11bd252aa26100f27531 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -13,6 +13,7 @@ import net.minecraft.network.chat.IChatBaseComponent;
@@ -19,7 +19,7 @@ index 5b142e96248278c6bb6068879bb5ad1578b0f79f..92501a415813b3b0f2be492a47119623
  import net.minecraft.world.ITileInventory;
  import net.minecraft.world.entity.Entity;
  import net.minecraft.world.entity.EntityTypes;
-@@ -127,6 +128,22 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -126,6 +127,22 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          return getHandle().sleepTicks;
      }
  

--- a/Spigot-Server-Patches/0567-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/Spigot-Server-Patches/0567-Add-additional-open-container-api-to-HumanEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add additional open container api to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 92501a415813b3b0f2be492a4711962320264a76..b99423b3b413fc6364c6530a99e3c74dd406e1b4 100644
+index 6fa61912cf9e4632bf4e11bd252aa26100f27531..f13abfc93f6dbb22abc55d836c43c613d07d4c20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -458,6 +458,70 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -457,6 +457,70 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          return this.getHandle().activeContainer.getBukkitView();
      }
  

--- a/Spigot-Server-Patches/0706-add-isDeeplySleeping-to-HumanEntity.patch
+++ b/Spigot-Server-Patches/0706-add-isDeeplySleeping-to-HumanEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add isDeeplySleeping to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index b99423b3b413fc6364c6530a99e3c74dd406e1b4..f2b2db663198037ba4b7942815bfcd5ddd0e2a8d 100644
+index f13abfc93f6dbb22abc55d836c43c613d07d4c20..a5507f7907e211caff5c79650b26e116b0e64af2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-@@ -123,6 +123,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+@@ -122,6 +122,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
          }
      }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
59128434 SPIGOT-6478: Double chests opened by plugins don't play their closing animation.