### PR TITLE
Do not cancel chunk load on ticket level change

### DIFF
--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -2299,7 +2299,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..7ce854edba32ffcafaa5268d4bb2822a
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataFixers.getDataFixer(), minecraftsessionservice, gameprofilerepository, usercache, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a7244e66b7bbf2b474304ab41ad31a606ab6ba9c..bd892f477a04172aaae3925d81cb30cda74abfdc 100644
+index 20a1869b2b42e998e63126a6ff20724d28e99524..0a1e8fc6c47379ff7fc403710012bf4b50679e98 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -976,7 +976,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2312,7 +2312,7 @@ index a7244e66b7bbf2b474304ab41ad31a606ab6ba9c..bd892f477a04172aaae3925d81cb30cd
  
      public String getLocalIp() {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 24f72050229031898fd9da585ad2ceec835f83f9..828e885baf2d47962cdd4188c66d8345a7f46707 100644
+index 24f72050229031898fd9da585ad2ceec835f83f9..2b235508ffd01de14714de1a31c2139e7c15bd27 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -151,6 +151,18 @@ public class ChunkHolder {
@@ -2343,19 +2343,6 @@ index 24f72050229031898fd9da585ad2ceec835f83f9..828e885baf2d47962cdd4188c66d8345
          ChunkHolder.FullChunkStatus playerchunk_state = ChunkHolder.getFullChunkStatus(this.oldTicketLevel);
          ChunkHolder.FullChunkStatus playerchunk_state1 = ChunkHolder.getFullChunkStatus(this.ticketLevel);
          // CraftBukkit start
-@@ -411,6 +423,12 @@ public class ChunkHolder {
-                 }
-             });
- 
-+            // Paper start
-+            if (!flag1) {
-+                chunkStorage.level.asyncChunkTaskManager.cancelChunkLoad(this.pos.x, this.pos.z);
-+            }
-+            // Paper end
-+
-             for (int i = flag1 ? chunkstatus1.getIndex() + 1 : 0; i <= chunkstatus.getIndex(); ++i) {
-                 completablefuture = (CompletableFuture) this.futures.get(i);
-                 if (completablefuture == null) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
 index b794922eeccc845632f2442a3ed923f1d826a9e1..36bc19cbb5242207ff019f62f59205e1a6336728 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
@@ -2815,7 +2802,7 @@ index 03c90069e8fca2291e66f5d99175f029530a4434..1176dd8ebd59c5bda1b74c532ca21ae3
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1ddf92d4a70243217181efd477e01e34d55a1291..b60f035394c9c0949e4cc68d895918510e3c67cf 100644
+index 70e4e10ee3f3ace590881a9284160324ad882243..ab4dba5af019b60cbb82360eae7f6008aafcd38c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -210,6 +210,79 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -2920,7 +2907,7 @@ index 0d536d72ac918fbd403397ff369d10143ee9c204..be677d437d17b74c6188ce1bd5fc6fdc
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index eb52ca159e895608a6a662821f14910970759dd2..05d5d976c18149491124263b056224a384eee06d 100644
+index 4cddb545fded4a7dc543f523902702e8b01b019c..76dfbd19e15d123d9138dc3fce12236a804ce3b6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -712,6 +712,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -889,7 +889,7 @@ index 0000000000000000000000000000000000000000..118988c39e58f28e8a2851792b9c014f
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index edf0432967c4621e101611924c4ce826f54e3e34..413743bc1bf82c07f85192924e4783b08dbcee79 100644
+index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..8104b9be5a8e8d57f6f50475788aec6a762a0f7e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -86,6 +86,19 @@ public class ChunkHolder {
@@ -912,7 +912,7 @@ index edf0432967c4621e101611924c4ce826f54e3e34..413743bc1bf82c07f85192924e4783b0
  
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
          this.futures = new AtomicReferenceArray(ChunkHolder.CHUNK_STATUSES.size());
-@@ -544,6 +557,10 @@ public class ChunkHolder {
+@@ -538,6 +551,10 @@ public class ChunkHolder {
                  either.ifLeft(chunk -> {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      ChunkHolder.this.isTickingReady = true;
@@ -941,7 +941,7 @@ index d2d0350bd16cd818be328afcc2c07f4381dac169..0d948d4d247a12a49fae99e68874a9e6
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, boolean flag, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkstatusupdatelistener, Supplier<DimensionDataStorage> supplier) {
          this.level = world;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 87a18dcbfbb55410f04e99e84958f22f21193066..cb1efab5c5cfd47cfbdab609009cc6a5cd6f1dc4 100644
+index 29e41754cca805c281ee48c35b149ebb58c3f2f6..755b413ff2c28f9811e4b4c44461beca2ebd5273 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -295,6 +295,15 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl

--- a/patches/server/0456-incremental-chunk-saving.patch
+++ b/patches/server/0456-incremental-chunk-saving.patch
@@ -31,7 +31,7 @@ index 9e5810eb0085ad956f0bd1cd69fa88909d9d638a..77e90a6b7d29ad989fd961e00a6fd97c
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 407f18a9c7a688eaac8ad7018ae4f1a5fc628379..9f80206f966689b79df4e3b9b82ef9f4d2170bfe 100644
+index a57af6cd317c56e28db060c50e55a4531c90e069..aed08b85e24c1c8c8e703d6c5c42075c5fbeda9e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -300,6 +300,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -72,7 +72,7 @@ index 407f18a9c7a688eaac8ad7018ae4f1a5fc628379..9f80206f966689b79df4e3b9b82ef9f4
          this.profiler.push("snooper");
          if (((DedicatedServer) this).getProperties().snooperEnabled && !this.snooper.isStarted() && this.tickCount > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 38b624e5817f5b2ce70da777b2bb834784de914f..87319eadeba490bdfd0783cacd33e3ec1dcba302 100644
+index e6883cad6c604673535deacc19463aeeb060199a..e26b65c3b2594ae45b68bcbd135152130663be7f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -111,6 +111,8 @@ public class ChunkHolder {
@@ -84,7 +84,7 @@ index 38b624e5817f5b2ce70da777b2bb834784de914f..87319eadeba490bdfd0783cacd33e3ec
  
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
          this.futures = new AtomicReferenceArray(ChunkHolder.CHUNK_STATUSES.size());
-@@ -530,7 +532,19 @@ public class ChunkHolder {
+@@ -524,7 +526,19 @@ public class ChunkHolder {
          boolean flag2 = playerchunk_state.isOrAfter(ChunkHolder.FullChunkStatus.BORDER);
          boolean flag3 = playerchunk_state1.isOrAfter(ChunkHolder.FullChunkStatus.BORDER);
  
@@ -104,7 +104,7 @@ index 38b624e5817f5b2ce70da777b2bb834784de914f..87319eadeba490bdfd0783cacd33e3ec
          if (!flag2 && flag3) {
              int expectCreateCount = ++this.fullChunkCreateCount; // Paper
              this.fullChunkFuture = chunkStorage.prepareAccessibleChunk(this);
-@@ -651,9 +665,33 @@ public class ChunkHolder {
+@@ -645,9 +659,33 @@ public class ChunkHolder {
      }
  
      public void refreshAccessibility() {
@@ -260,7 +260,7 @@ index 147f6fd5174a2c489dfb7ea2ce2d2dc7dacfb89d..6c565751c36daa0084196dce5d2f82df
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cd322d31a079dcd50ca62a2898608e2cf89a3edf..4b8748d955fce10536847a44e22d53d6d491ac1d 100644
+index 5fbe0f6b152d92f4415361709e7394c114104812..74efffabe349a5272694c3af9bd2c36221779f73 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1003,6 +1003,37 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -302,7 +302,7 @@ index cd322d31a079dcd50ca62a2898608e2cf89a3edf..4b8748d955fce10536847a44e22d53d6
          ServerChunkCache chunkproviderserver = this.getChunkSource();
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
-index a857953f3488e79fd601ac63881bc4d87708afa7..3cf3b0486f786d7d043cce75767753e1cdacf781 100644
+index ba409922a5274fbb9a02a897cf7fe490b02fd781..63203172a127d812fd59cea0546b67e855ce3ad5 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 @@ -29,6 +29,7 @@ public interface ChunkAccess extends BlockGetter, FeatureAccess {
@@ -314,7 +314,7 @@ index a857953f3488e79fd601ac63881bc4d87708afa7..3cf3b0486f786d7d043cce75767753e1
      default boolean generateFlatBedrock() {
          if (this instanceof ProtoChunk) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 61c70e17401ec85c0a7e6e1793f6689506b8059a..d866997b974b971245111cac43ac6edf92052de4 100644
+index 7d33ad1ec939de4527d0acb0915f05870c387565..cc02b577453fa251f0f1b508281ddea2513138a1 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -108,6 +108,13 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -80,7 +80,7 @@ index 2d5b8e35d52b0dfd075af81a3a936d8a21053b31..9ddedd310eb0323a5a09f51a61bfb7b3
                  chunkData.addProperty("queued-for-unload", chunkMap.toDrop.contains(playerChunk.pos.longKey));
                  chunkData.addProperty("status", status == null ? "unloaded" : status.toString());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 87319eadeba490bdfd0783cacd33e3ec1dcba302..f9207e3661ba630ee1791d0842e0de684b22fd17 100644
+index e26b65c3b2594ae45b68bcbd135152130663be7f..3e004f391668865c0e6f1c38cef9661f7372fffe 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -60,7 +60,7 @@ public class ChunkHolder {
@@ -244,7 +244,7 @@ index 87319eadeba490bdfd0783cacd33e3ec1dcba302..f9207e3661ba630ee1791d0842e0de68
                  LevelChunk chunk = (LevelChunk)either.left().orElse(null);
                  if (chunk != null) {
                      chunkStorage.callbackExecutor.execute(() -> {
-@@ -550,13 +679,14 @@ public class ChunkHolder {
+@@ -544,13 +673,14 @@ public class ChunkHolder {
              this.fullChunkFuture = chunkStorage.prepareAccessibleChunk(this);
              this.scheduleFullChunkPromotion(chunkStorage, this.fullChunkFuture, executor, ChunkHolder.FullChunkStatus.BORDER);
              // Paper start - cache ticking ready status
@@ -260,7 +260,7 @@ index 87319eadeba490bdfd0783cacd33e3ec1dcba302..f9207e3661ba630ee1791d0842e0de68
                  }
              });
              this.updateChunkToSave(this.fullChunkFuture, "full");
-@@ -580,7 +710,7 @@ public class ChunkHolder {
+@@ -574,7 +704,7 @@ public class ChunkHolder {
              this.tickingChunkFuture = chunkStorage.prepareTickingChunk(this);
              this.scheduleFullChunkPromotion(chunkStorage, this.tickingChunkFuture, executor, ChunkHolder.FullChunkStatus.TICKING);
              // Paper start - cache ticking ready status
@@ -269,7 +269,7 @@ index 87319eadeba490bdfd0783cacd33e3ec1dcba302..f9207e3661ba630ee1791d0842e0de68
                  either.ifLeft(chunk -> {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      ChunkHolder.this.isTickingReady = true;
-@@ -610,7 +740,7 @@ public class ChunkHolder {
+@@ -604,7 +734,7 @@ public class ChunkHolder {
              this.entityTickingChunkFuture = chunkStorage.prepareEntityTickingChunk(this.pos);
              this.scheduleFullChunkPromotion(chunkStorage, this.entityTickingChunkFuture, executor, ChunkHolder.FullChunkStatus.ENTITY_TICKING);
              // Paper start - cache ticking ready status
@@ -278,7 +278,7 @@ index 87319eadeba490bdfd0783cacd33e3ec1dcba302..f9207e3661ba630ee1791d0842e0de68
                  either.ifLeft(chunk -> {
                      ChunkHolder.this.isEntityTickingReady = true;
                  });
-@@ -628,12 +758,30 @@ public class ChunkHolder {
+@@ -622,12 +752,30 @@ public class ChunkHolder {
              this.demoteFullChunk(chunkStorage, playerchunk_state1);
          }
  
@@ -1144,7 +1144,7 @@ index 71fce0c38386b3f0a63a5d9bc1cb47e01027d10c..c4bdce99df37fbe5bfc1238dac9d043c
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c0f7b78dbe8f9baf68aa48dd763ab51312e916c6..73c81f0883645dca0ce32efae914d7f40b265c3c 100644
+index 0b50701b64cbeb8884dca3b7d89583a9e1721a16..9f8e210961ff61db67b274236b9f906b7a3b3da1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -223,7 +223,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n


### PR DESCRIPTION
New chunk system doesn't do cancellations anymore.

https://github.com/Tuinity/Tuinity/blob/3a57f640b7c63ffcd27ab5ff2ac9e8610312f010/patches/server/0060-Do-not-cancel-chunk-load-on-ticket-level-change.patch

Tested to at least improve (but hopefully fix) #5909 and #5910 using reproduction steps provided [here](https://github.com/PaperMC/Paper/issues/5910#issuecomment-866588606). I was able to cause the server to lock up and be unable to save 100% consistently within 2-30 seconds without this fix applied, and with it applied, I have not been able to lock up the server yet, and have been able to execute `/save-all flush` without issue.