### PR TITLE
Revert "Fix PaperTickList"

### DIFF
--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -924,7 +924,7 @@ index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..8104b9be5a8e8d57f6f50475788aec6a
              });
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 550338a7170437415342df7bc1b0a5c445480300..57aa6d18d181c50071bcfcc933cde9fa828be792 100644
+index 550338a7170437415342df7bc1b0a5c445480300..34174c3cdcb69c96e8601e28ecaf01df9b8c0f37 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -219,6 +219,13 @@ public class ServerChunkCache extends ChunkSource {
@@ -935,7 +935,7 @@ index 550338a7170437415342df7bc1b0a5c445480300..57aa6d18d181c50071bcfcc933cde9fa
 +    public final boolean isPositionTickingWithEntitiesLoaded(BlockPos pos) {
 +        long position = net.minecraft.server.MCUtil.getCoordinateKey(pos);
 +        ChunkHolder chunkHolder = this.chunkMap.getUpdatingChunkIfPresent(position);
-+        return chunkHolder != null && chunkHolder.isTickingReady() && this.level.entityManager.areEntitiesLoaded(position);
++        return chunkHolder != null && chunkHolder.isTickingReady() /* && this.level.entityManager.areEntitiesLoaded(position) */; // TODO Needs to wait for entities, but has to be manually marked as ready
 +    }
 +    // Paper end - rewrite ticklistserver
  


### PR DESCRIPTION
Hotunfixes the PaperTickList due to the fix causing more issues than before (*probably* due to the ticklistentry having to be marked as ready manually when entities are actually loaded with everything else, otherwise it will forever remain in the unready list).