### PR TITLE
Fix incorrect variable usage in per-player mob spawning patch

### DIFF
--- a/build-data/mappings-patch.tiny
+++ b/build-data/mappings-patch.tiny
@@ -25,6 +25,10 @@ c	net/minecraft/world/entity/projectile/EntityTippedArrow	net/minecraft/world/en
 c	net/minecraft/server/level/WorldServer	net/minecraft/server/level/ServerLevel
 	m	(Lnet/minecraft/server/level/WorldServer;Lnet/minecraft/world/entity/Entity;)V	a	makeObsidianPlatform
 
+# CraftBukkit adds limit param
+c	net/minecraft/world/level/SpawnerCreature$d	net/minecraft/world/level/NaturalSpawner$SpawnState
+	m	(Lnet/minecraft/world/entity/EnumCreatureType;I)Z	a	canSpawnForCategory
+
 # missed mapping?
 c	net/minecraft/world/level/block/MultifaceBlock	net/minecraft/world/level/block/MultifaceBlock
 	m	(Lnet/minecraft/world/level/block/state/IBlockData;Lnet/minecraft/world/level/IBlockAccess;Lnet/minecraft/core/BlockPosition;Lnet/minecraft/core/EnumDirection;)Lnet/minecraft/world/level/block/state/IBlockData;	c	getStateForPlacement

--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -545,7 +545,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index dde0d2be31e686b4d5324affd03743345d8af2ed..7e62a86e4ab376c47340d96620f6b1df19fa95ca 100644
+index 13dbeae83158d174032e3de1c447bd32555a6dfa..f921bc3a0e2b448ae0f9cccc608fc9d735d7936a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -145,6 +145,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -582,8 +582,8 @@ index dde0d2be31e686b4d5324affd03743345d8af2ed..7e62a86e4ab376c47340d96620f6b1df
 +        }
 +    }
 +
