### PR TITLE
Add advancement display API

### DIFF
--- a/patches/api/0340-Add-advancement-display-API.patch
+++ b/patches/api/0340-Add-advancement-display-API.patch
@@ -1,0 +1,214 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: syldium <syldium@mailo.com>
+Date: Fri, 9 Jul 2021 18:49:40 +0200
+Subject: [PATCH] Add advancement display API
+
+
+diff --git a/src/main/java/io/papermc/paper/advancement/AdvancementDisplay.java b/src/main/java/io/papermc/paper/advancement/AdvancementDisplay.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..67341bb70762a2326030abd2548372b92474f544
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/advancement/AdvancementDisplay.java
+@@ -0,0 +1,156 @@
++package io.papermc.paper.advancement;
++
++import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.format.NamedTextColor;
++import net.kyori.adventure.text.format.TextColor;
++import net.kyori.adventure.translation.Translatable;
++import net.kyori.adventure.util.Index;
++import org.bukkit.NamespacedKey;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++/**
++ * Describes the display of an advancement.
++ * <p>
++ * The display is used in the chat, in the toast messages and the advancements
++ * screen.
++ */
++public interface AdvancementDisplay {
++
++    /**
++     * Gets the {@link Frame}.
++     * <p>
++     * This defines the appearance of the tile in the advancements screen and
++     * the text when it's completed.
++     *
++     * @return the frame type
++     */
++    @NotNull
++    Frame frame();
++
++    /**
++     * Gets the advancement title.
++     *
++     * @return the title
++     */
++    @NotNull
++    Component title();
++
++    /**
++     * Gets the description.
++     *
++     * @return the description
++     */
++    @NotNull
++    Component description();
++
++    /**
++     * Gets the icon shown in the frame in the advancements screen.
++     *
++     * @return a copy of the icon
++     */
++    @NotNull
++    ItemStack icon();
++
++    /**
++     * Gets whether a toast should be displayed.
++     * <p>
++     * A toast is a notification that will be displayed in the top right corner
++     * of the screen.
++     *
++     * @return {@code true} if a toast should be shown
++     */
++    boolean doesShowToast();
++
++    /**
++     * Gets whether a message should be sent in the chat.
++     *
++     * @return {@code true} if a message should be sent
++     * @see org.bukkit.event.player.PlayerAdvancementDoneEvent#message() to edit
++     * the message
++     */
++    boolean doesAnnounceToChat();
++
++    /**
++     * Gets whether this advancement is hidden.
++     * <p>
++     * Hidden advancements cannot be viewed by the player until they have been
++     * unlocked.
++     *
++     * @return {@code true} if hidden
++     */
++    boolean isHidden();
++
++    /**
++     * Gets the texture displayed behind the advancement tree when selected.
++     * <p>
++     * This only affects root advancements without any parent. If the background
++     * is not specified or doesn't exist, the tab background will be the missing
++     * texture.
++     *
++     * @return the background texture path
++     */
++    @Nullable
++    NamespacedKey backgroundPath();
++
++    /**
++     * Defines how the {@link #icon()} appears in the advancements screen and
++     * the color used with the {@link #title() advancement name}.
++     */
++    enum Frame implements Translatable {
++
++        /**
++         * "Challenge complete" advancement.
++         * <p>
++         * The client will play the {@code ui.toast.challenge_complete} sound
++         * when the challenge is completed and the toast is shown.
++         */
++        CHALLENGE("challenge", NamedTextColor.DARK_PURPLE),
++
++        /**
++         * "Goal reached" advancement.
++         */
++        GOAL("goal", NamedTextColor.GREEN),
++
++        /**
++         * "Advancement made" advancement.
++         */
++        TASK("task", NamedTextColor.GREEN);
++
++        /**
++         * The name map.
++         */
++        public static final Index<String, Frame> NAMES = Index.create(Frame.class, frame -> frame.name);
++        private final String name;
++        private final TextColor color;
++
++        Frame(String name, TextColor color) {
++            this.name = name;
++            this.color = color;
++        }
++
++        /**
++         * Gets the {@link TextColor} used for the advancement name.
++         *
++         * @return the text color
++         */
++        @NotNull
++        public TextColor color() {
++            return this.color;
++        }
++
++        /**
++         * Gets the translation key used when an advancement is completed.
++         * <p>
++         * This is the first line of the toast displayed by the client.
++         *
++         * @return the toast message key
++         */
++        @Override
++        @NotNull
++        public String translationKey() {
++            return "advancements.toast." + this.name;
++        }
++    }
++}
+diff --git a/src/main/java/org/bukkit/advancement/Advancement.java b/src/main/java/org/bukkit/advancement/Advancement.java
+index 7c5009974ac8d64d0e738e60cec45acb0d4ca89a..3bbc7dffc36fa31099a8794ceeec77aeae0c49cb 100644
+--- a/src/main/java/org/bukkit/advancement/Advancement.java
++++ b/src/main/java/org/bukkit/advancement/Advancement.java
+@@ -17,4 +17,41 @@ public interface Advancement extends Keyed {
+      */
+     @NotNull
+     Collection<String> getCriteria();
++    // Paper start
++    /**
++     * Get the display info of this advancement.
++     * <p>
++     * Will be {@code null} when totally hidden, for example with crafting
++     * recipes.
++     *
++     * @return the display info
++     */
++    @org.jetbrains.annotations.Nullable
++    io.papermc.paper.advancement.AdvancementDisplay getDisplay();
++
++    /**
++     * Gets the parent advancement, if any.
++     *
++     * @return the parent advancement
++     */
++    @org.jetbrains.annotations.Nullable
++    Advancement getParent();
++
++    /**
++     * Gets all the direct children advancements.
++     *
++     * @return the children advancements
++     */
++    @NotNull
++    @org.jetbrains.annotations.Unmodifiable
++    Collection<Advancement> getChildren();
++
++    /**
++     * Gets the root advancement of the tree this is located in.
++     *
++     * @return the root advancement
++     */
++    @NotNull
++    Advancement getRoot();
++    // Paper end
+ }

