### PR TITLE
Move log message for named entity deaths into correct location

### DIFF
--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -70,7 +70,7 @@ index 2c32d7c37d7d9b9c12c5af3a9af576ac88618049..b4d2b9a25ee1c407b3803d59c4fd80f7
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b0c01686a 100644
+index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..76ebd1c85fed688ad42ea5f709638015e965cec6 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -261,6 +261,7 @@ public abstract class LivingEntity extends Entity {
@@ -108,16 +108,11 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, source);
              }
-@@ -1609,24 +1609,47 @@ public abstract class LivingEntity extends Entity {
-             if (this.isSleeping()) {
-                 this.stopSleeping();
-             }
-+             */ // Paper - move down to make death event cancellable - this is the runKillTrigger below
-+
- 
+@@ -1613,20 +1613,46 @@ public abstract class LivingEntity extends Entity {
              if (!this.level.isClientSide && this.hasCustomName()) {
                  LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString());
              }
++             */ // Paper - move down to make death event cancellable - this is the runKillTrigger below
  
              this.dead = true;
 -            this.getCombatTracker().recheckStatus();
@@ -140,6 +135,10 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
 +                        this.stopSleeping();
 +                    }
 +
++                    if (!this.level.isClientSide && this.hasCustomName()) {
++                        LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString());
++                    }
++
 +                    this.getCombatTracker().recheckStatus();
 +                    if (entity != null) {
 +                        entity.killed((ServerLevel) this.level, this);
@@ -159,7 +158,7 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
          }
      }
  
-@@ -1634,7 +1657,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1634,7 +1660,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.level.isClientSide) {
              boolean flag = false;
  
@@ -168,7 +167,7 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1662,7 +1685,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1662,7 +1688,7 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
@@ -177,7 +176,7 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
          Entity entity = source.getEntity();
          int i;
  
-@@ -1680,15 +1703,18 @@ public abstract class LivingEntity extends Entity {
+@@ -1680,15 +1706,18 @@ public abstract class LivingEntity extends Entity {
              this.dropCustomDeathLoot(source, i, flag);
          }
          // CraftBukkit start - Call death event
@@ -197,7 +196,7 @@ index 9c2a6fd75f4380230256d9de91082d1bfe2eb961..4e7ecdde929466120004c4e2b9848c2b
  
      // CraftBukkit start
      public int getExpReward() {
-@@ -1766,6 +1792,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1766,6 +1795,7 @@ public abstract class LivingEntity extends Entity {
          return SoundEvents.GENERIC_HURT;
      }
  
@@ -278,7 +277,7 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 96d924299f20f96fbf94b491da0ff3f692344334..39b307074f7addc6223a2a2212a3f92feffc4379 100644
+index abe7052b7b5c98328e4ecc1d199e911d5e9dcc2b..6a075a31690633e277e094290cfb05c3d94a1d91 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1862,7 +1862,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4e7ecdde929466120004c4e2b9848c2b0c01686a..af2ab0847127c1c1c7024570fbb9a23ef33fc80a 100644
+index 76ebd1c85fed688ad42ea5f709638015e965cec6..24d53ec5a4dc49c6489cf8007197ed11381081e3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -116,6 +116,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 4e7ecdde929466120004c4e2b9848c2b0c01686a..af2ab0847127c1c1c7024570fbb9a23e
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3733,6 +3734,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3736,6 +3737,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0297-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0297-force-entity-dismount-during-teleportation.patch
@@ -93,10 +93,10 @@ index 35f83b559002886b8728297eb9fecc7588bdc950..dbf002a6967812fd58ed9bcfa615dc52
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index af2ab0847127c1c1c7024570fbb9a23ef33fc80a..330d72b8851e3a9fb9988117f908c561ee9c65f8 100644
+index 24d53ec5a4dc49c6489cf8007197ed11381081e3..84a2b846022a198a93ca924882d503b889290363 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3332,11 +3332,13 @@ public abstract class LivingEntity extends Entity {
+@@ -3335,11 +3335,13 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 4) != 0;
      }
  

--- a/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 330d72b8851e3a9fb9988117f908c561ee9c65f8..f635e60e55ae43c0f2acf7e82ca6014e757da186 100644
+index 84a2b846022a198a93ca924882d503b889290363..1f46e8eaa41c37bcd065ae064521c3c0772d7832 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3551,15 +3551,18 @@ public abstract class LivingEntity extends Entity {
+@@ -3554,15 +3554,18 @@ public abstract class LivingEntity extends Entity {
          this.entityData.set(LivingEntity.DATA_LIVING_ENTITY_FLAGS, (byte) j);
      }
  
@@ -31,7 +31,7 @@ index 330d72b8851e3a9fb9988117f908c561ee9c65f8..f635e60e55ae43c0f2acf7e82ca6014e
              }
  
          }
-@@ -3632,6 +3635,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3635,6 +3638,7 @@ public abstract class LivingEntity extends Entity {
              this.releaseUsingItem();
          } else {
              if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -39,7 +39,7 @@ index 330d72b8851e3a9fb9988117f908c561ee9c65f8..f635e60e55ae43c0f2acf7e82ca6014e
                  this.triggerItemUseEffects(this.useItem, 16);
                  // CraftBukkit start - fire PlayerItemConsumeEvent
                  ItemStack itemstack;
-@@ -3666,8 +3670,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3669,8 +3673,8 @@ public abstract class LivingEntity extends Entity {
                  }
  
                  this.stopUsingItem();

--- a/patches/server/0360-Lag-compensate-eating.patch
+++ b/patches/server/0360-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f635e60e55ae43c0f2acf7e82ca6014e757da186..3df3bc95bff4a170f4fc5757239c7e0efd6fae62 100644
+index 1f46e8eaa41c37bcd065ae064521c3c0772d7832..e7673a72892c2a6b08020c1abaf4f89b82148024 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3495,6 +3495,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3498,6 +3498,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index f635e60e55ae43c0f2acf7e82ca6014e757da186..3df3bc95bff4a170f4fc5757239c7e0e
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3512,8 +3517,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3515,8 +3520,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index f635e60e55ae43c0f2acf7e82ca6014e757da186..3df3bc95bff4a170f4fc5757239c7e0e
              this.completeUsingItem();
          }
  
-@@ -3559,7 +3568,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3562,7 +3571,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index f635e60e55ae43c0f2acf7e82ca6014e757da186..3df3bc95bff4a170f4fc5757239c7e0e
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, enumhand == InteractionHand.OFF_HAND);
-@@ -3583,7 +3595,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3586,7 +3598,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index f635e60e55ae43c0f2acf7e82ca6014e757da186..3df3bc95bff4a170f4fc5757239c7e0e
              }
          }
  
