### PR TITLE
Better fix for invulnerable crystals and improve Origin API

### DIFF
--- a/Spigot-Server-Patches/0026-Entity-Origin-API.patch
+++ b/Spigot-Server-Patches/0026-Entity-Origin-API.patch
@@ -17,7 +17,7 @@ index 4f6f6f51f9807bafa88482c0fe776c8b163107d7..ce6572df63c4e7341708aee60330fb21
          if (i >= 0 && i < this.list.size()) {
              NBTBase nbtbase = (NBTBase) this.list.get(i);
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 4170743875d2fb16987e513713b2d141918219a5..701b00e65c4d5eb66e974f8d622eecef0f744f82 100644
+index cf38d517821659e25e786a805e229ef2d626d75f..26d461196b4a998b445f8c6e67fd7ec0606344f6 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -1246,6 +1246,11 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -33,7 +33,7 @@ index 4170743875d2fb16987e513713b2d141918219a5..701b00e65c4d5eb66e974f8d622eecef
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cae9da158f54438d2a397665c7ce964f6f755469..83006297e59971f4c358eacc3da586417982540c 100644
+index cae9da158f54438d2a397665c7ce964f6f755469..f6f0d551e22ff085935c1543bf84392de0368214 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -247,6 +247,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -44,33 +44,38 @@ index cae9da158f54438d2a397665c7ce964f6f755469..83006297e59971f4c358eacc3da58641
      // Spigot start
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
-@@ -1625,6 +1626,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1625,6 +1626,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  this.bukkitEntity.storeBukkitValues(nbttagcompound);
              }
              // CraftBukkit end
 +            // Paper start - Save the entity's origin location
 +            if (this.origin != null) {
++                nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
 +                nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
 +            }
 +            // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.a(throwable, "Saving entity NBT");
