### PR TITLE
Skip loading chunk in check if chunk is loaded

### DIFF
--- a/patches/server/0064-Add-World-Util-Methods.patch
+++ b/patches/server/0064-Add-World-Util-Methods.patch
@@ -6,20 +6,24 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9b98eddb8238e36b17989d6f685ddc950151a7f8..b8a816a2f58c1ab51271f027f500d08bc3a63503 100644
+index 194041b9c2bb6994ad9006d7c4c2610dfaddc508..d7b321ee5f8a1037ad430ddf7cadba917ce5a29e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -202,7 +202,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -202,8 +202,10 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      public final LevelStorageSource.LevelStorageAccess convertable;
      public final UUID uuid;
  
 -    public LevelChunk getChunkIfLoaded(int x, int z) {
-+    @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
-         return this.chunkSource.getChunk(x, z, false);
+-        return this.chunkSource.getChunk(x, z, false);
++    // Paper start - this was added in world too but keeping here for NMS ABI
++    @Override public LevelChunk getChunkIfLoaded(int x, int z) {
++        return super.getChunkIfLoaded(x, z);
++        // Paper end
      }
  
+     // Add env and gen to constructor, WorldData -> WorldDataServer
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 76182fd83d6dcd2359dd8d8a75e7e15304dc5d0f..9f69dfcb5d9cbbcd01dd2e5e02437967da7a4a17 100644
+index 547f18f9713dc0fb0346ca5c412129eac6f0b444..37818b25440eab99eb6d5e8a13f0202bf27af13e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -309,11 +309,27 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -22,10 +22,10 @@ index 3c78d3234054ce2dc46ef77decb6adb0cbd10620..cd64fb9d0c6d123e1c86cb33f12cd9ce
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6aab4ba5da83f523632a0a39d45a0bcb2405f0cc..69b52097eede1a5c408aa7f34442e42255386436 100644
+index d7b321ee5f8a1037ad430ddf7cadba917ce5a29e..d97e87c25cca04f081fff5997abb6db830396ef6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -596,7 +596,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -598,7 +598,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              blockposition = this.findLightningTargetAround(this.getBlockRandomPos(j, 0, k, 15));
              if (this.isRainingAt(blockposition)) {
                  DifficultyInstance difficultydamagescaler = this.getCurrentDifficultyAt(blockposition);

--- a/patches/server/0070-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0070-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -18,7 +18,7 @@ index 6826d1e4b7f1595f17a118e8f146bb19f3ef9256..e250db8035b2d53e724a47da6dc6118d
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0d6a67fdd83de0c62f6e2a90d0107cbebbac3a37..a846f7136d29bd1d8f8ed30d79fa8936fe386618 100644
+index d97e87c25cca04f081fff5997abb6db830396ef6..084683a320872870389f9bda4fbdcf539759ea0a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -201,6 +201,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -27,10 +27,10 @@ index 0d6a67fdd83de0c62f6e2a90d0107cbebbac3a37..a846f7136d29bd1d8f8ed30d79fa8936
      public final UUID uuid;
 +    public boolean hasPhysicsEvent = true; // Paper
  
-     @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
-         return this.chunkSource.getChunk(x, z, false);
+     // Paper start - this was added in world too but keeping here for NMS ABI
+     @Override public LevelChunk getChunkIfLoaded(int x, int z) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index bbe2d5eab844880f2fde674aa1c78d60d6152231..285389edd01b1b36dfa8363e7ceea3903229a618 100644
+index a979a53e8bf8d0198f409a367914fcfc408b57f1..bb041677139e0347d3ea429c2fd60a868d4f97da 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -470,7 +470,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0071-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/server/0071-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 005d8d32ad3a7129688ba919e0ab6a5ee8b711c8..3129332c9e520c5f774b846e81f52103cbf97b8e 100644
+index 084683a320872870389f9bda4fbdcf539759ea0a..0a862334a73fa535d4b11f3f2b041dda9bfe0c80 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1904,6 +1904,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1906,6 +1906,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
                  entity.setOrigin(entity.getOriginVector().toLocation(getWorld()));
              }
              // Paper end
@@ -16,7 +16,7 @@ index 005d8d32ad3a7129688ba919e0ab6a5ee8b711c8..3129332c9e520c5f774b846e81f52103
          }
  
          public void onTrackingEnd(Entity entity) {
-@@ -1968,6 +1969,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1970,6 +1971,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              }
  
              entity.valid = false; // CraftBukkit

