### PR TITLE
Add option for logging named entity deaths

### DIFF
--- a/patches/server/0725-Config-option-for-named-entity-death-logging.patch
+++ b/patches/server/0725-Config-option-for-named-entity-death-logging.patch
@@ -29,7 +29,7 @@ index 0c38298ce04b28bb41b3c10b44b026a9b54c612b..62cf17beaeaae2544bd5b268b3846b4d
                      }
  
 -                    if (!this.level.isClientSide && this.hasCustomName()) {
-+                    if (!this.level.isClientSide && this.hasCustomName() && com.destroystokyo.paper.PaperConfig.logNamedEntityDeaths) { // Paper - add setting for entity death logging
++                    if (com.destroystokyo.paper.PaperConfig.logNamedEntityDeaths && !this.level.isClientSide && this.hasCustomName()) { // Paper - add setting for entity death logging
                          LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString());
                      }
  

--- a/patches/server/0725-Config-option-for-named-entity-death-logging.patch
+++ b/patches/server/0725-Config-option-for-named-entity-death-logging.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Malfrador <malfrador@gmail.com>
+Date: Wed, 7 Jul 2021 12:48:50 +0200
+Subject: [PATCH] Config option for named entity death logging
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 98b71384508447adc80c2175f8e35e5d86b0c378..f101302892a7f95ffa0e6d63cb69d8a3ddbd67a7 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -492,6 +492,11 @@ public class PaperConfig {
+         deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
+     }
+ 
++    public static boolean logNamedEntityDeaths = true;
++    private static void namedEntityDeaths() {
++        logNamedEntityDeaths = getBoolean("settings.log-named-entity-deaths", logNamedEntityDeaths);
++    }
++
+     public static int itemValidationDisplayNameLength = 8192;
+     public static int itemValidationLocNameLength = 8192;
+     public static int itemValidationLoreLineLength = 8192;
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 0c38298ce04b28bb41b3c10b44b026a9b54c612b..62cf17beaeaae2544bd5b268b3846b4d0a9190e0 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1634,7 +1634,7 @@ public abstract class LivingEntity extends Entity {
+                         this.stopSleeping();
+                     }
+ 
+-                    if (!this.level.isClientSide && this.hasCustomName()) {
++                    if (!this.level.isClientSide && this.hasCustomName() && com.destroystokyo.paper.PaperConfig.logNamedEntityDeaths) { // Paper - add setting for entity death logging
+                         LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString());
+                     }
+ 


### PR DESCRIPTION
This PR adds a new config option, ``settings.log-named-entity-deaths`` that allows you to turn off the entity death logging introduced by Mojang in 1.17.1.
This can be useful if you have a lot of named mobs, for example because you are running a custom mob plugin.

Its my first time adding a config setting, hope I did everything right. 

I also looked at https://github.com/PaperMC/Paper/issues/6106 but I couldn't figure out why that would ever happen. This PR however would add a workaround for that.

PaperDocs PR for the config setting: https://github.com/PaperMC/PaperDocs/pull/84