### PR TITLE
Rewrite LogEvents to contain the source jar of stack traces

### DIFF
--- a/patches/api/0326-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/api/0326-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SirYwell <hannesgreule@outlook.de>
+Date: Sat, 10 Jul 2021 11:11:43 +0200
+Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
+
+
+diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+index 81292899918c4dc880661ee628384cb840a6244f..1ab107d5bb20b9a12fc8843513bd9a3ada50c0a3 100644
+--- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
+@@ -51,7 +51,7 @@ public final class PluginClassLoader extends URLClassLoader { // Spigot
+     }
+ 
+     PluginClassLoader(@NotNull final JavaPluginLoader loader, @Nullable final ClassLoader parent, @NotNull final PluginDescriptionFile description, @NotNull final File dataFolder, @NotNull final File file, @Nullable ClassLoader libraryLoader) throws IOException, InvalidPluginException, MalformedURLException {
+-        super(new URL[] {file.toURI().toURL()}, parent);
++        super(file.getName(), new URL[] {file.toURI().toURL()}, parent); // Paper - rewrite LogEvents to contain source jar info
+         Validate.notNull(loader, "Loader cannot be null");
+ 
+         this.loader = loader;

--- a/patches/server/0735-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
+++ b/patches/server/0735-Rewrite-LogEvents-to-contain-the-source-jars-in-stac.patch
@@ -1,0 +1,254 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SirYwell <hannesgreule@outlook.de>
+Date: Sat, 10 Jul 2021 11:12:30 +0200
+Subject: [PATCH] Rewrite LogEvents to contain the source jars in stack traces
+
+
+diff --git a/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java b/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..6ffd1befe64c6c3036c22e05ed1c44808d64bd28
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/logging/DelegateLogEvent.java
+@@ -0,0 +1,130 @@
++package io.papermc.paper.logging;
++
++import org.apache.logging.log4j.Level;
++import org.apache.logging.log4j.Marker;
++import org.apache.logging.log4j.ThreadContext;
++import org.apache.logging.log4j.core.LogEvent;
++import org.apache.logging.log4j.core.impl.ThrowableProxy;
++import org.apache.logging.log4j.core.time.Instant;
++import org.apache.logging.log4j.message.Message;
++import org.apache.logging.log4j.util.ReadOnlyStringMap;
++
++import java.util.Map;
++
++public class DelegateLogEvent implements LogEvent {
++    private final LogEvent original;
++
++    protected DelegateLogEvent(LogEvent original) {
++        this.original = original;
++    }
++
++    @Override
++    public LogEvent toImmutable() {
++        return this.original.toImmutable();
++    }
++
++    @Override
++    public Map<String, String> getContextMap() {
++        return this.original.getContextMap();
++    }
++
++    @Override
++    public ReadOnlyStringMap getContextData() {
++        return this.original.getContextData();
++    }
++
++    @Override
++    public ThreadContext.ContextStack getContextStack() {
++        return this.original.getContextStack();
++    }
++
++    @Override
++    public String getLoggerFqcn() {
++        return this.original.getLoggerFqcn();
++    }
++
++    @Override
++    public Level getLevel() {
++        return this.original.getLevel();
++    }
++
++    @Override
++    public String getLoggerName() {
++        return this.original.getLoggerName();
++    }
++
++    @Override
++    public Marker getMarker() {
++        return this.original.getMarker();
++    }
++
++    @Override
++    public Message getMessage() {
++        return this.original.getMessage();
++    }
++
++    @Override
++    public long getTimeMillis() {
++        return this.original.getTimeMillis();
++    }
++
++    @Override
++    public Instant getInstant() {
++        return this.original.getInstant();
++    }
++
++    @Override
++    public StackTraceElement getSource() {
++        return this.original.getSource();
++    }
++
++    @Override
++    public String getThreadName() {
++        return this.original.getThreadName();
++    }
++
++    @Override
++    public long getThreadId() {
++        return this.original.getThreadId();
++    }
++
++    @Override
++    public int getThreadPriority() {
++        return this.original.getThreadPriority();
++    }
++
++    @Override
++    public Throwable getThrown() {
++        return this.original.getThrown();
++    }
++
++    @Override
++    public ThrowableProxy getThrownProxy() {
++        return this.original.getThrownProxy();
++    }
++
++    @Override
++    public boolean isEndOfBatch() {
++        return this.original.isEndOfBatch();
++    }
++
++    @Override
++    public boolean isIncludeLocation() {
++        return this.original.isIncludeLocation();
++    }
++
++    @Override
++    public void setEndOfBatch(boolean endOfBatch) {
++        this.original.setEndOfBatch(endOfBatch);
++    }
++
++    @Override
++    public void setIncludeLocation(boolean locationRequired) {
++        this.original.setIncludeLocation(locationRequired);
++    }
++
++    @Override
++    public long getNanoTime() {
++        return this.original.getNanoTime();
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java b/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..558427c65b4051923f73d15d85ee519be005060a
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/logging/ExtraClassInfoLogEvent.java
+@@ -0,0 +1,48 @@
++package io.papermc.paper.logging;
++
++import org.apache.logging.log4j.core.LogEvent;
++import org.apache.logging.log4j.core.impl.ExtendedClassInfo;
++import org.apache.logging.log4j.core.impl.ExtendedStackTraceElement;
++import org.apache.logging.log4j.core.impl.ThrowableProxy;
++
++public class ExtraClassInfoLogEvent extends DelegateLogEvent {
++
++    private boolean fixed;
++
++    public ExtraClassInfoLogEvent(LogEvent original) {
++        super(original);
++    }
++
++    @Override
++    public ThrowableProxy getThrownProxy() {
++        if (fixed) {
++            return super.getThrownProxy();
++        }
++        rewriteStackTrace(super.getThrownProxy());
++        fixed = true;
++        return super.getThrownProxy();
++    }
++
++    private void rewriteStackTrace(ThrowableProxy throwable) {
++        ExtendedStackTraceElement[] stackTrace = throwable.getExtendedStackTrace();
++        for (int i = 0; i < stackTrace.length; i++) {
++            ExtendedClassInfo classInfo = stackTrace[i].getExtraClassInfo();
++            if (classInfo.getLocation().equals("?")) {
++                StackTraceElement element = stackTrace[i].getStackTraceElement();
++                String classLoaderName = element.getClassLoaderName();
++                if (classLoaderName != null) {
++                    stackTrace[i] = new ExtendedStackTraceElement(element,
++                        new ExtendedClassInfo(classInfo.getExact(), classLoaderName, "?"));
++                }
++            }
++        }
++        if (throwable.getCauseProxy() != null) {
++            rewriteStackTrace(throwable.getCauseProxy());
++        }
++        if (throwable.getSuppressedProxies() != null) {
++            for (ThrowableProxy proxy : throwable.getSuppressedProxies()) {
++                rewriteStackTrace(proxy);
++            }
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java b/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..34734bb969a1a74c7a4f9c17d40ebf007ad5d701
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/logging/ExtraClassInfoRewritePolicy.java
+@@ -0,0 +1,29 @@
++package io.papermc.paper.logging;
++
++import org.apache.logging.log4j.core.Core;
++import org.apache.logging.log4j.core.LogEvent;
++import org.apache.logging.log4j.core.appender.rewrite.RewritePolicy;
++import org.apache.logging.log4j.core.config.plugins.Plugin;
++import org.apache.logging.log4j.core.config.plugins.PluginFactory;
++import org.jetbrains.annotations.NotNull;
++
++@Plugin(
++    name = "ExtraClassInfoRewritePolicy",
++    category = Core.CATEGORY_NAME,
++    elementType = "rewritePolicy",
++    printObject = true
++)
++public final class ExtraClassInfoRewritePolicy implements RewritePolicy {
++    @Override
++    public LogEvent rewrite(LogEvent source) {
++        if (source.getThrown() != null) {
++            return new ExtraClassInfoLogEvent(source);
++        }
++        return source;
++    }
++
++    @PluginFactory
++    public static @NotNull ExtraClassInfoRewritePolicy createPolicy() {
++        return new ExtraClassInfoRewritePolicy();
++    }
++}
+diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
+index f91d0df569b2f1d430ea5eee5f53779902a4f32c..e2b30a3f71d0b6d9402c5f840d721ed743a40ad1 100644
+--- a/src/main/resources/log4j2.xml
++++ b/src/main/resources/log4j2.xml
+@@ -35,13 +35,17 @@
+             <AppenderRef ref="TerminalConsole" level="info"/>
+             <AppenderRef ref="ServerGuiConsole" level="info"/>
+         </Rewrite>
++        <Rewrite name="rewrite2">
++            <ExtraClassInfoRewritePolicy />
++            <AppenderRef ref="rewrite"/>
++        </Rewrite>
+     </Appenders>
+     <Loggers>
+         <Root level="info">
+             <filters>
+                 <MarkerFilter marker="NETWORK_PACKETS" onMatch="DENY" onMismatch="NEUTRAL" />
+             </filters>
+-            <AppenderRef ref="rewrite"/>
++            <AppenderRef ref="rewrite2"/>
+         </Root>
+     </Loggers>
+ </Configuration>

--- a/patches/server/0736-Improve-boat-collision-performance.patch
+++ b/patches/server/0736-Improve-boat-collision-performance.patch
@@ -1,0 +1,81 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <spottedleaf@spottedleaf.dev>
+Date: Mon, 2 Aug 2021 10:10:40 +0200
+Subject: [PATCH] Improve boat collision performance
+
+
+diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
+index 81f4f26a6b83079d36acd1fd86dede0eb1116c01..59437f04911662f06596ef61b91017caa6427eec 100644
+--- a/src/main/java/net/minecraft/Util.java
++++ b/src/main/java/net/minecraft/Util.java
+@@ -75,6 +75,7 @@ public class Util {
+     }).findFirst().orElseThrow(() -> {
+         return new IllegalStateException("No jar file system provider found");
+     });
++    public static final double COLLISION_EPSILON = 1.0E-7; // Paper
+     static final Logger LOGGER = LogManager.getLogger();
+ 
+     public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> toMap() {
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 24c629d5f26bc5aadebcf39a63930b3448525242..2b7eeb5659b1083ef550eb9feb0b7ba8a92a92e3 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1321,7 +1321,7 @@ public abstract class LivingEntity extends Entity {
+                 if (!source.isProjectile()) {
+                     Entity entity = source.getDirectEntity();
+ 
+-                    if (entity instanceof LivingEntity) {
++                    if (entity instanceof LivingEntity && entity.distanceToSqr(this) <= (200.0D * 200.0D)) { // Paper
+                         this.blockUsingShield((LivingEntity) entity);
+                     }
+                 }
+@@ -1430,11 +1430,12 @@ public abstract class LivingEntity extends Entity {
+                 }
+ 
+                 if (entity1 != null) {
+-                    double d0 = entity1.getX() - this.getX();
++                    final boolean far = entity1.distanceToSqr(this) > (200.0 * 200.0); // Paper
++                    double d0 = far ? (Math.random() - Math.random()) : entity1.getX() - this.getX(); // Paper
+ 
+                     double d1;
+ 
+-                    for (d1 = entity1.getZ() - this.getZ(); d0 * d0 + d1 * d1 < 1.0E-4D; d1 = (Math.random() - Math.random()) * 0.01D) {
++                    for (d1 = far ? Math.random() - Math.random() : entity1.getZ() - this.getZ(); d0 * d0 + d1 * d1 < 1.0E-4D; d1 = (Math.random() - Math.random()) * 0.01D) { // Paper
+                         d0 = (Math.random() - Math.random()) * 0.01D;
+                     }
+ 
+@@ -2086,7 +2087,7 @@ public abstract class LivingEntity extends Entity {
+                 this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
+                 Entity entity = damagesource.getDirectEntity();
+ 
+-                if (entity instanceof LivingEntity) {
++                if (entity instanceof LivingEntity && entity.distanceToSqr(this) <= (200.0D * 200.0D)) { // Paper
+                     this.blockUsingShield((LivingEntity) entity);
+                 }
+             }
+diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
+index aa7c022c4faade23bd9061311d4152cf845d3331..95ccf785fd8a4fb4903807840c2fe41d58658354 100644
+--- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
++++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
+@@ -689,7 +689,7 @@ public class Boat extends Entity {
+         if (this.oldStatus == Boat.Status.IN_AIR && this.status != Boat.Status.IN_AIR && this.status != Boat.Status.ON_LAND) {
+             this.waterLevel = this.getY(1.0D);
+             this.setPos(this.getX(), (double) (this.getWaterLevelAbove() - this.getBbHeight()) + 0.101D, this.getZ());
+-            this.setDeltaMovement(this.getDeltaMovement().multiply(1.0D, 0.0D, 1.0D));
++            this.setDeltaMovement(this.getDeltaMovement().multiply(1.0D, 0.0D, 1.0D).add(0.0, ((double) (this.getWaterLevelAbove() - this.getBbHeight()) + 0.101D) - this.getY(), 0.0)); // Paper
+             this.lastYd = 0.0D;
+             this.status = Boat.Status.IN_WATER;
+         } else {
+diff --git a/src/main/java/net/minecraft/world/item/BoatItem.java b/src/main/java/net/minecraft/world/item/BoatItem.java
+index c0864c833fd313e6ba9339ecc7f9e2359954bda3..87e0faaab1ec98123fd735112d15da332a830554 100644
+--- a/src/main/java/net/minecraft/world/item/BoatItem.java
++++ b/src/main/java/net/minecraft/world/item/BoatItem.java
+@@ -67,7 +67,7 @@ public class BoatItem extends Item {
+ 
+                 entityboat.setType(this.type);
+                 entityboat.setYRot(user.getYRot());
+-                if (!world.noCollision(entityboat, entityboat.getBoundingBox().inflate(-0.1D))) {
++                if (!world.noCollision(entityboat, entityboat.getBoundingBox().inflate(net.minecraft.Util.COLLISION_EPSILON))) {
+                     return InteractionResultHolder.fail(itemstack);
+                 } else {
+                     if (!world.isClientSide) {


### PR DESCRIPTION
Previously, log4j2 logged extended exceptions (`xEx`) but wasn't able to find the source jars of classes loaded by the `PluginClassLoader`. With Java 9, `StackTraceElement`s got [a new property that holds the name of the class loader](https://docs.oracle.com/en/java/javase/16/docs/api/java.base/java/lang/StackTraceElement.html#getClassLoaderName()). With this, it's possible to identify the source of a class.

This implementation is super simple, we're just setting the class loader name to the jar file name. This way it can directly be used when rewriting the `ExtentedStackTraceElement`s. Theoretically, it would be possible to use another unique identifier for the class loader name and keep a map to access even more plugin information, but I think that's already way better.

My original reasoning was that I had people like weekly coming around with weird issues that were caused by them wrongly shading other plugins (or at least their API components). As differnet classes with the same fqn can be loaded by different class loaders, that was difficult to debug but is pretty easy now.

Output before:
```
[10:42:35] [Server thread/WARN]: Unexpected exception while parsing console command "test"
org.bukkit.command.CommandException: Unhandled exception executing command 'test' in plugin TestPlugin2 v0.0.1
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.17.1.jar:git-Paper-90]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.17.1.jar:git-Paper-90]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchCommand(CraftServer.java:821) ~[patched_1.17.1.jar:git-Paper-90]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchServerCommand(CraftServer.java:784) ~[patched_1.17.1.jar:git-Paper-90]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:518) ~[patched_1.17.1.jar:git-Paper-90]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:480) ~[patched_1.17.1.jar:git-Paper-90]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1406) ~[patched_1.17.1.jar:git-Paper-90]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1188) ~[patched_1.17.1.jar:git-Paper-90]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[patched_1.17.1.jar:git-Paper-90]
	at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.RuntimeException
	at de.sirywell.testplugin.TestCommand.onCommand(TestCommand.java:11) ~[?:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.17.1.jar:git-Paper-90]
	... 9 more
```

Output now:
```
[10:44:15] [Server thread/WARN]: Unexpected exception while parsing console command "test"
org.bukkit.command.CommandException: Unhandled exception executing command 'test' in plugin TestPlugin2 v0.0.1
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchCommand(CraftServer.java:821) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchServerCommand(CraftServer.java:784) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:518) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:480) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1406) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1188) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.RuntimeException
	at de.sirywell.testplugin.TestCommand.onCommand(TestCommand.java:11) ~[TestPlugin-1.0-SNAPSHOT-2.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	... 9 more
```

(Instead of `~[?:?]` it now mentions the plugin file name)

This is how it looks like with *one* plugin where only the jar name and the name and command aliases in the plugin.yml were changed:
<details>
<summary>Click to see two different stacktraces that would have been (nearly) identical before</summary>

```
[10:44:18] [Server thread/WARN]: Unexpected exception while parsing console command "test1"
org.bukkit.command.CommandException: Unhandled exception executing command 'test1' in plugin TestPlugin v0.0.1
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchCommand(CraftServer.java:821) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchServerCommand(CraftServer.java:784) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:518) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:480) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1406) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1188) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.RuntimeException
	at de.sirywell.testplugin.TestCommand.onCommand(TestCommand.java:11) ~[TestPlugin-1.0-SNAPSHOT.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	... 9 more
[10:44:20] [Server thread/WARN]: Unexpected exception while parsing console command "test2"
org.bukkit.command.CommandException: Unhandled exception executing command 'test2' in plugin TestPlugin2 v0.0.1
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:47) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.command.SimpleCommandMap.dispatch(SimpleCommandMap.java:159) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchCommand(CraftServer.java:821) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at org.bukkit.craftbukkit.v1_17_R1.CraftServer.dispatchServerCommand(CraftServer.java:784) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.handleConsoleInputs(DedicatedServer.java:518) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.dedicated.DedicatedServer.tickChildren(DedicatedServer.java:480) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.tickServer(MinecraftServer.java:1406) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1188) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at net.minecraft.server.MinecraftServer.lambda$spin$0(MinecraftServer.java:316) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	at java.lang.Thread.run(Thread.java:831) [?:?]
Caused by: java.lang.RuntimeException
	at de.sirywell.testplugin.TestCommand.onCommand(TestCommand.java:11) ~[TestPlugin-1.0-SNAPSHOT-2.jar:?]
	at org.bukkit.command.PluginCommand.execute(PluginCommand.java:45) ~[patched_1.17.1.jar:git-Paper-"416ec98"]
	... 9 more
```

</details>


Note: I just called the rewrite rule `rewrite2`, but I'm happy to give it a better name if wanted.