--- a/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -13,10 +13,10 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3129332c9e520c5f774b846e81f52103cbf97b8e..8a43b7ebf0195198f11b26a18d6f57bf97885889 100644
+index 0a862334a73fa535d4b11f3f2b041dda9bfe0c80..cfd6d9852c8c98877f2b7f03b55252909e4eb8ba 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1924,6 +1924,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1926,6 +1926,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
                              {
                                  if ( iter.next().player == entity )
                                  {

--- a/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 766edb072a38a4b5613e0f26f5070d3fcab835f4..c98c7dabc2274fe758cafb334ec4c4d3952b85e7 100644
+index cfd6d9852c8c98877f2b7f03b55252909e4eb8ba..cc3f501b9a12c560cc20967e1347830370597f7c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1281,12 +1281,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1283,12 +1283,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      }
  
      public <T extends ParticleOptions> int sendParticles(ServerPlayer sender, T t0, double d0, double d1, double d2, int i, double d3, double d4, double d5, double d6, boolean force) {

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -7,10 +7,10 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9fb3998a9fc8ce6ffd50e800dccc331df5ab86df..4d816f0b2225677b31f39730ac13dcea28f55520 100644
+index cc3f501b9a12c560cc20967e1347830370597f7c..24364509623d964a2dacec30570026068441909a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1055,7 +1055,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1057,7 +1057,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          for (BlockEntity tileentity : chunk.getBlockEntities().values()) {
              if (tileentity instanceof net.minecraft.world.Container) {
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((net.minecraft.world.Container) tileentity).getViewers())) {
@@ -19,7 +19,7 @@ index 9fb3998a9fc8ce6ffd50e800dccc331df5ab86df..4d816f0b2225677b31f39730ac13dcea
                  }
              }
          }
-@@ -1941,7 +1941,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1943,7 +1943,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((org.bukkit.inventory.InventoryHolder) entity.getBukkitEntity()).getInventory().getViewers())) {
@@ -114,7 +114,7 @@ index f3f0229c4fbbc1c54d3472b3ee6357ff1f542a1f..f07dcd1b01780b2980e021a008e8fc50
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 9f27c6fa106a11ea56a4be2d41f8a00f2aa4961f..a68e342112002782560268350b88f617b9bf86e1 100644
+index ecbd9c6a707f6603e76d7241d6200592996c9a74..1716467eef4703d74983f71a5b770d0ded42bccc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -500,7 +500,7 @@ public abstract class PlayerList {
@@ -185,7 +185,7 @@ index c839ea0b68fbdccfb7ed667c705a3f0f347fd89c..43cee8b0b2b94d6db6303a1631731ed5
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 60b8d4f974952c131c94c0dd23e44e28135beff9..1800119160d5711b694c14e9dde175b11c06ce61 100644
+index c674ff33ebbb7e214205b3521d414a0442a46cbb..295f82fcdc42103e99bb5c0ab472388f83ac5646 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -921,7 +921,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0239-Add-hand-to-bucket-events.patch
+++ b/patches/server/0239-Add-hand-to-bucket-events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add hand to bucket events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d1c1cf5061f9294d67086b5361166e940536a8a0..e9b1d967f5e97ec9a85465e8cfbcac98020d5ecc 100644
+index 24364509623d964a2dacec30570026068441909a..067e31a2d5099b2482745f130ebaed0aea32a25e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1413,15 +1413,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1415,15 +1415,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          this.getServer().getPlayerList().broadcastAll(new ClientboundSetDefaultSpawnPositionPacket(pos, angle));
      }
  
@@ -117,7 +117,7 @@ index 24272b384b96bb98a8231fe8583f404ad0c96de5..7c3e94c6bf8337ef660473d8ed451606
                  int i = blockposition.getX();
                  int j = blockposition.getY();
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a74895271378571583e33c8d3992f2eb863b5a40..c9e6dd18193c7dc2ae76f688e6bbf9463a1149c7 100644
+index 8521e7de5c676282464991c85c58ef988a60b250..2594718cf6f180a1ce446c902def74d037e47bef 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -291,6 +291,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0244-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0244-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -29,7 +29,7 @@ index 94c5577a887ab4801dae5a1a0accd4b2f448bcc2..b794922eeccc845632f2442a3ed923f1
  
      protected void tick() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4df153a3b2cc4b6be499107a997a054abe3569d8..774f37e02feb83be3b92620aa4a0227a0c4acc93 100644
+index 067e31a2d5099b2482745f130ebaed0aea32a25e..ab0b3e43245b208eaba3002322badb20c3518b27 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -202,6 +202,9 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
@@ -40,9 +40,9 @@ index 4df153a3b2cc4b6be499107a997a054abe3569d8..774f37e02feb83be3b92620aa4a0227a
 +        return new Throwable(entity + " Added to world at " + new java.util.Date());
 +    }
  
