### PR TITLE
Add methods to `ProtoWorld` for working with `BlockState`s

### DIFF
--- a/patches/api/0319-Add-Feature-Stage-API.patch
+++ b/patches/api/0319-Add-Feature-Stage-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Feature Stage API
 
 diff --git a/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java b/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5a911a322
+index 0000000000000000000000000000000000000000..f3b465d3883547d53e55183c2a4e22c63525a787
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java
 @@ -0,0 +1,313 @@
@@ -56,6 +56,48 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +     */
 +    default void setBlockData(@NotNull Vector vector, @NotNull BlockData data) {
 +        setBlockData(vector.getBlockX(), vector.getBlockY(), vector.getBlockZ(), data);
++    }
++
++    /**
++     * Sets the {@link BlockState} at a location.
++     *
++     * @param x X coordinate.
++     * @param y Y coordinate.
++     * @param z Z coordinate.
++     * @param state The block state.
++     */
++    void setBlockState(int x, int y, int z, @NotNull BlockState state);
++
++    /**
++     * Sets the {@link BlockState} at a location.
++     *
++     * @param location Location to set block state.
++     * @param state The block state.
++     */
++    default void setBlockState(@NotNull Vector location, @NotNull BlockState state) {
++        setBlockState(location.getBlockX(), location.getBlockY(), location.getBlockZ(), state);
++    }
++
++    /**
++     * Gets the {@link BlockState} at a location.
++     *
++     * @param x X coordinate.
++     * @param y Y coordinate.
++     * @param z Z coordinate.
++     * @return The block state.
++     */
++    @NotNull
++    BlockState getBlockState(int x, int y, int z);
++
++    /**
++     * Gets the {@link BlockState} at a location.
++     *
++     * @param location Location to get block state from.
++     * @return The block state.
++     */
++    @NotNull
++    default BlockState getBlockState(@NotNull Vector location) {
++        return getBlockState(location.getBlockX(), location.getBlockY(), location.getBlockZ());
 +    }
 +
 +    /**
@@ -135,7 +177,7 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +    int getCenterChunkX();
 +
 +    /**
-+     * Get the X-coordinate of the block in the center of this ProtoWorld
++     * Get the X-coordinate of the block in the center of this {@link ProtoWorld}
 +     *
 +     * @return The center chunk's X coordinate.
 +     */
@@ -144,14 +186,14 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +    }
 +
 +    /**
-+     * Get the Z-coordinate of the chunk in the center of this ProtoWorld
++     * Get the Z-coordinate of the chunk in the center of this {@link ProtoWorld}
 +     *
 +     * @return The center chunk's Z coordinate.
 +     */
 +    int getCenterChunkZ();
 +
 +    /**
-+     * Get the Z-coordinate of the block in the center of this ProtoWorld
++     * Get the Z-coordinate of the block in the center of this {@link ProtoWorld}
 +     *
 +     * @return The center chunk's Z coordinate.
 +     */