-@@ -1747,6 +1753,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1747,6 +1754,17 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
              // CraftBukkit end
  
 +            // Paper start - Restore the entity's origin location
 +            NBTTagList originTag = nbttagcompound.getList("Paper.Origin", 6);
 +            if (!originTag.isEmpty()) {
-+                origin = new org.bukkit.Location(world.getWorld(), originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
++                org.bukkit.World originWorld = world.getWorld();
++                if (nbttagcompound.hasKey("Paper.OriginWorld")) {
++                    originWorld = Bukkit.getWorld(nbttagcompound.getUUID("Paper.OriginWorld"));
++                }
++                origin = new org.bukkit.Location(originWorld, originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
 +            }
 +            // Paper end
 +
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.a(throwable, "Loading entity NBT");
              CrashReportSystemDetails crashreportsystemdetails = crashreport.a("Entity being loaded");
-@@ -1808,6 +1821,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1808,6 +1826,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      protected abstract void saveData(NBTTagCompound nbttagcompound);
  

--- a/Spigot-Server-Patches/0052-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0052-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601cc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 10cbf66f06b31c9a4cae2359b3fbb9988abb9278..40eb6bae8ca4e2b57d4f91547808eb00ac1fd455 100644
+index 77cc0aeb979369df2156f8fb916067f608b61ebf..caae8bdae592a1ae4f99861088458d7461f4c97a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2613,7 +2613,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2618,7 +2618,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  double d4 = DimensionManager.a(this.world.getDimensionManager(), worldserver.getDimensionManager());
                  BlockPosition blockposition = new BlockPosition(MathHelper.a(this.locX() * d4, d0, d2), this.locY(), MathHelper.a(this.locZ() * d4, d1, d3));
                  // CraftBukkit start

--- a/Spigot-Server-Patches/0057-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0057-Disable-Scoreboards-for-non-players-by-default.patch
@@ -25,10 +25,10 @@ index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb137166
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 40eb6bae8ca4e2b57d4f91547808eb00ac1fd455..b7df4d8eb3ccb9e8dc85898352f41c5c20abcb34 100644
+index caae8bdae592a1ae4f99861088458d7461f4c97a..bfced192c1e8fd3fa0250a0f93adfc061d7e71e5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2284,6 +2284,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2289,6 +2289,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      @Nullable
      public ScoreboardTeamBase getScoreboardTeam() {
@@ -37,7 +37,7 @@ index 40eb6bae8ca4e2b57d4f91547808eb00ac1fd455..b7df4d8eb3ccb9e8dc85898352f41c5c
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 3598db4144141a8701a2879be13a81a8ee48018c..318c96ee92fc8c6f5926aeadaa597d32ad590974 100644
+index 49e95369882847c90ee7417abea6270386cd622f..70211129e6ab2f7cdb975adcb532be595bc3834f 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -741,6 +741,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
@@ -32,7 +32,7 @@ index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..6eca3f300020006f02dd36253b522db4
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java b/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
-index f5227aa761d326376d057eaadcdbef024ed30241..44b79c97d5cc7570683e1b7f025b4f3ad65beb81 100644
+index beb0beb716869978be6bc5a78ce3b6cf785c5aee..e3cdea3c85d762af6984f3dbe544fdfe101f6ff6 100644
 --- a/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
 +++ b/src/main/java/net/minecraft/server/level/EntityTrackerEntry.java
 @@ -67,7 +67,7 @@ public class EntityTrackerEntry {
@@ -45,10 +45,10 @@ index f5227aa761d326376d057eaadcdbef024ed30241..44b79c97d5cc7570683e1b7f025b4f3a
      private java.util.Map<EntityPlayer, Boolean> trackedPlayerMap = null;
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f942d75982409f7640f073f9c77f8939225c6939..88ffc594a2ee7f8718337883609ad4c082f85f50 100644
+index 092ee75f9527af25a48ab052659e3304986b50e0..d314cdd9341e6aa5748a5b1afdd9569bec956c74 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2766,6 +2766,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2771,6 +2771,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean bV() {

--- a/Spigot-Server-Patches/0136-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/Spigot-Server-Patches/0136-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ee160558d84b24e1309262874a9d433bbe6593f3..49da1525cfc46743013bbac0528ec58501cab6eb 100644
+index d314cdd9341e6aa5748a5b1afdd9569bec956c74..00e79363b3f961111595c50758332f6c1c1b31bb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2041,6 +2041,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2046,6 +2046,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/Spigot-Server-Patches/0156-Entity-fromMobSpawner.patch
+++ b/Spigot-Server-Patches/0156-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b798190628c1d83b5bf9e5497b515ef1e9f26707..6b6de18e368d48b61482a7210794b756d805a460 100644
+index dcaf5c107bb77b63333f924a33961f9e5cad7082..43039c14e087259e3ce4b5091b887759b66fe52d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -268,6 +268,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -16,8 +16,8 @@ index b798190628c1d83b5bf9e5497b515ef1e9f26707..6b6de18e368d48b61482a7210794b756
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end
-@@ -1665,6 +1666,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-             if (this.origin != null) {
+@@ -1666,6 +1667,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
                  nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
              }
 +            // Save entity's from mob spawner status
@@ -27,9 +27,9 @@ index b798190628c1d83b5bf9e5497b515ef1e9f26707..6b6de18e368d48b61482a7210794b756
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -1793,6 +1798,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-             if (!originTag.isEmpty()) {
-                 origin = new org.bukkit.Location(world.getWorld(), originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
+@@ -1798,6 +1803,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 }
+                 origin = new org.bukkit.Location(originWorld, originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
              }
 +
 +            spawnedViaMobSpawner = nbttagcompound.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/Spigot-Server-Patches/0240-add-more-information-to-Entity.toString.patch
+++ b/Spigot-Server-Patches/0240-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 828f238e8f3b1a98310532e07c72161582c91c5b..bd9cd050c72792c3d5a2094991b21e3a998b2cd9 100644
+index 43039c14e087259e3ce4b5091b887759b66fe52d..f15c60e56fc32a7dd525eefb2d622c33e00037c7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2522,7 +2522,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2527,7 +2527,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public String toString() {

--- a/Spigot-Server-Patches/0279-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0279-Improve-death-events.patch
@@ -78,7 +78,7 @@ index f6f79ed9c38206cc6a4feb5504e854a476868aec..7d2b947b3c2b255c01241f2c4a6d7377
          int i = this.f ? 300 : 100;
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 046b191e771ed9be337e095214a67febd768e5f6..b6b4eb9ac883cfdfab5f114767fb5cfb29445730 100644
+index 37497d7ff04b84d4758997970dbdbf88b40d0493..28390d3830ed9f3f5d97ab38913e6c40f9943a70 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1538,6 +1538,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -89,7 +89,7 @@ index 046b191e771ed9be337e095214a67febd768e5f6..b6b4eb9ac883cfdfab5f114767fb5cfb
      public void a(Entity entity, int i, DamageSource damagesource) {
          if (entity instanceof EntityPlayer) {
              CriterionTriggers.c.a((EntityPlayer) entity, this, damagesource);
-@@ -2437,6 +2438,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2442,6 +2443,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.fallDistance = 0.0F;
      }
  

--- a/Spigot-Server-Patches/0303-Reset-players-airTicks-on-respawn.patch
+++ b/Spigot-Server-Patches/0303-Reset-players-airTicks-on-respawn.patch
@@ -17,10 +17,10 @@ index f5be9554e1fd01a35b926196b30fd64f1567a799..3e7ac6699ad1f147220c286e251ce0ec
          this.fallDistance = 0;
          this.foodData = new FoodMetaData(this);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b6b4eb9ac883cfdfab5f114767fb5cfb29445730..0b61d03506bd56cf7e373daacbf4fb2e29bb0a58 100644
+index 28390d3830ed9f3f5d97ab38913e6c40f9943a70..2292295bac55651850b5e033f1ca9819bb7fa96f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2350,6 +2350,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2355,6 +2355,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  

--- a/Spigot-Server-Patches/0315-force-entity-dismount-during-teleportation.patch
+++ b/Spigot-Server-Patches/0315-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 3e7ac6699ad1f147220c286e251ce0ec1ca25035..e755191435e74246b309f8fe5a668dae
  
          if (entity1 != entity && this.playerConnection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449fb667016f 100644
+index 2292295bac55651850b5e033f1ca9819bb7fa96f..af38b81df3f60163cafc341543ecad0865225943 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2040,12 +2040,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2045,12 +2045,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  
@@ -62,7 +62,7 @@ index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449f
          }
  
      }
-@@ -2100,7 +2103,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2105,7 +2108,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449f
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2110,7 +2116,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2115,7 +2121,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              if (getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) getBukkitEntity(),
@@ -83,7 +83,7 @@ index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449f
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2124,7 +2130,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2129,7 +2135,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
              // CraftBukkit end
              // Spigot start
@@ -93,7 +93,7 @@ index 0b61d03506bd56cf7e373daacbf4fb2e29bb0a58..1e5930f5ae75b82abf6ea2a50558449f
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index b3c2976a48c2349e5c22d58dd1ac64a02cd969d5..6ada2fe58966553b52a8a890088c78d5ea0dfd73 100644
+index e20acbd904f12e9036cb0565d6aa9a3f63008d43..32a2d6fd22ba69694a2f620174f618a95964074d 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -3015,11 +3015,13 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0334-Add-LivingEntity-getTargetEntity.patch
+++ b/Spigot-Server-Patches/0334-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1e5930f5ae75b82abf6ea2a50558449fb667016f..e9b535622d6c33083c575ee4691598014dba0e2c 100644
+index af38b81df3f60163cafc341543ecad0865225943..413f715c98dc0a0953e60032ad1ebef2b0b3bbe3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1504,6 +1504,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -16,7 +16,7 @@ index 1e5930f5ae75b82abf6ea2a50558449fb667016f..e9b535622d6c33083c575ee469159801
      public final Vec3D j(float f) {
          if (f == 1.0F) {
              return new Vec3D(this.locX(), this.getHeadY(), this.locZ());
-@@ -2149,6 +2150,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2154,6 +2155,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.getPassengers().size() < 1;
      }
  
@@ -128,7 +128,7 @@ index 3941dd33da4b5c09d0087143f1d8a2d76fc18792..62513c812b497bb9d8dafe1d9c2f5740
          double[] adouble = new double[]{1.0D};
          double d0 = vec3d1.x - vec3d.x;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c692626b747008a5418ecabf550fc67e3b676f5b..ff586b8366a6298f1906551b068e8abb26fcabc7 100644
+index 194583522c53ae838dfc0ccfa49f906c1a628984..db5d9a8107babd42200f911d2b8ebdc15b4d7c8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -1,6 +1,7 @@

--- a/Spigot-Server-Patches/0336-Entity-getEntitySpawnReason.patch
+++ b/Spigot-Server-Patches/0336-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index 1ae969aff1d44ad9af28fc94d8821884b9ad0563..47aa69dfe43390b811c264adc0af1d01
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e9b535622d6c33083c575ee4691598014dba0e2c..cbdd75feb7250e771111184b1fac7c4a6bf6e575 100644
+index 413f715c98dc0a0953e60032ad1ebef2b0b3bbe3..712c81fe2cf6da6b80fea21fd6c3d0e0adc5a35a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -63,6 +63,8 @@ import net.minecraft.world.EnumHand;
@@ -55,8 +55,8 @@ index e9b535622d6c33083c575ee4691598014dba0e2c..cbdd75feb7250e771111184b1fac7c4a
      // Paper end
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
-@@ -1673,6 +1676,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-             if (this.origin != null) {
+@@ -1674,6 +1677,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
                  nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
              }
 +            if (spawnReason != null) {
@@ -65,7 +65,7 @@ index e9b535622d6c33083c575ee4691598014dba0e2c..cbdd75feb7250e771111184b1fac7c4a
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbttagcompound.setBoolean("Paper.FromMobSpawner", true);
-@@ -1807,6 +1813,26 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1812,6 +1818,26 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              spawnedViaMobSpawner = nbttagcompound.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
@@ -224,10 +224,10 @@ index 4e26db120e544d8867d895395241e425f23f575b..fbff779fa581a661cc03850bffa0da34
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cbdd75feb7250e771111184b1fac7c4a6bf6e575..5acf61ece9ca38a262387fd0395bd464312501fd 100644
+index 712c81fe2cf6da6b80fea21fd6c3d0e0adc5a35a..efa8d9a16e87475adf7e71a0dfa2861653f73c06 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2799,6 +2799,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2804,6 +2804,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          });
      }
  

--- a/Spigot-Server-Patches/0400-Entity-Activation-Range-2.0.patch
+++ b/Spigot-Server-Patches/0400-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/WorldServer.java b/src/main/java/net/minecraft/server/level/WorldServer.java
-index 6cbf8d00da6d99719f9ece14aa46c0abf38666e3..fda19e1639cfbae00c8ba946b41c16faa09acbd5 100644
+index de4e0477c5c777ce9ac601f88d24f2dd2786eb6f..17c6118fb1ea1f16d37eb13116e11f886274ba95 100644
 --- a/src/main/java/net/minecraft/server/level/WorldServer.java
 +++ b/src/main/java/net/minecraft/server/level/WorldServer.java
 @@ -861,17 +861,17 @@ public class WorldServer extends World implements GeneratorAccessSeed {
@@ -105,7 +105,7 @@ index 6cbf8d00da6d99719f9ece14aa46c0abf38666e3..fda19e1639cfbae00c8ba946b41c16fa
              }
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5acf61ece9ca38a262387fd0395bd464312501fd..bc136276cad4e87d8658072b2f62f608670f39ca 100644
+index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f4399f9f39f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -68,6 +68,7 @@ import net.minecraft.world.entity.animal.EntityFish;
@@ -155,7 +155,7 @@ index 5acf61ece9ca38a262387fd0395bd464312501fd..bc136276cad4e87d8658072b2f62f608
  
              vec3d = this.a(vec3d, enummovetype);
              Vec3D vec3d1 = this.g(vec3d);
-@@ -2007,6 +2017,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2012,6 +2022,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          }
      }
  
@@ -163,7 +163,7 @@ index 5acf61ece9ca38a262387fd0395bd464312501fd..bc136276cad4e87d8658072b2f62f608
      public void k(Entity entity) {
          this.a(entity, Entity::setPosition);
      }
-@@ -2817,6 +2828,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2822,6 +2833,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.ae;
      }
  
@@ -184,7 +184,7 @@ index a9322e7cd8e07a2d5578c861991d53ec85fbfbcc..bbf0f345bfdd8a3a1f7fe902a42b2b18
      protected EntityCreature(EntityTypes<? extends EntityCreature> entitytypes, World world) {
          super(entitytypes, world);
 diff --git a/src/main/java/net/minecraft/world/entity/EntityInsentient.java b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
-index db72b685f4a4b95f345f1d34f9eeb83b8731120a..89d24d7532a256434513a45c901946e28db396bd 100644
+index 0489fb4869c9a0b56df6f44ef3925de7651baef2..da190d0b21098e327fab42e79a4ae18629bcf6e5 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityInsentient.java
 @@ -115,7 +115,7 @@ public abstract class EntityInsentient extends EntityLiving {
@@ -217,7 +217,7 @@ index db72b685f4a4b95f345f1d34f9eeb83b8731120a..89d24d7532a256434513a45c901946e2
          if (this.isPassenger() && this.getVehicle() instanceof EntityInsentient) {
              EntityInsentient entityinsentient = (EntityInsentient) this.getVehicle();
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index f851a9806e3b936093275cf404caca82c6662ab4..02d3b792cc9769b5daa6fcac57f5cda320a2a29e 100644
+index 6a81aa44d2acde7575e0ed74ea8bf4070739f10e..ffb4072f46456b3a2b2daa55947787cee774d26d 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -192,7 +192,7 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0401-Fix-items-vanishing-through-end-portal.patch
+++ b/Spigot-Server-Patches/0401-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bc136276cad4e87d8658072b2f62f608670f39ca..d676eaad8179cdeae410038e58ddafe0fe541ccc 100644
+index 32dad0b72ee0d0a1ac30decb0fb52f4399f9f39f..b1495da5fdead24caf9e936a385d97fd2db2a0cc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2730,6 +2730,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2735,6 +2735,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              BlockPosition blockposition1;
  
              if (flag1) {

--- a/Spigot-Server-Patches/0408-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0408-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -19,7 +19,7 @@ index 7fbd501d70dccf869a4454e2789a5d68f2e15754..9e4591ddc4b755f4ff5a6f1078b51cb1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d676eaad8179cdeae410038e58ddafe0fe541ccc..68fdb01c3f11c3b060d3d621099d67f6b29431d6 100644
+index b1495da5fdead24caf9e936a385d97fd2db2a0cc..334d60c71fa13841f9d04af5404cc25acbc0ec76 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -278,6 +278,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -30,7 +30,7 @@ index d676eaad8179cdeae410038e58ddafe0fe541ccc..68fdb01c3f11c3b060d3d621099d67f6
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end
-@@ -1693,6 +1694,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1694,6 +1695,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              if (spawnedViaMobSpawner) {
                  nbttagcompound.setBoolean("Paper.FromMobSpawner", true);
              }
@@ -40,7 +40,7 @@ index d676eaad8179cdeae410038e58ddafe0fe541ccc..68fdb01c3f11c3b060d3d621099d67f6
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -1823,6 +1827,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1828,6 +1832,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              spawnedViaMobSpawner = nbttagcompound.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/Spigot-Server-Patches/0452-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/Spigot-Server-Patches/0452-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8ca7012264528f17ac2e4f15ced96c774fa566d7..675d0cb32efc99f66c4d2b000bf49cf1c065a5e2 100644
+index 896b4d016de78e98276d7cdf9328d8951572e3be..fbd473d39cd71510b5fe8b7a4d34d3b824301f73 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1808,9 +1808,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1809,9 +1809,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                      bworld = server.getWorld(worldName);
                  }
  

--- a/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 675d0cb32efc99f66c4d2b000bf49cf1c065a5e2..cb5c93dca3b947462b89f79c60c7562085684b87 100644
+index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a19249ffec 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1969,11 +1969,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1974,11 +1974,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof EntityLiving && !((EntityLiving) this).forceDrops) {
@@ -34,7 +34,7 @@ index 675d0cb32efc99f66c4d2b000bf49cf1c065a5e2..cb5c93dca3b947462b89f79c60c75620
  
              entityitem.defaultPickupDelay();
              // CraftBukkit start
-@@ -2621,6 +2622,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2626,6 +2627,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      @Nullable
      public Entity teleportTo(WorldServer worldserver, BlockPosition location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 675d0cb32efc99f66c4d2b000bf49cf1c065a5e2..cb5c93dca3b947462b89f79c60c75620
          if (this.world instanceof WorldServer && !this.dead) {
              this.world.getMethodProfiler().enter("changeDimension");
              // CraftBukkit start
-@@ -2641,6 +2648,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2646,6 +2653,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  // CraftBukkit end
  
                  this.world.getMethodProfiler().exitEnter("reloading");
@@ -59,7 +59,7 @@ index 675d0cb32efc99f66c4d2b000bf49cf1c065a5e2..cb5c93dca3b947462b89f79c60c75620
                  Entity entity = this.getEntityType().a((World) worldserver);
  
                  if (entity != null) {
-@@ -2654,10 +2666,6 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2659,10 +2671,6 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 675d0cb32efc99f66c4d2b000bf49cf1c065a5e2..cb5c93dca3b947462b89f79c60c75620
                      // CraftBukkit end
                  }
  
-@@ -2782,7 +2790,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2787,7 +2795,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean canPortal() {

--- a/Spigot-Server-Patches/0506-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/Spigot-Server-Patches/0506-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index da2b5bfd3966ded2d5dde0d65646583576a088c5..c50b89ee8f16821923933025bf19243771dd1604 100644
+index b244f5d204938452ea19335947830de47336bbd4..8151403b2a7f5f8441c6810d1bd2bf3df4cefa80 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -66,6 +66,7 @@ import net.minecraft.world.INamableTileEntity;
@@ -25,7 +25,7 @@ index da2b5bfd3966ded2d5dde0d65646583576a088c5..c50b89ee8f16821923933025bf192437
          if (valid) ((WorldServer) world).chunkCheck(this); // CraftBukkit
      }
  
-@@ -2994,6 +2995,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2999,6 +3000,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return new AxisAlignedBB(vec3d, vec3d1);
      }
  
@@ -33,7 +33,7 @@ index da2b5bfd3966ded2d5dde0d65646583576a088c5..c50b89ee8f16821923933025bf192437
      public void a(AxisAlignedBB axisalignedbb) {
          // CraftBukkit start - block invalid bounding boxes
          double minX = axisalignedbb.minX,
-@@ -3432,6 +3434,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3437,6 +3439,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public void setPositionRaw(double d0, double d1, double d2) {

--- a/Spigot-Server-Patches/0571-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-Server-Patches/0571-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 344862c3f479ae7b6d4f929c9ef7882aba983ffb..e2301dbeb3d76684b2a0ab4262bb76cab3557789 100644
+index a1fb19d45ee3809ee6a515669ba64ea45b31428c..9b6e5f279a22efc2d015e2d31076a8c06e6b3886 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3473,4 +3473,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3478,4 +3478,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
          void accept(Entity entity, double d0, double d1, double d2);
      }

--- a/Spigot-Server-Patches/0573-Entity-isTicking.patch
+++ b/Spigot-Server-Patches/0573-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e2301dbeb3d76684b2a0ab4262bb76cab3557789..f1fa11217ab09133f4f19f5c73dfdab2f2b434e2 100644
+index 9b6e5f279a22efc2d015e2d31076a8c06e6b3886..d072e3fb26f32db80be68f0e23526e34f57ff331 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -48,6 +48,7 @@ import net.minecraft.resources.MinecraftKey;
@@ -16,7 +16,7 @@ index e2301dbeb3d76684b2a0ab4262bb76cab3557789..f1fa11217ab09133f4f19f5c73dfdab2
  import net.minecraft.server.level.EntityPlayer;
  import net.minecraft.server.level.PlayerChunkMap;
  import net.minecraft.server.level.TicketType;
-@@ -3478,5 +3479,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3483,5 +3484,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public static int nextEntityId() {
          return entityCount.incrementAndGet();
      }

--- a/Spigot-Server-Patches/0576-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0576-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CME on adding a passenger in CreatureSpawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f1fa11217ab09133f4f19f5c73dfdab2f2b434e2..2a3025793db52a18e58f832c9da78c6c3b39d33c 100644
+index d072e3fb26f32db80be68f0e23526e34f57ff331..0841cf7e968a8a3b577e91f6dcd0487169474329 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3177,7 +3177,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3182,7 +3182,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public Stream<Entity> recursiveStream() {

--- a/Spigot-Server-Patches/0677-do-not-create-unnecessary-copies-of-passenger-list.patch
+++ b/Spigot-Server-Patches/0677-do-not-create-unnecessary-copies-of-passenger-list.patch
@@ -57,10 +57,10 @@ index 169fa174f86f8a8dc42d3b9c4954a39d0a738c06..6835401bd7863bbd655502547a9fd4ae
              }
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da676468bc 100644
+index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1c6e17e8e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2230,7 +2230,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2235,7 +2235,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      protected boolean q(Entity entity) {
@@ -69,7 +69,7 @@ index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da
      }
  
      public final float getCollisionBorderSize() { return bg(); } // Paper - OBFHELPER
-@@ -2326,7 +2326,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2331,7 +2331,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean isVehicle() {
@@ -78,7 +78,7 @@ index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da
      }
  
      public boolean bt() {
-@@ -3138,7 +3138,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3143,7 +3143,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean w(Entity entity) {
@@ -87,7 +87,7 @@ index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da
  
          Entity entity1;
  
-@@ -3154,7 +3154,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3159,7 +3159,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean a(Class<? extends Entity> oclass) {
@@ -96,7 +96,7 @@ index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da
  
          Entity entity;
  
-@@ -3171,7 +3171,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3176,7 +3176,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      public Collection<Entity> getAllPassengers() {
          Set<Entity> set = Sets.newHashSet();
@@ -105,7 +105,7 @@ index 7abeeefeb579a43bc9ee85fd4150afacfb11c802..429f0591c6a55f6c5d08a0755f7d39da
  
          while (iterator.hasNext()) {
              Entity entity = (Entity) iterator.next();
-@@ -3197,7 +3197,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3202,7 +3202,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      private void a(boolean flag, Set<Entity> set) {
          Entity entity;
  

--- a/Spigot-Server-Patches/0752-Fix-invulnerable-end-crystals.patch
+++ b/Spigot-Server-Patches/0752-Fix-invulnerable-end-crystals.patch
@@ -1,5 +1,5 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Jake Potrebic <jake.m.potrebic@gmail.com>
+From: Max Lee <max@themoep.de>
 Date: Thu, 27 May 2021 14:52:30 -0700
 Subject: [PATCH] Fix invulnerable end crystals
 
@@ -19,34 +19,54 @@ index 25db335f457eefd13798394ebfb6b6684be26610..5c91c007691efeea1d4383efcd1ca069
 +        fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
 +    }
  }
-diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java b/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
-index 0ab6319aa3e4e1f5679f37be36999ca56ca2484c..558216ea96bcdc34ffa595c848151278c33b5ca1 100644
---- a/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
-+++ b/src/main/java/net/minecraft/world/level/dimension/end/EnderDragonBattle.java
-@@ -570,6 +570,7 @@ public class EnderDragonBattle {
+diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EntityEnderCrystal.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EntityEnderCrystal.java
+index 9658d93615a51375204481cfe0a1fce6f105fd70..5d48c2640f776c9e29598e19afe779ed6997acfc 100644
+--- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EntityEnderCrystal.java
++++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EntityEnderCrystal.java
+@@ -30,6 +30,7 @@ public class EntityEnderCrystal extends Entity {
+     private static final DataWatcherObject<Optional<BlockPosition>> c = DataWatcher.a(EntityEnderCrystal.class, DataWatcherRegistry.m);
+     private static final DataWatcherObject<Boolean> d = DataWatcher.a(EntityEnderCrystal.class, DataWatcherRegistry.i);
+     public int b;
++    public boolean generatedByDragonFight = false; // Paper - Fix invulnerable end crystals
  
-         while (iterator.hasNext()) {
-             WorldGenEnder.Spike worldgenender_spike = (WorldGenEnder.Spike) iterator.next();
-+            if (!this.world.paperConfig.fixInvulnerableEndCrystalExploit || worldgenender_spike.crystal == null) { // Paper
-             List<EntityEnderCrystal> list = this.world.a(EntityEnderCrystal.class, worldgenender_spike.f());
-             Iterator iterator1 = list.iterator();
- 
-@@ -579,6 +580,13 @@ public class EnderDragonBattle {
-                 entityendercrystal.setInvulnerable(false);
-                 entityendercrystal.setBeamTarget((BlockPosition) null);
+     public EntityEnderCrystal(EntityTypes<? extends EntityEnderCrystal> entitytypes, World world) {
+         super(entitytypes, world);
+@@ -66,6 +67,17 @@ public class EntityEnderCrystal extends Entity {
+                 }
+                 // CraftBukkit end
              }
-+            // Paper start
-+            } else {
-+                worldgenender_spike.crystal.setInvulnerable(false);
-+                worldgenender_spike.crystal.setBeamTarget(null);
-+                worldgenender_spike.crystal = null;
++            // Paper start - Fix invulnerable end crystals
++            if (this.world.paperConfig.fixInvulnerableEndCrystalExploit && this.generatedByDragonFight && this.isInvulnerable()) {
++                if ((this.origin.getWorld() != null && !((WorldServer) this.world).uuid.equals(this.origin.getWorld().getUID()))
++                    || ((WorldServer) this.world).getDragonBattle() == null
++                    || ((WorldServer) this.world).getDragonBattle().respawnPhase == null
++                    || ((WorldServer) this.world).getDragonBattle().respawnPhase.ordinal() > net.minecraft.world.level.dimension.end.EnumDragonRespawn.SUMMONING_DRAGON.ordinal()) {
++                    this.setInvulnerable(false);
++                    this.setBeamTarget(null);
++                }
 +            }
 +            // Paper end
          }
  
      }
+@@ -77,6 +89,7 @@ public class EntityEnderCrystal extends Entity {
+         }
+ 
+         nbttagcompound.setBoolean("ShowBottom", this.isShowingBottom());
++        if (this.generatedByDragonFight) nbttagcompound.setBoolean("Paper.GeneratedByDragonFight", this.generatedByDragonFight); // Paper - Fix invulnerable end crystals
+     }
+ 
+     @Override
+@@ -88,6 +101,7 @@ public class EntityEnderCrystal extends Entity {
+         if (nbttagcompound.hasKeyOfType("ShowBottom", 1)) {
+             this.setShowingBottom(nbttagcompound.getBoolean("ShowBottom"));
+         }
++        if (nbttagcompound.hasKeyOfType("Paper.GeneratedByDragonFight", 1)) this.generatedByDragonFight = nbttagcompound.getBoolean("Paper.GeneratedByDragonFight"); // Paper - Fix invulnerable end crystals
+ 
+     }
+ 
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/feature/WorldGenEnder.java b/src/main/java/net/minecraft/world/level/levelgen/feature/WorldGenEnder.java
-index dd623702131eaa1a65937a19a0e986e865322258..1960fc029262d54c6a5ee05c99d86428386cba4a 100644
+index dd623702131eaa1a65937a19a0e986e865322258..1bf09c99ba318813755ea3d3456d0fbb60847e5c 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/feature/WorldGenEnder.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/feature/WorldGenEnder.java
 @@ -42,7 +42,7 @@ public class WorldGenEnder extends WorldGenerator<WorldGenFeatureEndSpikeConfigu
@@ -58,19 +78,11 @@ index dd623702131eaa1a65937a19a0e986e865322258..1960fc029262d54c6a5ee05c99d86428
          List<WorldGenEnder.Spike> list = worldgenfeatureendspikeconfiguration.c();
  
          if (list.isEmpty()) {
-@@ -107,6 +107,7 @@ public class WorldGenEnder extends WorldGenerator<WorldGenFeatureEndSpikeConfigu
+@@ -106,6 +106,7 @@ public class WorldGenEnder extends WorldGenerator<WorldGenFeatureEndSpikeConfigu
+         entityendercrystal.setBeamTarget(worldgenfeatureendspikeconfiguration.d());
          entityendercrystal.setInvulnerable(worldgenfeatureendspikeconfiguration.b());
          entityendercrystal.setPositionRotation((double) worldgenender_spike.a() + 0.5D, (double) (worldgenender_spike.d() + 1), (double) worldgenender_spike.b() + 0.5D, random.nextFloat() * 360.0F, 0.0F);
++        entityendercrystal.generatedByDragonFight = true;
          worldaccess.addEntity(entityendercrystal);
-+        worldgenender_spike.crystal = entityendercrystal; // Paper
          this.a(worldaccess, new BlockPosition(worldgenender_spike.a(), worldgenender_spike.d(), worldgenender_spike.b()), Blocks.BEDROCK.getBlockData());
      }
- 
-@@ -156,6 +157,7 @@ public class WorldGenEnder extends WorldGenerator<WorldGenFeatureEndSpikeConfigu
-         private final int e;
-         private final boolean f;
-         private final AxisAlignedBB g;
-+        public EntityEnderCrystal crystal; // Paper
- 
-         public Spike(int i, int j, int k, int l, boolean flag) {
-             this.b = i;

--- a/Spigot-Server-Patches/0755-Fix-dangerous-end-portal-logic.patch
+++ b/Spigot-Server-Patches/0755-Fix-dangerous-end-portal-logic.patch
@@ -23,7 +23,7 @@ index 558af73ac16550ee6964c4dce681a404633b2552..75bcfb3a2b4a104aeebb2fe3298714b2
      public Entity b(WorldServer worldserver, PlayerTeleportEvent.TeleportCause cause) {
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6fdcd96fd75cd63d769b012827519f554af4cf54..8ef41182056052686055b7eb88ab19c161e84ed4 100644
+index 89b2be0e9e42d65b7d2d2833de4e6cd1c6e17e8e..6e1304f7169c11f67c573b2c8dc11825bcc7da0d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -314,6 +314,37 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -64,7 +64,7 @@ index 6fdcd96fd75cd63d769b012827519f554af4cf54..8ef41182056052686055b7eb88ab19c1
      public Entity(EntityTypes<?> entitytypes, World world) {
          this.id = Entity.entityCount.incrementAndGet();
          this.passengers = Lists.newArrayList();
-@@ -2294,6 +2325,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2299,6 +2330,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              this.E();


### PR DESCRIPTION
This implements a better fix for the invulnerable end crystals exploit by storing whether or not a crystal was created by the ender dragon battle and resetting the crystal properties if the dragon battle is not in the correct phase anymore or if the crystal was somehow moved to a different world.

In order to check the world properly this also fixes that the entity origin location did not store the correct world but simply used the current world the entity was added to which made it impossible before to check if the entity was moved to a different world.