-     @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
-         return this.chunkSource.getChunk(x, z, false);
-@@ -1018,7 +1021,28 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+     // Paper start - this was added in world too but keeping here for NMS ABI
+     @Override public LevelChunk getChunkIfLoaded(int x, int z) {
+@@ -1020,7 +1023,28 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      // CraftBukkit start
      private boolean addEntity0(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
          org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot
@@ -72,7 +72,7 @@ index 4df153a3b2cc4b6be499107a997a054abe3569d8..774f37e02feb83be3b92620aa4a0227a
              return false;
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a6ba0c7fe05aae72b98072aaa008a1346bf2704e..2138db2c7dc750cc9c2eb49b7878e4f172fb97e5 100644
+index d32b3ae17d61753f759008316aa6818cdaa1ef83..ca03f791a44cc3c44f42c705fb1715826eefa664 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -171,6 +171,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -85,7 +85,7 @@ index a6ba0c7fe05aae72b98072aaa008a1346bf2704e..2138db2c7dc750cc9c2eb49b7878e4f1
          if (this.bukkitEntity == null) {
              this.bukkitEntity = CraftEntity.getEntity(this.level.getCraftServer(), this);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index f354fe35c7fb4b869c9229b14a2cb6b00c7f0973..7bcb67df44a231d9b598a57c1b10bec18823bf74 100644
+index 2594718cf6f180a1ce446c902def74d037e47bef..c782af1ad9d2cb9de915889af39e419bf06971ed 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -141,6 +141,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -2802,11 +2802,11 @@ index 03c90069e8fca2291e66f5d99175f029530a4434..1176dd8ebd59c5bda1b74c532ca21ae3
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 70e4e10ee3f3ace590881a9284160324ad882243..ab4dba5af019b60cbb82360eae7f6008aafcd38c 100644
+index ab0b3e43245b208eaba3002322badb20c3518b27..64ecfb9ac3b2e2d869777f1012448b07bc1efdef 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -210,6 +210,79 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
-         return this.chunkSource.getChunk(x, z, false);
+@@ -212,6 +212,79 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+         // Paper end
      }
  
 +    // Paper start - Asynchronous IO
@@ -2885,7 +2885,7 @@ index 70e4e10ee3f3ace590881a9284160324ad882243..ab4dba5af019b60cbb82360eae7f6008
      // Add env and gen to constructor, WorldData -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
-@@ -281,6 +354,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -283,6 +356,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
  
          this.sleepStatus = new SleepStatus();
          this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -10,10 +10,10 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ab4dba5af019b60cbb82360eae7f6008aafcd38c..cdb19ab7e0d90dcd6885226aa2fd3a58ed53d29b 100644
+index 64ecfb9ac3b2e2d869777f1012448b07bc1efdef..97dfa0c833f92fbdc842c202a10e6b9cfc8edfce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1111,6 +1111,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1113,6 +1113,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              return true;
          }
          // Paper end
@@ -22,7 +22,7 @@ index ab4dba5af019b60cbb82360eae7f6008aafcd38c..cdb19ab7e0d90dcd6885226aa2fd3a58
              // Paper start
              if (DEBUG_ENTITIES) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f1e3ea6b023119adc69eb0b414994bc7f9f3ed4a..42b7568d1c3ce145b2816202e6f5c8ca9e904de7 100644
+index fed6dce0fe98d8742fe804f41e3aee6aeb3d309d..7038cf481934df1ddb8c1faaa23dfe3df266477b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -341,7 +341,7 @@ public abstract class PlayerList {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -23,7 +23,7 @@ index 13e730b18c346934c061fb570048623ad66e7344..090958a30ce20ff01ae77d4cd821a167
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 15928916ec8001ec57068b945300517d60dec0b0..49c87dfc50033b22f67f45ad1d67003864ce5ecb 100644
+index e6d3275a1ec8a9a6cfe7a39b8920caeb28bb35c2..21dab3d2f511e05db92aaebcdde3cfe7f473e4bf 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -775,35 +775,36 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -85,7 +85,7 @@ index 15928916ec8001ec57068b945300517d60dec0b0..49c87dfc50033b22f67f45ad1d670038
          // CraftBukkit start
          // this.updateSpawnFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 03fde7df39384436e31bf57476feb680a0849030..54c2f27208a826b04dba5cb3dd4873987731ef54 100644
+index 97dfa0c833f92fbdc842c202a10e6b9cfc8edfce..60d8883de276cfed3f40eeac4cbdcbf9f0b735af 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -61,6 +61,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
@@ -96,7 +96,7 @@ index 03fde7df39384436e31bf57476feb680a0849030..54c2f27208a826b04dba5cb3dd487398
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.ServerScoreboard;
  import net.minecraft.server.level.progress.ChunkProgressListener;
-@@ -1504,12 +1505,84 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1506,12 +1507,84 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          return ((MapIndex) this.getServer().overworld().getDataStorage().computeIfAbsent(MapIndex::load, MapIndex::new, "idcounts")).getFreeAuxValueForMap();
      }
  

--- a/patches/server/0358-Optimise-IEntityAccess-getPlayerByUUID.patch
+++ b/patches/server/0358-Optimise-IEntityAccess-getPlayerByUUID.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise IEntityAccess#getPlayerByUUID
 Use the world entity map instead of iterating over all players
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 708bc5689e68d9e3e415e9d2dc1082cf85ee8b58..95fed7617c2b37886e912e35e7ad446c39e791ab 100644
+index 60d8883de276cfed3f40eeac4cbdcbf9f0b735af..ecdbb0cfd62a37f77b4af075226982dabb0c4f76 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -284,6 +284,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -286,6 +286,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      public final com.destroystokyo.paper.io.chunk.ChunkTaskManager asyncChunkTaskManager;
      // Paper end
  

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2aa631f55 100644
+index ecdbb0cfd62a37f77b4af075226982dabb0c4f76..dc3af5670fdf9b9c29a9ec50384f3d1f45744fb5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -41,7 +41,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
  import net.minecraft.world.level.entity.EntityPersistentStorage;
  import net.minecraft.world.level.entity.EntityTickList;
  import net.minecraft.world.level.entity.EntityTypeTest;
-@@ -891,17 +888,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -893,17 +890,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          ++TimingHistory.entityTicks; // Paper - timings
          // Spigot start
          co.aikar.timings.Timing timer; // Paper
@@ -63,7 +63,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
          try {
          // Paper end - timings
          entity.setOldPosAndRot();
-@@ -912,9 +909,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -914,9 +911,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              return Registry.ENTITY_TYPE.getKey(entity.getType()).toString();
          });
          gameprofilerfiller.incrementCounter("tickNonPassenger");
