### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/Spigot-Server-Patches/0560-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/Spigot-Server-Patches/0560-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -100,7 +100,7 @@ index 2a785ea58a7bdc80c703a60bc6ed602dc8040aa0..9af91784544dbb0555824a9108825765
      public void onPlace(IBlockData iblockdata, World world, BlockPosition blockposition, IBlockData iblockdata1, boolean flag) {
          org.spigotmc.AsyncCatcher.catchOp("block onPlace"); // Spigot
 diff --git a/src/main/java/net/minecraft/world/level/portal/BlockPortalShape.java b/src/main/java/net/minecraft/world/level/portal/BlockPortalShape.java
-index 9f7ff56e43a3dc0cc57ed3a2c6dbc729afafa1f8..3f8a674345bcad8289a48d2daa5e2a283528e952 100644
+index 7c43a12f86cce829b2afb42ebcc95c2449985c10..0bce061d5a0dd0fc08f0aa4d46ead9326beb4bc7 100644
 --- a/src/main/java/net/minecraft/world/level/portal/BlockPortalShape.java
 +++ b/src/main/java/net/minecraft/world/level/portal/BlockPortalShape.java
 @@ -11,6 +11,7 @@ import net.minecraft.tags.Tag;
@@ -111,7 +111,7 @@ index 9f7ff56e43a3dc0cc57ed3a2c6dbc729afafa1f8..3f8a674345bcad8289a48d2daa5e2a28
  import net.minecraft.world.level.GeneratorAccess;
  import net.minecraft.world.level.block.BlockPortal;
  import net.minecraft.world.level.block.Blocks;
-@@ -177,7 +178,10 @@ public class BlockPortalShape {
+@@ -182,7 +183,10 @@ public class BlockPortalShape {
      }
  
      // CraftBukkit start - return boolean
@@ -123,12 +123,13 @@ index 9f7ff56e43a3dc0cc57ed3a2c6dbc729afafa1f8..3f8a674345bcad8289a48d2daa5e2a28
          org.bukkit.World bworld = this.b.getMinecraftWorld().getWorld();
  
          // Copy below for loop
-@@ -189,7 +193,7 @@ public class BlockPortalShape {
-             blocks.add(state);
+@@ -191,8 +195,7 @@ public class BlockPortalShape {
+         BlockPosition.a(this.position, this.position.shift(EnumDirection.UP, this.height - 1).shift(this.d, this.width - 1)).forEach((blockposition) -> {
+             blocks.setTypeAndData(blockposition, iblockdata, 18);
          });
- 
--        PortalCreateEvent event = new PortalCreateEvent(blocks, bworld, null, PortalCreateEvent.CreateReason.FIRE);
-+        PortalCreateEvent event = new PortalCreateEvent(blocks, bworld, itemActionContext == null || itemActionContext.getEntity() == null ? null : itemActionContext.getEntity().getBukkitEntity(), PortalCreateEvent.CreateReason.FIRE); // Paper - pass entity param
+-
+-        PortalCreateEvent event = new PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) blocks.getList(), bworld, null, PortalCreateEvent.CreateReason.FIRE);
++        PortalCreateEvent event = new PortalCreateEvent((java.util.List<org.bukkit.block.BlockState>) (java.util.List) blocks.getList(), bworld, itemActionContext == null || itemActionContext.getEntity() == null ? null : itemActionContext.getEntity().getBukkitEntity(), PortalCreateEvent.CreateReason.FIRE); // Paper - pass entity param
          this.b.getMinecraftWorld().getMinecraftServer().server.getPluginManager().callEvent(event);
  
          if (event.isCancelled()) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
3797d93e3 SPIGOT-6492: PortalCreateEvent#getBlocks() returns not all blocks by reason fire