### PR TITLE
Don't apply cramming damage to players

### DIFF
--- a/patches/server/0716-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0716-Don-t-apply-cramming-damage-to-players.patch
@@ -1,0 +1,40 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <max@themoep.de>
+Date: Sun, 20 Jun 2021 16:35:42 +0100
+Subject: [PATCH] Don't apply cramming damage to players
+
+It does not make a lot of sense to damage players if they get crammed,
+ especially as the usecase of teleporting lots of players to the same
+ location isn't too uncommon and killing all those players isn't
+ really what one would expect to happen.
+
+For those who really want it a config option is provided.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 26e18a08a7f0bd704ff3055ce3a7814191450c85..deafdf54d4ebddf225533b0372217d250c5f3f08 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -820,5 +820,10 @@ public class PaperWorldConfig {
+     private void fixInvulnerableEndCrystalExploit() {
+         fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
+     }
++
++    public boolean allowPlayerCrammingDamage = false;
++    private void playerCrammingDamage() {
++        allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
++    }
+ }
+ 
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 181ab56448796a617f30f1b9e0fec8917b5d8e07..3e9d2272d7a8ec38a0e9cb0929e188cf58fccfb6 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -1418,7 +1418,7 @@ public class ServerPlayer extends Player {
+ 
+     @Override
+     public boolean isInvulnerableTo(DamageSource damageSource) {
+-        return super.isInvulnerableTo(damageSource) || this.isChangingDimension() || this.getAbilities().invulnerable && damageSource == DamageSource.WITHER;
++        return super.isInvulnerableTo(damageSource) || this.isChangingDimension() || (!level.paperConfig.allowPlayerCrammingDamage && damageSource == DamageSource.CRAMMING) || this.getAbilities().invulnerable && damageSource == DamageSource.WITHER;
+     }
+ 
+     @Override

--- a/patches/server/0729-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0729-Don-t-apply-cramming-damage-to-players.patch
@@ -11,12 +11,12 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26e18a08a7f0bd704ff3055ce3a7814191450c85..deafdf54d4ebddf225533b0372217d250c5f3f08 100644
+index 857ef2377d2e6fd84d70e301860692e670983f0c..171321d4f1b73a25266175dfb5529dfc5cb8a5ca 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -820,5 +820,10 @@ public class PaperWorldConfig {
-     private void fixInvulnerableEndCrystalExploit() {
-         fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
+@@ -840,5 +840,10 @@ public class PaperWorldConfig {
+     private void showSignClickCommandFailureMessagesToPlayer() {
+         showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }
 +
 +    public boolean allowPlayerCrammingDamage = false;
@@ -26,15 +26,15 @@ index 26e18a08a7f0bd704ff3055ce3a7814191450c85..deafdf54d4ebddf225533b0372217d25
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 181ab56448796a617f30f1b9e0fec8917b5d8e07..3e9d2272d7a8ec38a0e9cb0929e188cf58fccfb6 100644
+index 8e2bccc3a9ddb17a4978596056189eb776976338..e32da100eabf0d3de12375402e9378c726811358 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1418,7 +1418,7 @@ public class ServerPlayer extends Player {
+@@ -1419,7 +1419,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {
 -        return super.isInvulnerableTo(damageSource) || this.isChangingDimension() || this.getAbilities().invulnerable && damageSource == DamageSource.WITHER;
-+        return super.isInvulnerableTo(damageSource) || this.isChangingDimension() || (!level.paperConfig.allowPlayerCrammingDamage && damageSource == DamageSource.CRAMMING) || this.getAbilities().invulnerable && damageSource == DamageSource.WITHER;
++        return super.isInvulnerableTo(damageSource) || this.isChangingDimension() || this.getAbilities().invulnerable && damageSource == DamageSource.WITHER || !level.paperConfig.allowPlayerCrammingDamage && damageSource == DamageSource.CRAMMING; // Paper - disable player cramming
      }
  
      @Override


### PR DESCRIPTION
It does not make a lot of sense to damage players if they get crammed, especially as the usecase of teleporting lots of players to the same location isn't too uncommon and killing all those players isn't really what one would expect to happen. (And I have seen this happen before, it could even result in a server crash when the items of 100 players get dropped...)

For those who really want it a config option is provided.