-+    public int getMobCountNear(ServerPlayer entityPlayer, net.minecraft.world.entity.MobCategory enumCreatureType) {
-+        return entityPlayer.mobCounts[enumCreatureType.ordinal()];
++    public int getMobCountNear(ServerPlayer entityPlayer, net.minecraft.world.entity.MobCategory mobCategory) {
++        return entityPlayer.mobCounts[mobCategory.ordinal()];
 +    }
 +    // Paper end
 +
@@ -591,7 +591,7 @@ index dde0d2be31e686b4d5324affd03743345d8af2ed..7e62a86e4ab376c47340d96620f6b1df
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 734b204d53a4b9e9b1112efe3a50b53cf1aa9f47..26f99965e63d36ce4b8cd0482ae21b0c37994caa 100644
+index ddaa4dfa4611e8d659e9d0211873b6f503e3d230..1ed75e33d566e58314f733d02ff89d5f174a606a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -754,7 +754,22 @@ public class ServerChunkCache extends ChunkSource {
@@ -619,36 +619,22 @@ index 734b204d53a4b9e9b1112efe3a50b53cf1aa9f47..26f99965e63d36ce4b8cd0482ae21b0c
  
              this.lastSpawnState = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6ecf85579acb186f076f258368051a4ae09c3354..14f88e575f46d81175eaa04b3e7294990e749a14 100644
+index cbc8a0c6ad214cfea8ac1476c1eda074f3128aaf..4ea2203d1acbaa60839acb9cdf48fbcc73e4eff0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -90,12 +90,7 @@ import net.minecraft.world.damagesource.DamageSource;
- import net.minecraft.world.damagesource.EntityDamageSource;
- import net.minecraft.world.effect.MobEffectInstance;
- import net.minecraft.world.effect.MobEffects;
--import net.minecraft.world.entity.Entity;
--import net.minecraft.world.entity.EntitySelector;
--import net.minecraft.world.entity.HumanoidArm;
--import net.minecraft.world.entity.LivingEntity;
--import net.minecraft.world.entity.Mob;
--import net.minecraft.world.entity.NeutralMob;
-+import net.minecraft.world.entity.*;
- import net.minecraft.world.entity.animal.horse.AbstractHorse;
- import net.minecraft.world.entity.item.ItemEntity;
- import net.minecraft.world.entity.monster.Monster;
-@@ -223,6 +218,11 @@ public class ServerPlayer extends Player {
+@@ -223,6 +223,11 @@ public class ServerPlayer extends Player {
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
      // Paper end
 +    // Paper start - mob spawning rework
-+    public static final int ENUMCREATURETYPE_TOTAL_ENUMS = MobCategory.values().length;
-+    public final int[] mobCounts = new int[ENUMCREATURETYPE_TOTAL_ENUMS]; // Paper
++    public static final int MOBCATEGORY_TOTAL_ENUMS = net.minecraft.world.entity.MobCategory.values().length;
++    public final int[] mobCounts = new int[MOBCATEGORY_TOTAL_ENUMS]; // Paper
 +    public final com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleMobDistanceMap;
 +    // Paper end
  
      // CraftBukkit start
      public String displayName;
-@@ -317,6 +317,7 @@ public class ServerPlayer extends Player {
+@@ -317,6 +322,7 @@ public class ServerPlayer extends Player {
          this.adventure$displayName = net.kyori.adventure.text.Component.text(this.getScoreboardName()); // Paper
          this.bukkitPickUpLoot = true;
          this.maxHealthCache = this.getMaxHealth();
@@ -657,7 +643,7 @@ index 6ecf85579acb186f076f258368051a4ae09c3354..14f88e575f46d81175eaa04b3e729499
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 19d0ed5ff8569b0280117750f9ce05095afd9f70..55b937f802ee7066cb13b9a497932038b2905ff0 100644
+index 0211b572dc46b3c4fc098f0ef31843a401cd3613..31fbcf6a35b902ce80c0a5a23dabb8ec3d8cbdfc 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -17,6 +17,7 @@ import net.minecraft.core.Registry;
@@ -697,7 +683,7 @@ index 19d0ed5ff8569b0280117750f9ce05095afd9f70..55b937f802ee7066cb13b9a497932038
                  continue;
              }
  
--            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (rareSpawn || !enumcreaturetype.isPersistent()) && info.a(enumcreaturetype, limit)) {
+-            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (rareSpawn || !enumcreaturetype.isPersistent()) && info.canSpawnForCategory(enumcreaturetype, limit)) {
 +            // Paper start - only allow spawns upto the limit per chunk and update count afterwards
 +            int currEntityCount = info.mobCategoryCounts.getInt(enumcreaturetype);
 +            int k1 = limit * info.getSpawnableChunkCount() / NaturalSpawner.MAGIC_NUMBER;
@@ -713,7 +699,7 @@ index 19d0ed5ff8569b0280117750f9ce05095afd9f70..55b937f802ee7066cb13b9a497932038
 +            // Paper end
 +
 +            // Paper start - per player mob spawning
-+            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (spawnAnimals || !enumcreaturetype.isPersistent())  && info.a(enumcreaturetype, limit) && difference > 0) {
++            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (rareSpawn || !enumcreaturetype.isPersistent()) && info.canSpawnForCategory(enumcreaturetype, limit) && difference > 0) {
                  // CraftBukkit end
                  Objects.requireNonNull(info);
                  NaturalSpawner.SpawnPredicate spawnercreature_c = info::canSpawn;

--- a/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -36,10 +36,10 @@ index 9dc8a9e49cac89e236d9fa0c053b70bf10ed6f6e..2d038185846ae34bc301ab93d881022a
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 14f88e575f46d81175eaa04b3e7294990e749a14..f758a85306b9df817e60577b7ffcf777a4c82ee8 100644
+index 4ea2203d1acbaa60839acb9cdf48fbcc73e4eff0..0f0b8ea55c4917e5ee8698eb19970af876b65978 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -214,6 +214,7 @@ public class ServerPlayer extends Player {
+@@ -219,6 +219,7 @@ public class ServerPlayer extends Player {
      public boolean wonGame;
      private int containerUpdateDelay; // Paper
      public long loginTime; // Paper
@@ -48,7 +48,7 @@ index 14f88e575f46d81175eaa04b3e7294990e749a14..f758a85306b9df817e60577b7ffcf777
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/PatrolSpawner.java b/src/main/java/net/minecraft/world/level/levelgen/PatrolSpawner.java
-index 744b58d59a5f34ed3bd6f2d4a0f876acfa6a7135..4594252a89d5f8abe2b0c43507758c5cbd2a4744 100644
+index 744b58d59a5f34ed3bd6f2d4a0f876acfa6a7135..a3bb1d83e413a1f31b9ece4291e9ef11b3a70f0c 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/PatrolSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/PatrolSpawner.java
 @@ -4,11 +4,12 @@ import java.util.Random;

--- a/patches/server/0394-Don-t-tick-dead-players.patch
+++ b/patches/server/0394-Don-t-tick-dead-players.patch
@@ -7,10 +7,10 @@ Causes sync chunk loads and who knows what all else.
 This is safe because Spectators are skipped in unloaded chunks too in vanilla.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f758a85306b9df817e60577b7ffcf777a4c82ee8..ff965e67ba260a7a8e94514f8eca745f81c200b2 100644
+index 0f0b8ea55c4917e5ee8698eb19970af876b65978..572b0e5911d8a7b0f3dea07301241696958d53fe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -638,7 +638,7 @@ public class ServerPlayer extends Player {
+@@ -643,7 +643,7 @@ public class ServerPlayer extends Player {
  
      public void doTick() {
          try {

--- a/patches/server/0398-Don-t-move-existing-players-to-world-spawn.patch
+++ b/patches/server/0398-Don-t-move-existing-players-to-world-spawn.patch
@@ -10,10 +10,10 @@ larger than the keep loaded range.
 By skipping this, we avoid potential for a large spike on server start.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b4e273363dcdafef1eef76a313c08cf707991603..9dc42d44aa37985374a35c716a867a4c5ddbc1df 100644
+index 572b0e5911d8a7b0f3dea07301241696958d53fe..bb69775a9c96b064be24fe740b3eaa2c916a6760 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -309,7 +309,7 @@ public class ServerPlayer extends Player {
+@@ -314,7 +314,7 @@ public class ServerPlayer extends Player {
          this.stats = server.getPlayerList().getStatisticManager(this);
          this.advancements = server.getPlayerList().getPlayerAdvancements(this);
          this.maxUpStep = 1.0F;
@@ -22,7 +22,7 @@ index b4e273363dcdafef1eef76a313c08cf707991603..9dc42d44aa37985374a35c716a867a4c
  
          this.cachedSingleHashSet = new com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
  
-@@ -528,7 +528,7 @@ public class ServerPlayer extends Player {
+@@ -533,7 +533,7 @@ public class ServerPlayer extends Player {
                  position = Vec3.atCenterOf(((ServerLevel) world).getSharedSpawnPos());
              }
              this.level = world;
@@ -32,7 +32,7 @@ index b4e273363dcdafef1eef76a313c08cf707991603..9dc42d44aa37985374a35c716a867a4c
          this.gameMode.setLevel((ServerLevel) world);
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 22c1aacb517c8bb4a745a52437cfa687de2fe272..7928fe911f56d28ea8baaf0c15685bce4600f883 100644
+index 18dbd79b02e032e082eba3ab42c729cadee79af7..99711578f0f0281f71990a0fac0a727fdd49449f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -208,6 +208,8 @@ public abstract class PlayerList {

--- a/patches/server/0409-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0409-Prevent-opening-inventories-when-frozen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 1d585171862972fef62e903aeacb507d2383cb80..6a715a5dfc109efd2904e6392c7769cff80b7a4c 100644
+index bb69775a9c96b064be24fe740b3eaa2c916a6760..cb547b06724d5d4947580232198597deee9e480d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -609,7 +609,7 @@ public class ServerPlayer extends Player {
+@@ -614,7 +614,7 @@ public class ServerPlayer extends Player {
              containerUpdateDelay = level.paperConfig.containerUpdateTickRate;
          }
          // Paper end
@@ -17,7 +17,7 @@ index 1d585171862972fef62e903aeacb507d2383cb80..6a715a5dfc109efd2904e6392c7769cf
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1450,7 +1450,7 @@ public class ServerPlayer extends Player {
+@@ -1455,7 +1455,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0413-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0413-Implement-Player-Client-Options-API.patch
@@ -85,10 +85,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6a715a5dfc109efd2904e6392c7769cff80b7a4c..c2dd937938e120472d0a2609c1afef693a342682 100644
+index cb547b06724d5d4947580232198597deee9e480d..017a809ce774ea63104c952151786a214a00f29d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1802,6 +1802,7 @@ public class ServerPlayer extends Player {
+@@ -1807,6 +1807,7 @@ public class ServerPlayer extends Player {
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
@@ -97,7 +97,7 @@ index 6a715a5dfc109efd2904e6392c7769cff80b7a4c..c2dd937938e120472d0a2609c1afef69
          if (getMainArm() != packet.getMainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8c19f5b79fd846bea4eb5c4776eb9a4a282b24c1..a98394d9bab490c1bdb5817cb30806cab85de730 100644
+index 29d1f363348c67f158b8f4aac923e5f30d54b080..a69b9535c18597fec37ce6b50140188203d2b78d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -520,6 +520,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0417-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
+++ b/patches/server/0417-Fix-Longstanding-Broken-behavior-of-PlayerJoinEvent.patch
@@ -28,7 +28,7 @@ receives a deterministic result, and should no longer require 1 tick
 delays anymore.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 357289223b9e13eb5ab9d24f41b11f14aee0adab..17d34bb608254d134c15bd31890f8ecc09ccc100 100644
+index bebdff5bc9d2e25d8799d4a9c1b388efd00b66e0..38a23cf4e5ab8d5d4a8af5cbf4990dca219e6ce2 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1600,6 +1600,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -40,10 +40,10 @@ index 357289223b9e13eb5ab9d24f41b11f14aee0adab..17d34bb608254d134c15bd31890f8ecc
          if (!(entity instanceof EnderDragonPart)) {
              EntityType<?> entitytypes = entity.getType();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 842c35daca37b793ff2c6dbb1c442db9dac879f8..5c2a19b054558d260ddb2f7282ea3b54a4dc2c03 100644
+index 017a809ce774ea63104c952151786a214a00f29d..7603ad40ede34625be1cb906062a43e9b0eb9ab3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -237,6 +237,7 @@ public class ServerPlayer extends Player {
+@@ -242,6 +242,7 @@ public class ServerPlayer extends Player {
      public double maxHealthCache;
      public boolean joining = true;
      public boolean sentListPacket = false;
@@ -52,7 +52,7 @@ index 842c35daca37b793ff2c6dbb1c442db9dac879f8..5c2a19b054558d260ddb2f7282ea3b54
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c14fba206e2f124cded3e00e2cb584e21a43971d..aad3f28147b5ae9f3a81ec9b500559ed222daf93 100644
+index 7fdc16e91cbac7fbe07e1cca1f68c7c14497d5a7..cb2024035fbb6352e4be46be0cdbaf85fdc0ed40 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -275,6 +275,12 @@ public abstract class PlayerList {

--- a/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 5c2a19b054558d260ddb2f7282ea3b54a4dc2c03..68ef26c0b3124aa1bd37df9f762401b700a6b8ba 100644
+index 7603ad40ede34625be1cb906062a43e9b0eb9ab3..8f67cbf2b66adfcebff1c6caef5b0996bb7c24ae 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -172,6 +172,7 @@ public class ServerPlayer extends Player {
+@@ -177,6 +177,7 @@ public class ServerPlayer extends Player {
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
@@ -16,7 +16,7 @@ index 5c2a19b054558d260ddb2f7282ea3b54a4dc2c03..68ef26c0b3124aa1bd37df9f762401b7
      public final MinecraftServer server;
      public final ServerPlayerGameMode gameMode;
      private final PlayerAdvancements advancements;
-@@ -238,6 +239,7 @@ public class ServerPlayer extends Player {
+@@ -243,6 +244,7 @@ public class ServerPlayer extends Player {
      public boolean joining = true;
      public boolean sentListPacket = false;
      public boolean supressTrackerForLogin = false; // Paper
@@ -96,7 +96,7 @@ index 12f945e91827470a9a61951e45c062deee8cf281..195f5d1519c3fc2fdd03ecd0d49d7fba
              try {
                  ServerPlayer entityplayer1 = this.server.getPlayerList().processLogin(this.gameProfile, s); // CraftBukkit - add player reference
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index aad3f28147b5ae9f3a81ec9b500559ed222daf93..95f229dcb1b003215c602847a351b313fb0980ba 100644
+index cb2024035fbb6352e4be46be0cdbaf85fdc0ed40..dccba18f87fa8e288d05a1df51fb9ee2489af567 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -38,6 +38,7 @@ import net.minecraft.network.protocol.Packet;
@@ -244,7 +244,7 @@ index aad3f28147b5ae9f3a81ec9b500559ed222daf93..95f229dcb1b003215c602847a351b313
          Iterator iterator = list.iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1a3d6368b84aa24b6d0361dd30bc06b79f1d5133..4d2209baf88a3f097e0df1645f88d4afd718c414 100644
+index c11d1fddd54a0a909bf9952086bff25a3aa82188..9783b06104f6dfe12988733f580ce5e3c5cf1e28 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1511,7 +1511,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimize isOutsideRange to use distance maps
 Use a distance map to find the players in range quickly
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 55f355d1218ddb3f320752666407151291c0f398..948a817a1d6f4435655931357aa094b889771e82 100644
+index 8104b9be5a8e8d57f6f50475788aec6a762a0f7e..e6883cad6c604673535deacc19463aeeb060199a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -100,6 +100,18 @@ public class ChunkHolder {
@@ -37,7 +37,7 @@ index 55f355d1218ddb3f320752666407151291c0f398..948a817a1d6f4435655931357aa094b8
  
      // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 9ce330be998f3392288d8eb0386a48237ff3a880..708c135fbdc5f071bd979dc496aefb1fac7a2284 100644
+index d2ac486acadd3a1ac829208f9f4594418594f459..19bf44ab6b1f6803eb41208fd07ec0f3dad22c6e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -241,6 +241,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -291,7 +291,7 @@ index b49d380ef088aed3204ec71abc437c348ef004fa..577b391dcba1db712c1e2c83296e1c87
  
      public String getDebugStatus() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 0bb931ae8faa8e1fe36895d8321a9b36d325c3ed..135d162a926bd258d2aa001b7d0ef880fd3f2fb9 100644
+index ba10da7899143e8a8c16bc1413fd8de4e5645f46..147f6fd5174a2c489dfb7ea2ce2d2dc7dacfb89d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -730,6 +730,37 @@ public class ServerChunkCache extends ChunkSource {
@@ -362,10 +362,10 @@ index 0bb931ae8faa8e1fe36895d8321a9b36d325c3ed..135d162a926bd258d2aa001b7d0ef880
                              if (chunksTicked[0]++ % 10 == 0) this.level.getServer().midTickLoadChunks(); // Paper
                          }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 04260e1e8cf17d2af06504fae949958b91c86bef..384f38b3c7dd030f107991137912866ae045f811 100644
+index 8f67cbf2b66adfcebff1c6caef5b0996bb7c24ae..eefe6f77d616768d3cfc93b7e2030d59b49b9e21 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -244,6 +244,7 @@ public class ServerPlayer extends Player {
+@@ -249,6 +249,7 @@ public class ServerPlayer extends Player {
      // CraftBukkit end
      public PlayerNaturallySpawnCreaturesEvent playerNaturallySpawnedEvent; // Paper
  

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -312,7 +312,7 @@ index e26b65c3b2594ae45b68bcbd135152130663be7f..3e004f391668865c0e6f1c38cef9661f
                  if (chunk != null) {
                      chunkStorage.callbackExecutor.execute(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 8d97e0a38a1cf6fcbc458654e2e85a8eb6033dd9..15dba7f2e6a7c670b415f67345fad37873a1130c 100644
+index ed4ff389a175d8708c667ee212e11a3f7a1d3a79..84245016423e9d151f98b5ef8d2c9fbf3a3136ab 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -149,6 +149,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1027,10 +1027,10 @@ index 6c565751c36daa0084196dce5d2f82df64a0c77a..0b22fd8ac75146bc7b647cfbefc73ce8
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d41d1d860cc26d8dd441324680a44c635f78a047..e67a4657191d6dbe526470820e6813f54ecdc1fe 100644
+index eefe6f77d616768d3cfc93b7e2030d59b49b9e21..24223a6a58047312bd82cd1e29b5db61b0853159 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -183,6 +183,14 @@ public class ServerPlayer extends Player {
+@@ -188,6 +188,14 @@ public class ServerPlayer extends Player {
      private int lastRecordedArmor = Integer.MIN_VALUE;
      private int lastRecordedLevel = Integer.MIN_VALUE;
      private int lastRecordedExperience = Integer.MIN_VALUE;
@@ -1045,7 +1045,7 @@ index d41d1d860cc26d8dd441324680a44c635f78a047..e67a4657191d6dbe526470820e6813f5
      private float lastSentHealth = -1.0E8F;
      private int lastSentFood = -99999999;
      private boolean lastFoodSaturationZero = true;
-@@ -324,6 +332,21 @@ public class ServerPlayer extends Player {
+@@ -329,6 +337,21 @@ public class ServerPlayer extends Player {
          this.maxHealthCache = this.getMaxHealth();
          this.cachedSingleMobDistanceMap = new com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<>(this); // Paper
      }
@@ -1067,7 +1067,7 @@ index d41d1d860cc26d8dd441324680a44c635f78a047..e67a4657191d6dbe526470820e6813f5
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
      // If this is an issue, PRs are welcome
-@@ -645,6 +668,7 @@ public class ServerPlayer extends Player {
+@@ -650,6 +673,7 @@ public class ServerPlayer extends Player {
              if (valid && !this.isSpectator() || !this.touchingUnloadedChunk()) { // Paper - don't tick dead players that are not in the world currently (pending respawn)
                  super.tick();
              }
@@ -1113,7 +1113,7 @@ index 92e8257734a8d46bf63b8bd9173b0d680f41fe97..80bf42c9586ba45b2174b89e3d432409
      }
  
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 71fce0c38386b3f0a63a5d9bc1cb47e01027d10c..c4bdce99df37fbe5bfc1238dac9d043ccdaa3f1a 100644
+index 10d3a8477502f991c03c665a192eda91a288f4c3..45b48275a3f944d495cc090abc4af5a4f8512028 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -284,8 +284,8 @@ public abstract class PlayerList {
@@ -1174,7 +1174,7 @@ index f72471ac82907a0d5112598b3289689495285944..6e1f8323d028790d1f55d51edb3214d0
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a98394d9bab490c1bdb5817cb30806cab85de730..535fb8f029dc09862e42e239a0fc7326e31508ef 100644
+index a69b9535c18597fec37ce6b50140188203d2b78d..5aba300b2aa99bcf17fdf19f8203a52bc814168e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -889,6 +889,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0500-Incremental-player-saving.patch
+++ b/patches/server/0500-Incremental-player-saving.patch
@@ -25,7 +25,7 @@ index b67ba8f75e4a3358d7c2462918b85b0bf9b5a922..fdbd8b89bb8bf3b61f60b812b90483c9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 21c16bf341e846f90a24fe2395ff89f1ace70d73..a962209749c7cc7f6d304073f5f2bce55014a29e 100644
+index 913f2aee362e574ae39df64c392e1c0fe2d77b98..4440e429f13767c675f0450a534e9885a2b18173 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -955,7 +955,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -55,10 +55,10 @@ index 21c16bf341e846f90a24fe2395ff89f1ace70d73..a962209749c7cc7f6d304073f5f2bce5
          } // Paper start
          for (ServerLevel level : this.getAllLevels()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e67a4657191d6dbe526470820e6813f54ecdc1fe..d3209044b25f30edc3676d75f4784aaf93449687 100644
+index 24223a6a58047312bd82cd1e29b5db61b0853159..af74e31b0e55038b04198e80f2fc021e3069e6a1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -169,6 +169,7 @@ public class ServerPlayer extends Player {
+@@ -174,6 +174,7 @@ public class ServerPlayer extends Player {
      public final int getViewDistance() { return this.getLevel().getChunkSource().chunkMap.viewDistance - 1; } // Paper - placeholder
  
      private static final Logger LOGGER = LogManager.getLogger();
@@ -67,7 +67,7 @@ index e67a4657191d6dbe526470820e6813f54ecdc1fe..d3209044b25f30edc3676d75f4784aaf
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 64b09b5c5676ae5cc77d7dcac9c9256bba4ac9e8..b64b7ea33576cdcc9179e5849667b0cb5f52dcd6 100644
+index 4f37d3e95c4f20fccbff16dd619bfe841431f548..28c073fd8877280dd0433d748748a98b03bc092f 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -567,6 +567,7 @@ public abstract class PlayerList {

--- a/patches/server/0552-Add-API-for-quit-reason.patch
+++ b/patches/server/0552-Add-API-for-quit-reason.patch
@@ -25,10 +25,10 @@ index 01b9c360c6d687c6a774bf3375802be487cb0e0c..35a03d15f87be8eb86d65e1863a3e0cb
                          Connection.LOGGER.debug("Failed to sent packet", throwable);
                          ConnectionProtocol enumprotocol = this.getCurrentProtocol();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d3209044b25f30edc3676d75f4784aaf93449687..7132c1281b9ce65d844cdb12905ceb7370b55b8f 100644
+index af74e31b0e55038b04198e80f2fc021e3069e6a1..ca954dc06a76fc42af476e2a1733e5c1232db6ba 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -256,6 +256,7 @@ public class ServerPlayer extends Player {
+@@ -261,6 +261,7 @@ public class ServerPlayer extends Player {
      public double lastEntitySpawnRadiusSquared; // Paper - optimise isOutsideRange, this field is in blocks
      public final com.destroystokyo.paper.util.misc.PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleHashSet; // Paper
      boolean needsChunkCenterUpdate; // Paper - no-tick view distance
@@ -49,7 +49,7 @@ index e98d20b0790a2bb581e8916ec17627830eedbd26..1a5c33407bfe3cdb91953a7067b00f38
              this.connection.disconnect(ichatbasecomponent);
          });
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fd6d9fd1469190435abe16fb3ba15e9522243d42..4cf9e944bf4a88391a290f703931e551e26cf7f5 100644
+index 91ce39579e9e46f2c10df5f750f52ba68777e4cc..81571c7af33ef273fd2833eb9e0ad38c5787e96b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -594,7 +594,7 @@ public abstract class PlayerList {

--- a/patches/server/0570-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/server/0570-Player-Chunk-Load-Unload-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9a729aecfa8c901159c74c42544ba31b69bab199..b057d99f6777b1e051235f228aaa6d10457b76d0 100644
+index ca954dc06a76fc42af476e2a1733e5c1232db6ba..430ffb96e137cdfc02634ddf3050dd5a3012cc28 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2089,11 +2089,21 @@ public class ServerPlayer extends Player {
+@@ -2094,11 +2094,21 @@ public class ServerPlayer extends Player {
      public void trackChunk(ChunkPos chunkcoordintpair, Packet<?> packet, Packet<?> packet1) {
          this.connection.send(packet1);
          this.connection.send(packet);

--- a/patches/server/0616-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0616-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b057d99f6777b1e051235f228aaa6d10457b76d0..25fb48d3ff5b0116a6a942fd9d0958ab9ea0bdeb 100644
+index 430ffb96e137cdfc02634ddf3050dd5a3012cc28..afbab46c35338470cd1e1b2ccf8bcf04d200c8a4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1141,6 +1141,11 @@ public class ServerPlayer extends Player {
+@@ -1146,6 +1146,11 @@ public class ServerPlayer extends Player {
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/patches/server/0678-call-PortalCreateEvent-players-and-end-platform.patch
+++ b/patches/server/0678-call-PortalCreateEvent-players-and-end-platform.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] call PortalCreateEvent players and end platform
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 25fb48d3ff5b0116a6a942fd9d0958ab9ea0bdeb..5de75fb683fb98c8d3948f84e3b65f92665222cd 100644
+index afbab46c35338470cd1e1b2ccf8bcf04d200c8a4..d5949a9733da55dc547cff04f4937ed7d6188609 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1168,15 +1168,21 @@ public class ServerPlayer extends Player {
+@@ -1173,15 +1173,21 @@ public class ServerPlayer extends Player {
      private void createEndPlatform(ServerLevel world, BlockPos centerPos) {
          BlockPos.MutableBlockPos blockposition_mutableblockposition = centerPos.mutable();
  

--- a/patches/server/0683-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0683-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index d75f78d2e3fb1376e8f6a8668c98a04a693c99e1..79f6089b934124c3309c6bee2e48b36b
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 5de75fb683fb98c8d3948f84e3b65f92665222cd..181ab56448796a617f30f1b9e0fec8917b5d8e07 100644
+index d5949a9733da55dc547cff04f4937ed7d6188609..a0acaac510aa2206a5c58f2b7aafdbc2bdf7a3dd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1785,8 +1785,15 @@ public class ServerPlayer extends Player {
+@@ -1790,8 +1790,15 @@ public class ServerPlayer extends Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -66,7 +66,7 @@ index 5de75fb683fb98c8d3948f84e3b65f92665222cd..181ab56448796a617f30f1b9e0fec891
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -1798,7 +1805,7 @@ public class ServerPlayer extends Player {
+@@ -1803,7 +1810,7 @@ public class ServerPlayer extends Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -75,7 +75,7 @@ index 5de75fb683fb98c8d3948f84e3b65f92665222cd..181ab56448796a617f30f1b9e0fec891
          }
      }
  
-@@ -2180,6 +2187,14 @@ public class ServerPlayer extends Player {
+@@ -2185,6 +2192,14 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -91,7 +91,7 @@ index 5de75fb683fb98c8d3948f84e3b65f92665222cd..181ab56448796a617f30f1b9e0fec891
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index b096384cdc7596166e010e06272534b8001693c9..4b756c0a4b607faa03b00ab81761335be63c39eb 100644
+index ddacf7ca035d4d0802572ce806e21b484c366550..e572088cad8b9e09b1d64f7971bacac2f10c5b17 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -74,18 +74,24 @@ public class ServerPlayerGameMode {
@@ -123,7 +123,7 @@ index b096384cdc7596166e010e06272534b8001693c9..4b756c0a4b607faa03b00ab81761335b
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d63bc35d37b2d6628ff2fdd97fca7978c2dded0e..084b17d6496799fd49a9f81bb6bcbff512fd8f78 100644
+index 8440aadf080a9a9669f62d1c01923389e17ceb5f..da99d8c01db614941239a695cc0c22add9b0d938 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2469,7 +2469,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -136,7 +136,7 @@ index d63bc35d37b2d6628ff2fdd97fca7978c2dded0e..084b17d6496799fd49a9f81bb6bcbff5
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4f61acf44b40bf15ae6465d7999e2bc2da837c82..f50772b5c07d5aa7dcd0ed015507c3f6440328c8 100644
+index 313bfab694bb93968db927b5e4bd98a7c7931184..3e52ce2bc3a4b1327ab0e01b78966558d77cec9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1249,7 +1249,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
`spawnAnimals` was being used twice and `rareSpawn` was unused

Also added a mappings patch for a method where CB modifies params