### PR TITLE
Use ChatRenderer.defaultRenderer() when legacy events have not modified the format

### DIFF
--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -114,10 +114,10 @@ index 0000000000000000000000000000000000000000..e597a90def72c5903382d7169fb7a2fb
 +}
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..185a6d966711628e8937e8ab16f807bffd713c6d
+index 0000000000000000000000000000000000000000..8166a7572a8bbace29fab47f89b5486795b784a7
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-@@ -0,0 +1,224 @@
+@@ -0,0 +1,228 @@
 +package io.papermc.paper.adventure;
 +
 +import io.papermc.paper.chat.ChatRenderer;
@@ -162,6 +162,7 @@ index 0000000000000000000000000000000000000000..185a6d966711628e8937e8ab16f807bf
 +        })
 +        .build();
 +    // copied from adventure-text-serializer-legacy -->
++    private static final String DEFAULT_LEGACY_FORMAT = "<%1$s> %2$s"; // copied from PlayerChatEvent/AsyncPlayerChatEvent
 +    final MinecraftServer server;
 +    final ServerPlayer player;
 +    final String message;
@@ -316,6 +317,9 @@ index 0000000000000000000000000000000000000000..185a6d966711628e8937e8ab16f807bf
 +    }
 +
 +    private static ChatRenderer legacyRenderer(final String format) {
++        if (DEFAULT_LEGACY_FORMAT.equals(format)) {
++            return ChatRenderer.defaultRenderer();
++        }
 +        return ChatRenderer.viewerUnaware((player, displayName, message) -> PaperAdventure.LEGACY_SECTION_UXRC.deserialize(String.format(format, legacyDisplayName((CraftPlayer) player), PaperAdventure.LEGACY_SECTION_UXRC.serialize(message))).replaceText(URL_REPLACEMENT_CONFIG));
 +    }
 +

--- a/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -26,22 +26,19 @@ index 2c3754c0bcebc33f88168136b519baef6927553b..d9590dbc3db4ec4d32d86906bb290fbe
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-index 185a6d966711628e8937e8ab16f807bffd713c6d..eaac7c1d50788c2519b0c279ab0e1ad6749c3113 100644
+index 0bc2c2ef9312ebcc32dacdd2ba9f17d2ba072586..9507ba43cacc31c02423a4f576feda32291101e7 100644
 --- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-@@ -17,7 +17,11 @@ import net.kyori.adventure.text.TextReplacementConfig;
- import net.kyori.adventure.text.event.ClickEvent;
+@@ -18,6 +18,8 @@ import net.kyori.adventure.text.event.ClickEvent;
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerPlayer;
-+import net.minecraft.world.scores.PlayerTeam;
-+import net.minecraft.world.scores.Team;
  import org.bukkit.Bukkit;
 +import org.bukkit.ChatColor;
 +import org.bukkit.craftbukkit.CraftWorld;
  import org.bukkit.craftbukkit.entity.CraftPlayer;
  import org.bukkit.craftbukkit.util.LazyPlayerSet;
  import org.bukkit.craftbukkit.util.Waitable;
-@@ -188,10 +192,16 @@ public final class ChatProcessor {
+@@ -189,10 +191,16 @@ public final class ChatProcessor {
      }
  
      private static String legacyDisplayName(final CraftPlayer player) {


### PR DESCRIPTION
Closes #6093

Not 100% certain this is a safe change in regards to not breaking behavior of the legacy events. Seems relatively harmless but you know how legacy text is...