### PR TITLE
Fix /version for GitHub builds

### DIFF
--- a/patches/server/0019-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0019-Implement-Paper-VersionChecker.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b24b68898c
+index 0000000000000000000000000000000000000000..291a009084e88084cd8f55fb409604244c9a41de
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,123 @@
 +package com.destroystokyo.paper;
 +
 +import com.destroystokyo.paper.util.VersionFetcher;
@@ -109,6 +109,7 @@ index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b2
 +    private static int fetchDistanceFromGitHub(@Nonnull String repo, @Nonnull String branch, @Nonnull String hash) {
 +        try {
 +            HttpURLConnection connection = (HttpURLConnection) new URL("https://api.github.com/repos/" + repo + "/compare/" + branch + "..." + hash).openConnection();
++            connection.setRequestProperty("User-Agent", "PaperVersionChecker");
 +            connection.connect();
 +            if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_FOUND) return -2; // Unknown commit
 +            try (BufferedReader reader = new BufferedReader(new InputStreamReader(connection.getInputStream(), Charsets.UTF_8))) {

--- a/patches/server/0020-Add-version-history-to-version-command.patch
+++ b/patches/server/0020-Add-version-history-to-version-command.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add version history to version command
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 1a1b50e475b9ede544b2f6d0d36632b24b68898c..580bae0d414d371a07a6bfeefc41fdd989dc0083 100644
+index 291a009084e88084cd8f55fb409604244c9a41de..9c59453ef1d0c6f5f6037e5abcd78642dba8caf0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -5,7 +5,9 @@ import com.google.common.base.Charsets;
@@ -30,7 +30,7 @@ index 1a1b50e475b9ede544b2f6d0d36632b24b68898c..580bae0d414d371a07a6bfeefc41fdd9
      }
  
      private static @Nullable String getMinecraftVersion() {
-@@ -119,4 +124,19 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -120,4 +125,19 @@ public class PaperVersionFetcher implements VersionFetcher {
              return -1;
          }
      }


### PR DESCRIPTION
Recently, while testing another bug fix from a personally compiled Paper jar, a friend experienced this bug:
```
Pugabyte issued server command: /ver
[WARN] java.io.IOException: Server returned HTTP response code: 403 for URL: https://api.github.com/repos/PaperMC/Paper/compare/master...22280c5
<internal stuff>
[WARN] at com.destroystokyo.paper.PaperVersionFetcher.fetchDistanceFromGitHub(PaperVersionFetcher.java:107)
[WARN] at com.destroystokyo.paper.PaperVersionFetcher.getUpdateStatusMessage(PaperVersionFetcher.java:62)
[WARN] at com.destroystokyo.paper.PaperVersionFetcher.getVersionMessage(PaperVersionFetcher.java:33)
[WARN] at org.bukkit.command.defaults.VersionCommand.obtainVersion(VersionCommand.java:205)
[WARN] at org.bukkit.command.defaults.VersionCommand$1.run(VersionCommand.java:189)
```

Testing in Postman, he discovered GitHub requires a User-Agent to be set ([documentation](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#user-agent-required)):
![image](https://user-images.githubusercontent.com/13265322/122822838-9a4ede80-d2ac-11eb-99ec-1badeb2d7a14.png)

Despite my best efforts, I haven't actually been able to reproduce this bug (not even on his machine! GitHub just keeps returning a 200 OK now! what the hell GitHub!?), but it should fix it in theory :P
