### PR TITLE
Update upstreaming scripts

### DIFF
--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -31,7 +31,7 @@ function main() {
 
   if [ -n "${updated:-}" ]; then
     log="${UP_LOG_PREFIX:-}Updated Upstream ($updated)\n\n${disclaimer}${logsuffix}"
-    echo -e "${log}" | git commit -F -
+    printf '%b' "${log}" | git commit -F -
   fi
 }
 

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -1,41 +1,44 @@
 #!/usr/bin/env bash
 
-(
-set -e
-PS1="$"
-basedir="$(cd "$1" && pwd -P)"
-workdir="$basedir/work"
-gitcmd="git -c commit.gpgsign=false"
+set -euo pipefail
 
-updated="0"
-function getRef {
-    git ls-tree $1 $2  | cut -d' ' -f3 | cut -f1
+function git {
+  command git -c commit.gpgsign=false "${@}"
 }
+
+readonly basedir="$(cd "$(dirname "$0")/.." && pwd -P)"
+readonly workdir="${basedir}/work"
+
 function update {
-    cd "$workdir/$1"
-    $gitcmd fetch && $gitcmd clean -fd && $gitcmd reset --hard origin/master
-    refRemote=$(git rev-parse HEAD)
-    cd ../
-    $gitcmd add --force $1
-    refHEAD=$(getRef HEAD "$workdir/$1")
-    echo "$1 $refHEAD - $refRemote"
-    if [ "$refHEAD" != "$refRemote" ]; then
-        export updated="1"
-    fi
+  local -r submodule="${1?Submodule is missing}"
+  local -r submodule_dir="${workdir}/${submodule}"
+  cd "${submodule_dir}"
+  git fetch && git clean -fd && git reset --hard origin/master || return 1
+  cd "${basedir}"
+  git add --force "${submodule_dir}"
 }
 
-update Bukkit
-update CraftBukkit
-update Spigot
-
-if [[ "$2" = "all" || "$2" = "a" ]] ; then
-	update BuildData
-fi
-if [ "$updated" == "1" ]; then
+function main {
+  local -r update_all="${1:-}"
+  local -r skip_rebuild="${2:-}"
+  cd "${basedir}"
+  git submodule update --init
+  update Bukkit
+  update CraftBukkit
+  update Spigot
+  if [[ "${update_all}" == @(all|a|yes|y) ]]; then
+    update BuildData
+  fi
+  if ! git diff --cached --quiet --exit-code -- "${workdir}" && [[ "${skip_rebuild,,}" != @(yes|y) ]]; then
     echo "Rebuilding patches without filtering to improve apply ability"
-    cd "$basedir"
+    cd "${basedir}"
     ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary
     ./gradlew applyPatches -Dpaperweight.debug=true || exit 1
     ./gradlew rebuildPatches || exit 1
+  fi
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  main "$@"
 fi
-)

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -8,6 +8,7 @@ function gitcmd {
 
 readonly basedir="$(cd "$(dirname "$0")/.." && pwd -P)"
 readonly workdir="${basedir}/work"
+readonly patchdir="${basedir}/patches"
 
 function update {
   local -r submodule="${1?Submodule is missing}"
@@ -18,10 +19,29 @@ function update {
   gitcmd add --force "${submodule_dir}"
 }
 
+function apply_rebuild {
+  ./gradlew applyPatches -Dpaperweight.debug=true || return $?
+  ./gradlew rebuildPatches -Ppaperweight.filter-patches=false || return $?
+}
+
+function is_yes {
+  local -r value="${1:-}"
+  [ "${value:-}" = yes ] || [ "${value:-}" = y ]
+}
+
+function skip_rebuild {
+  # expected to have variable called `skip_rebuild` set in context
+  is_yes "${skip_rebuild:-}"
+}
+
 function main {
   local -r update_all="${1:-}"
   local -r skip_rebuild="${2:-}"
   cd "${basedir}"
+  if ! skip_rebuild; then
+    echo "Rebuilding patches without filtering to improve mergeability"
+    apply_rebuild || return $?
+  fi
   gitcmd submodule update --init
   update Bukkit
   update CraftBukkit
@@ -29,15 +49,18 @@ function main {
   case "${update_all:-}" in
     all|a|yes|y) update BuildData
   esac
-  if ! gitcmd diff --cached --quiet --exit-code -- "${workdir}" \
-      && [[ "${skip_rebuild:-}" != yes ]] \
-      && [[ "${skip_rebuild:-}" != y ]]
-    then
-    echo "Rebuilding patches without filtering to improve apply ability"
-    cd "${basedir}"
-    ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary
-    ./gradlew applyPatches -Dpaperweight.debug=true || exit 1
-    ./gradlew rebuildPatches --filter-patches=false || exit 1
+  if ! gitcmd diff --cached --quiet --exit-code -- "${workdir}"; then
+    if ! skip_rebuild; then
+      echo "Rebuilding patches without filtering to improve apply ability"
+      cd "${basedir}"
+      ./gradlew cleanCache || return $? # todo: Figure out why this is necessary
+      apply_rebuild || return $?
+    else
+      echo "Skipping rebuild..."
+    fi
+  elif ! skip_rebuild; then
+    echo "No updates - reverting changes to patches"
+    gitcmd restore -- "${patchdir}"
   fi
 }
 

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -2,8 +2,8 @@
 
 set -euo pipefail
 
-function git {
-  command git -c commit.gpgsign=false "${@}"
+function gitcmd {
+  git -c commit.gpgsign=false "${@}"
 }
 
 readonly basedir="$(cd "$(dirname "$0")/.." && pwd -P)"
@@ -13,23 +13,26 @@ function update {
   local -r submodule="${1?Submodule is missing}"
   local -r submodule_dir="${workdir}/${submodule}"
   cd "${submodule_dir}"
-  git fetch && git clean -fd && git reset --hard origin/master || return 1
+  gitcmd fetch && gitcmd clean -fd && gitcmd reset --hard origin/master || return 1
   cd "${basedir}"
-  git add --force "${submodule_dir}"
+  gitcmd add --force "${submodule_dir}"
 }
 
 function main {
   local -r update_all="${1:-}"
   local -r skip_rebuild="${2:-}"
   cd "${basedir}"
-  git submodule update --init
+  gitcmd submodule update --init
   update Bukkit
   update CraftBukkit
   update Spigot
-  if [[ "${update_all}" == @(all|a|yes|y) ]]; then
-    update BuildData
-  fi
-  if ! git diff --cached --quiet --exit-code -- "${workdir}" && [[ "${skip_rebuild,,}" != @(yes|y) ]]; then
+  case "${update_all:-}" in
+    all|a|yes|y) update BuildData
+  esac
+  if ! gitcmd diff --cached --quiet --exit-code -- "${workdir}" \
+      && [[ "${skip_rebuild:-}" != yes ]] \
+      && [[ "${skip_rebuild:-}" != y ]]
+    then
     echo "Rebuilding patches without filtering to improve apply ability"
     cd "${basedir}"
     ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -33,11 +33,14 @@ function main {
       && [[ "${skip_rebuild:-}" != yes ]] \
       && [[ "${skip_rebuild:-}" != y ]]
     then
-    echo "Rebuilding patches without filtering to improve apply ability"
+    echo "Rebuilding patches"
     cd "${basedir}"
     ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary
     ./gradlew applyPatches -Dpaperweight.debug=true || exit 1
-    ./gradlew rebuildPatches --filter-patches=false || exit 1
+    # TODO: rebuild patches without filtering to improve apply ability
+    # Use separate steps for rebuild{Api,Server}Patches due to https://docs.gradle.org/current/userguide/custom_tasks.html#limitations
+    # Can't use it for now, since you can't set boolean gradle option to false through CLI: https://github.com/gradle/gradle/issues/4311
+    ./gradlew rebuildPatches || exit 1
   fi
 }
 

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -37,7 +37,7 @@ function main {
     cd "${basedir}"
     ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary
     ./gradlew applyPatches -Dpaperweight.debug=true || exit 1
-    ./gradlew rebuildPatches || exit 1
+    ./gradlew rebuildPatches --filter-patches=false || exit 1
   fi
 }
 

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -51,7 +51,6 @@ function skip_rebuild {
 function main {
   local -r update_all="${1:-}"
   local -r skip_rebuild="${2:-}"
-  set -x
   local submodules_to_update=(
     Bukkit
     CraftBukkit

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -33,14 +33,11 @@ function main {
       && [[ "${skip_rebuild:-}" != yes ]] \
       && [[ "${skip_rebuild:-}" != y ]]
     then
-    echo "Rebuilding patches"
+    echo "Rebuilding patches without filtering to improve apply ability"
     cd "${basedir}"
     ./gradlew cleanCache || exit 1 # todo: Figure out why this is necessary
     ./gradlew applyPatches -Dpaperweight.debug=true || exit 1
-    # TODO: rebuild patches without filtering to improve apply ability
-    # Use separate steps for rebuild{Api,Server}Patches due to https://docs.gradle.org/current/userguide/custom_tasks.html#limitations
-    # Can't use it for now, since you can't set boolean gradle option to false through CLI: https://github.com/gradle/gradle/issues/4311
-    ./gradlew rebuildPatches || exit 1
+    ./gradlew rebuildPatches --filter-patches=false || exit 1
   fi
 }
 

--- a/scripts/upstreamMerge.sh
+++ b/scripts/upstreamMerge.sh
@@ -18,6 +18,14 @@ function update {
   gitcmd add --force "${submodule_dir}"
 }
 
+function update_submodules() {
+  gitcmd submodule update --init
+  local submodule
+  for submodule in "${@}"; do
+    update "${submodule}"
+  done
+}
+
 function submodule_has_update {
   local -r submodule="${1?Submodule is missing}"
   local -r submodule_dir="${workdir}/${submodule}"
@@ -68,11 +76,7 @@ function main {
     echo "Rebuilding patches without filtering to improve mergeability"
     apply_rebuild || return $?
   fi
-  gitcmd submodule update --init
-  local submodule
-  for submodule in "${submodules_to_update[@]}"; do
-    update "${submodule}"
-  done
+  update_submodules "${submodules_to_update[@]}"
   if ! gitcmd diff --cached --quiet --exit-code -- "${workdir}"; then
     if ! skip_rebuild; then
       echo "Rebuilding patches without filtering to improve apply ability"


### PR DESCRIPTION
Script cleanup and fixes. Notable behavioral changes:
1. I've removed a "feature" where running `upstreamMerge.sh` without checked out submodules deleted your workspace.
2. Added a way to disable patch rebuild process - useful for automation ("Aikar script").

I've tried my best to not use too modern Bash features, everything should be very standard.

CC for script review: @Proximyst 