--- a/patches/server/0830-Add-advancement-display-API.patch
+++ b/patches/server/0830-Add-advancement-display-API.patch
@@ -1,0 +1,155 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: syldium <syldium@mailo.com>
+Date: Fri, 9 Jul 2021 18:50:40 +0200
+Subject: [PATCH] Add advancement display API
+
+
+diff --git a/src/main/java/io/papermc/paper/advancement/PaperAdvancementDisplay.java b/src/main/java/io/papermc/paper/advancement/PaperAdvancementDisplay.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0567e500c40d3d424ddc19062c4f6da902e8586e
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/advancement/PaperAdvancementDisplay.java
+@@ -0,0 +1,63 @@
++package io.papermc.paper.advancement;
++
++import io.papermc.paper.adventure.PaperAdventure;
++import net.kyori.adventure.text.Component;
++import net.minecraft.advancements.DisplayInfo;
++import net.minecraft.advancements.FrameType;
++import org.bukkit.NamespacedKey;
++import org.bukkit.craftbukkit.inventory.CraftItemStack;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++public record PaperAdvancementDisplay(DisplayInfo handle) implements AdvancementDisplay {
++
++    @Override
++    public @NotNull Frame frame() {
++        return asPaperFrame(this.handle.getFrame());
++    }
++
++    @Override
++    public @NotNull Component title() {
++        return PaperAdventure.asAdventure(this.handle.getTitle());
++    }
++
++    @Override
++    public @NotNull Component description() {
++        return PaperAdventure.asAdventure(this.handle.getDescription());
++    }
++
++    @Override
++    public @NotNull ItemStack icon() {
++        return CraftItemStack.asBukkitCopy(this.handle.getIcon());
++    }
++
++    @Override
++    public boolean doesShowToast() {
++        return this.handle.shouldShowToast();
++    }
++
++    @Override
++    public boolean doesAnnounceToChat() {
++        return this.handle.shouldAnnounceChat();
++    }
++
++    @Override
++    public boolean isHidden() {
++        return this.handle.isHidden();
++    }
++
++    @Override
++    public @Nullable NamespacedKey backgroundPath() {
++        return this.handle.getBackground() == null ? null : CraftNamespacedKey.fromMinecraft(this.handle.getBackground());
++    }
++
++    public static @NotNull Frame asPaperFrame(@NotNull FrameType frameType) {
++        return switch (frameType) {
++            case TASK -> Frame.TASK;
++            case CHALLENGE -> Frame.CHALLENGE;
++            case GOAL -> Frame.GOAL;
++        };
++    }
++}
+diff --git a/src/main/java/net/minecraft/advancements/DisplayInfo.java b/src/main/java/net/minecraft/advancements/DisplayInfo.java
+index dea17bc7a6e4db470afaaad3c98940297a50e4e4..0b78ccceb55a1c0fa1f27f9ff1e303396c8f447d 100644
+--- a/src/main/java/net/minecraft/advancements/DisplayInfo.java
++++ b/src/main/java/net/minecraft/advancements/DisplayInfo.java
+@@ -27,6 +27,7 @@ public class DisplayInfo {
+     private final boolean hidden;
+     private float x;
+     private float y;
++    public final io.papermc.paper.advancement.AdvancementDisplay paper = new io.papermc.paper.advancement.PaperAdvancementDisplay(this); // Paper
+ 
+     public DisplayInfo(ItemStack icon, Component title, Component description, @Nullable ResourceLocation background, FrameType frame, boolean showToast, boolean announceToChat, boolean hidden) {
+         this.title = title;
+diff --git a/src/main/java/org/bukkit/craftbukkit/advancement/CraftAdvancement.java b/src/main/java/org/bukkit/craftbukkit/advancement/CraftAdvancement.java
+index 20d51358b4b47cbf43c3d172765243e96aa1966c..fd42cf61699337acde751249131c016555fd1ea5 100644
+--- a/src/main/java/org/bukkit/craftbukkit/advancement/CraftAdvancement.java
++++ b/src/main/java/org/bukkit/craftbukkit/advancement/CraftAdvancement.java
+@@ -27,4 +27,33 @@ public class CraftAdvancement implements org.bukkit.advancement.Advancement {
+     public Collection<String> getCriteria() {
+         return Collections.unmodifiableCollection(this.handle.getCriteria().keySet());
+     }
++    // Paper start
++    @Override
++    public io.papermc.paper.advancement.AdvancementDisplay getDisplay() {
++        return this.handle.getDisplay() == null ? null : this.handle.getDisplay().paper;
++    }
++
++    @Override
++    public org.bukkit.advancement.Advancement getParent() {
++        return this.handle.getParent() == null ? null : this.handle.getParent().bukkit;
++    }
++
++    @Override
++    public Collection<org.bukkit.advancement.Advancement> getChildren() {
++        final var children = com.google.common.collect.ImmutableList.<org.bukkit.advancement.Advancement>builder();
++        for (Advancement advancement : this.handle.getChildren()) {
++            children.add(advancement.bukkit);
++        }
++        return children.build();
++    }
++
++    @Override
++    public org.bukkit.advancement.Advancement getRoot() {
++        Advancement advancement = this.handle;
++        while (advancement.getParent() != null) {
++            advancement = advancement.getParent();
++        }
++        return advancement.bukkit;
++    }
++    // Paper end
+ }
+diff --git a/src/test/java/io/papermc/paper/advancement/AdvancementFrameTest.java b/src/test/java/io/papermc/paper/advancement/AdvancementFrameTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..520801e294a33ae62d9aa24dc0247591e379311d
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/advancement/AdvancementFrameTest.java
+@@ -0,0 +1,24 @@
++package io.papermc.paper.advancement;
++
++import io.papermc.paper.adventure.PaperAdventure;
++import net.kyori.adventure.text.format.TextColor;
++import net.minecraft.advancements.FrameType;
++import net.minecraft.network.chat.TranslatableComponent;
++import org.junit.Test;
++
++import static org.junit.Assert.assertEquals;
++
++public class AdvancementFrameTest {
++
++    @Test
++    public void test() {
++        for (FrameType nmsFrameType : FrameType.values()) {
++            final TextColor expectedColor = PaperAdventure.asAdventure(nmsFrameType.getChatColor());
++            final String expectedTranslationKey = ((TranslatableComponent) nmsFrameType.getDisplayName()).getKey();
++            final var frame = PaperAdvancementDisplay.asPaperFrame(nmsFrameType);
++            assertEquals("The translation keys should be the same", expectedTranslationKey, frame.translationKey());
++            assertEquals("The frame colors should be the same", expectedColor, frame.color());
++            assertEquals(nmsFrameType.getName(), AdvancementDisplay.Frame.NAMES.key(frame));
++        }
++    }
++}


### PR DESCRIPTION
Adds API for displaying advancements.
This allows custom menus and the use of translatable components.
Example: https://gist.github.com/syldium/4f304340ee26d31bea009295a7196522