### PR TITLE
Fix issue with soft despawn distance

### DIFF
--- a/Spigot-Server-Patches/0015-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/Spigot-Server-Patches/0015-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -30,10 +30,10 @@ index b41e7922dd96c3358eb849ab39982a75736e3476..2f0d582baf0eb2bb477944d0cb1369db
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index 28aa0a9361e8a32763d7fe1af060f0016e8c1e50..f93af56f68d5fd27eca38d333ca429ce22fc397b 100644
+index 28aa0a9361e8a32763d7fe1af060f0016e8c1e50..6e30fc88fa7a3ff00c9b4b78842c3a533649bd50 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-@@ -763,14 +763,14 @@ public abstract class EntityInsentient extends EntityLiving {
+@@ -763,16 +763,16 @@ public abstract class EntityInsentient extends EntityLiving {
                  int i = this.getEntityType().e().f();
                  int j = i * i;
  
@@ -48,5 +48,8 @@ index 28aa0a9361e8a32763d7fe1af060f0016e8c1e50..f93af56f68d5fd27eca38d333ca429ce
 -                if (this.ticksFarFromPlayer > 600 && this.random.nextInt(800) == 0 && d0 > (double) l) { // CraftBukkit - remove isTypeNotPersistent() check
 +                if (this.ticksFarFromPlayer > 600 && this.random.nextInt(800) == 0 && d0 > world.paperConfig.softDespawnDistance) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
                      this.die();
-                 } else if (d0 < (double) l) {
+-                } else if (d0 < (double) l) {
++                } else if (d0 < world.paperConfig.softDespawnDistance) { // Paper - custom despawn distances
                      this.ticksFarFromPlayer = 0;
+                 }
+             }


### PR DESCRIPTION
Previously setting the soft despawn distance above the default value of 32 would mean that an entity outside of the 32 range would still count `ticksFarFromPlayer` up every tick without resetting it which might lead to the entity (almost) instantly despawning once it went outside of the configured distance instead of waiting 600 ticks.