### PR TITLE
[ci skip] Add a test plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,7 +24,6 @@ dependency-reduced-pom.xml
 .*.sw[a-p]
 
 # various other potential build files
-build/
 bin/
 dist/
 manifest.mf
@@ -68,3 +67,5 @@ paperclip-*.jar
 paperclip.properties
 
 !gradle/wrapper/gradle-wrapper.jar
+
+test-plugin.settings.gradle.kts

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -20,10 +20,10 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a
  /.project
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..be565d252e326991f491cab3bfd3acc8356bbc7f
+index 0000000000000000000000000000000000000000..e76b9f9012c7ba7253f455fa92b3891737f4ffd3
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,145 @@
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 +import io.papermc.paperweight.util.Git
@@ -127,6 +127,13 @@ index 0000000000000000000000000000000000000000..be565d252e326991f491cab3bfd3acc8
 +    workingDir = rootProject.layout.projectDirectory.dir(
 +        providers.gradleProperty("runWorkDir").forUseAtConfigurationTime().orElse("run")
 +    ).get().asFile
++
++    if (rootProject.childProjects["test-plugin"] != null) {
++        val testPluginJar = rootProject.project(":test-plugin").tasks.jar.flatMap { it.archiveFile }
++        inputs.file(testPluginJar)
++        args("-add-plugin=${testPluginJar.get().asFile.absolutePath}")
++    }
++
 +    args("--nogui")
 +    systemProperty("net.kyori.adventure.text.warnWhenLegacyFormattingDetected", true)
 +    if (project.hasProperty("disableWatchdog")) {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -8,3 +8,10 @@ pluginManagement {
 rootProject.name = "Paper"
 
 include("Paper-API", "Paper-Server", "Paper-MojangAPI")
+
+val testPlugin = file("test-plugin.settings.gradle.kts")
+if (testPlugin.exists()) {
+    apply(from = testPlugin)
+} else {
+    testPlugin.writeText("// Uncomment to enable the test plugin module\n//include(\":test-plugin\")\n")
+}

--- a/test-plugin/build.gradle.kts
+++ b/test-plugin/build.gradle.kts
@@ -1,0 +1,17 @@
+version = "1.0.0-SNAPSHOT"
+
+repositories {
+    maven("https://libraries.minecraft.net")
+}
+
+dependencies {
+    compileOnly(project(":Paper-API"))
+    compileOnly(project(":Paper-MojangAPI"))
+}
+
+tasks.processResources {
+    inputs.property("version", project.version)
+    filesMatching("plugin.yml") {
+        expand("version" to project.version)
+    }
+}

--- a/test-plugin/src/main/java/io/papermc/paper/testplugin/TestPlugin.java
+++ b/test-plugin/src/main/java/io/papermc/paper/testplugin/TestPlugin.java
@@ -1,0 +1,11 @@
+package io.papermc.paper.testplugin;
+
+import org.bukkit.event.Listener;
+import org.bukkit.plugin.java.JavaPlugin;
+
+public final class TestPlugin extends JavaPlugin implements Listener {
+    @Override
+    public void onEnable() {
+        this.getServer().getPluginManager().registerEvents(this, this);
+    }
+}

--- a/test-plugin/src/main/resources/plugin.yml
+++ b/test-plugin/src/main/resources/plugin.yml
@@ -1,0 +1,7 @@
+name: Paper-Test-Plugin
+version: ${version}
+main: io.papermc.paper.testplugin.TestPlugin
+description: Paper Test Plugin
+author: PaperMC
+api-version: 1.17
+load: STARTUP


### PR DESCRIPTION
Adds a test plugin. Disabled by default, enable by uncommenting a line in the gitignored `test-plugin.settings.gradle.kts`. The plugin will be loaded during all 3 run tasks if enabled.