-@@ -3709,7 +3724,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3712,7 +3727,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0379-Entity-Jump-API.patch
+++ b/patches/server/0379-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3df3bc95bff4a170f4fc5757239c7e0efd6fae62..cac53191c09e434a952d463d55eb525ecdf3fb38 100644
+index e7673a72892c2a6b08020c1abaf4f89b82148024..f6f519a37038ec6b9dbde61d13b7a55b33784c40 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3162,8 +3162,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3165,8 +3165,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid((Tag) FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {

--- a/patches/server/0411-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0411-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cac53191c09e434a952d463d55eb525ecdf3fb38..2941786fd39f4feb99e7b40fc28410863eb20961 100644
+index f6f519a37038ec6b9dbde61d13b7a55b33784c40..885a628657bcb9e7591f1ec3f14d5ebb83d37d3b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3259,10 +3259,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3262,10 +3262,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0420-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0420-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2941786fd39f4feb99e7b40fc28410863eb20961..00610ef5a724a9ab6ec6df29c721a93f3b12bd1d 100644
+index 885a628657bcb9e7591f1ec3f14d5ebb83d37d3b..4f996f0216aa1255d2031bb151d2a43d61a7e42b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2037,7 +2037,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2040,7 +2040,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0487-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0487-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 00610ef5a724a9ab6ec6df29c721a93f3b12bd1d..eb4089aa6986edd709d2b0a7853a19a020f02e57 100644
+index 4f996f0216aa1255d2031bb151d2a43d61a7e42b..cda994992814109f4fac8f031ec82e98c482c0ad 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3356,7 +3356,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3359,7 +3359,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0563-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0563-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -61,10 +61,10 @@ index 8fb89326395a7e70982c0d757b506565e98b12a4..a060cca08631fb42041e3a79a9abc422
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index eb4089aa6986edd709d2b0a7853a19a020f02e57..c0dbfa4a03c2c575b24fd960bea338532d64eac7 100644
+index cda994992814109f4fac8f031ec82e98c482c0ad..515e551c365d799bebac3997f85c99243667caf5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3274,7 +3274,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3277,7 +3277,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index eb4089aa6986edd709d2b0a7853a19a020f02e57..c0dbfa4a03c2c575b24fd960bea33853
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3441,9 +3441,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3444,9 +3444,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0619-EntityMoveEvent.patch
+++ b/patches/server/0619-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index 30d4188c3c7c0419ea3aaa4b0b1175940e5c089e..9098a6515c732197f843a4612add23fd
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c0dbfa4a03c2c575b24fd960bea338532d64eac7..820ac7b271e2fc5d541e48d87e444ab9bf96134b 100644
+index 515e551c365d799bebac3997f85c99243667caf5..a0861a9c97c8cd300485dfd8b528092ad4ed17ba 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3220,6 +3220,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3223,6 +3223,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0655-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0655-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 820ac7b271e2fc5d541e48d87e444ab9bf96134b..ae0d3e15ef92e4a58e5c95c407681850d6ba419c 100644
+index a0861a9c97c8cd300485dfd8b528092ad4ed17ba..9f57ebcf4f1fafe38ebdf9b78f186e244853101d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3699,6 +3699,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3702,6 +3702,7 @@ public abstract class LivingEntity extends Entity {
                      level.getCraftServer().getPluginManager().callEvent(event);
  
                      if (event.isCancelled()) {

--- a/patches/server/0710-Add-more-line-of-sight-methods.patch
+++ b/patches/server/0710-Add-more-line-of-sight-methods.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add more line of sight methods
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ae0d3e15ef92e4a58e5c95c407681850d6ba419c..ed745776316c5346ee1b44c8f022c40359b7e642 100644
+index 9f57ebcf4f1fafe38ebdf9b78f186e244853101d..0c38298ce04b28bb41b3c10b44b026a9b54c612b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3427,6 +3427,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3430,6 +3430,7 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  


### PR DESCRIPTION
Log message is being printed before the death event, meaning it will print for entities whose death later gets cancelled by plugins.