### PR TITLE
Add Recipe API

### DIFF
--- a/patches/api/0374-Add-Recipe-API.patch
+++ b/patches/api/0374-Add-Recipe-API.patch
@@ -1,0 +1,273 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lexikiq <noellekiq@gmail.com>
+Date: Thu, 15 Jul 2021 01:39:12 -0400
+Subject: [PATCH] Add Recipe API
+
+Adds methods to utilize the RecipeManager to obtain recipes
+
+diff --git a/src/main/java/io/papermc/paper/inventory/RecipeType.java b/src/main/java/io/papermc/paper/inventory/RecipeType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2ddcaacb7
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/inventory/RecipeType.java
+@@ -0,0 +1,102 @@
++package io.papermc.paper.inventory;
++
++import com.google.common.base.Preconditions;
++import net.kyori.adventure.key.Key;
++import net.kyori.adventure.key.Keyed;
++import org.bukkit.NamespacedKey;
++import org.bukkit.inventory.BlastingRecipe;
++import org.bukkit.inventory.CampfireRecipe;
++import org.bukkit.inventory.CraftingInventory;
++import org.bukkit.inventory.FurnaceRecipe;
++import org.bukkit.inventory.Inventory;
++import org.bukkit.inventory.Recipe;
++import org.bukkit.inventory.SmithingRecipe;
++import org.bukkit.inventory.SmokingRecipe;
++import org.bukkit.inventory.StonecuttingRecipe;
++import org.jetbrains.annotations.NotNull;
++import org.jetbrains.annotations.Nullable;
++
++import java.util.HashMap;
++import java.util.Iterator;
++import java.util.Map;
++import java.util.Objects;
++
++/**
++ * A type of recipe registered by the game or a datapack.
++ * @param <R> recipe class this type represents
++ * @param <I> inventory class used for matching recipes
++ */
++public class RecipeType<R extends Recipe, I extends Inventory> implements Keyed, org.bukkit.Keyed {
++    private final @NotNull NamespacedKey key;
++
++    public RecipeType(@NotNull String key) {
++        this.key = Objects.requireNonNull(org.bukkit.NamespacedKey.fromString(key));
++    }
++
++    public RecipeType(@NotNull NamespacedKey key) {
++        this.key = Preconditions.checkNotNull(key, "key");
++    }
++
++    @Override
++    public @NotNull NamespacedKey getKey() {
++        return key;
++    }
++
++    @Override
++    public @NotNull Key key() {
++        return key;
++    }
++
++    private static final Map<NamespacedKey, RecipeType<?, ?>> recipeTypes = new HashMap<>(7);
++
++    private static <R extends Recipe, C extends Inventory> RecipeType<R, C> register(final @NotNull String id) {
++        RecipeType<R, C> recipeType = new RecipeType<>(id);
++        recipeTypes.put(recipeType.key, recipeType);
++        return recipeType;
++    }
++
++    /**
++     * Recipes for crafting in a {@link org.bukkit.Material#CRAFTING_TABLE CRAFTING_TABLE}.
++     */
++    public static final RecipeType<Recipe, CraftingInventory> CRAFTING = register("crafting");
++    /**
++     * Recipes for smelting inside of a {@link org.bukkit.Material#FURNACE FURNACE}.
++     */
++    public static final RecipeType<FurnaceRecipe, Inventory> SMELTING = register("smelting");
++    /**
++     * Recipes for smelting inside of a {@link org.bukkit.Material#BLAST_FURNACE BLAST_FURNACE}.
++     */
++    public static final RecipeType<BlastingRecipe, Inventory> BLASTING = register("blasting");
++    /**
++     * Recipes for smelting inside of a {@link org.bukkit.Material#SMOKER SMOKER}.
++     */
++    public static final RecipeType<SmokingRecipe, Inventory> SMOKING = register("smoking");
++    /**
++     * Recipes for smelting on a {@link org.bukkit.Material#CAMPFIRE CAMPFIRE}.
++     */
++    public static final RecipeType<CampfireRecipe, Inventory> CAMPFIRE_COOKING = register("campfire_cooking");
++    /**
++     * Recipes for cutting in a {@link org.bukkit.Material#STONECUTTER STONECUTTER}.
++     */
++    public static final RecipeType<StonecuttingRecipe, Inventory> STONECUTTING = register("stonecutting");
++    /**
++     * Recipes for upgrading items in a {@link org.bukkit.Material#SMITHING_TABLE SMITHING_TABLE}.
++     */
++    public static final RecipeType<SmithingRecipe, Inventory> SMITHING = register("smithing");
++
++    /**
++     * Gets a registered recipe type by its key.
++     * @return a registered recipe type or null
++     */
++    public static @Nullable RecipeType<?, ?> getByKey(final @NotNull NamespacedKey key) {
++        return recipeTypes.get(Preconditions.checkNotNull(key, "key"));
++    }
++
++    /**
++     * Gets an iterator across all registered recipe types.
++     * @return recipe type iterator
++     */
++    public static @NotNull Iterator<RecipeType<?, ?>> iterator() {
++        return recipeTypes.values().iterator();
++    }
++}
+diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
+index 944f9b87a11472ac6d7e328acc00bf09f899e648..3804690913598f8b31d68be7624bb2b0cd305eea 100644
+--- a/src/main/java/org/bukkit/Bukkit.java
++++ b/src/main/java/org/bukkit/Bukkit.java
+@@ -2306,6 +2306,16 @@ public final class Bukkit {
+     public static @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer() {
+         return server.getPotionBrewer();
+     }
++
++    /**
++     * Gets all recipes of a certain type.
++     *
++     * @param recipeType recipe type to check against
++     * @return all recipes registered under the input type
++     */
++    public static @NotNull <R extends org.bukkit.inventory.Recipe> List<R> getAllRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType) {
++        return server.getAllRecipes(recipeType);
++    }
+     // Paper end
+ 
+     @NotNull
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 41363490b1e72d53ab3f1f26fe464858bb7b8f72..b4abb933df577c86f5060db4e633b781e17e6c5c 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -233,6 +233,24 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+             return StructureType.getStructureTypes().values().iterator();
+         }
+     };
++    /**
++     * Recipe types.
++     *
++     * @see io.papermc.paper.inventory.RecipeType RecipeType
++     */
++    Registry<io.papermc.paper.inventory.RecipeType<?, ?>> RECIPE_TYPE = new Registry<>() {
++        @NotNull
++        @Override
++        public Iterator<io.papermc.paper.inventory.RecipeType<?, ?>> iterator() {
++            return io.papermc.paper.inventory.RecipeType.iterator();
++        }
++
++        @Nullable
++        @Override
++        public io.papermc.paper.inventory.RecipeType<?, ?> get(@org.jetbrains.annotations.NotNull NamespacedKey key) {
++            return io.papermc.paper.inventory.RecipeType.getByKey(key);
++        }
++    };
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
+index f63587cfa651a3893d2efa3730dc80f271d56b1c..1aafd95dc21c400ad9fdee6676c64fd2a172a5e2 100644
+--- a/src/main/java/org/bukkit/Server.java
++++ b/src/main/java/org/bukkit/Server.java
+@@ -2002,5 +2002,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+      * @return the potion brewer
+      */
+     @NotNull org.bukkit.potion.PotionBrewer getPotionBrewer();
++
++    /**
++     * Gets all recipes of a certain type.
++     *
++     * @param recipeType recipe type to check against
++     * @return all recipes registered under the input type
++     */
++    @NotNull
++    <R extends org.bukkit.inventory.Recipe> List<R> getAllRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05c94ac2f1 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -3929,6 +3929,84 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     @Nullable
+     public DragonBattle getEnderDragonBattle();
+ 
++    // Paper start
++    /**
++     * Gets a recipe from the items inside of an inventory.
++     *
++     * @param recipeType recipe type to check against
++     * @param inventory the inventory to check
++     * @return a recipe resulting from the input items, or null if no result is found
++     */
++    @Nullable
++    <R extends org.bukkit.inventory.Recipe, I extends org.bukkit.inventory.Inventory> R getRecipe(io.papermc.paper.inventory.@NotNull RecipeType<R, I> recipeType, @NotNull I inventory);
++
++    /**
++     * Gets a recipe from a collection of items.
++     * <p>
++     * The collection should be ordered from left-to-right, top-to-bottom.
++     * The zeroth index would be the top left slot of a crafting table,
++     * the first index would be the top middle slot, et cetera.
++     *
++     * @param recipeType recipe type to check against
++     * @param items items to craft with
++     * @return a recipe resulting from the input items, or null if no result is found
++     */
++    @Nullable
++    <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @NotNull Collection<@Nullable ItemStack> items);
++
++    /**
++     * Gets a recipe from an index of items.
++     * <p>
++     * The index should be ordered from left-to-right, top-to-bottom.
++     * The zeroth index would be the top left slot of a crafting table,
++     * the first index would be the top middle slot, et cetera.
++     *
++     * @param recipeType recipe type to check against
++     * @param items items to craft with
++     * @return a recipe resulting from the input items, or null if no result is found
++     */
++    @Nullable
++    <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @Nullable ItemStack... items);
++
++    /**
++     * Gets all applicable recipes from the items inside of an inventory.
++     *
++     * @param recipeType recipe type to check against
++     * @param inventory the inventory to check
++     * @return the recipes resulting from the input items
++     */
++    @NotNull
++    <R extends org.bukkit.inventory.Recipe, I extends org.bukkit.inventory.Inventory> List<R> getRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, I> recipeType, @NotNull I inventory);
++
++    /**
++     * Gets all applicable recipes from a collection of items.
++     * <p>
++     * The collection should be ordered from left-to-right, top-to-bottom.
++     * The zeroth index would be the top left slot of a crafting table,
++     * the first index would be the top middle slot, et cetera.
++     *
++     * @param recipeType recipe type to check against
++     * @param items items to craft with
++     * @return the recipes resulting from the input items
++     */
++    @Nullable
++    <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @NotNull Collection<@Nullable ItemStack> items);
++
++    /**
++     * Gets all applicable recipes from an array of items.
++     * <p>
++     * The array should be ordered from left-to-right, top-to-bottom.
++     * The zeroth index would be the top left slot of a crafting table,
++     * the first index would be the top middle slot, et cetera.
++     *
++     * @param recipeType recipe type to check against
++     * @param items items to craft with
++     * @return the recipes resulting from the input items
++     */
++    @NotNull
++    <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @Nullable ItemStack... items);
++    // Paper end
++
+     /**
+      * Represents various map environment types that a world may be
+      */

