### PR TITLE
Add minimum nether portal height

### DIFF
--- a/Spigot-Server-Patches/0760-mininum-nether-portal-generation-height.patch
+++ b/Spigot-Server-Patches/0760-mininum-nether-portal-generation-height.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Malfrador <malfrador@gmail.com>
+Date: Wed, 9 Jun 2021 00:13:04 +0200
+Subject: [PATCH] mininum nether portal generation height
+
+
+diff --git a/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java b/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
+index 77dfa7eaf178baa55041a829c9dec4851efeedfc..2d0ba85789f967792f562d5ae62974f567b47106 100644
+--- a/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
++++ b/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
+@@ -99,7 +99,7 @@ public class PortalTravelAgent {
+                             ;
+                         }
+ 
+-                        if (k + 4 <= i) {
++                        if (k + 4 <= i && k - 4 > 0) { // Paper - Add min portal generation height
+                             int i1 = l - k;
+ 
+                             if (i1 <= 0 || i1 >= 3) {

--- a/Spigot-Server-Patches/0760-mininum-nether-portal-generation-height.patch
+++ b/Spigot-Server-Patches/0760-mininum-nether-portal-generation-height.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Malfrador <malfrador@gmail.com>
+Date: Wed, 9 Jun 2021 00:13:04 +0200
+Subject: [PATCH] mininum nether portal generation height
+
+
+diff --git a/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java b/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
+index 77dfa7eaf178baa55041a829c9dec4851efeedfc..73fad302747a930c79de94ca31445519852bf576 100644
+--- a/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
++++ b/src/main/java/net/minecraft/world/level/portal/PortalTravelAgent.java
+@@ -99,7 +99,7 @@ public class PortalTravelAgent {
+                             ;
+                         }
+ 
+-                        if (k + 4 <= i) {
++                        if (k + 4 <= i && k - 4 > 0) { // Paper - fix MC-101602
+                             int i1 = l - k;
+ 
+                             if (i1 <= 0 || i1 >= 3) {


### PR DESCRIPTION
Adds a minimum nether portal generation height, in addition to the maximum height check vanilla already does. This only affects normal portal generation, forced portal generation (no free space found) already uses a minimum height of 70. 

Im a bit unsure about this PR, as this needs to be updated with 1.17 to use the minimum world height instead of just an hardcoded value, assuming Paper supports the datapack. On the other hand this is a somewhat serious exploit, its an easy update and the diff is very small. 

This was tested with approx. 50 portal generation attempts, according to the steps provided in the [issue.](https://github.com/PaperMC/Paper/issues/5773) Compared to that, without the patch I was successful at generating a portal at y =0 in just 4 attempts. 