### PR TITLE
Use cause and cancel component in PlayerGameModeChanteEvent

### DIFF
--- a/patches/server/0684-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0684-additions-to-PlayerGameModeChangeEvent.patch
@@ -91,7 +91,7 @@ index 91a03f4ed215c882d2ae930402220e4cbbf1ea00..8e2bccc3a9ddb17a4978596056189eb7
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index ddacf7ca035d4d0802572ce806e21b484c366550..e572088cad8b9e09b1d64f7971bacac2f10c5b17 100644
+index ddacf7ca035d4d0802572ce806e21b484c366550..b842de825c106d36512c17449ae6bda18f0ef5ba 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -74,18 +74,24 @@ public class ServerPlayerGameMode {
@@ -102,14 +102,15 @@ index ddacf7ca035d4d0802572ce806e21b484c366550..e572088cad8b9e09b1d64f7971bacac2
 +        PlayerGameModeChangeEvent event = this.changeGameModeForPlayer(gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.UNKNOWN, null);
 +        return event == null ? false : event.isCancelled();
 +    }
-+    public PlayerGameModeChangeEvent changeGameModeForPlayer(GameType gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause cause, net.kyori.adventure.text.Component component) {
++    public PlayerGameModeChangeEvent changeGameModeForPlayer(GameType gameMode, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause cause, net.kyori.adventure.text.Component cancelMessage) {
 +        // Paper end
          if (gameMode == this.gameModeForPlayer) {
 -            return false;
 +            return null; // Paper
          } else {
              // CraftBukkit start
-             PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this.player.getBukkitEntity(), GameMode.getByValue(gameMode.getId()));
+-            PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this.player.getBukkitEntity(), GameMode.getByValue(gameMode.getId()));
++            PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(this.player.getBukkitEntity(), GameMode.getByValue(gameMode.getId()), cause, cancelMessage); // Paper
              this.level.getCraftServer().getPluginManager().callEvent(event);
              if (event.isCancelled()) {
 -                return false;


### PR DESCRIPTION
I think I messed this up when I was applying this patch in the 1.17 update. I remember this one having the logic moved around a bit so I just missed this bit of diff it seems.