### PR TITLE
[ci skip] Use commit timestamp instead of build time in manifest

### DIFF
--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -20,10 +20,10 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a
  /.project
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..0abd89ceb7a3cb3d808ac26d562899c6ec149c5f
+index 0000000000000000000000000000000000000000..f99a9702fe9282a1982c25cd0c003d8df80e97de
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,146 @@
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 +import io.papermc.paperweight.util.Git
@@ -72,11 +72,12 @@ index 0000000000000000000000000000000000000000..0abd89ceb7a3cb3d808ac26d562899c6
 +        val git = Git(rootProject.layout.projectDirectory.path)
 +        val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
 +        val implementationVersion = System.getenv("BUILD_NUMBER") ?: "\"$gitHash\""
++        val date = git("show", "-s", "--format=%ci", gitHash).getText().trim() // Paper
 +        attributes(
 +            "Main-Class" to "org.bukkit.craftbukkit.Main",
 +            "Implementation-Title" to "CraftBukkit",
 +            "Implementation-Version" to "git-Paper-$implementationVersion",
-+            "Implementation-Vendor" to SimpleDateFormat("yyyy-MM-dd-Z").format(Date()), // Paper
++            "Implementation-Vendor" to date, // Paper
 +            "Specification-Title" to "Bukkit",
 +            "Specification-Version" to project.version,
 +            "Specification-Vendor" to "Bukkit Team",

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -20,7 +20,7 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a
  /.project
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..e76b9f9012c7ba7253f455fa92b3891737f4ffd3
+index 0000000000000000000000000000000000000000..0abd89ceb7a3cb3d808ac26d562899c6ec149c5f
 --- /dev/null
 +++ b/build.gradle.kts
 @@ -0,0 +1,145 @@
@@ -76,7 +76,7 @@ index 0000000000000000000000000000000000000000..e76b9f9012c7ba7253f455fa92b38917
 +            "Main-Class" to "org.bukkit.craftbukkit.Main",
 +            "Implementation-Title" to "CraftBukkit",
 +            "Implementation-Version" to "git-Paper-$implementationVersion",
-+            "Implementation-Vendor" to SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(Date()), // Paper
++            "Implementation-Vendor" to SimpleDateFormat("yyyy-MM-dd-Z").format(Date()), // Paper
 +            "Specification-Title" to "Bukkit",
 +            "Specification-Version" to project.version,
 +            "Specification-Vendor" to "Bukkit Team",

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ecc68a9bb80d72307b930863c84ee47cac272aef..d9cc094235b84a0541650abbdeb5e934cfad00d8 100644
+index 0abd89ceb7a3cb3d808ac26d562899c6ec149c5f..55614dc59a945aceeb0393adfbed529f3c398ff0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -20,21 +20,23 @@ repositories {
@@ -70,7 +70,7 @@ index ecc68a9bb80d72307b930863c84ee47cac272aef..d9cc094235b84a0541650abbdeb5e934
          "org.eclipse.aether", "org.eclipse.sisu", "org.objectweb.asm"
      ).forEach { pack ->
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..358475974cf7dfced302bdd7d2390bd95848c737 100644
+index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..7afb0c15aafb9ef78992154bc1b2d80b82e48ed9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -190,7 +190,7 @@ public class Main {
@@ -78,7 +78,7 @@ index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..358475974cf7dfced302bdd7d2390bd9
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
 -                    Date buildDate = new Date(Integer.parseInt(Main.class.getPackage().getImplementationVendor()) * 1000L);
-+                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").parse(Main.class.getPackage().getImplementationVendor()); // Paper
++                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd-Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
                      deadline.add(Calendar.DAY_OF_YEAR, -7);

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 0abd89ceb7a3cb3d808ac26d562899c6ec149c5f..55614dc59a945aceeb0393adfbed529f3c398ff0 100644
+index f99a9702fe9282a1982c25cd0c003d8df80e97de..f06e7871780e863f5dd34338b008b739a471709a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -20,21 +20,23 @@ repositories {
@@ -36,7 +36,7 @@ index 0abd89ceb7a3cb3d808ac26d562899c6ec149c5f..55614dc59a945aceeb0393adfbed529f
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
  }
-@@ -54,6 +56,7 @@ tasks.jar {
+@@ -55,6 +57,7 @@ tasks.jar {
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
@@ -44,7 +44,7 @@ index 0abd89ceb7a3cb3d808ac26d562899c6ec149c5f..55614dc59a945aceeb0393adfbed529f
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -71,15 +74,23 @@ publishing {
+@@ -72,15 +75,23 @@ publishing {
      }
  }
  
@@ -70,7 +70,7 @@ index 0abd89ceb7a3cb3d808ac26d562899c6ec149c5f..55614dc59a945aceeb0393adfbed529f
          "org.eclipse.aether", "org.eclipse.sisu", "org.objectweb.asm"
      ).forEach { pack ->
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..7afb0c15aafb9ef78992154bc1b2d80b82e48ed9 100644
+index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..7f818c6bed25e0b793cca268b786f61440c429ef 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -190,7 +190,7 @@ public class Main {
@@ -78,7 +78,7 @@ index b06a4c8f5e1dfcbda171910279d6861dc3d4d2e7..7afb0c15aafb9ef78992154bc1b2d80b
  
                  if (Main.class.getPackage().getImplementationVendor() != null && System.getProperty("IReallyKnowWhatIAmDoingISwear") == null) {
 -                    Date buildDate = new Date(Integer.parseInt(Main.class.getPackage().getImplementationVendor()) * 1000L);
-+                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd-Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
++                    Date buildDate = new java.text.SimpleDateFormat("yyyy-MM-dd HH:mm:ss Z").parse(Main.class.getPackage().getImplementationVendor()); // Paper
  
                      Calendar deadline = Calendar.getInstance();
                      deadline.add(Calendar.DAY_OF_YEAR, -7);

--- a/patches/server/0152-Fix-this-stupid-bullshit.patch
+++ b/patches/server/0152-Fix-this-stupid-bullshit.patch
@@ -31,7 +31,7 @@ index c7d5018cb6acef12e6da90626c75543ac279a101..64576ddd8363be55755fa50d1c16d95e
              Bootstrap.isBootstrapped = true;
              if (Registry.REGISTRY.keySet().isEmpty()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 787db22e4d7df30ccf3d92297fbd2f08ff87beb5..b14fa970679dc000cd203949c73f117d4573be9e 100644
+index 806e5e55ea2596d221e375f7a005488abef33d19..d087645dd83b4c4748cfe0dc151e31e195affdfe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -228,10 +228,12 @@ public class Main {

--- a/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 98e93720833b50275ab16de87969b65052a5ddc9..9ac8a46478ee945d0425d4d713e8e7239f3156cd 100644
+index ac8d8342094158d83e179b8b4906c96cb12b488b..88694b73f7c9d02c8d0d4f38ef0533b9eb9e3497 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,8 +1,12 @@
@@ -46,7 +46,7 @@ index 98e93720833b50275ab16de87969b65052a5ddc9..9ac8a46478ee945d0425d4d713e8e723
      testImplementation("io.github.classgraph:classgraph:4.8.47") // Paper - mob goal test
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
-@@ -114,6 +128,44 @@ tasks.shadowJar {
+@@ -115,6 +129,44 @@ tasks.shadowJar {
      transform(ModifiedLog4j2PluginsCacheFileTransformer::class.java)
  }
  

--- a/patches/server/0718-Add-git-branch-and-commit-to-manifest.patch
+++ b/patches/server/0718-Add-git-branch-and-commit-to-manifest.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Add git branch and commit to manifest
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 9ac8a46478ee945d0425d4d713e8e7239f3156cd..4605634d1e0d2c6592d4152e697680e078380868 100644
+index 88694b73f7c9d02c8d0d4f38ef0533b9eb9e3497..682935762008602ca214f68147766792cbedeea9 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -76,6 +76,7 @@ tasks.jar {
-         val git = Git(rootProject.layout.projectDirectory.path)
+@@ -77,6 +77,7 @@ tasks.jar {
          val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
          val implementationVersion = System.getenv("BUILD_NUMBER") ?: "\"$gitHash\""
+         val date = git("show", "-s", "--format=%ci", gitHash).getText().trim() // Paper
 +        val gitBranch = git("rev-parse", "--abbrev-ref", "HEAD").getText().trim() // Paper
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
-@@ -85,6 +86,8 @@ tasks.jar {
+@@ -86,6 +87,8 @@ tasks.jar {
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
              "Multi-Release" to "true", // Paper


### PR DESCRIPTION
Allows shadowJar up-to-date check to function properly