### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -3323,7 +3323,7 @@ index 9591f50922343283597bad6d9ac17c175d8ae230..8639ffa2347e3d5c44ab30de0aa98623
  
                  Objects.requireNonNull(playerchunk);
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index a1a4e4fe7b635c632a024f8591c44f20c2f16618..1e1908649a19fe067defe3c0d9c798a6a2988d82 100644
+index 67c59c4b2b9dbe911d5b04b8cebec362af4ef7a9..912c9b0c010436854fab7540b0c9cc63115e39a4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -9,6 +9,7 @@ import it.unimi.dsi.fastutil.longs.LongSet;
@@ -3775,7 +3775,7 @@ index 00118cc80ebc31e5fac95c31c07634f0e2904263..138b6792bc6ee26e0b9aaaef7bf58fb2
      @Override
      public BlockEntity getBlockEntity(BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 62417156dd3e7e68e657f322c089fb6f30a11c0e..0d0f721fe80c52d92d91843ae9970c5fd55ca143 100644
+index 0d117a6b319340a0f13a516a6c43501f752bc89a..e9a04017df42312e4e0e7e414c9ccc95c71ddae1 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -33,6 +33,7 @@ import net.minecraft.core.SectionPos;
@@ -3943,7 +3943,7 @@ index 62417156dd3e7e68e657f322c089fb6f30a11c0e..0d0f721fe80c52d92d91843ae9970c5f
      @Nullable
      public BlockEntity getBlockEntity(BlockPos pos, LevelChunk.EntityCreationType creationType) {
          // CraftBukkit start
-@@ -578,7 +697,25 @@ public class LevelChunk implements ChunkAccess {
+@@ -584,7 +703,25 @@ public class LevelChunk implements ChunkAccess {
  
      // CraftBukkit start
      public void loadCallback() {
@@ -3969,7 +3969,7 @@ index 62417156dd3e7e68e657f322c089fb6f30a11c0e..0d0f721fe80c52d92d91843ae9970c5f
          if (server != null) {
              /*
               * If it's a new world, the first few chunks are generated inside
-@@ -617,6 +754,22 @@ public class LevelChunk implements ChunkAccess {
+@@ -623,6 +760,22 @@ public class LevelChunk implements ChunkAccess {
          server.getPluginManager().callEvent(unloadEvent);
          // note: saving can be prevented, but not forced if no saving is actually required
          this.mustNotSave = !unloadEvent.isSaveChunk();
@@ -3992,7 +3992,7 @@ index 62417156dd3e7e68e657f322c089fb6f30a11c0e..0d0f721fe80c52d92d91843ae9970c5f
      }
      // CraftBukkit end
  
-@@ -896,19 +1049,13 @@ public class LevelChunk implements ChunkAccess {
+@@ -902,19 +1055,13 @@ public class LevelChunk implements ChunkAccess {
      }
  
      public void packTicks(ServerLevel world) {

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -1759,10 +1759,10 @@ index 92b042080f06fb95958ff5e824830a84f2d1f2a6..7b333e2d6884b272abefbc820bcce802
      private static final CraftPersistentDataTypeRegistry DATA_TYPE_REGISTRY = new CraftPersistentDataTypeRegistry();
      public CraftPersistentDataContainer persistentDataContainer;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 0d0f721fe80c52d92d91843ae9970c5fd55ca143..3e2bc640a06667f0d4f3c2367ac794514a1be35c 100644
+index e9a04017df42312e4e0e7e414c9ccc95c71ddae1..4a13b18ce609fc6a86da48b0673ccf9d3e0d8292 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -725,6 +725,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -731,6 +731,7 @@ public class LevelChunk implements ChunkAccess {
              server.getPluginManager().callEvent(new org.bukkit.event.world.ChunkLoadEvent(this.bukkitChunk, this.needsDecoration));
  
              if (this.needsDecoration) {
@@ -1770,7 +1770,7 @@ index 0d0f721fe80c52d92d91843ae9970c5fd55ca143..3e2bc640a06667f0d4f3c2367ac79451
                  this.needsDecoration = false;
                  java.util.Random random = new java.util.Random();
                  random.setSeed(this.level.getSeed());
-@@ -744,6 +745,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -750,6 +751,7 @@ public class LevelChunk implements ChunkAccess {
                      }
                  }
                  server.getPluginManager().callEvent(new org.bukkit.event.world.ChunkPopulateEvent(this.bukkitChunk));
@@ -2022,7 +2022,7 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5b58118308225010f16aa46676ef6b82886ffd31..969d5071dbf3356b80da38526351d488ab936c08 100644
+index 73556aa988cdd969642bad89345637c534f753b6..d4836d251eeca4c550bf2e7e0d5c039fb1529e9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1819,6 +1819,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1813,7 +1813,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index ce548fe73dcef10adb99045b06ce58135935aee6..3fd48807c554b176cd8e925bdcd68e7f808e5881 100644
+index 1ac3243555c2c61d6b6717e6826539d9d6a3248b..4d1f1f1438da0cb41188a89c23f6d295b6840808 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -2110,7 +2110,7 @@ index 042691349dd5659e8db526199641cbcfa21c6005..841dbf4a86b19d7c8ea41930ecb1f88c
          player.initMenu(container);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 969d5071dbf3356b80da38526351d488ab936c08..d72354a670ad41b3dba8a7ffe8bc64bb8569d15c 100644
+index d4836d251eeca4c550bf2e7e0d5c039fb1529e9a..cc97a1fb78037e4b09ebe825b5135702f2f19e00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2454,10 +2454,10 @@ index 969d5071dbf3356b80da38526351d488ab936c08..d72354a670ad41b3dba8a7ffe8bc64bb
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 247c00d35647838264e7acd58019abf1939a594d..bd1e9c1bd9af8bf3fb599cfb0a54a0c948cc2b1b 100644
+index 606f6b790c3680e3cf4e4bb31b98f1684c72a50f..631a2e301d4940486a401c427b7b2db44bd68e3c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -787,9 +787,9 @@ public class CraftEventFactory {
+@@ -802,9 +802,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2469,7 +2469,7 @@ index 247c00d35647838264e7acd58019abf1939a594d..bd1e9c1bd9af8bf3fb599cfb0a54a0c9
          event.setKeepInventory(keepInventory);
          org.bukkit.World world = entity.getWorld();
          Bukkit.getServer().getPluginManager().callEvent(event);
-@@ -813,7 +813,7 @@ public class CraftEventFactory {
+@@ -828,7 +828,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0026-Prevent-tile-entity-and-entity-crashes.patch
+++ b/patches/server/0026-Prevent-tile-entity-and-entity-crashes.patch
@@ -44,10 +44,10 @@ index 7b333e2d6884b272abefbc820bcce8026a4cdf7e..66ab4deedd177f507d170a61ceca4c3e
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 743aafec1f1c819846813688355dd90534dddb3e..5bd2172a88c95722b86959e42442e8a3ab76879c 100644
+index be1d7d2be46c746b593c3842030412940e2e57f8..ea894662b41cddfc5702a7d6305978be71da79b4 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -1241,11 +1241,11 @@ public class LevelChunk implements ChunkAccess {
+@@ -1247,11 +1247,11 @@ public class LevelChunk implements ChunkAccess {
  
                          gameprofilerfiller.pop();
                      } catch (Throwable throwable) {

--- a/patches/server/0053-Add-exception-reporting-event.patch
+++ b/patches/server/0053-Add-exception-reporting-event.patch
@@ -61,7 +61,7 @@ index 4788946d7fb25c1b0f26e6a038924c4a62978d53..82b25044e1852f5dbde1a658fe5f4f75
              }
          }
 diff --git a/src/main/java/net/minecraft/server/players/OldUsersConverter.java b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
-index ddeb3c4c46f22ca651588fed02b4941c31c5be9d..aafd67d5b4f2a0555bc2fa0444d22f545ad71bf4 100644
+index b0ed7d12bee6b247762fff3d5a24f0cc9411e3dc..f6cb864c45f960811acc02829d1f7883b916de29 100644
 --- a/src/main/java/net/minecraft/server/players/OldUsersConverter.java
 +++ b/src/main/java/net/minecraft/server/players/OldUsersConverter.java
 @@ -1,5 +1,6 @@
@@ -151,7 +151,7 @@ index 808fd30d4b86ca9029c182ffdceaf27f3c204377..4ea02bfe348cec26bbb2c15ddacbbc11
                                  }
  
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 5bd2172a88c95722b86959e42442e8a3ab76879c..bf5a039553a31ed6e9d9bfa64cbd435b3e551a08 100644
+index ea894662b41cddfc5702a7d6305978be71da79b4..aa6db78339d6b0661ac3be12c82da92742b5f519 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -1,6 +1,7 @@
@@ -182,7 +182,7 @@ index 5bd2172a88c95722b86959e42442e8a3ab76879c..bf5a039553a31ed6e9d9bfa64cbd435b
              // CraftBukkit end
          }
      }
-@@ -1244,6 +1250,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -1250,6 +1256,7 @@ public class LevelChunk implements ChunkAccess {
                          // Paper start - Prevent tile entity and entity crashes
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);

--- a/patches/server/0072-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0072-Configurable-Chunk-Inhabited-Time.patch
@@ -30,10 +30,10 @@ index cd64fb9d0c6d123e1c86cb33f12cd9cefc9f80d0..74ba5dbb83c13ce1721619b755036a78
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 7e5e16fd61b39d2093459766e8aaa10bb05f6763..5c5a55003658d75ad8295cbd7ff0450e08600d68 100644
+index 29fda19d7e1a8b6675598de22967e2aec81091fa..702dbe24bfd19b0999648d4364f68a5675bee6e0 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -978,7 +978,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -984,7 +984,7 @@ public class LevelChunk implements ChunkAccess {
  
      @Override
      public long getInhabitedTime() {

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -44,10 +44,10 @@ index c5a8edf426e79b8746c7a5a5a5de3e3df1708740..f030c8d7c28039fde273e6b30c63ea79
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ae12d4a7b56ec70ac5f529e0f336019e97f667ce..8e9ae16441057fb5e42154c081f8677f4575587d 100644
+index 631a2e301d4940486a401c427b7b2db44bd68e3c..5ec43b4fdb059080a744e199a6a1f6c14b78ae33 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1098,6 +1098,14 @@ public class CraftEventFactory {
+@@ -1113,6 +1113,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add source to PlayerExpChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index ec47da6c086a6f6640ea2f41d766c900fa992459..919fbe73f46238a1846c969bf64c309f3b9ad9d6 100644
+index 8b8181cfdd8d826dd132eb9475f6ff8e04afa465..4000480a14d2ba52149f4fa47f824abfa2e0e5f8 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -246,7 +246,7 @@ public class ExperienceOrb extends Entity {
@@ -18,10 +18,10 @@ index ec47da6c086a6f6640ea2f41d766c900fa992459..919fbe73f46238a1846c969bf64c309f
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8e9ae16441057fb5e42154c081f8677f4575587d..2f6aef39f1f9f3da09a596936f57e1cf51c9d6db 100644
+index 5ec43b4fdb059080a744e199a6a1f6c14b78ae33..894deb67940a131832d25daae7ab28d5a304101a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1057,6 +1057,17 @@ public class CraftEventFactory {
+@@ -1072,6 +1072,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index f81be1c6a5efc5090fbb8832f44dbb2ae6aa2f4a..8e81b19706a14c21b5ffdc4f12818fe7
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2f6aef39f1f9f3da09a596936f57e1cf51c9d6db..deb331a95d1c8e53c21e2ab68f205c2427cdbef4 100644
+index 894deb67940a131832d25daae7ab28d5a304101a..1ecd631c169e137669a154eecd0a1f4cd1230240 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1201,6 +1201,16 @@ public class CraftEventFactory {
+@@ -1216,6 +1216,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -7,7 +7,7 @@ Provides counts without the ineffeciency of using .getEntities().size()
 which creates copy of the collections.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 52d80086deff664fcfd8952b7cabbfa1f48ad131..a86b5272c0ac4dd64f796f7fd025c7a34a5d2f8d 100644
+index 05f94017546f3bb326f445d06add401498524d4d..43febeede5fcc9d52e6682f94afb26c18b61648e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -110,7 +110,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -20,10 +20,10 @@ index 52d80086deff664fcfd8952b7cabbfa1f48ad131..a86b5272c0ac4dd64f796f7fd025c7a3
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1de08dd42366c9988fdcde265b92823e25e48b99..7b1f853913a3d858718a6067b3927946c7e50114 100644
+index 2889ac5f94787b1af65c8a691c227fbddb638c2e..e228a59166c6e492d96ebf72890f8925e96c4575 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -272,6 +272,57 @@ public class CraftWorld implements World {
+@@ -273,6 +273,57 @@ public class CraftWorld implements World {
      private int waterAmbientSpawn = -1;
      private int ambientSpawn = -1;
  

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,7 +129,7 @@ index 4000480a14d2ba52149f4fa47f824abfa2e0e5f8..ea01f84448693ca740b5f3381a9c500e
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 60f966b56adcc232fe8c53ec0a04e69c93f0765d..a3dae798fe63e21f86a380f09ba802b2104ad7e8 100644
+index fe74e130309fbef3f763d875310cbd7a5d9b74fd..9fb669c0199a73136bf5b5a86fa60036dc67bd3e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1703,7 +1703,8 @@ public abstract class LivingEntity extends Entity {
@@ -288,10 +288,10 @@ index 72ef08a59dbf72bec2ce54ab76455c4230395959..6a31e3a3466369ede28e28bc3b9fda8d
  
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 98633fe921a30e89715a62ca39b77347a96e5fd7..e43fd7185b4570713d8ee2361d633c94d187fe2b 100644
+index 61ab07be21759df7b92ba71e31c537860f4e5dc2..265fa3cb96b7d39194a7e83b8b77b811bc3e8b40 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -610,7 +610,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -624,7 +624,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          j = event.getExpToDrop();
          // CraftBukkit end
  
@@ -301,10 +301,10 @@ index 98633fe921a30e89715a62ca39b77347a96e5fd7..e43fd7185b4570713d8ee2361d633c94
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7b1f853913a3d858718a6067b3927946c7e50114..efff3e9590e3fd66d9ab56173c986f5b51bbe559 100644
+index e228a59166c6e492d96ebf72890f8925e96c4575..49ef818c6601855924472e655d3419d82c28e339 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1838,7 +1838,7 @@ public class CraftWorld implements World {
+@@ -1839,7 +1839,7 @@ public class CraftWorld implements World {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new PrimedTnt(this.world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index 160da347ed52739e930044fe456a4dd36e561a43..d06fa20dd605e9ce0e41a4d69ffeec98
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index efff3e9590e3fd66d9ab56173c986f5b51bbe559..8574cca2582d5eaf3720df1c42fda38957d18230 100644
+index 49ef818c6601855924472e655d3419d82c28e339..18e4c893f86cdaf816e5d88416fe3fe7be953bc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2358,11 +2358,17 @@ public class CraftWorld implements World {
+@@ -2359,11 +2359,17 @@ public class CraftWorld implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0203-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/patches/server/0203-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8574cca2582d5eaf3720df1c42fda38957d18230..082ca9db7e925dfb36998135bea7be298a691b86 100644
+index 18e4c893f86cdaf816e5d88416fe3fe7be953bc5..1aab57f7eabc1acce9827017fde7daf382b46dce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1507,6 +1507,10 @@ public class CraftWorld implements World {
+@@ -1508,6 +1508,10 @@ public class CraftWorld implements World {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.vehicle.Boat(this.world, x, y, z);
              entity.moveTo(x, y, z, yaw, pitch);

--- a/patches/server/0215-Expand-Explosions-API.patch
+++ b/patches/server/0215-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 082ca9db7e925dfb36998135bea7be298a691b86..20269c9084dd2a4f941e98e25c40bd3f3af43bcc 100644
+index 1aab57f7eabc1acce9827017fde7daf382b46dce..9b9dc5b8e5c2ce6ab4876067374e24d6cbf2fa12 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -891,6 +891,12 @@ public class CraftWorld implements World {
+@@ -892,6 +892,12 @@ public class CraftWorld implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0219-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0219-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 20269c9084dd2a4f941e98e25c40bd3f3af43bcc..951445d5dba92ada70ce239098c702dd7b8ce0f1 100644
+index 9b9dc5b8e5c2ce6ab4876067374e24d6cbf2fa12..dac119e71c53f246944b3d2072f1fa7d6c8fa828 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1297,6 +1297,15 @@ public class CraftWorld implements World {
+@@ -1298,6 +1298,15 @@ public class CraftWorld implements World {
          return list;
      }
  

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -185,7 +185,7 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..a9f8ffa1772de39c74394f8cf324ab77
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f0d0becf8730eac257d5b3d5f6a14ac881359220..281b9fa69f8eb1d1eb6a199228e6a1c53b34714f 100644
+index 0ce5e35d1ca59587301edba56ddcf2a4e7fbe247..9c1a2ac04facba52af09ee87a96e8911d41a3f32 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -922,7 +922,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -198,10 +198,10 @@ index f0d0becf8730eac257d5b3d5f6a14ac881359220..281b9fa69f8eb1d1eb6a199228e6a1c5
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aa1487318dd8c3287c32817e71920cc2ac931cdf..e9a7c4a29491b4281f7c96c002bf405b10eb97a2 100644
+index 1ecd631c169e137669a154eecd0a1f4cd1230240..7fab5ae695763350669fb20e3c765c947098d74e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1170,7 +1170,7 @@ public class CraftEventFactory {
+@@ -1185,7 +1185,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -210,7 +210,7 @@ index aa1487318dd8c3287c32817e71920cc2ac931cdf..e9a7c4a29491b4281f7c96c002bf405b
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1336,8 +1336,18 @@ public class CraftEventFactory {
+@@ -1351,8 +1351,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0233-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0233-Vanished-players-don-t-have-rights.patch
@@ -99,10 +99,10 @@ index a84c8e135511eed9db5895bdf7fc68b3952a5521..1fef077a6d5efc8bdc171b5c6e2a4912
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e9a7c4a29491b4281f7c96c002bf405b10eb97a2..5d2e1c12feac542463edc7b0e44501c241812310 100644
+index 7fab5ae695763350669fb20e3c765c947098d74e..5ea27e14b42336d60fa689f73e952aac76f0867c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1206,6 +1206,14 @@ public class CraftEventFactory {
+@@ -1221,6 +1221,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 951445d5dba92ada70ce239098c702dd7b8ce0f1..ad9a4d4a9363741cc47f142c24fa6f4858dd947f 100644
+index dac119e71c53f246944b3d2072f1fa7d6c8fa828..ce723a4340202c16eaf7544f77c1075c4f277cb9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -507,7 +507,7 @@ public class CraftWorld implements World {
+@@ -508,7 +508,7 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -3619,10 +3619,10 @@ index e5e138fb23d03eb63e547e74d3e14ec9d96d8107..90f7b06bd2c558be35c4577044fa033e
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ad9a4d4a9363741cc47f142c24fa6f4858dd947f..a19de8405de8ee29afc112556e4684b042c6f4ab 100644
+index ce723a4340202c16eaf7544f77c1075c4f277cb9..03a7e5d61d8888e1e836bd5a69ee9443b723f72c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2425,6 +2425,34 @@ public class CraftWorld implements World {
+@@ -2426,6 +2426,34 @@ public class CraftWorld implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -277,7 +277,7 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b588814417c2eb0069228cb54a5e4845388276ce..02af5c7038dd56d77eaa9ca08bb81950f6f5f499 100644
+index 886a75f2b6402ed2e8c884fa5e125f4a4750f11d..e3e158946ceff4c383e5da46bce09554f7526a6f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1863,7 +1863,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -297,10 +297,10 @@ index b588814417c2eb0069228cb54a5e4845388276ce..02af5c7038dd56d77eaa9ca08bb81950
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 52597fe89ed9bb42dcd74f8e9a9d80e1644b2dca..cd82e2068ea87f3e596cbbd7e304654956c36ddd 100644
+index 6fd016daeab42b43bf4b1efb4f715b28c45a88c3..934ea2cf75c44e7e5f2e302a2d2fc14da54d3310 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -787,9 +787,16 @@ public class CraftEventFactory {
+@@ -802,9 +802,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -317,7 +317,7 @@ index 52597fe89ed9bb42dcd74f8e9a9d80e1644b2dca..cd82e2068ea87f3e596cbbd7e3046549
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -805,8 +812,15 @@ public class CraftEventFactory {
+@@ -820,8 +827,15 @@ public class CraftEventFactory {
          CraftPlayer entity = victim.getBukkitEntity();
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
@@ -333,7 +333,7 @@ index 52597fe89ed9bb42dcd74f8e9a9d80e1644b2dca..cd82e2068ea87f3e596cbbd7e3046549
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -823,6 +837,31 @@ public class CraftEventFactory {
+@@ -838,6 +852,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
@@ -11,10 +11,10 @@ to the nearest Integer when updating its current cook time.
 Modified by: Eric Su <ericsu@alumni.usc.edu>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2035921c1 100644
+index 265fa3cb96b7d39194a7e83b8b77b811bc3e8b40..348196524eb3770541966e7e842ff0ae7afd94ad 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -71,6 +71,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -73,6 +73,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
      protected NonNullList<ItemStack> items;
      public int litTime;
      int litDuration;
@@ -22,7 +22,7 @@ index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2
      public int cookingProgress;
      public int cookingTotalTime;
      protected final ContainerData dataAccess;
-@@ -273,6 +274,11 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -275,6 +276,11 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
              this.recipesUsed.put(new ResourceLocation(s), nbttagcompound1.getInt(s));
          }
  
@@ -34,7 +34,7 @@ index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2
      }
  
      @Override
-@@ -281,6 +287,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -283,6 +289,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          nbt.putShort("BurnTime", (short) this.litTime);
          nbt.putShort("CookTime", (short) this.cookingProgress);
          nbt.putShort("CookTimeTotal", (short) this.cookingTotalTime);
@@ -42,9 +42,9 @@ index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2
          ContainerHelper.saveAllItems(nbt, this.items);
          CompoundTag nbttagcompound1 = new CompoundTag();
  
-@@ -340,9 +347,9 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -354,9 +361,9 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+                 // CraftBukkit end
  
-             if (blockEntity.isLit() && AbstractFurnaceBlockEntity.canBurn(irecipe, blockEntity.items, i)) {
                  ++blockEntity.cookingProgress;
 -                if (blockEntity.cookingProgress == blockEntity.cookingTotalTime) {
 +                if (blockEntity.cookingProgress >= blockEntity.cookingTotalTime) { // Paper - cook speed multiplier API
@@ -54,7 +54,7 @@ index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2
                      if (AbstractFurnaceBlockEntity.burn(blockEntity.level, blockEntity.worldPosition, irecipe, blockEntity.items, i)) { // CraftBukkit
                          blockEntity.setRecipeUsed(irecipe);
                      }
-@@ -442,9 +449,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -456,9 +463,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          }
      }
  
@@ -70,7 +70,7 @@ index e43fd7185b4570713d8ee2361d633c94d187fe2b..6c8518cdf768bd2b613f3f2159d977d2
  
      public static boolean isFuel(ItemStack stack) {
          return AbstractFurnaceBlockEntity.getFuel().containsKey(stack.getItem());
-@@ -513,7 +524,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -527,7 +538,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          }
  
          if (slot == 0 && !flag) {

--- a/patches/server/0275-Add-sun-related-API.patch
+++ b/patches/server/0275-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a19de8405de8ee29afc112556e4684b042c6f4ab..be4c05259f176e9ef5c25db2b1745df5ea4d5789 100644
+index 03a7e5d61d8888e1e836bd5a69ee9443b723f72c..01e63133d769e3d5c33944907a04ce4def8bbb45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -867,6 +867,13 @@ public class CraftWorld implements World {
+@@ -868,6 +868,13 @@ public class CraftWorld implements World {
          }
      }
  

--- a/patches/server/0324-Add-Heightmap-API.patch
+++ b/patches/server/0324-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index be4c05259f176e9ef5c25db2b1745df5ea4d5789..ea587597bfb205531c03eb0c0c9bde31ea6ab53b 100644
+index 01e63133d769e3d5c33944907a04ce4def8bbb45..1adcb0a90fb1e8318223a51637ce83a50efe6213 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -342,6 +342,29 @@ public class CraftWorld implements World {
+@@ -343,6 +343,29 @@ public class CraftWorld implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ea587597bfb205531c03eb0c0c9bde31ea6ab53b..a112daf93daeab6d34416bc7c8a69acfc207c98b 100644
+index 1adcb0a90fb1e8318223a51637ce83a50efe6213..3e2ab97daf807a6cc3502214f85559ecd21c59f7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -413,13 +413,13 @@ public class CraftWorld implements World {
+@@ -414,13 +414,13 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a112daf93daeab6d34416bc7c8a69acfc207c98b..98b2d054b6436e3fdb8fadd03369a65cf4156843 100644
+index 3e2ab97daf807a6cc3502214f85559ecd21c59f7..c6373fe0361bd5c77036d36ac8ebe66408335b0c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1975,15 +1975,21 @@ public class CraftWorld implements World {
+@@ -1976,15 +1976,21 @@ public class CraftWorld implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
@@ -108,7 +108,7 @@ index 6d024db8bfbd5139d4c94be3d3a48cfa1a240c62..6f5e1f7c23b19257c89b7c5a992ad766
          // Spigot start
          return this.isOutsideOfRange(chunkPos, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 68b618168c8c484e3902561f290adaa6568551c1..d81d84b948842088c93a32e307b7430d81438da9 100644
+index 7239dd29ff622a2823d7c25a89cd3dc9e0bafac1..3beef93cd23b3f1171e090c87c3f96747a276678 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -323,6 +323,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -235,7 +235,7 @@ index 24092d3d3d234b6f1f2b90e22d90f297532358cc..43510774d489bfdd30f10d521e424fa1
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 98b2d054b6436e3fdb8fadd03369a65cf4156843..f9c58de7fa8b3c2ab5ac78cf0b366df69e0b40df 100644
+index c6373fe0361bd5c77036d36ac8ebe66408335b0c..479693f9703f743c8e64bb6b949b2803109f4fa0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -20,6 +20,7 @@ import java.util.Objects;
@@ -246,7 +246,7 @@ index 98b2d054b6436e3fdb8fadd03369a65cf4156843..f9c58de7fa8b3c2ab5ac78cf0b366df6
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -418,8 +419,22 @@ public class CraftWorld implements World {
+@@ -419,8 +420,22 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -270,7 +270,7 @@ index 98b2d054b6436e3fdb8fadd03369a65cf4156843..f9c58de7fa8b3c2ab5ac78cf0b366df6
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -530,20 +545,48 @@ public class CraftWorld implements World {
+@@ -531,20 +546,48 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0346-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
+++ b/patches/server/0346-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix spawning of hanging entities that are not ItemFrames and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f9c58de7fa8b3c2ab5ac78cf0b366df69e0b40df..053878ce00b77367b403a8c52f0d81f485022c59 100644
+index 479693f9703f743c8e64bb6b949b2803109f4fa0..2c4ffaa4e9ce7759e6782547300ec6f457530c3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1882,7 +1882,12 @@ public class CraftWorld implements World {
+@@ -1883,7 +1883,12 @@ public class CraftWorld implements World {
                  height = 9;
              }
  

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -582,7 +582,7 @@ index 2007b0b04e7037e1444b5d1964638ccd06e7a2df..fa8cf70d7d24a82757326ff8f7f240cf
  
              if ((i & 1) != 0) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 7661f956e7c900602ceedbcd030d3049d90b8cca..fc8214a082da0f8eedaf86e7730ac62e77b76687 100644
+index 515e28eea8cbab261320352ee0db9b877807f3ed..83ed84f89a036d3768b22a36bc8a0bfc2bc29ec7 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -33,7 +33,10 @@ import net.minecraft.core.Registry;
@@ -648,7 +648,7 @@ index 7661f956e7c900602ceedbcd030d3049d90b8cca..fc8214a082da0f8eedaf86e7730ac62e
      }
  
      public final boolean isAnyNeighborsLoaded() {
-@@ -1005,7 +1052,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -1011,7 +1058,7 @@ public class LevelChunk implements ChunkAccess {
                      BlockState iblockdata = this.getBlockState(blockposition);
                      BlockState iblockdata1 = Block.updateFromNeighbourShapes(iblockdata, (LevelAccessor) this.level, blockposition);
  
@@ -658,10 +658,10 @@ index 7661f956e7c900602ceedbcd030d3049d90b8cca..fc8214a082da0f8eedaf86e7730ac62e
  
                  this.postProcessing[i].clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 053878ce00b77367b403a8c52f0d81f485022c59..b6134895d1b04d3ea7340e77f70efa23cff8b568 100644
+index 2c4ffaa4e9ce7759e6782547300ec6f457530c3b..a4d05aeccc142808981f1ecebd001c905ae721ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2541,10 +2541,39 @@ public class CraftWorld implements World {
+@@ -2542,10 +2542,39 @@ public class CraftWorld implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -246,10 +246,10 @@ index 57aa6d18d181c50071bcfcc933cde9fa828be792..ed3ce0f87eaf4777aedc93fe5bd67971
  
                  if (optional.isPresent()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b6134895d1b04d3ea7340e77f70efa23cff8b568..72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd 100644
+index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e149744237679262174 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -287,6 +287,7 @@ public class CraftWorld implements World {
+@@ -288,6 +288,7 @@ public class CraftWorld implements World {
  
      @Override
      public int getTileEntityCount() {
@@ -257,7 +257,7 @@ index b6134895d1b04d3ea7340e77f70efa23cff8b568..72c9ad9f75c20d6c1a6d54e2913e2f99
          // We don't use the full world tile entity list, so we must iterate chunks
          Long2ObjectLinkedOpenHashMap<ChunkHolder> chunks = world.getChunkSource().chunkMap.visibleChunkMap;
          int size = 0;
-@@ -298,6 +299,7 @@ public class CraftWorld implements World {
+@@ -299,6 +300,7 @@ public class CraftWorld implements World {
              size += chunk.blockEntities.size();
          }
          return size;
@@ -265,7 +265,7 @@ index b6134895d1b04d3ea7340e77f70efa23cff8b568..72c9ad9f75c20d6c1a6d54e2913e2f99
      }
  
      @Override
-@@ -307,6 +309,7 @@ public class CraftWorld implements World {
+@@ -308,6 +310,7 @@ public class CraftWorld implements World {
  
      @Override
      public int getChunkCount() {
@@ -273,7 +273,7 @@ index b6134895d1b04d3ea7340e77f70efa23cff8b568..72c9ad9f75c20d6c1a6d54e2913e2f99
          int ret = 0;
  
          for (ChunkHolder chunkHolder : world.getChunkSource().chunkMap.visibleChunkMap.values()) {
-@@ -315,7 +318,7 @@ public class CraftWorld implements World {
+@@ -316,7 +319,7 @@ public class CraftWorld implements World {
              }
          }
  
@@ -282,7 +282,7 @@ index b6134895d1b04d3ea7340e77f70efa23cff8b568..72c9ad9f75c20d6c1a6d54e2913e2f99
      }
  
      @Override
-@@ -442,6 +445,14 @@ public class CraftWorld implements World {
+@@ -443,6 +446,14 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {

--- a/patches/server/0404-Improved-Watchdog-Support.patch
+++ b/patches/server/0404-Improved-Watchdog-Support.patch
@@ -311,10 +311,10 @@ index fd23c7913b7a426443515e14be0ac9814a5e934e..9cf64082555d848e4149f9a982dd770d
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level.getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
              MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index fcacaa9e41c2418484d2fe9e7952be47943a2177..7d33ad1ec939de4527d0acb0915f05870c387565 100644
+index 016c2302d8bcf121eafd1be7eb4f3b206dbdbeec..1de1566b76c73ddfaf7e022296068db02044d5f3 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-@@ -1319,6 +1319,7 @@ public class LevelChunk implements ChunkAccess {
+@@ -1325,6 +1325,7 @@ public class LevelChunk implements ChunkAccess {
  
                          gameprofilerfiller.pop();
                      } catch (Throwable throwable) {
@@ -323,7 +323,7 @@ index fcacaa9e41c2418484d2fe9e7952be47943a2177..7d33ad1ec939de4527d0acb0915f0587
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e3fc72a86aea884b9bd85803baf8cd2c0bb7eb1c..7af2baea88a29d43afffbaa11ce57d69ca606be0 100644
+index 796decb4d6a011fae263d6bced59d2399a61a60b..fc1b0fe8c45f133715488f02f41e0c078c4b6803 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1845,7 +1845,7 @@ public final class CraftServer implements Server {
@@ -336,7 +336,7 @@ index e3fc72a86aea884b9bd85803baf8cd2c0bb7eb1c..7af2baea88a29d43afffbaa11ce57d69
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3f219234355edc961f07ae1a75759b6e44ddcfdf..15d6975e6470e1affad9adc73964a720a3de36e9 100644
+index b4c00b280438e59b604905e2cc329b1818c13a56..98be7909a892a8a566d68ef693d1093791aa902b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,6 +12,8 @@ import java.util.logging.Level;

--- a/patches/server/0424-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0424-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bd807a3d06457e619df0e77cf6114b0802b7d685..8d0f5ca024d7b473f2d5b5e92b190df6502587b0 100644
+index ba109e4ccf5bc3d985781f087f172eeb1b1b9be2..5e261f5d591f7f34073d65aad20feced0e94586f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2151,11 +2151,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -102,10 +102,10 @@ index bbde9b758643c087733064a126d90689d71830cf..069cdfce085909991a69ebec3004d407
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8e4bd4818cf9d50dec7b94e5f1263086b6a6b86a..09c152123d055432266bbb5a1434c21aed64da1f 100644
+index 19fa07423caefe601456ee775812b9c032384e9e..17d776bc9ab861497538f5eeebe41abf68cad061 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -807,7 +807,8 @@ public class CraftEventFactory {
+@@ -822,7 +822,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/patches/server/0435-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0435-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -22,10 +22,10 @@ index 1460cd36e8d38c1c4318adf818b87961bfe07aec..b6742a4ef1a798e60289586f5cccf688
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 09c152123d055432266bbb5a1434c21aed64da1f..7b59cfc35968a82c5db78c5107b175d994df3535 100644
+index 17d776bc9ab861497538f5eeebe41abf68cad061..005759e55bc83c6487ae79591f6a4df0da4c74d4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -610,16 +610,30 @@ public class CraftEventFactory {
+@@ -625,16 +625,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0436-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0436-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7b59cfc35968a82c5db78c5107b175d994df3535..1ee76da3b609bf91e9e8529eb402d670b32e4b18 100644
+index 005759e55bc83c6487ae79591f6a4df0da4c74d4..6fcef73d07432bedf73861f35426719e11a8623d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -620,7 +620,7 @@ public class CraftEventFactory {
+@@ -635,7 +635,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 89f9fc6ce6ba0d4bb6bb133d26bed6ec03a55694..30552c2dcb2b8e648ee6519478e830f3e86a10b9 100644
+index 610dab96b6dcb5bf5dbd19a7f075241b8bd3e50f..49a907e0761cea917db3aa7cfbc6ed237acc59f6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -345,7 +345,7 @@ public final class CraftServer implements Server {
@@ -44,10 +44,10 @@ index 89f9fc6ce6ba0d4bb6bb133d26bed6ec03a55694..30552c2dcb2b8e648ee6519478e830f3
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b3289689495285944 100644
+index e6b7302554b2a54363d55e149744237679262174..8536452ccd65814b55bc78736060b387e051c3db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -405,8 +405,21 @@ public class CraftWorld implements World {
+@@ -406,8 +406,21 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b32896894
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -481,7 +494,7 @@ public class CraftWorld implements World {
+@@ -482,7 +495,7 @@ public class CraftWorld implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b32896894
          }
  
          return true;
-@@ -558,9 +571,12 @@ public class CraftWorld implements World {
+@@ -559,9 +572,12 @@ public class CraftWorld implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b32896894
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -568,7 +584,7 @@ public class CraftWorld implements World {
+@@ -569,7 +585,7 @@ public class CraftWorld implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b32896894
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -594,7 +610,7 @@ public class CraftWorld implements World {
+@@ -595,7 +611,7 @@ public class CraftWorld implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 72c9ad9f75c20d6c1a6d54e2913e2f9918c11ffd..f72471ac82907a0d5112598b32896894
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2544,6 +2560,7 @@ public class CraftWorld implements World {
+@@ -2545,6 +2561,7 @@ public class CraftWorld implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0485-Add-PrepareResultEvent.patch
+++ b/patches/server/0485-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 3df5031ec2c50dc6eb2533318cf8a98f21b03d2a..c971a534ded962e3be92c71059c75cc1
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 1c0f8d636658133b1f5152a3325791d05ae0d4cb..b9cfd8ea29351fb712b90f810c2b7078f5cbaa7c 100644
+index 6fcef73d07432bedf73861f35426719e11a8623d..a26ac24817f2480326cb9140625c82335d90c9a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1529,19 +1529,44 @@ public class CraftEventFactory {
+@@ -1544,19 +1544,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1101,7 +1101,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d182b6ef4431c5ca291619bc8920a18cccad6327..aec4d7987ed168bc6a70c178d44b8d0d1822b845 100644
+index ecb22bd5f7ed3e5969b2fe8dc6bfb404c05f0f7c..99cc9b89e1c271bc4a128f7fedccc0998aa04010 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1545,6 +1545,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -1157,10 +1157,10 @@ index 21a3c5fe4cf0ac4f21ffda3d7c0b20f82d4cadf1..2a5f58a87cfe312d2118c1b6ba4df98b
      public float yRotO;
      public float xRotO;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f72471ac82907a0d5112598b3289689495285944..6e1f8323d028790d1f55d51edb3214d0161a0072 100644
+index 8536452ccd65814b55bc78736060b387e051c3db..881af8e0b8383b25b94958b03cfdb6602c4a33cf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2558,6 +2558,12 @@ public class CraftWorld implements World {
+@@ -2559,6 +2559,12 @@ public class CraftWorld implements World {
              return future;
          }
  
@@ -1174,7 +1174,7 @@ index f72471ac82907a0d5112598b3289689495285944..6e1f8323d028790d1f55d51edb3214d0
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 638dc61594e86a1423536d2a7fe8405d2451a4ee..ead9c15cfe31d1c9582826ad079691a1f147f3fa 100644
+index 7fc48e63ac610f65475e3a8d3d6f902cc70925ed..9144fbd3754b21295248103eac8cf9ac989d4614 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -890,6 +890,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0500-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0500-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6e1f8323d028790d1f55d51edb3214d0161a0072..6c5b6a5f1b9ee3fb5a6bae4d57c70cfcaba75624 100644
+index 881af8e0b8383b25b94958b03cfdb6602c4a33cf..d53918ec0911ef2becccb4dc6e11a9b1c8b8bf34 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2629,6 +2629,7 @@ public class CraftWorld implements World {
+@@ -2630,6 +2630,7 @@ public class CraftWorld implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0510-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0510-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -17,10 +17,10 @@ index 15d27aa11594b668ca7715ed1c465c6003d6e9bf..3fc9847d26395a19abc5a16150ff8816
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6c5b6a5f1b9ee3fb5a6bae4d57c70cfcaba75624..8c8627f70f29834e19093b6298127008e75b7d74 100644
+index d53918ec0911ef2becccb4dc6e11a9b1c8b8bf34..44cec5c379f1c15a323a44cf6721ed2cc043bb2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -386,11 +386,13 @@ public class CraftWorld implements World {
+@@ -387,11 +387,13 @@ public class CraftWorld implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0511-Add-moon-phase-API.patch
+++ b/patches/server/0511-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8c8627f70f29834e19093b6298127008e75b7d74..82964cfbe172e22e19203d37addf9fedbe8edaa5 100644
+index 44cec5c379f1c15a323a44cf6721ed2cc043bb2a..6fc9b8a3daf9ecf3d4231ea872d62025d04a394e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -325,6 +325,11 @@ public class CraftWorld implements World {
+@@ -326,6 +326,11 @@ public class CraftWorld implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0557-Expose-world-spawn-angle.patch
+++ b/patches/server/0557-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index b9f6f8441cafeb3e64ce7943bfd1e92fe983a5c5..f8b917b2d1a1744f7a6c3b9cf60be417
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 82964cfbe172e22e19203d37addf9fedbe8edaa5..f7bf59f63cc3a5c4201857835ae136cbfdb61f8f 100644
+index 6fc9b8a3daf9ecf3d4231ea872d62025d04a394e..59543c88dcde9d2056bb481383a2784be0637ae8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -377,7 +377,7 @@ public class CraftWorld implements World {
+@@ -378,7 +378,7 @@ public class CraftWorld implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0581-Cache-burn-durations.patch
+++ b/patches/server/0581-Cache-burn-durations.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache burn durations
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 60cbb6616851758c7b8a9c90f4bb7e169358f123..f7d068e9d6ad1915bec06738c99dc04e2cff10b4 100644
+index 348196524eb3770541966e7e842ff0ae7afd94ad..381e14e9c5c818aa7022726c193c14e69f021275 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -125,7 +125,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -127,7 +127,13 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          this.recipeType = recipeType;
      }
  
@@ -22,7 +22,7 @@ index 60cbb6616851758c7b8a9c90f4bb7e169358f123..f7d068e9d6ad1915bec06738c99dc04e
          Map<Item, Integer> map = Maps.newLinkedHashMap();
  
          AbstractFurnaceBlockEntity.add(map, (ItemLike) Items.LAVA_BUCKET, 20000);
-@@ -190,7 +196,10 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -192,7 +198,10 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
          AbstractFurnaceBlockEntity.add(map, (ItemLike) Blocks.COMPOSTER, 300);
          AbstractFurnaceBlockEntity.add(map, (ItemLike) Blocks.AZALEA, 100);
          AbstractFurnaceBlockEntity.add(map, (ItemLike) Blocks.FLOWERING_AZALEA, 100);

--- a/patches/server/0590-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0590-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f7bf59f63cc3a5c4201857835ae136cbfdb61f8f..071214bf8776959f2240b89501cd9ded2e07fdd7 100644
+index 59543c88dcde9d2056bb481383a2784be0637ae8..7647caea0fb8dbb2b8837dc4379f0bc634df719e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2363,8 +2363,13 @@ public class CraftWorld implements World {
+@@ -2364,8 +2364,13 @@ public class CraftWorld implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index f7bf59f63cc3a5c4201857835ae136cbfdb61f8f..071214bf8776959f2240b89501cd9ded
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -2399,8 +2404,12 @@ public class CraftWorld implements World {
+@@ -2400,8 +2405,12 @@ public class CraftWorld implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0593-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0593-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 51723c8f740c7b0bbd15acc0f1c848790c2ff299..5a95b550c767284563c124df1ff45322
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 42cf9d69555bb4f94bacbcec126823125b5c1d56..03250ab358f46095c4fbe969d6d678d7e79b4a96 100644
+index f9dfee7b1a4382002805b68d88b9c19476b66a66..e6474142eb8f7f19f083d1ad8797b662eca27565 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1792,4 +1792,12 @@ public class CraftEventFactory {
+@@ -1807,4 +1807,12 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(event);
          return event;
      }

--- a/patches/server/0608-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0608-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 501a5483160dba050261bb3448317a097cdb7ef2..2dcac4b638073aa1748f26f61219dbf9
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a2c8deb54e9a8448f2473b58a01329b44f6a3d8f..c2ddbde78c861c33f25c63483fc8928307161f1a 100644
+index 5e030bddc8e9fe9cbe16a53242b6be8f2232fbc1..c8c3a8d8e4e5e7df66b69011ad95bb6bd6d3b6ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1810,5 +1810,11 @@ public class CraftEventFactory {
+@@ -1825,5 +1825,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0615-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0615-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index b9b67134f02fd7484ed19905c9ae1f9b8a26ce26..c05f173b7642380900fdd77ce5d2c020
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c2ddbde78c861c33f25c63483fc8928307161f1a..b4509c4a03b82d7c49329aa74087818499430e58 100644
+index c8c3a8d8e4e5e7df66b69011ad95bb6bd6d3b6ee..1ab0c25dabd19dd53f255b76b2a5c85399cffaaf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1466,8 +1466,10 @@ public class CraftEventFactory {
+@@ -1481,8 +1481,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0639-Add-recipe-to-cook-events.patch
+++ b/patches/server/0639-Add-recipe-to-cook-events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add recipe to cook events
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index f7d068e9d6ad1915bec06738c99dc04e2cff10b4..15287764fcc8f1ea10c3157e9874a3d697e4756d 100644
+index 381e14e9c5c818aa7022726c193c14e69f021275..5c1283c15c7e2b42b06b5f37c276cd0752e352e6 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -408,7 +408,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -422,7 +422,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
              CraftItemStack source = CraftItemStack.asCraftMirror(itemstack);
              org.bukkit.inventory.ItemStack result = CraftItemStack.asBukkitCopy(itemstack1);
  

--- a/patches/server/0642-Implement-Keyed-on-World.patch
+++ b/patches/server/0642-Implement-Keyed-on-World.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f4835006439ce3effeb5817e11f3ec49eea374e4..273f80fc0325c2ccd2320e35ca36639f92345aea 100644
+index f30ab74020f3b766242bcb81c480009e72fbdb2c..aaf176deb2f28b02f474efdbce40f9db9f70dad9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1150,7 +1150,7 @@ public final class CraftServer implements Server {
@@ -34,10 +34,10 @@ index f4835006439ce3effeb5817e11f3ec49eea374e4..273f80fc0325c2ccd2320e35ca36639f
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 071214bf8776959f2240b89501cd9ded2e07fdd7..7b1b64dfbac25e19bc97762fd6d8d8b09c6b5489 100644
+index 7647caea0fb8dbb2b8837dc4379f0bc634df719e..1a078b6c16d5932d4383113e455bd89884d2a98b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2586,6 +2586,11 @@ public class CraftWorld implements World {
+@@ -2587,6 +2587,11 @@ public class CraftWorld implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0657-Set-area-affect-cloud-rotation.patch
+++ b/patches/server/0657-Set-area-affect-cloud-rotation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Set area affect cloud rotation
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7b1b64dfbac25e19bc97762fd6d8d8b09c6b5489..effe4d8c64c99d320d501187dce87d87ee9d3247 100644
+index 1a078b6c16d5932d4383113e455bd89884d2a98b..753b9773a46ebb4afefa9ccb2435bf48ff09b4b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1974,6 +1974,7 @@ public class CraftWorld implements World {
+@@ -1975,6 +1975,7 @@ public class CraftWorld implements World {
              entity = net.minecraft.world.entity.EntityType.LIGHTNING_BOLT.create(world);
          } else if (AreaEffectCloud.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.AreaEffectCloud(this.world, x, y, z);

--- a/patches/server/0660-add-consumeFuel-to-FurnaceBurnEvent.patch
+++ b/patches/server/0660-add-consumeFuel-to-FurnaceBurnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add consumeFuel to FurnaceBurnEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 15287764fcc8f1ea10c3157e9874a3d697e4756d..c559ec5041474e585e4d95a664c84e1fa895cf16 100644
+index 5c1283c15c7e2b42b06b5f37c276cd0752e352e6..242d9b2ecb852d812d4887883cb2aabfd21e3715 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-@@ -341,7 +341,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+@@ -343,7 +343,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
                  if (blockEntity.isLit() && furnaceBurnEvent.isBurning()) {
                      // CraftBukkit end
                      flag1 = true;

--- a/patches/server/0666-More-World-API.patch
+++ b/patches/server/0666-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index effe4d8c64c99d320d501187dce87d87ee9d3247..e4132642d4c72bc7697cb8796da7438c9da3d1d9 100644
+index 753b9773a46ebb4afefa9ccb2435bf48ff09b4b5..36283d4b07a7cfea09da88bcad3c406cb6e0d880 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2533,6 +2533,75 @@ public class CraftWorld implements World {
+@@ -2534,6 +2534,75 @@ public class CraftWorld implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0695-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0695-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -104,10 +104,10 @@ index cd840dc4a8ca432868fb3e9c912ea928e5303e0d..4d0af984490b556a9911c3b8fdca1e16
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e4132642d4c72bc7697cb8796da7438c9da3d1d9..2247d1c7c7dd1c225c511b44d6aeb5c3e75bdb2a 100644
+index 36283d4b07a7cfea09da88bcad3c406cb6e0d880..fea56803b648bdda9ba8ead14816b1b4fa6cd73a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1456,7 +1456,7 @@ public class CraftWorld implements World {
+@@ -1457,7 +1457,7 @@ public class CraftWorld implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -116,7 +116,7 @@ index e4132642d4c72bc7697cb8796da7438c9da3d1d9..2247d1c7c7dd1c225c511b44d6aeb5c3
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1478,7 +1478,7 @@ public class CraftWorld implements World {
+@@ -1479,7 +1479,7 @@ public class CraftWorld implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0709-Line-Of-Sight-Changes.patch
+++ b/patches/server/0709-Line-Of-Sight-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9f57ebcf4f1fafe38ebdf9b78f186e244853101d..02a944ee1ab3a0d8c8ed84d3ec4d9bc6fcdfb9bb 100644
+index 99b33003c97bb86b2cfc4a77298ac52efad6e78f..442d0df276defbbea1b4282b99460ab463c2e5e0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3430,7 +3430,8 @@ public abstract class LivingEntity extends Entity {
@@ -19,10 +19,10 @@ index 9f57ebcf4f1fafe38ebdf9b78f186e244853101d..02a944ee1ab3a0d8c8ed84d3ec4d9bc6
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2247d1c7c7dd1c225c511b44d6aeb5c3e75bdb2a..50ab10f1a131ac35a2edff71dbe0b199d588bcc0 100644
+index fea56803b648bdda9ba8ead14816b1b4fa6cd73a..39f8ff65ae06a072ad37e80769244895e98a727a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -330,6 +330,18 @@ public class CraftWorld implements World {
+@@ -331,6 +331,18 @@ public class CraftWorld implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0710-add-per-world-spawn-limits.patch
+++ b/patches/server/0710-add-per-world-spawn-limits.patch
@@ -30,10 +30,10 @@ index 417cf3d8988f28fa1e0b05f11b89ef2c02d59ed9..26e18a08a7f0bd704ff3055ce3a78141
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1cc8a85ae69c98987ab516418808b688c266711c..3403b75c8311f1e52a0533363c5f0307442f8a15 100644
+index 39f8ff65ae06a072ad37e80769244895e98a727a..7dc26321e20e26821096e79356a358879306cd78 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -351,6 +351,13 @@ public class CraftWorld implements World {
+@@ -352,6 +352,13 @@ public class CraftWorld implements World {
          this.generator = gen;
  
          this.environment = env;


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
5662c2b3 SPIGOT-6642: Throw better message if plugin.yml is empty
aa8e0351 #&#x2060;636: Add FurnaceStartSmeltEvent
52073b30 SPIGOT-6646: Issue with map palette ranges
5f772da9 #&#x2060;640: Add new Causes for LightningStrikeEvent

CraftBukkit Changes:
4e187045 #&#x2060;874: Add FurnaceStartSmeltEvent
ed2b91c2 SPIGOT-6649: Call BlockFadeEvent when Nylium fades to Netherrack
b7e3ce02 #&#x2060;890: Include yaw in player's spawn location
aeb711dd #&#x2060;889: Fix CraftChest close() sound being replaced with open sound.
ca0fe5b5 SPIGOT-5561: Warning in logs when changing a Mob Spawner to Air on chunk load
2f038f2d #&#x2060;886: Add new Causes for LightningStrikeEvent

Spigot Changes:
38e6c03d Rebuild patches