### PR TITLE
Ensure shulker bounding box is updated

### DIFF
--- a/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 912723108af2ffe660f0c2e528e4e028f7f74bcb..b208f561ab8bb0ea9ad06fb2a30becef4583c2e6 100644
+index 912723108af2ffe660f0c2e528e4e028f7f74bcb..7606f6fd9a79b1becd7af5b203ababbc6c6e4b7e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -560,7 +560,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -17,19 +17,20 @@ index 912723108af2ffe660f0c2e528e4e028f7f74bcb..b208f561ab8bb0ea9ad06fb2a30becef
      }
  
      protected AABB makeBoundingBox() {
-@@ -3740,6 +3740,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
-     }
+@@ -3750,6 +3750,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+                 this.blockPosition = new BlockPos(i, j, k);
+             }
+
++            // Paper start - never allow AABB to become desynced from position
++            // hanging has its own special logic
++            if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity)) {
++                this.setBoundingBox(this.makeBoundingBox());
++            }
++            // Paper end
++
+             this.levelCallback.onMove();
+             GameEventListenerRegistrar gameeventlistenerregistrar = this.getGameEventListenerRegistrar();
  
-     public final void setPosRaw(double x, double y, double z) {
-+        // Paper start - never allow AABB to become desynced from position
-+        // hanging has its own special logic
-+        if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity) && (this.position.x != x || this.position.y != y || this.position.z != z)) {
-+            this.setBoundingBox(this.dimensions.makeBoundingBox(x, y, z));
-+        }
-+        // Paper end
-         if (this.position.x != x || this.position.y != y || this.position.z != z) {
-             this.position = new Vec3(x, y, z);
-             int i = Mth.floor(x);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
 index ca0d1c059a6ad94590bcbff34b37b9c13ef19474..c61f127342f404fbf766c64254fd191ff01f1507 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java

--- a/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 912723108af2ffe660f0c2e528e4e028f7f74bcb..7606f6fd9a79b1becd7af5b203ababbc6c6e4b7e 100644
+index 581f1ba9a24f5c5267dea29c892c6dfe03468f0c..e3ad8f9d995b93ab670904726b8f2cdd31b80ee4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -560,7 +560,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -17,29 +17,41 @@ index 912723108af2ffe660f0c2e528e4e028f7f74bcb..7606f6fd9a79b1becd7af5b203ababbc
      }
  
      protected AABB makeBoundingBox() {
-@@ -3750,6 +3750,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3740,7 +3740,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+     }
+
+     public final void setPosRaw(double x, double y, double z) {
+-        if (this.position.x != x || this.position.y != y || this.position.z != z) {
++        // Paper start - never allow AABB to become desynced from position
++        final boolean changedPosition = this.position.x != x || this.position.y != y || this.position.z != z;
++        if (changedPosition) { // Paper - update internal position references if position changed.
+             this.position = new Vec3(x, y, z);
+             int i = Mth.floor(x);
+             int j = Mth.floor(y);
+@@ -3749,7 +3751,18 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+             if (i != this.blockPosition.getX() || j != this.blockPosition.getY() || k != this.blockPosition.getZ()) {
                  this.blockPosition = new BlockPos(i, j, k);
              }
-
-+            // Paper start - never allow AABB to become desynced from position
-+            // hanging has its own special logic
-+            if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity)) {
-+                this.setBoundingBox(this.makeBoundingBox());
-+            }
-+            // Paper end
++        }
 +