@@ -77,7 +77,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
          Iterator iterator = entity.getPassengers().iterator();
  
          while (iterator.hasNext()) {
-@@ -923,13 +924,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -925,13 +926,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              this.tickPassenger(entity, entity1);
          }
  
@@ -97,7 +97,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
                  passenger.setOldPosAndRot();
                  ++passenger.tickCount;
                  ProfilerFiller gameprofilerfiller = this.getProfiler();
-@@ -938,8 +944,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -940,8 +946,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
                      return Registry.ENTITY_TYPE.getKey(passenger.getType()).toString();
                  });
                  gameprofilerfiller.incrementCounter("tickPassenger");
@@ -115,7 +115,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
                  gameprofilerfiller.pop();
                  Iterator iterator = passenger.getPassengers().iterator();
  
-@@ -949,6 +964,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -951,6 +966,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
                      this.tickPassenger(passenger, entity2);
                  }
  
@@ -124,7 +124,7 @@ index 95fed7617c2b37886e912e35e7ad446c39e791ab..22db34272c6635438d11f525fb4f08e2
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5bd250a9f9edb0391aaf935d51334bdb0a4e8575..0a3b0919f3de645de6d63d67a2e6bf64d1d3048c 100644
+index 16c1b0135cbd466c7e404e2f3ee638c511dc8e37..b108ba1c99423011f75881bf3d7440c501084c28 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -326,6 +326,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -158,7 +158,7 @@ index 5bd250a9f9edb0391aaf935d51334bdb0a4e8575..0a3b0919f3de645de6d63d67a2e6bf64
              movement = this.maybeBackOffFromEdge(movement, movementType);
              Vec3 vec3d1 = this.collide(movement);
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 5595150b0da580fce4d5d23993d77314e225ad58..9306340721e2aae4dfb2025e47b4624a8e351420 100644
+index 5cd549d6dcf32a74d01e1e24f8f72123e29b0c38..108c5871c2171f22a8e0db8c00bfcaa4438b6137 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -198,6 +198,19 @@ public abstract class Mob extends LivingEntity {
@@ -262,7 +262,7 @@ index 27ea9c10b7f66c2133b0829c0b1c37143dd80b56..c28ade67f6a59146064a57bf016a6461
                          }
                      }
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 555cf6d39108d40998adbbaf6b09dd9973f5f2e3..426fa33c9e5ddf2de5435859ee4a5f352313869c 100644
+index 5d50557ecce9fe4736be7e24fb5be11b57f2cc0e..cad80978510b50a3061cc5c898d6e7cb2b62b3b0 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -227,17 +227,29 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
@@ -317,7 +317,7 @@ index 555cf6d39108d40998adbbaf6b09dd9973f5f2e3..426fa33c9e5ddf2de5435859ee4a5f35
          super.customServerAiStep();
      }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 76ef2337d87b6ae3f190d4bd5410b04af917a507..fff1d38e07439ab1bc83aa9e7153b3666a351129 100644
