### PR TITLE
Optimize Anti-Xray

### DIFF
--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -255,7 +255,7 @@ index 0000000000000000000000000000000000000000..280ece653cdda74e9c8fab4e9e5b3a95
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09c22af61c
+index 0000000000000000000000000000000000000000..58052a5f773b5882acd90bc0214a36e8a512817c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/antixray/ChunkPacketBlockControllerAntiXray.java
 @@ -0,0 +1,635 @@
@@ -608,7 +608,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +            next[0][1] = true;
 +            next[1][0] = true;
 +        } else {
-+            if (nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(0, y, 15))] || nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, 0))] || current[0][0]) {
++            if (current[0][0] || nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(0, y, 15))] || nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, 0))]) {
 +                bitStorageWriter.skip();
 +            } else {
 +                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -629,7 +629,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +                next[0][x + 1] = true;
 +                next[1][x] = true;
 +            } else {
-+                if (nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(x, y, 15))] || current[0][x]) {
++                if (current[0][x] || nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(x, y, 15))]) {
 +                    bitStorageWriter.skip();
 +                } else {
 +                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -649,7 +649,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +            next[0][14] = true;
 +            next[1][15] = true;
 +        } else {
-+            if (nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(15, y, 15))] || nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, 0))] || current[0][15]) {
++            if (current[0][15] || nearbyChunkSections[2] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[2].getBlockState(15, y, 15))] || nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, 0))]) {
 +                bitStorageWriter.skip();
 +            } else {
 +                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -671,7 +671,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +                next[z - 1][0] = true;
 +                next[z + 1][0] = true;
 +            } else {
-+                if (nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, z))] || current[z][0]) {
++                if (current[z][0] || nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, z))]) {
 +                    bitStorageWriter.skip();
 +                } else {
 +                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -714,7 +714,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +                next[z - 1][15] = true;
 +                next[z + 1][15] = true;
 +            } else {
-+                if (nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, z))] || current[z][15]) {
++                if (current[z][15] || nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, z))]) {
 +                    bitStorageWriter.skip();
 +                } else {
 +                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -734,7 +734,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +            next[15][1] = true;
 +            next[14][0] = true;
 +        } else {
-+            if (nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(0, y, 0))] || nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, 15))] || current[15][0]) {
++            if (current[15][0] || nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(0, y, 0))] || nearbyChunkSections[0] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[0].getBlockState(15, y, 15))]) {
 +                bitStorageWriter.skip();
 +            } else {
 +                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -755,7 +755,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +                next[15][x + 1] = true;
 +                next[14][x] = true;
 +            } else {
-+                if (nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(x, y, 0))] || current[15][x]) {
++                if (current[15][x] || nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(x, y, 0))]) {
 +                    bitStorageWriter.skip();
 +                } else {
 +                    bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -775,7 +775,7 @@ index 0000000000000000000000000000000000000000..020dc2351bc47b9c03ccdcc8f94b2d09
 +            next[15][14] = true;
 +            next[14][15] = true;
 +        } else {
-+            if (nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(15, y, 0))] || nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, 15))] || current[15][15]) {
++            if (current[15][15] || nearbyChunkSections[3] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[3].getBlockState(15, y, 0))] || nearbyChunkSections[1] == LevelChunk.EMPTY_SECTION || !solidGlobal[LevelChunkSection.GLOBAL_BLOCKSTATE_PALETTE.idFor(nearbyChunkSections[1].getBlockState(0, y, 15))]) {
 +                bitStorageWriter.skip();
 +            } else {
 +                bitStorageWriter.write(presetBlockStateBits[random.getAsInt()]);
@@ -1104,7 +1104,7 @@ index badac53382c776eba3efccfda42283912d07b99a..06e581bc0c0ea4e8141f7b9610cc5a7e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 39997c5028fe51e2fefbd2d50353575080d92f3c..a5c7dccac12013ef24dc0091dce35403dff5fbba 100644
+index c0a897aa1fe275f308cf594f0c875096850f5271..d6e7b8ee31372c2c92da8ab4f5915f95c9382ae3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -292,7 +292,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -1139,7 +1139,7 @@ index f4a056185990181e486f452960159a5287947382..b932580dc10703c8a7dbecd4cf389548
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 6d9c74595cd8883167554e8b52008a99d6e113c3..0cd747bd368715c76cd27387ffe513b4a760f8e9 100644
+index d59126240c568614cb43ea42ad3e2c9eb8701071..2c6cd2909bdc41d4a1deaeb1ed41aab81189e540 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -164,6 +164,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {


### PR DESCRIPTION
This PR simple reorders boolean expressions in hot code, making use of short-circuit evaluation to optimize Anti-Xray. I don't know how I didn't notice this earlier.

Some context: The value `current[z][x]` describes if the block at `x`, `z` in the current chunk layer shouldn't be obfuscated (`false` ... obfuscate, `true` ... don't obfuscate). Usually in engine-mode 1 much less blocks must be obfuscated than in engine-mode 2. This means that the expression `current[z][x]` will evaluate much more often to `true` in engine-mode 1 and thus trigger the short-circuit evaluation much more often. However, even engine-mode 2 will profit from these changes.