### PR TITLE
Fix recursive connection call causing StackOverflowException

### DIFF
--- a/patches/server/0306-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/patches/server/0306-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 9f0537799a3cae43fb120056b8fe805a4883cc4d..5897bdb4d1372fa3d7bdc482d02f0a54d8767bda 100644
+index 9f0537799a3cae43fb120056b8fe805a4883cc4d..7607bf75968cc32d616e2b44e89901b3681b1131 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -87,6 +87,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -106,9 +106,6 @@ index 9f0537799a3cae43fb120056b8fe805a4883cc4d..5897bdb4d1372fa3d7bdc482d02f0a54
      public void send(Packet<?> packet, @Nullable GenericFutureListener<? extends Future<? super Void>> callback) {
 -        if (this.isConnected()) {
 -            this.flushQueue();
--            this.sendPacket(packet, callback);
--        } else {
--            this.queue.add(new Connection.PacketHolder(packet, callback));
 +        // Paper start - handle oversized packets better
 +        boolean connected = this.isConnected();
 +        if (!connected && !preparing) {
@@ -119,7 +116,9 @@ index 9f0537799a3cae43fb120056b8fe805a4883cc4d..5897bdb4d1372fa3d7bdc482d02f0a54
 +            net.minecraft.server.MCUtil.isMainThread() && packet.isReady() && this.queue.isEmpty() &&
 +            (packet.getExtraPackets() == null || packet.getExtraPackets().isEmpty())
 +        ))) {
-+            this.send(packet, callback);
+             this.sendPacket(packet, callback);
+-        } else {
+-            this.queue.add(new Connection.PacketHolder(packet, callback));
 +            return;
          }
 +        // write the packets to the queue, then flush - antixray hooks there already


### PR DESCRIPTION
This was probably caused by the rename sendPacket->send and dispatchPacket->sendPacket

When joining the game, you were greeted with logs:
```
[17:32:53 WARN]: [io.netty.channel.AbstractChannelHandlerContext] An exception 'java.lang.StackOverflowError' [enable DEBUG level for full stacktrace] was thrown by a user handler's exceptionCaught() method while handling the following exception:
java.lang.StackOverflowError: null
    at net.minecraft.network.Connection.isConnected(Connection.java:496) ~[Paper-Server-1.17-R0.1-SNAPSHOT-all.jar:git-Paper-"0ea382b"]
    at net.minecraft.network.Connection.send(Connection.java:245) ~[Paper-Server-1.17-R0.1-SNAPSHOT-all.jar:git-Paper-"0ea382b"]
    at net.minecraft.network.Connection.send(Connection.java:254) ~[Paper-Server-1.17-R0.1-SNAPSHOT-all.jar:git-Paper-"0ea382b"]
    at net.minecraft.network.Connection.send(Connection.java:254) ~[Paper-Server-1.17-R0.1-SNAPSHOT-all.jar:git-Paper-"0ea382b"]
    at net.minecraft.network.Connection.send(Connection.java:254) ~[Paper-Server-1.17-R0.1-SNAPSHOT-all.jar:git-Paper-"0ea382b"
[...]
```
This doesn't happen now.