### PR TITLE
Skip sync chunk load for MoveToBlock (fixes #6045)

### DIFF
--- a/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
+++ b/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Prevent Mob AI Rules from Loading Chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 70a51ba19fb34f652858b18f24554261787d97e2..1a1f885ab5a181d5552e3c2ec2231086070467e1 100644
+index 70a51ba19fb34f652858b18f24554261787d97e2..5f593700053b17acc2a1fc9d280c6900655d3cd5 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -107,6 +107,7 @@ public abstract class MoveToBlockGoal extends Goal {
                  for(int m = 0; m <= l; m = m > 0 ? -m : 1 - m) {
                      for(int n = m < l && m > -l ? l : 0; n <= l; n = n > 0 ? -n : 1 - n) {
                          mutableBlockPos.setWithOffset(blockPos, m, k - 1, n);
-+                        if (!this.mob.level.hasChunkAt(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
++                        if (!this.mob.level.hasChunkAt(mutableBlockPos)) continue; // Paper - it's an invalid target if it's not loaded
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
                              return true;

--- a/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
+++ b/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Prevent Mob AI Rules from Loading Chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 70a51ba19fb34f652858b18f24554261787d97e2..6adf2486a43603d7872a14a08d8ff32797d1a95b 100644
+index 70a51ba19fb34f652858b18f24554261787d97e2..1a1f885ab5a181d5552e3c2ec2231086070467e1 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -107,6 +107,7 @@ public abstract class MoveToBlockGoal extends Goal {
                  for(int m = 0; m <= l; m = m > 0 ? -m : 1 - m) {
                      for(int n = m < l && m > -l ? l : 0; n <= l; n = n > 0 ? -n : 1 - n) {
                          mutableBlockPos.setWithOffset(blockPos, m, k - 1, n);
-+                        if (!this.mob.level.isLoaded(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
++                        if (!this.mob.level.hasChunkAt(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
                              return true;

--- a/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
+++ b/patches/server/0268-Prevent-Mob-AI-Rules-from-Loading-Chunks.patch
@@ -4,6 +4,18 @@ Date: Mon, 10 Sep 2018 23:56:36 -0400
 Subject: [PATCH] Prevent Mob AI Rules from Loading Chunks
 
 
+diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
+index 70a51ba19fb34f652858b18f24554261787d97e2..6adf2486a43603d7872a14a08d8ff32797d1a95b 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
++++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
+@@ -107,6 +107,7 @@ public abstract class MoveToBlockGoal extends Goal {
+                 for(int m = 0; m <= l; m = m > 0 ? -m : 1 - m) {
+                     for(int n = m < l && m > -l ? l : 0; n <= l; n = n > 0 ? -n : 1 - n) {
+                         mutableBlockPos.setWithOffset(blockPos, m, k - 1, n);
++                        if (!this.mob.level.isLoaded(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
+                         if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
+                             this.blockPos = mutableBlockPos;
+                             return true;
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java
 index b255eed15cfc7282167a9bed01653b34bb8d13f1..ac5779319081a6894373877067edf958da8a9cf5 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/RemoveBlockGoal.java

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -227,7 +227,7 @@ index dc7da3b806d1c759958d7c51b05efbc4b6c42653..69bf112655615337e0df3ea56b9e42fa
          this.availableGoals.stream().filter((wrappedGoal) -> {
              return wrappedGoal.getGoal() == goal;
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 0175c48373101a38b750b7356c3c0017b7e4d37a..9df16c678c75746ebb28b25d45e81837585bcc8c 100644
+index 77d113e3d16306e3737d7d75e40ae6f963cb27ed..4af57fce6896270b5f4e2e4cd05b24cd6fe21c79 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -14,7 +14,7 @@ public abstract class MoveToBlockGoal extends Goal {
@@ -254,7 +254,7 @@ index 0175c48373101a38b750b7356c3c0017b7e4d37a..9df16c678c75746ebb28b25d45e81837
      public MoveToBlockGoal(PathfinderMob mob, double speed, int range, int maxYDifference) {
          this.mob = mob;
 @@ -110,6 +117,7 @@ public abstract class MoveToBlockGoal extends Goal {
-                         if (!this.mob.level.isLoaded(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
+                         if (!this.mob.level.hasChunkAt(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
 +                            setTargetPosition(mutableBlockPos.immutable()); // Paper

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -227,7 +227,7 @@ index dc7da3b806d1c759958d7c51b05efbc4b6c42653..69bf112655615337e0df3ea56b9e42fa
          this.availableGoals.stream().filter((wrappedGoal) -> {
              return wrappedGoal.getGoal() == goal;
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 27ea9c10b7f66c2133b0829c0b1c37143dd80b56..c28ade67f6a59146064a57bf016a646197f47ac4 100644
+index 0175c48373101a38b750b7356c3c0017b7e4d37a..9df16c678c75746ebb28b25d45e81837585bcc8c 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -14,7 +14,7 @@ public abstract class MoveToBlockGoal extends Goal {
@@ -253,8 +253,8 @@ index 27ea9c10b7f66c2133b0829c0b1c37143dd80b56..c28ade67f6a59146064a57bf016a6461
  
      public MoveToBlockGoal(PathfinderMob mob, double speed, int range, int maxYDifference) {
          this.mob = mob;
-@@ -109,6 +116,7 @@ public abstract class MoveToBlockGoal extends Goal {
-                         mutableBlockPos.setWithOffset(blockPos, m, k - 1, n);
+@@ -110,6 +117,7 @@ public abstract class MoveToBlockGoal extends Goal {
+                         if (!this.mob.level.isLoaded(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
 +                            setTargetPosition(mutableBlockPos.immutable()); // Paper

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -227,7 +227,7 @@ index dc7da3b806d1c759958d7c51b05efbc4b6c42653..69bf112655615337e0df3ea56b9e42fa
          this.availableGoals.stream().filter((wrappedGoal) -> {
              return wrappedGoal.getGoal() == goal;
 diff --git a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
-index 77d113e3d16306e3737d7d75e40ae6f963cb27ed..4af57fce6896270b5f4e2e4cd05b24cd6fe21c79 100644
+index 6c7bd4b3c753cb568615f287839aed7a95236d2a..d927993c751fce4dd536eec627947996b7e4a807 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/goal/MoveToBlockGoal.java
 @@ -14,7 +14,7 @@ public abstract class MoveToBlockGoal extends Goal {
@@ -254,7 +254,7 @@ index 77d113e3d16306e3737d7d75e40ae6f963cb27ed..4af57fce6896270b5f4e2e4cd05b24cd
      public MoveToBlockGoal(PathfinderMob mob, double speed, int range, int maxYDifference) {
          this.mob = mob;
 @@ -110,6 +117,7 @@ public abstract class MoveToBlockGoal extends Goal {
-                         if (!this.mob.level.hasChunkAt(blockPos)) continue; // Paper - it's an invalid target if it's not loaded
+                         if (!this.mob.level.hasChunkAt(mutableBlockPos)) continue; // Paper - it's an invalid target if it's not loaded
                          if (this.mob.isWithinRestriction(mutableBlockPos) && this.isValidTarget(this.mob.level, mutableBlockPos)) {
                              this.blockPos = mutableBlockPos;
 +                            setTargetPosition(mutableBlockPos.immutable()); // Paper


### PR DESCRIPTION
Any goal which extends this does a sync chunk/block lookup, which for
mobs close to the loaded chunk border will repeatedly lag the main
thread loading these.

This has been tested on production servers for a few weeks without any issues.