### PR TITLE
Make item validations configurable

### DIFF
--- a/Spigot-Server-Patches/0756-Make-item-validations-configurable.patch
+++ b/Spigot-Server-Patches/0756-Make-item-validations-configurable.patch
@@ -1,0 +1,83 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 4 Jun 2021 12:12:35 -0700
+Subject: [PATCH] Make item validations configurable
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index efc1e42d606e1c9feb1a4871c0714933ae92a1b2..7acf077bc131af718c7548cc29deef558c04e463 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -486,4 +486,19 @@ public class PaperConfig {
+         enableBrigadierConsoleHighlighting = getBoolean("settings.console.enable-brigadier-highlighting", enableBrigadierConsoleHighlighting);
+         enableBrigadierConsoleCompletions = getBoolean("settings.console.enable-brigadier-completions", enableBrigadierConsoleCompletions);
+     }
++
++    public static int itemValidationDisplayNameLength = 8192;
++    public static int itemValidationLocNameLength = 8192;
++    public static int itemValidationLoreLineLength = 8192;
++    public static int itemValidationBookTitleLength = 8192;
++    public static int itemValidationBookAuthorLength = 8192;
++    public static int itemValidationBookPageLength = 16384;
++    private static void itemValidationSettings() {
++        itemValidationDisplayNameLength = getInt("settings.item-validation.display-name", itemValidationDisplayNameLength);
++        itemValidationLocNameLength = getInt("settings.item-validation.loc-name", itemValidationLocNameLength);
++        itemValidationLoreLineLength = getInt("settings.item-validation.lore-line", itemValidationLoreLineLength);
++        itemValidationBookTitleLength = getInt("settings.item-validation.book.title", itemValidationBookTitleLength);
++        itemValidationBookAuthorLength = getInt("settings.item-validation.book.author", itemValidationBookAuthorLength);
++        itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
++    }
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+index 1a4c1763e883e445433b3780fe20db7f62b780e8..bf1b6fa34b32730b493c37d3a0aa69a904c2d2b6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBook.java
+@@ -92,11 +92,11 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+         super(tag);
+ 
+         if (tag.hasKey(BOOK_TITLE.NBT)) {
+-            this.title = limit( tag.getString(BOOK_TITLE.NBT), 8192 ); // Spigot
++            this.title = limit( tag.getString(BOOK_TITLE.NBT), com.destroystokyo.paper.PaperConfig.itemValidationBookTitleLength); // Spigot // Paper - make configurable
+         }
+ 
+         if (tag.hasKey(BOOK_AUTHOR.NBT)) {
+-            this.author = limit( tag.getString(BOOK_AUTHOR.NBT), 8192 ); // Spigot
++            this.author = limit( tag.getString(BOOK_AUTHOR.NBT), com.destroystokyo.paper.PaperConfig.itemValidationBookAuthorLength ); // Spigot // Paper - make configurable
+         }
+ 
+         if (tag.hasKey(RESOLVED.NBT)) {
+@@ -124,7 +124,7 @@ public class CraftMetaBook extends CraftMetaItem implements BookMeta {
+                 } else {
+                     page = validatePage(page);
+                 }
+-                this.pages.add( limit( page, 16384 ) ); // Spigot
++                this.pages.add( limit( page, com.destroystokyo.paper.PaperConfig.itemValidationBookPageLength ) ); // Spigot // Paper - make configurable
+             }
+         }
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index 5c1319a86f6314c1d0a979af34424ee025a8030f..3db4826139f3e1f3859c04bae72310bfe2c53c1d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -358,18 +358,18 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+             NBTTagCompound display = tag.getCompound(DISPLAY.NBT);
+ 
+             if (display.hasKey(NAME.NBT)) {
+-                displayName = limit( display.getString(NAME.NBT), 8192 ); // Spigot
++                displayName = limit( display.getString(NAME.NBT), com.destroystokyo.paper.PaperConfig.itemValidationDisplayNameLength); // Spigot // Paper - make configurable
+             }
+ 
+             if (display.hasKey(LOCNAME.NBT)) {
+-                locName = limit( display.getString(LOCNAME.NBT), 8192 ); // Spigot
++                locName = limit( display.getString(LOCNAME.NBT), com.destroystokyo.paper.PaperConfig.itemValidationLocNameLength ); // Spigot // Paper - make configurable
+             }
+ 
+             if (display.hasKey(LORE.NBT)) {
+                 NBTTagList list = display.getList(LORE.NBT, CraftMagicNumbers.NBT.TAG_STRING);
+                 lore = new ArrayList<String>(list.size());
+                 for (int index = 0; index < list.size(); index++) {
+-                    String line = limit( list.getString(index), 8192 ); // Spigot
++                    String line = limit( list.getString(index), com.destroystokyo.paper.PaperConfig.itemValidationLoreLineLength ); // Spigot // Paper - make configurable
+                     lore.add(line);
+                 }
+             }


### PR DESCRIPTION
Ran into a datapack that was having problems because some lore lines were exceeding 8192 characters in length, so I thought, why not let server owners adjust various settings in case something they use might require a higher limit.  
Defaults should all be the same values.  
The book page one might be redundant in several places, I just added settings for all the ones added in the spigot commit which added them.