### PR TITLE
fix: origin world can be unknown while knowing location

### DIFF
--- a/Spigot-Server-Patches/0026-Entity-Origin-API.patch
+++ b/Spigot-Server-Patches/0026-Entity-Origin-API.patch
@@ -33,31 +33,35 @@ index cf38d517821659e25e786a805e229ef2d626d75f..26d461196b4a998b445f8c6e67fd7ec0
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cae9da158f54438d2a397665c7ce964f6f755469..f6f0d551e22ff085935c1543bf84392de0368214 100644
+index cae9da158f54438d2a397665c7ce964f6f755469..63772205358715ff77be64da418aeb31ff0c3cef 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -247,6 +247,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -247,6 +247,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public org.bukkit.projectiles.ProjectileSource projectileSource; // For projectiles only
      public boolean forceExplosionKnockback; // SPIGOT-949
      public boolean persistentInvisibility = false;
 +    public org.bukkit.Location origin; // Paper
++    private @Nullable UUID originWorldId; // Paper
      // Spigot start
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
-@@ -1625,6 +1626,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1625,6 +1627,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  this.bukkitEntity.storeBukkitValues(nbttagcompound);
              }
              // CraftBukkit end
 +            // Paper start - Save the entity's origin location
 +            if (this.origin != null) {
-+                nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
++                if (this.originWorldId != null) {
++                    // Technically it is legal to no longer know the origin world... so that's fun.
++                    nbttagcompound.setUUID("Paper.OriginWorld", this.originWorldId);
++                }
 +                nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
 +            }
 +            // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.a(throwable, "Saving entity NBT");
-@@ -1747,6 +1754,17 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1747,6 +1758,18 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
              // CraftBukkit end
  
@@ -68,6 +72,7 @@ index cae9da158f54438d2a397665c7ce964f6f755469..f6f0d551e22ff085935c1543bf84392d
 +                if (nbttagcompound.hasKey("Paper.OriginWorld")) {
 +                    originWorld = Bukkit.getWorld(nbttagcompound.getUUID("Paper.OriginWorld"));
 +                }
++                this.originWorldId = originWorld == null ? null : originWorld.getUID();
 +                origin = new org.bukkit.Location(originWorld, originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
 +            }
 +            // Paper end
@@ -75,7 +80,7 @@ index cae9da158f54438d2a397665c7ce964f6f755469..f6f0d551e22ff085935c1543bf84392d
          } catch (Throwable throwable) {
              CrashReport crashreport = CrashReport.a(throwable, "Loading entity NBT");
              CrashReportSystemDetails crashreportsystemdetails = crashreport.a("Entity being loaded");
-@@ -1808,6 +1826,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1808,6 +1831,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      protected abstract void saveData(NBTTagCompound nbttagcompound);
  

--- a/Spigot-Server-Patches/0028-Configurable-top-of-nether-void-damage.patch
+++ b/Spigot-Server-Patches/0028-Configurable-top-of-nether-void-damage.patch
@@ -29,10 +29,10 @@ index d16ae924bcbe31c964f7fb448757c748e5c4418c..4bba6977a0287837b8927718c040ac61
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dce47ec1fc186d12ffa30bfd3d71870aecb95d40..cf92de7c138ef9cbbc1263bee29b9d0017b45827 100644
+index 63772205358715ff77be64da418aeb31ff0c3cef..72c7602c0a97c8fb2699c556a5ed758aebfb0957 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -500,9 +500,16 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -501,9 +501,16 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              this.fallDistance *= 0.5F;
          }
  
@@ -49,7 +49,7 @@ index dce47ec1fc186d12ffa30bfd3d71870aecb95d40..cf92de7c138ef9cbbc1263bee29b9d00
  
          if (!this.world.isClientSide) {
              this.setFlag(0, this.fireTicks > 0);
-@@ -595,6 +602,17 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -596,6 +603,17 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.setFireTicks(0);
      }
  

--- a/Spigot-Server-Patches/0043-Add-PlayerInitialSpawnEvent.patch
+++ b/Spigot-Server-Patches/0043-Add-PlayerInitialSpawnEvent.patch
@@ -9,7 +9,7 @@ This is a duplicate API from spigot, so use our duplicate subclass and
 improve setPosition to use raw
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 15418868c2b92498139e66d913ee1c35b3abf0cf..cfd0af520dd3dcf364a3ffd03a74e3b9ee6045af 100644
+index 6ebd4ec781aa215c2b941261250c15c87c223cab..46c516b9ff089a3c885d635244942fd5a6ecf132 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -213,7 +213,7 @@ public abstract class PlayerList {
@@ -34,10 +34,10 @@ index 15418868c2b92498139e66d913ee1c35b3abf0cf..cfd0af520dd3dcf364a3ffd03a74e3b9
  
          // CraftBukkit - Moved message to after join
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cf92de7c138ef9cbbc1263bee29b9d0017b45827..10cbf66f06b31c9a4cae2359b3fbb9988abb9278 100644
+index 72c7602c0a97c8fb2699c556a5ed758aebfb0957..8c8f1f0f368d41c746c4ccb02dc95482f3336df3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -398,7 +398,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -399,7 +399,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return d1 * d1 + d2 * d2 + d3 * d3 < d0 * d0;
      }
  

