### PR TITLE
Add rate options and timings for sensors and behaviors

### DIFF
--- a/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -1,0 +1,190 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Phoenix616 <max@themoep.de>
+Date: Mon, 28 Jun 2021 22:38:29 +0100
+Subject: [PATCH] Rate options and timings for sensors and behaviors
+
+This adds config options to specify the tick rate for sensors
+ and behaviors of different entity types as well as timings
+ for those in order to be able to have some metrics as to which
+ ones might need tweaking.
+
+diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
+index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092c25a3645 100644
+--- a/src/main/java/co/aikar/timings/MinecraftTimings.java
++++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
+@@ -114,6 +114,14 @@ public final class MinecraftTimings {
+         return Timings.ofSafe("Minecraft", "## tickEntity - " + entityType + " - " + type, tickEntityTimer);
+     }
+ 
++    public static Timing getBehaviorTimings(String type) {
++        return Timings.ofSafe("Behavior - " + type);
++    }
++
++    public static Timing getSensorTimings(String type) {
++        return Timings.ofSafe("Sensor - " + type);
++    }
++
+     /**
+      * Get a named timer for the specified tile entity type to track type specific timings.
+      * @param entity
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 26e18a08a7f0bd704ff3055ce3a7814191450c85..2a3be23f52de7a960e0e323dd507579422b5b30d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -3,6 +3,7 @@ package com.destroystokyo.paper;
+ import java.util.Arrays;
+ import java.util.HashMap;
+ import java.util.List;
++import java.util.Locale;
+ import java.util.Map;
+ import java.util.stream.Collectors;
+ import net.minecraft.world.Difficulty;
+@@ -11,6 +12,7 @@ import net.minecraft.world.entity.monster.Vindicator;
+ import net.minecraft.world.entity.monster.Zombie;
+ import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+ import org.bukkit.Bukkit;
++import org.bukkit.configuration.ConfigurationSection;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.spigotmc.SpigotWorldConfig;
+ 
+@@ -820,5 +822,33 @@ public class PaperWorldConfig {
+     private void fixInvulnerableEndCrystalExploit() {
+         fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
+     }
++
++    private Map<String, Integer> tickRates = new HashMap<>();
++    private void tickRates() {
++        config.addDefault("world-settings.default.tick-rates.sensor.villager.secondaryplaces", 40);
++        config.addDefault("world-settings.default.tick-rates.behavior.villager.positionvalidate", 20);
++        tickRates = new HashMap<>();
++        log("Tick rates:");
++        ConfigurationSection tickRatesSection = config.getConfigurationSection("world-settings." + worldName + ".tick-rates");
++        if (tickRatesSection == null) {
++            tickRatesSection = config.getConfigurationSection("world-settings.default.tick-rates");
++        }
++        if (tickRatesSection != null) {
++            for (String key : tickRatesSection.getKeys(true)) {
++                if (tickRatesSection.isInt(key)) {
++                    int tickRate = tickRatesSection.getInt(key);
++                    tickRates.put(key.toLowerCase(Locale.ROOT), tickRate);
++                    log("  " + key + ": " + tickRate);
++                }
++            }
++        }
++        if (tickRates.isEmpty()) {
++            log("  None configured");
++        }
++    }
++    public int getTickRate(String type, String typeName, String entityType, int def) {
++        int rate = tickRates.getOrDefault(type + "." + entityType + "." + typeName, -1);
++        return rate > -1 ? rate : def;
++    }
+ }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
+index b1212e162ba938b3abe0df747a633ba9cbbe57c8..35036afea3713f7a1869355a0e05660069f96a8e 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
+@@ -14,6 +14,11 @@ public abstract class Behavior<E extends LivingEntity> {
+     private long endTimestamp;
+     private final int minDuration;
+     private final int maxDuration;
++    // Paper start - configurable behavior tick rate and timings
++    private static final String RATE_TYPE = "behavior";
++    private final String configKey;
++    private final co.aikar.timings.Timing timing;
++    // Paper end
+ 
+     public Behavior(Map<MemoryModuleType<?>, MemoryStatus> requiredMemoryState) {
+         this(requiredMemoryState, 60);
+@@ -27,6 +32,15 @@ public abstract class Behavior<E extends LivingEntity> {
+         this.minDuration = minRunTime;
+         this.maxDuration = maxRunTime;
+         this.entryCondition = requiredMemoryState;
++        // Paper start - configurable behavior tick rate and timings
++        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
++        key = key.toLowerCase(java.util.Locale.ROOT);
++        if (key.startsWith(RATE_TYPE)) {
++            key = key.substring(RATE_TYPE.length());
++        }
++        this.configKey = key;
++        this.timing = co.aikar.timings.MinecraftTimings.getBehaviorTimings(configKey);
++        // Paper end
+     }
+ 
+     public Behavior.Status getStatus() {
+@@ -34,11 +48,19 @@ public abstract class Behavior<E extends LivingEntity> {
+     }
+ 
+     public final boolean tryStart(ServerLevel world, E entity, long time) {
++        // Paper start - behavior tick rate
++        int tickRate = world.paperConfig.getTickRate(RATE_TYPE, configKey, entity.getType().id, -1);
++        if (tickRate > -1 && time < this.endTimestamp + tickRate) {
++            return false;
++        }
++        // Paper end
+         if (this.hasRequiredMemories(entity) && this.checkExtraStartConditions(world, entity)) {
+             this.status = Behavior.Status.RUNNING;
+             int i = this.minDuration + world.getRandom().nextInt(this.maxDuration + 1 - this.minDuration);
+             this.endTimestamp = time + (long)i;
++            timing.startTiming(); // Paper - behavior timings
+             this.start(world, entity, time);
++            timing.stopTiming(); // Paper - behavior timings
+             return true;
+         } else {
+             return false;
+@@ -49,11 +71,13 @@ public abstract class Behavior<E extends LivingEntity> {
+     }
+ 
+     public final void tickOrStop(ServerLevel world, E entity, long time) {
++        timing.startTiming(); // Paper - behavior timings
+         if (!this.timedOut(time) && this.canStillUse(world, entity, time)) {
+             this.tick(world, entity, time);
+         } else {
+             this.doStop(world, entity, time);
+         }
++        timing.stopTiming(); // Paper - behavior timings
+ 
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
+index 650a3f256b60998efd07b4acfd2f6168da2ff00a..85bb2305d185f0133afd5e924722456fe093ec6e 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
++++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
+@@ -17,8 +17,22 @@ public abstract class Sensor<E extends LivingEntity> {
+     private static final TargetingConditions ATTACK_TARGET_CONDITIONS_IGNORE_INVISIBILITY_TESTING = TargetingConditions.forCombat().range(16.0D).ignoreInvisibilityTesting();
+     private final int scanRate;
+     private long timeToTick;
++    // Paper start - configurable sensor tick rate and timings
++    private static final String AI_TYPE = "sensor";
++    private final String configKey;
++    private final co.aikar.timings.Timing timing;
++    // Paper end
+ 
+     public Sensor(int senseInterval) {
++        // Paper start - configurable sensor tick rate and timings
++        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
++        key = key.toLowerCase(java.util.Locale.ROOT);
++        if (key.startsWith(AI_TYPE)) {
++            key = key.substring(AI_TYPE.length());
++        }
++        this.configKey = key;
++        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey);
++        // Paper end
+         this.scanRate = senseInterval;
+         this.timeToTick = (long)RANDOM.nextInt(senseInterval);
+     }
+@@ -29,8 +43,12 @@ public abstract class Sensor<E extends LivingEntity> {
+ 
+     public final void tick(ServerLevel world, E entity) {
+         if (--this.timeToTick <= 0L) {
+-            this.timeToTick = (long)this.scanRate;
++            // Paper start - configurable sensor tick rate and timings
++            this.timeToTick = (long) world.paperConfig.getTickRate(AI_TYPE, configKey, entity.getType().id, this.scanRate);
++            timing.startTiming();
++            // Paper end
+             this.doTick(world, entity);
++            timing.stopTiming(); // Paper - sensor timings
+         }
+ 
+     }

--- a/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,18 +28,22 @@ index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26e18a08a7f0bd704ff3055ce3a7814191450c85..2a3be23f52de7a960e0e323dd507579422b5b30d 100644
+index 26e18a08a7f0bd704ff3055ce3a7814191450c85..08e53efb563360f212425c1b090266ed8b9fe7ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -3,6 +3,7 @@ package com.destroystokyo.paper;
+@@ -3,14 +3,19 @@ package com.destroystokyo.paper;
  import java.util.Arrays;
  import java.util.HashMap;
  import java.util.List;
 +import java.util.Locale;
  import java.util.Map;
  import java.util.stream.Collectors;
++
++import com.google.common.collect.HashBasedTable;
++import com.google.common.collect.Table;
  import net.minecraft.world.Difficulty;
-@@ -11,6 +12,7 @@ import net.minecraft.world.entity.monster.Vindicator;
+ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.entity.monster.Vindicator;
  import net.minecraft.world.entity.monster.Zombie;
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
  import org.bukkit.Bukkit;
@@ -47,65 +51,89 @@ index 26e18a08a7f0bd704ff3055ce3a7814191450c85..2a3be23f52de7a960e0e323dd5075794
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -820,5 +822,33 @@ public class PaperWorldConfig {
+@@ -820,5 +825,58 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }
 +
-+    private Map<String, Integer> tickRates = new HashMap<>();
++    private Table<String, String, Integer> sensorTickRates;
++    private Table<String, String, Integer> behaviorTickRates;
 +    private void tickRates() {
 +        config.addDefault("world-settings.default.tick-rates.sensor.villager.secondaryplaces", 40);
 +        config.addDefault("world-settings.default.tick-rates.behavior.villager.positionvalidate", 20);
-+        tickRates = new HashMap<>();
 +        log("Tick rates:");
-+        ConfigurationSection tickRatesSection = config.getConfigurationSection("world-settings." + worldName + ".tick-rates");
-+        if (tickRatesSection == null) {
-+            tickRatesSection = config.getConfigurationSection("world-settings.default.tick-rates");
++        sensorTickRates = loadTickRates("sensor");
++        behaviorTickRates = loadTickRates("behavior");
++    }
++
++    private Table<String, String, Integer> loadTickRates(String type) {
++        log("  " + type + ":");
++        Table<String, String, Integer> table = HashBasedTable.create();
++
++        ConfigurationSection typeSection = config.getConfigurationSection("world-settings." + worldName + ".tick-rates." + type);
++        if (typeSection == null) {
++            typeSection = config.getConfigurationSection("world-settings.default.tick-rates." + type);
 +        }
-+        if (tickRatesSection != null) {
-+            for (String key : tickRatesSection.getKeys(true)) {
-+                if (tickRatesSection.isInt(key)) {
-+                    int tickRate = tickRatesSection.getInt(key);
-+                    tickRates.put(key.toLowerCase(Locale.ROOT), tickRate);
-+                    log("  " + key + ": " + tickRate);
++        if (typeSection != null) {
++            for (String entity : typeSection.getKeys(false)) {
++                ConfigurationSection entitySection = typeSection.getConfigurationSection(entity);
++                if (entitySection != null) {
++                    log("    " + entity + ":");
++                    for (String typeName : entitySection.getKeys(false)) {
++                        if (entitySection.isInt(typeName)) {
++                            int tickRate = entitySection.getInt(typeName);
++                            table.put(entity.toUpperCase(Locale.ROOT), typeName.toUpperCase(Locale.ROOT), tickRate);
++                            log("      " + typeName + ": " + tickRate);
++                        }
++                    }
 +                }
 +            }
 +        }
-+        if (tickRates.isEmpty()) {
-+            log("  None configured");
++
++        if (table.isEmpty()) {
++            log("    None configured");
 +        }
++        return table;
 +    }
-+    public int getTickRate(String type, String typeName, String entityType, int def) {
-+        int rate = tickRates.getOrDefault(type + "." + entityType + "." + typeName, -1);
-+        return rate > -1 ? rate : def;
++
++    public int getBehaviorTickRate(String typeName, String entityType, int def) {
++        return getIntOrDefault(behaviorTickRates, typeName, entityType, def);
++    }
++
++    public int getSensorTickRate(String typeName, String entityType, int def) {
++        return getIntOrDefault(sensorTickRates, typeName, entityType, def);
++    }
++
++    private int getIntOrDefault(Table<String, String, Integer> table, String rowKey, String columnKey, int def) {
++        Integer rate = table.get(columnKey, rowKey);
++        return rate != null && rate > -1 ? rate : def;
 +    }
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-index b1212e162ba938b3abe0df747a633ba9cbbe57c8..35036afea3713f7a1869355a0e05660069f96a8e 100644
+index b1212e162ba938b3abe0df747a633ba9cbbe57c8..f689fad6f4b728f676fb1feaf742c0305dbf4dae 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-@@ -14,6 +14,11 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -14,6 +14,10 @@ public abstract class Behavior<E extends LivingEntity> {
      private long endTimestamp;
      private final int minDuration;
      private final int maxDuration;
 +    // Paper start - configurable behavior tick rate and timings
-+    private static final String RATE_TYPE = "behavior";
 +    private final String configKey;
 +    private final co.aikar.timings.Timing timing;
 +    // Paper end
  
      public Behavior(Map<MemoryModuleType<?>, MemoryStatus> requiredMemoryState) {
          this(requiredMemoryState, 60);
-@@ -27,6 +32,15 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -27,6 +31,15 @@ public abstract class Behavior<E extends LivingEntity> {
          this.minDuration = minRunTime;
          this.maxDuration = maxRunTime;
          this.entryCondition = requiredMemoryState;
 +        // Paper start - configurable behavior tick rate and timings
 +        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
 +        key = key.toLowerCase(java.util.Locale.ROOT);
-+        if (key.startsWith(RATE_TYPE)) {
-+            key = key.substring(RATE_TYPE.length());
++        if (key.startsWith("behavior")) {
++            key = key.substring("behavior".length());
 +        }
 +        this.configKey = key;
 +        this.timing = co.aikar.timings.MinecraftTimings.getBehaviorTimings(configKey);
@@ -113,12 +141,12 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..35036afea3713f7a1869355a0e056600
      }
  
      public Behavior.Status getStatus() {
-@@ -34,11 +48,19 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -34,11 +47,19 @@ public abstract class Behavior<E extends LivingEntity> {
      }
  
      public final boolean tryStart(ServerLevel world, E entity, long time) {
 +        // Paper start - behavior tick rate
-+        int tickRate = world.paperConfig.getTickRate(RATE_TYPE, configKey, entity.getType().id, -1);
++        int tickRate = world.paperConfig.getBehaviorTickRate(configKey, entity.getType().id, -1);
 +        if (tickRate > -1 && time < this.endTimestamp + tickRate) {
 +            return false;
 +        }
@@ -133,7 +161,7 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..35036afea3713f7a1869355a0e056600
              return true;
          } else {
              return false;
-@@ -49,11 +71,13 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -49,11 +70,13 @@ public abstract class Behavior<E extends LivingEntity> {
      }
  
      public final void tickOrStop(ServerLevel world, E entity, long time) {
@@ -148,15 +176,14 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..35036afea3713f7a1869355a0e056600
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index 650a3f256b60998efd07b4acfd2f6168da2ff00a..85bb2305d185f0133afd5e924722456fe093ec6e 100644
+index 650a3f256b60998efd07b4acfd2f6168da2ff00a..24c47d13347961477c030c65f64e4cfe1c76a34a 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-@@ -17,8 +17,22 @@ public abstract class Sensor<E extends LivingEntity> {
+@@ -17,8 +17,21 @@ public abstract class Sensor<E extends LivingEntity> {
      private static final TargetingConditions ATTACK_TARGET_CONDITIONS_IGNORE_INVISIBILITY_TESTING = TargetingConditions.forCombat().range(16.0D).ignoreInvisibilityTesting();
      private final int scanRate;
      private long timeToTick;
 +    // Paper start - configurable sensor tick rate and timings
-+    private static final String AI_TYPE = "sensor";
 +    private final String configKey;
 +    private final co.aikar.timings.Timing timing;
 +    // Paper end
@@ -165,8 +192,8 @@ index 650a3f256b60998efd07b4acfd2f6168da2ff00a..85bb2305d185f0133afd5e924722456f
 +        // Paper start - configurable sensor tick rate and timings
 +        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
 +        key = key.toLowerCase(java.util.Locale.ROOT);
-+        if (key.startsWith(AI_TYPE)) {
-+            key = key.substring(AI_TYPE.length());
++        if (key.startsWith("sensor")) {
++            key = key.substring("sensor".length());
 +        }
 +        this.configKey = key;
 +        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey);
@@ -174,13 +201,13 @@ index 650a3f256b60998efd07b4acfd2f6168da2ff00a..85bb2305d185f0133afd5e924722456f
          this.scanRate = senseInterval;
          this.timeToTick = (long)RANDOM.nextInt(senseInterval);
      }
-@@ -29,8 +43,12 @@ public abstract class Sensor<E extends LivingEntity> {
+@@ -29,8 +42,12 @@ public abstract class Sensor<E extends LivingEntity> {
  
      public final void tick(ServerLevel world, E entity) {
          if (--this.timeToTick <= 0L) {
 -            this.timeToTick = (long)this.scanRate;
 +            // Paper start - configurable sensor tick rate and timings
-+            this.timeToTick = (long) world.paperConfig.getTickRate(AI_TYPE, configKey, entity.getType().id, this.scanRate);
++            this.timeToTick = world.paperConfig.getSensorTickRate(configKey, entity.getType().id, this.scanRate);
 +            timing.startTiming();
 +            // Paper end
              this.doTick(world, entity);

--- a/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0722-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -111,7 +111,7 @@ index 26e18a08a7f0bd704ff3055ce3a7814191450c85..08e53efb563360f212425c1b090266ed
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-index b1212e162ba938b3abe0df747a633ba9cbbe57c8..f689fad6f4b728f676fb1feaf742c0305dbf4dae 100644
+index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570a70c4cf2 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 @@ -14,6 +14,10 @@ public abstract class Behavior<E extends LivingEntity> {
@@ -146,7 +146,7 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..f689fad6f4b728f676fb1feaf742c030
  
      public final boolean tryStart(ServerLevel world, E entity, long time) {
 +        // Paper start - behavior tick rate
-+        int tickRate = world.paperConfig.getBehaviorTickRate(configKey, entity.getType().id, -1);
++        int tickRate = world.paperConfig.getBehaviorTickRate(this.configKey, entity.getType().id, -1);
 +        if (tickRate > -1 && time < this.endTimestamp + tickRate) {
 +            return false;
 +        }
@@ -155,9 +155,9 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..f689fad6f4b728f676fb1feaf742c030
              this.status = Behavior.Status.RUNNING;
              int i = this.minDuration + world.getRandom().nextInt(this.maxDuration + 1 - this.minDuration);
              this.endTimestamp = time + (long)i;
-+            timing.startTiming(); // Paper - behavior timings
++            this.timing.startTiming(); // Paper - behavior timings
              this.start(world, entity, time);
-+            timing.stopTiming(); // Paper - behavior timings
++            this.timing.stopTiming(); // Paper - behavior timings
              return true;
          } else {
              return false;
@@ -165,18 +165,18 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..f689fad6f4b728f676fb1feaf742c030
      }
  
      public final void tickOrStop(ServerLevel world, E entity, long time) {
-+        timing.startTiming(); // Paper - behavior timings
++        this.timing.startTiming(); // Paper - behavior timings
          if (!this.timedOut(time) && this.canStillUse(world, entity, time)) {
              this.tick(world, entity, time);
          } else {
              this.doStop(world, entity, time);
          }
-+        timing.stopTiming(); // Paper - behavior timings
++        this.timing.stopTiming(); // Paper - behavior timings
  
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index 650a3f256b60998efd07b4acfd2f6168da2ff00a..24c47d13347961477c030c65f64e4cfe1c76a34a 100644
+index 650a3f256b60998efd07b4acfd2f6168da2ff00a..cb817f524e6c224f8923c66b2c00153748c8c8c8 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 @@ -17,8 +17,21 @@ public abstract class Sensor<E extends LivingEntity> {
@@ -207,11 +207,11 @@ index 650a3f256b60998efd07b4acfd2f6168da2ff00a..24c47d13347961477c030c65f64e4cfe
          if (--this.timeToTick <= 0L) {
 -            this.timeToTick = (long)this.scanRate;
 +            // Paper start - configurable sensor tick rate and timings
-+            this.timeToTick = world.paperConfig.getSensorTickRate(configKey, entity.getType().id, this.scanRate);
-+            timing.startTiming();
++            this.timeToTick = world.paperConfig.getSensorTickRate(this.configKey, entity.getType().id, this.scanRate);
++            this.timing.startTiming();
 +            // Paper end
              this.doTick(world, entity);
-+            timing.stopTiming(); // Paper - sensor timings
++            this.timing.stopTiming(); // Paper - sensor timings
          }
  
      }

--- a/patches/server/0730-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0730-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26e18a08a7f0bd704ff3055ce3a7814191450c85..08e53efb563360f212425c1b090266ed8b9fe7ae 100644
+index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..eb99eed57d45e680f2ae3eea62e5eee72e4dffaa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,14 +3,19 @@ package com.destroystokyo.paper;
@@ -51,9 +51,9 @@ index 26e18a08a7f0bd704ff3055ce3a7814191450c85..08e53efb563360f212425c1b090266ed
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -820,5 +825,58 @@ public class PaperWorldConfig {
-     private void fixInvulnerableEndCrystalExploit() {
-         fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
+@@ -845,5 +850,58 @@ public class PaperWorldConfig {
+     private void playerCrammingDamage() {
+         allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }
 +
 +    private Table<String, String, Integer> sensorTickRates;
@@ -176,11 +176,11 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index 650a3f256b60998efd07b4acfd2f6168da2ff00a..cb817f524e6c224f8923c66b2c00153748c8c8c8 100644
+index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..d9fc867c6414d36d76411ad012d1aff9a6cf6772 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-@@ -17,8 +17,21 @@ public abstract class Sensor<E extends LivingEntity> {
-     private static final TargetingConditions ATTACK_TARGET_CONDITIONS_IGNORE_INVISIBILITY_TESTING = TargetingConditions.forCombat().range(16.0D).ignoreInvisibilityTesting();
+@@ -19,8 +19,21 @@ public abstract class Sensor<E extends LivingEntity> {
+     private static final TargetingConditions ATTACK_TARGET_CONDITIONS_IGNORE_INVISIBILITY_AND_LINE_OF_SIGHT = TargetingConditions.forCombat().range(16.0D).ignoreLineOfSight().ignoreInvisibilityTesting();
      private final int scanRate;
      private long timeToTick;
 +    // Paper start - configurable sensor tick rate and timings
@@ -201,7 +201,7 @@ index 650a3f256b60998efd07b4acfd2f6168da2ff00a..cb817f524e6c224f8923c66b2c001537
          this.scanRate = senseInterval;
          this.timeToTick = (long)RANDOM.nextInt(senseInterval);
      }
-@@ -29,8 +42,12 @@ public abstract class Sensor<E extends LivingEntity> {
+@@ -31,8 +44,12 @@ public abstract class Sensor<E extends LivingEntity> {
  
      public final void tick(ServerLevel world, E entity) {
          if (--this.timeToTick <= 0L) {


### PR DESCRIPTION
Seeing as now Axolotls too use the new sensor and behaviour "brain" system (additionally to Villagers and Piglins) I thought it would be nice to have the ability to both time and configure how expensive these parts of the entities are individually. I have been running a variation of this on my server for over a year now and have successfully mitigated any Villager farm lag simply by adjusting their behaviour and sensor ticking rates without fully disabling their AI or similar hacks. (Of course at higher values this will be noticeable like any other tick reduction)

The default options are there to a) provide an example and b) slightly improve the Villager performance out of the box without any noticeable differences (the villager secondaryplaces sensor has the default value, the villager positionvalidate one is set to 2 seconds to improve performance as this is by far the most expensive check which is done every tick by default)

The options can be set per entity type as well as every sensor/behaviour type (with the same names as the timings entries, detailed documentation and how to get all the names from timings will be submitted once I have confirmation that this patch is at least under consideration)

Things that were considered and not implemented:
- **Having the config options not be per world or entity type in order to further improve the performance of the options**
This would've meant that no map check needs to be done and the option would be per behaviour/sensor instance but imo this has the downside that different entities get influenced by the same option as some types share the same behaviour. Someone might not want to gimp both villagers and piglins at the same time.
Also changing this would've meant loosing reload support but that wasn't a big factor in the decision.
- **Having timings include the entity/world name**
In lots of cases the timings names seem to include the entity/world name. I'm unsure how important that is for the inner workings of the timings system but as far as I can tell it seems to still group them correctly. Doing so would've meant to lookup the Timing instance on each ticking which seems to be pointless in my eyes. Hence I opted for not including that and to only use one Timing instance per Sensor/Behavior instance as there seems to be no real trade of regarding the actual usefulness.