+index c968c9482cb3e0dab74a316567a5faa17c0f66fd..d59126240c568614cb43ea42ad3e2c9eb8701071 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -154,6 +154,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1104,10 +1104,10 @@ index badac53382c776eba3efccfda42283912d07b99a..06e581bc0c0ea4e8141f7b9610cc5a7e
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c0a897aa1fe275f308cf594f0c875096850f5271..d6e7b8ee31372c2c92da8ab4f5915f95c9382ae3 100644
+index dc3af5670fdf9b9c29a9ec50384f3d1f45744fb5..2caed0954099c9b11e2c1223cb814bf28dba209b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -292,7 +292,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -294,7 +294,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      // Add env and gen to constructor, WorldData -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error

--- a/patches/server/0376-Add-debug-for-sync-chunk-loads.patch
+++ b/patches/server/0376-Add-debug-for-sync-chunk-loads.patch
@@ -10,7 +10,7 @@ chunks, however it must be enabled by setting the startup flag
 To get a debug log for sync loads, the command is /paper syncloadinfo
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index 7b5afc5d34b78e6404c1a5c6bb823d9589471f13..de45163023f436d386e90e6ded5e6105ba3ecf35 100644
+index c6254f39f98b821f75a21c0ecea457f73247385f..42583cc3a6e2631614a4b9c303b1cfa4c9ae92c6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -1,11 +1,17 @@
@@ -279,7 +279,7 @@ index 0000000000000000000000000000000000000000..524f33371b9de1d4dd6972fe59ffbe18
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index c849ded5448112289a3c37f05dc49fadbf619f81..77f88e081991e85d03540e30b9def5dac9ad59be 100644
+index 2461110293afd84c6a26891c3a5b8071d68ce8e6..d2d0350bd16cd818be328afcc2c07f4381dac169 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -483,6 +483,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -291,10 +291,10 @@ index c849ded5448112289a3c37f05dc49fadbf619f81..77f88e081991e85d03540e30b9def5da
              chunkproviderserver_a.managedBlock(completablefuture::isDone);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.popChunkWait(); // Paper - async chunk debug
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fcf5c7b28e927db977ad5b851edaf68e59de8d5b..87a18dcbfbb55410f04e99e84958f22f21193066 100644
+index 2caed0954099c9b11e2c1223cb814bf28dba209b..e971672685ea7ddb76aaf8cb54b336f54ce42e0e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -280,6 +280,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -282,6 +282,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      };
      public final com.destroystokyo.paper.io.chunk.ChunkTaskManager asyncChunkTaskManager;
      // Paper end

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -941,10 +941,10 @@ index d2d0350bd16cd818be328afcc2c07f4381dac169..0d948d4d247a12a49fae99e68874a9e6
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, boolean flag, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkstatusupdatelistener, Supplier<DimensionDataStorage> supplier) {
          this.level = world;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 29e41754cca805c281ee48c35b149ebb58c3f2f6..755b413ff2c28f9811e4b4c44461beca2ebd5273 100644
+index e971672685ea7ddb76aaf8cb54b336f54ce42e0e..9b6275c41530b6a525cb57ff3318425169155b37 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -295,6 +295,15 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -297,6 +297,15 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      }
      // Paper end
  
