### PR TITLE
Make PlayerArmorChangeEvent not fire on player join

### DIFF
--- a/patches/api/0072-Add-PlayerArmorChangeEvent.patch
+++ b/patches/api/0072-Add-PlayerArmorChangeEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..da9845f7a857ee1c900d8ff1f056368ef360af90
+index 0000000000000000000000000000000000000000..6a72446300a6818cbcfb552d74840491103b6cdb
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
-@@ -0,0 +1,137 @@
+@@ -0,0 +1,135 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Material;
@@ -29,8 +29,6 @@ index 0000000000000000000000000000000000000000..da9845f7a857ee1c900d8ff1f056368e
 +
 +/**
 + * Called when the player's armor is changed(manual armor change, equip through dispenser, loss of durability, etc.)
-+ * <p>
-+ * This event does <strong>not</strong> fire when a player joins the server with armor equipped.
 + */
 +public class PlayerArmorChangeEvent extends PlayerEvent {
 +    private static final HandlerList HANDLERS = new HandlerList();

--- a/patches/api/0072-Add-PlayerArmorChangeEvent.patch
+++ b/patches/api/0072-Add-PlayerArmorChangeEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e406ce639a2e88b78f82f25e71678a669d0a958b
+index 0000000000000000000000000000000000000000..da9845f7a857ee1c900d8ff1f056368ef360af90
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerArmorChangeEvent.java
 @@ -0,0 +1,137 @@
@@ -28,9 +28,9 @@ index 0000000000000000000000000000000000000000..e406ce639a2e88b78f82f25e71678a66
 +import static org.bukkit.Material.*;
 +
 +/**
-+ * Called when the player themselves change their armor items
++ * Called when the player's armor is changed(manual armor change, equip through dispenser, loss of durability, etc.)
 + * <p>
-+ * Not currently called for environmental factors though it <strong>MAY BE IN THE FUTURE</strong>
++ * This event does <strong>not</strong> fire when a player joins the server with armor equipped.
 + */
 +public class PlayerArmorChangeEvent extends PlayerEvent {
 +    private static final HandlerList HANDLERS = new HandlerList();

--- a/patches/server/0164-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0164-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8044082ed3ca6076af38e4299e50f1f690d02a72..0dc03f53c80aac91a914bea91958a6c11c4f2061 100644
+index 8044082ed3ca6076af38e4299e50f1f690d02a72..210237665ef016cc24f2fe09e1ea00cfb4324d8e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@
@@ -20,7 +20,7 @@ index 8044082ed3ca6076af38e4299e50f1f690d02a72..0dc03f53c80aac91a914bea91958a6c1
  
              if (!ItemStack.matches(itemstack1, itemstack)) {
 +                // Paper start - PlayerArmorChangeEvent
-+                if (this instanceof ServerPlayer && enumitemslot.getType() == EquipmentSlot.Type.ARMOR) {
++                if (this instanceof ServerPlayer && enumitemslot.getType() == EquipmentSlot.Type.ARMOR && !((ServerPlayer) this).joining) {
 +                    final org.bukkit.inventory.ItemStack oldItem = CraftItemStack.asBukkitCopy(itemstack);
 +                    final org.bukkit.inventory.ItemStack newItem = CraftItemStack.asBukkitCopy(itemstack1);
 +                    new PlayerArmorChangeEvent((Player) this.getBukkitEntity(), PlayerArmorChangeEvent.SlotType.valueOf(enumitemslot.name()), oldItem, newItem).callEvent();


### PR DESCRIPTION
As the name of the event suggests, it seems unfitting that the event is called when the player joins a server.  I can't think of a use case where you would want this event to call when a player joins, and that could easily be handled on PlayerJoinEvent or similar.

I also updated the description of the event in the javadocs to more accurately reflect when the event fires.

~~An afterthought I had while writing this is that the event be renamed PlayerArmorUpdateEvent.~~