++        // Paper - only recreate bounding box if position changed to reuse the existing instance as long as possible.
++        // Shulkers always require an updated bounding box, even if their position did not change
++        // as they change their bounding box while peeking.
++        // Hanging entities have their own logic and never require a bounding box update.
++        if ((changedPosition || this instanceof net.minecraft.world.entity.Shulker)
++            && !(this instanceof net.minecraft.world.entity.decoration.HangingEntity) {
++            this.setBoundingBox(this.makeBoundingBox());
++        }
+
++        if (changedPosition) {
              this.levelCallback.onMove();
              GameEventListenerRegistrar gameeventlistenerregistrar = this.getGameEventListenerRegistrar();
  
-diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-index ca0d1c059a6ad94590bcbff34b37b9c13ef19474..c61f127342f404fbf766c64254fd191ff01f1507 100644
---- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-+++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
-@@ -236,6 +236,7 @@ public class Shulker extends AbstractGolem implements Enemy {
+@@ -3757,6 +3770,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+                 gameeventlistenerregistrar.onListenerMove(this.level);
+             }
+         }
++        // Paper end
 
-     private void onPeekAmountChange() {
-         this.reapplyPosition();
-+        this.setBoundingBox(this.makeBoundingBox()); // Paper - manually update bounding box as paper caches bounding box if the entity did not move (See Entity#setPosRaw)
-         float f = Shulker.getPhysicalPeek(this.currentPeekAmount);
-         float f1 = Shulker.getPhysicalPeek(this.currentPeekAmountO);
-         Direction enumdirection = this.getAttachFace().getOpposite();
+     }
+

--- a/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -30,3 +30,15 @@ index 912723108af2ffe660f0c2e528e4e028f7f74bcb..b208f561ab8bb0ea9ad06fb2a30becef
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Shulker.java b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+index ca0d1c059a6ad94590bcbff34b37b9c13ef19474..c61f127342f404fbf766c64254fd191ff01f1507 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Shulker.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Shulker.java
+@@ -236,6 +236,7 @@ public class Shulker extends AbstractGolem implements Enemy {
+
+     private void onPeekAmountChange() {
+         this.reapplyPosition();
++        this.setBoundingBox(this.makeBoundingBox()); // Paper - manually update bounding box as paper caches bounding box if the entity did not move (See Entity#setPosRaw)
+         float f = Shulker.getPhysicalPeek(this.currentPeekAmount);
+         float f1 = Shulker.getPhysicalPeek(this.currentPeekAmountO);
+         Direction enumdirection = this.getAttachFace().getOpposite();

--- a/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,53 +5,42 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 581f1ba9a24f5c5267dea29c892c6dfe03468f0c..e3ad8f9d995b93ab670904726b8f2cdd31b80ee4 100644
+index 581f1ba9a24f5c5267dea29c892c6dfe03468f0c..8278d38d6d61bff836c49ae5651f2be195389d1b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -560,7 +560,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -559,8 +559,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+     }
  
      public void setPos(double x, double y, double z) {
-         this.setPosRaw(x, y, z);
+-        this.setPosRaw(x, y, z);
 -        this.setBoundingBox(this.makeBoundingBox());
++        this.setPosRaw(x, y, z, true); // Paper - force bounding box update
 +        // this.setBoundingBox(this.makeBoundingBox()); // Paper - move into setPositionRaw
      }
  
      protected AABB makeBoundingBox() {
-@@ -3740,7 +3740,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3740,6 +3740,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
-
+ 
      public final void setPosRaw(double x, double y, double z) {
--        if (this.position.x != x || this.position.y != y || this.position.z != z) {
-+        // Paper start - never allow AABB to become desynced from position
-+        final boolean changedPosition = this.position.x != x || this.position.y != y || this.position.z != z;
-+        if (changedPosition) { // Paper - update internal position references if position changed.
++        // Paper start
++        this.setPosRaw(x, y, z, false);
++    }
++    public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
++        // Paper end
+         if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-             int j = Mth.floor(y);
-@@ -3749,7 +3751,18 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
-             if (i != this.blockPosition.getX() || j != this.blockPosition.getY() || k != this.blockPosition.getZ()) {
-                 this.blockPosition = new BlockPos(i, j, k);
-             }
-+        }
-+
-+        // Paper - only recreate bounding box if position changed to reuse the existing instance as long as possible.
-+        // Shulkers always require an updated bounding box, even if their position did not change
-+        // as they change their bounding box while peeking.
-+        // Hanging entities have their own logic and never require a bounding box update.
-+        if ((changedPosition || this instanceof net.minecraft.world.entity.Shulker)
-+            && !(this instanceof net.minecraft.world.entity.decoration.HangingEntity) {
-+            this.setBoundingBox(this.makeBoundingBox());
-+        }
-
-+        if (changedPosition) {
-             this.levelCallback.onMove();
-             GameEventListenerRegistrar gameeventlistenerregistrar = this.getGameEventListenerRegistrar();
- 
-@@ -3757,6 +3770,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
-                 gameeventlistenerregistrar.onListenerMove(this.level);
+@@ -3758,6 +3763,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              }
          }
+ 
++        // Paper start - never allow AABB to become desynced from position
++        // hanging has its own special logic
++        if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity) && (forceBoundingBoxUpdate || this.position.x != x || this.position.y != y || this.position.z != z)) {
++            this.setBoundingBox(this.makeBoundingBox());
++        }
 +        // Paper end
-
      }
-
+ 
+     public void checkDespawn() {}

--- a/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6fe23851c3ab105c8ebc4fd7ded47da205d5036c..487b22171521de0cae30e57ca7f62cf05aeb3b0c 100644
+index 1e0a9fb7db34350191d1ddb2633df31c8528e17f..8e1d9ffd52a4988a436ba67507f36fd5623ea81f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3927,4 +3927,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3928,4 +3928,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8a07fdb74bf726b53479134e7cbf88d8d7fa998c..2866a9e01d335c8d441e1034879a33772bd40195 100644
+index c9ea809bcfd394f5a9483351ee0d4619c541f481..14edbf6b2dc7697f9b703aa83d8529dd8ffe73a8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3935,4 +3935,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3932,4 +3932,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0529-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1e0a9fb7db34350191d1ddb2633df31c8528e17f..8e1d9ffd52a4988a436ba67507f36fd5623ea81f 100644
+index 8a07fdb74bf726b53479134e7cbf88d8d7fa998c..2866a9e01d335c8d441e1034879a33772bd40195 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3928,4 +3928,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3935,4 +3935,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
  
          void accept(Entity entity, double x, double y, double z);
      }