--- a/Spigot-Server-Patches/0052-Add-configurable-portal-search-radius.patch
+++ b/Spigot-Server-Patches/0052-Add-configurable-portal-search-radius.patch
@@ -23,10 +23,10 @@ index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601cc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 77cc0aeb979369df2156f8fb916067f608b61ebf..caae8bdae592a1ae4f99861088458d7461f4c97a 100644
+index 8c8f1f0f368d41c746c4ccb02dc95482f3336df3..121e559dea10f9471e8bac9d18b267fec9cdcf1d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2618,7 +2618,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2623,7 +2623,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  double d4 = DimensionManager.a(this.world.getDimensionManager(), worldserver.getDimensionManager());
                  BlockPosition blockposition = new BlockPosition(MathHelper.a(this.locX() * d4, d0, d2), this.locY(), MathHelper.a(this.locZ() * d4, d1, d3));
                  // CraftBukkit start

--- a/Spigot-Server-Patches/0057-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/Spigot-Server-Patches/0057-Disable-Scoreboards-for-non-players-by-default.patch
@@ -25,10 +25,10 @@ index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb137166
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index caae8bdae592a1ae4f99861088458d7461f4c97a..bfced192c1e8fd3fa0250a0f93adfc061d7e71e5 100644
+index 121e559dea10f9471e8bac9d18b267fec9cdcf1d..3bc10943c98aedb863df005d578a6865450b5e02 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2289,6 +2289,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2294,6 +2294,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      @Nullable
      public ScoreboardTeamBase getScoreboardTeam() {

--- a/Spigot-Server-Patches/0069-Use-a-Shared-Random-for-Entities.patch
+++ b/Spigot-Server-Patches/0069-Use-a-Shared-Random-for-Entities.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b7df4d8eb3ccb9e8dc85898352f41c5c20abcb34..6cbb797cb0de4b26d8ddd7f0bf567f49bd36f9c0 100644
+index 3bc10943c98aedb863df005d578a6865450b5e02..08457284f8decbf23378267f8c53be481fdb616b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -143,6 +143,21 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -31,7 +31,7 @@ index b7df4d8eb3ccb9e8dc85898352f41c5c20abcb34..6cbb797cb0de4b26d8ddd7f0bf567f49
      private CraftEntity bukkitEntity;
  
      public CraftEntity getBukkitEntity() {
-@@ -272,7 +287,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -273,7 +288,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.x = Vec3D.ORIGIN;
          this.am = 1.0F;
          this.an = 1.0F;

--- a/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
+++ b/Spigot-Server-Patches/0101-Optional-TNT-doesn-t-move-in-water.patch
@@ -45,10 +45,10 @@ index beb0beb716869978be6bc5a78ce3b6cf785c5aee..e3cdea3c85d762af6984f3dbe544fdfe
      private java.util.Map<EntityPlayer, Boolean> trackedPlayerMap = null;
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 092ee75f9527af25a48ab052659e3304986b50e0..d314cdd9341e6aa5748a5b1afdd9569bec956c74 100644
+index 1bc226adb1f959f3c0e350a4d6f8794f9eb7584f..7152d23a4d493ca90ac4e83b5589c5e620250fe0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2771,6 +2771,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2776,6 +2776,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean bV() {

--- a/Spigot-Server-Patches/0136-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/Spigot-Server-Patches/0136-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d314cdd9341e6aa5748a5b1afdd9569bec956c74..00e79363b3f961111595c50758332f6c1c1b31bb 100644
+index 7152d23a4d493ca90ac4e83b5589c5e620250fe0..d531db4892e775c6bf8dc4e09cbf4f754ab7c5ef 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2046,6 +2046,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2051,6 +2051,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
+++ b/Spigot-Server-Patches/0138-Cap-Entity-Collisions.patch
@@ -27,10 +27,10 @@ index 2dc58b9f769ea43b737804456aafab47ecc143b8..c611b5a63498f5ad1f50a75ccd5d7299
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 49da1525cfc46743013bbac0528ec58501cab6eb..b798190628c1d83b5bf9e5497b515ef1e9f26707 100644
+index d531db4892e775c6bf8dc4e09cbf4f754ab7c5ef..d41c9bd566283065b524d8a22effd236a32dcbaa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -268,6 +268,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -269,6 +269,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
      public long activatedTick = Integer.MIN_VALUE;
@@ -39,7 +39,7 @@ index 49da1525cfc46743013bbac0528ec58501cab6eb..b798190628c1d83b5bf9e5497b515ef1
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/world/entity/EntityLiving.java b/src/main/java/net/minecraft/world/entity/EntityLiving.java
-index 6fa269cec002fcffd6d02125c20efa9314148243..2eee92f74a7c82ec7df05db6df79743b4345cc86 100644
+index f26f02856e7cca0ca62325adf992619dd15b3885..dd9c51b28e32389429887e9c9cef0a554eff8a40 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityLiving.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityLiving.java
 @@ -2903,8 +2903,11 @@ public abstract class EntityLiving extends Entity {

--- a/Spigot-Server-Patches/0156-Entity-fromMobSpawner.patch
+++ b/Spigot-Server-Patches/0156-Entity-fromMobSpawner.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dcaf5c107bb77b63333f924a33961f9e5cad7082..43039c14e087259e3ce4b5091b887759b66fe52d 100644
+index d41c9bd566283065b524d8a22effd236a32dcbaa..c3f1490696b1aeba20fde7554010caa4150f5856 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -268,6 +268,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -269,6 +269,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
      public long activatedTick = Integer.MIN_VALUE;
@@ -16,8 +16,8 @@ index dcaf5c107bb77b63333f924a33961f9e5cad7082..43039c14e087259e3ce4b5091b887759
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end
-@@ -1666,6 +1667,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-                 nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
+@@ -1670,6 +1671,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 }
                  nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
              }
 +            // Save entity's from mob spawner status
@@ -27,8 +27,8 @@ index dcaf5c107bb77b63333f924a33961f9e5cad7082..43039c14e087259e3ce4b5091b887759
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -1798,6 +1803,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-                 }
+@@ -1803,6 +1808,8 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 this.originWorldId = originWorld == null ? null : originWorld.getUID();
                  origin = new org.bukkit.Location(originWorld, originTag.getDoubleAt(0), originTag.getDoubleAt(1), originTag.getDoubleAt(2));
              }
 +

