### PR TITLE
Permission message upgrades

### DIFF
--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -43,20 +43,22 @@ index ca4e2d3b27f629e0d5e672fc915a5d03f0c0581d..17f8dd9870a47227a7c9bb09cceedb94
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 7c80dc54776d0d66f7816b77136f6dbd9b801704..1994f15831de1ca1bb7b4f52c23567825766d3f9 100644
+index 7c80dc54776d0d66f7816b77136f6dbd9b801704..3f7f5017c8c1c0fc68cfc75c4c1ca87a60e7249f 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
-@@ -185,7 +185,12 @@ public abstract class Command {
+@@ -184,10 +184,11 @@ public abstract class Command {
+             return true;
          }
  
-         if (permissionMessage == null) {
+-        if (permissionMessage == null) {
 -            target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is a mistake.");
-+            // Paper start
-+            String bukkitPermissionMessage = Bukkit.getPermissionMessage();
-+            if (org.apache.commons.lang.StringUtils.isNotBlank(bukkitPermissionMessage)) {
-+                target.sendMessage(bukkitPermissionMessage);
-+            }
-+            // Paper end
-         } else if (permissionMessage.length() != 0) {
-             for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
+-        } else if (permissionMessage.length() != 0) {
+-            for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
++        // Paper start
++        String msg = this.permissionMessage != null ? this.permissionMessage : Bukkit.getPermissionMessage();
++        for (String line : msg.replace("<permission>", permission).split("\n")) {
++            if (org.apache.commons.lang.StringUtils.isNotBlank(line)) {
++                // Paper end
                  target.sendMessage(line);
+             }
+         }

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -43,22 +43,20 @@ index ca4e2d3b27f629e0d5e672fc915a5d03f0c0581d..17f8dd9870a47227a7c9bb09cceedb94
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 7c80dc54776d0d66f7816b77136f6dbd9b801704..13b039eb02cd9fbff484e3d1f2670714bad61007 100644
+index 7c80dc54776d0d66f7816b77136f6dbd9b801704..fed7281a912ea256f4b0cb1a5880ac4494a53c18 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
-@@ -184,10 +184,11 @@ public abstract class Command {
+@@ -184,9 +184,10 @@ public abstract class Command {
              return true;
          }
  
 -        if (permissionMessage == null) {
 -            target.sendMessage(ChatColor.RED + "I'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is a mistake.");
 -        } else if (permissionMessage.length() != 0) {
--            for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
 +        // Paper start
-+        String msg = this.permissionMessage != null ? this.permissionMessage : Bukkit.getPermissionMessage();
-+        if (org.apache.commons.lang.StringUtils.isNotBlank(msg)) {
-+            for (String line : msg.replace("<permission>", permission).split("\n")) {
-+                // Paper end
++        String permissionMessage = this.permissionMessage != null ? this.permissionMessage : Bukkit.getPermissionMessage();
++        if (!permissionMessage.isBlank()) {
++            // Paper end
+             for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
                  target.sendMessage(line);
              }
-         }

--- a/patches/api/0163-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0163-Make-the-default-permission-message-configurable.patch
@@ -43,7 +43,7 @@ index ca4e2d3b27f629e0d5e672fc915a5d03f0c0581d..17f8dd9870a47227a7c9bb09cceedb94
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/command/Command.java b/src/main/java/org/bukkit/command/Command.java
-index 7c80dc54776d0d66f7816b77136f6dbd9b801704..3f7f5017c8c1c0fc68cfc75c4c1ca87a60e7249f 100644
+index 7c80dc54776d0d66f7816b77136f6dbd9b801704..13b039eb02cd9fbff484e3d1f2670714bad61007 100644
 --- a/src/main/java/org/bukkit/command/Command.java
 +++ b/src/main/java/org/bukkit/command/Command.java
 @@ -184,10 +184,11 @@ public abstract class Command {
@@ -56,8 +56,8 @@ index 7c80dc54776d0d66f7816b77136f6dbd9b801704..3f7f5017c8c1c0fc68cfc75c4c1ca87a
 -            for (String line : permissionMessage.replace("<permission>", permission).split("\n")) {
 +        // Paper start
 +        String msg = this.permissionMessage != null ? this.permissionMessage : Bukkit.getPermissionMessage();
-+        for (String line : msg.replace("<permission>", permission).split("\n")) {
-+            if (org.apache.commons.lang.StringUtils.isNotBlank(line)) {
++        if (org.apache.commons.lang.StringUtils.isNotBlank(msg)) {
++            for (String line : msg.replace("<permission>", permission).split("\n")) {
 +                // Paper end
                  target.sendMessage(line);
              }


### PR DESCRIPTION
I saw #5892 and figured why not go the extra mile and fit it in better with CraftBukkit's system.

This change not only fixes the blank messages, but also allows for newlines (`\n`), the `<permission>` placeholder, and retains the ability for blank lines after splitting newlines.