### PR TITLE
Improve behaviour of chat events original message 

### DIFF
--- a/Spigot-API-Patches/0005-Adventure.patch
+++ b/Spigot-API-Patches/0005-Adventure.patch
@@ -255,10 +255,10 @@ index 0000000000000000000000000000000000000000..85fd5d6777b53bab09cc54c360bb7514
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java b/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..dc6db537ceba0baf6e7cc532cfb58290b241e096
+index 0000000000000000000000000000000000000000..718b860ace4077affad715a4e43961e10a83e9d9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AbstractChatEvent.java
-@@ -0,0 +1,273 @@
+@@ -0,0 +1,299 @@
 +package io.papermc.paper.event.player;
 +
 +import io.papermc.paper.chat.ChatComposer;
@@ -292,6 +292,19 @@ index 0000000000000000000000000000000000000000..dc6db537ceba0baf6e7cc532cfb58290
 +    private final Component originalMessage;
 +    private Component message;
 +
++    AbstractChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(player, async);
++        this.viewers = viewers;
++        this.recipients = new HashSet<>(Bukkit.getOnlinePlayers());
++        this.renderer = renderer;
++        this.message = message;
++        this.originalMessage = originalMessage;
++    }
++
++    /**
++     * @deprecated for removal with 1.17
++     */
++    @Deprecated
 +    AbstractChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message) {
 +        super(player, async);
 +        this.viewers = viewers;
@@ -299,6 +312,19 @@ index 0000000000000000000000000000000000000000..dc6db537ceba0baf6e7cc532cfb58290
 +        this.renderer = renderer;
 +        this.message = message;
 +        this.originalMessage = message;
++    }
++
++    /**
++     * @deprecated for removal with 1.17
++     */
++    @Deprecated
++    AbstractChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(player, async);
++        this.recipients = recipients;
++        this.viewers = viewers;
++        this.renderer = renderer;
++        this.message = message;
++        this.originalMessage = originalMessage;
 +    }
 +
 +    /**
@@ -534,10 +560,10 @@ index 0000000000000000000000000000000000000000..dc6db537ceba0baf6e7cc532cfb58290
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d85006591808b61518545c9f5b0b5915c19e0a9d
+index 0000000000000000000000000000000000000000..ee7ec316a2f814ec759e0a3e5dfe5efbee782b22
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/AsyncChatEvent.java
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,73 @@
 +package io.papermc.paper.event.player;
 +
 +import io.papermc.paper.chat.ChatComposer;
@@ -556,12 +582,28 @@ index 0000000000000000000000000000000000000000..d85006591808b61518545c9f5b0b5915
 +public final class AsyncChatEvent extends AbstractChatEvent {
 +    private static final HandlerList HANDLERS = new HandlerList();
 +
++    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(async, player, viewers, renderer, message, originalMessage);
++    }
++
++    /**
++     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component, Component)}
++     */
++    @Deprecated
 +    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message) {
 +        super(async, player, viewers, renderer, message);
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component, Component)}
++     */
++    @Deprecated
++    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(async, player, recipients, viewers, renderer, message, originalMessage);
++    }
++
++    /**
++     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component, Component)}
 +     */
 +    @Deprecated
 +    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message) {
@@ -569,7 +611,7 @@ index 0000000000000000000000000000000000000000..d85006591808b61518545c9f5b0b5915
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component, Component)}
 +     */
 +    @Deprecated
 +    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull ChatComposer composer, final @NotNull Component message) {
@@ -577,7 +619,7 @@ index 0000000000000000000000000000000000000000..d85006591808b61518545c9f5b0b5915
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #AsyncChatEvent(boolean, Player, Set, ChatRenderer, Component, Component)}
 +     */
 +    @Deprecated
 +    public AsyncChatEvent(final boolean async, final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull ChatFormatter formatter, final @NotNull Component message) {
@@ -597,10 +639,10 @@ index 0000000000000000000000000000000000000000..d85006591808b61518545c9f5b0b5915
 +}
 diff --git a/src/main/java/io/papermc/paper/event/player/ChatEvent.java b/src/main/java/io/papermc/paper/event/player/ChatEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6219aabaf40ab89f8e08c256d1255bf5522db4d3
+index 0000000000000000000000000000000000000000..c6bcf0dc3f77c631aa7eeb9b1e88b5bbfe445fc6
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/event/player/ChatEvent.java
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,70 @@
 +package io.papermc.paper.event.player;
 +
 +import io.papermc.paper.chat.ChatComposer;
@@ -624,19 +666,28 @@ index 0000000000000000000000000000000000000000..6219aabaf40ab89f8e08c256d1255bf5
 +public final class ChatEvent extends AbstractChatEvent {
 +    private static final HandlerList HANDLERS = new HandlerList();
 +
++    public ChatEvent(final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(false, player, viewers, renderer, message, originalMessage);
++    }
++
++    /**
++     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component, Component)}
++     */
++    @Deprecated
 +    public ChatEvent(final @NotNull Player player, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message) {
 +        super(false, player, viewers, renderer, message);
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component, Component)}
 +     */
-+    public ChatEvent(final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message) {
-+        super(false, player, recipients, viewers, renderer, message);
++    @Deprecated
++    public ChatEvent(final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull Set<Audience> viewers, final @NotNull ChatRenderer renderer, final @NotNull Component message, final @NotNull Component originalMessage) {
++        super(false, player, recipients, viewers, renderer, message, originalMessage);
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component, Component)}
 +     */
 +    @Deprecated
 +    public ChatEvent(final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull ChatComposer composer, final @NotNull Component message) {
@@ -644,7 +695,7 @@ index 0000000000000000000000000000000000000000..6219aabaf40ab89f8e08c256d1255bf5
 +    }
 +
 +    /**
-+     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component)}
++     * @deprecated for removal with 1.17, use {@link #ChatEvent(Player, Set, ChatRenderer, Component, Component)}
 +     */
 +    @Deprecated
 +    public ChatEvent(final @NotNull Player player, final @NotNull Set<Player> recipients, final @NotNull ChatFormatter formatter, final @NotNull Component message) {

--- a/Spigot-Server-Patches/0010-Adventure.patch
+++ b/Spigot-Server-Patches/0010-Adventure.patch
@@ -105,10 +105,10 @@ index 0000000000000000000000000000000000000000..89597b4a3064c3c6001c7e927a848ee7
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e7ca0a44919ad052fa2ef279b4cd8989f8969a20
+index 0000000000000000000000000000000000000000..909968952a7ae2aa0196f12d1b3177cade380db2
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-@@ -0,0 +1,213 @@
+@@ -0,0 +1,215 @@
 +package io.papermc.paper.adventure;
 +
 +import io.papermc.paper.chat.ChatRenderer;
@@ -157,12 +157,14 @@ index 0000000000000000000000000000000000000000..e7ca0a44919ad052fa2ef279b4cd8989
 +    final EntityPlayer player;
 +    final String message;
 +    final boolean async;
++    final Component originalMessage;
 +
 +    public ChatProcessor(final MinecraftServer server, final EntityPlayer player, final String message, final boolean async) {
 +        this.server = server;
 +        this.player = player;
 +        this.message = message;
 +        this.async = async;
++        this.originalMessage = Component.text(message);
 +    }
 +
 +    @SuppressWarnings({"CodeBlock2Expr", "deprecated"})
@@ -280,11 +282,11 @@ index 0000000000000000000000000000000000000000..e7ca0a44919ad052fa2ef279b4cd8989
 +    }
 +
 +    private AsyncChatEvent createAsync(final ChatRenderer renderer, final Set<Player> recipients, final Set<Audience> viewers, final Component message) {
-+        return new AsyncChatEvent(this.async, this.player.getBukkitEntity(), recipients, viewers, renderer, message);
++        return new AsyncChatEvent(this.async, this.player.getBukkitEntity(), recipients, viewers, renderer, message, this.originalMessage);
 +    }
 +
 +    private ChatEvent createSync(final ChatRenderer renderer, final Set<Player> recipients, final Set<Audience> viewers, final Component message) {
-+        return new ChatEvent(this.player.getBukkitEntity(), recipients, viewers, renderer, message);
++        return new ChatEvent(this.player.getBukkitEntity(), recipients, viewers, renderer, message, this.originalMessage);
 +    }
 +
 +    private static String legacyDisplayName(final CraftPlayer player) {

--- a/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/Spigot-Server-Patches/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -26,7 +26,7 @@ index db2dddd12f54e6d15916c4cee623676541de37fb..1942f5224aaebb18adb591d6f70a419c
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-index bab8156acf87731ccdc841de5b341176ddedaae6..ab0e91e1e2b293dc51b251ded8bbfd386f08b3dc 100644
+index f4d0c4ed270769de7a9ed35643a6cc649c482ed5..294b8ac155c77ae84732c7aeeef9ee6269ff85b1 100644
 --- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 @@ -17,7 +17,11 @@ import net.kyori.adventure.text.event.ClickEvent;
@@ -41,7 +41,7 @@ index bab8156acf87731ccdc841de5b341176ddedaae6..ab0e91e1e2b293dc51b251ded8bbfd38
  import org.bukkit.craftbukkit.entity.CraftPlayer;
  import org.bukkit.craftbukkit.util.LazyPlayerSet;
  import org.bukkit.craftbukkit.util.Waitable;
-@@ -177,10 +181,22 @@ public final class ChatProcessor {
+@@ -179,10 +183,22 @@ public final class ChatProcessor {
      }
  
      private static String legacyDisplayName(final CraftPlayer player) {


### PR DESCRIPTION
Before this pr AbstractChatEvent#originalMessage would not return the original user entry but instead the result of the legacy chat event handlers. 

This corrects that behaviour by adding a new param to their constructors