--- a/patches/api/0374-Add-Recipe-API.patch
+++ b/patches/api/0374-Add-Recipe-API.patch
@@ -7,15 +7,15 @@ Adds methods to utilize the RecipeManager to obtain recipes
 
 diff --git a/src/main/java/io/papermc/paper/inventory/RecipeType.java b/src/main/java/io/papermc/paper/inventory/RecipeType.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2ddcaacb7
+index 0000000000000000000000000000000000000000..48f059982b452eacdefcb4d8fcbda6230a90ad0f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/RecipeType.java
-@@ -0,0 +1,102 @@
+@@ -0,0 +1,111 @@
 +package io.papermc.paper.inventory;
 +
 +import com.google.common.base.Preconditions;
 +import net.kyori.adventure.key.Key;
-+import net.kyori.adventure.key.Keyed;
++import org.bukkit.Keyed;
 +import org.bukkit.NamespacedKey;
 +import org.bukkit.inventory.BlastingRecipe;
 +import org.bukkit.inventory.CampfireRecipe;
@@ -36,27 +36,34 @@ index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2
 +
 +/**
 + * A type of recipe registered by the game or a datapack.
++ *
 + * @param <R> recipe class this type represents
 + * @param <I> inventory class used for matching recipes
 + */
-+public class RecipeType<R extends Recipe, I extends Inventory> implements Keyed, org.bukkit.Keyed {
++public class RecipeType<R extends Recipe, I extends Inventory> implements Keyed {
 +    private final @NotNull NamespacedKey key;
 +
++    /**
++     * Creates a recipe type given the provided key.
++     *
++     * @param key a {@link NamespacedKey#fromString(String) NamespacedKey-like string} that
++     *            identifies a type of recipe
++     */
 +    public RecipeType(@NotNull String key) {
-+        this.key = Objects.requireNonNull(org.bukkit.NamespacedKey.fromString(key));
++        this.key = Objects.requireNonNull(NamespacedKey.fromString(key), "Unable to parse key '" + key + "'");
 +    }
 +
++    /**
++     * Creates a recipe type for the provided key.
++     *
++     * @param key the key that identifies a type of recipe.
++     */
 +    public RecipeType(@NotNull NamespacedKey key) {
-+        this.key = Preconditions.checkNotNull(key, "key");
++        this.key = Objects.requireNonNull(key, "key cannot be null");
 +    }
 +
 +    @Override
 +    public @NotNull NamespacedKey getKey() {
-+        return key;
-+    }
-+
-+    @Override
-+    public @NotNull Key key() {
 +        return key;
 +    }
 +
@@ -73,15 +80,15 @@ index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2
 +     */
 +    public static final RecipeType<Recipe, CraftingInventory> CRAFTING = register("crafting");
 +    /**
-+     * Recipes for smelting inside of a {@link org.bukkit.Material#FURNACE FURNACE}.
++     * Recipes for smelting inside a {@link org.bukkit.Material#FURNACE FURNACE}.
 +     */
 +    public static final RecipeType<FurnaceRecipe, Inventory> SMELTING = register("smelting");
 +    /**
-+     * Recipes for smelting inside of a {@link org.bukkit.Material#BLAST_FURNACE BLAST_FURNACE}.
++     * Recipes for smelting inside a {@link org.bukkit.Material#BLAST_FURNACE BLAST_FURNACE}.
 +     */
 +    public static final RecipeType<BlastingRecipe, Inventory> BLASTING = register("blasting");
 +    /**
-+     * Recipes for smelting inside of a {@link org.bukkit.Material#SMOKER SMOKER}.
++     * Recipes for smelting inside a {@link org.bukkit.Material#SMOKER SMOKER}.
 +     */
 +    public static final RecipeType<SmokingRecipe, Inventory> SMOKING = register("smoking");
 +    /**
@@ -99,6 +106,7 @@ index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2
 +
 +    /**
 +     * Gets a registered recipe type by its key.
++     *
 +     * @return a registered recipe type or null
 +     */
 +    public static @Nullable RecipeType<?, ?> getByKey(final @NotNull NamespacedKey key) {
@@ -107,6 +115,7 @@ index 0000000000000000000000000000000000000000..bc3991590c6ffb29a267abc9efcf06d2
 +
 +    /**
 +     * Gets an iterator across all registered recipe types.
++     *
 +     * @return recipe type iterator
 +     */
 +    public static @NotNull Iterator<RecipeType<?, ?>> iterator() {
@@ -183,10 +192,10 @@ index f63587cfa651a3893d2efa3730dc80f271d56b1c..1aafd95dc21c400ad9fdee6676c64fd2
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05c94ac2f1 100644
+index 8a688583e65cd22e0417f9fd24e51803486d095e..c9961f764872d149077cf4c871115dcaef32a4a0 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3929,6 +3929,84 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+@@ -3929,6 +3929,92 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
      @Nullable
      public DragonBattle getEnderDragonBattle();
  
@@ -207,6 +216,8 @@ index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05
 +     * The collection should be ordered from left-to-right, top-to-bottom.
 +     * The zeroth index would be the top left slot of a crafting table,
 +     * the first index would be the top middle slot, et cetera.
++     * </p>
++     * The collection of items must not be null, but the items contained inside it may be null.
 +     *
 +     * @param recipeType recipe type to check against
 +     * @param items items to craft with
@@ -221,13 +232,15 @@ index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05
 +     * The index should be ordered from left-to-right, top-to-bottom.
 +     * The zeroth index would be the top left slot of a crafting table,
 +     * the first index would be the top middle slot, et cetera.
++     * </p>
++     * The array of items must not be null, but the items contained inside it may be null.
 +     *
 +     * @param recipeType recipe type to check against
 +     * @param items items to craft with
 +     * @return a recipe resulting from the input items, or null if no result is found
 +     */
 +    @Nullable
-+    <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @Nullable ItemStack... items);
++    <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, ItemStack @NotNull ... items);
 +
 +    /**
 +     * Gets all applicable recipes from the items inside of an inventory.
@@ -245,6 +258,8 @@ index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05
 +     * The collection should be ordered from left-to-right, top-to-bottom.
 +     * The zeroth index would be the top left slot of a crafting table,
 +     * the first index would be the top middle slot, et cetera.
++     * </p>
++     * The collection of items must not be null, but the items contained inside it may be null.
 +     *
 +     * @param recipeType recipe type to check against
 +     * @param items items to craft with
@@ -259,13 +274,15 @@ index 8a688583e65cd22e0417f9fd24e51803486d095e..c16eb81d1491e68187f2140ad5a12a05
 +     * The array should be ordered from left-to-right, top-to-bottom.
 +     * The zeroth index would be the top left slot of a crafting table,
 +     * the first index would be the top middle slot, et cetera.
++     * </p>
++     * The array of items must not be null, but the items contained inside it may be null.
 +     *
 +     * @param recipeType recipe type to check against
 +     * @param items items to craft with
 +     * @return the recipes resulting from the input items
 +     */
 +    @NotNull
-+    <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, @Nullable ItemStack... items);
++    <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.@NotNull RecipeType<R, ?> recipeType, ItemStack @NotNull ... items);
 +    // Paper end
 +
      /**

--- a/patches/api/0374-Add-Recipe-API.patch
+++ b/patches/api/0374-Add-Recipe-API.patch
@@ -7,16 +7,16 @@ Adds methods to utilize the RecipeManager to obtain recipes
 
 diff --git a/src/main/java/io/papermc/paper/inventory/RecipeType.java b/src/main/java/io/papermc/paper/inventory/RecipeType.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..48f059982b452eacdefcb4d8fcbda6230a90ad0f
+index 0000000000000000000000000000000000000000..ae47efbc112a22ab69546ced519f78c6b3db471a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/inventory/RecipeType.java
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,87 @@
 +package io.papermc.paper.inventory;
 +
-+import com.google.common.base.Preconditions;
-+import net.kyori.adventure.key.Key;
++import io.papermc.paper.registry.Reference;
 +import org.bukkit.Keyed;
 +import org.bukkit.NamespacedKey;
++import org.bukkit.Registry;
 +import org.bukkit.inventory.BlastingRecipe;
 +import org.bukkit.inventory.CampfireRecipe;
 +import org.bukkit.inventory.CraftingInventory;
@@ -27,15 +27,12 @@ index 0000000000000000000000000000000000000000..48f059982b452eacdefcb4d8fcbda623
 +import org.bukkit.inventory.SmokingRecipe;
 +import org.bukkit.inventory.StonecuttingRecipe;
 +import org.jetbrains.annotations.NotNull;
-+import org.jetbrains.annotations.Nullable;
 +
-+import java.util.HashMap;
-+import java.util.Iterator;
-+import java.util.Map;
 +import java.util.Objects;
 +
 +/**
 + * A type of recipe registered by the game or a datapack.
++ * The most common recipe type is the {@link #CRAFTING crafting table} type.
 + *
 + * @param <R> recipe class this type represents
 + * @param <I> inventory class used for matching recipes
@@ -67,60 +64,39 @@ index 0000000000000000000000000000000000000000..48f059982b452eacdefcb4d8fcbda623
 +        return key;
 +    }
 +
-+    private static final Map<NamespacedKey, RecipeType<?, ?>> recipeTypes = new HashMap<>(7);
-+
-+    private static <R extends Recipe, C extends Inventory> RecipeType<R, C> register(final @NotNull String id) {
-+        RecipeType<R, C> recipeType = new RecipeType<>(id);
-+        recipeTypes.put(recipeType.key, recipeType);
-+        return recipeType;
++    private static <R extends Recipe, C extends Inventory> Reference<RecipeType<R, C>> register(final @NotNull String id) {
++        Object reference = Reference.create(Registry.RECIPE_TYPE, NamespacedKey.minecraft(id));
++        return (Reference<RecipeType<R, C>>) reference;
 +    }
 +
 +    /**
 +     * Recipes for crafting in a {@link org.bukkit.Material#CRAFTING_TABLE CRAFTING_TABLE}.
 +     */
