### PR TITLE
Fix Stonecutter #6180 issue

### DIFF
--- a/patches/server/0614-Added-PlayerStonecutterRecipeSelectEvent.patch
+++ b/patches/server/0614-Added-PlayerStonecutterRecipeSelectEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Added PlayerStonecutterRecipeSelectEvent
 Co-Authored-By: MiniDigger <admin@minidigger.me>
 
 diff --git a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
-index eac9765ecf0b33cab8b04204591de8d56c6f75c7..72d1d7722691ff411cb481ac8be6afba0c3b989c 100644
+index c971a534ded962e3be92c71059c75cc1d54970b5..dd1d05ce730fdada2278b5cd9d72955df35c70c5 100644
 --- a/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/StonecutterMenu.java
 @@ -62,7 +62,7 @@ public class StonecutterMenu extends AbstractContainerMenu {
@@ -14,7 +14,7 @@ index eac9765ecf0b33cab8b04204591de8d56c6f75c7..72d1d7722691ff411cb481ac8be6afba
      public StonecutterMenu(int syncId, Inventory playerInventory, final ContainerLevelAccess context) {
          super(MenuType.STONECUTTER, syncId);
 -        this.selectedRecipeIndex = DataSlot.standalone();
-+        this.selectedRecipeIndex = addDataSlot(DataSlot.shared(new int[1], 0)); // Paper - allow replication
++        this.selectedRecipeIndex = DataSlot.shared(new int[1], 0); // Paper - allow replication
          this.recipes = Lists.newArrayList();
          this.input = ItemStack.EMPTY;
          this.slotUpdateListener = () -> {


### PR DESCRIPTION
```java
public StonecutterMenu(int syncId, Inventory playerInventory, final ContainerLevelAccess context) {
    super(MenuType.STONECUTTER, syncId);
    this.selectedRecipeIndex = addDataSlot(DataSlot.shared(new int[1], 0)); // Paper - allow replication
    
    ...

    this.addDataSlot(this.selectedRecipeIndex);
    ...
}
```
Why add `selectedRecipeIndex` to the `dataSlots` list twice in this code(original patch)?

This PR is fix #6180
The PlayerStonecutterRecipeSelectEvent works correctly, and no errors occur on the client.