### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -1130,7 +1130,7 @@ index 2b62f4664f439808661d559dc99762bfbac09b16..4788946d7fb25c1b0f26e6a038924c4a
  
      public void broadcast(Entity entity, Packet<?> packet) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 1bb7faf3b25e4a0dd1407c8e9b33cd7afa2c149e..672c6651043a4efd65e472bbd519f54861ec008a 100644
+index 8639ffa2347e3d5c44ab30de0aa98623f95d1fe7..bafd97074461d5b17b21579ba493ba8eae8468d8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -348,13 +348,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -1234,7 +1234,7 @@ index 1bb7faf3b25e4a0dd1407c8e9b33cd7afa2c149e..672c6651043a4efd65e472bbd519f548
  
      private void getFullChunk(long pos, Consumer<LevelChunk> chunkConsumer) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074675253dd 100644
+index 912c9b0c010436854fab7540b0c9cc63115e39a4..253d62b0da6bd59363a85139a5a5d5f11169466a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1246,15 +1246,15 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
  import com.google.common.collect.Lists;
  import com.mojang.datafixers.DataFixer;
  import it.unimi.dsi.fastutil.ints.Int2ObjectMap;
-@@ -158,7 +160,6 @@ import org.apache.logging.log4j.Logger;
- import java.util.logging.Level;
+@@ -154,7 +156,6 @@ import org.apache.logging.log4j.LogManager;
+ import org.apache.logging.log4j.Logger;
  import org.bukkit.Bukkit;
  import org.bukkit.WeatherType;
 -import org.bukkit.craftbukkit.SpigotTimings; // Spigot
  import org.bukkit.craftbukkit.event.CraftEventFactory;
  import org.bukkit.craftbukkit.util.WorldUUID;
  import org.bukkit.event.entity.CreatureSpawnEvent;
-@@ -221,13 +222,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -217,13 +218,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
          DefaultedRegistry registryblocks = Registry.BLOCK;
  
          Objects.requireNonNull(registryblocks);
@@ -1270,7 +1270,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
          this.navigatingMobs = new ObjectOpenHashSet();
          this.blockEvents = new ObjectLinkedOpenHashSet();
          this.dragonParts = new Int2ObjectOpenHashMap();
-@@ -469,17 +470,21 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -430,17 +431,21 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.updateSkyBrightness();
          this.tickTime();
          gameprofilerfiller.popPush("tickPending");
@@ -1294,7 +1294,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
          gameprofilerfiller.popPush("blockEvents");
          timings.doSounds.startTiming(); // Spigot
          this.runBlockEvents();
-@@ -637,6 +642,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -598,6 +603,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          gameprofilerfiller.popPush("tickBlocks");
@@ -1302,7 +1302,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
          if (randomTickSpeed > 0) {
              LevelChunkSection[] achunksection = chunk.getSections();
              int l = achunksection.length;
-@@ -668,7 +674,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -629,7 +635,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  }
              }
          }
@@ -1311,7 +1311,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
          gameprofilerfiller.pop();
      }
  
-@@ -794,14 +800,22 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -755,14 +761,22 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      public void tickNonPassenger(Entity entity) {
@@ -1335,7 +1335,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
          entity.setOldPosAndRot();
          ProfilerFiller gameprofilerfiller = this.getProfiler();
  
-@@ -820,7 +834,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -781,7 +795,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
              this.tickPassenger(entity, entity1);
          }
@@ -1345,7 +1345,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
  
      }
  
-@@ -862,6 +877,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -823,6 +838,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          if (!flag1) {
              org.bukkit.Bukkit.getPluginManager().callEvent(new org.bukkit.event.world.WorldSaveEvent(getWorld())); // CraftBukkit
@@ -1353,7 +1353,7 @@ index 1e1908649a19fe067defe3c0d9c798a6a2988d82..1ec05701b0a1d6f6ecd17b2830a7c074
              if (progressListener != null) {
                  progressListener.progressStartNoAbort(new TranslatableComponent("menu.savingLevel"));
              }
-@@ -871,7 +887,10 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -832,7 +848,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  progressListener.progressStage(new TranslatableComponent("menu.savingChunks"));
              }
  
@@ -1817,7 +1817,7 @@ index b645a2fc839dbf922ce73b23b7d53e9a5fe1a2ee..1b478ebfe6792a157772a5812d0daa1a
  
      private static CompoundTag packStructureData(ServerLevel world, ChunkPos chunkcoordintpair, Map<StructureFeature<?>, StructureStart<?>> map, Map<StructureFeature<?>, LongSet> map1) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 57a44f1d466caeccebe0e2498e3833cb953ffd5a..878af195b64b7c25cb7ef130846d30aea2474897 100644
