### PR TITLE
Fix Cannot be adventure component serialized when the legacy component is null

### DIFF
--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -475,7 +475,7 @@ index 0000000000000000000000000000000000000000..caa9708f321f04cd02534161231c0599
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..c60457e9240c33a4721b82a00cef081fb320c8a7
+index 0000000000000000000000000000000000000000..e2d94a0e36be5b82c891acc1447287d119475c93
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -0,0 +1,344 @@
@@ -612,7 +612,7 @@ index 0000000000000000000000000000000000000000..c60457e9240c33a4721b82a00cef081f
 +    public static ArrayList<Component> asAdventure(final List<IChatBaseComponent> vanillas) {
 +        final ArrayList<Component> adventures = new ArrayList<>(vanillas.size());
 +        for (final IChatBaseComponent vanilla : vanillas) {
-+            adventures.add(asAdventure(vanilla));
++            adventures.add(vanilla == null ? Component.empty() : asAdventure(vanilla));
 +        }
 +        return adventures;
 +    }

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -475,7 +475,7 @@ index 0000000000000000000000000000000000000000..caa9708f321f04cd02534161231c0599
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2d94a0e36be5b82c891acc1447287d119475c93
+index 0000000000000000000000000000000000000000..7b14b3c2486f03778d4673cf9684aa576dc2724a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
 @@ -0,0 +1,344 @@
@@ -606,13 +606,13 @@ index 0000000000000000000000000000000000000000..e2d94a0e36be5b82c891acc1447287d1
 +    // Component
 +
 +    public static Component asAdventure(final IChatBaseComponent component) {
-+        return GSON.serializer().fromJson(IChatBaseComponent.ChatSerializer.toJsonTree(component), Component.class);
++        return component == null ? Component.empty() : GSON.serializer().fromJson(IChatBaseComponent.ChatSerializer.toJsonTree(component), Component.class);
 +    }
 +
 +    public static ArrayList<Component> asAdventure(final List<IChatBaseComponent> vanillas) {
 +        final ArrayList<Component> adventures = new ArrayList<>(vanillas.size());
 +        for (final IChatBaseComponent vanilla : vanillas) {
-+            adventures.add(vanilla == null ? Component.empty() : asAdventure(vanilla));
++            adventures.add(asAdventure(vanilla));
 +        }
 +        return adventures;
 +    }


### PR DESCRIPTION
I recently converted the map that was used in version 1.2.5(or 1.5.2) and a problem occurred a this problem.

```
[03:16:53 ERROR]: Could not pass event PlayerInteractEvent to caramelDaydreamTester v1.0-SNAPSHOT
java.lang.NullPointerException: input
        at java.util.Objects.requireNonNull(Objects.java:228) ~[?:1.8.0_282]
        at net.kyori.adventure.text.flattener.ComponentFlattenerImpl.flatten0(ComponentFlattenerImpl.java:79) ~[patched_1.16.5.jar:git-Paper-705]
        at net.kyori.adventure.text.flattener.ComponentFlattenerImpl.flatten(ComponentFlattenerImpl.java:75) ~[patched_1.16.5.jar:git-Paper-705]
        at net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializerImpl.serialize(LegacyComponentSerializerImpl.java:275) ~[patched_1.16.5.jar:git-Paper-705]
        at org.bukkit.craftbukkit.v1_16_R3.block.CraftSign.getLine(CraftSign.java:68) ~[patched_1.16.5.jar:git-Paper-705]
        at moe.caramel.daydreamtester.PlayerEvent.legacyTextTest(TestEvent.java:305) ~[?:?]
        ...
```


As shown in the picture below, very old NBT can have a null value.
If the value is null, this PR will return an empty component to solve the problem.

Normal NBT
![image](https://user-images.githubusercontent.com/45729082/120116252-46c40600-c1c2-11eb-9bd2-4216118179ef.png)

very very old... NBT
![image](https://user-images.githubusercontent.com/45729082/120116267-55aab880-c1c2-11eb-8562-feb5bea93583.png)


This may not be a good solution, but I think it's a good one to solve temporarily.