--- a/Spigot-Server-Patches/0240-add-more-information-to-Entity.toString.patch
+++ b/Spigot-Server-Patches/0240-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 43039c14e087259e3ce4b5091b887759b66fe52d..f15c60e56fc32a7dd525eefb2d622c33e00037c7 100644
+index c3f1490696b1aeba20fde7554010caa4150f5856..a2feecdca8423ef02248b1abae823d8518c7bcb7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2527,7 +2527,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2532,7 +2532,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public String toString() {

--- a/Spigot-Server-Patches/0253-Ignore-Dead-Entities-in-entityList-iteration.patch
+++ b/Spigot-Server-Patches/0253-Ignore-Dead-Entities-in-entityList-iteration.patch
@@ -43,10 +43,10 @@ index e39f1ea4eefb0d8e0ca379b116b3699c13bb3f35..9151d84e2f6fb316525c744665891787
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 102c2bb98a99cdbfcdf1297341dbba91434ee0e3..046b191e771ed9be337e095214a67febd768e5f6 100644
+index 71afcc1a829212f4d7cab3afe757d6eae8874500..8d005bbc2bdc8694d80cdb1470e540f113b79062 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -276,6 +276,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -277,6 +277,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end

--- a/Spigot-Server-Patches/0279-Improve-death-events.patch
+++ b/Spigot-Server-Patches/0279-Improve-death-events.patch
@@ -78,10 +78,10 @@ index f6f79ed9c38206cc6a4feb5504e854a476868aec..7d2b947b3c2b255c01241f2c4a6d7377
          int i = this.f ? 300 : 100;
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 37497d7ff04b84d4758997970dbdbf88b40d0493..28390d3830ed9f3f5d97ab38913e6c40f9943a70 100644
+index 8d005bbc2bdc8694d80cdb1470e540f113b79062..4161d189613b5fb542cef8c128852e6e7d548833 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1538,6 +1538,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1539,6 +1539,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
      // CraftBukkit end
  
@@ -89,7 +89,7 @@ index 37497d7ff04b84d4758997970dbdbf88b40d0493..28390d3830ed9f3f5d97ab38913e6c40
      public void a(Entity entity, int i, DamageSource damagesource) {
          if (entity instanceof EntityPlayer) {
              CriterionTriggers.c.a((EntityPlayer) entity, this, damagesource);
-@@ -2442,6 +2443,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2447,6 +2448,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.fallDistance = 0.0F;
      }
  

--- a/Spigot-Server-Patches/0303-Reset-players-airTicks-on-respawn.patch
+++ b/Spigot-Server-Patches/0303-Reset-players-airTicks-on-respawn.patch
@@ -17,10 +17,10 @@ index f5be9554e1fd01a35b926196b30fd64f1567a799..3e7ac6699ad1f147220c286e251ce0ec
          this.fallDistance = 0;
          this.foodData = new FoodMetaData(this);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 28390d3830ed9f3f5d97ab38913e6c40f9943a70..2292295bac55651850b5e033f1ca9819bb7fa96f 100644
+index 4161d189613b5fb542cef8c128852e6e7d548833..441d8efa24a377b81eb53c3997ae9d30a5f7bc67 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2355,6 +2355,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2360,6 +2360,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  

--- a/Spigot-Server-Patches/0315-force-entity-dismount-during-teleportation.patch
+++ b/Spigot-Server-Patches/0315-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 3e7ac6699ad1f147220c286e251ce0ec1ca25035..e755191435e74246b309f8fe5a668dae
  
          if (entity1 != entity && this.playerConnection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2292295bac55651850b5e033f1ca9819bb7fa96f..af38b81df3f60163cafc341543ecad0865225943 100644
+index 441d8efa24a377b81eb53c3997ae9d30a5f7bc67..fd9bb9b7b59c9dcd797e52109afc2f6dd2160bb1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2045,12 +2045,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2050,12 +2050,15 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      }
  
@@ -62,7 +62,7 @@ index 2292295bac55651850b5e033f1ca9819bb7fa96f..af38b81df3f60163cafc341543ecad08
          }
  
      }
-@@ -2105,7 +2108,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2110,7 +2113,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index 2292295bac55651850b5e033f1ca9819bb7fa96f..af38b81df3f60163cafc341543ecad08
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2115,7 +2121,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2120,7 +2126,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              if (getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) getBukkitEntity(),
@@ -83,7 +83,7 @@ index 2292295bac55651850b5e033f1ca9819bb7fa96f..af38b81df3f60163cafc341543ecad08
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2129,7 +2135,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2134,7 +2140,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
              // CraftBukkit end
              // Spigot start