+index a3f27b2e766e0477410e14e55a0c800ab307984c..bf26a5175e672b51561a6c5a32a32068541ae656 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2083,12 +2083,31 @@ public final class CraftServer implements Server {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1671,7 +1671,7 @@ index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 878af195b64b7c25cb7ef130846d30aea2474897..d6cb58d5c5f6d2f4aa769f4338ba63b2d55dc971 100644
+index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d1801dcb2d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -564,8 +564,10 @@ public final class CraftServer implements Server {
@@ -2052,10 +2052,10 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 78d1621c1b5f1870829d92720e2151e9f9d9a8b5..6722d97d498fb2951b7dd8af3b68dd771ce8f5c1 100644
+index f337cae2f34ddd5412136bb2a2df4f6a12c5a0f4..ee7c920a5a3154927c675b2e1cd0c16f99d0e9a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -808,6 +808,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -810,6 +810,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getVehicle().getBukkitEntity();
      }
  

--- a/patches/server/0025-Entity-Origin-API.patch
+++ b/patches/server/0025-Entity-Origin-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Origin API
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5c5cfc31ced6695af7b1dd06cb867274fa38d85f..fb6e3f0c86c78024203e24d1d7ef51e0ed0283cd 100644
+index 253d62b0da6bd59363a85139a5a5d5f11169466a..d721d05841d9557583045ab3adc347c24a6d751d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1894,6 +1894,15 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1855,6 +1855,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
              entity.valid = true; // CraftBukkit
@@ -25,7 +25,7 @@ index 5c5cfc31ced6695af7b1dd06cb867274fa38d85f..fb6e3f0c86c78024203e24d1d7ef51e0
  
          public void onTrackingEnd(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 018792503e5d18470ad17b9f4b4524d5dfba31e9..c8b9381c83d62c8884ec5bbe4aa7ba89d51e5e16 100644
+index 04f2cee8045ba74993e10230c3ad7ca80fb048d6..fe08d13e0d25119c48a8872fac6fd2a6ce0170be 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -280,6 +280,27 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -132,10 +132,10 @@ index 394164f50256ad9a167e15531a9202875abb6cb6..8ad1b3cb16533d62deda643ce0cdda30
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 6722d97d498fb2951b7dd8af3b68dd771ce8f5c1..af1a792a456c2efdc959497c02c1e060ed545724 100644
+index ee7c920a5a3154927c675b2e1cd0c16f99d0e9a2..1c6473b496ca05e9e0fcd505caaa18b5546d1d3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1098,4 +1098,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1116,4 +1116,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0034-Disable-thunder.patch
+++ b/patches/server/0034-Disable-thunder.patch
@@ -19,10 +19,10 @@ index 2222c1bb5f8625eee4d88946e4bfdfa2fe598977..083e421f8496b5336af473b108498ed2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d26e8803222276fb7bb1bedd9fd13a8861ce671c..4792280988ac13593d59f6a10fa111eafa08328f 100644
+index d721d05841d9557583045ab3adc347c24a6d751d..2176d1db94de2a608deadf0cd3e95c3c9ffac019 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -592,7 +592,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -553,7 +553,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          gameprofilerfiller.push("thunder");
          BlockPos blockposition;
  

--- a/patches/server/0035-Disable-ice-and-snow.patch
+++ b/patches/server/0035-Disable-ice-and-snow.patch
@@ -19,10 +19,10 @@ index 083e421f8496b5336af473b108498ed28b984774..2f7a5a4a5a7b29750cfd777e0bc5d19a
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4792280988ac13593d59f6a10fa111eafa08328f..b0ecf3c491e802aa292a0a8b7be37362c38ce084 100644
+index 2176d1db94de2a608deadf0cd3e95c3c9ffac019..6bde7dee09b9cf2b3acd66f9c9d55b338f20fe25 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -616,7 +616,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -577,7 +577,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
  
          gameprofilerfiller.popPush("iceandsnow");

--- a/patches/server/0051-Add-velocity-warnings.patch
+++ b/patches/server/0051-Add-velocity-warnings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4b6e6f120edc0e2c3dd3f81c5b9fb96980e41a33..6dab7f65401d5f01e094454b392042cc79ea315e 100644
+index 6d5567fde20508a060a7c13e54e1cfa3924f4d0d..2e479cd5f7effeadc1ea41f91f5019e42ece0ac1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -263,6 +263,7 @@ public final class CraftServer implements Server {
@@ -17,10 +17,10 @@ index 4b6e6f120edc0e2c3dd3f81c5b9fb96980e41a33..6dab7f65401d5f01e094454b392042cc
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 417357f6a187747a5e27fa60a57cee3fb91f3d2e..808169e6d78b9e3647763239bbd05fcfba6449a6 100644
+index 1c6473b496ca05e9e0fcd505caaa18b5546d1d3c..db430d20186fc8d307fd4e521778316845cd8581 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -433,10 +433,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -435,10 +435,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public void setVelocity(Vector velocity) {
          Preconditions.checkArgument(velocity != null, "velocity");
          velocity.checkFinite();

--- a/patches/server/0064-Add-World-Util-Methods.patch
+++ b/patches/server/0064-Add-World-Util-Methods.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add World Util Methods
 Methods that can be used for other patches to help improve logic.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index addd1e75b796b01d15d8c087329bfc4fb9823fbe..62bf85a8590c3dc00c74671303b4e7ce790fdc0b 100644
+index 6bde7dee09b9cf2b3acd66f9c9d55b338f20fe25..a13d70d6e4a6c60e61f0c8c1b5bb88b092a110a0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -202,7 +202,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -198,7 +198,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public final LevelStorageSource.LevelStorageAccess convertable;
      public final UUID uuid;
  

--- a/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0068-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -22,10 +22,10 @@ index 3c78d3234054ce2dc46ef77decb6adb0cbd10620..cd64fb9d0c6d123e1c86cb33f12cd9ce
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 6aab4ba5da83f523632a0a39d45a0bcb2405f0cc..69b52097eede1a5c408aa7f34442e42255386436 100644
+index a13d70d6e4a6c60e61f0c8c1b5bb88b092a110a0..7251c939dabb4591f1c30bd1b33b6e707615b6e9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -596,7 +596,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -557,7 +557,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              blockposition = this.findLightningTargetAround(this.getBlockRandomPos(j, 0, k, 15));
              if (this.isRainingAt(blockposition)) {
                  DifficultyInstance difficultydamagescaler = this.getCurrentDifficultyAt(blockposition);
@@ -33,4 +33,4 @@ index 6aab4ba5da83f523632a0a39d45a0bcb2405f0cc..69b52097eede1a5c408aa7f34442e422
 +                boolean flag1 = this.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && this.random.nextDouble() < (double) difficultydamagescaler.getEffectiveDifficulty() * paperConfig.skeleHorseSpawnChance && !this.getBlockState(blockposition.below()).is(Blocks.LIGHTNING_ROD); // Paper
  
                  if (flag1) {
-                     SkeletonHorse entityhorseskeleton = (SkeletonHorse) EntityType.SKELETON_HORSE.create((net.minecraft.world.level.Level) this);
+                     SkeletonHorse entityhorseskeleton = (SkeletonHorse) EntityType.SKELETON_HORSE.create((Level) this);

--- a/patches/server/0070-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0070-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -18,10 +18,10 @@ index d1267242746fe2aee0fd12ed01900e4e72df3f89..4ed4744c887ca52fa3f85ad4ea41e795
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9551e819a9a1ae1f4dc52e1a347d8ee5924d092b..aa9278ff7514fd93a8d0d5f925456a66c4ce8736 100644
+index 7251c939dabb4591f1c30bd1b33b6e707615b6e9..ba964bc8b2d86b86be2d527fdc8d8aa342ac0e5e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -201,6 +201,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -197,6 +197,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      private int tickPosition;
      public final LevelStorageSource.LevelStorageAccess convertable;
      public final UUID uuid;

--- a/patches/server/0071-Entity-AddTo-RemoveFrom-World-Events.patch
+++ b/patches/server/0071-Entity-AddTo-RemoveFrom-World-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity AddTo/RemoveFrom World Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 005d8d32ad3a7129688ba919e0ab6a5ee8b711c8..3129332c9e520c5f774b846e81f52103cbf97b8e 100644
+index ba964bc8b2d86b86be2d527fdc8d8aa342ac0e5e..4291492dc5cf0c845af30f62e2dcb15826842d12 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1904,6 +1904,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1865,6 +1865,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  entity.setOrigin(entity.getOriginVector().toLocation(getWorld()));
              }
              // Paper end
@@ -16,7 +16,7 @@ index 005d8d32ad3a7129688ba919e0ab6a5ee8b711c8..3129332c9e520c5f774b846e81f52103
          }
  
          public void onTrackingEnd(Entity entity) {
-@@ -1968,6 +1969,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1929,6 +1930,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
              entity.valid = false; // CraftBukkit

--- a/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -13,10 +13,10 @@ custom renderers are in use, defaulting to the much simpler Vanilla system.
 Additionally, numerous issues to player position tracking on maps has been fixed.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5ed7028c50ca5dcb2cabada3d8a15874181f6ce8..ee124aa7d18abd266836c79b9acf12c838676135 100644
+index 4291492dc5cf0c845af30f62e2dcb15826842d12..160da347ed52739e930044fe456a4dd36e561a43 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1924,6 +1924,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1885,6 +1885,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                              {
                                  if ( iter.next().player == entity )
                                  {

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7c8df6781ffe142b6d1c4fd7b18f9a2f280194e7..2aa6c6b4a5a431b6860e91684cf20514fbb52676 100644
+index 01cfa488e7b25b7c65e71908bb6f5e6b7b61ca89..b0422e655fa836b5ff44f56a2ba9b4318e56e93e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -321,6 +321,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -49,10 +49,10 @@ index 037dafb59e54047d1d54474c44897d35b8f46c98..e310c1eb1108780bcff4d7ba9d49cefa
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 52f9c17558ed19e7ff3e913287bcd4f6014630fe..e132d38199766e3e787169501d8bb05964506e0f 100644
+index db430d20186fc8d307fd4e521778316845cd8581..2840228aa6aa8f1559b976d396aa9d1f8f4d6a40 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1144,5 +1144,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1162,5 +1162,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          //noinspection ConstantConditions
          return originVector.toLocation(world);
      }

--- a/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ Adds an option to control the force mode of the particle.
 This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 766edb072a38a4b5613e0f26f5070d3fcab835f4..c98c7dabc2274fe758cafb334ec4c4d3952b85e7 100644
+index 160da347ed52739e930044fe456a4dd36e561a43..d06fa20dd605e9ce0e41a4d69ffeec98bceb3a63 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1281,12 +1281,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1242,12 +1242,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      public <T extends ParticleOptions> int sendParticles(ServerPlayer sender, T t0, double d0, double d1, double d2, int i, double d3, double d4, double d5, double d6, boolean force) {

--- a/patches/server/0208-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0208-Fix-CraftEntity-hashCode.patch
@@ -21,10 +21,10 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index e132d38199766e3e787169501d8bb05964506e0f..16e8cfb21f090e0c17e55c1b45ff56bed01839eb 100644
+index 2840228aa6aa8f1559b976d396aa9d1f8f4d6a40..84316ea7f1ad285009f02cdf6e501c577958a170 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -784,14 +784,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -786,14 +786,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
          final CraftEntity other = (CraftEntity) obj;

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -7,11 +7,11 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 673af9a823d7b16c6dd37a3db700aba676fb5585..eaaf2887bfeccb18fc2b011ba39180ee6b7838a5 100644
+index d06fa20dd605e9ce0e41a4d69ffeec98bceb3a63..19f8e74f292e83f7438683efddbaa4930f1a7c48 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1055,7 +1055,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
-         for (BlockEntity tileentity : chunk.getBlockEntities().values()) {
+@@ -1016,7 +1016,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         for (net.minecraft.world.level.block.entity.BlockEntity tileentity : chunk.getBlockEntities().values()) {
              if (tileentity instanceof net.minecraft.world.Container) {
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((net.minecraft.world.Container) tileentity).getViewers())) {
 -                    h.closeInventory();
@@ -19,7 +19,7 @@ index 673af9a823d7b16c6dd37a3db700aba676fb5585..eaaf2887bfeccb18fc2b011ba39180ee
                  }
              }
          }
-@@ -1941,7 +1941,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1902,7 +1902,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((org.bukkit.inventory.InventoryHolder) entity.getBukkitEntity()).getInventory().getViewers())) {
@@ -185,7 +185,7 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..a9f8ffa1772de39c74394f8cf324ab77
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c674ff33ebbb7e214205b3521d414a0442a46cbb..295f82fcdc42103e99bb5c0ab472388f83ac5646 100644
+index 9a245d64ce75fbf3cb1953f91d41eff528baefb8..37d1d84d05812adb48e6116c0506f1d460de4038 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -921,7 +921,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0239-Add-hand-to-bucket-events.patch
+++ b/patches/server/0239-Add-hand-to-bucket-events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add hand to bucket events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index eaaf2887bfeccb18fc2b011ba39180ee6b7838a5..9eca5fc914400c1118927cd4424b3eed9f8ed8dc 100644
+index 19f8e74f292e83f7438683efddbaa4930f1a7c48..4e0e5d3e0b91d4b7be4eaa6fe252287d90bc010e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1413,15 +1413,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1374,15 +1374,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.getServer().getPlayerList().broadcastAll(new ClientboundSetDefaultSpawnPositionPacket(pos, angle));
      }
  

--- a/patches/server/0244-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0244-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -29,10 +29,10 @@ index 919a489a5c7b338659c62ae67fc0a6ceee9dcdf9..db4dac607cf24d3d2cd407255c60678a
  
      protected void tick() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 9eca5fc914400c1118927cd4424b3eed9f8ed8dc..a33bed2282acba9df7d5d1b38bdab4fe984af2ee 100644
+index 4e0e5d3e0b91d4b7be4eaa6fe252287d90bc010e..a67905f4cc6ade36b17eeb6c77d00f4837c42c86 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -202,6 +202,9 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -198,6 +198,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public final LevelStorageSource.LevelStorageAccess convertable;
      public final UUID uuid;
      public boolean hasPhysicsEvent = true; // Paper
@@ -42,7 +42,7 @@ index 9eca5fc914400c1118927cd4424b3eed9f8ed8dc..a33bed2282acba9df7d5d1b38bdab4fe
  
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
          return this.chunkSource.getChunk(x, z, false);
-@@ -1018,7 +1021,28 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -979,7 +982,28 @@ public class ServerLevel extends Level implements WorldGenLevel {
      // CraftBukkit start
      private boolean addEntity0(Entity entity, CreatureSpawnEvent.SpawnReason spawnReason) {
          org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -2623,7 +2623,7 @@ index db4dac607cf24d3d2cd407255c60678ae4be1a1b..6d024db8bfbd5139d4c94be3d3a48cfa
          return this.poiManager;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 6757971ee556da2470de8b4579d906452acd36fe..68b618168c8c484e3902561f290adaa6568551c1 100644
+index 2c0dd4b5a751e413936f399106367d4b22c17dda..7239dd29ff622a2823d7c25a89cd3dc9e0bafac1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -322,10 +322,128 @@ public class ServerChunkCache extends ChunkSource {
@@ -2802,10 +2802,10 @@ index 6757971ee556da2470de8b4579d906452acd36fe..68b618168c8c484e3902561f290adaa6
          } finally {
              chunkMap.callbackExecutor.run();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index a33bed2282acba9df7d5d1b38bdab4fe984af2ee..863981519bf0c62c00484cf9ee6d7ff1ea8ed946 100644
+index a67905f4cc6ade36b17eeb6c77d00f4837c42c86..1bd378a60e761f9aeca347ebb80546ef4cf58eb4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -210,6 +210,79 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -206,6 +206,79 @@ public class ServerLevel extends Level implements WorldGenLevel {
          return this.chunkSource.getChunk(x, z, false);
      }
  
@@ -2883,9 +2883,9 @@ index a33bed2282acba9df7d5d1b38bdab4fe984af2ee..863981519bf0c62c00484cf9ee6d7ff1
 +    // Paper end
 +
      // Add env and gen to constructor, WorldData -> WorldDataServer
-     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
+     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
-@@ -281,6 +354,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -277,6 +350,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          this.sleepStatus = new SleepStatus();
          this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
@@ -2893,7 +2893,7 @@ index a33bed2282acba9df7d5d1b38bdab4fe984af2ee..863981519bf0c62c00484cf9ee6d7ff1
 +        this.asyncChunkTaskManager = new com.destroystokyo.paper.io.chunk.ChunkTaskManager(this); // Paper
      }
  
-     // CraftBukkit start
+     public void setWeatherParameters(int clearDuration, int rainDuration, boolean raining, boolean thundering) {
 diff --git a/src/main/java/net/minecraft/server/level/TicketType.java b/src/main/java/net/minecraft/server/level/TicketType.java
 index 0d536d72ac918fbd403397ff369d10143ee9c204..be677d437d17b74c6188ce1bd5fc6fdc228fd92f 100644
 --- a/src/main/java/net/minecraft/server/level/TicketType.java
@@ -3658,18 +3658,18 @@ index ad9a4d4a9363741cc47f142c24fa6f4858dd947f..a19de8405de8ee29afc112556e4684b0
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 16e8cfb21f090e0c17e55c1b45ff56bed01839eb..bcb616ade47b445dd6faec0fd938ee4d728d6d16 100644
+index 84316ea7f1ad285009f02cdf6e501c577958a170..5178cd001064c089cb2e6a78696b4702c78bc37a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -13,6 +13,7 @@ import net.minecraft.nbt.CompoundTag;
- import net.minecraft.nbt.Tag;
- import net.minecraft.network.chat.Component;
+@@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
+ import net.minecraft.server.level.ChunkMap;
+ import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
 +import net.minecraft.server.level.TicketType;
  import net.minecraft.world.damagesource.DamageSource;
  import net.minecraft.world.entity.AreaEffectCloud;
  import net.minecraft.world.entity.Entity;
-@@ -516,6 +517,28 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -518,6 +519,28 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          this.entity.setYHeadRot(yaw);
      }
  

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -10,10 +10,10 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 863981519bf0c62c00484cf9ee6d7ff1ea8ed946..ac9c9b32100de0e2f542f38c87451fb3e55c4edd 100644
+index 1bd378a60e761f9aeca347ebb80546ef4cf58eb4..4f53eb165616d690683a35d64abdf741f690a2a0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1111,6 +1111,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1072,6 +1072,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              return true;
          }
          // Paper end
@@ -93,7 +93,7 @@ index dbf002a6967812fd58ed9bcfa615dc525586c1a0..a8a91ed20c1b97368acdbb6ed7cd73dd
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 7bf688057d684aa1b60f29294c9a7e81ab6742d1..66ae43c40d4bad373b3a5269e8c78d7a3b3ac498 100644
+index 494174608c0c6d0e0d9820ad4f263bef90c3dfdf..fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -188,6 +188,7 @@ public abstract class BaseSpawner {
@@ -105,10 +105,10 @@ index 7bf688057d684aa1b60f29294c9a7e81ab6742d1..66ae43c40d4bad373b3a5269e8c78d7a
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index bcb616ade47b445dd6faec0fd938ee4d728d6d16..a28afbe66363e69a502b66d4124bb8fccf07be37 100644
+index 5178cd001064c089cb2e6a78696b4702c78bc37a..0b6720625b5fba07276972c484e032efdf9233c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1173,5 +1173,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1191,5 +1191,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean fromMobSpawner() {
          return getHandle().spawnedViaMobSpawner;
      }

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -85,7 +85,7 @@ index 85477d81a38aefa09f95671951cd06da713fd79c..01969206a55f332126169cd1e9c89abd
          // CraftBukkit start
          // this.updateSpawnFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ac9c9b32100de0e2f542f38c87451fb3e55c4edd..60eec0b54536b48ad1468e495afa9771ed71a763 100644
+index 4f53eb165616d690683a35d64abdf741f690a2a0..92de3821e8b510012736468b880ad18c0eb153a0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -61,6 +61,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
@@ -96,7 +96,7 @@ index ac9c9b32100de0e2f542f38c87451fb3e55c4edd..60eec0b54536b48ad1468e495afa9771
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.ServerScoreboard;
  import net.minecraft.server.level.progress.ChunkProgressListener;
-@@ -1504,12 +1505,84 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1465,12 +1466,84 @@ public class ServerLevel extends Level implements WorldGenLevel {
          return ((MapIndex) this.getServer().overworld().getDataStorage().computeIfAbsent(MapIndex::load, MapIndex::new, "idcounts")).getFreeAuxValueForMap();
      }
  

--- a/patches/server/0358-Optimise-IEntityAccess-getPlayerByUUID.patch
+++ b/patches/server/0358-Optimise-IEntityAccess-getPlayerByUUID.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise IEntityAccess#getPlayerByUUID
 Use the world entity map instead of iterating over all players
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 708bc5689e68d9e3e415e9d2dc1082cf85ee8b58..95fed7617c2b37886e912e35e7ad446c39e791ab 100644
+index 92de3821e8b510012736468b880ad18c0eb153a0..ae2606215a43a49b5e65052c407df715f260e400 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -284,6 +284,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -280,6 +280,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public final com.destroystokyo.paper.io.chunk.ChunkTaskManager asyncChunkTaskManager;
      // Paper end
  
@@ -22,5 +22,5 @@ index 708bc5689e68d9e3e415e9d2dc1082cf85ee8b58..95fed7617c2b37886e912e35e7ad446c
 +    // Paper end
 +
      // Add env and gen to constructor, WorldData -> WorldDataServer
-     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
+     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb4470e7ff4cc 100644
+index ae2606215a43a49b5e65052c407df715f260e400..60de95d72ca4e4b2e12a2b3363c59a08b75d0aae 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -33,7 +33,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
  import it.unimi.dsi.fastutil.objects.ObjectIterator;
  import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
  import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-@@ -123,7 +121,6 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
+@@ -122,7 +120,6 @@ import net.minecraft.world.level.chunk.LevelChunkSection;
  import net.minecraft.world.level.chunk.storage.EntityStorage;
  import net.minecraft.world.level.dimension.DimensionType;
  import net.minecraft.world.level.dimension.end.EndDragonFight;
@@ -41,7 +41,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
  import net.minecraft.world.level.entity.EntityPersistentStorage;
  import net.minecraft.world.level.entity.EntityTickList;
  import net.minecraft.world.level.entity.EntityTypeTest;
-@@ -891,17 +888,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -852,17 +849,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
          ++TimingHistory.entityTicks; // Paper - timings
          // Spigot start
          co.aikar.timings.Timing timer; // Paper
@@ -63,7 +63,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
          try {
          // Paper end - timings
          entity.setOldPosAndRot();
-@@ -912,9 +909,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -873,9 +870,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
              return Registry.ENTITY_TYPE.getKey(entity.getType()).toString();
          });
          gameprofilerfiller.incrementCounter("tickNonPassenger");
@@ -77,7 +77,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
          Iterator iterator = entity.getPassengers().iterator();
  
          while (iterator.hasNext()) {
-@@ -923,13 +924,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -884,13 +885,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
              this.tickPassenger(entity, entity1);
          }
  
@@ -97,7 +97,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
                  passenger.setOldPosAndRot();
                  ++passenger.tickCount;
                  ProfilerFiller gameprofilerfiller = this.getProfiler();
-@@ -938,8 +944,17 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -899,8 +905,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      return Registry.ENTITY_TYPE.getKey(passenger.getType()).toString();
                  });
                  gameprofilerfiller.incrementCounter("tickPassenger");
@@ -115,7 +115,7 @@ index 0941e9aa40aed7b872bb953ee7df8fa9cbde2962..175e911f8d12c5870d167a65cdeeb447
                  gameprofilerfiller.pop();
                  Iterator iterator = passenger.getPassengers().iterator();
  
-@@ -949,6 +964,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -910,6 +925,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
                      this.tickPassenger(passenger, entity2);
                  }
  

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1104,12 +1104,12 @@ index 6ddb24ae627b9bfdfd82b19b1a746f32bb8d0532..5e7fe43d1b27bed51f8a7c0fcddb8604
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 175e911f8d12c5870d167a65cdeeb4470e7ff4cc..59f14aa0ffcd61848ae6747d7a0330129a97d5a2 100644
+index 60de95d72ca4e4b2e12a2b3363c59a08b75d0aae..fac80bdbf0fa68cd8e63130a6a9de3b60a44583e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -292,7 +292,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -288,7 +288,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      // Add env and gen to constructor, WorldData -> WorldDataServer
-     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
+     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
 -        super(iworlddataserver, resourcekey, dimensionmanager, minecraftserver::getProfiler, false, flag, i, gen, env);
 +        super(iworlddataserver, resourcekey, dimensionmanager, minecraftserver::getProfiler, false, flag, i, gen, env, executor); // Paper - Anti-Xray - Pass executor

--- a/patches/server/0376-Add-debug-for-sync-chunk-loads.patch
+++ b/patches/server/0376-Add-debug-for-sync-chunk-loads.patch
@@ -279,7 +279,7 @@ index 0000000000000000000000000000000000000000..524f33371b9de1d4dd6972fe59ffbe18
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index b336b3ff4425dc6ba3dc55a6faa48660b7a4fc99..fa95d7aae33e7cd0c5d178247cf785cb58041a0d 100644
+index bb57e3b917b0e987273796ee7a348326350784f4..550338a7170437415342df7bc1b0a5c445480300 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -482,6 +482,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -291,10 +291,10 @@ index b336b3ff4425dc6ba3dc55a6faa48660b7a4fc99..fa95d7aae33e7cd0c5d178247cf785cb
              chunkproviderserver_a.managedBlock(completablefuture::isDone);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.popChunkWait(); // Paper - async chunk debug
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 59f14aa0ffcd61848ae6747d7a0330129a97d5a2..f0ce4150e863ea0d1f4a2f6a22d1be6a482cc78d 100644
+index fac80bdbf0fa68cd8e63130a6a9de3b60a44583e..00a064305dd8c671566dc32b8cd85f593ad139a3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -280,6 +280,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -276,6 +276,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
      };
      public final com.destroystokyo.paper.io.chunk.ChunkTaskManager asyncChunkTaskManager;
      // Paper end

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,7 +42,7 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8bf4d2b8c38c02d6a5b2fea37113689a252f1571..da93d38fe63035e4ff198ada84a4431f52d97c01 100644
+index 4c97fa63d912548324e93f366c86666d52738bfb..bfdf4b302860d56dec485af77c69d18db22dc6f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -354,6 +354,13 @@ public class PaperConfig {
@@ -924,7 +924,7 @@ index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..8104b9be5a8e8d57f6f50475788aec6a
              });
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index fa95d7aae33e7cd0c5d178247cf785cb58041a0d..b9516560183d37ef2917a3f9aaba60a53bcdfd72 100644
+index 550338a7170437415342df7bc1b0a5c445480300..a0d96ca2e63157e5995774c5a7a5f535e700bbfa 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -219,6 +219,12 @@ public class ServerChunkCache extends ChunkSource {
@@ -941,10 +941,10 @@ index fa95d7aae33e7cd0c5d178247cf785cb58041a0d..b9516560183d37ef2917a3f9aaba60a5
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, boolean flag, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkstatusupdatelistener, Supplier<DimensionDataStorage> supplier) {
          this.level = world;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f0ce4150e863ea0d1f4a2f6a22d1be6a482cc78d..2b7e10a65221a7ffd6211306f974c79deb897852 100644
+index 00a064305dd8c671566dc32b8cd85f593ad139a3..e51a393a31af71c18465b460dcf8d6d80a7f1c0f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -295,6 +295,15 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -291,6 +291,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
      // Paper end
  
@@ -958,9 +958,9 @@ index f0ce4150e863ea0d1f4a2f6a22d1be6a482cc78d..2b7e10a65221a7ffd6211306f974c79d
 +    // Paper end - rewrite ticklistserver
 +
      // Add env and gen to constructor, WorldData -> WorldDataServer
-     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<net.minecraft.world.level.Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
+     public ServerLevel(MinecraftServer minecraftserver, Executor executor, LevelStorageSource.LevelStorageAccess convertable_conversionsession, ServerLevelData iworlddataserver, ResourceKey<Level> resourcekey, DimensionType dimensionmanager, ChunkProgressListener worldloadlistener, ChunkGenerator chunkgenerator, boolean flag, long i, List<CustomSpawner> list, boolean flag1, org.bukkit.World.Environment env, org.bukkit.generator.ChunkGenerator gen) {
          // Objects.requireNonNull(minecraftserver); // CraftBukkit - decompile error
-@@ -311,13 +320,19 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -307,13 +316,19 @@ public class ServerLevel extends Level implements WorldGenLevel {
          DefaultedRegistry registryblocks = Registry.BLOCK;
  
          Objects.requireNonNull(registryblocks);
@@ -981,7 +981,7 @@ index f0ce4150e863ea0d1f4a2f6a22d1be6a482cc78d..2b7e10a65221a7ffd6211306f974c79d
          this.navigatingMobs = new ObjectOpenHashSet();
          this.blockEvents = new ObjectLinkedOpenHashSet();
          this.dragonParts = new Int2ObjectOpenHashMap();
-@@ -638,7 +653,9 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -599,7 +614,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
          if (this.tickTime) {
              long i = this.levelData.getGameTime() + 1L;
  

--- a/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -26,10 +26,10 @@ index b2d88e0423d93fdb45dc8ca7d53c98069ade749e..2b291296821dc6d6a8437bd977eeba51
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2b7e10a65221a7ffd6211306f974c79deb897852..4ab1b6b8fb2e320c5654f8d0399bd40b40e3e0cf 100644
+index e51a393a31af71c18465b460dcf8d6d80a7f1c0f..bc467846e98e9c8e8e060939ef8795c7a7845c0a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2100,7 +2100,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2061,7 +2061,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTrackingStart(Entity entity) {
              org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
@@ -38,7 +38,7 @@ index 2b7e10a65221a7ffd6211306f974c79deb897852..4ab1b6b8fb2e320c5654f8d0399bd40b
              if (entity instanceof ServerPlayer) {
                  ServerLevel.this.players.add((ServerPlayer) entity);
                  ServerLevel.this.updateSleepingPlayerList();
-@@ -2122,6 +2122,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2083,6 +2083,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
              entity.valid = true; // CraftBukkit

--- a/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -235,10 +235,10 @@ index a4c043d33b83003b440eb2baf1cc1bc7081019d3..902394e45ed6d34aa33ed8d3c74ddcaf
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          public boolean pollTask() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 4ab1b6b8fb2e320c5654f8d0399bd40b40e3e0cf..c05b5cdd26abcf90f4c44099d186938ccdd57608 100644
+index bc467846e98e9c8e8e060939ef8795c7a7845c0a..b31271a50740a77bc97ab47fdfe23f11a2a76618 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -583,6 +583,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -544,6 +544,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          }
          timings.scheduledBlocks.stopTiming(); // Paper
  
@@ -246,7 +246,7 @@ index 4ab1b6b8fb2e320c5654f8d0399bd40b40e3e0cf..c05b5cdd26abcf90f4c44099d186938c
          gameprofilerfiller.popPush("raid");
          this.timings.raids.startTiming(); // Paper - timings
          this.raids.tick();
-@@ -595,6 +596,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -556,6 +557,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          timings.doSounds.startTiming(); // Spigot
          this.runBlockEvents();
          timings.doSounds.stopTiming(); // Spigot
@@ -254,7 +254,7 @@ index 4ab1b6b8fb2e320c5654f8d0399bd40b40e3e0cf..c05b5cdd26abcf90f4c44099d186938c
          this.handlingTick = false;
          gameprofilerfiller.pop();
          boolean flag3 = true || !this.players.isEmpty() || !this.getForcedChunks().isEmpty(); // CraftBukkit - this prevents entity cleanup, other issues on servers with no players
-@@ -641,10 +643,12 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -602,10 +604,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
              timings.entityTick.stopTiming(); // Spigot
              timings.tickEntities.stopTiming(); // Spigot
              gameprofilerfiller.pop();

--- a/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -8,10 +8,10 @@ so inline where possible, and avoid the abstraction of the
 Either class.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c05b5cdd26abcf90f4c44099d186938ccdd57608..8ebcd5947688a1f0a8216e934ac90da0e5a8540e 100644
+index b31271a50740a77bc97ab47fdfe23f11a2a76618..79338bd6349b1e454f190e4daab030859d5fdf47 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2073,15 +2073,18 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -2034,15 +2034,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public boolean isPositionTickingWithEntitiesLoaded(BlockPos blockposition) {
          long i = ChunkPos.asLong(blockposition);
  

--- a/patches/server/0456-incremental-chunk-saving.patch
+++ b/patches/server/0456-incremental-chunk-saving.patch
@@ -260,10 +260,10 @@ index d8bf5a86a3eb0ae3fd6308e817a707ae98961479..ec0a9f46b50280324ae0d2eed208c8f3
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 8ebcd5947688a1f0a8216e934ac90da0e5a8540e..8cd2764e5d07975304b52ec5d995f4e7a9b5ff4d 100644
+index 79338bd6349b1e454f190e4daab030859d5fdf47..15d27aa11594b668ca7715ed1c465c6003d6e9bf 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1003,6 +1003,37 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -964,6 +964,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
          return !this.server.isUnderSpawnProtection(this, pos, player) && this.getWorldBorder().isWithinBounds(pos);
      }
  

--- a/patches/server/0482-Add-entity-liquid-API.patch
+++ b/patches/server/0482-Add-entity-liquid-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 895c4d0f8f6b829de426543c51181a88a1fd340f..c0f7b78dbe8f9baf68aa48dd763ab51312e916c6 100644
+index a0d1eaa72b88ff312112420c1b6da4c918bfcbe4..21a3c5fe4cf0ac4f21ffda3d7c0b20f82d4cadf1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1339,7 +1339,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -17,10 +17,10 @@ index 895c4d0f8f6b829de426543c51181a88a1fd340f..c0f7b78dbe8f9baf68aa48dd763ab513
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index a28afbe66363e69a502b66d4124bb8fccf07be37..0455f5f25baeaf23921dffc105c8c39e2063e368 100644
+index 0b6720625b5fba07276972c484e032efdf9233c2..49b1761efee2d38afbd93388d506194b142560bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1178,5 +1178,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1196,5 +1196,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
          return getHandle().spawnReason;
      }

--- a/patches/server/0510-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0510-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SpawnChangeEvent not firing for all use-cases
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 73d8505a2ec101e1e98fdea54019a37d70d64b16..10c978bae5e50db2156cbf454140db0bd178afac 100644
+index 15d27aa11594b668ca7715ed1c465c6003d6e9bf..3fc9847d26395a19abc5a16150ff8816a1b95dc8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1660,6 +1660,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1621,6 +1621,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
          //ChunkCoordIntPair chunkcoordintpair = new ChunkCoordIntPair(new BlockPosition(this.worldData.a(), 0, this.worldData.c()));
  
          this.levelData.setSpawn(pos, angle);

--- a/patches/server/0524-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0524-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index 00ce5bfdae67befdb72b01c152ab403fe60ab663..118580de630408472727b99fbca92695
          this.player.connection.send(new ClientboundPlayerPositionPacket(d0 - d3, d1 - d4, d2 - d5, f - f2, f1 - f3, set, this.awaitingTeleport, flag));
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f948d0de66920e562f2edb0171637d586fb6baba..12f812ed461f4136c5e0f90b8662d5bb13f0fe2d 100644
+index 2a5f58a87cfe312d2118c1b6ba4df98b046c4db1..c9ea809bcfd394f5a9483351ee0d4619c541f481 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -152,6 +152,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -57,7 +57,7 @@ index f948d0de66920e562f2edb0171637d586fb6baba..12f812ed461f4136c5e0f90b8662d5bb
          this.setYRot(yaw);
          this.setXRot(pitch);
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index a87531f4669c7947e02764b5ceb098385ad99159..9228c0bc797fb95c8ac949bdc568eadafee84a80 100644
+index b9e738542692aba7b78fc514ae8e3248df9998ea..c601b8b12756682a4cb300be8ebed4319902c5b5 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -170,6 +170,7 @@ public abstract class BaseSpawner {
@@ -69,10 +69,10 @@ index a87531f4669c7947e02764b5ceb098385ad99159..9228c0bc797fb95c8ac949bdc568eada
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 0455f5f25baeaf23921dffc105c8c39e2063e368..3c3614f0f8af3fb2c593dd1154bd64c70713a42e 100644
+index 49b1761efee2d38afbd93388d506194b142560bb..291b59eb9859ebd4e69fef0b54ea911effadf13f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -563,7 +563,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -565,7 +565,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          // entity.setLocation() throws no event, and so cannot be cancelled

--- a/patches/server/0527-Extend-block-drop-capture-to-capture-all-items-added.patch
+++ b/patches/server/0527-Extend-block-drop-capture-to-capture-all-items-added.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Extend block drop capture to capture all items added to the
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 10c978bae5e50db2156cbf454140db0bd178afac..04334cb457adc61fade27de45c677e27d9849b11 100644
+index 3fc9847d26395a19abc5a16150ff8816a1b95dc8..c818a34e17718f0d60979aa24c7385ba3f1c7d8e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1205,6 +1205,13 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1166,6 +1166,13 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // WorldServer.LOGGER.warn("Tried to add entity {} but it was marked as removed already", EntityTypes.getName(entity.getEntityType())); // CraftBukkit
              return false;
          } else {
@@ -24,7 +24,7 @@ index 10c978bae5e50db2156cbf454140db0bd178afac..04334cb457adc61fade27de45c677e27
                  return false;
              }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index c21c5134308a2a83fb50bfe37f05d19c8e96ca7c..c3cdc5a7ae90b7d2dd5676d66086e1f0c5b23d0d 100644
+index 51d7c59e6b3f4ca84905b186d9b173ec2c36a0b1..55d0b15a7ea1576af8045e84fe47eff696bb369f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -7,6 +7,7 @@ import net.minecraft.world.InteractionResult;

--- a/patches/server/0531-Entity-isTicking.patch
+++ b/patches/server/0531-Entity-isTicking.patch
@@ -27,10 +27,10 @@ index 14edbf6b2dc7697f9b703aa83d8529dd8ffe73a8..477b6102361f0ae03541402578e1d053
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 3c3614f0f8af3fb2c593dd1154bd64c70713a42e..8246ad7ebecdfc0b7519fe4412fef7b07407e850 100644
+index 291b59eb9859ebd4e69fef0b54ea911effadf13f..3acb5f8a1f863b5ba47eac4190be8228324fc8e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1202,5 +1202,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1220,5 +1220,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInLava() {
          return getHandle().isInLava();
      }

--- a/patches/server/0599-Remove-stale-POIs.patch
+++ b/patches/server/0599-Remove-stale-POIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stale POIs
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 04334cb457adc61fade27de45c677e27d9849b11..021efe5bae6a7e95e9080ab28ed69607d03f2af0 100644
+index c818a34e17718f0d60979aa24c7385ba3f1c7d8e..7068413f9e7b1dcaffb3fbb79d36c4ae97b160b5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1742,6 +1742,11 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1703,6 +1703,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              });
              optional1.ifPresent((villageplacetype) -> {
                  this.getServer().execute(() -> {

--- a/patches/server/0619-EntityMoveEvent.patch
+++ b/patches/server/0619-EntityMoveEvent.patch
@@ -17,10 +17,10 @@ index e6da0975b46ef7dbce4dd4025d5f27f990a310bf..2309d2f307569070ebb4c9b388021c01
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 30d4188c3c7c0419ea3aaa4b0b1175940e5c089e..9098a6515c732197f843a4612add23fde3dd189c 100644
+index 7068413f9e7b1dcaffb3fbb79d36c4ae97b160b5..55125e02f9f0dde3abf1e4cc06cec55cdab4cb03 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -200,6 +200,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -196,6 +196,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public final LevelStorageSource.LevelStorageAccess convertable;
      public final UUID uuid;
      public boolean hasPhysicsEvent = true; // Paper
@@ -29,7 +29,7 @@ index 30d4188c3c7c0419ea3aaa4b0b1175940e5c089e..9098a6515c732197f843a4612add23fd
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 515e551c365d799bebac3997f85c99243667caf5..a0861a9c97c8cd300485dfd8b528092ad4ed17ba 100644
+index e159d6c77860790c20ca7b531ed23ffda0380810..fdf0c39111059d7030cfc1eddfdcdda375bd2640 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3223,6 +3223,20 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0620-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0620-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -20,10 +20,10 @@ index 7fc5bf095afa6d5881285b89091d2ff48ffb69f0..0eba516110b82d917c3374a9fe5bbf33
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2f3dc805d3015ce083865050a4b99f2ba8d69bce..b9588496dfc14eff48dddb747396cecc53d2bd44 100644
+index 55125e02f9f0dde3abf1e4cc06cec55cdab4cb03..1ae3dd0ed198e8f183892af44030634f5cc260b6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1339,6 +1339,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1300,6 +1300,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      @Override
      public void sendBlockUpdated(BlockPos pos, BlockState oldState, BlockState newState, int flags) {
          this.getChunkSource().blockChanged(pos);
@@ -31,7 +31,7 @@ index 2f3dc805d3015ce083865050a4b99f2ba8d69bce..b9588496dfc14eff48dddb747396cecc
          VoxelShape voxelshape = oldState.getCollisionShape(this, pos);
          VoxelShape voxelshape1 = newState.getCollisionShape(this, pos);
  
-@@ -1366,6 +1367,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -1327,6 +1328,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
          }

--- a/patches/server/0695-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0695-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add cause to Weather/ThunderChangeEvents
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b9588496dfc14eff48dddb747396cecc53d2bd44..b3312fa2fd218ffcfaa61d98584003c97fbda4ce 100644
+index 1ae3dd0ed198e8f183892af44030634f5cc260b6..4b582ae2a11864bfde7fb6a45e51a9938d9d4c08 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -425,8 +425,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -386,8 +386,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
          this.serverLevelData.setClearWeatherTime(clearDuration);
          this.serverLevelData.setRainTime(rainDuration);
          this.serverLevelData.setThunderTime(rainDuration);
@@ -19,7 +19,7 @@ index b9588496dfc14eff48dddb747396cecc53d2bd44..b3312fa2fd218ffcfaa61d98584003c9
      }
  
      @Override
-@@ -489,8 +489,8 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -450,8 +450,8 @@ public class ServerLevel extends Level implements WorldGenLevel {
                  this.serverLevelData.setThunderTime(j);
                  this.serverLevelData.setRainTime(k);
                  this.serverLevelData.setClearWeatherTime(i);
@@ -30,7 +30,7 @@ index b9588496dfc14eff48dddb747396cecc53d2bd44..b3312fa2fd218ffcfaa61d98584003c9
              }
  
              this.oThunderLevel = this.thunderLevel;
-@@ -873,14 +873,14 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -834,14 +834,14 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
      private void stopWeather() {
          // CraftBukkit start

--- a/patches/server/0721-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0721-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,10 +8,10 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index db1884bde77bb46ccd65ced67928928b1e569b84..6ecf60c69a27f8db1c245db15449bba581c3dbf5 100644
+index 4b582ae2a11864bfde7fb6a45e51a9938d9d4c08..c2e0417ee15018ec31c4aa8eec3dff7a0d16aa9e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -206,7 +206,7 @@ public class ServerLevel extends net.minecraft.world.level.Level implements Worl
+@@ -202,7 +202,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
      }
  
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
17c35d6e SPIGOT-6637: Revert "#636: Add FurnaceStartSmeltEvent"
4b27230b SPIGOT-6623: Missing API reasons for entity freezing
e1528c85 #636: Add FurnaceStartSmeltEvent

CraftBukkit Changes:
a6292cc3 SPIGOT-6637: Revert "#874: Add FurnaceStartSmeltEvent"
f4066854 SPIGOT-6579: DragonFireBall movement with setDirection jumps around a lot
9add952b SPIGOT-6623: Missing API reasons for entity freezing
2ea359f1 #874: Add FurnaceStartSmeltEvent
be8d625e SPIGOT-5560, SPIGOT-6574, SPIGOT-6632: Remove no longer needed tile entity fix

Spigot Changes:
eac3cd96 Rebuild patches