### PR TITLE
combat diamond clay mining by making configured features' seeds configurable

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -489,10 +489,10 @@ index 0000000000000000000000000000000000000000..2c0514892d3993bef57ecf677cf8bb0f
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b773d2be0
+index 0000000000000000000000000000000000000000..e9ef06a837c9174def8e5fd86688f5974daafc3c
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,73 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
@@ -544,6 +544,11 @@ index 0000000000000000000000000000000000000000..b31109d2dadd29e8852468c19265066b
 +    private int getInt(String path, int def) {
 +        config.addDefault("world-settings.default." + path, def);
 +        return config.getInt("world-settings." + worldName + "." + path, config.getInt("world-settings.default." + path));
++    }
++
++    private long getLong(String path, long def) {
++        config.addDefault("world-settings.default." + path, def);
++        return config.getLong("world-settings." + worldName + "." + path, config.getInt("world-settings.default." + path));
 +    }
 +
 +    private float getFloat(String path, float def) {
@@ -681,7 +686,7 @@ index 7f81dd05ec8945a851b6501854dc894cad240a66..d6b2e7d643f907ddd81d394d9b613e9c
          this.world = new CraftWorld((ServerLevel) this, gen, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1364a4a95e265c042880c99ea6b59dd2725b18ac..57a44f1d466caeccebe0e2498e3833cb953ffd5a 100644
+index 6c1a641f57011f3443e022758e37660034aa240f..a3f27b2e766e0477410e14e55a0c800ab307984c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -805,6 +805,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0011-Configurable-cactus-bamboo-and-reed-growth-heights.patch
+++ b/patches/server/0011-Configurable-cactus-bamboo-and-reed-growth-heights.patch
@@ -7,10 +7,10 @@ Bamboo - Both the minimum fully-grown heights and the maximum are configurable
 - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b31109d2dadd29e8852468c19265066b773d2be0..3618cc017feb60e257a28f67cbddca3f792a9833 100644
+index e9ef06a837c9174def8e5fd86688f5974daafc3c..14306288cff67d035fc4459b5939d5b1d18c5bcc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -65,4 +65,17 @@ public class PaperWorldConfig {
+@@ -70,4 +70,17 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def);
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }

--- a/patches/server/0012-Configurable-baby-zombie-movement-speed.patch
+++ b/patches/server/0012-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3618cc017feb60e257a28f67cbddca3f792a9833..796c17e0941922a9716212c6eae91643d8360418 100644
+index 14306288cff67d035fc4459b5939d5b1d18c5bcc..86cf8c8a54a7cee09ff75185af76d5f35c9af348 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -78,4 +78,15 @@ public class PaperWorldConfig {
+@@ -83,4 +83,15 @@ public class PaperWorldConfig {
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight + ". Max height for bamboo growth " + bambooMaxHeight + ". Min height for fully-grown bamboo " + bambooMinHeight + ".");
  
      }
@@ -25,7 +25,7 @@ index 3618cc017feb60e257a28f67cbddca3f792a9833..796c17e0941922a9716212c6eae91643
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 84a8269060acaa5bf55a1d0a3f79e093bf2e30e5..017d8de4d09f524aed2ee03af7ef79468503edf0 100644
+index 564e8cb28c094a1bb9ab7d214464d6e6d9788bcf..f8b97aa5819e228f31c7953ee6e5c4e69fe55666 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -79,7 +79,7 @@ import org.bukkit.event.entity.EntityTransformEvent;

--- a/patches/server/0013-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0013-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 796c17e0941922a9716212c6eae91643d8360418..78948c42b13194005bdbbbc69c2b7ae0732a78c5 100644
+index 86cf8c8a54a7cee09ff75185af76d5f35c9af348..9928161cb5cf834c66eac2edef9d6a695245f5e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -89,4 +89,12 @@ public class PaperWorldConfig {
+@@ -94,4 +94,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/patches/server/0014-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0014-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 78948c42b13194005bdbbbc69c2b7ae0732a78c5..b41e7922dd96c3358eb849ab39982a75736e3476 100644
+index 9928161cb5cf834c66eac2edef9d6a695245f5e2..cdb43714ec0b688aab872ed02ba9889dbda04c6b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -97,4 +97,9 @@ public class PaperWorldConfig {
+@@ -102,4 +102,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }

--- a/patches/server/0015-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0015-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b41e7922dd96c3358eb849ab39982a75736e3476..2f0d582baf0eb2bb477944d0cb1369db6ca33956 100644
+index cdb43714ec0b688aab872ed02ba9889dbda04c6b..49f7a853ce4ee4b896cc17e59ad96ec199cd0e75 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -102,4 +102,20 @@ public class PaperWorldConfig {
+@@ -107,4 +107,20 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }

--- a/patches/server/0016-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0016-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2f0d582baf0eb2bb477944d0cb1369db6ca33956..89e76dd73811fd0f6f8c8e7e5af804d5a4bb5a75 100644
+index 49f7a853ce4ee4b896cc17e59ad96ec199cd0e75..06e0a3367e5faecdb3341b68d6a9812ebaf13f31 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -118,4 +118,10 @@ public class PaperWorldConfig {
+@@ -123,4 +123,10 @@ public class PaperWorldConfig {
          softDespawnDistance = softDespawnDistance*softDespawnDistance;
          hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
      }

--- a/patches/server/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 * Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 89e76dd73811fd0f6f8c8e7e5af804d5a4bb5a75..d16ae924bcbe31c964f7fb448757c748e5c4418c 100644
+index 06e0a3367e5faecdb3341b68d6a9812ebaf13f31..741e622faf62b9011f0d8ce6c5577093cfcbbdd2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -124,4 +124,14 @@ public class PaperWorldConfig {
+@@ -129,4 +129,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }
@@ -25,7 +25,7 @@ index 89e76dd73811fd0f6f8c8e7e5af804d5a4bb5a75..d16ae924bcbe31c964f7fb448757c748
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 86493f18913f6d3a560de2e3f8690bd227d73cee..11ed0127e2ea268f16c6b4b380d132a71ec9b3dc 100644
+index 27707ccea8763dbfdfe80da45f26127e58bc7316..91c0e425de193be1e4e9779d1c92c8ea577e29e0 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -127,6 +127,17 @@ public class FallingBlockEntity extends Entity {

--- a/patches/server/0027-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0027-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d16ae924bcbe31c964f7fb448757c748e5c4418c..4bba6977a0287837b8927718c040ac61463f0469 100644
+index 741e622faf62b9011f0d8ce6c5577093cfcbbdd2..c281f055e93896e73ec4c847816f3a94d1c323e1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -134,4 +134,19 @@ public class PaperWorldConfig {
+@@ -139,4 +139,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }
@@ -29,7 +29,7 @@ index d16ae924bcbe31c964f7fb448757c748e5c4418c..4bba6977a0287837b8927718c040ac61
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e61f3decd7fa30c67acb4b2e4cb9c9c3ce2c9d7a..dbe30ad6a729c5a99f7ff977134738e509dcadad 100644
+index fe08d13e0d25119c48a8872fac6fd2a6ce0170be..2abaa7cac274d30319dd39170000eec9e7330e4d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -622,7 +622,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0030-Configurable-end-credits.patch
+++ b/patches/server/0030-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4bba6977a0287837b8927718c040ac61463f0469..e6e18f309dc09ea9416ea37dcc697ddc2b571a96 100644
+index c281f055e93896e73ec4c847816f3a94d1c323e1..ac8f30b6c3b0f0d5c161d91597bb56e9305de43d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -149,4 +149,10 @@ public class PaperWorldConfig {
+@@ -154,4 +154,10 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/patches/server/0032-Optimize-explosions.patch
+++ b/patches/server/0032-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e6e18f309dc09ea9416ea37dcc697ddc2b571a96..4881b03d470646843bad1bc343eb6a6ab9072d8e 100644
+index ac8f30b6c3b0f0d5c161d91597bb56e9305de43d..d3e98f82f91cbce5cd2939170604bc916072bc76 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -155,4 +155,10 @@ public class PaperWorldConfig {
+@@ -160,4 +160,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }

--- a/patches/server/0033-Disable-explosion-knockback.patch
+++ b/patches/server/0033-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4881b03d470646843bad1bc343eb6a6ab9072d8e..2222c1bb5f8625eee4d88946e4bfdfa2fe598977 100644
+index d3e98f82f91cbce5cd2939170604bc916072bc76..879b8ef496a1f3e4192a62bb137b621a380fe426 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -161,4 +161,9 @@ public class PaperWorldConfig {
+@@ -166,4 +166,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }
@@ -19,7 +19,7 @@ index 4881b03d470646843bad1bc343eb6a6ab9072d8e..2222c1bb5f8625eee4d88946e4bfdfa2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ebe33c891e25c729c4373190da86c7a8198b6a55..cc8fb033ca8241acb984e3440a44c7a083e2f3f6 100644
+index 759cd74cda7f0d1f3c0f3bc0a2a941e16258a1c0..5b285714ce231d45d879be83ae36d94eaa8310c0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1380,6 +1380,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0034-Disable-thunder.patch
+++ b/patches/server/0034-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2222c1bb5f8625eee4d88946e4bfdfa2fe598977..083e421f8496b5336af473b108498ed28b984774 100644
+index 879b8ef496a1f3e4192a62bb137b621a380fe426..19d46898fc2434c59012d30df26f645a9e1df56e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -166,4 +166,9 @@ public class PaperWorldConfig {
+@@ -171,4 +171,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }
@@ -19,7 +19,7 @@ index 2222c1bb5f8625eee4d88946e4bfdfa2fe598977..083e421f8496b5336af473b108498ed2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d26e8803222276fb7bb1bedd9fd13a8861ce671c..4792280988ac13593d59f6a10fa111eafa08328f 100644
+index 047672c4e47c72f06ccfe519ef4a9fb4935fdeca..aa1fac83609e3a5ff810c14179b3153d6b78a48a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -592,7 +592,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl

--- a/patches/server/0035-Disable-ice-and-snow.patch
+++ b/patches/server/0035-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 083e421f8496b5336af473b108498ed28b984774..2f7a5a4a5a7b29750cfd777e0bc5d19a14e93fa2 100644
+index 19d46898fc2434c59012d30df26f645a9e1df56e..412979bc3fde1613e472be8fdd50216850f405a8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -171,4 +171,9 @@ public class PaperWorldConfig {
+@@ -176,4 +176,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }
@@ -19,7 +19,7 @@ index 083e421f8496b5336af473b108498ed28b984774..2f7a5a4a5a7b29750cfd777e0bc5d19a
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4792280988ac13593d59f6a10fa111eafa08328f..b0ecf3c491e802aa292a0a8b7be37362c38ce084 100644
+index aa1fac83609e3a5ff810c14179b3153d6b78a48a..addd1e75b796b01d15d8c087329bfc4fb9823fbe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -616,7 +616,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl

--- a/patches/server/0036-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0036-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2f7a5a4a5a7b29750cfd777e0bc5d19a14e93fa2..4de86b09c6bc3c1974ce61b550ccb73d37f6f170 100644
+index 412979bc3fde1613e472be8fdd50216850f405a8..aad08c5577088388dd4c4f3eabd17ddaabd860a4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -176,4 +176,9 @@ public class PaperWorldConfig {
+@@ -181,4 +181,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/patches/server/0039-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0039-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4de86b09c6bc3c1974ce61b550ccb73d37f6f170..5a4c3a8c511f22c8c3240c9c7cd83a65119c1054 100644
+index aad08c5577088388dd4c4f3eabd17ddaabd860a4..6d239ada43926e111f0741cb48e70994dad1062c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -181,4 +181,9 @@ public class PaperWorldConfig {
+@@ -186,4 +186,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }

--- a/patches/server/0043-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/patches/server/0043-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5a4c3a8c511f22c8c3240c9c7cd83a65119c1054..70e074cdf2087e638af8e0f3878d0ef8eb7305cc 100644
+index 6d239ada43926e111f0741cb48e70994dad1062c..a39b2f4becff803d933f0f0563f151755cbeb7b9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -186,4 +186,9 @@ public class PaperWorldConfig {
+@@ -191,4 +191,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/patches/server/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 70e074cdf2087e638af8e0f3878d0ef8eb7305cc..416a6760883cb40367535c7c5acd779742bb8af5 100644
+index a39b2f4becff803d933f0f0563f151755cbeb7b9..13deb0bace32d823a3626ca2ed7fe84136b2488a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -191,4 +191,9 @@ public class PaperWorldConfig {
+@@ -196,4 +196,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
@@ -19,7 +19,7 @@ index 70e074cdf2087e638af8e0f3878d0ef8eb7305cc..416a6760883cb40367535c7c5acd7797
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index 0b0fb2331b126b6c0c7c3b2af81f3f9d2ad1f081..53130b34e5964acec191e1d8de6bde996f498699 100644
+index 26ed13505c5bcb03fd87bccf29cfdfbe0d1d6d87..2dbdc97bbc0f0960896528cfade12919fde137c4 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -322,7 +322,7 @@ public class Slime extends Mob implements Enemy {

--- a/patches/server/0050-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0050-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601ccc1f26e37 100644
+index 13deb0bace32d823a3626ca2ed7fe84136b2488a..984ce9d8f1add85c37d0cc60d232527468dbd079 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -196,4 +196,13 @@ public class PaperWorldConfig {
+@@ -201,4 +201,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
@@ -23,7 +23,7 @@ index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601cc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ab291f39efb8b4b41bf5b637caeaef8f7ad677ae..b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6 100644
+index 2abaa7cac274d30319dd39170000eec9e7330e4d..df636b5510693821d9e159624b5ae2c6451d2299 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2900,7 +2900,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730ac44aac8a 100644
+index 984ce9d8f1add85c37d0cc60d232527468dbd079..368cd221a0389319fef5e2ebf0505142ce80896a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -205,4 +205,9 @@ public class PaperWorldConfig {
+@@ -210,4 +210,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
          portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }
@@ -30,7 +30,7 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dab62713b33cdb7b2324216f7ad229db06e524d6..161fcf68dc85fc6d7b0034f137b1a5aee26cbb69 100644
+index f4e23ae54f611a264010834b10a8163f8159829c..65a55bdc3651900f2df0173c267d03335ce56a8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -885,7 +885,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0055-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0055-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb13716669ff64d3 100644
+index 368cd221a0389319fef5e2ebf0505142ce80896a..348047818cd2f5d3448dec3e64138ce529acfdfb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -210,4 +210,9 @@ public class PaperWorldConfig {
+@@ -215,4 +215,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }
@@ -25,7 +25,7 @@ index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb137166
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6..d5816bd67e468924a8f8ff8133883eef18872c4c 100644
+index df636b5510693821d9e159624b5ae2c6451d2299..edb75ce3fe60bc0730b99edca3a6e03ee15714c0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2549,6 +2549,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -37,7 +37,7 @@ index b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6..d5816bd67e468924a8f8ff8133883eef
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b750699a64a878fffb5cb6aa1cdda106116bbfb3..f23769ce887bfc646162dd9d14b4ba4cc6790c75 100644
+index 5b285714ce231d45d879be83ae36d94eaa8310c0..6c2adddb3d55e5384d1386788bce13ee4c7a6bbe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -803,6 +803,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0063-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0063-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3ac2ac3db9b1c271b3c21930bb13716669ff64d3..3c78d3234054ce2dc46ef77decb6adb0cbd10620 100644
+index 348047818cd2f5d3448dec3e64138ce529acfdfb..a75d63cb83b14ce7fe0cc8cdcf12150386314b7f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -215,4 +215,19 @@ public class PaperWorldConfig {
+@@ -220,4 +220,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }
@@ -30,7 +30,7 @@ index 3ac2ac3db9b1c271b3c21930bb13716669ff64d3..3c78d3234054ce2dc46ef77decb6adb0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index aa679dd070b9efd4b4450cfdb5e4d849f5793534..676e5ad3a23bfdccd8f5f7bb9e79c3fa004dc95f 100644
+index 860c4ca60adfbf265299c0db41eadc0384f68779..97a4d3b3709028d322617efdfe9a5aabe2197d82 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -310,7 +310,7 @@ public abstract class AbstractArrow extends Projectile {

--- a/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3c78d3234054ce2dc46ef77decb6adb0cbd10620..cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0 100644
+index a75d63cb83b14ce7fe0cc8cdcf12150386314b7f..0ba01765c9d2f91c1f1e90364e0cd9f7663e6459 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -230,4 +230,12 @@ public class PaperWorldConfig {
+@@ -235,4 +235,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }
@@ -22,7 +22,7 @@ index 3c78d3234054ce2dc46ef77decb6adb0cbd10620..cd64fb9d0c6d123e1c86cb33f12cd9ce
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6aab4ba5da83f523632a0a39d45a0bcb2405f0cc..69b52097eede1a5c408aa7f34442e42255386436 100644
+index 62bf85a8590c3dc00c74671303b4e7ce790fdc0b..9551e819a9a1ae1f4dc52e1a347d8ee5924d092b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -596,7 +596,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl

--- a/patches/server/0072-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0072-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0..74ba5dbb83c13ce1721619b755036a7864a1fb90 100644
+index 0ba01765c9d2f91c1f1e90364e0cd9f7663e6459..c7db946c6e2fd83df38a69a625d0eba5366eba75 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -238,4 +238,14 @@ public class PaperWorldConfig {
+@@ -243,4 +243,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }
@@ -30,7 +30,7 @@ index cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0..74ba5dbb83c13ce1721619b755036a78
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 7e5e16fd61b39d2093459766e8aaa10bb05f6763..5c5a55003658d75ad8295cbd7ff0450e08600d68 100644
+index db564e9a866c30d6d7b34fa97185b01e8c788449..805a5442fce7537a60f53bbba6362afd5ceca4a5 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -978,7 +978,7 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0078-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/patches/server/0078-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 74ba5dbb83c13ce1721619b755036a7864a1fb90..db2dddd12f54e6d15916c4cee623676541de37fb 100644
+index c7db946c6e2fd83df38a69a625d0eba5366eba75..86a0a91676250c055a7f751ca92bc112aa52f6ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -248,4 +248,10 @@ public class PaperWorldConfig {
+@@ -253,4 +253,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/patches/server/0081-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0081-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index db2dddd12f54e6d15916c4cee623676541de37fb..1942f5224aaebb18adb591d6f70a419cfc1a7bdd 100644
+index 86a0a91676250c055a7f751ca92bc112aa52f6ae..6205481b4a38fbe9008480122eb90b5b7442f068 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -254,4 +254,9 @@ public class PaperWorldConfig {
+@@ -259,4 +259,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/patches/server/0088-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/patches/server/0088-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1942f5224aaebb18adb591d6f70a419cfc1a7bdd..5baccb8d50c135ab20c38ffd0690f585514ce5af 100644
+index 6205481b4a38fbe9008480122eb90b5b7442f068..31d42ec4415aa3738ed5333fc6264b6d713786a8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -259,4 +259,14 @@ public class PaperWorldConfig {
+@@ -264,4 +264,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5baccb8d50c135ab20c38ffd0690f585514ce5af..eb04fdb172a50ec1f5b7fe78fa0e7655246abd60 100644
+index 31d42ec4415aa3738ed5333fc6264b6d713786a8..8ec1e836cf6001d3aef1e829c5eee7f26be22ab5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -269,4 +269,26 @@ public class PaperWorldConfig {
+@@ -274,4 +274,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }
@@ -515,7 +515,7 @@ index 0000000000000000000000000000000000000000..3377b86c337d0234bbb9b0349e4034a7
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4888c77c3bc415bc69d4aaf89899da7dcc81f402..27a6caea54ddd9efe3fc8da19877bee7fa7f4e3e 100644
+index 8d667633a01b33d9dd1fd3314f367e0ea8733735..8ccbaaed364bfbc0becc72f845bbb284b9f976ce 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -168,6 +168,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..9b2e9a02ff31c3cb37b67135d0a03441f247d8e2 100644
+index 8ec1e836cf6001d3aef1e829c5eee7f26be22ab5..bae18e486c8cae3576ef49f493abc1daefc28248 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -291,4 +291,14 @@ public class PaperWorldConfig {
+@@ -296,4 +296,14 @@ public class PaperWorldConfig {
              );
          }
      }
@@ -24,7 +24,7 @@ index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..9b2e9a02ff31c3cb37b67135d0a03441
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index ac57bfb00edd9268e89a7fd7cea36097d61d6951..ad9bbda31a4cdb306ca40f2b99e4b815c4f136bd 100644
+index a70bf50c3a17295bb9ffe30ea86f3b84e134cdbc..f835ef1c7109f56f32da394c9afc9fd35b05b51a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -68,7 +68,7 @@ public class ServerEntity {
@@ -37,7 +37,7 @@ index ac57bfb00edd9268e89a7fd7cea36097d61d6951..ad9bbda31a4cdb306ca40f2b99e4b815
      public ServerEntity(ServerLevel worldserver, Entity entity, int i, boolean flag, Consumer<Packet<?>> consumer, Set<ServerPlayerConnection> trackedPlayers) {
          this.trackedPlayers = trackedPlayers;
 diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
-index abc62c560816d945642d830a020deb28ff2efa37..5a16de4f080c31d6e278363fd1d3e23d48be3db5 100644
+index 8ad1b3cb16533d62deda643ce0cdda308743f78e..dcbd9ec44fb8d1334aca33c136b121ab5c25a0e2 100644
 --- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 +++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 @@ -97,6 +97,27 @@ public class PrimedTnt extends Entity {

--- a/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
+++ b/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b2e9a02ff31c3cb37b67135d0a03441f247d8e2..96247356d7888d5681bff60567add1188aedb18b 100644
+index bae18e486c8cae3576ef49f493abc1daefc28248..01e9f2450f9f256d7b09519350a2eb198620e17d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -301,4 +301,9 @@ public class PaperWorldConfig {
+@@ -306,4 +306,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }
@@ -19,7 +19,7 @@ index 9b2e9a02ff31c3cb37b67135d0a03441f247d8e2..96247356d7888d5681bff60567add118
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index eed2ef73c33b76222de0f4fd91525cc03eef19b0..521f199e495f3bec232cc9ca36e51e0392afe737 100644
+index 805a5442fce7537a60f53bbba6362afd5ceca4a5..0530de6e9167419b180a3fd6e890d27d9d86c04c 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -640,6 +640,12 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 96247356d7888d5681bff60567add1188aedb18b..e83216be5a00d5b927d8c2fc364551bd3077c974 100644
+index 01e9f2450f9f256d7b09519350a2eb198620e17d..11bcbed505f1c2f63e4071acd1910586d648c0e0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -306,4 +306,12 @@ public class PaperWorldConfig {
+@@ -311,4 +311,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e83216be5a00d5b927d8c2fc364551bd3077c974..2dc58b9f769ea43b737804456aafab47ecc143b8 100644
+index 11bcbed505f1c2f63e4071acd1910586d648c0e0..02ea1bce0326100e790b8dca6fe9d2e8c1a9a96a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -314,4 +314,14 @@ public class PaperWorldConfig {
+@@ -319,4 +319,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2dc58b9f769ea43b737804456aafab47ecc143b8..c611b5a63498f5ad1f50a75ccd5d7299e27df7e3 100644
+index 02ea1bce0326100e790b8dca6fe9d2e8c1a9a96a..bc18f69cff6a73b2fd89096a4eebf7f5d6b6bcd4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -324,4 +324,10 @@ public class PaperWorldConfig {
+@@ -329,4 +329,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c611b5a63498f5ad1f50a75ccd5d7299e27df7e3..9d1cddc6038f0fd0286e4a32013ae98ff0b00dd1 100644
+index bc18f69cff6a73b2fd89096a4eebf7f5d6b6bcd4..7c4f670d4c460132f90e3cbaa79061b3f3f1ab35 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -330,4 +330,10 @@ public class PaperWorldConfig {
+@@ -335,4 +335,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9d1cddc6038f0fd0286e4a32013ae98ff0b00dd1..90ca51dfdbb3045dd528450225cba96f5834166e 100644
+index 7c4f670d4c460132f90e3cbaa79061b3f3f1ab35..bf2d1020ae5b60235f86dd9fa1bdbddeeb077400 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -336,4 +336,10 @@ public class PaperWorldConfig {
+@@ -341,4 +341,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
+++ b/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 90ca51dfdbb3045dd528450225cba96f5834166e..3577100f850975020b74f077d688f59dbca78962 100644
+index bf2d1020ae5b60235f86dd9fa1bdbddeeb077400..fea7cb3833c2ad9bd19c2a1cf19ca3b82d910e74 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -342,4 +342,9 @@ public class PaperWorldConfig {
+@@ -347,4 +347,9 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3577100f850975020b74f077d688f59dbca78962..da4a110809eee691c1d5b072de335d75e1516eae 100644
+index fea7cb3833c2ad9bd19c2a1cf19ca3b82d910e74..f2929d0b298a891ba068210e2a878037250faecc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -192,6 +192,11 @@ public class PaperWorldConfig {
+@@ -197,6 +197,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  

--- a/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index da4a110809eee691c1d5b072de335d75e1516eae..9225372cb9ef51a8cfbd4cee543c250aa2ac9c49 100644
+index f2929d0b298a891ba068210e2a878037250faecc..3aa4437d8a333fb93eb6ea9725115bd24ca19d85 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -352,4 +352,9 @@ public class PaperWorldConfig {
+@@ -357,4 +357,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }

--- a/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9225372cb9ef51a8cfbd4cee543c250aa2ac9c49..a0a846a2e60bdc17537bd697137f65321c1a61d8 100644
+index 3aa4437d8a333fb93eb6ea9725115bd24ca19d85..d8c925d21bc1a40009b0a9b6c907b0c780edb995 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -357,4 +357,10 @@ public class PaperWorldConfig {
+@@ -362,4 +362,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }
@@ -27,7 +27,7 @@ index 9225372cb9ef51a8cfbd4cee543c250aa2ac9c49..a0a846a2e60bdc17537bd697137f6532
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index c72ec22beff6aa1f7932fa44dc7d591ceeec1158..c25cb17ef1a7c56e10ce3ccb5665c9dce3e6efa6 100644
+index e4294219be68c6f99cd0e5ea8330fae6dc03ddde..b09f52330b50879d5594b21302e70ca676b60951 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -88,6 +88,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a0a846a2e60bdc17537bd697137f65321c1a61d8..e1110274a9f6b8f7007537732ec8eff7e72040ee 100644
+index d8c925d21bc1a40009b0a9b6c907b0c780edb995..c50a52373c886c595c1e6c28d64074553f2b0800 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -363,4 +363,9 @@ public class PaperWorldConfig {
+@@ -368,4 +368,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e1110274a9f6b8f7007537732ec8eff7e72040ee..8f8a3ea51823a9cfba985efeb7e320ae42e0da8a 100644
+index c50a52373c886c595c1e6c28d64074553f2b0800..1e0dad18e3aad4562fc7225b6458a165a68e3ddd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -368,4 +368,9 @@ public class PaperWorldConfig {
+@@ -373,4 +373,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8f8a3ea51823a9cfba985efeb7e320ae42e0da8a..1f6b37bd3cbc825abab5ad2f673200ef5061746a 100644
+index 1e0dad18e3aad4562fc7225b6458a165a68e3ddd..1987d3f4ddd1b7a7ff9ee3041868a9a2f53c2cd3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -373,4 +373,9 @@ public class PaperWorldConfig {
+@@ -378,4 +378,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1f6b37bd3cbc825abab5ad2f673200ef5061746a..8bb33e1b631c3aa99cef2a63c140f0b0e11325e0 100644
+index 1987d3f4ddd1b7a7ff9ee3041868a9a2f53c2cd3..4761fb189348fe7304b4c6ed107a578d98c9e599 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -378,4 +378,10 @@ public class PaperWorldConfig {
+@@ -383,4 +383,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8bb33e1b631c3aa99cef2a63c140f0b0e11325e0..c17c504acdc12b6ef37d6643eb98a57fa5ca40c9 100644
+index 4761fb189348fe7304b4c6ed107a578d98c9e599..30dcc045088abb901741173f838ba0ebb0538b73 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -384,4 +384,10 @@ public class PaperWorldConfig {
+@@ -389,4 +389,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c17c504acdc12b6ef37d6643eb98a57fa5ca40c9..13e730b18c346934c061fb570048623ad66e7344 100644
+index 30dcc045088abb901741173f838ba0ebb0538b73..34440982a3f4661bdcc3131c097e7fddbe7a7bb9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -390,4 +390,9 @@ public class PaperWorldConfig {
+@@ -395,4 +395,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 090958a30ce20ff01ae77d4cd821a167474f0214..baf33659b021c89cbd02560cbfd9b0ddf205f0e2 100644
+index 744e17f2056e71e2e0179fe369c2df575141a2c1..368afbd7b6ac6484a53556271b86d0d8a00674b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -401,4 +401,15 @@ public class PaperWorldConfig {
+@@ -406,4 +406,15 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
@@ -37,7 +37,7 @@ index 090958a30ce20ff01ae77d4cd821a167474f0214..baf33659b021c89cbd02560cbfd9b0dd
  }
 +
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 6204bf41d410df9784b32f993b46d7adb2af5f13..19d0ed5ff8569b0280117750f9ce05095afd9f70 100644
+index 258b3b5ffd1ec82ab2ef8efc028cb623cd496339..0211b572dc46b3c4fc098f0ef31843a401cd3613 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -85,6 +85,13 @@ public final class NaturalSpawner {

--- a/patches/server/0339-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0339-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index baf33659b021c89cbd02560cbfd9b0ddf205f0e2..4c177a383b277debe8a7c02a70d029d862e6b048 100644
+index 368afbd7b6ac6484a53556271b86d0d8a00674b7..3204c9107af567bd09a40c752df888c49f05464e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -411,5 +411,10 @@ public class PaperWorldConfig {
+@@ -416,5 +416,10 @@ public class PaperWorldConfig {
              log("Using improved mob spawn limits (Only Natural Spawns impact spawn limits for more natural spawns)");
          }
      }
@@ -40,7 +40,7 @@ index baf33659b021c89cbd02560cbfd9b0ddf205f0e2..4c177a383b277debe8a7c02a70d029d8
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 7311923d36ee872b4331d84f80709bb6cee61086..69f439851fe1ff07d827eaed274940a5783d5f6c 100644
+index 21ce4be0d8d0147a92f87e17bb5078a211419984..37356b36f0ae12d55150f399318581fa77c30cee 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -161,7 +161,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0344-Generator-Settings.patch
+++ b/patches/server/0344-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4c177a383b277debe8a7c02a70d029d862e6b048..0c336a794d21d5084b9ea39308379b2ffb4a4330 100644
+index 3204c9107af567bd09a40c752df888c49f05464e..46786a63a6469e125ea667b0ceb3f57b380a07a4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -416,5 +416,10 @@ public class PaperWorldConfig {
+@@ -421,5 +421,10 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
+++ b/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0c336a794d21d5084b9ea39308379b2ffb4a4330..f46731897f4234b27dafa49a5f652535a99d2992 100644
+index 46786a63a6469e125ea667b0ceb3f57b380a07a4..4281c8260ba1274806a74b47112b5fb04114359f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -421,5 +421,10 @@ public class PaperWorldConfig {
+@@ -426,5 +426,10 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f46731897f4234b27dafa49a5f652535a99d2992..8190c30346c0fd2d86fb7cbcfc7ce17333e05146 100644
+index 4281c8260ba1274806a74b47112b5fb04114359f..bd47c8f2625037bbf3385d14bb8d34ba102bd03c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -426,5 +426,10 @@ public class PaperWorldConfig {
+@@ -431,5 +431,10 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8190c30346c0fd2d86fb7cbcfc7ce17333e05146..9860f5a0ddff83f1393ee13a96b38c3b14077512 100644
+index bd47c8f2625037bbf3385d14bb8d34ba102bd03c..e6739f27654573745b58205596a63af8b809ba44 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -402,6 +402,45 @@ public class PaperWorldConfig {
+@@ -407,6 +407,45 @@ public class PaperWorldConfig {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
  

--- a/patches/server/0353-Optimize-Hoppers.patch
+++ b/patches/server/0353-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9860f5a0ddff83f1393ee13a96b38c3b14077512..bf704993d0abd50dba91682a7fbb575e3696be62 100644
+index e6739f27654573745b58205596a63af8b809ba44..669a1e0993dccdf8468a61cc8c857065d3286533 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -470,5 +470,14 @@ public class PaperWorldConfig {
+@@ -475,5 +475,14 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
@@ -62,7 +62,7 @@ index 449d2e7b18608ca36282f1a29e69457fc525307e..c738cb0433ea4a86d82372bf66e29c01
      public double getLevelX() {
          return this.getX();
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 4348ecf7ca91fc38d59365aa5560d9d24f7b0703..30a339f56eb1edb730e4ce72b4ce314555bc8c15 100644
+index bfdb25461b76ce93ea19b3a1beecec91ec8b6a71..344d32e76e9bc4ece7838748e15939c647a5d67b 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -601,11 +601,12 @@ public final class ItemStack {

--- a/patches/server/0365-Increase-Light-Queue-Size.patch
+++ b/patches/server/0365-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bf704993d0abd50dba91682a7fbb575e3696be62..a91a7d8f56a068b18d50a8b987b71510b0a19d5b 100644
+index 669a1e0993dccdf8468a61cc8c857065d3286533..edd4ad8bf943bd85b80b1fb3ba479c0ab26d868c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -479,5 +479,10 @@ public class PaperWorldConfig {
+@@ -484,5 +484,10 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a91a7d8f56a068b18d50a8b987b71510b0a19d5b..b8ca1f73b2451307c3711076eaa43e2adb34d92e 100644
+index edd4ad8bf943bd85b80b1fb3ba479c0ab26d868c..36471f1729800152de6d739db83eebdbfb53ff1a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index a91a7d8f56a068b18d50a8b987b71510b0a19d5b..b8ca1f73b2451307c3711076eaa43e2a
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -484,5 +486,40 @@ public class PaperWorldConfig {
+@@ -489,5 +491,40 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index f27fadc15cb7f5c782e45885ec6a5a69963beade..2ff4d4921e2076abf415bd3c8f5173ec
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b8ca1f73b2451307c3711076eaa43e2adb34d92e..45e30c0d78b7625a6a55e6d7d60a823b674b75db 100644
+index 36471f1729800152de6d739db83eebdbfb53ff1a..7aa96012c092d270154d63822eb45b54bfaf81c4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -487,6 +487,11 @@ public class PaperWorldConfig {
+@@ -492,6 +492,11 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  

--- a/patches/server/0369-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0369-Implement-alternative-item-despawn-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 45e30c0d78b7625a6a55e6d7d60a823b674b75db..31f192773fe5159ed2109f0d367e6b7287ffd186 100644
+index 7aa96012c092d270154d63822eb45b54bfaf81c4..3d22cbb041ff0fc7c41e6eed8f005e1c2350b309 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -492,6 +492,54 @@ public class PaperWorldConfig {
+@@ -497,6 +497,54 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index fe79c0add4f7cb18d487c5bb9415c40c5b551ea2..8d9ddad1879e7616d980ca70de8aecac
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 31f192773fe5159ed2109f0d367e6b7287ffd186..f2e4939c8144b9bc7441130302ab3e2358c42063 100644
+index 3d22cbb041ff0fc7c41e6eed8f005e1c2350b309..739fe6e5de5c7911d2d48f53c25fa1eec1e1302b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -574,5 +574,10 @@ public class PaperWorldConfig {
+@@ -579,5 +579,10 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }
@@ -591,7 +591,7 @@ index c7d708cc5c20d46ed085f1f1db7666246614a57d..b2d88e0423d93fdb45dc8ca7d53c9806
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index d81d84b948842088c93a32e307b7430d81438da9..136c6db28ca4d9244ce9341e341b1f36cd643ea3 100644
+index 3beef93cd23b3f1171e090c87c3f96747a276678..d4d69c3f89a106d691ec8d0709ca45850f91d2a6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -753,7 +753,22 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f2e4939c8144b9bc7441130302ab3e2358c42063..3d14a7dbcc6bc46141596a7e04f790bfe8f560c6 100644
+index 739fe6e5de5c7911d2d48f53c25fa1eec1e1302b..ff907d47312e6545df39fe4529945bd066b0417a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -482,6 +482,11 @@ public class PaperWorldConfig {
+@@ -487,6 +487,11 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  
@@ -21,7 +21,7 @@ index f2e4939c8144b9bc7441130302ab3e2358c42063..3d14a7dbcc6bc46141596a7e04f790bf
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5d0118a753b044b1cd83298964be16a1ee87729f..c98938c1fa057001783b7f39e88f107b8cb700f0 100644
+index c11b4ff3907a0041db35a1dd7940a42755db3f0d..57a6f748891720ee65ba6fae700fe673967ade8c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -328,6 +328,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3d14a7dbcc6bc46141596a7e04f790bfe8f560c6..9fb1ea2e363de88c48530341fd11541ebdec8831 100644
+index ff907d47312e6545df39fe4529945bd066b0417a..88badd00a959bfd194ec89267c5c02f14084c161 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -382,6 +382,11 @@ public class PaperWorldConfig {
+@@ -387,6 +387,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9fb1ea2e363de88c48530341fd11541ebdec8831..9dc8a9e49cac89e236d9fa0c053b70bf10ed6f6e 100644
+index 88badd00a959bfd194ec89267c5c02f14084c161..466ac4e9b6735ba0dd11142f1207f50b9d72184b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -492,6 +492,11 @@ public class PaperWorldConfig {
+@@ -497,6 +497,11 @@ public class PaperWorldConfig {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
  
@@ -24,7 +24,7 @@ index 9fb1ea2e363de88c48530341fd11541ebdec8831..9dc8a9e49cac89e236d9fa0c053b70bf
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 4c5213fe89ec131addcc3d705f2e3268f51f1868..299dc59535d2cd73de346618731c65bc01063b66 100644
+index cf1b80350d15b55eecafa9ab53e49b9a754a8d0e..05a62a5d115d709ec1c29b36b09dfd8ce9626256 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -452,10 +452,13 @@ public class Zombie extends Monster {

--- a/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9dc8a9e49cac89e236d9fa0c053b70bf10ed6f6e..2d038185846ae34bc301ab93d881022a05ee458b 100644
+index 466ac4e9b6735ba0dd11142f1207f50b9d72184b..1be798cd5b9e8fce98dc9d8333749116e2e1e31a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -469,10 +469,21 @@ public class PaperWorldConfig {
+@@ -474,10 +474,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/patches/server/0423-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0423-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2d038185846ae34bc301ab93d881022a05ee458b..1460cd36e8d38c1c4318adf818b87961bfe07aec 100644
+index 1be798cd5b9e8fce98dc9d8333749116e2e1e31a..33caa810e5e04d872eebed2891b6f77731e2bd64 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -513,6 +513,13 @@ public class PaperWorldConfig {
+@@ -518,6 +518,13 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  
@@ -35,7 +35,7 @@ index d17b75ad13bbc8a38cdc2f2d77ee5d88438cec31..8fb89326395a7e70982c0d757b506565
      private EntitySelector() {}
      // Paper start
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Phantom.java b/src/main/java/net/minecraft/world/entity/monster/Phantom.java
-index d2a3927a263c445e647a4bbc5fe12addaf290c0e..6dbf806b5984ae16e747dce350c7cffcf0b190ad 100644
+index 877095c93e944293dfb52471eda59a24fad2dbc9..460a848bd2a417d05a0bbb084371c98b661a427f 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Phantom.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Phantom.java
 @@ -547,6 +547,7 @@ public class Phantom extends FlyingMob implements Enemy {

--- a/patches/server/0435-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0435-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1460cd36e8d38c1c4318adf818b87961bfe07aec..b6742a4ef1a798e60289586f5cccf6886afa360a 100644
+index 33caa810e5e04d872eebed2891b6f77731e2bd64..ebe7c657ab2f96f1edb184c680981cbe1903a958 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -356,6 +356,12 @@ public class PaperWorldConfig {
+@@ -361,6 +361,12 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  
@@ -22,7 +22,7 @@ index 1460cd36e8d38c1c4318adf818b87961bfe07aec..b6742a4ef1a798e60289586f5cccf688
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 09c152123d055432266bbb5a1434c21aed64da1f..7b59cfc35968a82c5db78c5107b175d994df3535 100644
+index 07620396c5fdea16b525ae9901c8cd594952573d..06f612081a65a655180ab96281eb6e14881b30e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -610,16 +610,30 @@ public class CraftEventFactory {

--- a/patches/server/0453-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0453-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b6742a4ef1a798e60289586f5cccf6886afa360a..9e5810eb0085ad956f0bd1cd69fa88909d9d638a 100644
+index ebe7c657ab2f96f1edb184c680981cbe1903a958..0878a77e278bf5df8f04f1fe735806fa4dc82683 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -531,6 +531,15 @@ public class PaperWorldConfig {
+@@ -536,6 +536,15 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0554-Seed-based-feature-search.patch
+++ b/patches/server/0554-Seed-based-feature-search.patch
@@ -21,10 +21,10 @@ changes but this should usually not happen. A config option to disable
 this completely is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a03b835320bb99c38ec5f23f0c23284c08bd4171..45e65d1c56b693d8f7c5c12da7774849c737aa96 100644
+index 9502d93b435490448f2d884cce2101bf53fde1fc..8a1b4c0158d5d811aa276155687af4fd2e8f525f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -376,6 +376,14 @@ public class PaperWorldConfig {
+@@ -381,6 +381,14 @@ public class PaperWorldConfig {
          }
      }
  
@@ -40,7 +40,7 @@ index a03b835320bb99c38ec5f23f0c23284c08bd4171..45e65d1c56b693d8f7c5c12da7774849
      private void maxEntityCollision() {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
-index 3878a7f6402a1dff1e019e16dd8772ec7303ebe7..ef77b7e54c9ce3379b3bd6991aebcb4889029907 100644
+index d7129f3379f2edecbcfd85f83d75e4d7064ce71d..7705ad4460ddf5166d922888f3a1368c50bb11ca 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 @@ -171,7 +171,24 @@ public abstract class StructureFeature<C extends FeatureConfiguration> {

--- a/patches/server/0592-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0592-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0079b4423c022a68aa9bee5b81910714ef3d1cd8..8d7acac29d5a8586f449e32f51c1213545e4d366 100644
+index 1e0344ae3747e2342f8e07d72ab02bd25ddc7401..5a5f0ac5de84591db516ab31573f433c85e20502 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -430,6 +430,14 @@ public class PaperWorldConfig {
+@@ -435,6 +435,14 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  

--- a/patches/server/0596-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0596-Configurable-door-breaking-difficulty.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable door breaking difficulty
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8d7acac29d5a8586f449e32f51c1213545e4d366..4227e7fc46e22265316b42bbdb166d60e5aed94e 100644
+index 5a5f0ac5de84591db516ab31573f433c85e20502..fa4598d6af12e64caf632cdf93589e24a5af1254 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -2,7 +2,10 @@ package com.destroystokyo.paper;
@@ -46,7 +46,7 @@ index 8d7acac29d5a8586f449e32f51c1213545e4d366..4227e7fc46e22265316b42bbdb166d60
      public short keepLoadedRange;
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
-@@ -140,6 +162,11 @@ public class PaperWorldConfig {
+@@ -145,6 +167,11 @@ public class PaperWorldConfig {
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }
  
@@ -72,7 +72,7 @@ index fafc4c4c7f5d6c4c03671bceec269250117ec472..51082fb81477b96c778796e8daf288b3
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 6c4c5756def8eb368cbc6e9319ae6f7ddccf0499..bb3b932c57fd1e5b1517940c7602c7f4aeeaf17e 100644
+index bcf80e22c815cf851a86e6cc9865c3cb5e89a143..ddda5d1e85864030db0cfecbf7a5fe134d7013a1 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -100,7 +100,7 @@ public class Zombie extends Monster {

--- a/patches/server/0607-Configurable-max-leash-distance.patch
+++ b/patches/server/0607-Configurable-max-leash-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max leash distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3d16e4a6bf842a209c760fd89f8edf995cabce7d..70815cb7393008f8b02e83e68fe27bb5202d00f6 100644
+index 92c9dd2ac69405bad3f3dc806c9bae5c89a85f74..c41bf1038c07c86178679beb25c7867c81f925fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -263,6 +263,12 @@ public class PaperWorldConfig {
+@@ -268,6 +268,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0613-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0613-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add toggle for always placing the dragon egg
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 70815cb7393008f8b02e83e68fe27bb5202d00f6..7fc5bf095afa6d5881285b89091d2ff48ffb69f0 100644
+index c41bf1038c07c86178679beb25c7867c81f925fe..ba63feb6e1782ce30aa657efb5562a8c8d43f136 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -754,5 +754,10 @@ public class PaperWorldConfig {
+@@ -759,5 +759,10 @@ public class PaperWorldConfig {
      private void perPlayerMobSpawns() {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", false);
      }

--- a/patches/server/0620-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0620-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7fc5bf095afa6d5881285b89091d2ff48ffb69f0..0eba516110b82d917c3374a9fe5bbf337b83fad6 100644
+index ba63feb6e1782ce30aa657efb5562a8c8d43f136..6654bc7e634d559b8f12e20ced5f1b95f18998b3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -759,5 +759,10 @@ public class PaperWorldConfig {
+@@ -764,5 +764,10 @@ public class PaperWorldConfig {
      private void enderDragonsDeathAlwaysPlacesDragonEgg() {
          enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
      }
@@ -20,7 +20,7 @@ index 7fc5bf095afa6d5881285b89091d2ff48ffb69f0..0eba516110b82d917c3374a9fe5bbf33
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2f3dc805d3015ce083865050a4b99f2ba8d69bce..b9588496dfc14eff48dddb747396cecc53d2bd44 100644
+index 9098a6515c732197f843a4612add23fde3dd189c..4b652da1023e59314b7fe080a37c89b5da5754fc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1339,6 +1339,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl

--- a/patches/server/0631-MC-29274-Fix-Wither-hostility-towards-players.patch
+++ b/patches/server/0631-MC-29274-Fix-Wither-hostility-towards-players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-29274: Fix Wither hostility towards players
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0eba516110b82d917c3374a9fe5bbf337b83fad6..20eb4aea24cc6699747b18b2c00e5b01dafb47c6 100644
+index 6654bc7e634d559b8f12e20ced5f1b95f18998b3..c3c1b3e52e4c0ee99073b5b186f1123b13599c0f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -764,5 +764,11 @@ public class PaperWorldConfig {
+@@ -769,5 +769,11 @@ public class PaperWorldConfig {
      private void setUpdatePathfindingOnBlockUpdate() {
          updatePathfindingOnBlockUpdate = getBoolean("update-pathfinding-on-block-update", this.updatePathfindingOnBlockUpdate);
      }
@@ -21,7 +21,7 @@ index 0eba516110b82d917c3374a9fe5bbf337b83fad6..20eb4aea24cc6699747b18b2c00e5b01
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index 1e479853ec239b5e970b478adb3419e400d2f1d6..1c8f6863b976cfcb559de9b3e3cf9292831166ee 100644
+index 40b7f71c1aa561462f7551ae6f7c36b18b41b93a..6e3bd5146c687922e7b4680d59a1ae2d1480ad40 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -105,6 +105,7 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob

--- a/patches/server/0641-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0641-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 20eb4aea24cc6699747b18b2c00e5b01dafb47c6..acd61a9033fdfb91e29a5fa6a10b8983ed94baa5 100644
+index c3c1b3e52e4c0ee99073b5b186f1123b13599c0f..df66aa5f832c8d8ca6458314787d9d840a6b707a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -770,5 +770,10 @@ public class PaperWorldConfig {
+@@ -775,5 +775,10 @@ public class PaperWorldConfig {
          fixWitherTargetingBug = getBoolean("fix-wither-targeting-bug", false);
          log("Withers properly target players: " + fixWitherTargetingBug);
      }

--- a/patches/server/0697-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0697-Limit-item-frame-cursors-on-maps.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c94579d5db6802ef27c6c64cde1cdfdff5040ed2..05c1aa7c49134e099e3d14a244252173e6755401 100644
+index 19b71cea35ae9b90cd3e1c554de811daae4ddf75..61e5f4f43126941c954c0e31f56dcc2f545a2776 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -792,5 +792,10 @@ public class PaperWorldConfig {
+@@ -797,5 +797,10 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }

--- a/patches/server/0702-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0702-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 05c1aa7c49134e099e3d14a244252173e6755401..258d54e450ff5aec06eaeb1d57c049d9b0b3ea48 100644
+index 61e5f4f43126941c954c0e31f56dcc2f545a2776..854f67d8cd2c18eb8bf0f649dcfcaef17016bb40 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -797,5 +797,10 @@ public class PaperWorldConfig {
+@@ -802,5 +802,10 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0704-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0704-Fix-invulnerable-end-crystals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 258d54e450ff5aec06eaeb1d57c049d9b0b3ea48..417cf3d8988f28fa1e0b05f11b89ef2c02d59ed9 100644
+index 854f67d8cd2c18eb8bf0f649dcfcaef17016bb40..4fc1deea48b3c2b700e0e08a8092285d1ef80f74 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -802,5 +802,10 @@ public class PaperWorldConfig {
+@@ -807,5 +807,10 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0710-add-per-world-spawn-limits.patch
+++ b/patches/server/0710-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 417cf3d8988f28fa1e0b05f11b89ef2c02d59ed9..26e18a08a7f0bd704ff3055ce3a7814191450c85 100644
+index 4fc1deea48b3c2b700e0e08a8092285d1ef80f74..3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -658,6 +658,19 @@ public class PaperWorldConfig {
+@@ -663,6 +663,19 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  

--- a/patches/server/0725-make-configured-features-seed-configurable.patch
+++ b/patches/server/0725-make-configured-features-seed-configurable.patch
@@ -46,7 +46,7 @@ index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..f2a9fe46cab707b79a0c14e60b73fae0
  }
  
 diff --git a/src/main/java/net/minecraft/world/level/biome/Biome.java b/src/main/java/net/minecraft/world/level/biome/Biome.java
-index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..a8e82019c288c7e44487279a0514db203de839cb 100644
+index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..3df1961df85c727f6bf5fb917795dad49aa64a06 100644
 --- a/src/main/java/net/minecraft/world/level/biome/Biome.java
 +++ b/src/main/java/net/minecraft/world/level/biome/Biome.java
 @@ -225,8 +225,10 @@ public final class Biome {
@@ -67,7 +67,7 @@ index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..a8e82019c288c7e44487279a0514db20
 +                    // Paper start - set the populationSeed back to the one defined by the region and if applicable, replace
 +                    populationSeed = populationCopy;
 +                    ResourceLocation location = registry.getKey(configuredFeature);
-+                    Long replacementSeed = region.getMinecraftWorld().paperConfig.configuredFeatureSeedReplacements.getLong(location);
++                    long replacementSeed = region.getMinecraftWorld().paperConfig.configuredFeatureSeedReplacements.getOrDefault(location, -1);
 +                    ChunkPos pos = region.getCenter();
 +                    int x = pos.getMinBlockX();
 +                    int z = pos.getMinBlockZ();

--- a/patches/server/0725-make-configured-features-seed-configurable.patch
+++ b/patches/server/0725-make-configured-features-seed-configurable.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Thonk <30448663+ExcessiveAmountsOfZombies@users.noreply.github.com>
+Date: Wed, 7 Jul 2021 20:32:34 -0500
+Subject: [PATCH] make configured features seed configurable
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..cc848b1fc8894d299ec1499a172bd328a5d9491f 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -5,12 +5,14 @@ import java.util.HashMap;
+ import java.util.List;
+ import java.util.Map;
+ import java.util.stream.Collectors;
++import net.minecraft.resources.ResourceLocation;
+ import net.minecraft.world.Difficulty;
+ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.entity.monster.Vindicator;
+ import net.minecraft.world.entity.monster.Zombie;
+ import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+ import org.bukkit.Bukkit;
++import org.bukkit.configuration.ConfigurationSection;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.spigotmc.SpigotWorldConfig;
+ 
+@@ -825,5 +827,19 @@ public class PaperWorldConfig {
+     private void fixInvulnerableEndCrystalExploit() {
+         fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
+     }
++
++    public Map<ResourceLocation, Long> configuredFeatureSeedReplacements = new HashMap<>();
++    private void setupConfiguredFeatureSeedReplacer() {
++        String path = "configured-feature.seed-replacements";
++        getLong(path + ".minecraft:disk_clay", -1);
++        ConfigurationSection values = config.getConfigurationSection("world-settings." + worldName + "." + path);
++        if (values == null) {
++            values = config.getConfigurationSection("world-settings.default." + path);
++        }
++        for (String key : values.getKeys(false)) {
++            ResourceLocation resourceKey = new ResourceLocation(key);
++            configuredFeatureSeedReplacements.put(resourceKey, values.getLong(key));
++        }
++    }
+ }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/biome/Biome.java b/src/main/java/net/minecraft/world/level/biome/Biome.java
+index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..6418db3ebcf42c8dbe9c400e4fe005c0cdf45aed 100644
+--- a/src/main/java/net/minecraft/world/level/biome/Biome.java
++++ b/src/main/java/net/minecraft/world/level/biome/Biome.java
+@@ -225,8 +225,10 @@ public final class Biome {
+         Registry<StructureFeature<?>> registry2 = region.registryAccess().registryOrThrow(Registry.STRUCTURE_FEATURE_REGISTRY);
+         int i = GenerationStep.Decoration.values().length;
+ 
++        long populationCopy = populationSeed; // Paper - keep a copy here so that any replacements don't override into features that don't need to be changed
+         for(int j = 0; j < i; ++j) {
+             int k = 0;
++            populationSeed = populationCopy; // Paper also don't want configuredFeatures to pollute StructureFeatures
+             if (structureAccessor.shouldGenerateFeatures()) {
+                 for(StructureFeature<?> structureFeature : this.structuresByStep.getOrDefault(j, Collections.emptyList())) {
+                     random.setFeatureSeed(populationSeed, k, j);
+@@ -263,6 +265,16 @@ public final class Biome {
+                     Supplier<String> supplier3 = () -> {
+                         return registry.getResourceKey(configuredFeature).map(Object::toString).orElseGet(configuredFeature::toString);
+                     };
++                    // Paper start - set the populationSeed back to the one defined by the region and if applicable, replace
++                    populationSeed = populationCopy;
++                    ResourceLocation location = registry.getKey(configuredFeature);
++                    Long replacementSeed = region.getMinecraftWorld().paperConfig.configuredFeatureSeedReplacements.getOrDefault(location, null);
++                    ChunkPos pos = region.getCenter();
++                    int x = pos.getMinBlockX();
++                    int z = pos.getMinBlockZ();
++                    if (replacementSeed != null && replacementSeed != -1) {
++                        populationSeed = random.setDecorationSeed(replacementSeed, x, z);
++                    } // Paper end
+                     random.setFeatureSeed(populationSeed, k, j);
+ 
+                     try {

--- a/patches/server/0725-make-configured-features-seed-configurable.patch
+++ b/patches/server/0725-make-configured-features-seed-configurable.patch
@@ -5,13 +5,14 @@ Subject: [PATCH] make configured features seed configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..cc848b1fc8894d299ec1499a172bd328a5d9491f 100644
+index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..f2a9fe46cab707b79a0c14e60b73fae08722706a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -5,12 +5,14 @@ import java.util.HashMap;
+@@ -5,12 +5,15 @@ import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
  import java.util.stream.Collectors;
++import it.unimi.dsi.fastutil.objects.Object2LongOpenHashMap;
 +import net.minecraft.resources.ResourceLocation;
  import net.minecraft.world.Difficulty;
  import net.minecraft.world.entity.EntityType;
@@ -23,13 +24,14 @@ index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..cc848b1fc8894d299ec1499a172bd328
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -825,5 +827,19 @@ public class PaperWorldConfig {
+@@ -825,5 +828,20 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }
 +
-+    public Map<ResourceLocation, Long> configuredFeatureSeedReplacements = new HashMap<>();
++    public Object2LongOpenHashMap<ResourceLocation> configuredFeatureSeedReplacements = new Object2LongOpenHashMap<>();
 +    private void setupConfiguredFeatureSeedReplacer() {
++        configuredFeatureSeedReplacements.defaultReturnValue(-1);
 +        String path = "configured-feature.seed-replacements";
 +        getLong(path + ".minecraft:disk_clay", -1);
 +        ConfigurationSection values = config.getConfigurationSection("world-settings." + worldName + "." + path);
@@ -44,7 +46,7 @@ index 3d7c8f007dc6b3454f23ee0d62b62d0931eb99ea..cc848b1fc8894d299ec1499a172bd328
  }
  
 diff --git a/src/main/java/net/minecraft/world/level/biome/Biome.java b/src/main/java/net/minecraft/world/level/biome/Biome.java
-index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..6418db3ebcf42c8dbe9c400e4fe005c0cdf45aed 100644
+index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..a8e82019c288c7e44487279a0514db203de839cb 100644
 --- a/src/main/java/net/minecraft/world/level/biome/Biome.java
 +++ b/src/main/java/net/minecraft/world/level/biome/Biome.java
 @@ -225,8 +225,10 @@ public final class Biome {
@@ -65,11 +67,11 @@ index a7a7e6cd87270e64a92448f03f8b0b0c7e375ec7..6418db3ebcf42c8dbe9c400e4fe005c0
 +                    // Paper start - set the populationSeed back to the one defined by the region and if applicable, replace
 +                    populationSeed = populationCopy;
 +                    ResourceLocation location = registry.getKey(configuredFeature);
-+                    Long replacementSeed = region.getMinecraftWorld().paperConfig.configuredFeatureSeedReplacements.getOrDefault(location, null);
++                    Long replacementSeed = region.getMinecraftWorld().paperConfig.configuredFeatureSeedReplacements.getLong(location);
 +                    ChunkPos pos = region.getCenter();
 +                    int x = pos.getMinBlockX();
 +                    int z = pos.getMinBlockZ();
-+                    if (replacementSeed != null && replacementSeed != -1) {
++                    if (replacementSeed != -1) {
 +                        populationSeed = random.setDecorationSeed(replacementSeed, x, z);
 +                    } // Paper end
                      random.setFeatureSeed(populationSeed, k, j);


### PR DESCRIPTION
This is my attempted fix for https://github.com/PaperMC/Paper/issues/6086

Technically with this you can change the seed of any ConfiguredFeature you want, as long as you know the name of it, but it seemed like a better idea to only make clay a default.

I did a little testing to see if it worked
Created a world with seed `123123`
/locatebiome minecraft:swamp

Before:
https://i.imgur.com/Xx99hyC.png

After:
https://i.imgur.com/XZ6vHzC.png


All the diamonds were in the same place, but the clay was moved.