### PR TITLE
Fix "Don't ignore result of PlayerEditBookEvent"

### DIFF
--- a/patches/server/0648-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0648-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1a0ab16e1337867e982af8cd1a4e646b06c6e8d2..6a40ce317bd0e5a0043cd156d4c32de95d5d2827 100644
+index 137213a4d98e1405eb34db06614cf245ad72bf98..e65da503059476e7877861ab4fb195324055a7ba 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1191,7 +1191,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -13,7 +13,7 @@ index 1a0ab16e1337867e982af8cd1a4e646b06c6e8d2..6a40ce317bd0e5a0043cd156d4c32de9
  
          itemstack.addTagElement("pages", (Tag) nbttaglist);
 -        CraftEventFactory.handleEditBookEvent(player, slot, handItem, itemstack); // CraftBukkit
-+        this.player.containerMenu.setItem(slot, CraftEventFactory.handleEditBookEvent(player, slot, handItem, itemstack)); // CraftBukkit // Paper - Don't ignore result (see other callsite for handleEditBookEvent)
++        this.player.getInventory().setItem(slot, CraftEventFactory.handleEditBookEvent(player, slot, handItem, itemstack)); // CraftBukkit // Paper - Don't ignore result (see other callsite for handleEditBookEvent)
      }
  
      @Override


### PR DESCRIPTION
Fixes #5911 

Looks like the wrong field was selected while updating/remapping, as the correct one should've been `inventory`, though it is private