-+    public static final RecipeType<Recipe, CraftingInventory> CRAFTING = register("crafting");
++    public static final Reference<RecipeType<Recipe, CraftingInventory>> CRAFTING = register("crafting");
 +    /**
 +     * Recipes for smelting inside a {@link org.bukkit.Material#FURNACE FURNACE}.
 +     */
-+    public static final RecipeType<FurnaceRecipe, Inventory> SMELTING = register("smelting");
++    public static final Reference<RecipeType<FurnaceRecipe, Inventory>> SMELTING = register("smelting");
 +    /**
 +     * Recipes for smelting inside a {@link org.bukkit.Material#BLAST_FURNACE BLAST_FURNACE}.
 +     */
-+    public static final RecipeType<BlastingRecipe, Inventory> BLASTING = register("blasting");
++    public static final Reference<RecipeType<BlastingRecipe, Inventory>> BLASTING = register("blasting");
 +    /**
 +     * Recipes for smelting inside a {@link org.bukkit.Material#SMOKER SMOKER}.
 +     */
-+    public static final RecipeType<SmokingRecipe, Inventory> SMOKING = register("smoking");
++    public static final Reference<RecipeType<SmokingRecipe, Inventory>> SMOKING = register("smoking");
 +    /**
 +     * Recipes for smelting on a {@link org.bukkit.Material#CAMPFIRE CAMPFIRE}.
 +     */
