### PR TITLE
Reset villager inventory on cancelled pickup event (again) (#5766) (Fixes #5765)

### DIFF
--- a/Spigot-Server-Patches/0754-Reset-villager-inventory-on-cancelled-pickup-event.patch
+++ b/Spigot-Server-Patches/0754-Reset-villager-inventory-on-cancelled-pickup-event.patch
@@ -1,0 +1,62 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Tue, 1 Jun 2021 22:05:08 -0500
+Subject: [PATCH] Reset villager inventory on cancelled pickup event
+
+
+diff --git a/src/main/java/net/minecraft/world/InventorySubcontainer.java b/src/main/java/net/minecraft/world/InventorySubcontainer.java
+index 6bbecc5ae98b4e3b480e89139354e5861eda344d..fc18c6c3d4b970552d2fdb64d4225ab1924ddf8f 100644
+--- a/src/main/java/net/minecraft/world/InventorySubcontainer.java
++++ b/src/main/java/net/minecraft/world/InventorySubcontainer.java
+@@ -34,6 +34,16 @@ public class InventorySubcontainer implements IInventory, AutoRecipeOutput {
+         return this.items;
+     }
+ 
++    // Paper start
++    public void setContents(List<ItemStack> items) {
++        this.items.clear();
++        for(int i = 0; i < items.size(); i++) {
++            this.items.set(i, items.get(i));
++        }
++        this.update();
++    }
++    // Paper end
++
+     public void onOpen(CraftHumanEntity who) {
+         transaction.add(who);
+     }
+@@ -146,6 +156,7 @@ public class InventorySubcontainer implements IInventory, AutoRecipeOutput {
+         return itemstack;
+     }
+ 
++    public ItemStack addItem(ItemStack itemstack) { return a(itemstack); } // Paper - OBFHELPER
+     public ItemStack a(ItemStack itemstack) {
+         ItemStack itemstack1 = itemstack.cloneItemStack();
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java b/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
+index c29f05b6fd0664345d8d09f898777a3e44f866c4..85374ac8f5460790de03b47d7c3ce19ed5596afe 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
+@@ -845,15 +845,19 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation
+             }
+ 
+             // CraftBukkit start
+-            ItemStack remaining = new InventorySubcontainer(inventorysubcontainer).a(itemstack);
+-            if (CraftEventFactory.callEntityPickupItemEvent(this, entityitem, remaining.getCount(), false).isCancelled()) {
++            // Paper start
++            List<ItemStack> contentsSnapshot = new java.util.ArrayList<>(inventorysubcontainer.getContents());
++            ItemStack itemstack1 = inventorysubcontainer.addItem(itemstack);
++            if (CraftEventFactory.callEntityPickupItemEvent(this, entityitem, itemstack1.getCount(), false).isCancelled()) {
++                inventorysubcontainer.setContents(contentsSnapshot);
++                // Paper end
+                 return;
+             }
+             // CraftBukkit end
+ 
+             this.a(entityitem);
+             this.receive(entityitem, itemstack.getCount());
+-            ItemStack itemstack1 = inventorysubcontainer.a(itemstack);
++            // ItemStack itemstack1 = inventorysubcontainer.a(itemstack); // Paper - moved up
+ 
+             if (itemstack1.isEmpty()) {
+                 entityitem.die();


### PR DESCRIPTION
Spigot's implementation broke this fix, and actually made it worse. Putting back my original fix that is known to work.

Fixes #5765 