### PR TITLE
Fix PlayerItemCooldownEvent Async Exception

### DIFF
--- a/Spigot-Server-Patches/0603-Add-PlayerItemCooldownEvent.patch
+++ b/Spigot-Server-Patches/0603-Add-PlayerItemCooldownEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerItemCooldownEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemCooldownPlayer.java b/src/main/java/net/minecraft/world/item/ItemCooldownPlayer.java
-index 5f70e39f4da2880a6f734a225be83061b00847c8..ef9ffad211473f1cbcd0b8fd200ff04ec2051f94 100644
+index 5f70e39f4da2880a6f734a225be83061b00847c8..fa6e433c6d0d3995f03b2712beb91ecc5e30bd1a 100644
 --- a/src/main/java/net/minecraft/world/item/ItemCooldownPlayer.java
 +++ b/src/main/java/net/minecraft/world/item/ItemCooldownPlayer.java
-@@ -3,14 +3,26 @@ package net.minecraft.world.item;
+@@ -3,14 +3,43 @@ package net.minecraft.world.item;
  import net.minecraft.network.protocol.game.PacketPlayOutSetCooldown;
  import net.minecraft.server.level.EntityPlayer;
  
@@ -26,9 +26,26 @@ index 5f70e39f4da2880a6f734a225be83061b00847c8..ef9ffad211473f1cbcd0b8fd200ff04e
 +    // Paper start
 +    @Override
 +    public void setCooldown(Item item, int ticks) {
-+        PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(getEntityPlayer().getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), ticks);
-+        if (event.callEvent()) {
-+            super.setCooldown(item, event.getCooldown());
++        if (PlayerItemCooldownEvent.getHandlerList().getRegisteredListeners().length == 0) super.setCooldown(item, ticks);
++        else {
++            PlayerItemCooldownEvent event = new PlayerItemCooldownEvent(getEntityPlayer().getBukkitEntity(), org.bukkit.craftbukkit.util.CraftMagicNumbers.getMaterial(item), ticks);
++            if (this.getEntityPlayer().server.server.isPrimaryThread()) {
++                if (event.callEvent()) super.setCooldown(item, event.getCooldown());
++            } else {
++                org.bukkit.craftbukkit.util.Waitable<Boolean> waitable = new org.bukkit.craftbukkit.util.Waitable<Boolean>() {
++                    @Override
++                    protected Boolean evaluate() {
++                        return event.callEvent();
++                    }
++                };
++                this.getEntityPlayer().server.processQueue.add(waitable);
++
++                try {
++                    if (waitable.get()) super.setCooldown(item, event.getCooldown());
++                } catch (InterruptedException | java.util.concurrent.ExecutionException e) {
++                    throw new RuntimeException("Exception processing Async ItemCooldownEvent", e.getCause());
++                }
++            }
 +        }
 +    }
 +    // Paper end


### PR DESCRIPTION
I use the Player#setCooldown method to apply chat cooldown in AsyncChatEvent.

Since PlayerItemCooldownEvent was added, IllegalStateException was invoked each time Player#setCooldown was used in async state.
This PR solves this problem.


error log
```
[03:12:43] [Async Chat Thread - #0/ERROR]: Could not pass event AsyncChatEvent to caramelDaydreamTester v1.0-SNAPSHOT
java.lang.IllegalStateException: PlayerItemCooldownEvent may only be triggered synchronously.
	at org.bukkit.plugin.SimplePluginManager.callEvent(SimplePluginManager.java:607) ~[patched_1.16.5.jar:git-Paper-705]
	at org.bukkit.event.Event.callEvent(Event.java:45) ~[patched_1.16.5.jar:git-Paper-705]
	at net.minecraft.server.v1_16_R3.ItemCooldownPlayer.setCooldown(ItemCooldownPlayer.java:20) ~[patched_1.16.5.jar:git-Paper-705]
	at org.bukkit.craftbukkit.v1_16_R3.entity.CraftHumanEntity.setCooldown(CraftHumanEntity.java:587) ~[patched_1.16.5.jar:git-Paper-705]
	at moe.caramel.daydreamtester.PlayerEvent.onPlayerJoin(PlayerEvent.java:44) ~[?:?]
        ...
```

example code
```java
@EventHandler
public void onAsyncChat(AsyncChatEvent event) {
      event.getPlayer().setCooldown(Material.OAK_SIGN, 50);
}
```