@@ -21,7 +21,7 @@ index 1e0a9fb7db34350191d1ddb2633df31c8528e17f..8e1d9ffd52a4988a436ba67507f36fd5
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 736cbdc118b7a19b724a3afd433927e8e8316d23..a6250143baced61e87900181f8b37cfd89c717ff 100644
+index 135749c789d44f0af1ad11ccd1b208f1e28853eb..8c1ac43cf5510a14d1d41ec45d189ad9711024da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -443,6 +443,10 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0531-Entity-isTicking.patch
+++ b/patches/server/0531-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8e1d9ffd52a4988a436ba67507f36fd5623ea81f..ef67543c0d571813264bc674ba5b5ad31ed842e8 100644
+index 2866a9e01d335c8d441e1034879a33772bd40195..b9a2094e04daaf96e6d88f8be6e83dab4e4efd98 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -52,6 +52,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 8e1d9ffd52a4988a436ba67507f36fd5623ea81f..ef67543c0d571813264bc674ba5b5ad3
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3933,5 +3934,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3940,5 +3941,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0531-Entity-isTicking.patch
+++ b/patches/server/0531-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2866a9e01d335c8d441e1034879a33772bd40195..b9a2094e04daaf96e6d88f8be6e83dab4e4efd98 100644
+index 14edbf6b2dc7697f9b703aa83d8529dd8ffe73a8..477b6102361f0ae03541402578e1d053572e52d3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -52,6 +52,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 2866a9e01d335c8d441e1034879a33772bd40195..b9a2094e04daaf96e6d88f8be6e83dab
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3940,5 +3941,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3937,5 +3938,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0531-Entity-isTicking.patch
+++ b/patches/server/0531-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 487b22171521de0cae30e57ca7f62cf05aeb3b0c..a8d000717a52e3896c0c81e8cf754d8cfbeadf52 100644
+index 8e1d9ffd52a4988a436ba67507f36fd5623ea81f..ef67543c0d571813264bc674ba5b5ad31ed842e8 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -52,6 +52,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 487b22171521de0cae30e57ca7f62cf05aeb3b0c..a8d000717a52e3896c0c81e8cf754d8c
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3932,5 +3933,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3933,5 +3934,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0570-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0570-MC-4-Fix-item-position-desync.patch
@@ -41,7 +41,7 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9c37264884d1353de9b1ef388773d1991f5db2b4..bf8e02e23fce3c48fc07c0bdb4ac137c8ba13e03 100644
+index debb4a8c9ed0153f0f3cdb9709681c4564d5ba38..49d89ddfe01d4002da50f22c811b9df4e0c70dc3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3754,6 +3754,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -58,6 +58,6 @@ index 9c37264884d1353de9b1ef388773d1991f5db2b4..bf8e02e23fce3c48fc07c0bdb4ac137c
 +            }
 +        }
 +        // Paper end - fix MC-4
