### PR TITLE
Fix collisions during world generation

### DIFF
--- a/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
@@ -52,10 +52,10 @@ index b980c26ab5cac02e03525177a9dc4fb0b6a2f9f6..2a784a8342e708e0813c7076a2ca8e42
  
      Stream<VoxelShape> getEntityCollisions(@Nullable Entity entity, AABB box, Predicate<Entity> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/CollisionSpliterator.java b/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
-index e6190bfb893de12e87e1da49001ebd963b3d6318..6f4acf1c7c98a6069b79db483b8c79a8f4b46d54 100644
+index e6190bfb893de12e87e1da49001ebd963b3d6318..e4122469b839103f5c0fce38822d408a903dc0a5 100644
 --- a/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
 +++ b/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
-@@ -64,21 +64,35 @@ public class CollisionSpliterator extends AbstractSpliterator<VoxelShape> {
+@@ -64,21 +64,42 @@ public class CollisionSpliterator extends AbstractSpliterator<VoxelShape> {
      boolean collisionCheck(Consumer<? super VoxelShape> action) {
          while(true) {
              if (this.cursor.advance()) {
@@ -76,11 +76,18 @@ index e6190bfb893de12e87e1da49001ebd963b3d6318..6f4acf1c7c98a6069b79db483b8c79a8
 +                boolean far = this.source != null && net.minecraft.server.MCUtil.distanceSq(this.source.getX(), y, this.source.getZ(), x, y, z) > 14;
 +                this.pos.set(x, y, z);
 +
-+                boolean isRegionLimited = this.collisionGetter instanceof net.minecraft.server.level.WorldGenRegion;
-+                BlockState blockState = isRegionLimited ? Blocks.VOID_AIR.defaultBlockState() : ((!far && this.source instanceof net.minecraft.server.level.ServerPlayer) || (this.source != null && this.source.collisionLoadChunks)
-+                    ? this.collisionGetter.getBlockState(this.pos)
-+                    : this.collisionGetter.getTypeIfLoaded(this.pos)
-+                );
++                BlockState blockState;
++                if (this.collisionGetter instanceof net.minecraft.server.level.WorldGenRegion) {
++                   BlockGetter blockGetter = this.getChunk(x, z);
++                   if (blockGetter == null) {
++                       continue;
++                   }
++                   blockState = blockGetter.getBlockState(this.pos);
++                } else if ((!far && this.source instanceof net.minecraft.server.level.ServerPlayer) || (this.source != null && this.source.collisionLoadChunks)) {
++                    blockState = this.collisionGetter.getBlockState(this.pos);
++                } else {
++                    blockState = this.collisionGetter.getTypeIfLoaded(this.pos);
++                }
 +
 +                if (blockState == null) {
 +                    if (!(this.source instanceof net.minecraft.server.level.ServerPlayer) || this.source.level.paperConfig.preventMovingIntoUnloadedChunks) {

--- a/patches/server/0468-Optimize-WorldBorder-collision-checks-and-air.patch
+++ b/patches/server/0468-Optimize-WorldBorder-collision-checks-and-air.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimize WorldBorder collision checks and air
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index dcc128fdf45b23fe07a20136f498ead2ac6ee4a7..895c4d0f8f6b829de426543c51181a88a1fd340f 100644
+index 8278d38d6d61bff836c49ae5651f2be195389d1b..a0d1eaa72b88ff312112420c1b6da4c918bfcbe4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1044,7 +1044,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -18,10 +18,10 @@ index dcc128fdf45b23fe07a20136f498ead2ac6ee4a7..895c4d0f8f6b829de426543c51181a88
              return true;
          });
 diff --git a/src/main/java/net/minecraft/world/level/CollisionSpliterator.java b/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
-index 6f4acf1c7c98a6069b79db483b8c79a8f4b46d54..e420c98d9ccc45d570984dc30fdb928883edec9f 100644
+index e4122469b839103f5c0fce38822d408a903dc0a5..6124e3a32325e8c74bf839010a79d7c82c49aaff 100644
 --- a/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
 +++ b/src/main/java/net/minecraft/world/level/CollisionSpliterator.java
-@@ -133,9 +133,10 @@ public class CollisionSpliterator extends AbstractSpliterator<VoxelShape> {
+@@ -140,9 +140,10 @@ public class CollisionSpliterator extends AbstractSpliterator<VoxelShape> {
          WorldBorder worldBorder = this.collisionGetter.getWorldBorder();
          AABB aABB = this.source.getBoundingBox();
          if (!isBoxFullyWithinWorldBorder(worldBorder, aABB)) {


### PR DESCRIPTION
Should fix entity suffocation on terrain generation.

Totally not sure this is the best fix but this **is** the patch that caused the broken behavior in the first place.

Feel free to push to this branch with a better change.