@@ -960,7 +960,7 @@ index 29e41754cca805c281ee48c35b149ebb58c3f2f6..755b413ff2c28f9811e4b4c44461beca
      // Add env and gen to constructor, WorldData -> WorldDataServer
      public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
-@@ -311,13 +320,19 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -313,13 +322,19 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          DefaultedRegistry registryblocks = Registry.BLOCK;
  
          Objects.requireNonNull(registryblocks);
@@ -981,7 +981,7 @@ index 29e41754cca805c281ee48c35b149ebb58c3f2f6..755b413ff2c28f9811e4b4c44461beca
          this.navigatingMobs = new ObjectOpenHashSet();
          this.blockEvents = new ObjectLinkedOpenHashSet();
          this.dragonParts = new Int2ObjectOpenHashMap();
-@@ -638,7 +653,9 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -640,7 +655,9 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          if (this.tickTime) {
              long i = this.levelData.getGameTime() + 1L;
  

--- a/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -26,10 +26,10 @@ index 1d22a2179fcd3b613bea609770b551c7702a581e..db7eb46f3b77835d1b5b67674d2e66fb
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index cafd2299ccc0a803f6c7e131c49644b6bdf508a6..a3b7bcdda3465e4ae8a9cdb8169673f2c7dbce5d 100644
+index 9b6275c41530b6a525cb57ff3318425169155b37..7b39b8a9df1d90fb4cb94fd39da81f8665341281 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2100,7 +2100,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2102,7 +2102,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
  
          public void onTrackingStart(Entity entity) {
              org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
@@ -38,7 +38,7 @@ index cafd2299ccc0a803f6c7e131c49644b6bdf508a6..a3b7bcdda3465e4ae8a9cdb8169673f2
              if (entity instanceof ServerPlayer) {
                  ServerLevel.this.players.add((ServerPlayer) entity);
                  ServerLevel.this.updateSleepingPlayerList();
-@@ -2122,6 +2122,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2124,6 +2124,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              }
  
              entity.valid = true; // CraftBukkit

--- a/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -56,7 +56,7 @@ index da93d38fe63035e4ff198ada84a4431f52d97c01..ddbc8cb712c50038922eded75dd6ca85
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ac53eb7bc69e1566d20df3b7cba33034c344952a..f1c08a811c05a29eda4686c1143cc27fd91d7311 100644
+index 714addefd1ac45fe7048aeb45c0d1484c2adb640..efc6760e3ff4f062f64150ce0f3493da00a37928 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1112,6 +1112,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -147,7 +147,7 @@ index ac53eb7bc69e1566d20df3b7cba33034c344952a..f1c08a811c05a29eda4686c1143cc27f
                  // Spigot Start
                  CrashReport crashreport;
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 6d999e0de0497114e46445981c64ee70f882c782..0c76218134bdf8d80e3680227934ff5f70c26df2 100644
+index 70c2a8667110e4d350d36bef2822b5767e6fd82b..7bfdbf82d9f1bd87087d3473a93839aafa3b3298 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -704,6 +704,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -226,10 +226,10 @@ index 6d999e0de0497114e46445981c64ee70f882c782..0c76218134bdf8d80e3680227934ff5f
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          public boolean pollTask() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fca0453ee83f7592e7ad7c572e238202247a93a1..16ff687d16bef0a485aacbcd80a3bcfa1bb08224 100644
+index 7b39b8a9df1d90fb4cb94fd39da81f8665341281..dc7bbebbb97d900c69ea06ffbcb5c3053e9e0c12 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -587,6 +587,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -589,6 +589,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          }
          timings.scheduledBlocks.stopTiming(); // Paper
  
@@ -237,7 +237,7 @@ index fca0453ee83f7592e7ad7c572e238202247a93a1..16ff687d16bef0a485aacbcd80a3bcfa
          gameprofilerfiller.popPush("raid");
          this.timings.raids.startTiming(); // Paper - timings
          this.raids.tick();
-@@ -595,6 +596,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -597,6 +598,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          timings.doSounds.startTiming(); // Spigot
          this.runBlockEvents();
          timings.doSounds.stopTiming(); // Spigot
@@ -245,7 +245,7 @@ index fca0453ee83f7592e7ad7c572e238202247a93a1..16ff687d16bef0a485aacbcd80a3bcfa
          this.handlingTick = false;
          gameprofilerfiller.pop();
          boolean flag3 = true || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players
-@@ -641,10 +643,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -643,10 +645,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              timings.entityTick.stopTiming(); // Spigot
              timings.tickEntities.stopTiming(); // Spigot
              gameprofilerfiller.pop();

--- a/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -8,10 +8,10 @@ so inline where possible, and avoid the abstraction of the
 Either class.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7e1062df9c2fd2d9be82fb84b7b93eb6fa207e57..3327fb07840e6dc6d2249b05a403f52ccd531b0f 100644
+index dc7bbebbb97d900c69ea06ffbcb5c3053e9e0c12..2ee2f5191a6bd3ee23cbb1f65e35255e04b75031 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2073,15 +2073,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2075,15 +2075,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      public boolean isPositionTickingWithEntitiesLoaded(BlockPos blockposition) {
          long i = ChunkPos.asLong(blockposition);
  
@@ -47,7 +47,7 @@ index 439f82a48e6f6ce7b4773505ced32324cacb302d..2a99aa989ac5c19d99bb3cbc0934425e
  
      public static int getX(long pos) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 624fd443d2cc71605cfff996140b00f37c8d8841..e94b5a7fe47831e2c3e0935e316737a2422e4250 100644
+index 8314400d4305d85f0ab68ab88ed26041742e28aa..79e733b3ea2e6589d60f3b322244479d2b3b9f86 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -326,6 +326,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A

--- a/patches/server/0456-incremental-chunk-saving.patch
+++ b/patches/server/0456-incremental-chunk-saving.patch
@@ -260,10 +260,10 @@ index 147f6fd5174a2c489dfb7ea2ce2d2dc7dacfb89d..6c565751c36daa0084196dce5d2f82df
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5fbe0f6b152d92f4415361709e7394c114104812..74efffabe349a5272694c3af9bd2c36221779f73 100644
+index 2ee2f5191a6bd3ee23cbb1f65e35255e04b75031..ce82e3beccc38783cb72bbf4ef93516d0495b973 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1003,6 +1003,37 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1005,6 +1005,37 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          return !this.server.isUnderSpawnProtection(this, pos, player) && this.getWorldBorder().isWithinBounds(pos);
      }
  

--- a/patches/server/0509-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0509-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4b8748d955fce10536847a44e22d53d6d491ac1d..82ec9d3a7844dd45433d07c3b48050b5de9b7377 100644
+index ce82e3beccc38783cb72bbf4ef93516d0495b973..0182fcefa1ca20efc854599e9faf93e543474282 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1660,6 +1660,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1662,6 +1662,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          //ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(new BlockPosition(this.worldData.a(), 0, this.worldData.c()));
  
          this.levelData.setSpawn(pos, angle);

--- a/patches/server/0526-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0526-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 82ec9d3a7844dd45433d07c3b48050b5de9b7377..aae3c8d5cbbdc6d736257c7454d97ff985ae4187 100644
+index 0182fcefa1ca20efc854599e9faf93e543474282..6e450a041e10318373aa95d75b6c5af68ff899cd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1205,6 +1205,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1207,6 +1207,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getName(entity.getEntityType())); // CraftBukkit
              return false;
          } else {
@@ -24,7 +24,7 @@ index 82ec9d3a7844dd45433d07c3b48050b5de9b7377..aae3c8d5cbbdc6d736257c7454d97ff9
                  return false;
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index c21c5134308a2a83fb50bfe37f05d19c8e96ca7c..c3cdc5a7ae90b7d2dd5676d66086e1f0c5b23d0d 100644
+index 51d7c59e6b3f4ca84905b186d9b173ec2c36a0b1..55d0b15a7ea1576af8045e84fe47eff696bb369f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -7,6 +7,7 @@ import net.minecraft.world.InteractionResult;

--- a/patches/server/0598-Remove-stale-POIs.patch
+++ b/patches/server/0598-Remove-stale-POIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stale POIs
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index aae3c8d5cbbdc6d736257c7454d97ff985ae4187..a194558e5dc0feb57681084240822a9d4b6b9bab 100644
+index 6e450a041e10318373aa95d75b6c5af68ff899cd..720c4c01a6f1b7db1eb1a59f0a39843ab73623ff 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1742,6 +1742,11 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1744,6 +1744,11 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              });
              optional1.ifPresent((villageplacetype) -> {
                  this.getServer().execute(() -> {

--- a/patches/server/0619-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0619-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -20,10 +20,10 @@ index 7fc5bf095afa6d5881285b89091d2ff48ffb69f0..0eba516110b82d917c3374a9fe5bbf33
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index e418bcda3d6b5f219fc8a6431b449ef4de9a8a4e..ecfa6089be3f81704a88877357e3aa0cf45ee332 100644
+index 17c227379dabaac32f218ba313cca4ca462a7ad4..50f2aafad7672fd78567d551d0d979599229028f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1339,6 +1339,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1341,6 +1341,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
      @Override
      public void sendBlockUpdated(BlockPos pos, BlockState oldState, BlockState newState, int flags) {
          this.getChunkSource().blockChanged(pos);
@@ -31,7 +31,7 @@ index e418bcda3d6b5f219fc8a6431b449ef4de9a8a4e..ecfa6089be3f81704a88877357e3aa0c
          VoxelShape voxelshape = oldState.getCollisionShape(this, pos);
          VoxelShape voxelshape1 = newState.getCollisionShape(this, pos);
  
-@@ -1366,6 +1367,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1368,6 +1369,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
              }
  
          }

--- a/patches/server/0694-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0694-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ecfa6089be3f81704a88877357e3aa0cf45ee332..746124647657d0ccfc9d6dc3db3657c05327d6ac 100644
+index 50f2aafad7672fd78567d551d0d979599229028f..b2e72cfcad0e6086502d37ee64aeaa29a8a26a0e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -425,8 +425,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -427,8 +427,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
          this.serverLevelData.setClearWeatherTime(clearDuration);
          this.serverLevelData.setRainTime(rainDuration);
          this.serverLevelData.setThunderTime(rainDuration);
@@ -19,7 +19,7 @@ index ecfa6089be3f81704a88877357e3aa0cf45ee332..746124647657d0ccfc9d6dc3db3657c0
      }
  
      @Override
-@@ -489,8 +489,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -491,8 +491,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
                  this.serverLevelData.setThunderTime(j);
                  this.serverLevelData.setRainTime(k);
                  this.serverLevelData.setClearWeatherTime(i);
@@ -30,7 +30,7 @@ index ecfa6089be3f81704a88877357e3aa0cf45ee332..746124647657d0ccfc9d6dc3db3657c0
              }
  
              this.oThunderLevel = this.thunderLevel;
-@@ -873,14 +873,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -875,14 +875,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
  
      private void stopWeather() {
          // CraftBukkit start


### PR DESCRIPTION
I've looked at all the uses of this method, none of them expect the
method to actually load the chunk off disk if it's not loaded. This is a
solid improvement as it reduces chunk loads from entities, xray, and
even fixes the "seed-based-feature-search-loads-chunks" configuration
option which was broken before.