### PR TITLE
Fix Player#playerListName nullability annotation

### DIFF
--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -1331,7 +1331,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..d7a4cfed4f46b34f83fb2c07bdab5a71
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index edf4623a831442e1f06daabc402a3f32610dd519..d026c791ee86cb45feadcad7a48dea41287e3da7 100644
+index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb8823e02d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -33,7 +33,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1398,7 +1398,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..d026c791ee86cb45feadcad7a48dea41
 +     *
 +     * @return the player list name
 +     */
-+    @Nullable net.kyori.adventure.text.Component playerListName();
++    @NotNull net.kyori.adventure.text.Component playerListName();
 +
 +    /**
 +     * Gets the currently displayed player list header for this player.


### PR DESCRIPTION
Closes #6080

This should be consisted with the now-deprecated Player#getPlayerListName which also is marked as NotNull