### PR TITLE
Temporarily state in CONTRIBUTING.md that documentation needs updating

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,9 +6,9 @@ can follow to make the approval process go more smoothly.
 
 ## Notice
 This guide was written for an old build system which is no longer in use and
-has been replaced by [paperweight](https://github.com/PaperMC/paperweight).
+has been replaced by [Paperweight](https://github.com/PaperMC/paperweight).
 This file will be updated shortly, but, in the meantime, simply
-run `./gradlew tasks` for a list of all tasks in paperweight.
+run `./gradlew tasks` for a list of all tasks in Paperweight.
 
 **Table of contents:**
 <!-- Please don't remove the following comments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ PaperMC is happy you're willing to contribute to our projects. We are usually
 very lenient with all submitted PRs, but there are still some guidelines you
 can follow to make the approval process go more smoothly.
 
+## Notice
+This guide was written for an old build system which is no longer in use and
+has been replaced by [paperweight](https://github.com/PaperMC/paperweight).
+This file will be updated shortly, but, in the meantime, simply
+run `./gradlew tasks` for a list of all tasks in paperweight.
+
 **Table of contents:**
 <!-- Please don't remove the following comments.
 To generate and update the TOC: https://github.com/mzlogin/vim-markdown-toc -->


### PR DESCRIPTION
I know there are plans to make more complete documentation on Paperweight, however many people have asked about this elsewhere and there have already been, to my knowledge at least, two separate issues filed on it. This is just a temporary solution until any changes to Paperweight have been finalized and that documentation can be made, as apparently the update has drawn many people to wanting to contribute.