-+    public static final RecipeType<CampfireRecipe, Inventory> CAMPFIRE_COOKING = register("campfire_cooking");
++    public static final Reference<RecipeType<CampfireRecipe, Inventory>> CAMPFIRE_COOKING = register("campfire_cooking");
 +    /**
 +     * Recipes for cutting in a {@link org.bukkit.Material#STONECUTTER STONECUTTER}.
 +     */
-+    public static final RecipeType<StonecuttingRecipe, Inventory> STONECUTTING = register("stonecutting");
++    public static final Reference<RecipeType<StonecuttingRecipe, Inventory>> STONECUTTING = register("stonecutting");
 +    /**
 +     * Recipes for upgrading items in a {@link org.bukkit.Material#SMITHING_TABLE SMITHING_TABLE}.
 +     */
-+    public static final RecipeType<SmithingRecipe, Inventory> SMITHING = register("smithing");
-+
-+    /**
-+     * Gets a registered recipe type by its key.
-+     *
-+     * @return a registered recipe type or null
-+     */
-+    public static @Nullable RecipeType<?, ?> getByKey(final @NotNull NamespacedKey key) {
-+        return recipeTypes.get(Preconditions.checkNotNull(key, "key"));
-+    }
-+
-+    /**
-+     * Gets an iterator across all registered recipe types.
-+     *
-+     * @return recipe type iterator
-+     */
-+    public static @NotNull Iterator<RecipeType<?, ?>> iterator() {
-+        return recipeTypes.values().iterator();
-+    }
++    public static final Reference<RecipeType<SmithingRecipe, Inventory>> SMITHING = register("smithing");
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
 index 944f9b87a11472ac6d7e328acc00bf09f899e648..3804690913598f8b31d68be7624bb2b0cd305eea 100644