@@ -160,7 +202,7 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +    }
 +
 +    /**
-+     * Creates a entity at the location represented by the given {@link Vector}
++     * Creates an entity at the location represented by the given {@link Vector}
 +     *
 +     * @param loc  The {@link Vector} representing the location to spawn the entity
 +     * @param type The entity to spawn
@@ -246,7 +288,7 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +    }
 +
 +    /**
-+     * Creates a entity at the location represented by the given {@link Vector}
++     * Creates an entity at the location represented by the given {@link Vector}
 +     *
 +     * @param loc    The {@link Vector} representing the location to spawn the entity
 +     * @param type   The entity to spawn
@@ -260,7 +302,7 @@ index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5
 +    }
 +
 +    /**
-+     * Creates a entity at the location represented by the given {@link Vector}, with
++     * Creates an entity at the location represented by the given {@link Vector}, with
 +     * the supplied function run before the entity is added to the world.
 +     * <br>
 +     * Note that when the function is run, the entity will not be actually in

--- a/patches/api/0319-Add-Feature-Stage-API.patch
+++ b/patches/api/0319-Add-Feature-Stage-API.patch
@@ -6,13 +6,14 @@ Subject: [PATCH] Add Feature Stage API
 
 diff --git a/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java b/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cf9443f1cd3039f0e53c645c894483027455465b
+index 0000000000000000000000000000000000000000..5f5a63af489b8c6a90b6ff6dbeb9edd5a911a322
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/generation/ProtoWorld.java
-@@ -0,0 +1,270 @@
+@@ -0,0 +1,313 @@
 +package io.papermc.paper.world.generation;
 +
 +import org.bukkit.World;
++import org.bukkit.block.BlockState;
 +import org.bukkit.block.data.BlockData;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.entity.EntityType;

--- a/patches/server/0714-Add-Feature-Generation-API.patch
+++ b/patches/server/0714-Add-Feature-Generation-API.patch
@@ -143,7 +143,7 @@ index 46ce973ca68420825316352ad4df907edf52bfec..65e9ecda0df8a22f93f5979a8c9ac74e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..8fb0049dc3b6c3b7b31e2c43e9d46494cbdc84d7 100644
+index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..5ec7a3903838ce2f60926782965107e84b44643c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 @@ -271,13 +271,18 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
@@ -169,7 +169,7 @@ index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..8fb0049dc3b6c3b7b31e2c43e9d46494
                      break;
                  case SHULKER_BOX:
                  case WHITE_SHULKER_BOX:
-@@ -296,251 +301,252 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -296,19 +301,19 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
                  case GREEN_SHULKER_BOX:
                  case RED_SHULKER_BOX:
                  case BLACK_SHULKER_BOX:
@@ -189,467 +189,207 @@ index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..8fb0049dc3b6c3b7b31e2c43e9d46494
 +        BlockEntity te = (blockEntityTag == null) ? null : BlockEntity.loadStatic(blockposition, iblockdata, blockEntityTag);
  
 -        switch (this.material) {
--        case ACACIA_SIGN:
--        case ACACIA_WALL_SIGN:
--        case BIRCH_SIGN:
--        case BIRCH_WALL_SIGN:
--        case CRIMSON_SIGN:
--        case CRIMSON_WALL_SIGN:
--        case DARK_OAK_SIGN:
--        case DARK_OAK_WALL_SIGN:
--        case JUNGLE_SIGN:
--        case JUNGLE_WALL_SIGN:
--        case OAK_SIGN:
--        case OAK_WALL_SIGN:
--        case SPRUCE_SIGN:
--        case SPRUCE_WALL_SIGN:
--        case WARPED_SIGN:
--        case WARPED_WALL_SIGN:
--            if (te == null) {
--                te = new SignBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftSign(this.material, (SignBlockEntity) te);
--        case CHEST:
--        case TRAPPED_CHEST:
--            if (te == null) {
--                te = new ChestBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftChest(this.material, (ChestBlockEntity) te);
--        case FURNACE:
--            if (te == null) {
--                te = new FurnaceBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftFurnaceFurnace(this.material, (FurnaceBlockEntity) te);
--        case DISPENSER:
--            if (te == null) {
--                te = new DispenserBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftDispenser(this.material, (DispenserBlockEntity) te);
--        case DROPPER:
--            if (te == null) {
--                te = new DropperBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftDropper(this.material, (DropperBlockEntity) te);
--        case END_GATEWAY:
--            if (te == null) {
--                te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftEndGateway(this.material, (TheEndGatewayBlockEntity) te);
--        case HOPPER:
--            if (te == null) {
--                te = new HopperBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftHopper(this.material, (HopperBlockEntity) te);
--        case SPAWNER:
--            if (te == null) {
--                te = new SpawnerBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftCreatureSpawner(this.material, (SpawnerBlockEntity) te);
--        case JUKEBOX:
--            if (te == null) {
--                te = new JukeboxBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftJukebox(this.material, (JukeboxBlockEntity) te);
--        case BREWING_STAND:
--            if (te == null) {
--                te = new BrewingStandBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBrewingStand(this.material, (BrewingStandBlockEntity) te);
--        case CREEPER_HEAD:
--        case CREEPER_WALL_HEAD:
--        case DRAGON_HEAD:
--        case DRAGON_WALL_HEAD:
--        case PLAYER_HEAD:
--        case PLAYER_WALL_HEAD:
--        case SKELETON_SKULL:
--        case SKELETON_WALL_SKULL:
--        case WITHER_SKELETON_SKULL:
--        case WITHER_SKELETON_WALL_SKULL:
--        case ZOMBIE_HEAD:
--        case ZOMBIE_WALL_HEAD:
--            if (te == null) {
--                te = new SkullBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftSkull(this.material, (SkullBlockEntity) te);
--        case COMMAND_BLOCK:
--        case REPEATING_COMMAND_BLOCK:
--        case CHAIN_COMMAND_BLOCK:
--            if (te == null) {
--                te = new CommandBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftCommandBlock(this.material, (CommandBlockEntity) te);
--        case BEACON:
--            if (te == null) {
--                te = new BeaconBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBeacon(this.material, (BeaconBlockEntity) te);
--        case SHIELD:
--            if (te == null) {
--                te = new BannerBlockEntity(blockposition, iblockdata);
--            }
--            ((BannerBlockEntity) te).baseColor = (this.blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(this.blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
--        case BLACK_BANNER:
--        case BLACK_WALL_BANNER:
--        case BLUE_BANNER:
--        case BLUE_WALL_BANNER:
--        case BROWN_BANNER:
--        case BROWN_WALL_BANNER:
--        case CYAN_BANNER:
--        case CYAN_WALL_BANNER:
--        case GRAY_BANNER:
--        case GRAY_WALL_BANNER:
--        case GREEN_BANNER:
--        case GREEN_WALL_BANNER:
--        case LIGHT_BLUE_BANNER:
--        case LIGHT_BLUE_WALL_BANNER:
--        case LIGHT_GRAY_BANNER:
--        case LIGHT_GRAY_WALL_BANNER:
--        case LIME_BANNER:
--        case LIME_WALL_BANNER:
--        case MAGENTA_BANNER:
--        case MAGENTA_WALL_BANNER:
--        case ORANGE_BANNER:
--        case ORANGE_WALL_BANNER:
--        case PINK_BANNER:
--        case PINK_WALL_BANNER:
--        case PURPLE_BANNER:
--        case PURPLE_WALL_BANNER:
--        case RED_BANNER:
--        case RED_WALL_BANNER:
--        case WHITE_BANNER:
--        case WHITE_WALL_BANNER:
--        case YELLOW_BANNER:
--        case YELLOW_WALL_BANNER:
--            if (te == null) {
--                te = new BannerBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBanner(this.material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag) : this.material, (BannerBlockEntity) te);
--        case STRUCTURE_BLOCK:
--            if (te == null) {
--                te = new StructureBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftStructureBlock(this.material, (StructureBlockEntity) te);
--        case SHULKER_BOX:
--        case WHITE_SHULKER_BOX:
--        case ORANGE_SHULKER_BOX:
--        case MAGENTA_SHULKER_BOX:
--        case LIGHT_BLUE_SHULKER_BOX:
--        case YELLOW_SHULKER_BOX:
--        case LIME_SHULKER_BOX:
--        case PINK_SHULKER_BOX:
--        case GRAY_SHULKER_BOX:
--        case LIGHT_GRAY_SHULKER_BOX:
--        case CYAN_SHULKER_BOX:
--        case PURPLE_SHULKER_BOX:
--        case BLUE_SHULKER_BOX:
--        case BROWN_SHULKER_BOX:
--        case GREEN_SHULKER_BOX:
--        case RED_SHULKER_BOX:
--        case BLACK_SHULKER_BOX:
--            if (te == null) {
--                te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftShulkerBox(this.material, (ShulkerBoxBlockEntity) te);
--        case ENCHANTING_TABLE:
--            if (te == null) {
--                te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftEnchantingTable(this.material, (EnchantmentTableBlockEntity) te);
--        case ENDER_CHEST:
--            if (te == null) {
--                te = new EnderChestBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftEnderChest(this.material, (EnderChestBlockEntity) te);
--        case DAYLIGHT_DETECTOR:
--            if (te == null) {
--                te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftDaylightDetector(this.material, (DaylightDetectorBlockEntity) te);
--        case COMPARATOR:
--            if (te == null) {
--                te = new ComparatorBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftComparator(this.material, (ComparatorBlockEntity) te);
--        case BARREL:
--            if (te == null) {
--                te = new BarrelBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBarrel(this.material, (BarrelBlockEntity) te);
--        case BELL:
--            if (te == null) {
--                te = new BellBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBell(this.material, (BellBlockEntity) te);
--        case BLAST_FURNACE:
--            if (te == null) {
--                te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBlastFurnace(this.material, (BlastFurnaceBlockEntity) te);
--        case CAMPFIRE:
--        case SOUL_CAMPFIRE:
--            if (te == null) {
--                te = new CampfireBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftCampfire(this.material, (CampfireBlockEntity) te);
--        case JIGSAW:
--            if (te == null) {
--                te = new JigsawBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftJigsaw(this.material, (JigsawBlockEntity) te);
--        case LECTERN:
--            if (te == null) {
--                te = new LecternBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftLectern(this.material, (LecternBlockEntity) te);
--        case SMOKER:
--            if (te == null) {
--                te = new SmokerBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftSmoker(this.material, (SmokerBlockEntity) te);
--        case BEE_NEST:
--        case BEEHIVE:
--            if (te == null) {
--                te = new BeehiveBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftBeehive(this.material, (BeehiveBlockEntity) te);
--        case SCULK_SENSOR:
--            if (te == null) {
--                te = new SculkSensorBlockEntity(blockposition, iblockdata);
--            }
--            return new CraftSculkSensor(this.material, (SculkSensorBlockEntity) te);
--        default:
--            throw new IllegalStateException("Missing blockState for " + this.material);
 +        switch (material) {
-+            case ACACIA_SIGN:
-+            case ACACIA_WALL_SIGN:
-+            case BIRCH_SIGN:
-+            case BIRCH_WALL_SIGN:
-+            case CRIMSON_SIGN:
-+            case CRIMSON_WALL_SIGN:
-+            case DARK_OAK_SIGN:
-+            case DARK_OAK_WALL_SIGN:
-+            case JUNGLE_SIGN:
-+            case JUNGLE_WALL_SIGN:
-+            case OAK_SIGN:
-+            case OAK_WALL_SIGN:
-+            case SPRUCE_SIGN:
-+            case SPRUCE_WALL_SIGN:
-+            case WARPED_SIGN:
-+            case WARPED_WALL_SIGN:
-+                if (te == null) {
-+                    te = new SignBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftSign(material, (SignBlockEntity) te);
-+            case CHEST:
-+            case TRAPPED_CHEST:
-+                if (te == null) {
-+                    te = new ChestBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftChest(material, (ChestBlockEntity) te);
-+            case FURNACE:
-+                if (te == null) {
-+                    te = new FurnaceBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftFurnaceFurnace(material, (FurnaceBlockEntity) te);
-+            case DISPENSER:
-+                if (te == null) {
-+                    te = new DispenserBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftDispenser(material, (DispenserBlockEntity) te);
-+            case DROPPER:
-+                if (te == null) {
-+                    te = new DropperBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftDropper(material, (DropperBlockEntity) te);
-+            case END_GATEWAY:
-+                if (te == null) {
-+                    te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftEndGateway(material, (TheEndGatewayBlockEntity) te);
-+            case HOPPER:
-+                if (te == null) {
-+                    te = new HopperBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftHopper(material, (HopperBlockEntity) te);
-+            case SPAWNER:
-+                if (te == null) {
-+                    te = new SpawnerBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftCreatureSpawner(material, (SpawnerBlockEntity) te);
-+            case JUKEBOX:
-+                if (te == null) {
-+                    te = new JukeboxBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftJukebox(material, (JukeboxBlockEntity) te);
-+            case BREWING_STAND:
-+                if (te == null) {
-+                    te = new BrewingStandBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBrewingStand(material, (BrewingStandBlockEntity) te);
-+            case CREEPER_HEAD:
-+            case CREEPER_WALL_HEAD:
-+            case DRAGON_HEAD:
-+            case DRAGON_WALL_HEAD:
-+            case PLAYER_HEAD:
-+            case PLAYER_WALL_HEAD:
-+            case SKELETON_SKULL:
-+            case SKELETON_WALL_SKULL:
-+            case WITHER_SKELETON_SKULL:
-+            case WITHER_SKELETON_WALL_SKULL:
-+            case ZOMBIE_HEAD:
-+            case ZOMBIE_WALL_HEAD:
-+                if (te == null) {
-+                    te = new SkullBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftSkull(material, (SkullBlockEntity) te);
-+            case COMMAND_BLOCK:
-+            case REPEATING_COMMAND_BLOCK:
-+            case CHAIN_COMMAND_BLOCK:
-+                if (te == null) {
-+                    te = new CommandBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftCommandBlock(material, (CommandBlockEntity) te);
-+            case BEACON:
-+                if (te == null) {
-+                    te = new BeaconBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBeacon(material, (BeaconBlockEntity) te);
-+            case SHIELD:
-+                if (te == null) {
-+                    te = new BannerBlockEntity(blockposition, iblockdata);
-+                }
-+                ((BannerBlockEntity) te).baseColor = (blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
-+            case BLACK_BANNER:
-+            case BLACK_WALL_BANNER:
-+            case BLUE_BANNER:
-+            case BLUE_WALL_BANNER:
-+            case BROWN_BANNER:
-+            case BROWN_WALL_BANNER:
-+            case CYAN_BANNER:
-+            case CYAN_WALL_BANNER:
-+            case GRAY_BANNER:
-+            case GRAY_WALL_BANNER:
-+            case GREEN_BANNER:
-+            case GREEN_WALL_BANNER:
-+            case LIGHT_BLUE_BANNER:
-+            case LIGHT_BLUE_WALL_BANNER:
-+            case LIGHT_GRAY_BANNER:
-+            case LIGHT_GRAY_WALL_BANNER:
-+            case LIME_BANNER:
-+            case LIME_WALL_BANNER:
-+            case MAGENTA_BANNER:
-+            case MAGENTA_WALL_BANNER:
-+            case ORANGE_BANNER:
-+            case ORANGE_WALL_BANNER:
-+            case PINK_BANNER:
-+            case PINK_WALL_BANNER:
-+            case PURPLE_BANNER:
-+            case PURPLE_WALL_BANNER:
-+            case RED_BANNER:
-+            case RED_WALL_BANNER:
-+            case WHITE_BANNER:
-+            case WHITE_WALL_BANNER:
-+            case YELLOW_BANNER:
-+            case YELLOW_WALL_BANNER:
-+                if (te == null) {
-+                    te = new BannerBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBanner(material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(blockEntityTag) : material, (BannerBlockEntity) te);
-+            case STRUCTURE_BLOCK:
-+                if (te == null) {
-+                    te = new StructureBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftStructureBlock(material, (StructureBlockEntity) te);
-+            case SHULKER_BOX:
-+            case WHITE_SHULKER_BOX:
-+            case ORANGE_SHULKER_BOX:
-+            case MAGENTA_SHULKER_BOX:
-+            case LIGHT_BLUE_SHULKER_BOX:
-+            case YELLOW_SHULKER_BOX:
-+            case LIME_SHULKER_BOX:
-+            case PINK_SHULKER_BOX:
-+            case GRAY_SHULKER_BOX:
-+            case LIGHT_GRAY_SHULKER_BOX:
-+            case CYAN_SHULKER_BOX:
-+            case PURPLE_SHULKER_BOX:
-+            case BLUE_SHULKER_BOX:
-+            case BROWN_SHULKER_BOX:
-+            case GREEN_SHULKER_BOX:
-+            case RED_SHULKER_BOX:
-+            case BLACK_SHULKER_BOX:
-+                if (te == null) {
-+                    te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftShulkerBox(material, (ShulkerBoxBlockEntity) te);
-+            case ENCHANTING_TABLE:
-+                if (te == null) {
-+                    te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftEnchantingTable(material, (EnchantmentTableBlockEntity) te);
-+            case ENDER_CHEST:
-+                if (te == null) {
-+                    te = new EnderChestBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftEnderChest(material, (EnderChestBlockEntity) te);
-+            case DAYLIGHT_DETECTOR:
-+                if (te == null) {
-+                    te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftDaylightDetector(material, (DaylightDetectorBlockEntity) te);
-+            case COMPARATOR:
-+                if (te == null) {
-+                    te = new ComparatorBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftComparator(material, (ComparatorBlockEntity) te);
-+            case BARREL:
-+                if (te == null) {
-+                    te = new BarrelBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBarrel(material, (BarrelBlockEntity) te);
-+            case BELL:
-+                if (te == null) {
-+                    te = new BellBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBell(material, (BellBlockEntity) te);
-+            case BLAST_FURNACE:
-+                if (te == null) {
-+                    te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBlastFurnace(material, (BlastFurnaceBlockEntity) te);
-+            case CAMPFIRE:
-+            case SOUL_CAMPFIRE:
-+                if (te == null) {
-+                    te = new CampfireBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftCampfire(material, (CampfireBlockEntity) te);
-+            case JIGSAW:
-+                if (te == null) {
-+                    te = new JigsawBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftJigsaw(material, (JigsawBlockEntity) te);
-+            case LECTERN:
-+                if (te == null) {
-+                    te = new LecternBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftLectern(material, (LecternBlockEntity) te);
-+            case SMOKER:
-+                if (te == null) {
-+                    te = new SmokerBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftSmoker(material, (SmokerBlockEntity) te);
-+            case BEE_NEST:
-+            case BEEHIVE:
-+                if (te == null) {
-+                    te = new BeehiveBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftBeehive(material, (BeehiveBlockEntity) te);
-+            case SCULK_SENSOR:
-+                if (te == null) {
-+                    te = new SculkSensorBlockEntity(blockposition, iblockdata);
-+                }
-+                return new CraftSculkSensor(material, (SculkSensorBlockEntity) te);
-+            default:
-+                throw new IllegalStateException("Missing blockState for " + material);
+         case ACACIA_SIGN:
+         case ACACIA_WALL_SIGN:
+         case BIRCH_SIGN:
+@@ -328,53 +333,53 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+             if (te == null) {
+                 te = new SignBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftSign(this.material, (SignBlockEntity) te);
++            return new CraftSign(material, (SignBlockEntity) te);
+         case CHEST:
+         case TRAPPED_CHEST:
+             if (te == null) {
+                 te = new ChestBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftChest(this.material, (ChestBlockEntity) te);
++            return new CraftChest(material, (ChestBlockEntity) te);
+         case FURNACE:
+             if (te == null) {
+                 te = new FurnaceBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftFurnaceFurnace(this.material, (FurnaceBlockEntity) te);
++            return new CraftFurnaceFurnace(material, (FurnaceBlockEntity) te);
+         case DISPENSER:
+             if (te == null) {
+                 te = new DispenserBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftDispenser(this.material, (DispenserBlockEntity) te);
++            return new CraftDispenser(material, (DispenserBlockEntity) te);
+         case DROPPER:
+             if (te == null) {
+                 te = new DropperBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftDropper(this.material, (DropperBlockEntity) te);
++            return new CraftDropper(material, (DropperBlockEntity) te);
+         case END_GATEWAY:
+             if (te == null) {
+                 te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftEndGateway(this.material, (TheEndGatewayBlockEntity) te);
++            return new CraftEndGateway(material, (TheEndGatewayBlockEntity) te);
+         case HOPPER:
+             if (te == null) {
+                 te = new HopperBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftHopper(this.material, (HopperBlockEntity) te);
++            return new CraftHopper(material, (HopperBlockEntity) te);
+         case SPAWNER:
+             if (te == null) {
+                 te = new SpawnerBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftCreatureSpawner(this.material, (SpawnerBlockEntity) te);
++            return new CraftCreatureSpawner(material, (SpawnerBlockEntity) te);
+         case JUKEBOX:
+             if (te == null) {
+                 te = new JukeboxBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftJukebox(this.material, (JukeboxBlockEntity) te);
++            return new CraftJukebox(material, (JukeboxBlockEntity) te);
+         case BREWING_STAND:
+             if (te == null) {
+                 te = new BrewingStandBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBrewingStand(this.material, (BrewingStandBlockEntity) te);
++            return new CraftBrewingStand(material, (BrewingStandBlockEntity) te);
+         case CREEPER_HEAD:
+         case CREEPER_WALL_HEAD:
+         case DRAGON_HEAD:
+@@ -390,24 +395,24 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+             if (te == null) {
+                 te = new SkullBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftSkull(this.material, (SkullBlockEntity) te);
++            return new CraftSkull(material, (SkullBlockEntity) te);
+         case COMMAND_BLOCK:
+         case REPEATING_COMMAND_BLOCK:
+         case CHAIN_COMMAND_BLOCK:
+             if (te == null) {
+                 te = new CommandBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftCommandBlock(this.material, (CommandBlockEntity) te);
++            return new CraftCommandBlock(material, (CommandBlockEntity) te);
+         case BEACON:
+             if (te == null) {
+                 te = new BeaconBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBeacon(this.material, (BeaconBlockEntity) te);
++            return new CraftBeacon(material, (BeaconBlockEntity) te);
+         case SHIELD:
+             if (te == null) {
+                 te = new BannerBlockEntity(blockposition, iblockdata);
+             }
+-            ((BannerBlockEntity) te).baseColor = (this.blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(this.blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
++            ((BannerBlockEntity) te).baseColor = (blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
+         case BLACK_BANNER:
+         case BLACK_WALL_BANNER:
+         case BLUE_BANNER:
+@@ -443,12 +448,12 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+             if (te == null) {
+                 te = new BannerBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBanner(this.material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag) : this.material, (BannerBlockEntity) te);
++            return new CraftBanner(material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(blockEntityTag) : material, (BannerBlockEntity) te);
+         case STRUCTURE_BLOCK:
+             if (te == null) {
+                 te = new StructureBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftStructureBlock(this.material, (StructureBlockEntity) te);
++            return new CraftStructureBlock(material, (StructureBlockEntity) te);
+         case SHULKER_BOX:
+         case WHITE_SHULKER_BOX:
+         case ORANGE_SHULKER_BOX:
+@@ -469,78 +474,79 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+             if (te == null) {
+                 te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftShulkerBox(this.material, (ShulkerBoxBlockEntity) te);
++            return new CraftShulkerBox(material, (ShulkerBoxBlockEntity) te);
+         case ENCHANTING_TABLE:
+             if (te == null) {
+                 te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftEnchantingTable(this.material, (EnchantmentTableBlockEntity) te);
++            return new CraftEnchantingTable(material, (EnchantmentTableBlockEntity) te);
+         case ENDER_CHEST:
+             if (te == null) {
+                 te = new EnderChestBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftEnderChest(this.material, (EnderChestBlockEntity) te);
++            return new CraftEnderChest(material, (EnderChestBlockEntity) te);
+         case DAYLIGHT_DETECTOR:
+             if (te == null) {
+                 te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftDaylightDetector(this.material, (DaylightDetectorBlockEntity) te);
++            return new CraftDaylightDetector(material, (DaylightDetectorBlockEntity) te);
+         case COMPARATOR:
+             if (te == null) {
+                 te = new ComparatorBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftComparator(this.material, (ComparatorBlockEntity) te);
++            return new CraftComparator(material, (ComparatorBlockEntity) te);
+         case BARREL:
+             if (te == null) {
+                 te = new BarrelBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBarrel(this.material, (BarrelBlockEntity) te);
++            return new CraftBarrel(material, (BarrelBlockEntity) te);
+         case BELL:
+             if (te == null) {
+                 te = new BellBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBell(this.material, (BellBlockEntity) te);
++            return new CraftBell(material, (BellBlockEntity) te);
+         case BLAST_FURNACE:
+             if (te == null) {
+                 te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBlastFurnace(this.material, (BlastFurnaceBlockEntity) te);
++            return new CraftBlastFurnace(material, (BlastFurnaceBlockEntity) te);
+         case CAMPFIRE:
+         case SOUL_CAMPFIRE:
+             if (te == null) {
+                 te = new CampfireBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftCampfire(this.material, (CampfireBlockEntity) te);
++            return new CraftCampfire(material, (CampfireBlockEntity) te);
+         case JIGSAW:
+             if (te == null) {
+                 te = new JigsawBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftJigsaw(this.material, (JigsawBlockEntity) te);
++            return new CraftJigsaw(material, (JigsawBlockEntity) te);
+         case LECTERN:
+             if (te == null) {
+                 te = new LecternBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftLectern(this.material, (LecternBlockEntity) te);
++            return new CraftLectern(material, (LecternBlockEntity) te);
+         case SMOKER:
+             if (te == null) {
+                 te = new SmokerBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftSmoker(this.material, (SmokerBlockEntity) te);
++            return new CraftSmoker(material, (SmokerBlockEntity) te);
+         case BEE_NEST:
+         case BEEHIVE:
+             if (te == null) {
+                 te = new BeehiveBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftBeehive(this.material, (BeehiveBlockEntity) te);
++            return new CraftBeehive(material, (BeehiveBlockEntity) te);
+         case SCULK_SENSOR:
+             if (te == null) {
+                 te = new SculkSensorBlockEntity(blockposition, iblockdata);
+             }
+-            return new CraftSculkSensor(this.material, (SculkSensorBlockEntity) te);
++            return new CraftSculkSensor(material, (SculkSensorBlockEntity) te);
+         default:
+-            throw new IllegalStateException("Missing blockState for " + this.material);
++            throw new IllegalStateException("Missing blockState for " + material);
          }
      }
 +    // Paper end

--- a/patches/server/0714-Add-Feature-Generation-API.patch
+++ b/patches/server/0714-Add-Feature-Generation-API.patch
@@ -6,20 +6,26 @@ Subject: [PATCH] Add Feature Generation API
 
 diff --git a/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java b/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..90a7c87d859d5d4f948a416eda0afbdf802e86ed
+index 0000000000000000000000000000000000000000..69b17fe56f28f8978abc3f363a9e805d7c7b007a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,115 @@
 +package io.papermc.paper.world.generation;
 +
 +import net.minecraft.core.BlockPos;
++import net.minecraft.nbt.CompoundTag;
 +import net.minecraft.server.level.WorldGenRegion;
 +import net.minecraft.world.entity.Mob;
 +import net.minecraft.world.entity.MobSpawnType;
 +import net.minecraft.world.entity.SpawnGroupData;
++import net.minecraft.world.level.block.entity.BlockEntity;
 +import org.bukkit.World;
++import org.bukkit.block.BlockState;
 +import org.bukkit.block.data.BlockData;
++import org.bukkit.craftbukkit.block.CraftBlockEntityState;
++import org.bukkit.craftbukkit.block.CraftBlockState;
 +import org.bukkit.craftbukkit.block.data.CraftBlockData;
++import org.bukkit.craftbukkit.inventory.CraftMetaBlockState;
 +import org.bukkit.entity.Entity;
 +import org.bukkit.event.entity.CreatureSpawnEvent;
 +import org.bukkit.util.Vector;
@@ -44,6 +50,21 @@ index 0000000000000000000000000000000000000000..90a7c87d859d5d4f948a416eda0afbdf
 +    public void setBlockData(int x, int y, int z, @NotNull BlockData data) {
 +        BlockPos position = new BlockPos(x, y, z);
 +        getDelegate().setBlock(position, ((CraftBlockData) data).getState(), 3);
++    }
++
++    @Override
++    public void setBlockState(int x, int y, int z, @NotNull BlockState state) {
++        BlockPos pos = new BlockPos(x, y, z);
++        if(!state.getBlockData().matches(getDelegate().getBlockState(pos).createCraftBlockData())) {
++            throw new IllegalArgumentException("BlockData does not match! Expected " + state.getBlockData().getAsString(false) + ", got " + getDelegate().getBlockState(pos).createCraftBlockData().getAsString(false));
++        }
++        getDelegate().getBlockEntity(pos).load(((CraftBlockEntityState<?>) state).getSnapshotNBT());
++    }
++
++    @Override
++    public @NotNull BlockState getBlockState(int x, int y, int z) {
++        BlockEntity entity = getDelegate().getBlockEntity(new BlockPos(x, y, z));
++        return CraftMetaBlockState.createBlockState(entity.getBlockState().getBukkitMaterial(), entity.save(new CompoundTag()));
 +    }
 +
 +    @Override
@@ -121,3 +142,517 @@ index 46ce973ca68420825316352ad4df907edf52bfec..65e9ecda0df8a22f93f5979a8c9ac74e
      }
  
      @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..8fb0049dc3b6c3b7b31e2c43e9d46494cbdc84d7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
+@@ -271,13 +271,18 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+         return this.blockEntityTag != null;
+     }
+ 
++    // Paper start - Delegate to utility method
+     @Override
+     public BlockState getBlockState() {
+-        Material stateMaterial = (this.material != Material.SHIELD) ? this.material : CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag); // Only actually used for jigsaws
+-        if (this.blockEntityTag != null) {
+-            switch (this.material) {
++        return createBlockState(this.material, this.blockEntityTag);
++    }
++
++    public static BlockState createBlockState(Material material, CompoundTag blockEntityTag) {
++        Material stateMaterial = (material != Material.SHIELD) ? material : CraftMetaBlockState.shieldToBannerHack(blockEntityTag); // Only actually used for jigsaws
++        if (blockEntityTag != null) {
++            switch (material) {
+                 case SHIELD:
+-                    this.blockEntityTag.putString("id", "banner");
++                    blockEntityTag.putString("id", "banner");
+                     break;
+                 case SHULKER_BOX:
+                 case WHITE_SHULKER_BOX:
+@@ -296,251 +301,252 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+                 case GREEN_SHULKER_BOX:
+                 case RED_SHULKER_BOX:
+                 case BLACK_SHULKER_BOX:
+-                    this.blockEntityTag.putString("id", "shulker_box");
++                    blockEntityTag.putString("id", "shulker_box");
+                     break;
+                 case BEE_NEST:
+                 case BEEHIVE:
+-                    this.blockEntityTag.putString("id", "beehive");
++                    blockEntityTag.putString("id", "beehive");
+                     break;
+             }
+         }
+         BlockPos blockposition = BlockPos.ZERO;
+         net.minecraft.world.level.block.state.BlockState iblockdata = CraftMagicNumbers.getBlock(stateMaterial).defaultBlockState();
+-        BlockEntity te = (this.blockEntityTag == null) ? null : BlockEntity.loadStatic(blockposition, iblockdata, blockEntityTag);
++        BlockEntity te = (blockEntityTag == null) ? null : BlockEntity.loadStatic(blockposition, iblockdata, blockEntityTag);
+ 
+-        switch (this.material) {
+-        case ACACIA_SIGN:
+-        case ACACIA_WALL_SIGN:
+-        case BIRCH_SIGN:
+-        case BIRCH_WALL_SIGN:
+-        case CRIMSON_SIGN:
+-        case CRIMSON_WALL_SIGN:
+-        case DARK_OAK_SIGN:
+-        case DARK_OAK_WALL_SIGN:
+-        case JUNGLE_SIGN:
+-        case JUNGLE_WALL_SIGN:
+-        case OAK_SIGN:
+-        case OAK_WALL_SIGN:
+-        case SPRUCE_SIGN:
+-        case SPRUCE_WALL_SIGN:
+-        case WARPED_SIGN:
+-        case WARPED_WALL_SIGN:
+-            if (te == null) {
+-                te = new SignBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftSign(this.material, (SignBlockEntity) te);
+-        case CHEST:
+-        case TRAPPED_CHEST:
+-            if (te == null) {
+-                te = new ChestBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftChest(this.material, (ChestBlockEntity) te);
+-        case FURNACE:
+-            if (te == null) {
+-                te = new FurnaceBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftFurnaceFurnace(this.material, (FurnaceBlockEntity) te);
+-        case DISPENSER:
+-            if (te == null) {
+-                te = new DispenserBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftDispenser(this.material, (DispenserBlockEntity) te);
+-        case DROPPER:
+-            if (te == null) {
+-                te = new DropperBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftDropper(this.material, (DropperBlockEntity) te);
+-        case END_GATEWAY:
+-            if (te == null) {
+-                te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftEndGateway(this.material, (TheEndGatewayBlockEntity) te);
+-        case HOPPER:
+-            if (te == null) {
+-                te = new HopperBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftHopper(this.material, (HopperBlockEntity) te);
+-        case SPAWNER:
+-            if (te == null) {
+-                te = new SpawnerBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftCreatureSpawner(this.material, (SpawnerBlockEntity) te);
+-        case JUKEBOX:
+-            if (te == null) {
+-                te = new JukeboxBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftJukebox(this.material, (JukeboxBlockEntity) te);
+-        case BREWING_STAND:
+-            if (te == null) {
+-                te = new BrewingStandBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBrewingStand(this.material, (BrewingStandBlockEntity) te);
+-        case CREEPER_HEAD:
+-        case CREEPER_WALL_HEAD:
+-        case DRAGON_HEAD:
+-        case DRAGON_WALL_HEAD:
+-        case PLAYER_HEAD:
+-        case PLAYER_WALL_HEAD:
+-        case SKELETON_SKULL:
+-        case SKELETON_WALL_SKULL:
+-        case WITHER_SKELETON_SKULL:
+-        case WITHER_SKELETON_WALL_SKULL:
+-        case ZOMBIE_HEAD:
+-        case ZOMBIE_WALL_HEAD:
+-            if (te == null) {
+-                te = new SkullBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftSkull(this.material, (SkullBlockEntity) te);
+-        case COMMAND_BLOCK:
+-        case REPEATING_COMMAND_BLOCK:
+-        case CHAIN_COMMAND_BLOCK:
+-            if (te == null) {
+-                te = new CommandBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftCommandBlock(this.material, (CommandBlockEntity) te);
+-        case BEACON:
+-            if (te == null) {
+-                te = new BeaconBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBeacon(this.material, (BeaconBlockEntity) te);
+-        case SHIELD:
+-            if (te == null) {
+-                te = new BannerBlockEntity(blockposition, iblockdata);
+-            }
+-            ((BannerBlockEntity) te).baseColor = (this.blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(this.blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
+-        case BLACK_BANNER:
+-        case BLACK_WALL_BANNER:
+-        case BLUE_BANNER:
+-        case BLUE_WALL_BANNER:
+-        case BROWN_BANNER:
+-        case BROWN_WALL_BANNER:
+-        case CYAN_BANNER:
+-        case CYAN_WALL_BANNER:
+-        case GRAY_BANNER:
+-        case GRAY_WALL_BANNER:
+-        case GREEN_BANNER:
+-        case GREEN_WALL_BANNER:
+-        case LIGHT_BLUE_BANNER:
+-        case LIGHT_BLUE_WALL_BANNER:
+-        case LIGHT_GRAY_BANNER:
+-        case LIGHT_GRAY_WALL_BANNER:
+-        case LIME_BANNER:
+-        case LIME_WALL_BANNER:
+-        case MAGENTA_BANNER:
+-        case MAGENTA_WALL_BANNER:
+-        case ORANGE_BANNER:
+-        case ORANGE_WALL_BANNER:
+-        case PINK_BANNER:
+-        case PINK_WALL_BANNER:
+-        case PURPLE_BANNER:
+-        case PURPLE_WALL_BANNER:
+-        case RED_BANNER:
+-        case RED_WALL_BANNER:
+-        case WHITE_BANNER:
+-        case WHITE_WALL_BANNER:
+-        case YELLOW_BANNER:
+-        case YELLOW_WALL_BANNER:
+-            if (te == null) {
+-                te = new BannerBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBanner(this.material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag) : this.material, (BannerBlockEntity) te);
+-        case STRUCTURE_BLOCK:
+-            if (te == null) {
+-                te = new StructureBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftStructureBlock(this.material, (StructureBlockEntity) te);
+-        case SHULKER_BOX:
+-        case WHITE_SHULKER_BOX:
+-        case ORANGE_SHULKER_BOX:
+-        case MAGENTA_SHULKER_BOX:
+-        case LIGHT_BLUE_SHULKER_BOX:
+-        case YELLOW_SHULKER_BOX:
+-        case LIME_SHULKER_BOX:
+-        case PINK_SHULKER_BOX:
+-        case GRAY_SHULKER_BOX:
+-        case LIGHT_GRAY_SHULKER_BOX:
+-        case CYAN_SHULKER_BOX:
+-        case PURPLE_SHULKER_BOX:
+-        case BLUE_SHULKER_BOX:
+-        case BROWN_SHULKER_BOX:
+-        case GREEN_SHULKER_BOX:
+-        case RED_SHULKER_BOX:
+-        case BLACK_SHULKER_BOX:
+-            if (te == null) {
+-                te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftShulkerBox(this.material, (ShulkerBoxBlockEntity) te);
+-        case ENCHANTING_TABLE:
+-            if (te == null) {
+-                te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftEnchantingTable(this.material, (EnchantmentTableBlockEntity) te);
+-        case ENDER_CHEST:
+-            if (te == null) {
+-                te = new EnderChestBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftEnderChest(this.material, (EnderChestBlockEntity) te);
+-        case DAYLIGHT_DETECTOR:
+-            if (te == null) {
+-                te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftDaylightDetector(this.material, (DaylightDetectorBlockEntity) te);
+-        case COMPARATOR:
+-            if (te == null) {
+-                te = new ComparatorBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftComparator(this.material, (ComparatorBlockEntity) te);
+-        case BARREL:
+-            if (te == null) {
+-                te = new BarrelBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBarrel(this.material, (BarrelBlockEntity) te);
+-        case BELL:
+-            if (te == null) {
+-                te = new BellBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBell(this.material, (BellBlockEntity) te);
+-        case BLAST_FURNACE:
+-            if (te == null) {
+-                te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBlastFurnace(this.material, (BlastFurnaceBlockEntity) te);
+-        case CAMPFIRE:
+-        case SOUL_CAMPFIRE:
+-            if (te == null) {
+-                te = new CampfireBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftCampfire(this.material, (CampfireBlockEntity) te);
+-        case JIGSAW:
+-            if (te == null) {
+-                te = new JigsawBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftJigsaw(this.material, (JigsawBlockEntity) te);
+-        case LECTERN:
+-            if (te == null) {
+-                te = new LecternBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftLectern(this.material, (LecternBlockEntity) te);
+-        case SMOKER:
+-            if (te == null) {
+-                te = new SmokerBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftSmoker(this.material, (SmokerBlockEntity) te);
+-        case BEE_NEST:
+-        case BEEHIVE:
+-            if (te == null) {
+-                te = new BeehiveBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftBeehive(this.material, (BeehiveBlockEntity) te);
+-        case SCULK_SENSOR:
+-            if (te == null) {
+-                te = new SculkSensorBlockEntity(blockposition, iblockdata);
+-            }
+-            return new CraftSculkSensor(this.material, (SculkSensorBlockEntity) te);
+-        default:
+-            throw new IllegalStateException("Missing blockState for " + this.material);
++        switch (material) {
++            case ACACIA_SIGN:
++            case ACACIA_WALL_SIGN:
++            case BIRCH_SIGN:
++            case BIRCH_WALL_SIGN:
++            case CRIMSON_SIGN:
++            case CRIMSON_WALL_SIGN:
++            case DARK_OAK_SIGN:
++            case DARK_OAK_WALL_SIGN:
++            case JUNGLE_SIGN:
++            case JUNGLE_WALL_SIGN:
++            case OAK_SIGN:
++            case OAK_WALL_SIGN:
++            case SPRUCE_SIGN:
++            case SPRUCE_WALL_SIGN:
++            case WARPED_SIGN:
++            case WARPED_WALL_SIGN:
++                if (te == null) {
++                    te = new SignBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftSign(material, (SignBlockEntity) te);
++            case CHEST:
++            case TRAPPED_CHEST:
++                if (te == null) {
++                    te = new ChestBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftChest(material, (ChestBlockEntity) te);
++            case FURNACE:
++                if (te == null) {
++                    te = new FurnaceBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftFurnaceFurnace(material, (FurnaceBlockEntity) te);
++            case DISPENSER:
++                if (te == null) {
++                    te = new DispenserBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftDispenser(material, (DispenserBlockEntity) te);
++            case DROPPER:
++                if (te == null) {
++                    te = new DropperBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftDropper(material, (DropperBlockEntity) te);
++            case END_GATEWAY:
++                if (te == null) {
++                    te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftEndGateway(material, (TheEndGatewayBlockEntity) te);
++            case HOPPER:
++                if (te == null) {
++                    te = new HopperBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftHopper(material, (HopperBlockEntity) te);
++            case SPAWNER:
++                if (te == null) {
++                    te = new SpawnerBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftCreatureSpawner(material, (SpawnerBlockEntity) te);
++            case JUKEBOX:
++                if (te == null) {
++                    te = new JukeboxBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftJukebox(material, (JukeboxBlockEntity) te);
++            case BREWING_STAND:
++                if (te == null) {
++                    te = new BrewingStandBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBrewingStand(material, (BrewingStandBlockEntity) te);
++            case CREEPER_HEAD:
++            case CREEPER_WALL_HEAD:
++            case DRAGON_HEAD:
++            case DRAGON_WALL_HEAD:
++            case PLAYER_HEAD:
++            case PLAYER_WALL_HEAD:
++            case SKELETON_SKULL:
++            case SKELETON_WALL_SKULL:
++            case WITHER_SKELETON_SKULL:
++            case WITHER_SKELETON_WALL_SKULL:
++            case ZOMBIE_HEAD:
++            case ZOMBIE_WALL_HEAD:
++                if (te == null) {
++                    te = new SkullBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftSkull(material, (SkullBlockEntity) te);
++            case COMMAND_BLOCK:
++            case REPEATING_COMMAND_BLOCK:
++            case CHAIN_COMMAND_BLOCK:
++                if (te == null) {
++                    te = new CommandBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftCommandBlock(material, (CommandBlockEntity) te);
++            case BEACON:
++                if (te == null) {
++                    te = new BeaconBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBeacon(material, (BeaconBlockEntity) te);
++            case SHIELD:
++                if (te == null) {
++                    te = new BannerBlockEntity(blockposition, iblockdata);
++                }
++                ((BannerBlockEntity) te).baseColor = (blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
++            case BLACK_BANNER:
++            case BLACK_WALL_BANNER:
++            case BLUE_BANNER:
++            case BLUE_WALL_BANNER:
++            case BROWN_BANNER:
++            case BROWN_WALL_BANNER:
++            case CYAN_BANNER:
++            case CYAN_WALL_BANNER:
++            case GRAY_BANNER:
++            case GRAY_WALL_BANNER:
++            case GREEN_BANNER:
++            case GREEN_WALL_BANNER:
++            case LIGHT_BLUE_BANNER:
++            case LIGHT_BLUE_WALL_BANNER:
++            case LIGHT_GRAY_BANNER:
++            case LIGHT_GRAY_WALL_BANNER:
++            case LIME_BANNER:
++            case LIME_WALL_BANNER:
++            case MAGENTA_BANNER:
++            case MAGENTA_WALL_BANNER:
++            case ORANGE_BANNER:
++            case ORANGE_WALL_BANNER:
++            case PINK_BANNER:
++            case PINK_WALL_BANNER:
++            case PURPLE_BANNER:
++            case PURPLE_WALL_BANNER:
++            case RED_BANNER:
++            case RED_WALL_BANNER:
++            case WHITE_BANNER:
++            case WHITE_WALL_BANNER:
++            case YELLOW_BANNER:
++            case YELLOW_WALL_BANNER:
++                if (te == null) {
++                    te = new BannerBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBanner(material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(blockEntityTag) : material, (BannerBlockEntity) te);
++            case STRUCTURE_BLOCK:
++                if (te == null) {
++                    te = new StructureBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftStructureBlock(material, (StructureBlockEntity) te);
++            case SHULKER_BOX:
++            case WHITE_SHULKER_BOX:
++            case ORANGE_SHULKER_BOX:
++            case MAGENTA_SHULKER_BOX:
++            case LIGHT_BLUE_SHULKER_BOX:
++            case YELLOW_SHULKER_BOX:
++            case LIME_SHULKER_BOX:
++            case PINK_SHULKER_BOX:
++            case GRAY_SHULKER_BOX:
++            case LIGHT_GRAY_SHULKER_BOX:
++            case CYAN_SHULKER_BOX:
++            case PURPLE_SHULKER_BOX:
++            case BLUE_SHULKER_BOX:
++            case BROWN_SHULKER_BOX:
++            case GREEN_SHULKER_BOX:
++            case RED_SHULKER_BOX:
++            case BLACK_SHULKER_BOX:
++                if (te == null) {
++                    te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftShulkerBox(material, (ShulkerBoxBlockEntity) te);
++            case ENCHANTING_TABLE:
++                if (te == null) {
++                    te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftEnchantingTable(material, (EnchantmentTableBlockEntity) te);
++            case ENDER_CHEST:
++                if (te == null) {
++                    te = new EnderChestBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftEnderChest(material, (EnderChestBlockEntity) te);
++            case DAYLIGHT_DETECTOR:
++                if (te == null) {
++                    te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftDaylightDetector(material, (DaylightDetectorBlockEntity) te);
++            case COMPARATOR:
++                if (te == null) {
++                    te = new ComparatorBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftComparator(material, (ComparatorBlockEntity) te);
++            case BARREL:
++                if (te == null) {
++                    te = new BarrelBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBarrel(material, (BarrelBlockEntity) te);
++            case BELL:
++                if (te == null) {
++                    te = new BellBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBell(material, (BellBlockEntity) te);
++            case BLAST_FURNACE:
++                if (te == null) {
++                    te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBlastFurnace(material, (BlastFurnaceBlockEntity) te);
++            case CAMPFIRE:
++            case SOUL_CAMPFIRE:
++                if (te == null) {
++                    te = new CampfireBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftCampfire(material, (CampfireBlockEntity) te);
++            case JIGSAW:
++                if (te == null) {
++                    te = new JigsawBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftJigsaw(material, (JigsawBlockEntity) te);
++            case LECTERN:
++                if (te == null) {
++                    te = new LecternBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftLectern(material, (LecternBlockEntity) te);
++            case SMOKER:
++                if (te == null) {
++                    te = new SmokerBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftSmoker(material, (SmokerBlockEntity) te);
++            case BEE_NEST:
++            case BEEHIVE:
++                if (te == null) {
++                    te = new BeehiveBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftBeehive(material, (BeehiveBlockEntity) te);
++            case SCULK_SENSOR:
++                if (te == null) {
++                    te = new SculkSensorBlockEntity(blockposition, iblockdata);
++                }
++                return new CraftSculkSensor(material, (SculkSensorBlockEntity) te);
++            default:
++                throw new IllegalStateException("Missing blockState for " + material);
+         }
+     }
++    // Paper end
+ 
+     @Override
+     public void setBlockState(BlockState blockState) {


### PR DESCRIPTION
I had a cosmic brain moment in #5727 and forgot to implement access to `BlockState`. This PR corrects this.

I've updated the test generator to test the new API as well: https://gist.github.com/dfsek/4b79e12f19fd3574a32701871a3aa8ed

![image](https://user-images.githubusercontent.com/39248502/122732067-c0369d80-d230-11eb-9e65-a100a0e47a71.png)
![image](https://user-images.githubusercontent.com/39248502/122732139-d47a9a80-d230-11eb-9caf-4c08789d54bd.png)