-         // Paper start - never allow AABB to become desynced from position
-         // hanging has its own special logic
-         if (!(this instanceof net.minecraft.world.entity.decoration.HangingEntity) && (this.position.x != x || this.position.y != y || this.position.z != z)) {
+         if (this.position.x != x || this.position.y != y || this.position.z != z) {
+             this.position = new Vec3(x, y, z);
+             int i = Mth.floor(x);

--- a/patches/server/0570-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0570-MC-4-Fix-item-position-desync.patch
@@ -41,13 +41,13 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bdea7ac5f14155455448b161bf324683ffc9fda5..c5bb8e5fabe12c339a35259eb1ebd6d18f81cab3 100644
+index db2ca58064000ac73c054d51590ccbcb9151d596..f744bf2d19291991ffa9c7b13fc62a479702d201 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3754,6 +3754,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3759,6 +3759,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
- 
-     public final void setPosRaw(double x, double y, double z) {
+     public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
+         // Paper end
 +        // Paper start - fix MC-4
 +        if (this instanceof ItemEntity) {
 +            if (com.destroystokyo.paper.PaperConfig.fixEntityPositionDesync) {
@@ -58,6 +58,6 @@ index bdea7ac5f14155455448b161bf324683ffc9fda5..c5bb8e5fabe12c339a35259eb1ebd6d1
 +            }
 +        }
 +        // Paper end - fix MC-4
-         // Paper start - never allow AABB to become desynced from position
-         final boolean changedPosition = this.position.x != x || this.position.y != y || this.position.z != z;
-         if (changedPosition) { // Paper - update internal position references if position changed.
+         if (this.position.x != x || this.position.y != y || this.position.z != z) {
+             this.position = new Vec3(x, y, z);
+             int i = Mth.floor(x);

--- a/patches/server/0570-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0570-MC-4-Fix-item-position-desync.patch
@@ -9,7 +9,7 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 652d87fc5d566dba8018c81676329f0e0bca471b..c56e7fb18f9a56c8025eb70a524f028b5942da37 100644
+index e62bb33852b0dca346aeb3cb2747d1a5686dea2d..ea4fa458113d68dc2ed3187e19b11d72fc05d36c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -474,4 +474,9 @@ public class PaperConfig {
@@ -41,7 +41,7 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index debb4a8c9ed0153f0f3cdb9709681c4564d5ba38..49d89ddfe01d4002da50f22c811b9df4e0c70dc3 100644
+index bdea7ac5f14155455448b161bf324683ffc9fda5..c5bb8e5fabe12c339a35259eb1ebd6d18f81cab3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3754,6 +3754,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -58,6 +58,6 @@ index debb4a8c9ed0153f0f3cdb9709681c4564d5ba38..49d89ddfe01d4002da50f22c811b9df4
 +            }
 +        }
 +        // Paper end - fix MC-4
-         if (this.position.x != x || this.position.y != y || this.position.z != z) {
-             this.position = new Vec3(x, y, z);
-             int i = Mth.floor(x);
+         // Paper start - never allow AABB to become desynced from position
+         final boolean changedPosition = this.position.x != x || this.position.y != y || this.position.z != z;
+         if (changedPosition) { // Paper - update internal position references if position changed.


### PR DESCRIPTION
A previous paper patch introduced bounding box reuse for entities on
position updates if the x,y and z coordinate did not change.
While this reusing in itself works fine, shulkers do update their
bounding box without actually changing their x,y and z coordinates which
is not respected due to the old bounding box being reused.

This commit fixes this issue by manually updating the shulker bounding
box after reapplying the position.

Another alternative solution would have been an exception specifically
made for shulkers to ignore the reuse logic, tho this would introduce a
new instanceOf check into the Entity#setPosRaw method and would be
evaulated for every type of entity.

See also: https://github.com/PaperMC/Paper/blob/master/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
Resolves: #5915