### PR TITLE
fix: Blank ('') `no-permission` messages shouldn't send blank lines

### DIFF
--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -43,15 +43,20 @@ index ca4e2d3b27f629e0d5e672fc915a5d03f0c0581d..17f8dd9870a47227a7c9bb09cceedb94
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 7c80dc54776d0d66f7816b77136f6dbd9b801704..c10fc8d2386301bc2caddcdb1cd18566bcaa8689 100644
+index 7c80dc54776d0d66f7816b77136f6dbd9b801704..1994f15831de1ca1bb7b4f52c23567825766d3f9 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
-@@ -185,7 +185,7 @@ public abstract class Command {
+@@ -185,7 +185,12 @@ public abstract class Command {
          }
  
          if (permissionMessage == null) {
 -            target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is a mistake.");
-+            target.sendMessage(Bukkit.getPermissionMessage()); // Paper
++            // Paper start
++            String bukkitPermissionMessage = Bukkit.getPermissionMessage();
++            if (org.apache.commons.lang.StringUtils.isNotBlank(bukkitPermissionMessage)) {
++                target.sendMessage(bukkitPermissionMessage);
++            }
++            // Paper end
          } else if (permissionMessage.length() != 0) {
              for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
                  target.sendMessage(line);


### PR DESCRIPTION
Closes #5870.

First time contributing, and while I'm fairly confident with my java, Paper's a bit more than the average project. Hopefully I did this right.