--- a/Spigot-Server-Patches/0334-Add-LivingEntity-getTargetEntity.patch
+++ b/Spigot-Server-Patches/0334-Add-LivingEntity-getTargetEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index af38b81df3f60163cafc341543ecad0865225943..413f715c98dc0a0953e60032ad1ebef2b0b3bbe3 100644
+index fd9bb9b7b59c9dcd797e52109afc2f6dd2160bb1..92c312eb431409c615ae63b01087ee2cb89b868f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1504,6 +1504,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1505,6 +1505,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.c(f - 90.0F, f1);
      }
  
@@ -16,7 +16,7 @@ index af38b81df3f60163cafc341543ecad0865225943..413f715c98dc0a0953e60032ad1ebef2
      public final Vec3D j(float f) {
          if (f == 1.0F) {
              return new Vec3D(this.locX(), this.getHeadY(), this.locZ());
-@@ -2154,6 +2155,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2159,6 +2160,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.getPassengers().size() < 1;
      }
  

--- a/Spigot-Server-Patches/0336-Entity-getEntitySpawnReason.patch
+++ b/Spigot-Server-Patches/0336-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index 1ae969aff1d44ad9af28fc94d8821884b9ad0563..47aa69dfe43390b811c264adc0af1d01
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 413f715c98dc0a0953e60032ad1ebef2b0b3bbe3..712c81fe2cf6da6b80fea21fd6c3d0e0adc5a35a 100644
+index 92c312eb431409c615ae63b01087ee2cb89b868f..4d41e741f0a1b11a8b98c34303018c032e4b1fe4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -63,6 +63,8 @@ import net.minecraft.world.EnumHand;
@@ -55,8 +55,8 @@ index 413f715c98dc0a0953e60032ad1ebef2b0b3bbe3..712c81fe2cf6da6b80fea21fd6c3d0e0
      // Paper end
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
-@@ -1674,6 +1677,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
-                 nbttagcompound.setUUID("Paper.OriginWorld", origin.getWorld().getUID());
+@@ -1678,6 +1681,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+                 }
                  nbttagcompound.set("Paper.Origin", this.createList(origin.getX(), origin.getY(), origin.getZ()));
              }
 +            if (spawnReason != null) {
@@ -65,7 +65,7 @@ index 413f715c98dc0a0953e60032ad1ebef2b0b3bbe3..712c81fe2cf6da6b80fea21fd6c3d0e0
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbttagcompound.setBoolean("Paper.FromMobSpawner", true);
-@@ -1812,6 +1818,26 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1817,6 +1823,26 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              spawnedViaMobSpawner = nbttagcompound.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
+++ b/Spigot-Server-Patches/0350-Duplicate-UUID-Resolve-Option.patch
@@ -224,10 +224,10 @@ index 4e26db120e544d8867d895395241e425f23f575b..fbff779fa581a661cc03850bffa0da34
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 712c81fe2cf6da6b80fea21fd6c3d0e0adc5a35a..efa8d9a16e87475adf7e71a0dfa2861653f73c06 100644
+index 4d41e741f0a1b11a8b98c34303018c032e4b1fe4..a3c74208df658ad7db79e7cbc29b2364602f4c37 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2804,6 +2804,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2809,6 +2809,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          });
      }
  

--- a/Spigot-Server-Patches/0400-Entity-Activation-Range-2.0.patch
+++ b/Spigot-Server-Patches/0400-Entity-Activation-Range-2.0.patch
@@ -105,7 +105,7 @@ index de4e0477c5c777ce9ac601f88d24f2dd2786eb6f..17c6118fb1ea1f16d37eb13116e11f88
              }
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f4399f9f39f 100644
+index a3c74208df658ad7db79e7cbc29b2364602f4c37..73d4e813df19cf423071181b710f6af85ca96c98 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -68,6 +68,7 @@ import net.minecraft.world.entity.animal.EntityFish;
@@ -125,7 +125,7 @@ index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f43
      protected int portalTicks;
      protected BlockPosition ac;
      private boolean invulnerable;
-@@ -275,6 +276,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -276,6 +277,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
      public long activatedTick = Integer.MIN_VALUE;
@@ -133,7 +133,7 @@ index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f43
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
-@@ -665,6 +667,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -666,6 +668,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              this.recalcPosition();
          } else {
              if (enummovetype == EnumMoveType.PISTON) {
@@ -141,7 +141,7 @@ index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f43
                  vec3d = this.b(vec3d);
                  if (vec3d.equals(Vec3D.ORIGIN)) {
                      return;
-@@ -677,6 +680,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -678,6 +681,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  this.x = Vec3D.ORIGIN;
                  this.setMot(Vec3D.ORIGIN);
              }
@@ -155,7 +155,7 @@ index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f43
  
              vec3d = this.a(vec3d, enummovetype);
              Vec3D vec3d1 = this.g(vec3d);
-@@ -2012,6 +2022,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2017,6 +2027,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          }
      }
  
@@ -163,7 +163,7 @@ index efa8d9a16e87475adf7e71a0dfa2861653f73c06..32dad0b72ee0d0a1ac30decb0fb52f43
      public void k(Entity entity) {
          this.a(entity, Entity::setPosition);
      }
-@@ -2822,6 +2833,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2827,6 +2838,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.ae;
      }
  