@@ -144,10 +120,10 @@ index 944f9b87a11472ac6d7e328acc00bf09f899e648..3804690913598f8b31d68be7624bb2b0
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
-index 41363490b1e72d53ab3f1f26fe464858bb7b8f72..b4abb933df577c86f5060db4e633b781e17e6c5c 100644
+index 41363490b1e72d53ab3f1f26fe464858bb7b8f72..d96776b0af2ae1d39961db7aa4a7da2e8449b016 100644
 --- a/src/main/java/org/bukkit/Registry.java
 +++ b/src/main/java/org/bukkit/Registry.java
-@@ -233,6 +233,24 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+@@ -233,6 +233,12 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
              return StructureType.getStructureTypes().values().iterator();
          }
      };
@@ -156,19 +132,7 @@ index 41363490b1e72d53ab3f1f26fe464858bb7b8f72..b4abb933df577c86f5060db4e633b781
 +     *
 +     * @see io.papermc.paper.inventory.RecipeType RecipeType
 +     */
-+    Registry<io.papermc.paper.inventory.RecipeType<?, ?>> RECIPE_TYPE = new Registry<>() {
-+        @NotNull
-+        @Override
-+        public Iterator<io.papermc.paper.inventory.RecipeType<?, ?>> iterator() {
-+            return io.papermc.paper.inventory.RecipeType.iterator();
-+        }
-+
-+        @Nullable
-+        @Override
-+        public io.papermc.paper.inventory.RecipeType<?, ?> get(@org.jetbrains.annotations.NotNull NamespacedKey key) {
-+            return io.papermc.paper.inventory.RecipeType.getByKey(key);
-+        }
-+    };
++    Registry<io.papermc.paper.inventory.RecipeType<?, ?>> RECIPE_TYPE = Bukkit.getUnsafe().registryFor((Class<io.papermc.paper.inventory.RecipeType<?, ?>>) (Object) io.papermc.paper.inventory.RecipeType.class);
      // Paper end
  
      /**

--- a/patches/server/0878-Add-Recipe-API.patch
+++ b/patches/server/0878-Add-Recipe-API.patch
@@ -1,0 +1,191 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: lexikiq <noellekiq@gmail.com>
+Date: Thu, 15 Jul 2021 01:39:12 -0400
+Subject: [PATCH] Add Recipe API
+
+Adds methods to utilize the RecipeManager to obtain recipes
+
+diff --git a/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java b/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..c26219e8834377910b5fa4f8ed54e7e80278ed53
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java
+@@ -0,0 +1,14 @@
++package io.papermc.paper.inventory;
++
++import net.minecraft.core.Registry;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++
++public class CraftRecipeType {
++    public static net.minecraft.world.item.crafting.RecipeType asNMS(RecipeType bukkit) {
++        return Registry.RECIPE_TYPE.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
++    }
++
++    public static RecipeType asBukkit(net.minecraft.world.item.crafting.RecipeType nms) {
++        return RecipeType.getByKey(CraftNamespacedKey.fromMinecraft(Registry.RECIPE_TYPE.getKey(nms)));
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/inventory/MenulessContainer.java b/src/main/java/io/papermc/paper/inventory/MenulessContainer.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..fa82f292583a862829f9a5c696b82539487f91e4
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/inventory/MenulessContainer.java
+@@ -0,0 +1,41 @@
++package io.papermc.paper.inventory;
++
++import net.minecraft.world.ContainerHelper;
++import net.minecraft.world.inventory.CraftingContainer;
++import net.minecraft.world.item.ItemStack;
++import org.bukkit.Location;
++
++import java.util.Collection;
++
++// "Simulates" an NMS crafting container by removing the need for a menu
++public class MenulessContainer extends CraftingContainer {
++    public MenulessContainer(int width, int height) {
++        super(null, width, height);
++    }
++
++    public MenulessContainer(int width, int height, ItemStack... items) {
++        super(null, width, height);
++        for (int i = 0; i < items.length && i < (width * height); i++) {
++            setItem(i, items[i]);
++        }
++    }
++
++    public MenulessContainer(int width, int height, Collection<ItemStack> items) {
++        this(width, height, items.toArray(new ItemStack[]{}));
++    }
++
++    @Override
++    public Location getLocation() {
++        return null;
++    }
++
++    @Override
++    public ItemStack removeItem(int slot, int amount) {
++        return ContainerHelper.removeItem(getContents(), slot, amount);
++    }
++
++    @Override
++    public void setItem(int slot, ItemStack stack) {
++        getContents().set(slot, stack);
++    }
++}
+diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+index 7ef0075cc16613709e145714204a728d8d8dd82b..1bd227fbc209f0b9655a281061d9417f21da84b4 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
++++ b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+@@ -111,6 +111,7 @@ public class RecipeManager extends SimpleJsonResourceReloadListener {
+     }
+ 
+     public <C extends Container, T extends Recipe<C>> List<T> getAllRecipesFor(RecipeType<T> type) {
++        if (true) return (List) new java.util.ArrayList<>(this.byType(type).values()); // Paper - fix unnecessary stream/map
+         return (List) this.byType(type).values().stream().map((irecipe) -> {
+             return irecipe;
+         }).collect(Collectors.toList());
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..e52c0a0c95e4b73df05745ff1cd1195560a7e307 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2852,5 +2852,14 @@ public final class CraftServer implements Server {
+         return this.potionBrewer;
+     }
+ 
++    @Override
++    public <R extends org.bukkit.inventory.Recipe> List<R> getAllRecipes(io.papermc.paper.inventory.RecipeType<R, ?> recipeType) {
++        Validate.notNull(recipeType, "recipeType parameter in getAllRecipes cannot be null");
++        List<R> recipes = new ArrayList<>();
++        for (net.minecraft.world.item.crafting.Recipe<?> nmsrecipe : (List<net.minecraft.world.item.crafting.Recipe<?>>) getServer().getRecipeManager().getAllRecipesFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType))) {
++            recipes.add((R) nmsrecipe.toBukkitRecipe());
++        }
++        return recipes;
++    }
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 028663b86970b8a1ae3e5275429516ee00ef0a04..d2de349f9038cc4fa7d38181f009f212874cfb63 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -2328,4 +2328,81 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         return this.adventure$pointers;
+     }
+     // Paper end
++
++    // Paper start
++    public <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, net.minecraft.world.Container container) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipe cannot be null");
++        Validate.notNull(container, "container parameter in getRecipe cannot be null");
++        java.util.Optional<net.minecraft.world.item.crafting.Recipe> optionalRecipe = this.world.getRecipeManager().getRecipeFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType), container, this.world);
++        return (R) optionalRecipe.map(recipe -> recipe.toBukkitRecipe()).orElse(null);
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe, I extends org.bukkit.inventory.Inventory> R getRecipe(io.papermc.paper.inventory.RecipeType<R, I> recipeType, I inventory) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipe cannot be null");
++        Validate.notNull(inventory, "inventory parameter in getRecipe cannot be null");
++        return getRecipe(recipeType, ((org.bukkit.craftbukkit.inventory.CraftInventory) inventory).getInventory());
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, java.util.Collection<org.bukkit.inventory.ItemStack> items) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipe cannot be null");
++        Validate.notNull(items, "items parameter in getRecipe cannot be null");
++        List<net.minecraft.world.item.ItemStack> nmsItems = new ArrayList<>();
++        for (ItemStack item : items) {
++            nmsItems.add(CraftItemStack.asNMSCopy(item));
++        }
++        return getRecipe(recipeType, new io.papermc.paper.inventory.MenulessContainer(3, 3, nmsItems));
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, ItemStack[] items) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipe cannot be null");
++        Validate.notNull(items, "items parameter in getRecipe cannot be null");
++        net.minecraft.world.item.ItemStack[] nmsItems = new net.minecraft.world.item.ItemStack[items.length];
++        for (int i = 0; i < items.length; i++) {
++            nmsItems[i] = CraftItemStack.asNMSCopy(items[i]);
++        }
++        return getRecipe(recipeType, new io.papermc.paper.inventory.MenulessContainer(3, 3, nmsItems));
++    }
++
++    public <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, net.minecraft.world.Container container) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipes cannot be null");
++        Validate.notNull(container, "container parameter in getRecipes cannot be null");
++        List<R> recipes = new ArrayList<>();
++        for (net.minecraft.world.item.crafting.Recipe recipe : (List<net.minecraft.world.item.crafting.Recipe>) this.world.getRecipeManager().getRecipesFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType), container, this.world)) {
++            recipes.add((R) recipe.toBukkitRecipe());
++        }
++        return recipes;
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe, I extends org.bukkit.inventory.Inventory> List<R> getRecipes(io.papermc.paper.inventory.RecipeType<R, I> recipeType, I inventory) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipes cannot be null");
++        Validate.notNull(inventory, "inventory parameter in getRecipes cannot be null");
++        return getRecipes(recipeType, ((org.bukkit.craftbukkit.inventory.CraftInventory) inventory).getInventory());
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, java.util.Collection<org.bukkit.inventory.ItemStack> items) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipes cannot be null");
++        Validate.notNull(items, "items parameter in getRecipes cannot be null");
++        List<net.minecraft.world.item.ItemStack> nmsItems = new ArrayList<>();
++        for (ItemStack item : items) {
++            nmsItems.add(CraftItemStack.asNMSCopy(item));
++        }
++        return getRecipes(recipeType, new io.papermc.paper.inventory.MenulessContainer(3, 3, nmsItems));
++    }
++
++    @Override
++    public <R extends org.bukkit.inventory.Recipe> List<R> getRecipes(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, ItemStack[] items) {
++        Validate.notNull(recipeType, "recipeType parameter in getRecipes cannot be null");
++        Validate.notNull(items, "items parameter in getRecipes cannot be null");
++        net.minecraft.world.item.ItemStack[] nmsItems = new net.minecraft.world.item.ItemStack[items.length];
++        for (int i = 0; i < items.length; i++) {
++            nmsItems[i] = CraftItemStack.asNMSCopy(items[i]);
++        }
++        return getRecipes(recipeType, new io.papermc.paper.inventory.MenulessContainer(3, 3, nmsItems));
++    }
++    // Paper end
+ }

--- a/patches/server/0878-Add-Recipe-API.patch
+++ b/patches/server/0878-Add-Recipe-API.patch
@@ -5,26 +5,6 @@ Subject: [PATCH] Add Recipe API
 
 Adds methods to utilize the RecipeManager to obtain recipes
 
-diff --git a/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java b/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java
-new file mode 100644
-index 0000000000000000000000000000000000000000..c26219e8834377910b5fa4f8ed54e7e80278ed53
---- /dev/null
-+++ b/src/main/java/io/papermc/paper/inventory/CraftRecipeType.java
-@@ -0,0 +1,14 @@
-+package io.papermc.paper.inventory;
-+
-+import net.minecraft.core.Registry;
-+import org.bukkit.craftbukkit.util.CraftNamespacedKey;
-+
-+public class CraftRecipeType {
-+    public static net.minecraft.world.item.crafting.RecipeType asNMS(RecipeType bukkit) {
-+        return Registry.RECIPE_TYPE.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
-+    }
-+
-+    public static RecipeType asBukkit(net.minecraft.world.item.crafting.RecipeType nms) {
-+        return RecipeType.getByKey(CraftNamespacedKey.fromMinecraft(Registry.RECIPE_TYPE.getKey(nms)));
-+    }
-+}
 diff --git a/src/main/java/io/papermc/paper/inventory/MenulessContainer.java b/src/main/java/io/papermc/paper/inventory/MenulessContainer.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..fa82f292583a862829f9a5c696b82539487f91e4
@@ -72,6 +52,70 @@ index 0000000000000000000000000000000000000000..fa82f292583a862829f9a5c696b82539
 +        getContents().set(slot, stack);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/inventory/PaperRecipeType.java b/src/main/java/io/papermc/paper/inventory/PaperRecipeType.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ed038cfe4fb2839f13cf98e9a56268d9e5582180
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/inventory/PaperRecipeType.java
+@@ -0,0 +1,40 @@
++package io.papermc.paper.inventory;
++
++import io.papermc.paper.registry.PaperRegistry;
++import io.papermc.paper.registry.RegistryKey;
++import net.minecraft.core.Registry;
++import org.bukkit.NamespacedKey;
++import org.bukkit.craftbukkit.util.CraftMagicNumbers;
++import org.bukkit.craftbukkit.util.CraftNamespacedKey;
++import org.checkerframework.checker.nullness.qual.NonNull;
++import org.checkerframework.framework.qual.DefaultQualifier;
++
++@DefaultQualifier(NonNull.class)
++public final class PaperRecipeType {
++
++    private PaperRecipeType() {
++    }
++
++    public static net.minecraft.world.item.crafting.RecipeType asNMS(RecipeType bukkit) {
++        return PaperRegistry.getRegistry(RegistryKey.RECIPE_TYPE_REGISTRY).getMinecraftValue(bukkit);
++    }
++
++    public static RecipeType asBukkit(net.minecraft.world.item.crafting.RecipeType nms) {
++        return PaperRegistry.getRegistry(RegistryKey.RECIPE_TYPE_REGISTRY).convertToApi(Registry.RECIPE_TYPE.getKey(nms), nms);
++    }
++
++    public static void init() {
++        new RecipeTypeRegistry().register();
++    }
++
++    static final class RecipeTypeRegistry extends PaperRegistry<RecipeType<?, ?>, net.minecraft.world.item.crafting.RecipeType<?>> {
++        public RecipeTypeRegistry() {
++            super(RegistryKey.RECIPE_TYPE_REGISTRY);
++        }
++
++        @Override
++        public RecipeType<?, ?> convertToApi(NamespacedKey key, net.minecraft.world.item.crafting.RecipeType<?> nms) {
++            return new RecipeType<>(key);
++        }
++    }
++}
+diff --git a/src/main/java/io/papermc/paper/registry/RegistryKey.java b/src/main/java/io/papermc/paper/registry/RegistryKey.java
+index cbff75f19e54b37c762b209b04f6d4799152cf5b..52da122a09f9701d0465e2fba3bd6c2f187ac1e6 100644
+--- a/src/main/java/io/papermc/paper/registry/RegistryKey.java
++++ b/src/main/java/io/papermc/paper/registry/RegistryKey.java
+@@ -1,5 +1,6 @@
+ package io.papermc.paper.registry;
+ 
++import io.papermc.paper.inventory.RecipeType;
+ import io.papermc.paper.world.structure.ConfiguredStructure;
+ import net.minecraft.core.Registry;
+ import net.minecraft.resources.ResourceKey;
+@@ -9,5 +10,6 @@ import org.bukkit.Keyed;
+ public record RegistryKey<API extends Keyed, MINECRAFT>(Class<API> apiClass, ResourceKey<? extends Registry<MINECRAFT>> resourceKey) {
+ 
+     public static final RegistryKey<ConfiguredStructure, ConfiguredStructureFeature<?, ?>> CONFIGURED_STRUCTURE_REGISTRY = new RegistryKey<>(ConfiguredStructure.class, Registry.CONFIGURED_STRUCTURE_FEATURE_REGISTRY);
++    public static final RegistryKey<RecipeType<?, ?>, net.minecraft.world.item.crafting.RecipeType<?>> RECIPE_TYPE_REGISTRY = new RegistryKey<>((Class<RecipeType<?, ?>>) (Object) RecipeType.class, Registry.RECIPE_TYPE_REGISTRY);
+ 
+ }
 diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
 index 7ef0075cc16613709e145714204a728d8d8dd82b..1bd227fbc209f0b9655a281061d9417f21da84b4 100644
 --- a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
@@ -84,8 +128,20 @@ index 7ef0075cc16613709e145714204a728d8d8dd82b..1bd227fbc209f0b9655a281061d9417f
          return (List) this.byType(type).values().stream().map((irecipe) -> {
              return irecipe;
          }).collect(Collectors.toList());
+diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeType.java b/src/main/java/net/minecraft/world/item/crafting/RecipeType.java
+index db098a1342fd5b30a3ee0dca8434a6696493930b..6d62b3c91b6f3e1aebe983cc74c68fc4cf705f1f 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/RecipeType.java
++++ b/src/main/java/net/minecraft/world/item/crafting/RecipeType.java
+@@ -21,6 +21,7 @@ public interface RecipeType<T extends Recipe<?>> {
+             public String toString() {
+                 return id;
+             }
++            static { io.papermc.paper.inventory.PaperRecipeType.init(); } // Paper
+         });
+     }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..e52c0a0c95e4b73df05745ff1cd1195560a7e307 100644
+index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..35773d299d94614998bd010bcfe20c323220ccc6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2852,5 +2852,14 @@ public final class CraftServer implements Server {
@@ -96,7 +152,7 @@ index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..e52c0a0c95e4b73df05745ff1cd11955
 +    public <R extends org.bukkit.inventory.Recipe> List<R> getAllRecipes(io.papermc.paper.inventory.RecipeType<R, ?> recipeType) {
 +        Validate.notNull(recipeType, "recipeType parameter in getAllRecipes cannot be null");
 +        List<R> recipes = new ArrayList<>();
-+        for (net.minecraft.world.item.crafting.Recipe<?> nmsrecipe : (List<net.minecraft.world.item.crafting.Recipe<?>>) getServer().getRecipeManager().getAllRecipesFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType))) {
++        for (net.minecraft.world.item.crafting.Recipe<?> nmsrecipe : (List<net.minecraft.world.item.crafting.Recipe<?>>) getServer().getRecipeManager().getAllRecipesFor(io.papermc.paper.inventory.PaperRecipeType.asNMS(recipeType))) {
 +            recipes.add((R) nmsrecipe.toBukkitRecipe());
 +        }
 +        return recipes;
@@ -104,7 +160,7 @@ index 55c981f2c8070fc1bd9ecd4f4df140d9d0c68319..e52c0a0c95e4b73df05745ff1cd11955
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 028663b86970b8a1ae3e5275429516ee00ef0a04..d2de349f9038cc4fa7d38181f009f212874cfb63 100644
+index 028663b86970b8a1ae3e5275429516ee00ef0a04..12c8a1511a88cf3f863d82e1538dab8fd2a07265 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -2328,4 +2328,81 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -116,7 +172,7 @@ index 028663b86970b8a1ae3e5275429516ee00ef0a04..d2de349f9038cc4fa7d38181f009f212
 +    public <R extends org.bukkit.inventory.Recipe> R getRecipe(io.papermc.paper.inventory.RecipeType<R, ?> recipeType, net.minecraft.world.Container container) {
 +        Validate.notNull(recipeType, "recipeType parameter in getRecipe cannot be null");
 +        Validate.notNull(container, "container parameter in getRecipe cannot be null");
-+        java.util.Optional<net.minecraft.world.item.crafting.Recipe> optionalRecipe = this.world.getRecipeManager().getRecipeFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType), container, this.world);
++        java.util.Optional<net.minecraft.world.item.crafting.Recipe> optionalRecipe = this.world.getRecipeManager().getRecipeFor(io.papermc.paper.inventory.PaperRecipeType.asNMS(recipeType), container, this.world);
 +        return (R) optionalRecipe.map(recipe -> recipe.toBukkitRecipe()).orElse(null);
 +    }
 +
@@ -153,7 +209,7 @@ index 028663b86970b8a1ae3e5275429516ee00ef0a04..d2de349f9038cc4fa7d38181f009f212
 +        Validate.notNull(recipeType, "recipeType parameter in getRecipes cannot be null");
 +        Validate.notNull(container, "container parameter in getRecipes cannot be null");
 +        List<R> recipes = new ArrayList<>();
-+        for (net.minecraft.world.item.crafting.Recipe recipe : (List<net.minecraft.world.item.crafting.Recipe>) this.world.getRecipeManager().getRecipesFor(io.papermc.paper.inventory.CraftRecipeType.asNMS(recipeType), container, this.world)) {
++        for (net.minecraft.world.item.crafting.Recipe recipe : (List<net.minecraft.world.item.crafting.Recipe>) this.world.getRecipeManager().getRecipesFor(io.papermc.paper.inventory.PaperRecipeType.asNMS(recipeType), container, this.world)) {
 +            recipes.add((R) recipe.toBukkitRecipe());
 +        }
 +        return recipes;


### PR DESCRIPTION
Adds several methods to the `World` for interacting with Minecraft's `RecipeManager`, allowing you to get a recipe via assorted means (such as by providing a container block or collection of items). A test plugin is available [here](https://gist.github.com/qixils/c4fa8a9de601508284eccb981092158e).

Patch is named "Add Recipe API" because the new methods that Spigot recently added are exclusive to the crafting table so they're hardly deserving of the title "Recipe API" >:(

Closes #616

Use cases:
- Custom crafting in an inventory like a dispenser or a custom chest
- Automatic crafting in a dispenser or automatically smelting block/mob drops
- etc

Implementation notes:
- the I type of RecipeType matches what container the recipes expect, not necessarily what they're typically associated with
- a custom MenulessContainer class is used to create a container that is compatible with all inventory types (specifically the outlier of CraftingContainer ~~which is only important because it uses width&height which should be abstracted out into an interface >:(~~) which overrides any methods that reference the `menu` field to prevent NPE (not that it should matter much because my code doesn't use any of them)
  - should this be moved to a CraftWorld subclass with a more specific name so other patches don't try to use it and possibly experience errors from future updates? or is it fine here?
- features [astronomical performance improvements!!!!!1!](https://github.com/qixils/Paper/blob/fa832ada6b42b4dfd1fed9eae1ee5f2836dba72c/patches/server/0728-Add-Recipe-API.patch#L83) i expect to see this implemented within every paper fork by the top of the hour

Feedback welcome! :D 