### PR TITLE
Preserve overstacked loot

### DIFF
--- a/patches/server/0811-Preserve-overstacked-loot.patch
+++ b/patches/server/0811-Preserve-overstacked-loot.patch
@@ -1,0 +1,72 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lexikiq <noellekiq@gmail.com>
+Date: Mon, 21 Jun 2021 23:21:58 -0400
+Subject: [PATCH] Preserve overstacked loot
+
+Preserves overstacked items in loot tables, such as shulker box drops, to prevent the items
+from being deleted (as they'd overflow past the bounds of the container)-- or worse, causing
+chunk bans via the large amount of NBT created by unstacking the items.
+
+Fixes GH-5140 and GH-4748.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 9a3f75288b1d743a7ec4bfd663c1c2988678d3e6..416ecbdf244716c2fb1277d7d1df697fe6f77756 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -887,6 +887,11 @@ public class PaperWorldConfig {
+         allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
+     }
+ 
++    public boolean splitOverstackedLoot = true;
++    private void splitOverstackedLoot() {
++        splitOverstackedLoot = getBoolean("split-overstacked-loot", splitOverstackedLoot);
++    }
++
+     private Table<String, String, Integer> sensorTickRates;
+     private Table<String, String, Integer> behaviorTickRates;
+     private void tickRates() {
+diff --git a/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java b/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
+index db80db9d6382dd4748aa8f27dd3c3d3ae9fe9380..9827229d125addcfec8b0025724b9a4570c40a12 100644
+--- a/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
++++ b/src/main/java/net/minecraft/world/level/storage/loot/LootTable.java
+@@ -54,9 +54,17 @@ public class LootTable {
+         this.compositeFunction = LootItemFunctions.compose(functions);
+     }
+ 
++    @Deprecated // Paper - preserve overstacked items
+     public static Consumer<ItemStack> createStackSplitter(Consumer<ItemStack> lootConsumer) {
++    // Paper start - preserve overstacked items
++        return createStackSplitter(lootConsumer, null);
++    }
++
++    public static Consumer<ItemStack> createStackSplitter(Consumer<ItemStack> lootConsumer, @org.jetbrains.annotations.Nullable net.minecraft.server.level.ServerLevel world) {
++        boolean skipSplitter = world != null && !world.paperConfig.splitOverstackedLoot;
++    // Paper end
+         return (itemstack) -> {
+-            if (itemstack.getCount() < itemstack.getMaxStackSize()) {
++            if (skipSplitter || itemstack.getCount() < itemstack.getMaxStackSize()) { // Paper - preserve overstacked items
+                 lootConsumer.accept(itemstack);
+             } else {
+                 int i = itemstack.getCount();
+@@ -93,7 +101,7 @@ public class LootTable {
+     }
+ 
+     public void getRandomItems(LootContext context, Consumer<ItemStack> lootConsumer) {
+-        this.getRandomItemsRaw(context, LootTable.createStackSplitter(lootConsumer));
++        this.getRandomItemsRaw(context, LootTable.createStackSplitter(lootConsumer, context.getLevel())); // Paper - preserve overstacked items
+     }
+ 
+     public List<ItemStack> getRandomItems(LootContext context) {
+diff --git a/src/main/java/net/minecraft/world/level/storage/loot/functions/SetContainerContents.java b/src/main/java/net/minecraft/world/level/storage/loot/functions/SetContainerContents.java
+index 6d63c5318e1711a27b254db950ae7576d333ad47..6b5e481980751ed83cda7badc160b738d5c56af9 100644
+--- a/src/main/java/net/minecraft/world/level/storage/loot/functions/SetContainerContents.java
++++ b/src/main/java/net/minecraft/world/level/storage/loot/functions/SetContainerContents.java
+@@ -39,7 +39,7 @@ public class SetContainerContents extends LootItemConditionalFunction {
+             NonNullList<ItemStack> nonNullList = NonNullList.create();
+             this.entries.forEach((entry) -> {
+                 entry.expand(context, (choice) -> {
+-                    choice.createItemStack(LootTable.createStackSplitter(nonNullList::add), context);
++                    choice.createItemStack(LootTable.createStackSplitter(nonNullList::add, context.getLevel()), context); // Paper - preserve overstacked items
+                 });
+             });
+             CompoundTag compoundTag = new CompoundTag();


### PR DESCRIPTION
Preserves overstacked items in loot tables, such as shulker box drops, to prevent the items from being deleted (as they'd overflow past the bounds of the container)-- or worse, causing chunk bans via the large amount of NBT created by unstacking the items.

Fixes #5140 and fixes #4748.