@@ -351,7 +351,7 @@ index 8b09aaa30dd753fd34bea155890bdd9e5cb180f5..2005cb484ba6b5929ad81d3d120521f2
          return this.bB != null;
      }
 diff --git a/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java b/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
-index 858bbfbc08a5f2e1ef93ff52d6708059b32fbbbf..d7e152f7147bb599ce21dc605ebbd76e82eced26 100644
+index 29957e79161db862c3eee5d0ed0cb8edb5dceb1c..596450d3cdb3be4abca3e75bed743abd071fb0b0 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/EntityVillager.java
 @@ -213,17 +213,29 @@ public class EntityVillager extends EntityVillagerAbstract implements Reputation

--- a/Spigot-Server-Patches/0401-Fix-items-vanishing-through-end-portal.patch
+++ b/Spigot-Server-Patches/0401-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 32dad0b72ee0d0a1ac30decb0fb52f4399f9f39f..b1495da5fdead24caf9e936a385d97fd2db2a0cc 100644
+index 73d4e813df19cf423071181b710f6af85ca96c98..522009c7ef56cd51e592c3bb985e33b4ee7d2532 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2735,6 +2735,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2740,6 +2740,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              BlockPosition blockposition1;
  
              if (flag1) {

--- a/Spigot-Server-Patches/0408-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/Spigot-Server-Patches/0408-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -19,10 +19,10 @@ index 7fbd501d70dccf869a4454e2789a5d68f2e15754..9e4591ddc4b755f4ff5a6f1078b51cb1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b1495da5fdead24caf9e936a385d97fd2db2a0cc..334d60c71fa13841f9d04af5404cc25acbc0ec76 100644
+index 522009c7ef56cd51e592c3bb985e33b4ee7d2532..1bfbbac3f6369f64350c5cba16d880f3d2c7fd79 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -278,6 +278,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -279,6 +279,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public long activatedTick = Integer.MIN_VALUE;
      public boolean isTemporarilyActive = false; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
@@ -30,7 +30,7 @@ index b1495da5fdead24caf9e936a385d97fd2db2a0cc..334d60c71fa13841f9d04af5404cc25a
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end
-@@ -1694,6 +1695,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1698,6 +1699,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              if (spawnedViaMobSpawner) {
                  nbttagcompound.setBoolean("Paper.FromMobSpawner", true);
              }
@@ -40,7 +40,7 @@ index b1495da5fdead24caf9e936a385d97fd2db2a0cc..334d60c71fa13841f9d04af5404cc25a
              // Paper end
              return nbttagcompound;
          } catch (Throwable throwable) {
-@@ -1828,6 +1832,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1833,6 +1837,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              spawnedViaMobSpawner = nbttagcompound.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/Spigot-Server-Patches/0451-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0451-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
-index 6e5d21af43261dc2f12ceec7b7e3269be635cf7a..ecf4cd6dfea777ab9daea0b40724d247df7ddb53 100644
+index cb098defa7b93864294befa9b9a427804461188b..fc7140e0eb11e4bec99e453647fce200bca0ed7f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkProviderServer.java
 @@ -629,7 +629,7 @@ public class ChunkProviderServer extends IChunkProvider {
@@ -71,7 +71,7 @@ index 218dc900e125a11548485887b1918742072c7a77..2c932d36f982e7f8713aabff9a6c6310
      public static final TicketType<ChunkCoordIntPair> UNKNOWN = a("unknown", Comparator.comparingLong(ChunkCoordIntPair::pair), 1);
      public static final TicketType<Unit> PLUGIN = a("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/LoginListener.java b/src/main/java/net/minecraft/server/network/LoginListener.java
-index 09ceac61f873ee0cb689c66a403c42677961011d..06e2b48ed6d6d52d0eb17301254ed07fb69cb8af 100644
+index 2e995103fba15c21dbe89321896c7df03ae5e67b..ef2aa000932c222e358789fcd2629dd8a46cfe80 100644
 --- a/src/main/java/net/minecraft/server/network/LoginListener.java
 +++ b/src/main/java/net/minecraft/server/network/LoginListener.java
 @@ -88,7 +88,7 @@ public class LoginListener implements PacketLoginInListener {
@@ -93,7 +93,7 @@ index 09ceac61f873ee0cb689c66a403c42677961011d..06e2b48ed6d6d52d0eb17301254ed07f
              if (entityplayer != null) {
                  this.g = LoginListener.EnumProtocolState.DELAY_ACCEPT;
 diff --git a/src/main/java/net/minecraft/server/network/PlayerConnection.java b/src/main/java/net/minecraft/server/network/PlayerConnection.java
-index f02ddd53df4674a2b5e0bb142db756d1f153d69b..443247b03b8352c4dd453270dccdbd7eb5f0944b 100644
+index 8a8f75acdd55e00ac2e7b5c621d1f522208df2c2..7c1d25feab71c325ce2379afa6c61732eebd74f9 100644
 --- a/src/main/java/net/minecraft/server/network/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/network/PlayerConnection.java
 @@ -222,6 +222,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
@@ -292,10 +292,10 @@ index 66c1a9ca392b29fe2191577d32c70b214fa7293d..c7e78d0626fa0dd18021c1a0827a10c0
          Iterator iterator = list.iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7bce3722fb00194f5a913c0b9866b73cfc74611d..8ca7012264528f17ac2e4f15ced96c774fa566d7 100644
+index d57a40000c257b7249bec828d38a5d50cd4199e6..e02d349f4353f96318d858a1aa70dfc4fadb6c71 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1372,7 +1372,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1373,7 +1373,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          this.lastY = d1;
          this.lastZ = d4;
          this.setPosition(d3, d1, d4);

--- a/Spigot-Server-Patches/0452-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/Spigot-Server-Patches/0452-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 896b4d016de78e98276d7cdf9328d8951572e3be..fbd473d39cd71510b5fe8b7a4d34d3b824301f73 100644
+index e02d349f4353f96318d858a1aa70dfc4fadb6c71..f78c79f34b4ee89a72fe5a57da0eb4010cfea07c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1809,9 +1809,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1813,9 +1813,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                      bworld = server.getWorld(worldName);
                  }
  

--- a/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/Spigot-Server-Patches/0457-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a19249ffec 100644
+index f78c79f34b4ee89a72fe5a57da0eb4010cfea07c..3cc5b0dc8d79c9d8e89a16ba150a6b4acb8c84d6 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1974,11 +1974,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1979,11 +1979,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof EntityLiving && !((EntityLiving) this).forceDrops) {
@@ -34,7 +34,7 @@ index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a1
  
              entityitem.defaultPickupDelay();
              // CraftBukkit start
-@@ -2626,6 +2627,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2631,6 +2632,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      @Nullable
      public Entity teleportTo(WorldServer worldserver, BlockPosition location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a1
          if (this.world instanceof WorldServer && !this.dead) {
              this.world.getMethodProfiler().enter("changeDimension");
              // CraftBukkit start
-@@ -2646,6 +2653,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2651,6 +2658,11 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                  // CraftBukkit end
  
                  this.world.getMethodProfiler().exitEnter("reloading");
@@ -59,7 +59,7 @@ index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a1
                  Entity entity = this.getEntityType().a((World) worldserver);
  
                  if (entity != null) {
-@@ -2659,10 +2671,6 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2664,10 +2676,6 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index fbd473d39cd71510b5fe8b7a4d34d3b824301f73..8d8d94219f9a556212763fce736452a1
                      // CraftBukkit end
                  }
  
-@@ -2787,7 +2795,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2792,7 +2800,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean canPortal() {

--- a/Spigot-Server-Patches/0465-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/Spigot-Server-Patches/0465-Use-distance-map-to-optimise-entity-tracker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use distance map to optimise entity tracker
 Use the distance map to find candidate players for tracking.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 11a412b1df98dea2826330b0b246655844a4f4ea..1d77d6254b024c286781be8dc74680bc1e8f1238 100644
+index 7f67773686a2d55153f7b2bfbe24df84fe1198be..1eb1da61ee2aa2cc5d28a46fd364a182cd16983b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1654,6 +1654,7 @@ public abstract class MinecraftServer extends IAsyncTaskHandlerReentrant<TickTas
@@ -316,7 +316,7 @@ index d509cfd2da99233e5142abd176cc50ccea7c32b6..9fc74f08b912ff885c9478167c7ef173
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cb5c93dca3b947462b89f79c60c7562085684b87..da2b5bfd3966ded2d5dde0d65646583576a088c5 100644
+index 3cc5b0dc8d79c9d8e89a16ba150a6b4acb8c84d6..019b602db883434c65964130bcac3f02e467332a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -46,6 +46,7 @@ import net.minecraft.network.syncher.DataWatcherObject;
@@ -327,7 +327,7 @@ index cb5c93dca3b947462b89f79c60c7562085684b87..da2b5bfd3966ded2d5dde0d656465835
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.EntityPlayer;
  import net.minecraft.server.level.PlayerChunkMap;
-@@ -295,6 +296,21 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -296,6 +297,21 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
      // CraftBukkit end
  

--- a/Spigot-Server-Patches/0506-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/Spigot-Server-Patches/0506-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b244f5d204938452ea19335947830de47336bbd4..8151403b2a7f5f8441c6810d1bd2bf3df4cefa80 100644
+index 019b602db883434c65964130bcac3f02e467332a..d058675b800cb73f235d5675aea32bac175e0534 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -66,6 +66,7 @@ import net.minecraft.world.INamableTileEntity;
@@ -16,7 +16,7 @@ index b244f5d204938452ea19335947830de47336bbd4..8151403b2a7f5f8441c6810d1bd2bf3d
  import net.minecraft.world.entity.item.EntityItem;
  import net.minecraft.world.entity.player.EntityHuman;
  import net.minecraft.world.entity.vehicle.EntityBoat;
-@@ -479,7 +480,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -480,7 +481,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      public void setPosition(double d0, double d1, double d2) {
          this.setPositionRaw(d0, d1, d2);
@@ -25,7 +25,7 @@ index b244f5d204938452ea19335947830de47336bbd4..8151403b2a7f5f8441c6810d1bd2bf3d
          if (valid) ((WorldServer) world).chunkCheck(this); // CraftBukkit
      }
  
-@@ -2999,6 +3000,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3004,6 +3005,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return new AxisAlignedBB(vec3d, vec3d1);
      }
  
@@ -33,7 +33,7 @@ index b244f5d204938452ea19335947830de47336bbd4..8151403b2a7f5f8441c6810d1bd2bf3d
      public void a(AxisAlignedBB axisalignedbb) {
          // CraftBukkit start - block invalid bounding boxes
          double minX = axisalignedbb.minX,
-@@ -3437,6 +3439,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3442,6 +3444,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public void setPositionRaw(double d0, double d1, double d2) {

--- a/Spigot-Server-Patches/0507-Optimize-WorldBorder-collision-checks-and-air.patch
+++ b/Spigot-Server-Patches/0507-Optimize-WorldBorder-collision-checks-and-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize WorldBorder collision checks and air
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c50b89ee8f16821923933025bf19243771dd1604..27e5ba64ed6406c1ece318bf79fca0f261a77818 100644
+index d058675b800cb73f235d5675aea32bac175e0534..d7e1e09cd3053220a5413b498108d57f23ec94a4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -909,7 +909,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -910,7 +910,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          AxisAlignedBB axisalignedbb = this.getBoundingBox();
          VoxelShapeCollision voxelshapecollision = VoxelShapeCollision.a(this);
          VoxelShape voxelshape = this.world.getWorldBorder().c();

--- a/Spigot-Server-Patches/0519-Add-entity-liquid-API.patch
+++ b/Spigot-Server-Patches/0519-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 27e5ba64ed6406c1ece318bf79fca0f261a77818..743d4725c0a26a8abd0a98eed2ec45ffba6211ad 100644
+index d7e1e09cd3053220a5413b498108d57f23ec94a4..e1927f019dfbabab9af357294c4b73fa41bd3f2e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1166,12 +1166,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1167,12 +1167,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.inWater;
      }
  
@@ -23,7 +23,7 @@ index 27e5ba64ed6406c1ece318bf79fca0f261a77818..743d4725c0a26a8abd0a98eed2ec45ff
      private boolean k() {
          return this.world.getType(this.getChunkCoordinates()).a(Blocks.BUBBLE_COLUMN);
      }
-@@ -1185,6 +1186,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1186,6 +1187,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.isInWater() || this.isInRain() || this.k();
      }
  
@@ -31,7 +31,7 @@ index 27e5ba64ed6406c1ece318bf79fca0f261a77818..743d4725c0a26a8abd0a98eed2ec45ff
      public boolean aH() {
          return this.isInWater() || this.k();
      }
-@@ -1327,6 +1329,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1328,6 +1330,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
          return this.O == tag;
      }
  

--- a/Spigot-Server-Patches/0566-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/Spigot-Server-Patches/0566-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index d3449dc9eeba0d8022c3a7b0280eaffcd42e7265..fe3bd1c54a7e366bd4f02b417f7725ba
          this.player.playerConnection.sendPacket(new PacketPlayOutPosition(d0 - d3, d1 - d4, d2 - d5, f - f2, f1 - f3, set, this.teleportAwait));
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 743d4725c0a26a8abd0a98eed2ec45ffba6211ad..58d9dce288ab9cc1989cfcb66703b76fdabf1319 100644
+index e1927f019dfbabab9af357294c4b73fa41bd3f2e..ec163bf527120a19cdc9fd7ccd69b6eb83d0bb54 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -145,6 +145,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
@@ -42,7 +42,7 @@ index 743d4725c0a26a8abd0a98eed2ec45ffba6211ad..58d9dce288ab9cc1989cfcb66703b76f
      static boolean isLevelAtLeast(NBTTagCompound tag, int level) {
          return tag.hasKey("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1408,6 +1409,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1409,6 +1410,13 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public void setPositionRotation(double d0, double d1, double d2, float f, float f1) {

--- a/Spigot-Server-Patches/0571-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/Spigot-Server-Patches/0571-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a1fb19d45ee3809ee6a515669ba64ea45b31428c..9b6e5f279a22efc2d015e2d31076a8c06e6b3886 100644
+index ec163bf527120a19cdc9fd7ccd69b6eb83d0bb54..48cbc44d5b502443be8205a6481d037f9fea491e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3478,4 +3478,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3483,4 +3483,10 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
          void accept(Entity entity, double d0, double d1, double d2);
      }

--- a/Spigot-Server-Patches/0573-Entity-isTicking.patch
+++ b/Spigot-Server-Patches/0573-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9b6e5f279a22efc2d015e2d31076a8c06e6b3886..d072e3fb26f32db80be68f0e23526e34f57ff331 100644
+index 48cbc44d5b502443be8205a6481d037f9fea491e..35b2e8dba3536febe997f3c562c56f0d5371a524 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -48,6 +48,7 @@ import net.minecraft.resources.MinecraftKey;
@@ -16,7 +16,7 @@ index 9b6e5f279a22efc2d015e2d31076a8c06e6b3886..d072e3fb26f32db80be68f0e23526e34
  import net.minecraft.server.level.EntityPlayer;
  import net.minecraft.server.level.PlayerChunkMap;
  import net.minecraft.server.level.TicketType;
-@@ -3483,5 +3484,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3488,5 +3489,9 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public static int nextEntityId() {
          return entityCount.incrementAndGet();
      }

--- a/Spigot-Server-Patches/0576-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
+++ b/Spigot-Server-Patches/0576-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix CME on adding a passenger in CreatureSpawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d072e3fb26f32db80be68f0e23526e34f57ff331..0841cf7e968a8a3b577e91f6dcd0487169474329 100644
+index 35b2e8dba3536febe997f3c562c56f0d5371a524..7f212d7471e96e91b990cc5432216b2c1e8fb01f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3182,7 +3182,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3187,7 +3187,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public Stream<Entity> recursiveStream() {

--- a/Spigot-Server-Patches/0605-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/Spigot-Server-Patches/0605-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -19,10 +19,10 @@ index 5a451cc855de57f79a57670ba38e3af2343cb510..7d3207a9af8360ddad228281d6aa65e1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bb1a3fb7d0c0b770636971877bed045005787e64..f35afa4d8d087649f57020e4f89185cffcb1ed3a 100644
+index 7f212d7471e96e91b990cc5432216b2c1e8fb01f..14ada3f197e625d922c8b39ecdb1ac76e5fc49e9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1575,6 +1575,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1576,6 +1576,12 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean isCollidable() {

--- a/Spigot-Server-Patches/0648-Collision-option-for-requiring-a-player-participant.patch
+++ b/Spigot-Server-Patches/0648-Collision-option-for-requiring-a-player-participant.patch
@@ -28,10 +28,10 @@ index d052d53771d868e6fa25d8854fc675a808722c65..c293efaa70c67d7a4227d779eac5d3a5
      public int wanderingTraderSpawnDayTicks = 24000;
      public int wanderingTraderSpawnChanceFailureIncrement = 25;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f35afa4d8d087649f57020e4f89185cffcb1ed3a..a76d32a978ec6fe749ffc0bd50004bda059b6196 100644
+index 14ada3f197e625d922c8b39ecdb1ac76e5fc49e9..bcb4ac7a3ca009b68498534eddc98d40bffeaf12 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1467,6 +1467,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -1468,6 +1468,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      public void collide(Entity entity) {
          if (!this.isSameVehicle(entity)) {
              if (!entity.noclip && !this.noclip) {

--- a/Spigot-Server-Patches/0677-do-not-create-unnecessary-copies-of-passenger-list.patch
+++ b/Spigot-Server-Patches/0677-do-not-create-unnecessary-copies-of-passenger-list.patch
@@ -57,10 +57,10 @@ index 169fa174f86f8a8dc42d3b9c4954a39d0a738c06..6835401bd7863bbd655502547a9fd4ae
              }
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1c6e17e8e 100644
+index 04127554c330aaa4e1685fb77058ed92def4ba80..ded22f1431a3e909996d6bbbc5bdf09247f46898 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2235,7 +2235,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2240,7 +2240,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      protected boolean q(Entity entity) {
@@ -69,7 +69,7 @@ index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1
      }
  
      public final float getCollisionBorderSize() { return bg(); } // Paper - OBFHELPER
-@@ -2331,7 +2331,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2336,7 +2336,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean isVehicle() {
@@ -78,7 +78,7 @@ index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1
      }
  
      public boolean bt() {
-@@ -3143,7 +3143,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3148,7 +3148,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean w(Entity entity) {
@@ -87,7 +87,7 @@ index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1
  
          Entity entity1;
  
-@@ -3159,7 +3159,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3164,7 +3164,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
  
      public boolean a(Class<? extends Entity> oclass) {
@@ -96,7 +96,7 @@ index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1
  
          Entity entity;
  
-@@ -3176,7 +3176,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3181,7 +3181,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
  
      public Collection<Entity> getAllPassengers() {
          Set<Entity> set = Sets.newHashSet();
@@ -105,7 +105,7 @@ index d62179765f93738e8444b507238b4fd79a1e9443..89b2be0e9e42d65b7d2d2833de4e6cd1
  
          while (iterator.hasNext()) {
              Entity entity = (Entity) iterator.next();
-@@ -3202,7 +3202,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -3207,7 +3207,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      private void a(boolean flag, Set<Entity> set) {
          Entity entity;
  

--- a/Spigot-Server-Patches/0755-Fix-dangerous-end-portal-logic.patch
+++ b/Spigot-Server-Patches/0755-Fix-dangerous-end-portal-logic.patch
@@ -23,10 +23,10 @@ index 558af73ac16550ee6964c4dce681a404633b2552..75bcfb3a2b4a104aeebb2fe3298714b2
      public Entity b(WorldServer worldserver, PlayerTeleportEvent.TeleportCause cause) {
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 89b2be0e9e42d65b7d2d2833de4e6cd1c6e17e8e..6e1304f7169c11f67c573b2c8dc11825bcc7da0d 100644
+index ded22f1431a3e909996d6bbbc5bdf09247f46898..0ec3589df774af366a896b8dc257f138e94e6e18 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -314,6 +314,37 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -315,6 +315,37 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
      }
      // Paper end - optimise entity tracking
  
@@ -64,7 +64,7 @@ index 89b2be0e9e42d65b7d2d2833de4e6cd1c6e17e8e..6e1304f7169c11f67c573b2c8dc11825
      public Entity(EntityTypes<?> entitytypes, World world) {
          this.id = Entity.entityCount.incrementAndGet();
          this.passengers = Lists.newArrayList();
-@@ -2299,6 +2330,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
+@@ -2304,6 +2335,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, ne
              }
  
              this.E();


### PR DESCRIPTION
If there is no world anymore (e.g. deleting the world an entity was
spawned in), it will be nulled while the location is still _technically_
legal.

I'm unsure whether this should rather keep the UUID in memory,
as that would be a very acceptable fix and would even retain the
origin world in these cases. That being said, it would be useless
information.

Fixes #5791.