### PR TITLE
Fix chicken jockey chicken persistence

### DIFF
--- a/patches/server/0722-Fix-chicken-jockey-persistence.patch
+++ b/patches/server/0722-Fix-chicken-jockey-persistence.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: KennyTV <jahnke.nassim@gmail.com>
+Date: Sat, 26 Jun 2021 10:43:53 +0200
+Subject: [PATCH] Fix chicken jockey persistence
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Chicken.java b/src/main/java/net/minecraft/world/entity/animal/Chicken.java
+index 8460bed561c09a647f6e0209f7c5448e5a42b281..9a4b133e4ecbd04753f55d9c4a8bd1ed83943476 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Chicken.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Chicken.java
+@@ -77,7 +77,7 @@ public class Chicken extends Animal {
+     public void aiStep() {
+         // CraftBukkit start
+         if (this.isChickenJockey()) {
+-            this.persistenceRequired = !this.removeWhenFarAway(0);
++            ((Mob) this).persistenceRequired = !this.removeWhenFarAway(0); // Paper - fix remap by explicitly casting to Mob
+         }
+         // CraftBukkit end
+         super.aiStep();


### PR DESCRIPTION
Fixes #5994

This issue is already present in Spigot, somehow failing at reobfuscating the scope properly.

Thanks to Billy for figuring out the cause, this patch is a bit more elegant tho.