### PR TITLE
[ci-skip] Fix description of add-plugin command line option

### DIFF
--- a/patches/server/0687-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0687-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0811c2804820b1dc0c49a354216b8d4eabc451c0..0e11c5f2e11a0d75740c8810421bd935691f47b5 100644
+index b483289bf016317d6ccb8baad2504e9091d72c5b..21f64f879ab71fd40d3f5bb1d0ded4e5802ae373 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -385,8 +385,13 @@ public final class CraftServer implements Server {
@@ -46,7 +46,7 @@ index 0811c2804820b1dc0c49a354216b8d4eabc451c0..0e11c5f2e11a0d75740c8810421bd935
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index daa881823f9a0757211e4fece8ebd9225f8b41bb..32f82c60b680180b256edff127e5a6ded42fccf4 100644
+index daa881823f9a0757211e4fece8ebd9225f8b41bb..d92a7e8e4f5a6e794ae4563f17a817ace36da73e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -153,6 +153,12 @@ public class Main {
@@ -54,11 +54,11 @@ index daa881823f9a0757211e4fece8ebd9225f8b41bb..32f82c60b680180b256edff127e5a6de
                          .defaultsTo("Unknown Server")
                          .describedAs("Name");
 +
-+                acceptsAll(asList("add-plugin", "add-extra-plugin-jar"))
++                acceptsAll(asList("add-plugin", "add-extra-plugin-jar"), "Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.")
 +                        .withRequiredArg()
 +                        .ofType(File.class)
 +                        .defaultsTo(new File[] {})
-+                        .describedAs("Specify paths to extra plugin jars to be loaded in addition to those in the plugins folder. This argument can be specified multiple times, once for each extra plugin jar path.");
++                        .describedAs("Jar file");
                  // Paper end
              }
          };


### PR DESCRIPTION
Somehow I managed to put the description string in the wrong place when adding this argument...