### PR TITLE
Implement Sound.Source.Provider

### DIFF
--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -971,6 +971,42 @@ index 2c8cc0c2af4741df9ae594ab9c436dea5347167c..445b6bf18e6ee26fe6cafca8cf5f1775
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/SoundCategory.java b/src/main/java/org/bukkit/SoundCategory.java
+index ac5e263d737973af077e3406a84a84baca4370db..919e1b9e6bb35076078171be0ea0f20bc6a1637e 100644
+--- a/src/main/java/org/bukkit/SoundCategory.java
++++ b/src/main/java/org/bukkit/SoundCategory.java
+@@ -3,7 +3,7 @@ package org.bukkit;
+ /**
+  * An Enum of categories for sounds.
+  */
+-public enum SoundCategory {
++public enum SoundCategory implements net.kyori.adventure.sound.Sound.Source.Provider { // Paper - implement Sound.Source.Provider
+ 
+     MASTER,
+     MUSIC,
+@@ -15,4 +15,22 @@ public enum SoundCategory {
+     PLAYERS,
+     AMBIENT,
+     VOICE;
++
++    // Paper start - implement Sound.Source.Provider
++    @Override
++    public net.kyori.adventure.sound.Sound.@org.checkerframework.checker.nullness.qual.NonNull Source soundSource() {
++        return switch (this) {
++            case MASTER -> net.kyori.adventure.sound.Sound.Source.MASTER;
++            case MUSIC -> net.kyori.adventure.sound.Sound.Source.MUSIC;
++            case RECORDS -> net.kyori.adventure.sound.Sound.Source.RECORD;
++            case WEATHER -> net.kyori.adventure.sound.Sound.Source.WEATHER;
++            case BLOCKS -> net.kyori.adventure.sound.Sound.Source.BLOCK;
++            case HOSTILE -> net.kyori.adventure.sound.Sound.Source.HOSTILE;
++            case NEUTRAL -> net.kyori.adventure.sound.Sound.Source.NEUTRAL;
++            case PLAYERS -> net.kyori.adventure.sound.Sound.Source.PLAYER;
++            case AMBIENT -> net.kyori.adventure.sound.Sound.Source.AMBIENT;
++            case VOICE -> net.kyori.adventure.sound.Sound.Source.VOICE;
++        };
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
 index 945b8b030d1b2a13afc0c4efad76997eb7bf00ba..207c656c0a11a3a630bc70491efcf433b2681e18 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -972,7 +972,7 @@ index 2c8cc0c2af4741df9ae594ab9c436dea5347167c..445b6bf18e6ee26fe6cafca8cf5f1775
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/SoundCategory.java b/src/main/java/org/bukkit/SoundCategory.java
-index ac5e263d737973af077e3406a84a84baca4370db..919e1b9e6bb35076078171be0ea0f20bc6a1637e 100644
+index ac5e263d737973af077e3406a84a84baca4370db..2d91924b7f5ef16a91d40cdc1bfc3d68e0fda38d 100644
 --- a/src/main/java/org/bukkit/SoundCategory.java
 +++ b/src/main/java/org/bukkit/SoundCategory.java
 @@ -3,7 +3,7 @@ package org.bukkit;
@@ -991,7 +991,7 @@ index ac5e263d737973af077e3406a84a84baca4370db..919e1b9e6bb35076078171be0ea0f20b
 +
 +    // Paper start - implement Sound.Source.Provider
 +    @Override
-+    public net.kyori.adventure.sound.Sound.@org.checkerframework.checker.nullness.qual.NonNull Source soundSource() {
++    public net.kyori.adventure.sound.Sound.@org.jetbrains.annotations.NotNull Source soundSource() {
 +        return switch (this) {
 +            case MASTER -> net.kyori.adventure.sound.Sound.Source.MASTER;
 +            case MUSIC -> net.kyori.adventure.sound.Sound.Source.MUSIC;


### PR DESCRIPTION
This PR implements Adventure's `Sound.Source.Provider` which allows people to create sounds using the Bukkit `SoundCategory` enum instead of Adventure's `Sound.Source` enum.

(an adventure PR that only touches one patch?? what sorcery is this?!)