### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add get-set drop chance to EntityEquipment
 
 
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index f905bf7a28a42d8bd2aecd42030d2b2092696fc3..58cfd450973f56bfbdd20f9dca8c1e7455260a55 100644
+index e85c4208f3536277fcd0f8a0f0b4841c4e073b2c..d0abfc3211a7ec451d83e59c7e39cfc7cc47f43e 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-@@ -405,4 +405,32 @@ public interface EntityEquipment {
+@@ -406,4 +406,32 @@ public interface EntityEquipment {
       */
      @Nullable
      Entity getHolder();

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -620,7 +620,7 @@ index 7bad75bd86fcb484e253fca8077d017d3161158b..fe83f13d71f84591f5506e1c6b9dfbf9
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 5bb6df24576948b1f5b66d14769d9137bad5a7e2..b4bc656a1c5fffd8c88bc61df3ac7f84dac52d29 100644
+index 16ca2a041139dd06922459df33e6eb058dbda3d2..cfe9930490489d506c91d174b5aad199314ffd17 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -23,6 +23,7 @@ import net.minecraft.core.BlockPos;
@@ -689,10 +689,10 @@ index b2083d26e3b239d0f26da77955db6a34b622a1bb..90854842fda0f91ac68c70efbcf8ad9e
          this.world = new CraftWorld((ServerLevel) this, gen, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7230982ee15d0584824e25aaad7b1adfe128e59a..933d5bd4b5871af83d2db5b52edac217fdf87188 100644
+index d233380baf0f4431992ce2aa58dccd534a7b271f..7d555968f2911c4ea12ca625da501e73828eb661 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -809,6 +809,7 @@ public final class CraftServer implements Server {
+@@ -805,6 +805,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -700,7 +700,7 @@ index 7230982ee15d0584824e25aaad7b1adfe128e59a..933d5bd4b5871af83d2db5b52edac217
          for (ServerLevel world : this.console.getAllLevels()) {
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
-@@ -842,12 +843,14 @@ public final class CraftServer implements Server {
+@@ -838,12 +839,14 @@ public final class CraftServer implements Server {
                  world.ticksPerAmbientSpawns = this.getTicksPerAmbientSpawns();
              }
              world.spigotConfig.init(); // Spigot
@@ -715,7 +715,7 @@ index 7230982ee15d0584824e25aaad7b1adfe128e59a..933d5bd4b5871af83d2db5b52edac217
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2105,4 +2108,35 @@ public final class CraftServer implements Server {
+@@ -2101,4 +2104,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end
@@ -752,7 +752,7 @@ index 7230982ee15d0584824e25aaad7b1adfe128e59a..933d5bd4b5871af83d2db5b52edac217
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 24e08ca0fca3e87f8a6b7670b266f3c2900b798c..3c4281ad770598ecf3b9fae0d6ed6e9130136dbb 100644
+index 358475974cf7dfced302bdd7d2390bd95848c737..ce548fe73dcef10adb99045b06ce58135935aee6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -1360,7 +1360,7 @@ index bcfc6ea89aa3b1df92d2b181d1d23902859e2584..5c5cfc31ced6695af7b1dd06cb867274
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index e02562f8d0160dc3516768555604ae47f3f55461..8a77e28c9b12a110c721943aca545270ef8bbaef 100644
+index 4c03678894cc23905634288e86906af4c939aac2..cf9cc3ef64ec95e1061fc109e7268c2b4bb1b942 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -209,6 +209,7 @@ import org.bukkit.inventory.EquipmentSlot;
@@ -1415,7 +1415,7 @@ index e02562f8d0160dc3516768555604ae47f3f55461..8a77e28c9b12a110c721943aca545270
          // this.minecraftServer.getCommandDispatcher().a(this.player.getCommandListener(), s);
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 01f3267c086837cbbc311d62974ecb034e429c23..34e386efda7ea52fb6f53333eda0f015b0666ff3 100644
+index 809b8510d638cc66ca0a72f88edd68e917dbbf26..524428ee32d18c76c0e9c46bbac3664888b1b35c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1,5 +1,6 @@
@@ -1425,7 +1425,7 @@ index 01f3267c086837cbbc311d62974ecb034e429c23..34e386efda7ea52fb6f53333eda0f015
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -1002,10 +1003,11 @@ public abstract class PlayerList {
+@@ -1008,10 +1009,11 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {
@@ -1812,10 +1812,10 @@ index 468b67babc628f7ff7c6fa138ed7944a8d77f0a6..22d5c4cc3aea19cbf53ea320765ecceb
  
      private static CompoundTag packStructureData(ServerLevel world, ChunkPos chunkcoordintpair, Map<StructureFeature<?>, StructureStart<?>> map, Map<StructureFeature<?>, LongSet> map1) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 933d5bd4b5871af83d2db5b52edac217fdf87188..bcd056ac91775c72809284bbc20c366e1ca31350 100644
+index 7d555968f2911c4ea12ca625da501e73828eb661..0a194d6d73a048897d7d8c41cdefc87c85db155c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2077,12 +2077,31 @@ public final class CraftServer implements Server {
+@@ -2073,12 +2073,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1191,7 +1191,7 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2b0d989119c9f69a68a6c1c69fb09dbbedd16716..172536147305f283bd14d356ff4f39531e8f3ad9 100644
+index ee9eefc6ed85aea4801b5588e797a247fc747c49..fff24cae9cbde5e0ca417ea368f8572e6d8e511a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -145,6 +145,7 @@ import net.minecraft.world.scores.Score;
@@ -1266,7 +1266,7 @@ index 2b0d989119c9f69a68a6c1c69fb09dbbedd16716..172536147305f283bd14d356ff4f3953
          // CraftBukkit end
          this.chatVisibility = packet.getChatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 8a77e28c9b12a110c721943aca545270ef8bbaef..8b082713c1bd41ff9d26ce45c949514ae8aec6ef 100644
+index cf9cc3ef64ec95e1061fc109e7268c2b4bb1b942..4fc871595a2449cb22bceb8ed279fe91166597f9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -162,6 +162,8 @@ import org.apache.logging.log4j.LogManager;
@@ -1306,7 +1306,7 @@ index 8a77e28c9b12a110c721943aca545270ef8bbaef..8b082713c1bd41ff9d26ce45c949514a
 -        String leaveMessage = ChatFormatting.YELLOW + this.player.getScoreboardName() + " left the game.";
 +        net.kyori.adventure.text.Component leaveMessage = net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, this.player.getBukkitEntity().displayName()); // Paper - Adventure
  
--        PlayerKickEvent event = new PlayerKickEvent(this.cserver.getPlayer(this.player), s, leaveMessage);
+-        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), s, leaveMessage);
 +        PlayerKickEvent event = new PlayerKickEvent(this.player.getBukkitEntity(), reason, leaveMessage); // Paper - Adventure
  
          if (this.cserver.getServer().isRunning()) {
@@ -1356,7 +1356,7 @@ index 8a77e28c9b12a110c721943aca545270ef8bbaef..8b082713c1bd41ff9d26ce45c949514a
  
 -            // CraftBukkit start
 +            // CraftBukkit start // Paper start - Adventure
-             Player player = this.cserver.getPlayer(this.player);
+             Player player = this.player.getBukkitEntity();
              int x = packetplayinupdatesign.getPos().getX();
              int y = packetplayinupdatesign.getPos().getY();
              int z = packetplayinupdatesign.getPos().getZ();
@@ -1374,7 +1374,7 @@ index 8a77e28c9b12a110c721943aca545270ef8bbaef..8b082713c1bd41ff9d26ce45c949514a
 +                    lines.add(net.kyori.adventure.text.Component.text(list.get(i).getRaw()));
                  }
              }
-             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.cserver.getPlayer(this.player), lines);
+             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.player.getBukkitEntity(), lines);
              this.cserver.getPluginManager().callEvent(event);
  
              if (!event.isCancelled()) {
@@ -1438,7 +1438,7 @@ index b632280e057ae6893bf5ebcde75cefac3ee62a09..9baa56d6da9c24706f1dbc8851fd68ca
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6937496ca 100644
+index 524428ee32d18c76c0e9c46bbac3664888b1b35c..186c745401a3320432f4aadfadfc6ef4b1d8041c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.authlib.GameProfile;
@@ -1457,7 +1457,7 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
  import com.google.common.base.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.server.dedicated.DedicatedServer;
-@@ -255,7 +257,7 @@ public abstract class PlayerList {
+@@ -256,7 +258,7 @@ public abstract class PlayerList {
          }
          // CraftBukkit start
          chatmessage.withStyle(ChatFormatting.YELLOW);
@@ -1466,12 +1466,12 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
  
          playerconnection.teleport(player.getX(), player.getY(), player.getZ(), player.getYRot(), player.getXRot());
          this.players.add(player);
-@@ -264,19 +266,18 @@ public abstract class PlayerList {
-         // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, new EntityPlayer[]{entityplayer})); // CraftBukkit - replaced with loop below
+@@ -270,19 +272,18 @@ public abstract class PlayerList {
+         // Ensure that player inventory is populated with its viewer
+         player.containerMenu.transferTo(player.containerMenu, bukkitPlayer);
  
-         // CraftBukkit start
--        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(this.cserver.getPlayer(player), joinMessage);
-+        PlayerJoinEvent playerJoinEvent = new org.bukkit.event.player.PlayerJoinEvent(this.cserver.getPlayer(player), PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
+-        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(bukkitPlayer, joinMessage);
++        PlayerJoinEvent playerJoinEvent = new PlayerJoinEvent(bukkitPlayer, PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
          this.cserver.getPluginManager().callEvent(playerJoinEvent);
  
          if (!player.connection.connection.isConnected()) {
@@ -1491,7 +1491,7 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
          }
          // CraftBukkit end
  
-@@ -473,7 +474,7 @@ public abstract class PlayerList {
+@@ -479,7 +480,7 @@ public abstract class PlayerList {
  
      }
  
@@ -1500,16 +1500,16 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
          ServerLevel worldserver = entityplayer.getLevel();
  
          entityplayer.awardStat(Stats.LEAVE_GAME);
-@@ -484,7 +485,7 @@ public abstract class PlayerList {
+@@ -490,7 +491,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer();
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getScoreboardName() + " left the game");
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), "\u00A7e" + entityplayer.getScoreboardName() + " left the game");
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
-@@ -537,7 +538,7 @@ public abstract class PlayerList {
+@@ -543,7 +544,7 @@ public abstract class PlayerList {
          this.cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -1518,12 +1518,12 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -583,10 +584,10 @@ public abstract class PlayerList {
+@@ -589,10 +590,10 @@ public abstract class PlayerList {
              }
  
              // return chatmessage;
--            if (!gameprofilebanentry.hasExpired()) event.disallow(PlayerLoginEvent.Result.KICK_BANNED, CraftChatMessage.fromComponent(chatmessage)); // Spigot
-+            if (!gameprofilebanentry.hasExpired()) event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Spigot // Paper - Adventure
+-            event.disallow(PlayerLoginEvent.Result.KICK_BANNED, CraftChatMessage.fromComponent(chatmessage));
++            event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
          } else if (!this.isWhiteListed(gameprofile)) {
              chatmessage = new TranslatableComponent("multiplayer.disconnect.not_whitelisted");
 -            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot
@@ -1531,7 +1531,7 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
          } else if (this.getIpBans().isBanned(socketaddress) && !this.getIpBans().get(socketaddress).hasExpired()) {
              IpBanListEntry ipbanentry = this.ipBans.get(socketaddress);
  
-@@ -596,17 +597,17 @@ public abstract class PlayerList {
+@@ -602,17 +603,17 @@ public abstract class PlayerList {
              }
  
              // return chatmessage;
@@ -1552,7 +1552,7 @@ index 34e386efda7ea52fb6f53333eda0f015b0666ff3..446dd8c15d4ccdced316deeaba379cb6
              return null;
          }
          return entity;
-@@ -1109,7 +1110,7 @@ public abstract class PlayerList {
+@@ -1115,7 +1116,7 @@ public abstract class PlayerList {
      public void removeAll() {
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {
@@ -1602,7 +1602,7 @@ index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0f2a93e7d 100644
+index 0a194d6d73a048897d7d8c41cdefc87c85db155c..4df54b9d778133a5868c9ce3975579beb301e31b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -564,8 +564,10 @@ public final class CraftServer implements Server {
@@ -1615,8 +1615,8 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
 +        // Paper end
      }
  
-     public Player getPlayer(final ServerPlayer entity) {
-@@ -1309,7 +1311,15 @@ public final class CraftServer implements Server {
+     @Override
+@@ -1305,7 +1307,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1632,7 +1632,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1426,7 +1436,20 @@ public final class CraftServer implements Server {
+@@ -1422,7 +1432,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1653,7 +1653,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1434,14 +1457,14 @@ public final class CraftServer implements Server {
+@@ -1430,14 +1453,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1670,7 +1670,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1667,6 +1690,14 @@ public final class CraftServer implements Server {
+@@ -1663,6 +1686,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1685,7 +1685,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1679,13 +1710,28 @@ public final class CraftServer implements Server {
+@@ -1675,13 +1706,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1714,7 +1714,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1729,6 +1775,12 @@ public final class CraftServer implements Server {
+@@ -1725,6 +1771,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1727,7 +1727,7 @@ index bcd056ac91775c72809284bbc20c366e1ca31350..e2564dee0603735d135d1de2af6801a0
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2157,5 +2209,15 @@ public final class CraftServer implements Server {
+@@ -2153,5 +2205,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }

--- a/patches/server/0023-Further-improve-server-tick-loop.patch
+++ b/patches/server/0023-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3a9d77a190ef96c06717ee00bcfba52b8f984c14..ca439ac2a09a2ce4e019282c0b75f2f5d41a2208 100644
+index 26f6a3d2d70078f300412a5076afb8a19818cd25..65b2fa69fd36addc9534f069cce8ec95cf1122a2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -285,7 +285,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -143,10 +143,10 @@ index 3a9d77a190ef96c06717ee00bcfba52b8f984c14..ca439ac2a09a2ce4e019282c0b75f2f5
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f00844d2953e6ead58bfd383a214695b3dbe5086..477097955ad36b2639f6304f762a529a1989ba5e 100644
+index d169323a505d8dc46796fc53d9e99633c62b2c5f..c00f2263b8cee28d32e73c1eddaeb02be9e8b68c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2125,6 +2125,17 @@ public final class CraftServer implements Server {
+@@ -2121,6 +2121,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0025-Entity-Origin-API.patch
+++ b/patches/server/0025-Entity-Origin-API.patch
@@ -85,10 +85,10 @@ index 018792503e5d18470ad17b9f4b4524d5dfba31e9..5d4d5628e5c0d82301f988691eac3637
              CrashReport crashreport = CrashReport.forThrowable(throwable, "Loading entity NBT");
              CrashReportCategory crashreportsystemdetails = crashreport.addCategory("Entity being loaded");
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 11ed0127e2ea268f16c6b4b380d132a71ec9b3dc..6c262832ba5259ec92d336114c203c254a39924c 100644
+index 91c0e425de193be1e4e9779d1c92c8ea577e29e0..1d538f490c7aa48991446fb55c7f0916bb5d5e29 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -329,6 +329,14 @@ public class FallingBlockEntity extends Entity {
+@@ -330,6 +330,14 @@ public class FallingBlockEntity extends Entity {
              this.blockState = Blocks.SAND.defaultBlockState();
          }
  

--- a/patches/server/0042-Add-PlayerInitialSpawnEvent.patch
+++ b/patches/server/0042-Add-PlayerInitialSpawnEvent.patch
@@ -9,19 +9,19 @@ This is a duplicate API from spigot, so use our duplicate subclass and
 improve setPosition to use raw
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 446dd8c15d4ccdced316deeaba379cb6937496ca..8e9d0ca8aa2b1403fc65ed8d792525047a610a3a 100644
+index 186c745401a3320432f4aadfadfc6ef4b1d8041c..cf1621fad7f9b3ec03f1c3722856186273c7935e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -213,7 +213,7 @@ public abstract class PlayerList {
+@@ -214,7 +214,7 @@ public abstract class PlayerList {
  
          // Spigot start - spawn location event
-         Player bukkitPlayer = player.getBukkitEntity();
--        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new org.spigotmc.event.player.PlayerSpawnLocationEvent(bukkitPlayer, bukkitPlayer.getLocation());
-+        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(bukkitPlayer, bukkitPlayer.getLocation()); // Paper use our duplicate event
+         Player spawnPlayer = player.getBukkitEntity();
+-        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new org.spigotmc.event.player.PlayerSpawnLocationEvent(spawnPlayer, spawnPlayer.getLocation());
++        org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(spawnPlayer, spawnPlayer.getLocation()); // Paper use our duplicate event
          this.cserver.getPluginManager().callEvent(ev);
  
          Location loc = ev.getSpawnLocation();
-@@ -221,7 +221,10 @@ public abstract class PlayerList {
+@@ -222,7 +222,10 @@ public abstract class PlayerList {
  
          player.setLevel(worldserver1);
          player.gameMode.setLevel((ServerLevel) player.level);

--- a/patches/server/0044-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0044-Ensure-commands-are-not-ran-async.patch
@@ -14,7 +14,7 @@ big slowdown in execution but throwing an exception at same time to raise awaren
 that it is happening so that plugin authors can fix their code to stop executing commands async.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c58f8cf20822439098648265917801509dda1a72..a6d1ce8fd971e8de720e01eaba4ee6c5872c39db 100644
+index 4fc871595a2449cb22bceb8ed279fe91166597f9..2bb324f8186c70319446af3f639191c8e99f9de5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1859,6 +1859,29 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -48,10 +48,10 @@ index c58f8cf20822439098648265917801509dda1a72..a6d1ce8fd971e8de720e01eaba4ee6c5
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4612557dfe8c81e6a9b6f11dc1c8d40eaa1337ec..452904333ce232855d61ff7d12cb8a5595ebb3f8 100644
+index c00f2263b8cee28d32e73c1eddaeb02be9e8b68c..d645c9d3d9b3af58e9fafb03cbf74c2ee49d1fd4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -762,6 +762,28 @@ public final class CraftServer implements Server {
+@@ -758,6 +758,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0046-Expose-server-CommandMap.patch
+++ b/patches/server/0046-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7154b5151375574a10e079b70dbd210d698f1d27..ae810acb2d54fc589ff59bbf97e3fbf86f76955c 100644
+index d645c9d3d9b3af58e9fafb03cbf74c2ee49d1fd4..f57cbaf3f6da17929f95281c2573008f8f437874 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1763,6 +1763,7 @@ public final class CraftServer implements Server {
+@@ -1759,6 +1759,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a9ca1e44eca6691e41c6b443f8953e77dbde62b2..610af41f33a41bd0465eace2c3e2b6ed8eeceac7 100644
+index 21d2684eb0d49b137ec56579d8ef493e5089f4f1..da1dbb6768825c42bb1d7533612be1f8accb2497 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2255,5 +2255,23 @@ public final class CraftServer implements Server {
+@@ -2251,5 +2251,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0061-Remove-Metadata-on-reload.patch
+++ b/patches/server/0061-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 610af41f33a41bd0465eace2c3e2b6ed8eeceac7..568777b6cad6f87f1ad7be361ebe47a6bc55cb2d 100644
+index da1dbb6768825c42bb1d7533612be1f8accb2497..be2f148d2b045d704df35b952b03cf88279de64f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -872,8 +872,16 @@ public final class CraftServer implements Server {
+@@ -868,8 +868,16 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/patches/server/0077-Fix-reducedDebugInfo-not-initialized-on-client.patch
+++ b/patches/server/0077-Fix-reducedDebugInfo-not-initialized-on-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix reducedDebugInfo not initialized on client
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8e9d0ca8aa2b1403fc65ed8d792525047a610a3a..ce72102870075fffd8be6f32230ceae269ea4f9c 100644
+index cf1621fad7f9b3ec03f1c3722856186273c7935e..dd0cde1ef149ae708fa7b0c043acfcc489fe497c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -246,6 +246,7 @@ public abstract class PlayerList {
+@@ -247,6 +247,7 @@ public abstract class PlayerList {
          playerconnection.send(new ClientboundSetCarriedItemPacket(player.getInventory().selected));
          playerconnection.send(new ClientboundUpdateRecipesPacket(this.server.getRecipeManager().getRecipes()));
          playerconnection.send(new ClientboundUpdateTagsPacket(this.server.getTags().serializeToNetwork((RegistryAccess) this.registryHolder)));

--- a/patches/server/0083-Configurable-Player-Collision.patch
+++ b/patches/server/0083-Configurable-Player-Collision.patch
@@ -32,7 +32,7 @@ index 8885220e4813b34627b42523834bbec995d8950d..4c9660176e783999301565790b8cf6f4
              buf.writeComponent(this.playerPrefix);
              buf.writeComponent(this.playerSuffix);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9e936078b388459bed7da3c6edfd0e65f3b1b1bf..15e26dbc38e23c5284246ef55d038eb011759ee2 100644
+index e250db8035b2d53e724a47da6dc6118d85ca148b..7dca3357b8a758172ed09a8c1f823d9a94435f25 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -163,6 +163,7 @@ import net.minecraft.world.level.storage.loot.LootTables;
@@ -65,7 +65,7 @@ index 9e936078b388459bed7da3c6edfd0e65f3b1b1bf..15e26dbc38e23c5284246ef55d038eb0
          this.server.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.STARTUP));
          this.connection.acceptConnections();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ce72102870075fffd8be6f32230ceae269ea4f9c..b9c4428bc9653e81ed046bda94e248218c1fa9c9 100644
+index dd0cde1ef149ae708fa7b0c043acfcc489fe497c..9cd5ed55c8ee13412662a2d7a5b636833e3a813e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -85,6 +85,7 @@ import net.minecraft.world.level.storage.PlayerDataStorage;
@@ -76,7 +76,7 @@ index ce72102870075fffd8be6f32230ceae269ea4f9c..b9c4428bc9653e81ed046bda94e24821
  import net.minecraft.world.scores.Team;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -146,6 +147,7 @@ public abstract class PlayerList {
+@@ -147,6 +148,7 @@ public abstract class PlayerList {
      // CraftBukkit start
      private CraftServer cserver;
      private final Map<String,ServerPlayer> playersByName = new java.util.HashMap<>();
@@ -84,7 +84,7 @@ index ce72102870075fffd8be6f32230ceae269ea4f9c..b9c4428bc9653e81ed046bda94e24821
  
      public PlayerList(MinecraftServer server, RegistryAccess.RegistryHolder registryManager, PlayerDataStorage saveHandler, int maxPlayers) {
          this.cserver = server.server = new CraftServer((DedicatedServer) server, this);
-@@ -377,6 +379,13 @@ public abstract class PlayerList {
+@@ -383,6 +385,13 @@ public abstract class PlayerList {
  
          player.initInventoryMenu();
          // CraftBukkit - Moved from above, added world
@@ -98,7 +98,7 @@ index ce72102870075fffd8be6f32230ceae269ea4f9c..b9c4428bc9653e81ed046bda94e24821
          PlayerList.LOGGER.info("{}[{}] logged in with entity id {} at ([{}]{}, {}, {})", player.getName().getString(), s1, player.getId(), worldserver1.serverLevelData.getLevelName(), player.getX(), player.getY(), player.getZ());
      }
  
-@@ -496,6 +505,16 @@ public abstract class PlayerList {
+@@ -502,6 +511,16 @@ public abstract class PlayerList {
          entityplayer.doTick(); // SPIGOT-924
          // CraftBukkit end
  
@@ -115,7 +115,7 @@ index ce72102870075fffd8be6f32230ceae269ea4f9c..b9c4428bc9653e81ed046bda94e24821
          this.save(entityplayer);
          if (entityplayer.isPassenger()) {
              Entity entity = entityplayer.getRootVehicle();
-@@ -1118,6 +1137,13 @@ public abstract class PlayerList {
+@@ -1124,6 +1143,13 @@ public abstract class PlayerList {
          }
          // CraftBukkit end
  

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index 8e27b43e2f6ce4d7f5007fe02db1722e73c30a58..6aacc724c8c8d6fbe3067226989039ca
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 568777b6cad6f87f1ad7be361ebe47a6bc55cb2d..6387f01a9aeb72817988d1609188ca20b5ca4f6e 100644
+index be2f148d2b045d704df35b952b03cf88279de64f..2e37c23ce815a5e38ac9b823d187d39057e81ec0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1516,7 +1516,7 @@ public final class CraftServer implements Server {
+@@ -1512,7 +1512,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -22,10 +22,10 @@ index 96247356d7888d5681bff60567add1188aedb18b..e83216be5a00d5b927d8c2fc364551bd
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 6c262832ba5259ec92d336114c203c254a39924c..0d476aa50170ad3623462306769020518c55cffb 100644
+index 1d538f490c7aa48991446fb55c7f0916bb5d5e29..69f385c57f3716a489781debb32b4adf1cb9383d 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -308,6 +308,18 @@ public class FallingBlockEntity extends Entity {
+@@ -309,6 +309,18 @@ public class FallingBlockEntity extends Entity {
      @Override
      protected void readAdditionalSaveData(CompoundTag nbt) {
          this.blockState = NbtUtils.readBlockState(nbt.getCompound("BlockState"));

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6387f01a9aeb72817988d1609188ca20b5ca4f6e..25cdff21377fdd9d3daf6af8da1f3db4ed65dab6 100644
+index 2e37c23ce815a5e38ac9b823d187d39057e81ec0..6c8e93bdb90c2df34aef55d9df8a0dd9ce220aea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2281,5 +2281,24 @@ public final class CraftServer implements Server {
+@@ -2277,5 +2277,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0127-Enforce-Sync-Player-Saves.patch
+++ b/patches/server/0127-Enforce-Sync-Player-Saves.patch
@@ -7,10 +7,10 @@ Saving players async is extremely dangerous. This will force it to main
 the same way we handle async chunk loads.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b9c4428bc9653e81ed046bda94e248218c1fa9c9..3eaf106f8f17288857ce1a149d0366cf04235307 100644
+index 9cd5ed55c8ee13412662a2d7a5b636833e3a813e..3485538af8de78df47b03331c211e0015c214304 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1027,11 +1027,13 @@ public abstract class PlayerList {
+@@ -1033,11 +1033,13 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0134-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/patches/server/0134-Properly-handle-async-calls-to-restart-the-server.patch
@@ -30,7 +30,7 @@ will have plugins and worlds saving to the disk has a high potential to result
 in corruption/dataloss.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3e2955013ce75034170b5eeae60482e1c174769d..220ead6455587a07375b6e86913865c6b590a87d 100644
+index 1d70c8b6c807b92a2411f5dd46bf616cb8d05569..3875a2902c6a737fed4e2df3f7aee8fbe6ddda15 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -233,6 +233,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -64,10 +64,10 @@ index 3e2955013ce75034170b5eeae60482e1c174769d..220ead6455587a07375b6e86913865c6
          if (flag) {
              try {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3eaf106f8f17288857ce1a149d0366cf04235307..79ebb15bed6eec80c12c1020b2b6b07c758332aa 100644
+index 3485538af8de78df47b03331c211e0015c214304..2c24e800094d425b40361f8729a03393861f723a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1133,8 +1133,15 @@ public abstract class PlayerList {
+@@ -1139,8 +1139,15 @@ public abstract class PlayerList {
      }
  
      public void removeAll() {

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 25cdff21377fdd9d3daf6af8da1f3db4ed65dab6..8bd458b8995c9019b5ae85eab062df44e9424703 100644
+index 6c8e93bdb90c2df34aef55d9df8a0dd9ce220aea..e11d454da896d52fe2a0d1d90027ed539b847911 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2300,5 +2300,10 @@ public final class CraftServer implements Server {
+@@ -2296,5 +2296,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -230,10 +230,10 @@ index e2095308a8ec8471b04acce929d314fd828bc3de..45ae21718df16e16b5a3835a92afbf71
          System.setOut(IoBuilder.forLogger(logger).setLevel(Level.INFO).buildPrintStream());
          System.setErr(IoBuilder.forLogger(logger).setLevel(Level.WARN).buildPrintStream());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 79ebb15bed6eec80c12c1020b2b6b07c758332aa..bf6c3ac7ae37067f345568fb6656cf6b4d864be2 100644
+index 2c24e800094d425b40361f8729a03393861f723a..992760580450a9b0e8dc226b73ba0b29707ec04e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -151,8 +151,7 @@ public abstract class PlayerList {
+@@ -152,8 +152,7 @@ public abstract class PlayerList {
  
      public PlayerList(MinecraftServer server, RegistryAccess.RegistryHolder registryManager, PlayerDataStorage saveHandler, int maxPlayers) {
          this.cserver = server.server = new CraftServer((DedicatedServer) server, this);
@@ -244,7 +244,7 @@ index 79ebb15bed6eec80c12c1020b2b6b07c758332aa..bf6c3ac7ae37067f345568fb6656cf6b
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8bd458b8995c9019b5ae85eab062df44e9424703..79fe58b09c9e0870a5ab55bc21b8ab933450a1d7 100644
+index e11d454da896d52fe2a0d1d90027ed539b847911..e95a01e582b6c8996f4b366f5fd9b783658e6bff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,7 +46,6 @@ import java.util.function.Consumer;
@@ -263,7 +263,7 @@ index 8bd458b8995c9019b5ae85eab062df44e9424703..79fe58b09c9e0870a5ab55bc21b8ab93
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.bossevents.CustomBossEvent;
  import net.minecraft.server.commands.ReloadCommand;
-@@ -1204,9 +1204,13 @@ public final class CraftServer implements Server {
+@@ -1200,9 +1200,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 79fe58b09c9e0870a5ab55bc21b8ab933450a1d7..2f25e4c26f2f418de738ba2fcf7f2485bb2dda3c 100644
+index e95a01e582b6c8996f4b366f5fd9b783658e6bff..66e4851eb8565fe1c3f49b48d62ca5d004746a36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -792,7 +792,13 @@ public final class CraftServer implements Server {
+@@ -788,7 +788,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -492,7 +492,7 @@ index 3eb4bee81a8543cc06b9d5898f5f6c0e9dbbf554..9a428e166561b4bc028732ec563d3b2e
      public GameProfile get(UUID uuid) {
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByUUID.get(uuid);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2f25e4c26f2f418de738ba2fcf7f2485bb2dda3c..46972308cf399ed02c450bc2d45b4dc88b234ab0 100644
+index 66e4851eb8565fe1c3f49b48d62ca5d004746a36..6a03863baa2347a084abe2699e30245a8873c2fc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -226,6 +226,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -505,7 +505,7 @@ index 2f25e4c26f2f418de738ba2fcf7f2485bb2dda3c..46972308cf399ed02c450bc2d45b4dc8
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2315,5 +2318,24 @@ public final class CraftServer implements Server {
+@@ -2311,5 +2314,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0151-ProfileWhitelistVerifyEvent.patch
+++ b/patches/server/0151-ProfileWhitelistVerifyEvent.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] ProfileWhitelistVerifyEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bf6c3ac7ae37067f345568fb6656cf6b4d864be2..429e6c7f9a5e5355e26deeae1e89ffea7439cd96 100644
+index 992760580450a9b0e8dc226b73ba0b29707ec04e..9f27c6fa106a11ea56a4be2d41f8a00f2aa4961f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -607,9 +607,9 @@ public abstract class PlayerList {
+@@ -613,9 +613,9 @@ public abstract class PlayerList {
  
              // return chatmessage;
-             if (!gameprofilebanentry.hasExpired()) event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Spigot // Paper - Adventure
+             event.disallow(PlayerLoginEvent.Result.KICK_BANNED, PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
 -        } else if (!this.isWhiteListed(gameprofile)) {
 -            chatmessage = new TranslatableComponent("multiplayer.disconnect.not_whitelisted");
 -            event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, PaperAdventure.LEGACY_SECTION_UXRC.deserialize(org.spigotmc.SpigotConfig.whitelistMessage)); // Spigot // Paper - Adventure
@@ -21,7 +21,7 @@ index bf6c3ac7ae37067f345568fb6656cf6b4d864be2..429e6c7f9a5e5355e26deeae1e89ffea
          } else if (this.getIpBans().isBanned(socketaddress) && !this.getIpBans().get(socketaddress).hasExpired()) {
              IpBanListEntry ipbanentry = this.ipBans.get(socketaddress);
  
-@@ -989,9 +989,25 @@ public abstract class PlayerList {
+@@ -995,9 +995,25 @@ public abstract class PlayerList {
          this.server.getCommands().sendCommands(player);
      }
  

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -14,7 +14,7 @@ completion, such as offline players.
 Also adds isCommand and getLocation to the sync TabCompleteEvent
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a679b30076cec74976cd04a7fab737fe88a83329..92f6f51d3642e1e8bcdb400da87f96ecf20c3218 100644
+index b91362681a3293e1acd044edad34e1e86e36d0f3..e12f0af47108b09e490f2a1e51a98accfcc6bd28 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -703,10 +703,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -72,10 +72,10 @@ index a679b30076cec74976cd04a7fab737fe88a83329..92f6f51d3642e1e8bcdb400da87f96ec
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 46972308cf399ed02c450bc2d45b4dc88b234ab0..c7dbe127e30cc6830794c3a81686908f076160ac 100644
+index 6a03863baa2347a084abe2699e30245a8873c2fc..1d767cf3f63569ce97132c5d0d6043584b54c658 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1850,7 +1850,7 @@ public final class CraftServer implements Server {
+@@ -1846,7 +1846,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0187-getPlayerUniqueId-API.patch
+++ b/patches/server/0187-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c7dbe127e30cc6830794c3a81686908f076160ac..8f2c7ca033a7c162395b6e5114895836e10534ab 100644
+index 1d767cf3f63569ce97132c5d0d6043584b54c658..38c7a8befad8633243b55d0f692f49f2e1b61256 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1518,6 +1518,25 @@ public final class CraftServer implements Server {
+@@ -1514,6 +1514,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0194-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
+++ b/patches/server/0194-Fix-exploit-that-allowed-colored-signs-to-be-created.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix exploit that allowed colored signs to be created
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 92f6f51d3642e1e8bcdb400da87f96ecf20c3218..52e51fe26c4c69842ac9d51e747cb10a7aab289f 100644
+index e12f0af47108b09e490f2a1e51a98accfcc6bd28..f3f0229c4fbbc1c54d3472b3ee6357ff1f542a1f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2787,9 +2787,9 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -19,4 +19,4 @@ index 92f6f51d3642e1e8bcdb400da87f96ecf20c3218..52e51fe26c4c69842ac9d51e747cb10a
 +                    lines.add(net.kyori.adventure.text.Component.text(SharedConstants.filterText(list.get(i).getRaw())));
                  }
              }
-             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.cserver.getPlayer(this.player), lines);
+             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.player.getBukkitEntity(), lines);

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 894e828280d6ccc175cffd8813602b3406c8e95a..0f45f6022a4dc9638032278cce0f8d6fc431bd56 100644
+index c98c7dabc2274fe758cafb334ec4c4d3952b85e7..d1c1cf5061f9294d67086b5361166e940536a8a0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1055,7 +1055,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -29,7 +29,7 @@ index 894e828280d6ccc175cffd8813602b3406c8e95a..0f45f6022a4dc9638032278cce0f8d6f
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 83a2c8e00d8445ad66bb8360f4e0e4b7cba44bb3..b9fdccfc9815b0aec7bb5f5ad633c69b8eba6af2 100644
+index 73fa8277ab107ef0ec690d81caac0e98535a3110..47f1a0e409f42e6694f143ce340eda7bb6a359c2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -602,7 +602,7 @@ public class ServerPlayer extends Player {
@@ -84,7 +84,7 @@ index 83a2c8e00d8445ad66bb8360f4e0e4b7cba44bb3..b9fdccfc9815b0aec7bb5f5ad633c69b
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 52e51fe26c4c69842ac9d51e747cb10a7aab289f..832233eea019b9a10b182ef1a2a072ece4b88ee4 100644
+index f3f0229c4fbbc1c54d3472b3ee6357ff1f542a1f..f07dcd1b01780b2980e021a008e8fc506bc2b3d7 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -188,6 +188,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -114,10 +114,10 @@ index 52e51fe26c4c69842ac9d51e747cb10a7aab289f..832233eea019b9a10b182ef1a2a072ec
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 429e6c7f9a5e5355e26deeae1e89ffea7439cd96..7c5a75fb34640bb4e7ef839412dbb30b0d0fc8e8 100644
+index 9f27c6fa106a11ea56a4be2d41f8a00f2aa4961f..a68e342112002782560268350b88f617b9bf86e1 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -494,7 +494,7 @@ public abstract class PlayerList {
+@@ -500,7 +500,7 @@ public abstract class PlayerList {
          // CraftBukkit start - Quitting must be before we do final save of data, in case plugins need to modify it
          // See SPIGOT-5799, SPIGOT-6145
          if (entityplayer.containerMenu != entityplayer.inventoryMenu) {
@@ -125,7 +125,7 @@ index 429e6c7f9a5e5355e26deeae1e89ffea7439cd96..7c5a75fb34640bb4e7ef839412dbb30b
 +            entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
-         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
 index 022bff6ac8ed5f2da438929c5ac455505bb16da7..1a7bd2462bab95fa6986cef705e5e5b82da30063 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java

--- a/patches/server/0229-PlayerLaunchProjectileEvent.patch
+++ b/patches/server/0229-PlayerLaunchProjectileEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerLaunchProjectileEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/EggItem.java b/src/main/java/net/minecraft/world/item/EggItem.java
-index 3516cd8ec5816e13df9850c6dc62ddd69b5cfaed..784c5c2b8299a5309ae190fef9923778fcfa00b4 100644
+index c33210c18445a93ca6445812471aaf1e55bcc44d..98b353f5cc05da5ee5a6c6110a08e43e819fe6d2 100644
 --- a/src/main/java/net/minecraft/world/item/EggItem.java
 +++ b/src/main/java/net/minecraft/world/item/EggItem.java
-@@ -23,21 +23,33 @@ public class EggItem extends Item {
+@@ -25,21 +25,33 @@ public class EggItem extends Item {
  
              entityegg.setItem(itemstack);
              entityegg.shootFromRotation(user, user.getXRot(), user.getYRot(), 0.0F, 1.5F, 1.0F);
@@ -34,7 +34,7 @@ index 3516cd8ec5816e13df9850c6dc62ddd69b5cfaed..784c5c2b8299a5309ae190fef9923778
 -            // CraftBukkit end
 +            // Paper end
          }
-         // world.playSound((EntityHuman) null, entityhuman.locX(), entityhuman.locY(), entityhuman.locZ(), SoundEffects.EGG_THROW, SoundCategory.PLAYERS, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F)); // CraftBukkit - from above
+         world.playSound((Player) null, user.getX(), user.getY(), user.getZ(), SoundEvents.EGG_THROW, SoundSource.PLAYERS, 0.5F, 0.4F / (world.getRandom().nextFloat() * 0.4F + 0.8F));
  
 +        /* // Paper start - moved up
          user.awardStat(Stats.ITEM_USED.get(this));

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,7 +36,7 @@ index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 80f8e994d4a85f5d240854ec492adba0633263b2..537efec03939b0f5640dfd974bb0bd68e93b4325 100644
+index d82015cd355a3450faf4cf3eb0f1a1cb10119c77..a7244e66b7bbf2b474304ab41ad31a606ab6ba9c 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1076,6 +1076,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,10 +48,10 @@ index 80f8e994d4a85f5d240854ec492adba0633263b2..537efec03939b0f5640dfd974bb0bd68
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8f2c7ca033a7c162395b6e5114895836e10534ab..e22b073a7a5f35a8edf58946144d1f1e9d94b6e3 100644
+index 38c7a8befad8633243b55d0f692f49f2e1b61256..02b85866b6f4b8975f66fd8c706cda8df49ac6a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -810,6 +810,7 @@ public final class CraftServer implements Server {
+@@ -806,6 +806,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index 8f2c7ca033a7c162395b6e5114895836e10534ab..e22b073a7a5f35a8edf58946144d1f1e
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -925,6 +926,7 @@ public final class CraftServer implements Server {
+@@ -921,6 +922,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0247-Use-ConcurrentHashMap-in-JsonList.patch
+++ b/patches/server/0247-Use-ConcurrentHashMap-in-JsonList.patch
@@ -23,10 +23,10 @@ Modified isEmpty to use the isEmpty() method instead of the slightly confusing s
 The point of this is readability, but does have a side-benefit of a small microptimization
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7c5a75fb34640bb4e7ef839412dbb30b0d0fc8e8..b62aa9f934c33b4d22b985b5e56937baa8454677 100644
+index a68e342112002782560268350b88f617b9bf86e1..4d2af64c5f084a7f1e5bb01e9d005b031c3731f6 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -610,7 +610,7 @@ public abstract class PlayerList {
+@@ -616,7 +616,7 @@ public abstract class PlayerList {
          } else if (!this.isWhitelisted(gameprofile, event)) { // Paper
              //chatmessage = new ChatMessage("multiplayer.disconnect.not_whitelisted"); // Paper
              //event.disallow(PlayerLoginEvent.Result.KICK_WHITELIST, org.spigotmc.SpigotConfig.whitelistMessage); // Spigot // Paper - moved to isWhitelisted

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -128,7 +128,7 @@ index 0000000000000000000000000000000000000000..41d73aa91fb401612e087aa1b7278ba6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index dbdd320eca27e82d5b058a7e6596b0a5fbc2631f..3d97f76f14b8c22c78c46a34c2da2e6406ba28b6 100644
+index eda7d7451571fdbb60a966ef75549fe6dfd57472..bda4807f70806feb020eb73494079f23e6b0d90e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -18,6 +18,7 @@ import javax.crypto.Cipher;
@@ -225,10 +225,10 @@ index dbdd320eca27e82d5b058a7e6596b0a5fbc2631f..3d97f76f14b8c22c78c46a34c2da2e64
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e22b073a7a5f35a8edf58946144d1f1e9d94b6e3..7f1d5725e156b9cf3273aa0f66c1e0d486df6a51 100644
+index 02b85866b6f4b8975f66fd8c706cda8df49ac6a8..246d9a3b4e618813ea4afbc790c90a3cdd683fef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -683,7 +683,7 @@ public final class CraftServer implements Server {
+@@ -679,7 +679,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -30,10 +30,10 @@ index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23a
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7f1d5725e156b9cf3273aa0f66c1e0d486df6a51..d9bfaff4880de1254a72869562b4c42aa29146f1 100644
+index 246d9a3b4e618813ea4afbc790c90a3cdd683fef..30c21064af97c210f739a945322bc5dd58f385cc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2340,6 +2340,11 @@ public final class CraftServer implements Server {
+@@ -2336,6 +2336,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e9dc0288ea1bb7645622ac6d9fc7567b86734ca6..c5635f20a64a2d3dfcf4aeab8dff8de59b85bbe1 100644
+index eb70747ec90770752a45ddf28cf207e2281d3a37..f047ea518bcc1ee7117fcc21af06e9ba4c97e2c0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -218,6 +218,7 @@ public class ServerPlayer extends Player {
@@ -28,10 +28,10 @@ index e9dc0288ea1bb7645622ac6d9fc7567b86734ca6..c5635f20a64a2d3dfcf4aeab8dff8de5
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index b62aa9f934c33b4d22b985b5e56937baa8454677..0df68991eb2ef3dabe779f42c2bf44846ac0d862 100644
+index 4d2af64c5f084a7f1e5bb01e9d005b031c3731f6..726e0bf623d17ee88e64d3cab1747133500c5d72 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -169,6 +169,7 @@ public abstract class PlayerList {
+@@ -170,6 +170,7 @@ public abstract class PlayerList {
      }
  
      public void placeNewPlayer(Connection connection, ServerPlayer player) {

--- a/patches/server/0308-Limit-Client-Sign-length-more.patch
+++ b/patches/server/0308-Limit-Client-Sign-length-more.patch
@@ -22,7 +22,7 @@ it only impacts data sent from the client.
 Set -DPaper.maxSignLength=XX to change limit or -1 to disable
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f0eda343820087497d20ed75d925ea6044f70816..58baed7f75ff0b573e072ad19026b7ef94a56172 100644
+index 649db78f7f1e2269d46c856aff95449d5ca6114a..569528a80fdb54cb461f71f712db1e22286f155e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -255,6 +255,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -55,4 +55,4 @@ index f0eda343820087497d20ed75d925ea6044f70816..58baed7f75ff0b573e072ad19026b7ef
 +                    lines.add(net.kyori.adventure.text.Component.text(SharedConstants.filterText(currentLine.getRaw())));
                  }
              }
-             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.cserver.getPlayer(this.player), lines);
+             SignChangeEvent event = new SignChangeEvent((org.bukkit.craftbukkit.block.CraftBlock) player.getWorld().getBlockAt(x, y, z), this.player.getBukkitEntity(), lines);

--- a/patches/server/0312-MC-145260-Fix-Whitelist-On-Off-inconsistency.patch
+++ b/patches/server/0312-MC-145260-Fix-Whitelist-On-Off-inconsistency.patch
@@ -11,7 +11,7 @@ everything to the Whitelist object.
 https://github.com/PaperMC/Paper/issues/1880
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0df68991eb2ef3dabe779f42c2bf44846ac0d862..4ae234a107d16bc71425af5f2729c428f79e3db7 100644
+index 726e0bf623d17ee88e64d3cab1747133500c5d72..20b218c658710055172c61fae5eaf255af5708a8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -62,6 +62,7 @@ import net.minecraft.network.protocol.game.ClientboundUpdateMobEffectPacket;
@@ -22,7 +22,7 @@ index 0df68991eb2ef3dabe779f42c2bf44846ac0d862..4ae234a107d16bc71425af5f2729c428
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.PlayerAdvancements;
  import net.minecraft.server.ServerScoreboard;
-@@ -996,9 +997,9 @@ public abstract class PlayerList {
+@@ -1002,9 +1003,9 @@ public abstract class PlayerList {
      }
      public boolean isWhitelisted(GameProfile gameprofile, org.bukkit.event.player.PlayerLoginEvent loginEvent) {
          boolean isOp = this.ops.contains(gameprofile);

--- a/patches/server/0314-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
+++ b/patches/server/0314-Call-WhitelistToggleEvent-when-whitelist-is-toggled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Call WhitelistToggleEvent when whitelist is toggled
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4ae234a107d16bc71425af5f2729c428f79e3db7..ea336bdf2f15aabe74de82ef6c29b93573254e31 100644
+index 20b218c658710055172c61fae5eaf255af5708a8..f1e3ea6b023119adc69eb0b414994bc7f9f3ed4a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1115,6 +1115,7 @@ public abstract class PlayerList {
+@@ -1121,6 +1121,7 @@ public abstract class PlayerList {
      }
  
      public void setUsingWhiteList(boolean whitelistEnabled) {

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -10,7 +10,7 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 434f3a56e373e584801d66c13ba2c045a383beea..1192033c0c2248554ba452c7f3f8f05f29d9ac3a 100644
+index b60f035394c9c0949e4cc68d895918510e3c67cf..03fde7df39384436e31bf57476feb680a0849030 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1111,6 +1111,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -22,10 +22,10 @@ index 434f3a56e373e584801d66c13ba2c045a383beea..1192033c0c2248554ba452c7f3f8f05f
              // Paper start
              if (DEBUG_ENTITIES) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ea336bdf2f15aabe74de82ef6c29b93573254e31..da3100d6577166e222164c174b28020541dd8e3a 100644
+index f1e3ea6b023119adc69eb0b414994bc7f9f3ed4a..42b7568d1c3ce145b2816202e6f5c8ca9e904de7 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -335,7 +335,7 @@ public abstract class PlayerList {
+@@ -341,7 +341,7 @@ public abstract class PlayerList {
              // CraftBukkit start
              ServerLevel finalWorldServer = worldserver1;
              Entity entity = EntityType.loadEntityRecursive(nbttagcompound1.getCompound("Entity"), finalWorldServer, (entity1) -> {

--- a/patches/server/0319-Implement-PlayerPostRespawnEvent.patch
+++ b/patches/server/0319-Implement-PlayerPostRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index da3100d6577166e222164c174b28020541dd8e3a..c7956664427ca97544d1b47992a62c95d2fc9690 100644
+index 42b7568d1c3ce145b2816202e6f5c8ca9e904de7..16e625d0a2777ddd14576952d704833fd0fb4f1a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -715,9 +715,14 @@ public abstract class PlayerList {
+@@ -721,9 +721,14 @@ public abstract class PlayerList {
  
          boolean flag2 = false;
  
@@ -24,7 +24,7 @@ index da3100d6577166e222164c174b28020541dd8e3a..c7956664427ca97544d1b47992a62c95
              ServerLevel worldserver1 = this.server.getLevel(entityplayer.getRespawnDimension());
              if (worldserver1 != null) {
                  Optional optional;
-@@ -768,6 +773,7 @@ public abstract class PlayerList {
+@@ -774,6 +779,7 @@ public abstract class PlayerList {
  
              location = respawnEvent.getRespawnLocation();
              if (!flag) entityplayer.reset(); // SPIGOT-4785
@@ -32,7 +32,7 @@ index da3100d6577166e222164c174b28020541dd8e3a..c7956664427ca97544d1b47992a62c95
          } else {
              location.setWorld(worldserver.getWorld());
          }
-@@ -825,6 +831,13 @@ public abstract class PlayerList {
+@@ -831,6 +837,13 @@ public abstract class PlayerList {
          if (entityplayer.connection.isDisconnected()) {
              this.save(entityplayer);
          }

--- a/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,7 +16,7 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d7ab2d4a470fed4b13bad6cf5811a7ce36e748cc..f24ce5a2543513650a3efb73e2bb5f8cd992ef88 100644
+index 2ea1f2019c1c575462064bd7bee56b094178a9ab..15928916ec8001ec57068b945300517d60dec0b0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2262,7 +2262,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -29,10 +29,10 @@ index d7ab2d4a470fed4b13bad6cf5811a7ce36e748cc..f24ce5a2543513650a3efb73e2bb5f8c
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d9bfaff4880de1254a72869562b4c42aa29146f1..334ea92dd16bf325961afd92e835e63163cbcecb 100644
+index 30c21064af97c210f739a945322bc5dd58f385cc..2e21cff810efc634f3c69535b5a2ee539bf3ed7d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1839,7 +1839,7 @@ public final class CraftServer implements Server {
+@@ -1835,7 +1835,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0335-Expose-the-internal-current-tick.patch
+++ b/patches/server/0335-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 334ea92dd16bf325961afd92e835e63163cbcecb..39e6db52421528f16ac4595faa8cfcf191771c77 100644
+index 2e21cff810efc634f3c69535b5a2ee539bf3ed7d..d52949d495068c2a725459d2e0f9a6c0bf9d6b7a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2363,5 +2363,10 @@ public final class CraftServer implements Server {
+@@ -2359,5 +2359,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0342-Fix-MC-158900.patch
+++ b/patches/server/0342-Fix-MC-158900.patch
@@ -7,10 +7,10 @@ The problem was we were checking isExpired() on the entry, but if it
 was expired at that point, then it would be null.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c7956664427ca97544d1b47992a62c95d2fc9690..6f9bd5da1504af296e7ee2a69d8afdd3bc4cfd5e 100644
+index 16e625d0a2777ddd14576952d704833fd0fb4f1a..6982f170aa1f9e8da3f3c9284edb9ef689f791bb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -599,8 +599,10 @@ public abstract class PlayerList {
+@@ -605,8 +605,10 @@ public abstract class PlayerList {
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.getRawAddress()).getAddress());
  

--- a/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
+++ b/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix stuck in sneak when changing worlds (MC-10657)
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 943516cbf4829b16dfb2631d526a65ace78da10d..e1d70824fd200c93848d5bec9cecad773f387765 100644
+index 36d563f0eb932024937b4f4d9ade0d5d09b3ea5c..e13213bcfb155da9d2778498139fd18bf46f47e2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1101,6 +1101,8 @@ public class ServerPlayer extends Player {
@@ -18,10 +18,10 @@ index 943516cbf4829b16dfb2631d526a65ace78da10d..e1d70824fd200c93848d5bec9cecad77
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6f9bd5da1504af296e7ee2a69d8afdd3bc4cfd5e..bcc946d2747443c34ee8ac2485a5ab41773c93af 100644
+index 6982f170aa1f9e8da3f3c9284edb9ef689f791bb..35f56aae927e97a8abaaebb444053b0ef1a57f09 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -820,6 +820,8 @@ public abstract class PlayerList {
+@@ -826,6 +826,8 @@ public abstract class PlayerList {
              entityplayer.connection.send(new ClientboundUpdateMobEffectPacket(entityplayer.getId(), mobEffect));
          }
  

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -520,7 +520,7 @@ index 45c7ebe67019cdbe88b6617a95d5c40d3a68286c..38eebda226e007c8910e04f502ce218c
                  if (withinViewDistance) {
                      DistanceManager.this.ticketThrottlerInput.tell(ChunkTaskPriorityQueueSorter.message(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2a493097cba7bde598eafcd2986c4ab0fd20b4e6..be01191507ff677de586355abbae27d30de5a837 100644
+index 1cd7072a84caf38a4f8495480f824c71f2f51fed..cbc8a0c6ad214cfea8ac1476c1eda074f3128aaf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -241,6 +241,7 @@ public class ServerPlayer extends Player {
@@ -532,10 +532,10 @@ index 2a493097cba7bde598eafcd2986c4ab0fd20b4e6..be01191507ff677de586355abbae27d3
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index bcc946d2747443c34ee8ac2485a5ab41773c93af..2730923bd0bf3b0f928765b9e09e2299fa9a393d 100644
+index 35f56aae927e97a8abaaebb444053b0ef1a57f09..43f2d2bbb2bcb4b77b4f11916143f3566b3dcaef 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -241,7 +241,7 @@ public abstract class PlayerList {
+@@ -242,7 +242,7 @@ public abstract class PlayerList {
          boolean flag1 = gamerules.getBoolean(GameRules.RULE_REDUCEDDEBUGINFO);
  
          // Spigot - view distance
@@ -544,7 +544,7 @@ index bcc946d2747443c34ee8ac2485a5ab41773c93af..2730923bd0bf3b0f928765b9e09e2299
          player.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.send(new ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.BRAND, (new FriendlyByteBuf(Unpooled.buffer())).writeUtf(this.getServer().getServerModName())));
          playerconnection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -789,7 +789,7 @@ public abstract class PlayerList {
+@@ -795,7 +795,7 @@ public abstract class PlayerList {
          // CraftBukkit start
          LevelData worlddata = worldserver1.getLevelData();
          entityplayer1.connection.send(new ClientboundRespawnPacket(worldserver1.dimensionType(), worldserver1.dimension(), BiomeManager.obfuscateSeed(worldserver1.getSeed()), entityplayer1.gameMode.getGameModeForPlayer(), entityplayer1.gameMode.getPreviousGameModeForPlayer(), worldserver1.isDebug(), worldserver1.isFlat(), flag));
@@ -553,7 +553,7 @@ index bcc946d2747443c34ee8ac2485a5ab41773c93af..2730923bd0bf3b0f928765b9e09e2299
          entityplayer1.setLevel(worldserver1);
          entityplayer1.unsetRemoved();
          entityplayer1.connection.teleport(new Location(worldserver1.getWorld(), entityplayer1.getX(), entityplayer1.getY(), entityplayer1.getZ(), entityplayer1.getYRot(), entityplayer1.getXRot()));
-@@ -1273,7 +1273,7 @@ public abstract class PlayerList {
+@@ -1279,7 +1279,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;

--- a/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2730923bd0bf3b0f928765b9e09e2299fa9a393d..f98a1c32e0c209473cf7268cbd8245ab9c134d28 100644
+index 43f2d2bbb2bcb4b77b4f11916143f3566b3dcaef..22c1aacb517c8bb4a745a52437cfa687de2fe272 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -783,6 +783,7 @@ public abstract class PlayerList {
+@@ -789,6 +789,7 @@ public abstract class PlayerList {
          entityplayer1.forceSetPositionRotation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
          // CraftBukkit end
  

--- a/patches/server/0398-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0398-Don-t-move-existing-players-to-world-spawn.patch
@@ -10,7 +10,7 @@ larger than the keep loaded range.
 By skipping this, we avoid potential for a large spike on server start.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ff965e67ba260a7a8e94514f8eca745f81c200b2..1d585171862972fef62e903aeacb507d2383cb80 100644
+index b4e273363dcdafef1eef76a313c08cf707991603..9dc42d44aa37985374a35c716a867a4c5ddbc1df 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -309,7 +309,7 @@ public class ServerPlayer extends Player {
@@ -32,10 +32,10 @@ index ff965e67ba260a7a8e94514f8eca745f81c200b2..1d585171862972fef62e903aeacb507d
          this.gameMode.setLevel((ServerLevel) world);
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f98a1c32e0c209473cf7268cbd8245ab9c134d28..18485689bcbf7818c3ca5b82086acef51888603b 100644
+index 22c1aacb517c8bb4a745a52437cfa687de2fe272..7928fe911f56d28ea8baaf0c15685bce4600f883 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -207,6 +207,8 @@ public abstract class PlayerList {
+@@ -208,6 +208,8 @@ public abstract class PlayerList {
              worldserver1 = worldserver;
          }
  

--- a/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
@@ -87,7 +87,7 @@ index ddbc8cb712c50038922eded75dd6ca85fe851078..78271b400c79578d043b20a5389a37b1
          version = getInt("config-version", 20);
          set("config-version", 20);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index f1c08a811c05a29eda4686c1143cc27fd91d7311..577681733454da4d62cae7199f494a56bab3cfa4 100644
+index 717673c099ecd23d525c75df7af262b96f896bfe..44ad235710dce2b159f891d91b7a0d71e5553507 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -249,6 +249,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -146,10 +146,10 @@ index f1c08a811c05a29eda4686c1143cc27fd91d7311..577681733454da4d62cae7199f494a56
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 39e6db52421528f16ac4595faa8cfcf191771c77..bc5034eff1e9d41c97a210b3b53c188395cb2574 100644
+index d52949d495068c2a725459d2e0f9a6c0bf9d6b7a..6263a646f1fbf7cb25d9e4f0821b94f2088acd92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2201,6 +2201,16 @@ public final class CraftServer implements Server {
+@@ -2197,6 +2197,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0400-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0400-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bc5034eff1e9d41c97a210b3b53c188395cb2574..2c8c800f04793493515782722d706db6e5f861af 100644
+index 6263a646f1fbf7cb25d9e4f0821b94f2088acd92..2f7ab3142f44c657f3585c8f8a6872fbfac81768 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2378,5 +2378,10 @@ public final class CraftServer implements Server {
+@@ -2374,5 +2374,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0404-Improved-Watchdog-Support.patch
+++ b/patches/server/0404-Improved-Watchdog-Support.patch
@@ -274,10 +274,10 @@ index 0aef7208937a4d35212186418beff1daf38c7a96..7aac9509849b9fb8d640437487fbfa00
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 18485689bcbf7818c3ca5b82086acef51888603b..3431d28fd69c634ee0a941796308b88bb51bdaac 100644
+index 7928fe911f56d28ea8baaf0c15685bce4600f883..449845bc547211fc0568871a60773c713a68a876 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -505,7 +505,7 @@ public abstract class PlayerList {
+@@ -511,7 +511,7 @@ public abstract class PlayerList {
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
@@ -323,10 +323,10 @@ index e19f5d5d58a8b2e4f35907e1c88224cac7f20e57..61c70e17401ec85c0a7e6e1793f66895
                          String msg = "TileEntity threw exception at " + LevelChunk.this.getLevel().getWorld().getName() + ":" + this.getPos().getX() + "," + this.getPos().getY() + "," + this.getPos().getZ();
                          System.err.println(msg);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2c8c800f04793493515782722d706db6e5f861af..e31a05dfe7e934692ac89c7cedcab736bcd9ca4f 100644
+index 2f7ab3142f44c657f3585c8f8a6872fbfac81768..a7d087875ec2d493ef6ed0fcdc03d89445d9008b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1839,7 +1839,7 @@ public final class CraftServer implements Server {
+@@ -1835,7 +1835,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0416-Broadcast-join-message-to-console.patch
+++ b/patches/server/0416-Broadcast-join-message-to-console.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Broadcast join message to console
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3431d28fd69c634ee0a941796308b88bb51bdaac..5432ce5b86b7731fe5d06d334e4e191f2eb2f429 100644
+index 449845bc547211fc0568871a60773c713a68a876..c14fba206e2f124cded3e00e2cb584e21a43971d 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -286,7 +286,9 @@ public abstract class PlayerList {
+@@ -292,7 +292,9 @@ public abstract class PlayerList {
  
          if (jm != null && !jm.equals(net.kyori.adventure.text.Component.empty())) { // Paper - Adventure
              joinMessage = PaperAdventure.asVanilla(jm); // Paper - Adventure

--- a/patches/server/0417-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0417-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,7 +28,7 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 7ef52d0ae501312590802acb5f54fcf6f7cdac9e..c1b7e9d515fc833759707ab3c5c952320dec103e 100644
+index 357289223b9e13eb5ab9d24f41b11f14aee0adab..17d34bb608254d134c15bd31890f8ecc09ccc100 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1600,6 +1600,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -40,7 +40,7 @@ index 7ef52d0ae501312590802acb5f54fcf6f7cdac9e..c1b7e9d515fc833759707ab3c5c95232
          if (!(entity instanceof EnderDragonPart)) {
              EntityType<?> entitytypes = entity.getType();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index c2dd937938e120472d0a2609c1afef693a342682..05e520165a86eb52e1fd4130b6f2ccc4c838934a 100644
+index 842c35daca37b793ff2c6dbb1c442db9dac879f8..5c2a19b054558d260ddb2f7282ea3b54a4dc2c03 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -237,6 +237,7 @@ public class ServerPlayer extends Player {
@@ -52,10 +52,10 @@ index c2dd937938e120472d0a2609c1afef693a342682..05e520165a86eb52e1fd4130b6f2ccc4
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5432ce5b86b7731fe5d06d334e4e191f2eb2f429..3a13c151066c8784fdc844e1d6310f77ff32e7f1 100644
+index c14fba206e2f124cded3e00e2cb584e21a43971d..aad3f28147b5ae9f3a81ec9b500559ed222daf93 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -274,6 +274,12 @@ public abstract class PlayerList {
+@@ -275,6 +275,12 @@ public abstract class PlayerList {
          this.playersByUUID.put(player.getUUID(), player);
          // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.ADD_PLAYER, new EntityPlayer[]{entityplayer})); // CraftBukkit - replaced with loop below
  
@@ -66,9 +66,9 @@ index 5432ce5b86b7731fe5d06d334e4e191f2eb2f429..3a13c151066c8784fdc844e1d6310f77
 +        mountSavedVehicle(player, worldserver1, nbttagcompound);
 +        // Paper end
          // CraftBukkit start
-         PlayerJoinEvent playerJoinEvent = new org.bukkit.event.player.PlayerJoinEvent(this.cserver.getPlayer(player), PaperAdventure.asAdventure(chatmessage)); // Paper - Adventure
-         this.cserver.getPluginManager().callEvent(playerJoinEvent);
-@@ -309,6 +315,8 @@ public abstract class PlayerList {
+         CraftPlayer bukkitPlayer = player.getBukkitEntity();
+ 
+@@ -315,6 +321,8 @@ public abstract class PlayerList {
              player.connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.ADD_PLAYER, new ServerPlayer[] { entityplayer1}));
          }
          player.sentListPacket = true;
@@ -77,7 +77,7 @@ index 5432ce5b86b7731fe5d06d334e4e191f2eb2f429..3a13c151066c8784fdc844e1d6310f77
          // CraftBukkit end
  
          player.connection.send(new ClientboundSetEntityDataPacket(player.getId(), player.getEntityData(), true)); // CraftBukkit - BungeeCord#2321, send complete data to self on spawn
-@@ -334,6 +342,11 @@ public abstract class PlayerList {
+@@ -340,6 +348,11 @@ public abstract class PlayerList {
              playerconnection.send(new ClientboundUpdateMobEffectPacket(player.getId(), mobeffect));
          }
  
@@ -89,7 +89,7 @@ index 5432ce5b86b7731fe5d06d334e4e191f2eb2f429..3a13c151066c8784fdc844e1d6310f77
          if (nbttagcompound != null && nbttagcompound.contains("RootVehicle", 10)) {
              CompoundTag nbttagcompound1 = nbttagcompound.getCompound("RootVehicle");
              // CraftBukkit start
-@@ -382,6 +395,10 @@ public abstract class PlayerList {
+@@ -388,6 +401,10 @@ public abstract class PlayerList {
              }
          }
  
@@ -100,7 +100,7 @@ index 5432ce5b86b7731fe5d06d334e4e191f2eb2f429..3a13c151066c8784fdc844e1d6310f77
          player.initInventoryMenu();
          // CraftBukkit - Moved from above, added world
          // Paper start - Add to collideRule team if needed
-@@ -391,6 +408,7 @@ public abstract class PlayerList {
+@@ -397,6 +414,7 @@ public abstract class PlayerList {
              scoreboard.addPlayerToTeam(player.getScoreboardName(), collideRuleTeam);
          }
          // Paper end

--- a/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7886ba1c08f3bc7cb889a430419d4ddb14bda787..b05598c2234cef011aef496829dfe54a69d58900 100644
+index 5c2a19b054558d260ddb2f7282ea3b54a4dc2c03..68ef26c0b3124aa1bd37df9f762401b700a6b8ba 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -172,6 +172,7 @@ public class ServerPlayer extends Player {
@@ -37,7 +37,7 @@ index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c8
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fae06882217adf20c6f81db2793ee3930cba30c0..c57b5cf7d61eab5a45e3fa69e8804fd0ef4a54ad 100644
+index aed93f66cdf8c5a97b04da59129b2ee1371816de..35b2c45991e2470fc565e7206f94c67f54fcdcd6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -221,6 +221,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -96,7 +96,7 @@ index 12f945e91827470a9a61951e45c062deee8cf281..195f5d1519c3fc2fdd03ecd0d49d7fba
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().processLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38925f8f09 100644
+index aad3f28147b5ae9f3a81ec9b500559ed222daf93..95f229dcb1b003215c602847a351b313fb0980ba 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -38,6 +38,7 @@ import net.minecraft.network.protocol.Packet;
@@ -107,15 +107,15 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
  import net.minecraft.network.protocol.game.ClientboundEntityEventPacket;
  import net.minecraft.network.protocol.game.ClientboundGameEventPacket;
  import net.minecraft.network.protocol.game.ClientboundInitializeBorderPacket;
-@@ -132,6 +133,7 @@ public abstract class PlayerList {
+@@ -133,6 +134,7 @@ public abstract class PlayerList {
      private final IpBanList ipBans;
      private final ServerOpList ops;
      private final UserWhiteList whitelist;
 +    private final Map<UUID, ServerPlayer> pendingPlayers = Maps.newHashMap(); // Paper
      // CraftBukkit start
-     // private final Map<UUID, ServerStatisticManager> o;
-     // private final Map<UUID, AdvancementDataPlayer> p;
-@@ -170,6 +172,11 @@ public abstract class PlayerList {
+     // private final Map<UUID, ServerStatisticManager> stats;
+     // private final Map<UUID, AdvancementDataPlayer> advancements;
+@@ -171,6 +173,11 @@ public abstract class PlayerList {
      }
  
      public void placeNewPlayer(Connection connection, ServerPlayer player) {
@@ -127,7 +127,7 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
          player.loginTime = System.currentTimeMillis(); // Paper
          GameProfile gameprofile = player.getGameProfile();
          GameProfileCache usercache = this.server.getProfileCache();
-@@ -183,7 +190,7 @@ public abstract class PlayerList {
+@@ -184,7 +191,7 @@ public abstract class PlayerList {
          if (nbttagcompound != null && nbttagcompound.contains("bukkit")) {
              CompoundTag bukkit = nbttagcompound.getCompound("bukkit");
              s = bukkit.contains("lastKnownName", 8) ? bukkit.getString("lastKnownName") : s;
@@ -136,7 +136,7 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
          // CraftBukkit end
  
          if (nbttagcompound != null) {
-@@ -257,6 +264,52 @@ public abstract class PlayerList {
+@@ -258,6 +265,52 @@ public abstract class PlayerList {
          player.getRecipeBook().sendInitialRecipeBook(player);
          this.updateEntireScoreboard(worldserver1.getScoreboard(), player);
          this.server.invalidateStatus();
@@ -189,7 +189,7 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
          TranslatableComponent chatmessage;
  
          if (player.getGameProfile().getName().equalsIgnoreCase(s)) {
-@@ -495,6 +548,7 @@ public abstract class PlayerList {
+@@ -501,6 +554,7 @@ public abstract class PlayerList {
  
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -197,17 +197,17 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -522,7 +576,7 @@ public abstract class PlayerList {
+@@ -528,7 +582,7 @@ public abstract class PlayerList {
          }
  
-         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
 -        this.cserver.getPluginManager().callEvent(playerQuitEvent);
 +        if (entityplayer.didPlayerJoinEvent) this.cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
          if (server.isSameThread()) entityplayer.doTick(); // SPIGOT-924 // Paper - don't tick during emergency shutdowns (Watchdog)
-@@ -567,6 +621,13 @@ public abstract class PlayerList {
-             // this.p.remove(uuid);
+@@ -573,6 +627,13 @@ public abstract class PlayerList {
+             // this.advancements.remove(uuid);
              // CraftBukkit end
          }
 +        // Paper start
@@ -220,7 +220,7 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
  
          // CraftBukkit start
          // this.sendAll(new PacketPlayOutPlayerInfo(PacketPlayOutPlayerInfo.EnumPlayerInfoAction.REMOVE_PLAYER, new EntityPlayer[]{entityplayer}));
-@@ -584,7 +645,7 @@ public abstract class PlayerList {
+@@ -590,7 +651,7 @@ public abstract class PlayerList {
          this.cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -229,7 +229,7 @@ index 3a13c151066c8784fdc844e1d6310f77ff32e7f1..529fc8732b67a3349672224723725e38
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -603,6 +664,13 @@ public abstract class PlayerList {
+@@ -609,6 +670,13 @@ public abstract class PlayerList {
                  list.add(entityplayer);
              }
          }

--- a/patches/server/0431-Implement-Mob-Goal-API.patch
+++ b/patches/server/0431-Implement-Mob-Goal-API.patch
@@ -895,10 +895,10 @@ index 8c2ec30a35e86f2b30863045b586a67e485c624b..9cb5ccf4815b56169b63b34da88e7394
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 130ab05393a7136020e06ec199256a031ba66091..8dd93620a770855450ed222dad6572e20760b08c 100644
+index 8d81e2a7c4c7ef2da36aa3fe93d8667ff556dc2a..51f1ca2455fb279ad996843eb926429db332d025 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2390,5 +2390,11 @@ public final class CraftServer implements Server {
+@@ -2386,5 +2386,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ff17bd6e7ccd82201256a2c3568297c3191b7e1f..0e6ec02b011eee8c75ddc6f7db254df735be8e91 100644
+index eb82dd9db7fef4b1f0f764ce153439c69c64168b..407f18a9c7a688eaac8ad7018ae4f1a5fc628379 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -945,6 +945,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index ff17bd6e7ccd82201256a2c3568297c3191b7e1f..0e6ec02b011eee8c75ddc6f7db254df7
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8dd93620a770855450ed222dad6572e20760b08c..e3338717bffe5f5e4a00fe1ebe3ba7cf74555b36 100644
+index 51f1ca2455fb279ad996843eb926429db332d025..35339d49458aded3f80ff162b9725ceb84ae47c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -936,6 +936,35 @@ public final class CraftServer implements Server {
+@@ -932,6 +932,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0449-Optimize-sending-packets-to-nearby-locations-sounds-.patch
+++ b/patches/server/0449-Optimize-sending-packets-to-nearby-locations-sounds-.patch
@@ -11,10 +11,10 @@ This will drastically cut down on packet sending cost for worlds with
 lots of players in them.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 529fc8732b67a3349672224723725e38925f8f09..28b203a5c8a65ba96bf239c270fa6445f94e887e 100644
+index 95f229dcb1b003215c602847a351b313fb0980ba..67c5d0a53f50896daa6bba3ac2816cfc15b0af75 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1129,16 +1129,40 @@ public abstract class PlayerList {
+@@ -1135,16 +1135,40 @@ public abstract class PlayerList {
      }
  
      public void broadcast(@Nullable net.minecraft.world.entity.player.Player player, double x, double y, double z, double distance, ResourceKey<Level> worldKey, Packet<?> packet) {

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e3338717bffe5f5e4a00fe1ebe3ba7cf74555b36..f7d542b828904fb51a30dfb7a50e01e4e2df0f3e 100644
+index 35339d49458aded3f80ff162b9725ceb84ae47c6..434a46dca55453815772eeb50ef412b02af2c0a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -346,7 +346,7 @@ public final class CraftServer implements Server {
@@ -34,7 +34,7 @@ index e3338717bffe5f5e4a00fe1ebe3ba7cf74555b36..f7d542b828904fb51a30dfb7a50e01e4
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -834,7 +834,7 @@ public final class CraftServer implements Server {
+@@ -830,7 +830,7 @@ public final class CraftServer implements Server {
          this.waterAmbientSpawn = this.configuration.getInt("spawn-limits.water-ambient");
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0484-Spawn-player-in-correct-world-on-login.patch
+++ b/patches/server/0484-Spawn-player-in-correct-world-on-login.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Spawn player in correct world on login
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 28b203a5c8a65ba96bf239c270fa6445f94e887e..cd31cc4f8d25e95792c4a2690e3a8df17edc406f 100644
+index 67c5d0a53f50896daa6bba3ac2816cfc15b0af75..71fce0c38386b3f0a63a5d9bc1cb47e01027d10c 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -193,7 +193,18 @@ public abstract class PlayerList {
+@@ -194,7 +194,18 @@ public abstract class PlayerList {
          }String lastKnownName = s; // Paper
          // CraftBukkit end
  

--- a/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f7d542b828904fb51a30dfb7a50e01e4e2df0f3e..407a91f64e040745dea17544d6b7c6d125866c62 100644
+index 434a46dca55453815772eeb50ef412b02af2c0a1..ac7034a922facb772a67580100627a7c85510693 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2032,6 +2032,32 @@ public final class CraftServer implements Server {
+@@ -2028,6 +2028,32 @@ public final class CraftServer implements Server {
          return new CraftChunkData(world);
      }
  

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1027,7 +1027,7 @@ index 6c565751c36daa0084196dce5d2f82df64a0c77a..0b22fd8ac75146bc7b647cfbefc73ce8
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1197322df389f9fdc891760230e18950f7295fc1..6acf0fb29261ba005562127894438797d5853573 100644
+index d41d1d860cc26d8dd441324680a44c635f78a047..e67a4657191d6dbe526470820e6813f54ecdc1fe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -183,6 +183,14 @@ public class ServerPlayer extends Player {
@@ -1101,7 +1101,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index fb010fb253f490a79e9172d7a3d017ad51dac958..3e91275b318904ffa31183987fcbc7b28692781a 100644
+index 92e8257734a8d46bf63b8bd9173b0d680f41fe97..80bf42c9586ba45b2174b89e3d432409b37eca7f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1565,6 +1565,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -1113,10 +1113,10 @@ index fb010fb253f490a79e9172d7a3d017ad51dac958..3e91275b318904ffa31183987fcbc7b2
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index cd31cc4f8d25e95792c4a2690e3a8df17edc406f..576541b061d792a24eaa30df57d00a2945a3ee1f 100644
+index 71fce0c38386b3f0a63a5d9bc1cb47e01027d10c..c4bdce99df37fbe5bfc1238dac9d043ccdaa3f1a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -283,8 +283,8 @@ public abstract class PlayerList {
+@@ -284,8 +284,8 @@ public abstract class PlayerList {
          net.minecraft.server.level.ChunkMap playerChunkMap = worldserver1.getChunkSource().chunkMap;
          net.minecraft.server.level.DistanceManager distanceManager = playerChunkMap.distanceManager;
          distanceManager.addTicketAtLevel(net.minecraft.server.level.TicketType.LOGIN, pos, 31, pos.toLong());
@@ -1127,7 +1127,7 @@ index cd31cc4f8d25e95792c4a2690e3a8df17edc406f..576541b061d792a24eaa30df57d00a29
              net.minecraft.server.level.ChunkHolder updatingChunk = playerChunkMap.getUpdatingChunkIfPresent(pos.toLong());
              if (updatingChunk != null) {
                  return updatingChunk.getEntityTickingChunkFuture();
-@@ -697,6 +697,7 @@ public abstract class PlayerList {
+@@ -703,6 +703,7 @@ public abstract class PlayerList {
          SocketAddress socketaddress = loginlistener.connection.getRemoteAddress();
  
          ServerPlayer entity = new ServerPlayer(this.server, this.server.getLevel(Level.OVERWORLD), gameprofile);
@@ -1135,7 +1135,7 @@ index cd31cc4f8d25e95792c4a2690e3a8df17edc406f..576541b061d792a24eaa30df57d00a29
          Player player = entity.getBukkitEntity();
          PlayerLoginEvent event = new PlayerLoginEvent(player, hostname, ((java.net.InetSocketAddress) socketaddress).getAddress(), ((java.net.InetSocketAddress) loginlistener.connection.getRawAddress()).getAddress());
  
-@@ -885,6 +886,7 @@ public abstract class PlayerList {
+@@ -891,6 +892,7 @@ public abstract class PlayerList {
          // CraftBukkit end
  
          worldserver1.getChunkSource().addRegionTicket(net.minecraft.server.level.TicketType.POST_TELEPORT, new net.minecraft.world.level.ChunkPos(location.getBlockX() >> 4, location.getBlockZ() >> 4), 1, entityplayer.getId()); // Paper

--- a/patches/server/0495-Fix-SPIGOT-5989.patch
+++ b/patches/server/0495-Fix-SPIGOT-5989.patch
@@ -10,7 +10,7 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 576541b061d792a24eaa30df57d00a2945a3ee1f..7acf01ee407555862ad2483eee4543e0284c2199 100644
+index c4bdce99df37fbe5bfc1238dac9d043ccdaa3f1a..64b09b5c5676ae5cc77d7dcac9c9256bba4ac9e8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -77,6 +77,7 @@ import net.minecraft.world.level.GameRules;
@@ -21,7 +21,7 @@ index 576541b061d792a24eaa30df57d00a2945a3ee1f..7acf01ee407555862ad2483eee4543e0
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.border.BorderChangeListener;
  import net.minecraft.world.level.border.WorldBorder;
-@@ -822,6 +823,7 @@ public abstract class PlayerList {
+@@ -828,6 +829,7 @@ public abstract class PlayerList {
          // Paper start
          boolean isBedSpawn = false;
          boolean isRespawn = false;
@@ -29,7 +29,7 @@ index 576541b061d792a24eaa30df57d00a2945a3ee1f..7acf01ee407555862ad2483eee4543e0
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -832,7 +834,7 @@ public abstract class PlayerList {
+@@ -838,7 +840,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -38,7 +38,7 @@ index 576541b061d792a24eaa30df57d00a2945a3ee1f..7acf01ee407555862ad2483eee4543e0
                  } else {
                      optional = Optional.empty();
                  }
-@@ -875,7 +877,12 @@ public abstract class PlayerList {
+@@ -881,7 +883,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -52,7 +52,7 @@ index 576541b061d792a24eaa30df57d00a2945a3ee1f..7acf01ee407555862ad2483eee4543e0
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -913,8 +920,12 @@ public abstract class PlayerList {
+@@ -919,8 +926,12 @@ public abstract class PlayerList {
          }
          // entityplayer1.syncInventory();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/patches/server/0500-Incremental-player-saving.patch
+++ b/patches/server/0500-Incremental-player-saving.patch
@@ -55,7 +55,7 @@ index 21c16bf341e846f90a24fe2395ff89f1ace70d73..a962209749c7cc7f6d304073f5f2bce5
          } // Paper start
          for (ServerLevel level : this.getAllLevels()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6acf0fb29261ba005562127894438797d5853573..88a7f2e69ad74303cbb779d06903d34a5ff40a6c 100644
+index e67a4657191d6dbe526470820e6813f54ecdc1fe..d3209044b25f30edc3676d75f4784aaf93449687 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -169,6 +169,7 @@ public class ServerPlayer extends Player {
@@ -67,10 +67,10 @@ index 6acf0fb29261ba005562127894438797d5853573..88a7f2e69ad74303cbb779d06903d34a
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7acf01ee407555862ad2483eee4543e0284c2199..8bedc2cad5faf621ac5515fafcd093e3bd180126 100644
+index 64b09b5c5676ae5cc77d7dcac9c9256bba4ac9e8..b64b7ea33576cdcc9179e5849667b0cb5f52dcd6 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -561,6 +561,7 @@ public abstract class PlayerList {
+@@ -567,6 +567,7 @@ public abstract class PlayerList {
      protected void save(ServerPlayer player) {
          if (!player.getBukkitEntity().isPersistent()) return; // CraftBukkit
          if (!player.didPlayerJoinEvent) return; // Paper - If we never fired PJE, we disconnected during login. Data has not changed, and additionally, our saved vehicle is not loaded! If we save now, we will lose our vehicle (CraftBukkit bug)
@@ -78,7 +78,7 @@ index 7acf01ee407555862ad2483eee4543e0284c2199..8bedc2cad5faf621ac5515fafcd093e3
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1200,10 +1201,21 @@ public abstract class PlayerList {
+@@ -1206,10 +1207,21 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0506-Add-setMaxPlayers-API.patch
+++ b/patches/server/0506-Add-setMaxPlayers-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 8bedc2cad5faf621ac5515fafcd093e3bd180126..eb12da04a495166e101b234ec3640363ec2403a5 100644
+index b64b7ea33576cdcc9179e5849667b0cb5f52dcd6..fd6d9fd1469190435abe16fb3ba15e9522243d42 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -142,7 +142,7 @@ public abstract class PlayerList {
+@@ -143,7 +143,7 @@ public abstract class PlayerList {
      public final PlayerDataStorage playerIo;
      private boolean doWhiteList;
      private final RegistryAccess.RegistryHolder registryHolder;
@@ -18,10 +18,10 @@ index 8bedc2cad5faf621ac5515fafcd093e3bd180126..eb12da04a495166e101b234ec3640363
      private boolean allowCheatsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 407a91f64e040745dea17544d6b7c6d125866c62..c4d7ac8abd7d86e8a4e2d8a3340d04f8710e925c 100644
+index ac7034a922facb772a67580100627a7c85510693..f6fd414e639f2880f1abc2e4c4ef0fbe05a562db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -616,6 +616,13 @@ public final class CraftServer implements Server {
+@@ -612,6 +612,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0545-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0545-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c4d7ac8abd7d86e8a4e2d8a3340d04f8710e925c..0d29e3163a637c742d100129cb650f53635ef765 100644
+index f6fd414e639f2880f1abc2e4c4ef0fbe05a562db..5412c537fa3c3c1e4613a3b3b0ebfdf983a6902a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1612,6 +1612,28 @@ public final class CraftServer implements Server {
+@@ -1608,6 +1608,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0552-Add-API-for-quit-reason.patch
+++ b/patches/server/0552-Add-API-for-quit-reason.patch
@@ -25,7 +25,7 @@ index 01b9c360c6d687c6a774bf3375802be487cb0e0c..35a03d15f87be8eb86d65e1863a3e0cb
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          ConnectionProtocol enumprotocol = this.getCurrentProtocol();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 88a7f2e69ad74303cbb779d06903d34a5ff40a6c..9a729aecfa8c901159c74c42544ba31b69bab199 100644
+index d3209044b25f30edc3676d75f4784aaf93449687..7132c1281b9ce65d844cdb12905ceb7370b55b8f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -256,6 +256,7 @@ public class ServerPlayer extends Player {
@@ -37,7 +37,7 @@ index 88a7f2e69ad74303cbb779d06903d34a5ff40a6c..9a729aecfa8c901159c74c42544ba31b
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3db026216308628321a334ccb64b0ea97e524393..1b6610cc04f6bcb6d3153886e62ce117c6a17e15 100644
+index e98d20b0790a2bb581e8916ec17627830eedbd26..1a5c33407bfe3cdb91953a7067b00f38b92189c5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -444,6 +444,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -49,15 +49,15 @@ index 3db026216308628321a334ccb64b0ea97e524393..1b6610cc04f6bcb6d3153886e62ce117
              this.connection.disconnect(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eb12da04a495166e101b234ec3640363ec2403a5..295a2c9328172923d470e2c9e8338e0edb020ede 100644
+index fd6d9fd1469190435abe16fb3ba15e9522243d42..4cf9e944bf4a88391a290f703931e551e26cf7f5 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -588,7 +588,7 @@ public abstract class PlayerList {
+@@ -594,7 +594,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(this.cserver.getPlayer(entityplayer), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())), entityplayer.quitReason); // Paper - quit reason
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())), entityplayer.quitReason); // Paper - quit reason
          if (entityplayer.didPlayerJoinEvent) this.cserver.getPluginManager().callEvent(playerQuitEvent); // Paper - if we disconnected before join ever fired, don't fire quit
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/patches/server/0556-Expose-world-spawn-angle.patch
+++ b/patches/server/0556-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 295a2c9328172923d470e2c9e8338e0edb020ede..d9a14f58b9249ff10cc7f5fde60f3aa8bd1e9235 100644
+index 4cf9e944bf4a88391a290f703931e551e26cf7f5..ff4ff0d2ab9870c16a4f7b2ee11bfcb5e95ce7a0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -866,7 +866,7 @@ public abstract class PlayerList {
+@@ -872,7 +872,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getLevel(Level.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);
@@ -16,7 +16,7 @@ index 295a2c9328172923d470e2c9e8338e0edb020ede..d9a14f58b9249ff10cc7f5fde60f3aa8
 +                location = new Location(worldserver1.getWorld(), (double) ((float) blockposition.getX() + 0.5F), (double) ((float) blockposition.getY() + 0.1F), (double) ((float) blockposition.getZ() + 0.5F), worldserver1.levelData.getSpawnAngle(), 0.0F); // Paper - use world spawn angle
              }
  
-             Player respawnPlayer = this.cserver.getPlayer(entityplayer1);
+             Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 index 82964cfbe172e22e19203d37addf9fedbe8edaa5..f7bf59f63cc3a5c4201857835ae136cbfdb61f8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java

--- a/patches/server/0599-Fix-villager-boat-exploit.patch
+++ b/patches/server/0599-Fix-villager-boat-exploit.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix villager boat exploit
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index d9a14f58b9249ff10cc7f5fde60f3aa8bd1e9235..043c846936955c8af0d05755bd62b0196d9ca86e 100644
+index ff4ff0d2ab9870c16a4f7b2ee11bfcb5e95ce7a0..d4de245b36e299c87b2c62d8e341c0fd027e6fc0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -613,6 +613,15 @@ public abstract class PlayerList {
+@@ -619,6 +619,15 @@ public abstract class PlayerList {
                  PlayerList.LOGGER.debug("Removing player mount");
                  entityplayer.stopRiding();
                  entity.getPassengersAndSelf().forEach((entity1) -> {

--- a/patches/server/0600-Add-sendOpLevel-API.patch
+++ b/patches/server/0600-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 043c846936955c8af0d05755bd62b0196d9ca86e..f030701a78aa2065756147531da0d6ffa1a41073 100644
+index d4de245b36e299c87b2c62d8e341c0fd027e6fc0..db4d33bdb00fd1eb40cae10ce4dedc31b57bfc41 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1115,22 +1115,29 @@ public abstract class PlayerList {
+@@ -1121,22 +1121,29 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {

--- a/patches/server/0608-Added-Vanilla-Entity-Tags.patch
+++ b/patches/server/0608-Added-Vanilla-Entity-Tags.patch
@@ -39,10 +39,10 @@ index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0d29e3163a637c742d100129cb650f53635ef765..4739b4c3035064de328595329ee0b65ea59e559b 100644
+index 5412c537fa3c3c1e4613a3b3b0ebfdf983a6902a..811cd39d8ce944abe0eff5d5d3e9af5b1fb0edf7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2221,6 +2221,11 @@ public final class CraftServer implements Server {
+@@ -2217,6 +2217,11 @@ public final class CraftServer implements Server {
                  Preconditions.checkArgument(clazz == org.bukkit.Fluid.class, "Fluid namespace must have fluid type");
  
                  return (org.bukkit.Tag<T>) new CraftFluidTag(FluidTags.getAllTags(), key);

--- a/patches/server/0626-misc-debugging-dumps.patch
+++ b/patches/server/0626-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index b8fb3f99e4af5768d8afc1b143e5585f08cc21a9..17a171f531c356e2c8abe2f26c012e9b
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4739b4c3035064de328595329ee0b65ea59e559b..989b6b91dc046e20332f0cef35105b290fdb2e43 100644
+index 811cd39d8ce944abe0eff5d5d3e9af5b1fb0edf7..f4835006439ce3effeb5817e11f3ec49eea374e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -935,6 +935,7 @@ public final class CraftServer implements Server {
+@@ -931,6 +931,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0634-fix-converting-txt-to-json-file.patch
+++ b/patches/server/0634-fix-converting-txt-to-json-file.patch
@@ -48,10 +48,10 @@ index a5c1114f9b323e8a49c84d0e68461e473bbcd690..eadacfa8449336c024f6154f46bb514d
          if (!OldUsersConverter.serverReadyAfterUserconversion(this)) {
              return false;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f030701a78aa2065756147531da0d6ffa1a41073..0a9420fccdb83a9475befdec265b7cf4d65abd11 100644
+index db4d33bdb00fd1eb40cae10ce4dedc31b57bfc41..f6dc67327746ebd1176bf95cc5d090d783357a6e 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -171,6 +171,7 @@ public abstract class PlayerList {
+@@ -172,6 +172,7 @@ public abstract class PlayerList {
          this.maxPlayers = maxPlayers;
          this.playerIo = saveHandler;
      }

--- a/patches/server/0641-Implement-Keyed-on-World.patch
+++ b/patches/server/0641-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 989b6b91dc046e20332f0cef35105b290fdb2e43..fb18b1f0bbc5b87f6895086f6d6a749543caf11f 100644
+index f4835006439ce3effeb5817e11f3ec49eea374e4..273f80fc0325c2ccd2320e35ca36639f92345aea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1154,7 +1154,7 @@ public final class CraftServer implements Server {
+@@ -1150,7 +1150,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index 989b6b91dc046e20332f0cef35105b290fdb2e43..fb18b1f0bbc5b87f6895086f6d6a7495
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1245,6 +1245,15 @@ public final class CraftServer implements Server {
+@@ -1241,6 +1241,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0646-Drop-carried-item-when-player-has-disconnected.patch
+++ b/patches/server/0646-Drop-carried-item-when-player-has-disconnected.patch
@@ -7,10 +7,10 @@ Fixes disappearance of held items, when a player gets disconnected and PlayerDro
 Closes #5036
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 0a9420fccdb83a9475befdec265b7cf4d65abd11..af2285e1f496111d3dcbddccaf4c1e7dadf4b1b5 100644
+index f6dc67327746ebd1176bf95cc5d090d783357a6e..0b5c58f36cea1950c63a35cc0ded8abe5569df2f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -606,6 +606,14 @@ public abstract class PlayerList {
+@@ -612,6 +612,14 @@ public abstract class PlayerList {
          }
          // Paper end
  

--- a/patches/server/0660-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/server/0660-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add get-set drop chance to EntityEquipment
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
-index cd882ef5c6b3e0e33c0caeda534928a7ee168c54..c9c85d7a7257c535e6360499893b3dd392608687 100644
+index 5a22c089f8c2c58f577ee32caa9985fff112de3c..1a88eafcba718f0c307ef6fcde72f156f644766f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftEntityEquipment.java
 @@ -244,6 +244,17 @@ public class CraftEntityEquipment implements EntityEquipment {
@@ -25,7 +25,7 @@ index cd882ef5c6b3e0e33c0caeda534928a7ee168c54..c9c85d7a7257c535e6360499893b3dd3
 +    // Paper end
  
      private void setDropChance(net.minecraft.world.entity.EquipmentSlot slot, float chance) {
-         if (slot == net.minecraft.world.entity.EquipmentSlot.MAINHAND || slot == net.minecraft.world.entity.EquipmentSlot.OFFHAND) {
+         Preconditions.checkArgument(this.entity.getHandle() instanceof Mob, "Cannot set drop chance for non-Mob entity");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 index 5ae4f2b6cfa4067a0589d6f909ac6a7d9b48fd6f..3354d13f657cecfc3cc756a99accd5d481e8b1dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java

--- a/patches/server/0668-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/patches/server/0668-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index af2285e1f496111d3dcbddccaf4c1e7dadf4b1b5..e7c126e9ed76026c0c814cf4278ae522c9fc39bf 100644
+index 0b5c58f36cea1950c63a35cc0ded8abe5569df2f..23dc5fcbfb64170a7b2d5ab42a1ffcc33092b516 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -841,6 +841,7 @@ public abstract class PlayerList {
+@@ -847,6 +847,7 @@ public abstract class PlayerList {
  
          // Paper start
          boolean isBedSpawn = false;
@@ -17,7 +17,7 @@ index af2285e1f496111d3dcbddccaf4c1e7dadf4b1b5..e7c126e9ed76026c0c814cf4278ae522
          boolean isRespawn = false;
          boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
          // Paper end
-@@ -861,6 +862,7 @@ public abstract class PlayerList {
+@@ -867,6 +868,7 @@ public abstract class PlayerList {
                  if (optional.isPresent()) {
                      BlockState iblockdata = worldserver1.getBlockState(blockposition);
                      boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
@@ -25,10 +25,10 @@ index af2285e1f496111d3dcbddccaf4c1e7dadf4b1b5..e7c126e9ed76026c0c814cf4278ae522
                      Vec3 vec3d = (Vec3) optional.get();
                      float f1;
  
-@@ -888,7 +890,7 @@ public abstract class PlayerList {
+@@ -894,7 +896,7 @@ public abstract class PlayerList {
              }
  
-             Player respawnPlayer = this.cserver.getPlayer(entityplayer1);
+             Player respawnPlayer = entityplayer1.getBukkitEntity();
 -            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !flag2, flag2);
 +            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !isAnchorSpawn, isAnchorSpawn); // Paper - Fix anchor respawn acting as a bed respawn from the end portal
              this.cserver.getPluginManager().callEvent(respawnEvent);

--- a/patches/server/0670-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/server/0670-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2958ff7f1ac66120fc9880d17ec4b46c72821aaa..d63bc35d37b2d6628ff2fdd97fca7978c2dded0e 100644
+index 097eb55439cb3c8557fa4e1f8db227d526ffdd5a..65975bc2aa2a00a1b371f965361e7994b4ad5197 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2460,7 +2460,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -18,10 +18,10 @@ index 2958ff7f1ac66120fc9880d17ec4b46c72821aaa..d63bc35d37b2d6628ff2fdd97fca7978
                  } else {
                      if (this.player.getHealth() > 0.0F) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e7c126e9ed76026c0c814cf4278ae522c9fc39bf..1e2ad223ae9c3270548de89acc91f1e6780af539 100644
+index 23dc5fcbfb64170a7b2d5ab42a1ffcc33092b516..aa8e3c9b5884b9de1cf6805b3033ca1c8cdb9cc6 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -800,6 +800,12 @@ public abstract class PlayerList {
+@@ -806,6 +806,12 @@ public abstract class PlayerList {
      }
  
      public ServerPlayer moveToWorld(ServerPlayer entityplayer, ServerLevel worldserver, boolean flag, Location location, boolean avoidSuffocation) {
@@ -34,10 +34,10 @@ index e7c126e9ed76026c0c814cf4278ae522c9fc39bf..1e2ad223ae9c3270548de89acc91f1e6
          entityplayer.stopRiding(); // CraftBukkit
          this.players.remove(entityplayer);
          this.playersByName.remove(entityplayer.getScoreboardName().toLowerCase(java.util.Locale.ROOT)); // Spigot
-@@ -890,7 +896,7 @@ public abstract class PlayerList {
+@@ -896,7 +902,7 @@ public abstract class PlayerList {
              }
  
-             Player respawnPlayer = this.cserver.getPlayer(entityplayer1);
+             Player respawnPlayer = entityplayer1.getBukkitEntity();
 -            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !isAnchorSpawn, isAnchorSpawn); // Paper - Fix anchor respawn acting as a bed respawn from the end portal
 +            PlayerRespawnEvent respawnEvent = new PlayerRespawnEvent(respawnPlayer, location, isBedSpawn && !isAnchorSpawn, isAnchorSpawn, com.google.common.collect.ImmutableSet.<org.bukkit.event.player.PlayerRespawnEvent.RespawnFlag>builder().add(respawnFlags)); // Paper - Fix anchor respawn acting as a bed respawn from the end portal
              this.cserver.getPluginManager().callEvent(respawnEvent);

--- a/patches/server/0681-Add-basic-Datapack-API.patch
+++ b/patches/server/0681-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fb18b1f0bbc5b87f6895086f6d6a749543caf11f..b7db2d68deeee0a213ee26e31475f05ba16d073e 100644
+index 273f80fc0325c2ccd2320e35ca36639f92345aea..8a90d38621a4877a798206fa8946fa60adf88e74 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -266,6 +266,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index fb18b1f0bbc5b87f6895086f6d6a749543caf11f..b7db2d68deeee0a213ee26e31475f05b
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2495,5 +2497,11 @@ public final class CraftServer implements Server {
+@@ -2491,5 +2493,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0688-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0688-Fix-and-optimise-world-force-upgrading.patch
@@ -350,10 +350,10 @@ index 43510774d489bfdd30f10d521e424fa1363b8919..6496108953effae82391b5c1ea6fdec8
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ca28dda0f9819e8d75fbaa48cf5ff5643910999a..8a98bd1018afd934696fedbed24e271ab6b75f51 100644
+index 915941adc290b62855e0a6431a34da321315f301..3948fd10d8bd0994d97dfd5f26fb0dc5f0b5ac8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1142,14 +1142,7 @@ public final class CraftServer implements Server {
+@@ -1138,14 +1138,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().isPresent());
@@ -369,7 +369,7 @@ index ca28dda0f9819e8d75fbaa48cf5ff5643910999a..8a98bd1018afd934696fedbed24e271a
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1166,6 +1159,14 @@ public final class CraftServer implements Server {
+@@ -1162,6 +1155,14 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  

--- a/patches/server/0698-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0698-Add-PlayerKickEvent-causes.patch
@@ -57,7 +57,7 @@ index 708ac03d5a849bf09c49547306e4a8c5a5ef8d91..5a8df368a4a25839cd4ac9be6972da2e
          }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 084b17d6496799fd49a9f81bb6bcbff512fd8f78..7d2ac8aa97805e8b022d3982b1332c5055fc8b90 100644
+index a6ea73a95963d1bb51e83c127acca8e1be326ab0..44a9021d6a1e7a9d4ed368aebaf917fa391ead0e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -321,7 +321,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -327,10 +327,10 @@ index 084b17d6496799fd49a9f81bb6bcbff512fd8f78..7d2ac8aa97805e8b022d3982b1332c50
          }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1e2ad223ae9c3270548de89acc91f1e6780af539..d76d8d8db7921d16f87dd162ccd115e351cde106 100644
+index aa8e3c9b5884b9de1cf6805b3033ca1c8cdb9cc6..a6ecbb7eb1df7923d58366327e0f00512a3a1677 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -708,7 +708,7 @@ public abstract class PlayerList {
+@@ -714,7 +714,7 @@ public abstract class PlayerList {
          while (iterator.hasNext()) {
              entityplayer = (ServerPlayer) iterator.next();
              this.save(entityplayer); // CraftBukkit - Force the player's inventory to be saved
@@ -339,7 +339,7 @@ index 1e2ad223ae9c3270548de89acc91f1e6780af539..d76d8d8db7921d16f87dd162ccd115e3
          }
  
          // Instead of kicking then returning, we need to store the kick reason
-@@ -1360,8 +1360,8 @@ public abstract class PlayerList {
+@@ -1366,8 +1366,8 @@ public abstract class PlayerList {
          // Paper end
          // CraftBukkit start - disconnect safely
          for (ServerPlayer player : this.players) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
70d24eb8 SPIGOT-6587: Update documentation/error of drop chance API

CraftBukkit Changes:
470050ad SPIGOT-6587: Update documentation/error of drop chance API
1c39efa3 Fix Inventory#getViewers on the player inventory not returning the player first time their inventory is opened
d161627d Fix PrepareItemCraftEvent#isRepair
aa1fae73 SPIGOT-6586: EntityChangeBlockEvent for falling block does not cancel properly
8a04072e SPIGOT-6583: Throwing eggs doesn't make sounds

Spigot Changes:
f773da84 Remove redundant patch
cd367234 Rebuild patches