### PR TITLE
Fix `EntityEquipment::setDropChance` Javadoc

### DIFF
--- a/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -36,7 +36,7 @@ index e85c4208f3536277fcd0f8a0f0b4841c4e073b2c..d0abfc3211a7ec451d83e59c7e39cfc7
 +     *
 +     * @param slot the slot to set the drop chance of
 +     * @param chance the drop chance for the slot
-+     * @throws UnsupportedOperationException when called on players
++     * @throws UnsupportedOperationException when called on non-Mob entities
 +     */
 +    void setDropChance(@NotNull EquipmentSlot slot, float chance);
 +    // Paper end

--- a/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/api/0288-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -36,7 +36,7 @@ index e85c4208f3536277fcd0f8a0f0b4841c4e073b2c..d0abfc3211a7ec451d83e59c7e39cfc7
 +     *
 +     * @param slot the slot to set the drop chance of
 +     * @param chance the drop chance for the slot
-+     * @throws UnsupportedOperationException when called on non-Mob entities
++     * @throws UnsupportedOperationException when called on non-{@link Mob} entities
 +     */
 +    void setDropChance(@NotNull EquipmentSlot slot, float chance);
 +    // Paper end


### PR DESCRIPTION
Only a little change in docs about the exception in setDropChance where no only in players can happen.

This exception happen in non EntityInsentient (like Players or ArmorStands)

Based in https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/470050ad1e8944e0fcd8c966043705c2b006c3a8