### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0004-Add-FastUtil-to-Bukkit.patch
+++ b/patches/api/0004-Add-FastUtil-to-Bukkit.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add FastUtil to Bukkit
 Doesn't expose to plugins, just allows Paper-API to use it for optimization
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index b1a33fdfd6495e5243315312aca97c2512a64dcc..2feb94aeb1eef2241963f6b541247d923913e560 100644
+index db6a7b2e60da0d96ef96545a781f1e056482d6ff..17fd7162ab32785252bf2579daae8d47aec21684 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,6 +18,7 @@ dependencies {

--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -2782,7 +2782,7 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 7305bbe87f010b2f6fa483c215c9c2aa9dc14bda..73dafe6093b4c5c385efc8529fab76189085e9d0 100644
+index 94089c0a616b06a7b4bb5e720fcebeab8636291e..05595fea641dbbc3d5eefb262731faad5bdb7965 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -673,7 +673,6 @@ public final class Bukkit {
@@ -2794,7 +2794,7 @@ index 7305bbe87f010b2f6fa483c215c9c2aa9dc14bda..73dafe6093b4c5c385efc8529fab7618
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index db3af8134c817d9bb8bb44bd717fafa733cc2708..b72a8d2ca0c5b6d78c0a5ca5cc30d8216c34ee88 100644
+index 0bd32af41e4965ce317d5781b092e8f5b641a8a2..bc4c4b6a10726347649a9232ee8ede28c967b8f4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1364,6 +1364,26 @@ public interface Server extends PluginMessageRecipient {

--- a/patches/api/0008-Player-affects-spawning-API.patch
+++ b/patches/api/0008-Player-affects-spawning-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d026c791ee86cb45feadcad7a48dea41287e3da7..58f3a5ada8f081b0a84d7e332f40d259df7e750b 100644
+index 8ed69c4be84db742f2ff53adfd40f9eb8823e02d..f7975a9146a1e21127ede13630f6d63d7a0285d7 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1407,6 +1407,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0009-Add-getTPS-method.patch
+++ b/patches/api/0009-Add-getTPS-method.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f0a28cbb92edf990a3aef076af183cc9796987f3..c256fa1efbf95fb2edb976e1a03d1825663fd356 100644
+index cc208227301b30c3717516ceb9529ca6cb2fd0de..43d35945a5c315fc324a7f6c2eef69d34be0dc45 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1567,6 +1567,17 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index f0a28cbb92edf990a3aef076af183cc9796987f3..c256fa1efbf95fb2edb976e1a03d1825
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 650b9afc846b1ead0322a4b3ebcdad2d449670da..8f6f410add6e8d5bf6f1d2233daef33623482bb1 100644
+index cb0f365c4829f382a8fef8c176b7ea4028cac876..0e0fd990e09619d89c1dcb645c22c6e4e73a7139 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1321,6 +1321,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0013-Add-player-view-distance-API.patch
+++ b/patches/api/0013-Add-player-view-distance-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add player view distance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 58f3a5ada8f081b0a84d7e332f40d259df7e750b..11667e04df85c72205bec0b8c34ef4ec5998b404 100644
+index f7975a9146a1e21127ede13630f6d63d7a0285d7..f41d6a76f768c9ffa6c2ba9379564d07163f60c3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1421,6 +1421,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0017-Expose-server-CommandMap.patch
+++ b/patches/api/0017-Expose-server-CommandMap.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c256fa1efbf95fb2edb976e1a03d1825663fd356..111706c2ae457687ad58cda58ff972559ee9bc0f 100644
+index 43d35945a5c315fc324a7f6c2eef69d34be0dc45..f01fca5854b161278f448788e4b391e764107490 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1741,6 +1741,19 @@ public final class Bukkit {
@@ -29,7 +29,7 @@ index c256fa1efbf95fb2edb976e1a03d1825663fd356..111706c2ae457687ad58cda58ff97255
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 8f6f410add6e8d5bf6f1d2233daef33623482bb1..9958a7ae1fd80808eb922c074344c8f9e34db60c 100644
+index 0e0fd990e09619d89c1dcb645c22c6e4e73a7139..019dcabdd21783cd4d14d407d4dcae739afcaadd 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1331,6 +1331,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 111706c2ae457687ad58cda58ff972559ee9bc0f..8cf060e7f0a96d5b51abe57c565cdc8e9f3f5b3a 100644
+index f01fca5854b161278f448788e4b391e764107490..914a435bc3651f1153dd4e8128abcdec779be97e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -309,6 +309,30 @@ public final class Bukkit {
@@ -41,7 +41,7 @@ index 111706c2ae457687ad58cda58ff972559ee9bc0f..8cf060e7f0a96d5b51abe57c565cdc8e
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 9958a7ae1fd80808eb922c074344c8f9e34db60c..5dd51e88dc2d9b7338afaa594efe1bddb17cc3ec 100644
+index 019dcabdd21783cd4d14d407d4dcae739afcaadd..25d6c59728c616f47dea4254a9317807ed6863be 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -254,6 +254,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -76,7 +76,7 @@ index 9958a7ae1fd80808eb922c074344c8f9e34db60c..5dd51e88dc2d9b7338afaa594efe1bdd
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 11667e04df85c72205bec0b8c34ef4ec5998b404..c5b41ebfd94a4969ce998b7ad539d11a1164168a 100644
+index f41d6a76f768c9ffa6c2ba9379564d07163f60c3..d3d412fc75ad0a849e8c81f0ba73ba980754c12e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -641,6 +641,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
@@ -432,7 +432,7 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c5b41ebfd94a4969ce998b7ad539d11a1164168a..9e4ef22c04b335d81baba2904c5571d17138092b 100644
+index d3d412fc75ad0a849e8c81f0ba73ba980754c12e..1a5d42d27299191f60fa1fd380dd0827dff4f7b1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;

--- a/patches/api/0025-Use-ASM-for-event-executors.patch
+++ b/patches/api/0025-Use-ASM-for-event-executors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ea3a12608a851b25afa01ee127c6ef91a3d64fff..97aa9d31d4366aefb05f6f703cc3c6b303c76c42 100644
+index 479d4e3b91e902e9b30d351aa65c8b079555d7e0..58b7df30d050156998aa88fb7e2b1973492294db 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -26,6 +26,8 @@ dependencies {

--- a/patches/api/0028-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0028-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 8cf060e7f0a96d5b51abe57c565cdc8e9f3f5b3a..d896d9508faa53aa6f6c036f99a134a5db0f4722 100644
+index 914a435bc3651f1153dd4e8128abcdec779be97e..03db21881383b52d5afd9c8fa00bbd533bdd609e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1776,6 +1776,13 @@ public final class Bukkit {
@@ -24,7 +24,7 @@ index 8cf060e7f0a96d5b51abe57c565cdc8e9f3f5b3a..d896d9508faa53aa6f6c036f99a134a5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5dd51e88dc2d9b7338afaa594efe1bddb17cc3ec..1b34e57d9c35d2228f36d52d44c2e55343d66c9d 100644
+index 25d6c59728c616f47dea4254a9317807ed6863be..f1b7d99eca33b9a4d193cdf589e1533c1f89b82e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1569,4 +1569,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0041-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0041-Allow-Reloading-of-Command-Aliases.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d896d9508faa53aa6f6c036f99a134a5db0f4722..e266a6ea144ee12f00b385b12a0fb99403643898 100644
+index 03db21881383b52d5afd9c8fa00bbd533bdd609e..1f9dcd8cc63c050ccb654a9818b8be372185db19 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1783,6 +1783,15 @@ public final class Bukkit {
@@ -26,7 +26,7 @@ index d896d9508faa53aa6f6c036f99a134a5db0f4722..e266a6ea144ee12f00b385b12a0fb994
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1b34e57d9c35d2228f36d52d44c2e55343d66c9d..7b7d5483e58548ea28fc572916ca3e26571a8668 100644
+index f1b7d99eca33b9a4d193cdf589e1533c1f89b82e..e5b66aaf0124a236b6353d4689c54865e7430652 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1571,4 +1571,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0044-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0044-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d6eeee1ec221e899f20d50aee9b4deed8a6ef8a2..cfdf93176160351e4fdf746e5c88d3e301e242dc 100644
+index b30d00f26da93688cc81c522d4a032a72194bd63..2ab6ca203428fffe7f04beb0b3d14157d2896617 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;

--- a/patches/api/0045-Add-API-methods-to-control-if-armour-stands-can-move.patch
+++ b/patches/api/0045-Add-API-methods-to-control-if-armour-stands-can-move.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add API methods to control if armour stands can move
 
 
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
-index 26223028f68534ee81c6452dd3b0ab7aca03f1e8..de9ddd2c40261486ee8de6693d118cffaa2dd793 100644
+index dc604d6ab9dcf67fa0791539d18c2f890a814ed8..91fc11dda99de506be83d40df8929bf7cd8e8d85 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
 +++ b/src/main/java/org/bukkit/entity/ArmorStand.java
 @@ -344,4 +344,21 @@ public interface ArmorStand extends LivingEntity {

--- a/patches/api/0052-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0052-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e266a6ea144ee12f00b385b12a0fb99403643898..35dbed257032f797484c2e7db49339c0325246f6 100644
+index 1f9dcd8cc63c050ccb654a9818b8be372185db19..4ff85202a61f43b175ba7b3c2191f0a5b9f6a59b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1792,6 +1792,16 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index e266a6ea144ee12f00b385b12a0fb99403643898..35dbed257032f797484c2e7db49339c0
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 7b7d5483e58548ea28fc572916ca3e26571a8668..39b5de22629880bb35e1fb1bb01f3e42693462f5 100644
+index e5b66aaf0124a236b6353d4689c54865e7430652..1a6142822eb3530649da564272fb40c9aab53ba8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1573,4 +1573,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
+++ b/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix upstream javadoc warnings and errors
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 88cfc75a7b55dd09c4577d61ac40c3e241fc9e6c..c4e166311234cbe1e91fa26e74eae1d9fc82f72f 100644
+index 2ab6ca203428fffe7f04beb0b3d14157d2896617..c7b3f8799a41c455b49bb601a48f6b5d33e68c08 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -661,7 +661,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -32,7 +32,7 @@ index 1b2267f4e8ebded198773ec80e2bff2c861c7084..1a58734d919fae247eeb85dd785fd599
          return to;
      }
 diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
-index 91afd844dafec4ed9ab9e2e16b220ffbd35e7495..1e45c9078ffffe9d3c25538fdd433780ae751270 100644
+index 99d900b2394b6c210ccf845768dae72864f32270..515587a958041e94f03c48ae87812abc39e1791c 100644
 --- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
 +++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
 @@ -106,7 +106,7 @@ public interface PlayerInventory extends Inventory {

--- a/patches/api/0057-Basic-PlayerProfile-API.patch
+++ b/patches/api/0057-Basic-PlayerProfile-API.patch
@@ -267,7 +267,7 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 35dbed257032f797484c2e7db49339c0325246f6..baf0a417970b95d5d9c057f252f4d37d13ad8ddb 100644
+index 4ff85202a61f43b175ba7b3c2191f0a5b9f6a59b..a903cc8e0fd6f44dc31b8b3998767d24a18f59b6 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1802,6 +1802,40 @@ public final class Bukkit {
@@ -312,7 +312,7 @@ index 35dbed257032f797484c2e7db49339c0325246f6..baf0a417970b95d5d9c057f252f4d37d
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 39b5de22629880bb35e1fb1bb01f3e42693462f5..df66b39ce9f3dd6c567bc71bacfd0b105c2e0e8d 100644
+index 1a6142822eb3530649da564272fb40c9aab53ba8..d1554849a8a0e698d6106487fea44ad8e8b438da 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1582,5 +1582,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,7 +14,7 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 97aa9d31d4366aefb05f6f703cc3c6b303c76c42..8c7a32c85aee1a0e1d727a52481bd5ec928f60df 100644
+index 58b7df30d050156998aa88fb7e2b1973492294db..7ad3e5153718f6d4ce8293a9790bc3c1158aeb8e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -28,6 +28,7 @@ dependencies {

--- a/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
@@ -57,7 +57,7 @@ index 0000000000000000000000000000000000000000..7b2af1bd72dfbcf4e962a982940fc49b
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c4e166311234cbe1e91fa26e74eae1d9fc82f72f..fe0238c0b7c001b69ba6f5f50faf535df59a2351 100644
+index c7b3f8799a41c455b49bb601a48f6b5d33e68c08..7434899dec25777b699022b4cb20266efd16289e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
@@ -10,7 +10,7 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fe0238c0b7c001b69ba6f5f50faf535df59a2351..4fa6080c151c3c2c0a7d95a2dc95692bd8bbee57 100644
+index 7434899dec25777b699022b4cb20266efd16289e..5d1f8bea2b1af036a3c5d869f8c20838ed19a8ae 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -919,12 +919,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0088-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
+++ b/patches/api/0088-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Ability to change PlayerProfile in AsyncPreLoginEvent
 This will allow you to change the players name or skin on login.
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index d3b4219a57fff4519ef8d803c333c854fafa7859..d512c23ad0275061593d99f005c72292dbb07e81 100644
+index 31f6f781a0403bf6388d668f0effaed5aae94468..25e0d571710403c334bd73ce1b97109dd65c3244 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -2,6 +2,9 @@ package org.bukkit.event.player;

--- a/patches/api/0090-Player.setPlayerProfile-API.patch
+++ b/patches/api/0090-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a65bfc33e36dec9a0e41628dcca53b0de9deb66b..6cc305ecf1854ff8cadbe1f677ac7fc69f947d73 100644
+index 5d1f8bea2b1af036a3c5d869f8c20838ed19a8ae..7ab92fce37eae47985345c9c0b610b808df98111 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;

--- a/patches/api/0091-getPlayerUniqueId-API.patch
+++ b/patches/api/0091-getPlayerUniqueId-API.patch
@@ -9,7 +9,7 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index baf0a417970b95d5d9c057f252f4d37d13ad8ddb..8fd87b32b5e80548bc62bb71ab36db142e7aa38a 100644
+index a903cc8e0fd6f44dc31b8b3998767d24a18f59b6..85cb12d2719ca42c04abcd63726059767bba6fe7 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -528,6 +528,20 @@ public final class Bukkit {
@@ -34,7 +34,7 @@ index baf0a417970b95d5d9c057f252f4d37d13ad8ddb..8fd87b32b5e80548bc62bb71ab36db14
       * Gets the plugin manager for interfacing with plugins.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index df66b39ce9f3dd6c567bc71bacfd0b105c2e0e8d..021f656dce58cc61883604411e219bd627f54d21 100644
+index d1554849a8a0e698d6106487fea44ad8e8b438da..d2fce537c80c73bd1711854fd4b86fb4730e6fe4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -449,6 +449,18 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,7 +74,7 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index ea4bad15720ce0a31d09999efa6df3988a67be20..b7bda78eab3a8146b2c361735a19b2a159af215e 100644
+index 7ab92fce37eae47985345c9c0b610b808df98111..54cb4de5f4f48924ad89b4a757255fce243d1187 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -5,6 +5,10 @@ import java.util.UUID;

--- a/patches/api/0097-Additional-world.getNearbyEntities-API-s.patch
+++ b/patches/api/0097-Additional-world.getNearbyEntities-API-s.patch
@@ -277,7 +277,7 @@ index 8804be419520859355b69660e6f3166d1aa8b1ea..6cc9c7fc913f229c4869a976e73253ac
       * Get a list of all players in this World
       *
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index d512c23ad0275061593d99f005c72292dbb07e81..c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9 100644
+index 25e0d571710403c334bd73ce1b97109dd65c3244..033960f566861e303b9cb61aae4c02add501d93f 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -42,8 +42,7 @@ public class AsyncPlayerPreLoginEvent extends Event {

--- a/patches/api/0098-Location.isChunkLoaded-API.patch
+++ b/patches/api/0098-Location.isChunkLoaded-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Location.isChunkLoaded() API
 
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 0939a8070f9cc4f66f1679fef74862debb7d32ae..6c8b8eddcdb81f7151202eb12541308040790d45 100644
+index 7c4db051472fb6a6c6d24092dc6f75487356690a..3be91f6c9b355c9e8562796d719f5a6ce566d85a 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -533,6 +533,7 @@ public class Location implements Cloneable, ConfigurationSerializable {

--- a/patches/api/0104-Location.toBlockLocation-toCenterLocation.patch
+++ b/patches/api/0104-Location.toBlockLocation-toCenterLocation.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Location.toBlockLocation/toCenterLocation()
 Convert location objects to their block coordinates, or the center of the block
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 6c8b8eddcdb81f7151202eb12541308040790d45..f61bf28afe99f83cdac6490bcc114509698d0aad 100644
+index 3be91f6c9b355c9e8562796d719f5a6ce566d85a..a90010fea189c5ac9a59a0e6d04c0457243a3280 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -534,6 +534,31 @@ public class Location implements Cloneable, ConfigurationSerializable {

--- a/patches/api/0111-Add-getNearbyXXX-methods-to-Location.patch
+++ b/patches/api/0111-Add-getNearbyXXX-methods-to-Location.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add "getNearbyXXX" methods to Location
 
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index f61bf28afe99f83cdac6490bcc114509698d0aad..4cf22afc3c1f1cc19b6e5350043431215908a612 100644
+index a90010fea189c5ac9a59a0e6d04c0457243a3280..bbc636baef2e2b0586c7d517be428438ca26ab66 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -12,6 +12,15 @@ import org.bukkit.util.Vector;

--- a/patches/api/0114-Expand-Explosions-API.patch
+++ b/patches/api/0114-Expand-Explosions-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 4cf22afc3c1f1cc19b6e5350043431215908a612..af2ee43f2c5133668c18710f526a107d94a5d898 100644
+index bbc636baef2e2b0586c7d517be428438ca26ab66..a8d4f7972d07ddde171b4a1ec470a4c616e02b2e 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -7,6 +7,7 @@ import java.util.HashMap;

--- a/patches/api/0127-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/api/0127-Allow-disabling-armour-stand-ticking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/org/bukkit/entity/ArmorStand.java b/src/main/java/org/bukkit/entity/ArmorStand.java
-index de9ddd2c40261486ee8de6693d118cffaa2dd793..575f48213cd8df038e41bead4c9d0fcba717f40f 100644
+index 91fc11dda99de506be83d40df8929bf7cd8e8d85..bf7ded92ed2d39f57bc828a6290a8e9e7afe3a0c 100644
 --- a/src/main/java/org/bukkit/entity/ArmorStand.java
 +++ b/src/main/java/org/bukkit/entity/ArmorStand.java
 @@ -360,5 +360,21 @@ public interface ArmorStand extends LivingEntity {

--- a/patches/api/0129-Expand-Location-Manipulation-API.patch
+++ b/patches/api/0129-Expand-Location-Manipulation-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expand Location Manipulation API
 Adds set(x, y, z), add(base, x, y, z), subtract(base, x, y, z);
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index af2ee43f2c5133668c18710f526a107d94a5d898..369ce9ff6c8bb97a64a8e229115564412e6e7654 100644
+index a8d4f7972d07ddde171b4a1ec470a4c616e02b2e..36ed248f0716f2cc465c08ab851b7d83d4c7c0a7 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -546,6 +546,54 @@ public class Location implements Cloneable, ConfigurationSerializable {

--- a/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0139-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -18,7 +18,7 @@ Y range: [0, 1023]
 X, Z range: [-67 108 864, 67 108 863]
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 369ce9ff6c8bb97a64a8e229115564412e6e7654..e700875beb76dadd55b585aca748338def286908 100644
+index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b63d1af36 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -15,7 +15,6 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0143-isChunkGenerated-API.patch
+++ b/patches/api/0143-isChunkGenerated-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] isChunkGenerated API
 
 
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index e700875beb76dadd55b585aca748338def286908..9c91c49ed7302c12fcb1d8e9bc58712efc199954 100644
+index 58728a0f0722b378efa129e26f0c822b63d1af36..88b3e0323dbc4f0fce31b147c7aaa08d65745852 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -3,6 +3,7 @@ package org.bukkit;

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 52d139ae39ceada353720e9928c430de71528233..dfe14cda858fee85c8675c129317951ee801ef04 100644
+index 54cb4de5f4f48924ad89b4a757255fce243d1187..14457e5ba8809273362b3cab9fc3a9c3e05edf8a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1980,6 +1980,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0164-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0164-Make-the-default-permission-message-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 8fd87b32b5e80548bc62bb71ab36db142e7aa38a..174e8bbe2b76556c4a6de338e83d7883b2e20ad9 100644
+index 85cb12d2719ca42c04abcd63726059767bba6fe7..1d586d7308d8b17e007dac6fabb53d7dffc660e9 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1817,6 +1817,15 @@ public final class Bukkit {
@@ -25,7 +25,7 @@ index 8fd87b32b5e80548bc62bb71ab36db142e7aa38a..174e8bbe2b76556c4a6de338e83d7883
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 021f656dce58cc61883604411e219bd627f54d21..fcfd1a7d306edb8e83e569b80e0e6fed706d1174 100644
+index d2fce537c80c73bd1711854fd4b86fb4730e6fe4..c9b792870f8329079ee7fb07e922f066d7832e81 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1595,6 +1595,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0173-Annotation-Test-changes.patch
+++ b/patches/api/0173-Annotation-Test-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Annotation Test changes
 
 
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index 002677ac589aa88b643c52a883a72a2bdc3696dd..dfd4174c8dca51600c2203e3f4c933507fb827e7 100644
+index f82f085ab9069abce10c2339446ef0d0bec8888c..15ae70ae69b27712d68270866d7940ff618c9fbe 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
 @@ -46,7 +46,17 @@ public class AnnotationTest {

--- a/patches/api/0178-Flip-some-Spigot-API-null-annotations.patch
+++ b/patches/api/0178-Flip-some-Spigot-API-null-annotations.patch
@@ -9,7 +9,7 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 174e8bbe2b76556c4a6de338e83d7883b2e20ad9..838c9c3eb3ec00632b885d6c9dc21437f66f69bc 100644
+index 1d586d7308d8b17e007dac6fabb53d7dffc660e9..bec68e0eff61e4d81b9723db601e37a9e1d47c42 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1413,7 +1413,7 @@ public final class Bukkit {
@@ -31,7 +31,7 @@ index 174e8bbe2b76556c4a6de338e83d7883b2e20ad9..838c9c3eb3ec00632b885d6c9dc21437
          return server.getTag(registry, tag, clazz);
      }
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index 9c91c49ed7302c12fcb1d8e9bc58712efc199954..d5d67b3d84cd88ed0f858497e68535ec0162c700 100644
+index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..1835d39f6259732e56d51fa746faf1e4c65eaf07 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -46,7 +46,7 @@ public class Location implements Cloneable, ConfigurationSerializable {
@@ -62,7 +62,7 @@ index 9c91c49ed7302c12fcb1d8e9bc58712efc199954..d5d67b3d84cd88ed0f858497e68535ec
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fcfd1a7d306edb8e83e569b80e0e6fed706d1174..b492f4e7c5a78bdbf45d80ba99aec33b493554f1 100644
+index c9b792870f8329079ee7fb07e922f066d7832e81..d7c73eaf5d3075c2f983c31feb303b853fa744b8 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1191,7 +1191,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0181-Add-Heightmap-API.patch
+++ b/patches/api/0181-Add-Heightmap-API.patch
@@ -51,7 +51,7 @@ index 0000000000000000000000000000000000000000..709e44ea1b14ab6917501c928e689cc6
 +    SOLID_OR_LIQUID_NO_LEAVES;
 +}
 diff --git a/src/main/java/org/bukkit/Location.java b/src/main/java/org/bukkit/Location.java
-index d5d67b3d84cd88ed0f858497e68535ec0162c700..432d5711b7ec34eafeb27df82d367612dfe1fe54 100644
+index 1835d39f6259732e56d51fa746faf1e4c65eaf07..c9b953aa55eeee87e81b9b712c0f501a58e641fb 100644
 --- a/src/main/java/org/bukkit/Location.java
 +++ b/src/main/java/org/bukkit/Location.java
 @@ -638,6 +638,47 @@ public class Location implements Cloneable, ConfigurationSerializable {

--- a/patches/api/0186-Expose-the-internal-current-tick.patch
+++ b/patches/api/0186-Expose-the-internal-current-tick.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 838c9c3eb3ec00632b885d6c9dc21437f66f69bc..1954bf1be7b6c11edb918327a0632d5eda732ae7 100644
+index bec68e0eff61e4d81b9723db601e37a9e1d47c42..5a74cce889b1c41701e862f854b3c45f4970828c 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1859,6 +1859,10 @@ public final class Bukkit {
@@ -20,7 +20,7 @@ index 838c9c3eb3ec00632b885d6c9dc21437f66f69bc..1954bf1be7b6c11edb918327a0632d5e
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b492f4e7c5a78bdbf45d80ba99aec33b493554f1..fd6c42f5ff067dba9c7547a0edff1d0d185f9ac5 100644
+index d7c73eaf5d3075c2f983c31feb303b853fa744b8..cadea9bc73eeb15be32505709caf0e9a99c04967 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1629,5 +1629,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0193-Add-tick-times-API.patch
+++ b/patches/api/0193-Add-tick-times-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1954bf1be7b6c11edb918327a0632d5eda732ae7..d07c493a755b6d89fae6ed7b8d54cc46dc93ba1d 100644
+index 5a74cce889b1c41701e862f854b3c45f4970828c..17c38075b1ac435d2f4446e759548a744e657eed 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1614,6 +1614,25 @@ public final class Bukkit {
@@ -35,7 +35,7 @@ index 1954bf1be7b6c11edb918327a0632d5eda732ae7..d07c493a755b6d89fae6ed7b8d54cc46
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index fd6c42f5ff067dba9c7547a0edff1d0d185f9ac5..c17f3267343fecb962914f653dd44c9173a58308 100644
+index cadea9bc73eeb15be32505709caf0e9a99c04967..5cfb1905a5e4b8812aa7128ebdab9ac32644bfa4 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1365,6 +1365,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0194-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0194-Expose-MinecraftServer-isRunning.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index d07c493a755b6d89fae6ed7b8d54cc46dc93ba1d..ca3690c502f0b269e13ebefa9797140a8243cc92 100644
+index 17c38075b1ac435d2f4446e759548a744e657eed..152ba4281d730643957ead601a91beefce7893da 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1882,6 +1882,15 @@ public final class Bukkit {
@@ -26,7 +26,7 @@ index d07c493a755b6d89fae6ed7b8d54cc46dc93ba1d..ca3690c502f0b269e13ebefa9797140a
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c17f3267343fecb962914f653dd44c9173a58308..6d313381c7aeb1cdc0e20bd4517af71b0897f886 100644
+index 5cfb1905a5e4b8812aa7128ebdab9ac32644bfa4..b45551e606369f69a3777d15c35ffa5af3dfdf67 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1651,5 +1651,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0198-Add-Player-Client-Options-API.patch
+++ b/patches/api/0198-Add-Player-Client-Options-API.patch
@@ -176,7 +176,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index dfe14cda858fee85c8675c129317951ee801ef04..051d33afa1e75156de37fda3d8d1753c46ece574 100644
+index 14457e5ba8809273362b3cab9fc3a9c3e05edf8a..9fdaec602522dbf261f0d91eed69284cea930d9a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;

--- a/patches/api/0200-Fix-Potion-toItemStack-swapping-the-extended-and-upg.patch
+++ b/patches/api/0200-Fix-Potion-toItemStack-swapping-the-extended-and-upg.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Fix Potion#toItemStack swapping the extended and upgraded
 While the Potion class is deprecated, it is still used in some plugins for cross-version potion handling. This issue has existed for a long time, and has caused many heaches along the way.
 
 diff --git a/src/main/java/org/bukkit/potion/Potion.java b/src/main/java/org/bukkit/potion/Potion.java
-index b9dbbfd07dea643d7ac749822548571968adaa94..ac02ae4fc179483b4ac3d1adc41684a8426197eb 100644
+index 2184c8620ca89e3cd769b16061dea1755ce8e03a..c0da4d307426684c1db112f41a729bcf5233452e 100644
 --- a/src/main/java/org/bukkit/potion/Potion.java
 +++ b/src/main/java/org/bukkit/potion/Potion.java
 @@ -267,7 +267,7 @@ public class Potion {

--- a/patches/api/0203-Add-Mob-Goal-API.patch
+++ b/patches/api/0203-Add-Mob-Goal-API.patch
@@ -520,7 +520,7 @@ index 0000000000000000000000000000000000000000..659193fc0596084031c09aa47fbb428a
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ca3690c502f0b269e13ebefa9797140a8243cc92..260f5432e979a19af23fa3150c3b5752ee269faf 100644
+index 152ba4281d730643957ead601a91beefce7893da..f9f9a3f0689e6494bd56f288319930018052c38b 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1891,6 +1891,16 @@ public final class Bukkit {
@@ -541,7 +541,7 @@ index ca3690c502f0b269e13ebefa9797140a8243cc92..260f5432e979a19af23fa3150c3b5752
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 6d313381c7aeb1cdc0e20bd4517af71b0897f886..6698320d76201b28811472a3185ddf129931bd3d 100644
+index b45551e606369f69a3777d15c35ffa5af3dfdf67..e0b79d23f4c16505cf54afb822b2f6c370560931 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1658,5 +1658,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0204-Expose-game-version.patch
+++ b/patches/api/0204-Expose-game-version.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 17553703d6dcb0c7852cc35b08da05075af435f2..4eb60f2772c80f9917e88c40ed2214993709e443 100644
+index f9f9a3f0689e6494bd56f288319930018052c38b..5bbb9e858253d31dc58d1eda1c88c8a84d2fb65a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -118,6 +118,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index 17553703d6dcb0c7852cc35b08da05075af435f2..4eb60f2772c80f9917e88c40ed221499
       * Gets a view of all currently logged in players. This {@linkplain
       * Collections#unmodifiableCollection(Collection) view} is a reused
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0a109e9157d9a9f15f71d2fa96d31b7f8eb3fde2..22495f576b05e3f0161bfd2c4ea5e5622fdb6302 100644
+index e0b79d23f4c16505cf54afb822b2f6c370560931..00904a803418865521c52088bf6fe9db2eb28b31 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -97,6 +97,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0217-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0217-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 38dffc8e66a7a650883a2f765e41443875dca2c6..62aecef4955182f8ba437fa67a88d9610b6a1d7b 100644
+index 5bbb9e858253d31dc58d1eda1c88c8a84d2fb65a..191fbd4441b9287dd0ae30e2a636c1f95e382572 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1514,6 +1514,22 @@ public final class Bukkit {
@@ -32,7 +32,7 @@ index 38dffc8e66a7a650883a2f765e41443875dca2c6..62aecef4955182f8ba437fa67a88d961
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d313a8f13f454c3dcf00a15dbaa83001320c9d61..641fc32df428e4fdc58082cc2c2a95c3925e5fcc 100644
+index 00904a803418865521c52088bf6fe9db2eb28b31..c8798700fbb3885c7522e1170242cba573826358 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1276,6 +1276,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0219-Add-setMaxPlayers-API.patch
+++ b/patches/api/0219-Add-setMaxPlayers-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add #setMaxPlayers API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 26099f95d68540d4e6c54c32fd9699ff01660236..af0cf1fe3db1efd39bc06a89216413fc4415b007 100644
+index 191fbd4441b9287dd0ae30e2a636c1f95e382572..c6648e84f762ae4b2d06e2a5cd08ff1f7739f49a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -171,6 +171,17 @@ public final class Bukkit {
@@ -27,7 +27,7 @@ index 26099f95d68540d4e6c54c32fd9699ff01660236..af0cf1fe3db1efd39bc06a89216413fc
       * Get the game port that the server runs on.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 864211431ebfe9bb333943c31892dfcbdeb33037..64316a3bcba881f9366d9bf9e16b205e2b817707 100644
+index c8798700fbb3885c7522e1170242cba573826358..bc7bfb56bd0291c3ab1d74970057d4b0c52b3075 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -144,6 +144,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0223-Brand-support.patch
+++ b/patches/api/0223-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 051d33afa1e75156de37fda3d8d1753c46ece574..b53eaacafc6515a501d96f68cf8eb20776aa7f33 100644
+index 9fdaec602522dbf261f0d91eed69284cea930d9a..e70e96139d88529e7a1156f61df3da3278da0b07 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2135,6 +2135,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0232-Player-elytra-boost-API.patch
+++ b/patches/api/0232-Player-elytra-boost-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b53eaacafc6515a501d96f68cf8eb20776aa7f33..d06e3bdfb9701451848683b4b6253854a47c39c2 100644
+index e70e96139d88529e7a1156f61df3da3278da0b07..c7e4a2c45c2183f1c9f96340a52f9ba0b30c5d5b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2007,6 +2007,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0233-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0233-Add-getOfflinePlayerIfCached-String.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e73025fcc60f251d7c8c0c961d92e13aeeb49197..eeba408c5942c6cd71739c5d3a5c53f02137cc41 100644
+index c6648e84f762ae4b2d06e2a5cd08ff1f7739f49a..cf7138a9251e92065fef8b0090eaaf779064e2fc 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -986,6 +986,27 @@ public final class Bukkit {
@@ -37,7 +37,7 @@ index e73025fcc60f251d7c8c0c961d92e13aeeb49197..eeba408c5942c6cd71739c5d3a5c53f0
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d3b2188cd2a5d2b597965a216afb08b2c093aab2..55b1cf6b92ac386f3ce50593ee12216a48597437 100644
+index bc7bfb56bd0291c3ab1d74970057d4b0c52b3075..724a32e4a4861f9f9a8ffc5b5a497b458efffc0f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -828,6 +828,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0261-Add-sendOpLevel-API.patch
+++ b/patches/api/0261-Add-sendOpLevel-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d06e3bdfb9701451848683b4b6253854a47c39c2..b5965be8687ded1f48757a43ae6b11edc91570ad 100644
+index c7e4a2c45c2183f1c9f96340a52f9ba0b30c5d5b..58c05bf819fc8b4427a4f07452a5ec18f5e3b445 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2020,6 +2020,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0276-Expose-Tracked-Players.patch
+++ b/patches/api/0276-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b5965be8687ded1f48757a43ae6b11edc91570ad..eede5c2b69388ec9055653b90b7ddce167213a2e 100644
+index 58c05bf819fc8b4427a4f07452a5ec18f5e3b445..69b1cd6d504e30b5c638882aa925033930d45964 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1,6 +1,7 @@

--- a/patches/api/0282-Implement-Keyed-on-World.patch
+++ b/patches/api/0282-Implement-Keyed-on-World.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index eeba408c5942c6cd71739c5d3a5c53f02137cc41..76450ea7a00481c77882a0a8ff4b8b78f8b6e40f 100644
+index cf7138a9251e92065fef8b0090eaaf779064e2fc..4bd7fee100800d0ede600afcde2277b1de9e52f2 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -663,6 +663,18 @@ public final class Bukkit {
@@ -28,7 +28,7 @@ index eeba408c5942c6cd71739c5d3a5c53f02137cc41..76450ea7a00481c77882a0a8ff4b8b78
      /**
       * Gets the map from the given item ID.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 55b1cf6b92ac386f3ce50593ee12216a48597437..3de8f6d9c0b4c19d1e406f0074b06c7afbd18acf 100644
+index 724a32e4a4861f9f9a8ffc5b5a497b458efffc0f..dcdd0c3f3d03e4a3043909cf051faeb665115c34 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -561,6 +561,17 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -79,7 +79,7 @@ index 27d97cde0fb5f6d727656c291e34dc468200f0c0..178a0853bd8136c6a7408f5d49604ceb
  
      /**
 diff --git a/src/main/java/org/bukkit/WorldCreator.java b/src/main/java/org/bukkit/WorldCreator.java
-index 6e6945dd4c770be04ec09da3958fae751717527a..e6a83252f42da31ad38f8dc1beccc7aa2c3f54b8 100644
+index 6774c8176c44dea9cbff69aaf0f27c0a53a2bbb4..c0454d977119b28115b7698a2c4287f0f56efa55 100644
 --- a/src/main/java/org/bukkit/WorldCreator.java
 +++ b/src/main/java/org/bukkit/WorldCreator.java
 @@ -11,6 +11,7 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0286-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
+++ b/patches/api/0286-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
@@ -393,7 +393,7 @@ index 0000000000000000000000000000000000000000..6f560a51277ccbd46a9142cfa057d276
 +    }
 +}
 diff --git a/src/test/java/org/bukkit/AnnotationTest.java b/src/test/java/org/bukkit/AnnotationTest.java
-index b94d87832a271a76a5c8c0c9bf403c35348b31ed..6f50e5b0422afc905650e5519def8ed403cb9c54 100644
+index 32af614abd761e39a412422abe2fcb5272a6374c..dc881ffaa947eac4ba34a9ea0c089eaaf06278c5 100644
 --- a/src/test/java/org/bukkit/AnnotationTest.java
 +++ b/src/test/java/org/bukkit/AnnotationTest.java
 @@ -48,6 +48,8 @@ public class AnnotationTest {

--- a/patches/api/0289-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/api/0289-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add get-set drop chance to EntityEquipment
 
 
 diff --git a/src/main/java/org/bukkit/inventory/EntityEquipment.java b/src/main/java/org/bukkit/inventory/EntityEquipment.java
-index e85c4208f3536277fcd0f8a0f0b4841c4e073b2c..04de95d658b5317937f1acdfd1280dcecfd3137f 100644
+index d5b50a4a954fed35d37f03f1a277cc173ca106df..3f2f5beadfd6df0aaab5853783001ec2cca7a819 100644
 --- a/src/main/java/org/bukkit/inventory/EntityEquipment.java
 +++ b/src/main/java/org/bukkit/inventory/EntityEquipment.java
 @@ -406,4 +406,32 @@ public interface EntityEquipment {

--- a/patches/api/0299-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0299-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
-index c9af02b0f62b3d18da1e91d1ea02ce0864fc60b9..77aefda5aac4602bf5bf71c29600e7450defdd4e 100644
+index 033960f566861e303b9cb61aae4c02add501d93f..694a81769076ea58aae9f14f076ab80c9952c957 100644
 --- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 +++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
 @@ -20,6 +20,7 @@ public class AsyncPlayerPreLoginEvent extends Event {

--- a/patches/api/0302-Add-basic-Datapack-API.patch
+++ b/patches/api/0302-Add-basic-Datapack-API.patch
@@ -70,7 +70,7 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 76450ea7a00481c77882a0a8ff4b8b78f8b6e40f..dec82b3e9c462e5eb815cd79b0711f19d56f4e86 100644
+index 4bd7fee100800d0ede600afcde2277b1de9e52f2..071a0013ac4bad6483c1400e8eb7b842fa1b7496 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1973,6 +1973,14 @@ public final class Bukkit {
@@ -89,7 +89,7 @@ index 76450ea7a00481c77882a0a8ff4b8b78f8b6e40f..dec82b3e9c462e5eb815cd79b0711f19
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 3de8f6d9c0b4c19d1e406f0074b06c7afbd18acf..07c9635ea2e09e823ed7fa164ed854af41fab7dc 100644
+index dcdd0c3f3d03e4a3043909cf051faeb665115c34..f05edac8cdd33daaf1d15a526be4d2ac2b08846d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -1729,5 +1729,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi

--- a/patches/api/0314-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0314-Add-PlayerKickEvent-causes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 38003de85a8098fc78fc947dd975990d478ee908..da83b4cbed0be6f693c7cbb1cc032356f12d7883 100644
+index 69b1cd6d504e30b5c638882aa925033930d45964..5e8814cc317a705eaf8bdd9f3876a5366c0a0226 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -240,6 +240,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM

--- a/patches/api/0321-Add-Git-information-to-version-command-on-startup.patch
+++ b/patches/api/0321-Add-Git-information-to-version-command-on-startup.patch
@@ -104,7 +104,7 @@ index 0000000000000000000000000000000000000000..02ad04c41b9c3ec68b1dcdc22c538340
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index e8414592b3afeb1e5db2b817b8fb7c13e073b9aa..b5158151960db5c474b3aaa24bfa428e2a158fd9 100644
+index 071a0013ac4bad6483c1400e8eb7b842fa1b7496..66580ade2cd8b8795b2d79f7958460162c3a17db 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -50,6 +50,7 @@ import org.bukkit.util.CachedServerIcon;

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -681,7 +681,7 @@ index 7f81dd05ec8945a851b6501854dc894cad240a66..d6b2e7d643f907ddd81d394d9b613e9c
          this.world = new CraftWorld((ServerLevel) this, gen, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1364a4a95e265c042880c99ea6b59dd2725b18ac..57a44f1d466caeccebe0e2498e3833cb953ffd5a 100644
+index 6c1a641f57011f3443e022758e37660034aa240f..a3f27b2e766e0477410e14e55a0c800ab307984c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -805,6 +805,7 @@ public final class CraftServer implements Server {
@@ -744,7 +744,7 @@ index 1364a4a95e265c042880c99ea6b59dd2725b18ac..57a44f1d466caeccebe0e2498e3833cb
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 358475974cf7dfced302bdd7d2390bd95848c737..ce548fe73dcef10adb99045b06ce58135935aee6 100644
+index 7f818c6bed25e0b793cca268b786f61440c429ef..1ac3243555c2c61d6b6717e6826539d9d6a3248b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -129,6 +129,14 @@ public class Main {

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -3484,7 +3484,7 @@ index d31c62b612a5a8016ffbfbb9dc85d9a941c08cf4..fc34cfa8bfb3b82a8e1b28d261f0e901
          super(type, world);
          this.xpReward = 5;
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 17267d9d58ece0140171a297deb59dd54993135a..4a1ca04332e5afe0379276f3cefab7e0bf03a07b 100644
+index d0a5cfd21969bc3d85b88e872c22e4469b754b5c..ddf0889b20b42c17edc2678d809bddf3dacf4c8f 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -725,6 +725,24 @@ public final class ItemStack {
@@ -4038,18 +4038,18 @@ index c0b68bd470d245121e14b75e2c97f6616b83c92a..39fe8f64528ad08594aaaa88e5c989c8
      public BlockState getBlockState(BlockPos pos) {
          int i = pos.getY();
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 836ee63b7ea73165257acbcdf5c7336a2a2e36f3..2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e 100644
+index 2f52148f36e56c503e619634eedd3d46d9f44938..054fcc3713f02e358dfe049491c8d1689ccc750b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -43,6 +43,7 @@ import org.bukkit.scheduler.BukkitWorker;
+@@ -44,6 +44,7 @@ import org.bukkit.scheduler.BukkitWorker;
   */
  public class CraftScheduler implements BukkitScheduler {
  
 +    static Plugin MINECRAFT = new MinecraftInternalPlugin();
      /**
-      * Counter for IDs. Order doesn't matter, only uniqueness.
+      * The start ID for the counter.
       */
-@@ -177,6 +178,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -192,6 +193,11 @@ public class CraftScheduler implements BukkitScheduler {
          this.runTaskTimer(plugin, (Object) task, delay, period);
      }
  
@@ -4061,7 +4061,7 @@ index 836ee63b7ea73165257acbcdf5c7336a2a2e36f3..2b4a922b84eeb2b1b64e43a2ca8bf16d
      public BukkitTask runTaskTimer(Plugin plugin, Object runnable, long delay, long period) {
          CraftScheduler.validate(plugin, runnable);
          if (delay < 0L) {
-@@ -400,13 +406,20 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -415,13 +421,20 @@ public class CraftScheduler implements BukkitScheduler {
                      task.run();
                      task.timings.stopTiming(); // Spigot
                  } catch (final Throwable throwable) {
@@ -4088,10 +4088,10 @@ index 836ee63b7ea73165257acbcdf5c7336a2a2e36f3..2b4a922b84eeb2b1b64e43a2ca8bf16d
                      this.currentTask = null;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index 40f00ccb4b7be6fcf9d4eaa38aba778bf61df6bb..aec92f03951ef15bdf8af84b9b1526a788fd7f4d 100644
+index 592a2a513ebf0002abf1255e11012ecc66adecf0..b89846e0f645c79afec018dae1d64a1bda043ed9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-@@ -39,6 +39,21 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -40,6 +40,21 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
      CraftTask(final Object task) {
          this(null, task, CraftTask.NO_REPEATING, CraftTask.NO_REPEATING);
      }

--- a/patches/server/0008-Add-MinecraftKey-Information-to-Objects.patch
+++ b/patches/server/0008-Add-MinecraftKey-Information-to-Objects.patch
@@ -37,7 +37,7 @@ index 0000000000000000000000000000000000000000..d02bd109399d6b32cbbb5e6f9ec7e650
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 89ab5fd43a7c5057025ed50d6978dbe4301371d5..430d286a73cfdd643e85bdaa97bf91c2c74a342c 100644
+index 0443353c7be86952b83a089b0bd591d37989a459..0b13a1464a9e6c4912e737879b00ae14da99fbf5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -146,7 +146,7 @@ import org.bukkit.event.player.PlayerTeleportEvent;

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -2041,7 +2041,7 @@ index 73556aa988cdd969642bad89345637c534f753b6..d4836d251eeca4c550bf2e7e0d5c039f
  
      public Player.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5fea5bb70 100644
+index 054fcc3713f02e358dfe049491c8d1689ccc750b..07c4d9cd5081378e1b903518f7174fca959cd9e3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 @@ -1,5 +1,6 @@
@@ -2051,7 +2051,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
  import com.google.common.util.concurrent.ThreadFactoryBuilder;
  import java.util.ArrayList;
  import java.util.Comparator;
-@@ -179,7 +180,8 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -194,7 +195,8 @@ public class CraftScheduler implements BukkitScheduler {
      }
  
      public BukkitTask scheduleInternalTask(Runnable run, int delay, String taskName) {
@@ -2061,7 +2061,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
          return handle(task, delay);
      }
  
-@@ -260,7 +262,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -275,7 +277,7 @@ public class CraftScheduler implements BukkitScheduler {
                          }
                          return false;
                      }
@@ -2070,7 +2070,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
          this.handle(task, 0L);
          for (CraftTask taskPending = this.head.getNext(); taskPending != null; taskPending = taskPending.getNext()) {
              if (taskPending == task) {
-@@ -295,7 +297,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -310,7 +312,7 @@ public class CraftScheduler implements BukkitScheduler {
                              }
                          }
                      }
@@ -2079,7 +2079,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
          this.handle(task, 0L);
          for (CraftTask taskPending = this.head.getNext(); taskPending != null; taskPending = taskPending.getNext()) {
              if (taskPending == task) {
-@@ -402,9 +404,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -417,9 +419,7 @@ public class CraftScheduler implements BukkitScheduler {
              if (task.isSync()) {
                  this.currentTask = task;
                  try {
@@ -2089,7 +2089,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
                  } catch (final Throwable throwable) {
                      // Paper start
                      String msg = String.format(
-@@ -438,8 +438,10 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -453,8 +453,10 @@ public class CraftScheduler implements BukkitScheduler {
                  this.runners.remove(task.getTaskId());
              }
          }
@@ -2100,7 +2100,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
          this.debugHead = this.debugHead.getNextHead(currentTick);
      }
  
-@@ -472,6 +474,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -492,6 +494,7 @@ public class CraftScheduler implements BukkitScheduler {
      }
  
      private void parsePending() {
@@ -2108,7 +2108,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
          CraftTask head = this.head;
          CraftTask task = head.getNext();
          CraftTask lastTask = head;
-@@ -490,6 +493,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -510,6 +513,7 @@ public class CraftScheduler implements BukkitScheduler {
              task.setNext(null);
          }
          this.head = lastTask;
@@ -2117,7 +2117,7 @@ index 2b4a922b84eeb2b1b64e43a2ca8bf16dcf58218e..e6a09ed5db245eaecd787503dbfb1ef5
  
      private boolean isReady(final int currentTick) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
-index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2e4efc2a7 100644
+index b89846e0f645c79afec018dae1d64a1bda043ed9..3f45bab0e9f7b3697e6d9d1092a1e6e579f7066f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftTask.java
 @@ -1,12 +1,15 @@
@@ -2137,7 +2137,7 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
  
  public class CraftTask implements BukkitTask, Runnable { // Spigot
  
-@@ -26,12 +29,12 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -26,13 +29,13 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
       */
      private volatile long period;
      private long nextRun;
@@ -2148,12 +2148,13 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
 +    public Timing timings; // Paper
      private final Plugin plugin;
      private final int id;
+     private final long createdAt = System.nanoTime();
  
 -    final CustomTimingsHandler timings; // Spigot
      CraftTask() {
          this(null, null, CraftTask.NO_REPEATING, CraftTask.NO_REPEATING);
      }
-@@ -51,7 +54,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -52,7 +55,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          this.id = id;
          this.period = CraftTask.NO_REPEATING;
          this.taskName = taskName;
@@ -2162,7 +2163,7 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
      }
      // Paper end
  
-@@ -72,7 +75,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -73,7 +76,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          }
          this.id = id;
          this.period = period;
@@ -2171,7 +2172,7 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
      }
  
      @Override
-@@ -92,11 +95,13 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -93,11 +96,13 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
  
      @Override
      public void run() {
@@ -2184,8 +2185,8 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
 +        } // Paper
      }
  
-     long getPeriod() {
-@@ -123,7 +128,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+     long getCreatedAt() {
+@@ -128,7 +133,7 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          this.next = next;
      }
  
@@ -2194,7 +2195,7 @@ index aec92f03951ef15bdf8af84b9b1526a788fd7f4d..0da2c5ef6180fe4da1be7376ba0fb9d2
          return (this.rTask != null) ? this.rTask.getClass() : ((this.cTask != null) ? this.cTask.getClass() : null);
      }
  
-@@ -147,9 +152,4 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
+@@ -152,9 +157,4 @@ public class CraftTask implements BukkitTask, Runnable { // Spigot
          return true;
      }
  

--- a/patches/server/0012-Configurable-baby-zombie-movement-speed.patch
+++ b/patches/server/0012-Configurable-baby-zombie-movement-speed.patch
@@ -25,7 +25,7 @@ index 3618cc017feb60e257a28f67cbddca3f792a9833..796c17e0941922a9716212c6eae91643
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 84a8269060acaa5bf55a1d0a3f79e093bf2e30e5..017d8de4d09f524aed2ee03af7ef79468503edf0 100644
+index 564e8cb28c094a1bb9ab7d214464d6e6d9788bcf..f8b97aa5819e228f31c7953ee6e5c4e69fe55666 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -79,7 +79,7 @@ import org.bukkit.event.entity.EntityTransformEvent;

--- a/patches/server/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0017-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -25,7 +25,7 @@ index 89e76dd73811fd0f6f8c8e7e5af804d5a4bb5a75..d16ae924bcbe31c964f7fb448757c748
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 86493f18913f6d3a560de2e3f8690bd227d73cee..11ed0127e2ea268f16c6b4b380d132a71ec9b3dc 100644
+index 27707ccea8763dbfdfe80da45f26127e58bc7316..91c0e425de193be1e4e9779d1c92c8ea577e29e0 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -127,6 +127,17 @@ public class FallingBlockEntity extends Entity {

--- a/patches/server/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -32,7 +32,7 @@ index fcc775723bcef7c6b740ee332c21ef70e591c77e..0ee92562ef7c6ac99f5bea0b6d0751d0
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d6cb58d5c5f6d2f4aa769f4338ba63b2d55dc971..171c78b405d35464ce0f66333a3798b6b8a0fb7b 100644
+index d096bd229ee581bd8fe40a4e02705d1801dcb2d5..e0a50b7d71d0ddee905e3799264dfb978d1ed0b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -227,7 +227,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -45,7 +45,7 @@ index d6cb58d5c5f6d2f4aa769f4338ba63b2d55dc971..171c78b405d35464ce0f66333a3798b6
      private final String bukkitVersion = Versioning.getBukkitVersion();
      private final Logger logger = Logger.getLogger("Minecraft");
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 3fd48807c554b176cd8e925bdcd68e7f808e5881..9aea2ecf232c91817ae0ff70b3343aa8a97962c2 100644
+index 4d1f1f1438da0cb41188a89c23f6d295b6840808..12ff16869c01aa5459274ae70bad5c9f91f5acbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -210,12 +210,25 @@ public class Main {

--- a/patches/server/0019-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0019-Implement-Paper-VersionChecker.patch
@@ -133,7 +133,7 @@ index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b2
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 409515c406f5b5cfac9872f925dbc67159a5d41f..c49d2dd323e7164ded499e561821da2c0e4be9da 100644
+index fa64a0ea5b6dd9c6031fe54c9030bdb1999ef109..2b54c6980166cb7378e3db42d3a68005ebf451a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -368,6 +368,11 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0021-Player-affects-spawning-API.patch
+++ b/patches/server/0021-Player-affects-spawning-API.patch
@@ -117,7 +117,7 @@ index 389985e022b82c675fb21f363422471bd15b84b0..849616d9ad140285f7aa4d2ffafd6371
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9c643472f0c271dcd41721cc121f7af161cafd9b..f253483eab0610b9c88174d7ae78b24ef5730242 100644
+index cc97a1fb78037e4b09ebe825b5135702f2f19e00..ff239a739ec8c72da82b142a3ecb7f55772e6e0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1778,8 +1778,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0022-Remove-invalid-mob-spawner-tile-entities.patch
+++ b/patches/server/0022-Remove-invalid-mob-spawner-tile-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove invalid mob spawner tile entities
 
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 485cb87e83dd4b4b052905fb7f5f83d3c26f542f..89d280ec732b2d023f9c7ba06b1c3e5be3ef86f5 100644
+index 4a13b18ce609fc6a86da48b0673ccf9d3e0d8292..be1d7d2be46c746b593c3842030412940e2e57f8 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -46,10 +46,12 @@ import net.minecraft.world.level.TickList;

--- a/patches/server/0023-Further-improve-server-tick-loop.patch
+++ b/patches/server/0023-Further-improve-server-tick-loop.patch
@@ -143,7 +143,7 @@ index 0ee92562ef7c6ac99f5bea0b6d0751d0add50f16..6225e9391ddff28d8f71a9f643ef2c41
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 171c78b405d35464ce0f66333a3798b6b8a0fb7b..6210e0ef9e44459c523c70bcb8dfb05f97b868fc 100644
+index e0a50b7d71d0ddee905e3799264dfb978d1ed0b1..200fd7bdd0e1ea45f77932ef16a9ddc4e73b75eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2131,6 +2131,17 @@ public final class CraftServer implements Server {

--- a/patches/server/0024-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0024-Only-refresh-abilities-if-needed.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ed5001c84d5be5c6220c97ae93e7277a32e64de6..13f2e3f6a7f4ffc3394264889b41d6791730d1e7 100644
+index ff239a739ec8c72da82b142a3ecb7f55772e6e0d..4178dc224e3cbff004a55e1e84512ae345d7ec9c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1447,12 +1447,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0027-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0027-Configurable-top-of-nether-void-damage.patch
@@ -29,7 +29,7 @@ index d16ae924bcbe31c964f7fb448757c748e5c4418c..4bba6977a0287837b8927718c040ac61
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e61f3decd7fa30c67acb4b2e4cb9c9c3ce2c9d7a..dbe30ad6a729c5a99f7ff977134738e509dcadad 100644
+index fe08d13e0d25119c48a8872fac6fd2a6ce0170be..2abaa7cac274d30319dd39170000eec9e7330e4d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -622,7 +622,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0031-Fix-lag-from-explosions-processing-dead-entities.patch
+++ b/patches/server/0031-Fix-lag-from-explosions-processing-dead-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix lag from explosions processing dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index d8cd0bb88a5e4de0f7c7731684f5c9829f853f33..a723b60bdb4b90b30b0b26c9488ede2b1177208f 100644
+index 73a2b98a7080f7f033ac79c097f0758fefdba5c0..83f542bc7c5cb9a309202bb37affac3432bb0535 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -208,7 +208,7 @@ public class Explosion {

--- a/patches/server/0032-Optimize-explosions.patch
+++ b/patches/server/0032-Optimize-explosions.patch
@@ -37,7 +37,7 @@ index 6225e9391ddff28d8f71a9f643ef2c41f69e6fe7..d1267242746fe2aee0fd12ed01900e4e
  
          this.profiler.popPush("connection");
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index a723b60bdb4b90b30b0b26c9488ede2b1177208f..5e06fa58bd5064fea4154f7f34fdef6aa08a2daf 100644
+index 83f542bc7c5cb9a309202bb37affac3432bb0535..f833041bb004203f327d33dc7aaade8e9ab36772 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -227,7 +227,7 @@ public class Explosion {

--- a/patches/server/0033-Disable-explosion-knockback.patch
+++ b/patches/server/0033-Disable-explosion-knockback.patch
@@ -19,7 +19,7 @@ index 4881b03d470646843bad1bc343eb6a6ab9072d8e..2222c1bb5f8625eee4d88946e4bfdfa2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ebe33c891e25c729c4373190da86c7a8198b6a55..cc8fb033ca8241acb984e3440a44c7a083e2f3f6 100644
+index 759cd74cda7f0d1f3c0f3bc0a2a941e16258a1c0..5b285714ce231d45d879be83ae36d94eaa8310c0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1380,6 +1380,7 @@ public abstract class LivingEntity extends Entity {
@@ -47,7 +47,7 @@ index ebe33c891e25c729c4373190da86c7a8198b6a55..cc8fb033ca8241acb984e3440a44c7a0
                  if (!this.checkTotemDeathProtection(source)) {
                      SoundEvent soundeffect = this.getDeathSound();
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 5e06fa58bd5064fea4154f7f34fdef6aa08a2daf..edc0845ae735a9cf3e0f1a3a2b7eabf726d62744 100644
+index f833041bb004203f327d33dc7aaade8e9ab36772..35ea80a18234d8125397edb5bab9e86ea526d3ca 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -243,14 +243,14 @@ public class Explosion {

--- a/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
@@ -20,7 +20,7 @@ index 094228ff071218f49d07f8e5343e1544c98e14d1..505cf31d1cc89d463c1b61fdf9b2247c
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3adbe2aa72ffc6441018026e14de54e640487b4f..9dc1339a3975cc3c08e408181dda29878c8f52e2 100644
+index 4178dc224e3cbff004a55e1e84512ae345d7ec9c..b2d17fa187d8de8ff99923fef0485209338f2783 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -371,6 +371,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0044-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0044-Ensure-commands-are-not-ran-async.patch
@@ -48,7 +48,7 @@ index da9f4b3337b49597c17b50964656457cd629a0b7..22c2c121bbcc7b0e15d73d20c9cc83d5
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6210e0ef9e44459c523c70bcb8dfb05f97b868fc..06e32113c6274f3e409f10e46a1162cc56afce88 100644
+index 200fd7bdd0e1ea45f77932ef16a9ddc4e73b75eb..c5b0bd10906a5da569dc6465e2b1913fd9513d51 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -758,6 +758,28 @@ public final class CraftServer implements Server {

--- a/patches/server/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0045-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -19,7 +19,7 @@ index 70e074cdf2087e638af8e0f3878d0ef8eb7305cc..416a6760883cb40367535c7c5acd7797
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index 0b0fb2331b126b6c0c7c3b2af81f3f9d2ad1f081..53130b34e5964acec191e1d8de6bde996f498699 100644
+index 26ed13505c5bcb03fd87bccf29cfdfbe0d1d6d87..2dbdc97bbc0f0960896528cfade12919fde137c4 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -322,7 +322,7 @@ public class Slime extends Mob implements Enemy {

--- a/patches/server/0046-Expose-server-CommandMap.patch
+++ b/patches/server/0046-Expose-server-CommandMap.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index efe86ff7f320c341e835142c96c8b60fddf88985..58fec7e4c83c633209d061bf56a8e76003c781f4 100644
+index c5b0bd10906a5da569dc6465e2b1913fd9513d51..6d5567fde20508a060a7c13e54e1cfa3924f4d0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1769,6 +1769,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0047-Be-a-bit-more-informative-in-maxHealth-exception.patch
+++ b/patches/server/0047-Be-a-bit-more-informative-in-maxHealth-exception.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Be a bit more informative in maxHealth exception
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 4d125e6830684930d78afb99f4865347b8b3e011..b2a91fdff5960975787d4cd8f340f631275290fe 100644
+index b7ca7c5c727f347ca1290176bae652387dffda6d..97dc4aa5dc3cb5cb21e9a2e316a3f729d6896b85 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -99,7 +99,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {

--- a/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9dc1339a3975cc3c08e408181dda29878c8f52e2..cd9998a6bd9f76cdda124ab4a0bc671ec1f00777 100644
+index b2d17fa187d8de8ff99923fef0485209338f2783..a1b816bc32adb4085c5d5457ed24996e0c5f3bc5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0050-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0050-Add-configurable-portal-search-radius.patch
@@ -23,7 +23,7 @@ index 416a6760883cb40367535c7c5acd779742bb8af5..670efbe53241a0ae32d618c83da601cc
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ab291f39efb8b4b41bf5b637caeaef8f7ad677ae..b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6 100644
+index 2abaa7cac274d30319dd39170000eec9e7330e4d..df636b5510693821d9e159624b5ae2c6451d2299 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2900,7 +2900,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
@@ -30,7 +30,7 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index dab62713b33cdb7b2324216f7ad229db06e524d6..161fcf68dc85fc6d7b0034f137b1a5aee26cbb69 100644
+index a1b816bc32adb4085c5d5457ed24996e0c5f3bc5..3a45ad211e5e35a87270b35725693d13f1fdd720 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -885,7 +885,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0053-Add-exception-reporting-event.patch
+++ b/patches/server/0053-Add-exception-reporting-event.patch
@@ -223,12 +223,12 @@ index 2fdb313e8eaed868c36f68c9b7f6a6f9f4864575..c8ed0673ff819cb88d0ee6f53f2a2b9b
                  fileInputStream.close();
              } catch (Throwable var10) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index e6a09ed5db245eaecd787503dbfb1ef5fea5bb70..0735c2fe139ce8d47a04fdba045fe462492723eb 100644
+index 07c4d9cd5081378e1b903518f7174fca959cd9e3..dfc2789009fcaa08baa8054bdac915590b8701d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicInteger;
- import java.util.concurrent.atomic.AtomicReference;
+@@ -17,6 +17,9 @@ import java.util.concurrent.atomic.AtomicReference;
  import java.util.function.Consumer;
+ import java.util.function.IntUnaryOperator;
  import java.util.logging.Level;
 +import com.destroystokyo.paper.ServerSchedulerReportingWrapper;
 +import com.destroystokyo.paper.event.server.ServerExceptionEvent;
@@ -236,7 +236,7 @@ index e6a09ed5db245eaecd787503dbfb1ef5fea5bb70..0735c2fe139ce8d47a04fdba045fe462
  import org.apache.commons.lang.Validate;
  import org.bukkit.plugin.IllegalPluginAccessException;
  import org.bukkit.plugin.Plugin;
-@@ -419,6 +422,8 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -434,6 +437,8 @@ public class CraftScheduler implements BukkitScheduler {
                              msg,
                              throwable);
                      }
@@ -245,7 +245,7 @@ index e6a09ed5db245eaecd787503dbfb1ef5fea5bb70..0735c2fe139ce8d47a04fdba045fe462
                      // Paper end
                  } finally {
                      this.currentTask = null;
-@@ -426,7 +431,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -441,7 +446,7 @@ public class CraftScheduler implements BukkitScheduler {
                  this.parsePending();
              } else {
                  this.debugTail = this.debugTail.setNext(new CraftAsyncDebugger(currentTick + CraftScheduler.RECENT_TICKS, task.getOwner(), task.getTaskClass()));

--- a/patches/server/0055-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0055-Disable-Scoreboards-for-non-players-by-default.patch
@@ -25,7 +25,7 @@ index abbbe1786eb68af02f9d39650aad730ac44aac8a..3ac2ac3db9b1c271b3c21930bb137166
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6..d5816bd67e468924a8f8ff8133883eef18872c4c 100644
+index df636b5510693821d9e159624b5ae2c6451d2299..edb75ce3fe60bc0730b99edca3a6e03ee15714c0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2549,6 +2549,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -37,7 +37,7 @@ index b64f8a4c07a0bb57f68b6fa2c1b12b509a634ad6..d5816bd67e468924a8f8ff8133883eef
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index b750699a64a878fffb5cb6aa1cdda106116bbfb3..f23769ce887bfc646162dd9d14b4ba4cc6790c75 100644
+index 5b285714ce231d45d879be83ae36d94eaa8310c0..6c2adddb3d55e5384d1386788bce13ee4c7a6bbe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -803,6 +803,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0057-Complete-resource-pack-API.patch
+++ b/patches/server/0057-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 65a55bdc3651900f2df0173c267d03335ce56a8a..47758fe59169d019d10f77b40843a44786b43b9b 100644
+index 3a45ad211e5e35a87270b35725693d13f1fdd720..6ee60169ecb5c04b27a4037b44d4d927bd39b5c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;

--- a/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
@@ -30,7 +30,7 @@ index 429b74474ced04d8dd8f038b8590b8dfe178bf4d..716f285e67019b8a62922d09c15883c9
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 43b0ecb3b1c06bbb3b7476c67b29e6deab424ac6..9ca44d8e2de750b821b0d760d49193e94001885a 100644
+index 2e479cd5f7effeadc1ea41f91f5019e42ece0ac1..47f9993c632ff0d8b1f1692b88efc4127be996b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -400,6 +400,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0104a17c07da4cd30baf3ad8aa087b4ca2393377..84b1405b48ab5db8de47e455bbf36412a016b469 100644
+index 47f9993c632ff0d8b1f1692b88efc4127be996b4..bd3c7de5ab0b81ef83ead5a0710240dd52b19728 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2261,5 +2261,23 @@ public final class CraftServer implements Server {

--- a/patches/server/0061-Remove-Metadata-on-reload.patch
+++ b/patches/server/0061-Remove-Metadata-on-reload.patch
@@ -7,7 +7,7 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index da1dbb6768825c42bb1d7533612be1f8accb2497..be2f148d2b045d704df35b952b03cf88279de64f 100644
+index bd3c7de5ab0b81ef83ead5a0710240dd52b19728..6c372692eb6ac813ed071337d6ea98e604133510 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -868,8 +868,16 @@ public final class CraftServer implements Server {

--- a/patches/server/0062-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0062-Handle-Item-Meta-Inconsistencies.patch
@@ -18,7 +18,7 @@ For consistency, the old API methods now forward to use the
 ItemMeta API equivalents, and should deprecate the old API's.
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 4a1ca04332e5afe0379276f3cefab7e0bf03a07b..c97021729460eb5710b38e9dbe6b8da70261da74 100644
+index ddf0889b20b42c17edc2678d809bddf3dacf4c8f..7f44e9e382aa87ad9be94394d05bbcacfb0bacc8 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -13,6 +13,8 @@ import java.text.DecimalFormatSymbols;

--- a/patches/server/0063-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0063-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -30,7 +30,7 @@ index 3ac2ac3db9b1c271b3c21930bb13716669ff64d3..3c78d3234054ce2dc46ef77decb6adb0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
-index aa679dd070b9efd4b4450cfdb5e4d849f5793534..676e5ad3a23bfdccd8f5f7bb9e79c3fa004dc95f 100644
+index 860c4ca60adfbf265299c0db41eadc0384f68779..97a4d3b3709028d322617efdfe9a5aabe2197d82 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/AbstractArrow.java
 @@ -310,7 +310,7 @@ public abstract class AbstractArrow extends Projectile {

--- a/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,7 +44,7 @@ index a492f0b8393c185f0464f0fb0e5d5dce4d0e3824..bcf7fc1bdee10baaff7ec15ad2572061
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 47758fe59169d019d10f77b40843a44786b43b9b..75272f2cd49344fdd243a210d245abc95b34f581 100644
+index 6ee60169ecb5c04b27a4037b44d4d927bd39b5c2..b08c99fc99266eb2dbca8e5c863864d7752fbc76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1703,6 +1703,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0067-Use-a-Shared-Random-for-Entities.patch
+++ b/patches/server/0067-Use-a-Shared-Random-for-Entities.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Shared Random for Entities
 Reduces memory usage and provides ensures more randomness, Especially since a lot of garbage entity objects get created.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0d8590368ed35bd95f3b8abcd34eb172ef8ae43b..9aa25ee1e4e3ad205e9e373bbf95d24bd305e078 100644
+index edb75ce3fe60bc0730b99edca3a6e03ee15714c0..8d667633a01b33d9dd1fd3314f367e0ea8733735 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -153,6 +153,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0069-Optimize-isValidLocation-getType-and-getBlockData-fo.patch
+++ b/patches/server/0069-Optimize-isValidLocation-getType-and-getBlockData-fo.patch
@@ -90,7 +90,7 @@ index c1beb6d5fc3cabfeacf0ffbf563e53ff7984c5d3..452b513e8b89d865a396066adaf4feb1
      @Override
      public FluidState getFluidState(BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index bf5a039553a31ed6e9d9bfa64cbd435b3e551a08..db564e9a866c30d6d7b34fa97185b01e8c788449 100644
+index aa6db78339d6b0661ac3be12c82da92742b5f519..29fda19d7e1a8b6675598de22967e2aec81091fa 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -337,12 +337,28 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0080-Optimize-DataBits.patch
+++ b/patches/server/0080-Optimize-DataBits.patch
@@ -11,7 +11,7 @@ After: http://i.imgur.com/nJ46crB.png
 Optimize redundant converting of static fields into an unsigned long each call by precomputing it in ctor
 
 diff --git a/src/main/java/net/minecraft/util/BitStorage.java b/src/main/java/net/minecraft/util/BitStorage.java
-index 3a2e8bdc215a6af604bfaad01b670a361eb8068d..9b955a027bd2c3cbcfa659a41a6687221c5fea63 100644
+index 65bd706ca96f5c0ec4573da9fb144fb51d2de919..07e1374ac3430662edd9f585e59b785e329f0820 100644
 --- a/src/main/java/net/minecraft/util/BitStorage.java
 +++ b/src/main/java/net/minecraft/util/BitStorage.java
 @@ -12,8 +12,8 @@ public class BitStorage {

--- a/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 75272f2cd49344fdd243a210d245abc95b34f581..b0aeda4898fcdfb8c4e005ba1c9ad3ff2adb70f9 100644
+index b08c99fc99266eb2dbca8e5c863864d7752fbc76..c1f8f0d616a480078abb83eff1c2ccf5b3488f45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -895,6 +895,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
@@ -30,7 +30,7 @@ index 3f676bab4448de3658a4c631916740be7be6a193..a21496bc07c4691b99f9f58a0493e6e0
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b0aeda4898fcdfb8c4e005ba1c9ad3ff2adb70f9..7f9c1eb4fcfae0fc03e59612de11d69493ddb24d 100644
+index c1f8f0d616a480078abb83eff1c2ccf5b3488f45..596ef79ea50c7c01a87ab37962195deb5327ccb5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1900,8 +1900,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0087-EntityRegainHealthEvent-isFastRegen-API.patch
+++ b/patches/server/0087-EntityRegainHealthEvent-isFastRegen-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] EntityRegainHealthEvent isFastRegen API
 Don't even get me started
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 83eaa3c6581c1a3f588278124fed4c811e81e53c..041a61e037e7f6fddd94567f2954be600c737811 100644
+index bcf7fc1bdee10baaff7ec15ad2572061c2c800ec..fe74e130309fbef3f763d875310cbd7a5d9b74fd 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1230,10 +1230,16 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0091-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -515,7 +515,7 @@ index 0000000000000000000000000000000000000000..3377b86c337d0234bbb9b0349e4034a7
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4888c77c3bc415bc69d4aaf89899da7dcc81f402..27a6caea54ddd9efe3fc8da19877bee7fa7f4e3e 100644
+index 8d667633a01b33d9dd1fd3314f367e0ea8733735..8ccbaaed364bfbc0becc72f845bbb284b9f976ce 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -168,6 +168,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -642,7 +642,7 @@ index b79d9d26a8e60f9c0ecd69e9c2f9cfd087e21d23..f23fff80d07ac7d06715efe67cb49ebb
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index 5cb17e8289db0ab38fd36318e2957701d6dfb341..f48b830a9ae8160388cb0d0220a44b1ec9f0d214 100644
+index 9c97a663f37c8a12d5b28e98688de59d62762b3f..79edaefe8f6c027b5ad67c6bdcc0bb84a0582887 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 @@ -13,8 +13,9 @@ import org.bukkit.craftbukkit.CraftWorld;

--- a/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0095-Optional-TNT-doesn-t-move-in-water.patch
@@ -24,7 +24,7 @@ index eb04fdb172a50ec1f5b7fe78fa0e7655246abd60..9b2e9a02ff31c3cb37b67135d0a03441
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index ac57bfb00edd9268e89a7fd7cea36097d61d6951..ad9bbda31a4cdb306ca40f2b99e4b815c4f136bd 100644
+index a70bf50c3a17295bb9ffe30ea86f3b84e134cdbc..f835ef1c7109f56f32da394c9afc9fd35b05b51a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -68,7 +68,7 @@ public class ServerEntity {
@@ -37,7 +37,7 @@ index ac57bfb00edd9268e89a7fd7cea36097d61d6951..ad9bbda31a4cdb306ca40f2b99e4b815
      public ServerEntity(ServerLevel worldserver, Entity entity, int i, boolean flag, Consumer<Packet<?>> consumer, Set<ServerPlayerConnection> trackedPlayers) {
          this.trackedPlayers = trackedPlayers;
 diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
-index abc62c560816d945642d830a020deb28ff2efa37..5a16de4f080c31d6e278363fd1d3e23d48be3db5 100644
+index 8ad1b3cb16533d62deda643ce0cdda308743f78e..dcbd9ec44fb8d1334aca33c136b121ab5c25a0e2 100644
 --- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 +++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 @@ -97,6 +97,27 @@ public class PrimedTnt extends Entity {

--- a/patches/server/0097-Add-server-name-parameter.patch
+++ b/patches/server/0097-Add-server-name-parameter.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add server-name parameter
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 399cb06c7ae3570d08430e8675f141657d1026d4..6985e8dc3d520eb65ae7d885138be81836452c01 100644
+index 12ff16869c01aa5459274ae70bad5c9f91f5acbb..07015442c0a7b9a008c8053dcaabb1caa6ef6a10 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -143,6 +143,14 @@ public class Main {

--- a/patches/server/0098-Only-send-Dragon-Wither-Death-sounds-to-same-world.patch
+++ b/patches/server/0098-Only-send-Dragon-Wither-Death-sounds-to-same-world.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Only send Dragon/Wither Death sounds to same world
 Also fix view distance lookup
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 3a2a20c407374e5e62aa8ef2967a5b189d4e9658..9d6d8bf5f38ec11f26665ae676c46e4ef089670b 100644
+index fb6aef4cdbd2ad4037e20c9302ae5ef07ff0c7ce..e17cf38b791f509447ce2c8ef38411530a0fb09b 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -640,8 +640,9 @@ public class EnderDragon extends Mob implements Enemy {
@@ -22,7 +22,7 @@ index 3a2a20c407374e5e62aa8ef2967a5b189d4e9658..9d6d8bf5f38ec11f26665ae676c46e4e
                      double deltaZ = this.getZ() - player.getZ();
                      double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index e231bb4d0bbb19b219ec78e4c1084103c0070733..03263689479d0f163fceb834bda07e7be13b798d 100644
+index c0fffca28b978e36c8d7324f2c4b1cd931da1251..2f849b21e39d04a27ef88f8c76275f10bf55db3b 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -260,8 +260,9 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob

--- a/patches/server/0101-Don-t-lookup-game-profiles-that-have-no-UUID-and-no-.patch
+++ b/patches/server/0101-Don-t-lookup-game-profiles-that-have-no-UUID-and-no-.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't lookup game profiles that have no UUID and no name
 
 
 diff --git a/src/main/java/net/minecraft/server/players/GameProfileCache.java b/src/main/java/net/minecraft/server/players/GameProfileCache.java
-index cbdd32685ac12c439e3c94a0432595e3052b2cad..caed3ae480f1937e89153287699473abb5e29e39 100644
+index 548627b5a12e79ac31136b2695e45f9452115348..7ef77c38537b85deb7d388a7331e895c54a8ba95 100644
 --- a/src/main/java/net/minecraft/server/players/GameProfileCache.java
 +++ b/src/main/java/net/minecraft/server/players/GameProfileCache.java
 @@ -101,7 +101,7 @@ public class GameProfileCache {

--- a/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
+++ b/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
@@ -19,7 +19,7 @@ index 9b2e9a02ff31c3cb37b67135d0a03441f247d8e2..96247356d7888d5681bff60567add118
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index eed2ef73c33b76222de0f4fd91525cc03eef19b0..521f199e495f3bec232cc9ca36e51e0392afe737 100644
+index 702dbe24bfd19b0999648d4364f68a5675bee6e0..8141935e2ee58bbb58c6b5cfdef5a9a88d7658ec 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -640,6 +640,12 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0111-Cache-user-authenticator-threads.patch
+++ b/patches/server/0111-Cache-user-authenticator-threads.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Cache user authenticator threads
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 0df683b7503d4c34fc8af33b82a4440383702043..16c1cf342532988d3e319fb41cc4dbde09403e1a 100644
+index c8d8d766de86dc3e47b06a355b28d2279820c570..a60b40d8cc802456374625af216c27998f8348b3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -117,6 +117,18 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d19f05f31e7f3b473914146c92984dfb407323b0..18b50fd4efaf25bd67a3c8a9bd879e7042b44451 100644
+index 94fe09fdf6e477eca467287c68d7a8b5a6fbaee0..9847c5d18fc9a6d1689341ea8a989a99880a5581 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2287,5 +2287,24 @@ public final class CraftServer implements Server {

--- a/patches/server/0118-Bound-Treasure-Maps-to-World-Border.patch
+++ b/patches/server/0118-Bound-Treasure-Maps-to-World-Border.patch
@@ -34,7 +34,7 @@ index a0c4bc4eb42a3d2de6f66510d88f92c06b535353..c2c54dc4bbfe469f2b8c751012b93d5e
          return (double) pos.getMaxBlockX() > this.getMinX() && (double) pos.getMinBlockX() < this.getMaxX() && (double) pos.getMaxBlockZ() > this.getMinZ() && (double) pos.getMinBlockZ() < this.getMaxZ();
      }
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
-index a66a02d2d1294060048c3c2b2219af87cdb13060..3878a7f6402a1dff1e019e16dd8772ec7303ebe7 100644
+index 9aaa5faff7cdabd54189598b0938fdc6354e2bb8..d7129f3379f2edecbcfd85f83d75e4d7064ce71d 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 @@ -168,6 +168,7 @@ public abstract class StructureFeature<C extends FeatureConfiguration> {

--- a/patches/server/0120-Optimize-ItemStack.isEmpty.patch
+++ b/patches/server/0120-Optimize-ItemStack.isEmpty.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimize ItemStack.isEmpty()
 Remove hashMap lookup every check, simplify code to remove ternary
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 7a50160c2cace5ef7a2f1f3834574e389fd32aaa..404a9f22b3a67aa042449fa2c1a1c31095c256b9 100644
+index 7f44e9e382aa87ad9be94394d05bbcacfb0bacc8..d921113214e7bf3693e80d417f3c5ae217500e7a 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -239,7 +239,7 @@ public final class ItemStack {

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,7 +26,7 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7f9c1eb4fcfae0fc03e59612de11d69493ddb24d..af292ee192b3ca4a4cfde2e7df114e6004d5c45c 100644
+index 596ef79ea50c7c01a87ab37962195deb5327ccb5..76c749566b9cd41dea3c4520f6773620f7caedf2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -249,6 +249,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0128-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/patches/server/0128-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8024e7d245960b3ef6ab33a285b63e9d2ad117e2..6e9155710d51b4f7a8143f0c1d0ecf0190fc8681 100644
+index 8ccbaaed364bfbc0becc72f845bbb284b9f976ce..5acc5d9150961223904b8d0bb9ea880feb60ebf5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2244,6 +2244,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -39,7 +39,7 @@ index 5acc5d9150961223904b8d0bb9ea880feb60ebf5..01cfa488e7b25b7c65e71908bb6f5e6b
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a3dae798fe63e21f86a380f09ba802b2104ad7e8..489ce149e1922ef4bd09716dee079c0cc5aa1de2 100644
+index 9fb669c0199a73136bf5b5a86fa60036dc67bd3e..966f2217a0b20f594d40a7a1f69d324d808a098c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3227,8 +3227,11 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0131-Remove-CraftScheduler-Async-Task-Debugger.patch
+++ b/patches/server/0131-Remove-CraftScheduler-Async-Task-Debugger.patch
@@ -9,10 +9,10 @@ One report of a suspected memory leak with the system.
 This adds additional overhead to asynchronous task dispatching
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 0735c2fe139ce8d47a04fdba045fe462492723eb..6435d53dcddc1a43420f1ea66fa08e154b82586d 100644
+index dfc2789009fcaa08baa8054bdac915590b8701d6..d96292052633941102c052894bef747817b2998f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -430,7 +430,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -445,7 +445,7 @@ public class CraftScheduler implements BukkitScheduler {
                  }
                  this.parsePending();
              } else {
@@ -21,7 +21,7 @@ index 0735c2fe139ce8d47a04fdba045fe462492723eb..6435d53dcddc1a43420f1ea66fa08e15
                  this.executor.execute(new ServerSchedulerReportingWrapper(task)); // Paper
                  // We don't need to parse pending
                  // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
-@@ -447,7 +447,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -462,7 +462,7 @@ public class CraftScheduler implements BukkitScheduler {
          this.pending.addAll(temp);
          temp.clear();
          MinecraftTimings.bukkitSchedulerFinishTimer.stopTiming(); // Paper
@@ -30,7 +30,7 @@ index 0735c2fe139ce8d47a04fdba045fe462492723eb..6435d53dcddc1a43420f1ea66fa08e15
      }
  
      private void addTask(final CraftTask task) {
-@@ -507,10 +507,15 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -527,10 +527,15 @@ public class CraftScheduler implements BukkitScheduler {
  
      @Override
      public String toString() {

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,7 +20,7 @@ index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 18b50fd4efaf25bd67a3c8a9bd879e7042b44451..ba57165ba28e497e75dcf1f239c404d48331a1ef 100644
+index 9847c5d18fc9a6d1689341ea8a989a99880a5581..9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2306,5 +2306,10 @@ public final class CraftServer implements Server {

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 5574354bc3422b0c3a2623e2b16565a6b80cadc7..05bc50229dcdcf173918a04e0e0ecaffb07e04a2 100644
+index f06e7871780e863f5dd34338b008b739a471709a..eaf938718764cae71f35077623796084ac0308d4 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -19,7 +19,17 @@ repositories {
@@ -244,7 +244,7 @@ index 24add1cd1f865012c5382548e415218d481ecefe..31dccb0b4ab60d6cedf236fc7d51a363
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dadb60f0a1d8d0753e030ed9fd5f4235083e7808..914d2e16dd47db5a44b738d4c45af24b22ff0c2b 100644
+index 9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b..c904c969b7a64f1b90f570d76ac5eb542eff9ba6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -46,7 +46,6 @@ import java.util.function.Consumer;
@@ -278,7 +278,7 @@ index dadb60f0a1d8d0753e030ed9fd5f4235083e7808..914d2e16dd47db5a44b738d4c45af24b
      @Override
      public PluginCommand getPluginCommand(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 213ff112be27f02c3742265cea6478a6f8130c99..787db22e4d7df30ccf3d92297fbd2f08ff87beb5 100644
+index 07015442c0a7b9a008c8053dcaabb1caa6ef6a10..806e5e55ea2596d221e375f7a005488abef33d19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -12,7 +12,7 @@ import java.util.logging.Level;

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e95a01e582b6c8996f4b366f5fd9b783658e6bff..66e4851eb8565fe1c3f49b48d62ca5d004746a36 100644
+index c904c969b7a64f1b90f570d76ac5eb542eff9ba6..8667373de82ce335fb0c55e39e6c1e1e791d70ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -788,7 +788,13 @@ public final class CraftServer implements Server {

--- a/patches/server/0146-Block-player-logins-during-server-shutdown.patch
+++ b/patches/server/0146-Block-player-logins-during-server-shutdown.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Block player logins during server shutdown
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 16c1cf342532988d3e319fb41cc4dbde09403e1a..da563f3dd075d4d0000f13e6b5a88e2b4a9bc871 100644
+index a60b40d8cc802456374625af216c27998f8348b3..ab3409dd3a7671b46cba210cfa326311d10a7ef4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -69,6 +69,12 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0154-Ocelot-despawns-should-honor-nametags-and-leash.patch
+++ b/patches/server/0154-Ocelot-despawns-should-honor-nametags-and-leash.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ocelot despawns should honor nametags and leash
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Ocelot.java b/src/main/java/net/minecraft/world/entity/animal/Ocelot.java
-index 38ddb72b53fcf0d6a9331d23b11572e9f85e70e3..8104ac0f77e8e94f294b82f7badefccd72419223 100644
+index d3ce5cb3d78788cbb34d947495eafd24695f1ccb..06bf44ceb6f959a99f268fe1e1dca494985fbf4e 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Ocelot.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Ocelot.java
 @@ -133,7 +133,7 @@ public class Ocelot extends Animal {

--- a/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -27,7 +27,7 @@ index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index da563f3dd075d4d0000f13e6b5a88e2b4a9bc871..cc7a4f8a4b351011dfd131b30c4b9386fde84e95 100644
+index ab3409dd3a7671b46cba210cfa326311d10a7ef4..82d0979e3239dddf3951df4a8b65ae7319d3d5b5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -297,6 +297,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0157-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0157-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,7 +15,7 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 168728c96f8a8aaf5912f4d70cb5939daeb9cb27..8967d19c1ffa3b6cc38b53cbbc1341fe0ed4c60b 100644
+index eaf938718764cae71f35077623796084ac0308d4..3360889a8a067a5f1cb703df88484b4f5f87c8ce 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -28,7 +28,7 @@ dependencies {

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,7 +90,7 @@ index c4ba069f5124ec151e05813beddf293fddc3b804..484221e5a9c246aa91e0eacef3911b0e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index af292ee192b3ca4a4cfde2e7df114e6004d5c45c..b894b849d0063ea54696de8d0cb8286a14c45e7b 100644
+index 76c749566b9cd41dea3c4520f6773620f7caedf2..284772518ecb00d9e83a9e22480842deeba47dd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -193,6 +193,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0164-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0164-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 489ce149e1922ef4bd09716dee079c0cc5aa1de2..4da63e5c35b1736f2d55713b39b64cc31ecbc9c9 100644
+index 966f2217a0b20f594d40a7a1f69d324d808a098c..571ca7409cdce36ce228c7f3ebf2bce7a87897df 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@

--- a/patches/server/0165-Prevent-logins-from-being-processed-when-the-player-.patch
+++ b/patches/server/0165-Prevent-logins-from-being-processed-when-the-player-.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Prevent logins from being processed when the player has
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index cc7a4f8a4b351011dfd131b30c4b9386fde84e95..7224aa974a3936a68d1c1210c671192812af93c9 100644
+index 82d0979e3239dddf3951df4a8b65ae7319d3d5b5..109d7f1bf37e442ff80f7f63d50e27e6e30e0b5e 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -76,7 +76,11 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -72,7 +72,7 @@ index cf42d59254f2786bfe8785249ad270d35996417a..8c2242d7e443bee26741608c65d314d8
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c9de4bda38ae28067b03ceef2e2a6972a6920370..40b0489faa4da7888addfd2a028bbf1e7578e6be 100644
+index df03db15e0a7d90ada2ae2a7990472ec2ca72806..c9bc580b1fb274ea2af31adab0440132e3775ba6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1856,7 +1856,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0170-PlayerPickupExperienceEvent.patch
+++ b/patches/server/0170-PlayerPickupExperienceEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] PlayerPickupExperienceEvent
 Allows plugins to cancel a player picking up an experience orb
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index cb0194d688ae176e0fba6c48cf59a51ceb1a5c4e..628407ad2f8fd01850dd4f9e25799bcd6a93961d 100644
+index ea01f84448693ca740b5f3381a9c500e5aa3914e..707380c41df3a5783953ee0b6fe81b55fc7ed3cd 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -300,7 +300,7 @@ public class ExperienceOrb extends Entity {

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,7 +28,7 @@ index 6f25e9f41d93a225acaa6575954967438a6cabbf..d439e8ce87bf7da03683a336941c7673
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b894b849d0063ea54696de8d0cb8286a14c45e7b..05a427f238d48c8bb815083c21e62f8e5cb75ed0 100644
+index 284772518ecb00d9e83a9e22480842deeba47dd0..18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -61,11 +61,14 @@ import net.minecraft.server.level.ServerPlayer;

--- a/patches/server/0173-PlayerNaturallySpawnCreaturesEvent.patch
+++ b/patches/server/0173-PlayerNaturallySpawnCreaturesEvent.patch
@@ -36,7 +36,7 @@ index 5ce8ac377b0d2b05dd90baa67f420945cc419609..919a489a5c7b338659c62ae67fc0a6ce
          });
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 672c6651043a4efd65e472bbd519f54861ec008a..6757971ee556da2470de8b4579d906452acd36fe 100644
+index bafd97074461d5b17b21579ba493ba8eae8468d8..2c0dd4b5a751e413936f399106367d4b22c17dda 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -631,6 +631,15 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0175-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0175-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,7 +7,7 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
-index 1879ae835c437883f76330d6e2707460273d02db..df0ba7ed56fc635a4aa30934d1990043dbc3d8dc 100644
+index b08975f337c41fb8211563703b46328baf858566..6f776b44c1bafc299b15fd17140f9619f86ddba9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 @@ -1,5 +1,7 @@

--- a/patches/server/0182-Disable-Explicit-Network-Manager-Flushing.patch
+++ b/patches/server/0182-Disable-Explicit-Network-Manager-Flushing.patch
@@ -12,7 +12,7 @@ flushing on the netty event loop, so it won't do the flush on the main thread.
 Renable flushing by passing -Dpaper.explicit-flush=true
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 1d46187969b5792c255d0bf1966b427b905cb69c..0c5c62be83223e20f216df84413b8c2438db81ff 100644
+index 06e965996a5c50bce617847e594ae0dd83403484..636ac646bec67dbd933f00614693af03481b6173 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -86,6 +86,7 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {

--- a/patches/server/0184-Improved-Async-Task-Scheduler.patch
+++ b/patches/server/0184-Improved-Async-Task-Scheduler.patch
@@ -159,10 +159,10 @@ index 0000000000000000000000000000000000000000..3c1992e212a6d6f1db4d5b807b38d719
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf7442a8ccd16 100644
+index d96292052633941102c052894bef747817b2998f..ea7ebbc2674df727cf44856f172731ee083b8800 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -63,7 +63,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -78,7 +78,7 @@ public class CraftScheduler implements BukkitScheduler {
      /**
       * Main thread logic only
       */
@@ -171,7 +171,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
              new Comparator<CraftTask>() {
                  @Override
                  public int compare(final CraftTask o1, final CraftTask o2) {
-@@ -80,12 +80,13 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -95,12 +95,13 @@ public class CraftScheduler implements BukkitScheduler {
      /**
       * These are tasks that are currently active. It's provided for 'viewing' the current state.
       */
@@ -187,7 +187,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
      private final Executor executor = Executors.newCachedThreadPool(new ThreadFactoryBuilder().setNameFormat("Craft Scheduler Thread - %d").build());
      private CraftAsyncDebugger debugHead = new CraftAsyncDebugger(-1, null, null) {
          @Override
-@@ -94,12 +95,31 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -109,12 +110,31 @@ public class CraftScheduler implements BukkitScheduler {
          }
      };
      private CraftAsyncDebugger debugTail = this.debugHead;
@@ -219,7 +219,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
      @Override
      public int scheduleSyncDelayedTask(final Plugin plugin, final Runnable task) {
          return this.scheduleSyncDelayedTask(plugin, task, 0L);
-@@ -222,7 +242,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -237,7 +257,7 @@ public class CraftScheduler implements BukkitScheduler {
          } else if (period < CraftTask.NO_REPEATING) {
              period = CraftTask.NO_REPEATING;
          }
@@ -228,7 +228,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
      }
  
      @Override
-@@ -238,6 +258,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -253,6 +273,11 @@ public class CraftScheduler implements BukkitScheduler {
          if (taskId <= 0) {
              return;
          }
@@ -240,7 +240,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          CraftTask task = this.runners.get(taskId);
          if (task != null) {
              task.cancel0();
-@@ -280,6 +305,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -295,6 +320,11 @@ public class CraftScheduler implements BukkitScheduler {
      @Override
      public void cancelTasks(final Plugin plugin) {
          Validate.notNull(plugin, "Cannot cancel tasks of null plugin");
@@ -252,7 +252,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          final CraftTask task = new CraftTask(
                  new Runnable() {
                      @Override
-@@ -319,6 +349,13 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -334,6 +364,13 @@ public class CraftScheduler implements BukkitScheduler {
  
      @Override
      public boolean isCurrentlyRunning(final int taskId) {
@@ -266,7 +266,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          final CraftTask task = this.runners.get(taskId);
          if (task == null) {
              return false;
-@@ -337,6 +374,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -352,6 +389,11 @@ public class CraftScheduler implements BukkitScheduler {
          if (taskId <= 0) {
              return false;
          }
@@ -278,7 +278,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          for (CraftTask task = this.head.getNext(); task != null; task = task.getNext()) {
              if (task.getTaskId() == taskId) {
                  return task.getPeriod() >= CraftTask.NO_REPEATING; // The task will run
-@@ -348,6 +390,12 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -363,6 +405,12 @@ public class CraftScheduler implements BukkitScheduler {
  
      @Override
      public List<BukkitWorker> getActiveWorkers() {
@@ -291,7 +291,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          final ArrayList<BukkitWorker> workers = new ArrayList<BukkitWorker>();
          for (final CraftTask taskObj : this.runners.values()) {
              // Iterator will be a best-effort (may fail to grab very new values) if called from an async thread
-@@ -385,6 +433,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -400,6 +448,11 @@ public class CraftScheduler implements BukkitScheduler {
                  pending.add(task);
              }
          }
@@ -303,7 +303,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          return pending;
      }
  
-@@ -392,6 +445,11 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -407,6 +460,11 @@ public class CraftScheduler implements BukkitScheduler {
       * This method is designed to never block or wait for locks; an immediate execution of all current tasks.
       */
      public void mainThreadHeartbeat(final int currentTick) {
@@ -315,7 +315,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          this.currentTick = currentTick;
          final List<CraftTask> temp = this.temp;
          this.parsePending();
-@@ -431,7 +489,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -446,7 +504,7 @@ public class CraftScheduler implements BukkitScheduler {
                  this.parsePending();
              } else {
                  //this.debugTail = this.debugTail.setNext(new CraftAsyncDebugger(currentTick + CraftScheduler.RECENT_TICKS, task.getOwner(), task.getTaskClass())); // Paper
@@ -324,7 +324,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
                  // We don't need to parse pending
                  // (async tasks must live with race-conditions if they attempt to cancel between these few lines of code)
              }
-@@ -450,7 +508,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -465,7 +523,7 @@ public class CraftScheduler implements BukkitScheduler {
          //this.debugHead = this.debugHead.getNextHead(currentTick); // Paper
      }
  
@@ -333,7 +333,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          final AtomicReference<CraftTask> tail = this.tail;
          CraftTask tailTask = tail.get();
          while (!tail.compareAndSet(tailTask, task)) {
-@@ -459,7 +517,13 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -474,7 +532,13 @@ public class CraftScheduler implements BukkitScheduler {
          tailTask.setNext(task);
      }
  
@@ -348,8 +348,8 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          task.setNextRun(this.currentTick + delay);
          this.addTask(task);
          return task;
-@@ -478,8 +542,8 @@ public class CraftScheduler implements BukkitScheduler {
-         return this.ids.incrementAndGet();
+@@ -498,8 +562,8 @@ public class CraftScheduler implements BukkitScheduler {
+         return id;
      }
  
 -    private void parsePending() {
@@ -359,7 +359,7 @@ index 6435d53dcddc1a43420f1ea66fa08e154b82586d..dd1e8b170e87bff2089f642f41dcf744
          CraftTask head = this.head;
          CraftTask task = head.getNext();
          CraftTask lastTask = head;
-@@ -498,7 +562,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -518,7 +582,7 @@ public class CraftScheduler implements BukkitScheduler {
              task.setNext(null);
          }
          this.head = lastTask;

--- a/patches/server/0185-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
+++ b/patches/server/0185-Ability-to-change-PlayerProfile-in-AsyncPreLoginEven.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Ability to change PlayerProfile in AsyncPreLoginEvent
 This will allow you to change the players name or skin on login.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 7224aa974a3936a68d1c1210c671192812af93c9..94b1ec73f2039c83203045db42bf0270c985d995 100644
+index 109d7f1bf37e442ff80f7f63d50e27e6e30e0b5e..261ebb134a5ff40406e74237f730aad1c78a8215 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -1,5 +1,7 @@

--- a/patches/server/0186-Player.setPlayerProfile-API.patch
+++ b/patches/server/0186-Player.setPlayerProfile-API.patch
@@ -39,7 +39,7 @@ index da0176ed9d51aef76d9c439a03718c1635c35333..f9593486e5382c629e0febd43b3d7464
      private ItemStack lastItemInMainHand;
      private final ItemCooldowns cooldowns;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 05a427f238d48c8bb815083c21e62f8e5cb75ed0..69314b3a371ba96a91fb9096dd24d7cedf341560 100644
+index 18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f..b24fa0876a3573b9000689fa540709f08d529f64 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -71,6 +71,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;

--- a/patches/server/0191-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0191-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 69314b3a371ba96a91fb9096dd24d7cedf341560..f0d0becf8730eac257d5b3d5f6a14ac881359220 100644
+index b24fa0876a3573b9000689fa540709f08d529f64..0ce5e35d1ca59587301edba56ddcf2a4e7fbe247 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -150,6 +150,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0196-Enderman.teleportRandomly.patch
+++ b/patches/server/0196-Enderman.teleportRandomly.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Enderman.teleportRandomly()
 Ability to trigger the vanilla "teleport randomly" mechanic of an enderman.
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index 29e53aebd1dc22d5dd2753cc7acbea425cb0054e..dedab212105f55ebce31f2309e34d8c3136c193f 100644
+index 8e8eea175e75f2a56a12bf1c23a5d22bf8047bb5..62717899cafaf5452e5bd5e665ecae38f3bd6a2b 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -277,7 +277,7 @@ public class EnderMan extends Monster implements NeutralMob {

--- a/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
@@ -27,7 +27,7 @@ index 9225372cb9ef51a8cfbd4cee543c250aa2ac9c49..a0a846a2e60bdc17537bd697137f6532
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index c72ec22beff6aa1f7932fa44dc7d591ceeec1158..c25cb17ef1a7c56e10ce3ccb5665c9dce3e6efa6 100644
+index e4294219be68c6f99cd0e5ea8330fae6dc03ddde..b09f52330b50879d5594b21302e70ca676b60951 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -88,6 +88,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0200-EndermanAttackPlayerEvent.patch
+++ b/patches/server/0200-EndermanAttackPlayerEvent.patch
@@ -8,7 +8,7 @@ Allow control over whether or not an enderman aggros a player.
 This allows you to override/extend the pumpkin/stare logic.
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index dedab212105f55ebce31f2309e34d8c3136c193f..abd1130529dd74780054e26bac89cf757ba9cdc1 100644
+index 62717899cafaf5452e5bd5e665ecae38f3bd6a2b..72e5e1edaa047d491daeef8ece3638dad30e32ca 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -220,7 +220,15 @@ public class EnderMan extends Monster implements NeutralMob {

--- a/patches/server/0201-WitchConsumePotionEvent.patch
+++ b/patches/server/0201-WitchConsumePotionEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] WitchConsumePotionEvent
 Fires when a witch consumes the potion in their hand
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index 0c04665c6e2f5624e21e269d706fea842d54cefd..ecb3843ff3b4f0034f6aaa16cfc09cbd046d9008 100644
+index c38161a20ec0f17cdba853b5267625aaa8c96222..01875b3199e193365f5da86023bb83ca819241aa 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
 @@ -124,7 +124,11 @@ public class Witch extends Raider implements RangedAttackMob {

--- a/patches/server/0202-WitchThrowPotionEvent.patch
+++ b/patches/server/0202-WitchThrowPotionEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] WitchThrowPotionEvent
 Fired when a witch throws a potion at a player
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index ecb3843ff3b4f0034f6aaa16cfc09cbd046d9008..e2762c6c37975eb2da59d408998a5c0368c146d1 100644
+index 01875b3199e193365f5da86023bb83ca819241aa..29c4ce6ae511833fd591d3bf8cceac910a429853 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
 @@ -236,9 +236,16 @@ public class Witch extends Raider implements RangedAttackMob {

--- a/patches/server/0204-WitchReadyPotionEvent.patch
+++ b/patches/server/0204-WitchReadyPotionEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] WitchReadyPotionEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Witch.java b/src/main/java/net/minecraft/world/entity/monster/Witch.java
-index e2762c6c37975eb2da59d408998a5c0368c146d1..5e2e8cb5eba4ba36065f07abed954b2aad022321 100644
+index 29c4ce6ae511833fd591d3bf8cceac910a429853..e26ce4d8b3a3af8d6347f8c8c36703aeb06da520 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Witch.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Witch.java
 @@ -157,7 +157,11 @@ public class Witch extends Raider implements RangedAttackMob {

--- a/patches/server/0205-ItemStack-getMaxItemUseDuration.patch
+++ b/patches/server/0205-ItemStack-getMaxItemUseDuration.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] ItemStack#getMaxItemUseDuration
 Allows you to determine how long it takes to use a usable/consumable item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index 799af645a0a39877dc36417110a73fe33d743ba4..982da5f98601c6b3095d78e69e02554640708c64 100644
+index 379612cb78d275fa61125390c7429fcb2920ab33..efdcccac85626835ff29ed00976978d5bb900356 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -172,6 +172,13 @@ public final class CraftItemStack extends ItemStack {

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -19,7 +19,7 @@ index a0a846a2e60bdc17537bd697137f65321c1a61d8..e1110274a9f6b8f7007537732ec8eff7
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4da63e5c35b1736f2d55713b39b64cc31ecbc9c9..848a000d7a959e161011b21012e5d9c438b55455 100644
+index 571ca7409cdce36ce228c7f3ebf2bce7a87897df..0a954a83e29f2ffc622675f671416bdadc1d3f6a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3668,12 +3668,24 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement EntityKnockbackByEntityEvent
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 848a000d7a959e161011b21012e5d9c438b55455..ab34cf7d603ba0fd8624db821b2c0e9e22286c63 100644
+index 0a954a83e29f2ffc622675f671416bdadc1d3f6a..91a0699ba30fa1e9c8172e07f034ea1fabee9d11 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1437,7 +1437,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0224-Use-asynchronous-Log4j-2-loggers.patch
+++ b/patches/server/0224-Use-asynchronous-Log4j-2-loggers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 8967d19c1ffa3b6cc38b53cbbc1341fe0ed4c60b..f66a20f09f86f754d020d8f1cd2d57f47003fe85 100644
+index 3360889a8a067a5f1cb703df88484b4f5f87c8ce..03a37d0429b6e1f18d90f0fa8268071965f6bae3 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -39,6 +39,7 @@ dependencies {

--- a/patches/server/0225-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0225-add-more-information-to-Entity.toString.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 2aa6c6b4a5a431b6860e91684cf20514fbb52676..d32b3ae17d61753f759008316aa6818cdaa1ef83 100644
+index b0422e655fa836b5ff44f56a2ba9b4318e56e93e..34bf0fd30a0a3549b35659d65edfe78a4e6e8fd4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2809,7 +2809,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0226-Add-CraftMagicNumbers.isSupportedApiVersion.patch
+++ b/patches/server/0226-Add-CraftMagicNumbers.isSupportedApiVersion.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add CraftMagicNumbers.isSupportedApiVersion()
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index c49d2dd323e7164ded499e561821da2c0e4be9da..ad8d6a84e1a66e03ae15269e36bc787148f12396 100644
+index 2b54c6980166cb7378e3db42d3a68005ebf451a1..f8cb210390958ddba9f9685f2ec1f8bb91690162 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -373,6 +373,11 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0233-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0233-Vanished-players-don-t-have-rights.patch
@@ -24,10 +24,10 @@ index b09f52330b50879d5594b21302e70ca676b60951..d7d4aa7ed2f321df8099adb97a3c699e
              return false;
          }
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index 86d245c9a817be5fd2be7f331d3a3a5f3169e8c2..44b28773fe8e79931e738d493bd9405e0ee3dca9 100644
+index b65736c8395c04b29f97d460a8559c2e44ed3a4f..8e6df16568c0dab482e10ad1b38920d77f6e684f 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
-@@ -191,7 +191,8 @@ public class BlockItem extends Item {
+@@ -195,7 +195,8 @@ public class BlockItem extends Item {
          Player entityhuman = context.getPlayer();
          CollisionContext voxelshapecollision = entityhuman == null ? CollisionContext.empty() : CollisionContext.of((Entity) entityhuman);
          // CraftBukkit start - store default return

--- a/patches/server/0238-AnvilDamageEvent.patch
+++ b/patches/server/0238-AnvilDamageEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] AnvilDamageEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
-index 6a9597572714706052103677bfb6142a5be2e134..1dad9577370bb58b27b32b997a505ce5145a6769 100644
+index 2e501ea5f2dc2f13bff9531dcc71e6b7d9b53864..0d1e828debc87c6ddc569dfa8f85be9918365dc1 100644
 --- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
 @@ -90,6 +90,16 @@ public class AnvilMenu extends ItemCombinerMenu {

--- a/patches/server/0239-Add-hand-to-bucket-events.patch
+++ b/patches/server/0239-Add-hand-to-bucket-events.patch
@@ -139,7 +139,7 @@ index 1fef077a6d5efc8bdc171b5c6e2a49129f8589ce..ac46dac8be79953720fab6485caf677f
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5d2e1c12feac542463edc7b0e44501c241812310..52597fe89ed9bb42dcd74f8e9a9d80e1644b2dca 100644
+index 5ea27e14b42336d60fa689f73e952aac76f0867c..6fd016daeab42b43bf4b1efb4f715b28c45a88c3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -222,7 +222,7 @@ public class CraftEventFactory {

--- a/patches/server/0240-Add-TNTPrimeEvent.patch
+++ b/patches/server/0240-Add-TNTPrimeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add TNTPrimeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
-index 401a105a161c23a8d3fe45d0a7c845072afb8bd9..c98202092752a9015aaf95bd1471135b88e84425 100644
+index 3a01ffffcc37a93866b8b6774874959dfcabba26..29aa428e019681af8d6b0020c12b18660ff6af6c 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/enderdragon/EnderDragon.java
 @@ -536,6 +536,11 @@ public class EnderDragon extends Mob implements Enemy {

--- a/patches/server/0242-MC-135506-Experience-should-save-as-Integers.patch
+++ b/patches/server/0242-MC-135506-Experience-should-save-as-Integers.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] MC-135506: Experience should save as Integers
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
-index 628407ad2f8fd01850dd4f9e25799bcd6a93961d..1947905e1e7e0208ad79f521cae8973c31c4eac1 100644
+index 707380c41df3a5783953ee0b6fe81b55fc7ed3cd..1caf10ecf949e0f465ffe573f3bed1a3c5733a7f 100644
 --- a/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/src/main/java/net/minecraft/world/entity/ExperienceOrb.java
 @@ -283,7 +283,7 @@ public class ExperienceOrb extends Entity {

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -48,7 +48,7 @@ index 2bbed2eb8f992764deac2cd5e08471aa0f967606..d0d524bfe7ae90f6d2edefa4063bf009
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b18247e6a798a8157e836d1f6b159b9b09c9884e..a81cc2169bf1fe44c8d6df95398210c6455713fd 100644
+index 096caeab9813d59e4b086c379e100d8b22713194..6338f32acb10fdb8a6cf8004e78096db33ce1aec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -806,6 +806,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0250-Optimize-BlockPosition-helper-methods.patch
+++ b/patches/server/0250-Optimize-BlockPosition-helper-methods.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimize BlockPosition helper methods
 Resolves #1338
 
 diff --git a/src/main/java/net/minecraft/core/BlockPos.java b/src/main/java/net/minecraft/core/BlockPos.java
-index cfc2a5145e47de86a5a738d86abf333ff3db7796..c4e622143073edbb4891ac9bd4fe30f32aede8f6 100644
+index ed52d042f41942ae512148fbba310093358ead68..80d8873bc2512ecde6a531e974b14e9b48402d64 100644
 --- a/src/main/java/net/minecraft/core/BlockPos.java
 +++ b/src/main/java/net/minecraft/core/BlockPos.java
 @@ -130,67 +130,84 @@ public class BlockPos extends Vec3i {

--- a/patches/server/0252-Slime-Pathfinder-Events.patch
+++ b/patches/server/0252-Slime-Pathfinder-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Slime Pathfinder Events
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index 95fadcb0b90f4824b5c06673266ae04e73c8a219..e9d3e5eddaee0c8ae98755119b3c0734166cafa9 100644
+index 2dbdc97bbc0f0960896528cfade12919fde137c4..6ac78ec82b6176771ab024e0c928b0881f67ca05 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -44,6 +44,12 @@ import net.minecraft.world.level.biome.Biomes;

--- a/patches/server/0261-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0261-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -28,7 +28,7 @@ index 49fd3486a6c595749f33bbe1c1bec0454e4725c5..5c290f263fc2b643987c96ea75729bf1
          switch (enumDirection) {
              case DOWN:
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index ab34cf7d603ba0fd8624db821b2c0e9e22286c63..9c2a6fd75f4380230256d9de91082d1bfe2eb961 100644
+index 91a0699ba30fa1e9c8172e07f034ea1fabee9d11..616d6404a966153f89ae63b559b5b66cbb832104 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3689,6 +3689,23 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 281b9fa69f8eb1d1eb6a199228e6a1c53b34714f..b588814417c2eb0069228cb54a5e4845388276ce 100644
+index 9c1a2ac04facba52af09ee87a96e8911d41a3f32..886a75f2b6402ed2e8c884fa5e125f4a4750f11d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2248,6 +2248,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0264-Allow-chests-to-be-placed-with-NBT-data.patch
+++ b/patches/server/0264-Allow-chests-to-be-placed-with-NBT-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow chests to be placed with NBT data
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 404a9f22b3a67aa042449fa2c1a1c31095c256b9..4348ecf7ca91fc38d59365aa5560d9d24f7b0703 100644
+index d921113214e7bf3693e80d417f3c5ae217500e7a..d0100eccc9f53d82f569a7de7d2715d0e5fc48ea 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -337,6 +337,7 @@ public final class ItemStack {

--- a/patches/server/0269-Prevent-mob-spawning-from-loading-generating-chunks.patch
+++ b/patches/server/0269-Prevent-mob-spawning-from-loading-generating-chunks.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Prevent mob spawning from loading/generating chunks
 also prevents if out of world border bounds
 
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index cf6bcbe7d75a52fe509e3b6c6c24b64bf9d460ad..6204bf41d410df9784b32f993b46d7adb2af5f13 100644
+index f208239b69dbd8788b799d8b28e457017edef9d5..c3fa1e8077f0f6a1f533c644dda9cb29265129a6 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -188,9 +188,9 @@ public final class NaturalSpawner {

--- a/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 76ebd1c85fed688ad42ea5f709638015e965cec6..24d53ec5a4dc49c6489cf8007197ed11381081e3 100644
+index 676d24a1c57b5d3d14c3599d09196da128b6e19e..ef3b47c30e9fa0a41268b61d3008507587999aa6 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -116,6 +116,7 @@ import net.minecraft.world.level.storage.loot.LootTable;

--- a/patches/server/0278-MC-50319-Check-other-worlds-for-shooter-of-projectil.patch
+++ b/patches/server/0278-MC-50319-Check-other-worlds-for-shooter-of-projectil.patch
@@ -11,7 +11,7 @@ If the projectile fails to find the shooter in the current world, check
 other worlds.
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 30118ff975da9491fa41db2133d217c2a797a8e3..7311923d36ee872b4331d84f80709bb6cee61086 100644
+index d7d4aa7ed2f321df8099adb97a3c699ed38ae6fc..21ce4be0d8d0147a92f87e17bb5078a211419984 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -57,6 +57,18 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -128,7 +128,7 @@ index 0000000000000000000000000000000000000000..41d73aa91fb401612e087aa1b7278ba6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index eda7d7451571fdbb60a966ef75549fe6dfd57472..bda4807f70806feb020eb73494079f23e6b0d90e 100644
+index 39bdda56aaa5503efc15207261634127b462c3e7..3fd913f3e963cf2da849a52364356e3b2da11eee 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -18,6 +18,7 @@ import javax.crypto.Cipher;
@@ -225,7 +225,7 @@ index eda7d7451571fdbb60a966ef75549fe6dfd57472..bda4807f70806feb020eb73494079f23
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 02b85866b6f4b8975f66fd8c706cda8df49ac6a8..246d9a3b4e618813ea4afbc790c90a3cdd683fef 100644
+index 6338f32acb10fdb8a6cf8004e78096db33ce1aec..5775b1656d636479f269f3863c04fcaa4027fd8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -679,7 +679,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0292-PreSpawnerSpawnEvent.patch
+++ b/patches/server/0292-PreSpawnerSpawnEvent.patch
@@ -9,7 +9,7 @@ SpawnerSpawnEvent gets called instead of the CreatureSpawnEvent for
 spawners.
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index cfb820636f819a7da56d0302d49f39cea1b5a93d..7bf688057d684aa1b60f29294c9a7e81ab6742d1 100644
+index 900cba8c2b04fc1b82a13af76d7079b6a6a2994d..494174608c0c6d0e0d9820ad4f263bef90c3dfdf 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -138,11 +138,11 @@ public abstract class BaseSpawner {

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -30,7 +30,7 @@ index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23a
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0b39fb58312a0fcc18024a42e666d12ab3d85a53..a0642558027e82dec054a5a92af44715b673e4f6 100644
+index 5775b1656d636479f269f3863c04fcaa4027fd8b..b044a4ab4f95476666f8b0c41bd5e63e9d02ffea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2346,6 +2346,11 @@ public final class CraftServer implements Server {

--- a/patches/server/0297-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0297-force-entity-dismount-during-teleportation.patch
@@ -93,7 +93,7 @@ index 35f83b559002886b8728297eb9fecc7588bdc950..dbf002a6967812fd58ed9bcfa615dc52
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 24d53ec5a4dc49c6489cf8007197ed11381081e3..84a2b846022a198a93ca924882d503b889290363 100644
+index ef3b47c30e9fa0a41268b61d3008507587999aa6..f6ed1ec062eef635b8e629b0e200185054c15919 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3335,11 +3335,13 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0298-Add-more-Zombie-API.patch
+++ b/patches/server/0298-Add-more-Zombie-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add more Zombie API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index eabdf345ddf208aaac681f249cb11356ade08673..0878e69aa5805f635971b5ce46783ce043c19bbe 100644
+index f8b97aa5819e228f31c7953ee6e5c4e69fe55666..c3cc876d1cbbce490a40550dbd0f02e52f1fc1bc 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -96,6 +96,7 @@ public class Zombie extends Monster {

--- a/patches/server/0299-Book-Size-Limits.patch
+++ b/patches/server/0299-Book-Size-Limits.patch
@@ -24,7 +24,7 @@ index 11d628869a9a6eda8bf21a4f213ff23ad753b18e..4c97fa63d912548324e93f366c86666d
      private static void asyncChunks() {
          ConfigurationSection section;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 12f722ad55abff59d133f91da804f7cfa09dbdb6..9e85045638d3496c80a215d2b589033ed5169981 100644
+index a615821cf605208c61be27f8bd026437b799de14..0103c76c183d0e866a98c26f2d1cf557ba4f67e8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1001,6 +1001,45 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0300-Add-PlayerConnectionCloseEvent.patch
+++ b/patches/server/0300-Add-PlayerConnectionCloseEvent.patch
@@ -34,7 +34,7 @@ how PlayerPreLoginEvent interacts with PlayerConnectionCloseEvent
 is undefined.
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 8bbf13a7aea1142b3154a1c76837a98aa5ed431d..7387990152e512cb186d76b5aa9d51838312ac03 100644
+index 3b943894750022aa84de8af97db3eebf71db1afa..e5f8c48c8d57ce0df4e7aacdbc3a6d3e9b3cb6e1 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -418,6 +418,26 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -65,7 +65,7 @@ index 8bbf13a7aea1142b3154a1c76837a98aa5ed431d..7387990152e512cb186d76b5aa9d5183
  
          }
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index bda4807f70806feb020eb73494079f23e6b0d90e..12f945e91827470a9a61951e45c062deee8cf281 100644
+index 3fd913f3e963cf2da849a52364356e3b2da11eee..b5d8987d2903086d69bbd6ba8092e568c94be63f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -59,7 +59,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0301-Prevent-Enderman-from-loading-chunks.patch
+++ b/patches/server/0301-Prevent-Enderman-from-loading-chunks.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent Enderman from loading chunks
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
-index abd1130529dd74780054e26bac89cf757ba9cdc1..a39f4a1585ba888d27588a86130f6dae24f5a71b 100644
+index 72e5e1edaa047d491daeef8ece3638dad30e32ca..e1e220b3e4967590a2a77370e2a6ab919ad50eaa 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/EnderMan.java
 @@ -465,7 +465,8 @@ public class EnderMan extends Monster implements NeutralMob {

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,7 +106,7 @@ index 93de44b05a698515457052c9c684c4ef44c5cc40..b20bfe5ab165bf86985e5ff2f93f415d
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 02af5c7038dd56d77eaa9ca08bb81950f6f5f499..8ce9a182cabd8a537cf847575654842829f133ee 100644
+index e3e158946ceff4c383e5da46bce09554f7526a6f..d98e7b91cb8e6f9369531a08887513b05ef0f96b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -151,6 +151,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,7 +12,7 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8ce9a182cabd8a537cf847575654842829f133ee..01b3749ba0ccd1f81bc966927c59e895e4400f66 100644
+index d98e7b91cb8e6f9369531a08887513b05ef0f96b..0a0ffdd0cb4fb2750c8b7939fb36e12190b6b085 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2295,6 +2295,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0310-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
+++ b/patches/server/0310-Optimize-Network-Manager-and-add-advanced-packet-sup.patch
@@ -28,7 +28,7 @@ and then catch exceptions and close if they fire.
 Part of this commit was authored by: Spottedleaf
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 9f0537799a3cae43fb120056b8fe805a4883cc4d..7607bf75968cc32d616e2b44e89901b3681b1131 100644
+index e5f8c48c8d57ce0df4e7aacdbc3a6d3e9b3cb6e1..3faf9bc694016f3f46576a549814ff8e6070598a 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -87,6 +87,10 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {

--- a/patches/server/0313-Set-Zombie-last-tick-at-start-of-drowning-process.patch
+++ b/patches/server/0313-Set-Zombie-last-tick-at-start-of-drowning-process.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Set Zombie last tick at start of drowning process
 Fixes GH-1887
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 0878e69aa5805f635971b5ce46783ce043c19bbe..4c5213fe89ec131addcc3d705f2e3268f51f1868 100644
+index c3cc876d1cbbce490a40550dbd0f02e52f1fc1bc..cf1b80350d15b55eecafa9ab53e49b9a754a8d0e 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -225,6 +225,7 @@ public class Zombie extends Monster {

--- a/patches/server/0325-Mob-Spawner-API-Enhancements.patch
+++ b/patches/server/0325-Mob-Spawner-API-Enhancements.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Mob Spawner API Enhancements
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 66ae43c40d4bad373b3a5269e8c78d7a3b3ac498..a87531f4669c7947e02764b5ceb098385ad99159 100644
+index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248df9998ea 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -31,7 +31,7 @@ public abstract class BaseSpawner {

--- a/patches/server/0326-Fix-CB-call-to-changed-postToMainThread-method.patch
+++ b/patches/server/0326-Fix-CB-call-to-changed-postToMainThread-method.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix CB call to changed postToMainThread method
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index bc4ec399c533c640229d95b84f5fdb7a1af4678d..f9329f32e6119ad0230c1fd2891439c9e654c5b2 100644
+index fafb0052efb2942955d3964967f203413cb09574..ea19697d8e60a993979d61a4d0f89110fd2cc574 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -439,7 +439,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,7 +29,7 @@ index 8908b61dc601dc8fd16976df350197ff1d3e3bd7..85477d81a38aefa09f95671951cd06da
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f58afdc5d270e59caa094205a96fbddb430b4449..71ae9d4643de10061a3858cc0be1773268710f0d 100644
+index b044a4ab4f95476666f8b0c41bd5e63e9d02ffea..f8e979d9e4b177bffa2b1357fcdce5fbf04aeac0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1845,7 +1845,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0331-ChunkMapDistance-CME.patch
+++ b/patches/server/0331-ChunkMapDistance-CME.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ChunkMapDistance CME
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 165e72873da877f7a29d58e4da489f68979725ad..ddaf9d682772d5dbbe6ee4891f9995a8ee365329 100644
+index 2b235508ffd01de14714de1a31c2139e7c15bd27..7af33e8c470e499b7ec47467cce7df699c96873a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -73,6 +73,7 @@ public class ChunkHolder {

--- a/patches/server/0335-Expose-the-internal-current-tick.patch
+++ b/patches/server/0335-Expose-the-internal-current-tick.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d32ee42eab1657b9b8056ab02e3c42dc57a94601..944adb2174f5671a151d3d17b297e45a6024e460 100644
+index f8e979d9e4b177bffa2b1357fcdce5fbf04aeac0..ab6518d8caf00c99a2c49c69a62923da98170cad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2369,5 +2369,10 @@ public final class CraftServer implements Server {

--- a/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -37,7 +37,7 @@ index 090958a30ce20ff01ae77d4cd821a167474f0214..baf33659b021c89cbd02560cbfd9b0dd
  }
 +
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 6204bf41d410df9784b32f993b46d7adb2af5f13..19d0ed5ff8569b0280117750f9ce05095afd9f70 100644
+index c3fa1e8077f0f6a1f533c644dda9cb29265129a6..95e5660e6cb1afb5ebdb3dbbe59a07c879bddb4b 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -85,6 +85,13 @@ public final class NaturalSpawner {

--- a/patches/server/0339-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0339-Configurable-projectile-relative-velocity.patch
@@ -40,7 +40,7 @@ index baf33659b021c89cbd02560cbfd9b0ddf205f0e2..4c177a383b277debe8a7c02a70d029d8
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 7311923d36ee872b4331d84f80709bb6cee61086..69f439851fe1ff07d827eaed274940a5783d5f6c 100644
+index 21ce4be0d8d0147a92f87e17bb5078a211419984..37356b36f0ae12d55150f399318581fa77c30cee 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -161,7 +161,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 84a2b846022a198a93ca924882d503b889290363..1f46e8eaa41c37bcd065ae064521c3c0772d7832 100644
+index f6ed1ec062eef635b8e629b0e200185054c15919..b9b01966cdaf01bfe222c89c8e5d7afc690ab415 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3554,15 +3554,18 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0353-Optimize-Hoppers.patch
+++ b/patches/server/0353-Optimize-Hoppers.patch
@@ -62,7 +62,7 @@ index 449d2e7b18608ca36282f1a29e69457fc525307e..c738cb0433ea4a86d82372bf66e29c01
      public double getLevelX() {
          return this.getX();
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 4348ecf7ca91fc38d59365aa5560d9d24f7b0703..30a339f56eb1edb730e4ce72b4ce314555bc8c15 100644
+index d0100eccc9f53d82f569a7de7d2715d0e5fc48ea..1f93ad93701339418b554eb3e1e3f74e62468f3f 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -601,11 +601,12 @@ public final class ItemStack {

--- a/patches/server/0357-Guard-against-serializing-mismatching-chunk-coordina.patch
+++ b/patches/server/0357-Guard-against-serializing-mismatching-chunk-coordina.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Guard against serializing mismatching chunk coordinate
 Should help if something dumb happens
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index 34a026dbeafff07401187d22ef8fd537c17fc615..c131f6093c395b4d9e401d3c447e7fb13c631ecf 100644
+index 575f0bcb4db4bd58c949acc3b6a15bbeb7f842a0..79a7221b0462931e94f31ccd7c6dc2720ddfb752 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -69,6 +69,13 @@ public class ChunkSerializer {

--- a/patches/server/0360-Lag-compensate-eating.patch
+++ b/patches/server/0360-Lag-compensate-eating.patch
@@ -7,7 +7,7 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1f46e8eaa41c37bcd065ae064521c3c0772d7832..e7673a72892c2a6b08020c1abaf4f89b82148024 100644
+index b9b01966cdaf01bfe222c89c8e5d7afc690ab415..560236c33d2afe289a534c8cd1d1df413eb5d78d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3498,6 +3498,11 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0361-Optimize-call-to-getFluid-for-explosions.patch
+++ b/patches/server/0361-Optimize-call-to-getFluid-for-explosions.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimize call to getFluid for explosions
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index edc0845ae735a9cf3e0f1a3a2b7eabf726d62744..cdf214fca3b0055efa56702470d9d2f890a8aead 100644
+index 35ea80a18234d8125397edb5bab9e86ea526d3ca..a861b4b55862b1c5583101fe7f28a3a43c547468 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -174,7 +174,7 @@ public class Explosion {

--- a/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
@@ -13,7 +13,7 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b108ba1c99423011f75881bf3d7440c501084c28..5d0118a753b044b1cd83298964be16a1ee87729f 100644
+index 6ce232c623d86af20b74d7ee1e7b258cd7342d24..c11b4ff3907a0041db35a1dd7940a42755db3f0d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3007,6 +3007,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -591,7 +591,7 @@ index c7d708cc5c20d46ed085f1f1db7666246614a57d..b2d88e0423d93fdb45dc8ca7d53c9806
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index d81d84b948842088c93a32e307b7430d81438da9..136c6db28ca4d9244ce9341e341b1f36cd643ea3 100644
+index 3beef93cd23b3f1171e090c87c3f96747a276678..d4d69c3f89a106d691ec8d0709ca45850f91d2a6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -753,7 +753,22 @@ public class ServerChunkCache extends ChunkSource {
@@ -643,7 +643,7 @@ index 74ad39234b89db61fab89ce6bac4f3f8b3eccb7c..f7e199a375a49756f9bbbc17b54d74c7
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 0211b572dc46b3c4fc098f0ef31843a401cd3613..31fbcf6a35b902ce80c0a5a23dabb8ec3d8cbdfc 100644
+index 95e5660e6cb1afb5ebdb3dbbe59a07c879bddb4b..88145f04989c71a686aae1b486087ecdf55e268c 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -17,6 +17,7 @@ import net.minecraft.core.Registry;

--- a/patches/server/0375-Optimise-getChunkAt-calls-for-loaded-chunks.patch
+++ b/patches/server/0375-Optimise-getChunkAt-calls-for-loaded-chunks.patch
@@ -7,7 +7,7 @@ bypass the need to get a player chunk, then get the either,
 then unwrap it...
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 136c6db28ca4d9244ce9341e341b1f36cd643ea3..b336b3ff4425dc6ba3dc55a6faa48660b7a4fc99 100644
+index d4d69c3f89a106d691ec8d0709ca45850f91d2a6..bb57e3b917b0e987273796ee7a348326350784f4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -450,6 +450,12 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0377-Allow-overriding-the-java-version-check.patch
+++ b/patches/server/0377-Allow-overriding-the-java-version-check.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow overriding the java version check
 -DPaper.IgnoreJavaVersion=true
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index b14fa970679dc000cd203949c73f117d4573be9e..3f219234355edc961f07ae1a75759b6e44ddcfdf 100644
+index d087645dd83b4c4748cfe0dc151e31e195affdfe..b4c00b280438e59b604905e2cc329b1818c13a56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -185,7 +185,7 @@ public class Main {

--- a/patches/server/0379-Entity-Jump-API.patch
+++ b/patches/server/0379-Entity-Jump-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e7673a72892c2a6b08020c1abaf4f89b82148024..f6f519a37038ec6b9dbde61d13b7a55b33784c40 100644
+index 560236c33d2afe289a534c8cd1d1df413eb5d78d..7caa240343a06a3956a7d75e2ccf16814076a6b4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3165,8 +3165,10 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -21,7 +21,7 @@ index f2e4939c8144b9bc7441130302ab3e2358c42063..3d14a7dbcc6bc46141596a7e04f790bf
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5d0118a753b044b1cd83298964be16a1ee87729f..c98938c1fa057001783b7f39e88f107b8cb700f0 100644
+index c11b4ff3907a0041db35a1dd7940a42755db3f0d..57a6f748891720ee65ba6fae700fe673967ade8c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -328,6 +328,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0382-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0382-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 9a84ac5aa03c645037daec23cc4422106a6ace1d..8e4bd4818cf9d50dec7b94e5f1263086b6a6b86a 100644
+index 934ea2cf75c44e7e5f2e302a2d2fc14da54d3310..19fa07423caefe601456ee775812b9c032384e9e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -339,13 +339,18 @@ public class CraftEventFactory {

--- a/patches/server/0383-Prevent-teleporting-dead-entities.patch
+++ b/patches/server/0383-Prevent-teleporting-dead-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent teleporting dead entities
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4d3d6a7bb4be76004539fd33c06a421b7052f4f5..b946747bf864369e5010689ee44bbc462a644d20 100644
+index b3527b60028663695f2b2e3d4e01d772ac23fbb5..67ede93bed3fafcb548c394397bcc2ca7a86c39f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1480,6 +1480,10 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
@@ -24,7 +24,7 @@ index 9fb1ea2e363de88c48530341fd11541ebdec8831..9dc8a9e49cac89e236d9fa0c053b70bf
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 4c5213fe89ec131addcc3d705f2e3268f51f1868..299dc59535d2cd73de346618731c65bc01063b66 100644
+index cf1b80350d15b55eecafa9ab53e49b9a754a8d0e..05a62a5d115d709ec1c29b36b09dfd8ce9626256 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -452,10 +452,13 @@ public class Zombie extends Monster {

--- a/patches/server/0387-Optimise-Chunk-getFluid.patch
+++ b/patches/server/0387-Optimise-Chunk-getFluid.patch
@@ -8,7 +8,7 @@ faster on its own, however removing the try catch makes it
 easier to inline due to code size
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index a088cb005525fda2c9d5521ab3bac43cfa38a393..085914b552583f54d0eb0eb5f1e4ac2146c5225c 100644
+index 83ed84f89a036d3768b22a36bc8a0bfc2bc29ec7..016c2302d8bcf121eafd1be7eb4f3b206dbdbeec 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -461,18 +461,20 @@ public class LevelChunk implements ChunkAccess {
@@ -49,7 +49,7 @@ index a088cb005525fda2c9d5521ab3bac43cfa38a393..085914b552583f54d0eb0eb5f1e4ac21
  
      // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
-index ec8b67c1b024df38d5e1ad81acff33537ae25626..9fcff5c8efe0bd357a102c488b6c55295d2188aa 100644
+index c9fefeef19bd46ade51b23eadb5eef3a88024ea1..cdac1f7b30e4c043dcb12ac9e29af926df8170bd 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunkSection.java
 @@ -50,7 +50,7 @@ public class LevelChunkSection {

--- a/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -233,7 +233,7 @@ index 2b291296821dc6d6a8437bd977eeba517cdb5003..962028a58ee54b99be20905c1fd16cfe
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 57aa6d18d181c50071bcfcc933cde9fa828be792..ed3ce0f87eaf4777aedc93fe5bd67971ffb10d86 100644
+index 34174c3cdcb69c96e8601e28ecaf01df9b8c0f37..1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -767,7 +767,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -147,7 +147,7 @@ index ce438760cbc92c08c079d06a8b97eaeda1018491..0115ffe84356468ddc254d8d5bdd719b
                  // Spigot Start
                  CrashReport crashreport;
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index ed3ce0f87eaf4777aedc93fe5bd67971ffb10d86..67c2f84bd2c184475f1a448898d381414bab9118 100644
+index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a8d75ae42 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -704,6 +704,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ddbc8cb712c50038922eded75dd6ca85fe851078..78271b400c79578d043b20a5389a37b1bef9a70d 100644
+index 5c67c51dd0a19357086d4ceb3ca724401e4d26b8..89a475429ede42f3a8aae16760e56bfba57bb1b5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -146,7 +146,7 @@ index 0115ffe84356468ddc254d8d5bdd719bc5e7e3f8..def1edb961ba41819ce30c427b161657
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a1c4479602245dba4b5a0b7fcb396cf3ed41e3b5..1d857a41ba86327f5e94607d6594629f758aa466 100644
+index ab6518d8caf00c99a2c49c69a62923da98170cad..48e1f49f6ada1a1a2a5e85ab3e12fe9816cb577a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2207,6 +2207,16 @@ public final class CraftServer implements Server {

--- a/patches/server/0400-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0400-Expose-MinecraftServer-isRunning.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f933be5c7c83139cb20d47612f1322ceff8ee6cb..814b64b792b76204f51b1ed49c72afb41e4589ff 100644
+index 48e1f49f6ada1a1a2a5e85ab3e12fe9816cb577a..796decb4d6a011fae263d6bced59d2399a61a60b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2384,5 +2384,10 @@ public final class CraftServer implements Server {

--- a/patches/server/0401-Add-Raw-Byte-ItemStack-Serialization.patch
+++ b/patches/server/0401-Add-Raw-Byte-ItemStack-Serialization.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add Raw Byte ItemStack Serialization
 Serializes using NBT which is safer for server data migrations than bukkits format.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index ad8d6a84e1a66e03ae15269e36bc787148f12396..d18f8d7c699893740fa709ef1f0caa4390e7eb20 100644
+index f8cb210390958ddba9f9685f2ec1f8bb91690162..6b79b1ea43b713105f37de517019c033477f9835 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -378,6 +378,46 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0403-Async-command-map-building.patch
+++ b/patches/server/0403-Async-command-map-building.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Async command map building
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 7ca6a1a3f10cb19d759f6d4dc9d5458ac0fc05d3..13e358e0eac3bfd426d924b6f745e001df76c64a 100644
+index 780f46c8fdbaafaca6babfa34ebd97f420d0d612..81146c07dad098a88d8bd3867d0aaf5c15e33961 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
 @@ -29,6 +29,7 @@ import net.minecraft.network.chat.MutableComponent;

--- a/patches/server/0411-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0411-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,7 +7,7 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f6f519a37038ec6b9dbde61d13b7a55b33784c40..885a628657bcb9e7591f1ec3f14d5ebb83d37d3b 100644
+index 7caa240343a06a3956a7d75e2ccf16814076a6b4..056a66e0bfe85d57e5c08473f6e30dc2b02224e5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3262,10 +3262,16 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0413-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0413-Implement-Player-Client-Options-API.patch
@@ -97,7 +97,7 @@ index 22aefdc7a096993c15c9b4e2f37ad84d1279a2df..3cab5fbfc1cae65efbf53b69cc0da012
          if (getMainArm() != packet.getMainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 01b3749ba0ccd1f81bc966927c59e895e4400f66..638dc61594e86a1423536d2a7fe8405d2451a4ee 100644
+index 0a0ffdd0cb4fb2750c8b7939fb36e12190b6b085..7fc48e63ac610f65475e3a8d3d6f902cc70925ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -521,6 +521,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0414-Fix-Chunk-Post-Processing-deadlock-risk.patch
+++ b/patches/server/0414-Fix-Chunk-Post-Processing-deadlock-risk.patch
@@ -46,7 +46,7 @@ index 6d810cdb538d078dbf7ccd2ef84a4be27eb1f3e7..aa9846c7d6b8499e01bf0ffeece6a940
  
          completablefuture1.thenAcceptAsync((either) -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 67c2f84bd2c184475f1a448898d381414bab9118..0d7de5a2feb75e9862da2926de5bb6afe28f8036 100644
+index a376fa2456607337d3eec007abd5622a8d75ae42..e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -1009,6 +1009,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
@@ -37,7 +37,7 @@ index be677d437d17b74c6188ce1bd5fc6fdc228fd92f..78fbb4c3e52e900956ae0811aaf934c8
      public static final TicketType<ChunkPos> UNKNOWN = TicketType.create("unknown", Comparator.comparingLong(ChunkPos::toLong), 1);
      public static final TicketType<Unit> PLUGIN = TicketType.create("plugin", (a, b) -> 0); // CraftBukkit
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 596eddd7d3814b7e25bbf253612c7a650b368b65..304cc4a82b92a8e27f3abc7a93d1ab8fcfd277f4 100644
+index 67ede93bed3fafcb548c394397bcc2ca7a86c39f..36815e17d521e420fb04db108a12c2b9d1a9dce8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -220,6 +220,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0419-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0419-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,7 +7,7 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9783b06104f6dfe12988733f580ce5e3c5cf1e28..bd807a3d06457e619df0e77cf6114b0802b7d685 100644
+index f7feec88a4f3c240eee4e2d9f866957bd00b5e4a..ba109e4ccf5bc3d985781f087f172eeb1b1b9be2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2002,9 +2002,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0420-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0420-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 885a628657bcb9e7591f1ec3f14d5ebb83d37d3b..4f996f0216aa1255d2031bb151d2a43d61a7e42b 100644
+index 056a66e0bfe85d57e5c08473f6e30dc2b02224e5..b6a36706846a3106f7e747ce761aa2064a934d05 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -2040,7 +2040,16 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0421-Allow-multiple-callbacks-to-schedule-for-Callback-Ex.patch
+++ b/patches/server/0421-Allow-multiple-callbacks-to-schedule-for-Callback-Ex.patch
@@ -14,7 +14,7 @@ Use an ArrayDeque to store this Queue
 We make sure to also implement a pattern that is recursion safe too.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c1b7e9d515fc833759707ab3c5c952320dec103e..c643919e17081c85717b0b00c227b914d7abcc0a 100644
+index 2b4c35d9bd186fd7c3650a7ad791cd67fb64e635..e7c78106aa34d948a77cf72d5716e17d10beae72 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -178,17 +178,29 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0422-Don-t-fire-BlockFade-on-worldgen-threads.patch
+++ b/patches/server/0422-Don-t-fire-BlockFade-on-worldgen-threads.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Don't fire BlockFade on worldgen threads
 Caused a deadlock
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index ad0b485dbc77717f16191d6950a2e91faaede94a..c86bf175853197dceaa91a2287ef51de87b9d5f9 100644
+index becf80cdbbeb6327958758779cc42ea894127988..3249b4a7e2267d8c321ae4cf592e9fc26dfdcb98 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 @@ -100,6 +100,7 @@ public class FireBlock extends BaseFireBlock {

--- a/patches/server/0423-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0423-Add-phantom-creative-and-insomniac-controls.patch
@@ -35,7 +35,7 @@ index d17b75ad13bbc8a38cdc2f2d77ee5d88438cec31..8fb89326395a7e70982c0d757b506565
      private EntitySelector() {}
      // Paper start
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Phantom.java b/src/main/java/net/minecraft/world/entity/monster/Phantom.java
-index d2a3927a263c445e647a4bbc5fe12addaf290c0e..6dbf806b5984ae16e747dce350c7cffcf0b190ad 100644
+index 877095c93e944293dfb52471eda59a24fad2dbc9..460a848bd2a417d05a0bbb084371c98b661a427f 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Phantom.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Phantom.java
 @@ -547,6 +547,7 @@ public class Phantom extends FlyingMob implements Enemy {

--- a/patches/server/0425-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0425-Implement-Brigadier-Mojang-API.patch
@@ -10,7 +10,7 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 4ec40f9556cecbf1c3ffdce7d253e2b10875d496..35eb06c3b55a93d46c61703c806f4048dcdb8734 100644
+index 03a37d0429b6e1f18d90f0fa8268071965f6bae3..8d08c4f2bedddc737dbefb89fa2f99fba2b66e4a 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -19,6 +19,7 @@ repositories {
@@ -61,7 +61,7 @@ index 880fc9fea286384d002518137972935fdf1d2d72..a59d14e61fcbca7861a5593d0717b812
      public boolean hasPermission(int level) {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 13e358e0eac3bfd426d924b6f745e001df76c64a..7156dea53be828acd01734fa1f9f7b9accf30ff6 100644
+index 81146c07dad098a88d8bd3867d0aaf5c15e33961..f9b37c873b6b02f14bb7a7225197c552a7f7c5b9 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
 @@ -362,6 +362,7 @@ public class Commands {
@@ -81,7 +81,7 @@ index 13e358e0eac3bfd426d924b6f745e001df76c64a..7156dea53be828acd01734fa1f9f7b9a
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 304cc4a82b92a8e27f3abc7a93d1ab8fcfd277f4..a18a9f86da8015fff02c3efe98c8afbb3ef61235 100644
+index 36815e17d521e420fb04db108a12c2b9d1a9dce8..9547869fa430c2e25348c763ea6e709cf2ffcf36 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -759,8 +759,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0426-Villager-Restocks-API.patch
+++ b/patches/server/0426-Villager-Restocks-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Villager Restocks API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index e22453a79371266c3dad450e6c82cb24babcece8..fe3a73e9cdb85fdf8385f0a0d096a991541cbf60 100644
+index a5faa655cb0169ca5088bcc39e7b988135d150d6..0e247979b5ced02c1de422547fc8ebf7067006ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 @@ -83,6 +83,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {

--- a/patches/server/0427-Validate-PickItem-Packet-and-kick-for-invalid.patch
+++ b/patches/server/0427-Validate-PickItem-Packet-and-kick-for-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Validate PickItem Packet and kick for invalid
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a18a9f86da8015fff02c3efe98c8afbb3ef61235..ca3991e3cea5de32418469540fe70b99ff21bed0 100644
+index 9547869fa430c2e25348c763ea6e709cf2ffcf36..5ec29d1d73a4a828d35cec259469c4929368623f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -876,7 +876,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0428-Expose-game-version.patch
+++ b/patches/server/0428-Expose-game-version.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e31a05dfe7e934692ac89c7cedcab736bcd9ca4f..130ab05393a7136020e06ec199256a031ba66091 100644
+index fc1b0fe8c45f133715488f02f41e0c078c4b6803..238901696feb8de28c8d543535b578decd146334 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -517,6 +517,13 @@ public final class CraftServer implements Server {

--- a/patches/server/0430-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
+++ b/patches/server/0430-Set-cap-on-JDK-per-thread-native-byte-buffer-cache.patch
@@ -17,7 +17,7 @@ keeping long lived large direct buffers in cache.
 Set system properly at server startup if not set already to help protect from this.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 15d6975e6470e1affad9adc73964a720a3de36e9..daa881823f9a0757211e4fece8ebd9225f8b41bb 100644
+index 98be7909a892a8a566d68ef693d1093791aa902b..f197d63c618b25c139852809c0b0a6e313c83f18 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -28,6 +28,7 @@ public class Main {

--- a/patches/server/0431-Implement-Mob-Goal-API.patch
+++ b/patches/server/0431-Implement-Mob-Goal-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 35eb06c3b55a93d46c61703c806f4048dcdb8734..b818cda07c04c7b4ab7178763993aec52b5bd8b7 100644
+index 8d08c4f2bedddc737dbefb89fa2f99fba2b66e4a..b898690863be9753910bb4af3be13c2e73db7b00 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -49,6 +49,7 @@ dependencies {
@@ -895,7 +895,7 @@ index 8c2ec30a35e86f2b30863045b586a67e485c624b..9cb5ccf4815b56169b63b34da88e7394
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e647314df36c80a6b1d2f3691f00c8d55670f673..28d4f370a1cba620c81ff625562d0be1ad7b6e69 100644
+index 238901696feb8de28c8d543535b578decd146334..644373b23cf228505dd23ba07bd9cacbdc365c6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2396,5 +2396,11 @@ public final class CraftServer implements Server {

--- a/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -291,7 +291,7 @@ index b49d380ef088aed3204ec71abc437c348ef004fa..577b391dcba1db712c1e2c83296e1c87
  
      public String getDebugStatus() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 0d7de5a2feb75e9862da2926de5bb6afe28f8036..08057df46f3044c5e84e55d1669c07426dbd63c6 100644
+index e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00..58b4d6a2c07a283d9077b23aaef2aeef9153dd4b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -730,6 +730,37 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0434-Add-villager-reputation-API.patch
+++ b/patches/server/0434-Add-villager-reputation-API.patch
@@ -20,7 +20,7 @@ index 0000000000000000000000000000000000000000..0f10c333d88f2e1c56a6c7f22d421084
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java b/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
-index 2e342e1c258180dc02080f76385351c0a65eade2..39c0fbae8b94dabd27ee8687015557c6a9279813 100644
+index 3eb1d640f53e0b8be53fa78aaa7bca6a7963d912..01df536b3b61281828ca2be03ac1bbb6a1096423 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
 @@ -29,7 +29,7 @@ import net.minecraft.util.VisibleForDebug;
@@ -62,7 +62,7 @@ index 2e342e1c258180dc02080f76385351c0a65eade2..39c0fbae8b94dabd27ee8687015557c6
  
      static class GossipEntry {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index fe3a73e9cdb85fdf8385f0a0d096a991541cbf60..aa6d3ff2abc9f0c65dd51b2a30d327fea827bb42 100644
+index 0e247979b5ced02c1de422547fc8ebf7067006ee..f7067789b0473bb8c2ec83b9c77e0cedb81cf0ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 @@ -16,6 +16,13 @@ import org.bukkit.entity.Villager;

--- a/patches/server/0439-Potential-bed-API.patch
+++ b/patches/server/0439-Potential-bed-API.patch
@@ -8,7 +8,7 @@ Adds a new method to fetch the location of a player's bed without generating any
 getPotentialBedLocation - Gets the last known location of a player's bed. This does not preform any check if the bed is still valid and does not load any chunks.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 31b62dc1ee06b254c398cbfe157283fb199ef0fe..36ea76bfe0bd96ead82ed1ad34f25de10b7fa30e 100644
+index c52a075ebc9ff041d9b08c38ed02dee80dd15bb9..1dec5e2d11888a8684a198d9951d7e9bdd729898 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -12,6 +12,7 @@ import net.minecraft.nbt.CompoundTag;

--- a/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,7 +22,7 @@ index 736cbb3430ba1d8c00ea43a80c978949108d8b6c..d285967a60903a73608a1f9cdc306e63
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dbe603a26ab622cf2ece48b1d0b9f0dd3de0a4d3..781f87f3f60f8d5628f479d58bc38952a314d3de 100644
+index 644373b23cf228505dd23ba07bd9cacbdc365c6c..610dab96b6dcb5bf5dbd19a7f075241b8bd3e50f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -932,6 +932,35 @@ public final class CraftServer implements Server {

--- a/patches/server/0442-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0442-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,7 +13,7 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 78271b400c79578d043b20a5389a37b1bef9a70d..5f3b0d95cc7e6a0434d78ea7305a70689c41c71c 100644
+index 89a475429ede42f3a8aae16760e56bfba57bb1b5..cbb7000aec6703c195e807014de8ecc5b5ec0756 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -416,4 +416,17 @@ public class PaperConfig {
@@ -35,7 +35,7 @@ index 78271b400c79578d043b20a5389a37b1bef9a70d..5f3b0d95cc7e6a0434d78ea7305a7068
 +
  }
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index cdf214fca3b0055efa56702470d9d2f890a8aead..a12af10e28f2d023ba6f916b5e7a53539416713f 100644
+index a861b4b55862b1c5583101fe7f28a3a43c547468..1575fb0bbad6e11f25fb9ce51fd1f15a1b11e0fe 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
 @@ -174,6 +174,7 @@ public class Explosion {

--- a/patches/server/0446-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0446-Add-option-for-console-having-all-permissions.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5f3b0d95cc7e6a0434d78ea7305a70689c41c71c..7f140333c2e62012fa572c1a061d84432426997f 100644
+index cbb7000aec6703c195e807014de8ecc5b5ec0756..2840a6369e6532dbed93dd09ba4f7e39c3ccb258 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -429,4 +429,9 @@ public class PaperConfig {

--- a/patches/server/0448-Fix-Non-Full-Status-Chunk-NBT-Memory-Leak.patch
+++ b/patches/server/0448-Fix-Non-Full-Status-Chunk-NBT-Memory-Leak.patch
@@ -16,7 +16,7 @@ We further improve it by making a copy of the nbt tag with only the memory
 it needs, so that we dont have to hold a copy to the entire compound.
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index c09a1c640075bde9f656b11258f5adbd2daa4b0b..dfa628aa486dff135a32a023421c803b8259271a 100644
+index afbb42595afeb151208880dcf48b94d7c00a8733..e850b8db05f4d66aec8eb74a5a48357b90ca77a5 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -27,6 +27,7 @@ import net.minecraft.nbt.CompoundTag;

--- a/patches/server/0451-Maps-shouldn-t-load-chunks.patch
+++ b/patches/server/0451-Maps-shouldn-t-load-chunks.patch
@@ -15,7 +15,7 @@ Previously maps would load all chunks in a certain radius depending on
  five ticks that movement occur in anyways.
 
 diff --git a/src/main/java/net/minecraft/world/item/MapItem.java b/src/main/java/net/minecraft/world/item/MapItem.java
-index 044111a5ea88d3f938c08b027ac6836355eff7c2..994a3c0253c7298fef1471736b74bd34ec87738a 100644
+index 2ac84599cd9c71c1a32d70e447b014dc6711cda7..d44cbcfc9e59365149823b594e3b313ed48ec511 100644
 --- a/src/main/java/net/minecraft/world/item/MapItem.java
 +++ b/src/main/java/net/minecraft/world/item/MapItem.java
 @@ -132,9 +132,9 @@ public class MapItem extends ComplexItem {

--- a/patches/server/0452-Use-seed-based-lookup-for-Treasure-Maps-Fixes-lag-fr.patch
+++ b/patches/server/0452-Use-seed-based-lookup-for-Treasure-Maps-Fixes-lag-fr.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use seed based lookup for Treasure Maps - Fixes lag from
 
 
 diff --git a/src/main/java/net/minecraft/world/item/MapItem.java b/src/main/java/net/minecraft/world/item/MapItem.java
-index 994a3c0253c7298fef1471736b74bd34ec87738a..305c0b0ca23eea6b8b32778a4bbe8a2eacc78107 100644
+index d44cbcfc9e59365149823b594e3b313ed48ec511..24700c7e6a32cc30c97dccc21c5f3e3e6b6438e5 100644
 --- a/src/main/java/net/minecraft/world/item/MapItem.java
 +++ b/src/main/java/net/minecraft/world/item/MapItem.java
 @@ -258,7 +258,7 @@ public class MapItem extends ComplexItem {

--- a/patches/server/0456-incremental-chunk-saving.patch
+++ b/patches/server/0456-incremental-chunk-saving.patch
@@ -240,7 +240,7 @@ index a1529fef41543486d29271b1de62a6246d07d384..f518fc7a39a807bff2e141fd238ab1bf
              ChunkPos chunkcoordintpair = chunk.getPos();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 08057df46f3044c5e84e55d1669c07426dbd63c6..c28eda68d744c0a1c9229790af3a89dfac94ae22 100644
+index 58b4d6a2c07a283d9077b23aaef2aeef9153dd4b..1255b1806dabf1417cfdd195ee331a35edc059c7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -672,6 +672,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -314,7 +314,7 @@ index 12d11a249c759e99568a76c791cc0d65adfcfe94..8393950a0b38ec7897d7643803d5accd
      default boolean generateFlatBedrock() {
          if (this.getLevel() != null) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 7d33ad1ec939de4527d0acb0915f05870c387565..cc02b577453fa251f0f1b508281ddea2513138a1 100644
+index 1de1566b76c73ddfaf7e022296068db02044d5f3..a84b75a53a0324fab9aeb9b80bf74eb0a84ecd2e 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -108,6 +108,13 @@ public class LevelChunk implements ChunkAccess {

--- a/patches/server/0458-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
+++ b/patches/server/0458-Fix-CraftScheduler-runTaskTimerAsynchronously-Plugin.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Fix CraftScheduler#runTaskTimerAsynchronously(Plugin,
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index dd1e8b170e87bff2089f642f41dcf7442a8ccd16..33480893ddee34a1983c5f1c4b14db98ff438528 100644
+index ea7ebbc2674df727cf44856f172731ee083b8800..a423970cf7c927ea8a1bf842aaa236d3cf2d54c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -184,7 +184,7 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -199,7 +199,7 @@ public class CraftScheduler implements BukkitScheduler {
  
      @Override
      public void runTaskTimerAsynchronously(Plugin plugin, Consumer<BukkitTask> task, long delay, long period) throws IllegalArgumentException {

--- a/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,7 +32,7 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 7f140333c2e62012fa572c1a061d84432426997f..b67ba8f75e4a3358d7c2462918b85b0bf9b5a922 100644
+index 2840a6369e6532dbed93dd09ba4f7e39c3ccb258..99879e8a14eeef80c082bc7c0fbadc02d7368485 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -434,4 +434,10 @@ public class PaperConfig {

--- a/patches/server/0460-Fix-sand-duping.patch
+++ b/patches/server/0460-Fix-sand-duping.patch
@@ -7,7 +7,7 @@ If the falling block dies during teleportation (entity#move), then we need
 to detect that by placing a check after the move.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 0d476aa50170ad3623462306769020518c55cffb..5d89acffe7df54b79733bebba342ea694339ac4b 100644
+index 69f385c57f3716a489781debb32b4adf1cb9383d..15ec064cb9336924e16a7c9b3f76a9b6ef18d947 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -106,6 +106,11 @@ public class FallingBlockEntity extends Entity {

--- a/patches/server/0461-Prevent-position-desync-in-playerconnection-causing-.patch
+++ b/patches/server/0461-Prevent-position-desync-in-playerconnection-causing-.patch
@@ -14,7 +14,7 @@ behaviour, we need to move all of this dangerous logic outside
 of the move call and into an appropriate place in the tick method.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1e25d05b157f79c9d77224676b2dc6b7940aaf05..cfdf6e6e4ef5921bfcbb8a010ea42f0c182b344c 100644
+index 5ec29d1d73a4a828d35cec259469c4929368623f..c9bc5e355411d9b6d7cabab6cb8d96bfefe635a5 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1325,6 +1325,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0465-Hide-sync-chunk-writes-behind-flag.patch
+++ b/patches/server/0465-Hide-sync-chunk-writes-behind-flag.patch
@@ -9,7 +9,7 @@ on harddrives.
 -DPaper.enable-sync-chunk-writes=true to enable
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServerProperties.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServerProperties.java
-index e3409d5f4ddcaa4edecfa4b3c638a12624b09f1b..c9d80a5430cc66d6189bf337770af43121a5bfd5 100644
+index 12e55aabf0daf341ec74688e79c43451e820e6dc..0544ac93513d3a274bfb53bb6120bd598f4d603b 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServerProperties.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServerProperties.java
 @@ -108,7 +108,7 @@ public class DedicatedServerProperties extends Settings<DedicatedServerPropertie

--- a/patches/server/0478-Remove-streams-from-classes-related-villager-gossip.patch
+++ b/patches/server/0478-Remove-streams-from-classes-related-villager-gossip.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Remove streams from classes related villager gossip
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java b/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
-index 39c0fbae8b94dabd27ee8687015557c6a9279813..9c08a3e93ca56479ccd7a76a9031683182f23e59 100644
+index 01df536b3b61281828ca2be03ac1bbb6a1096423..2d124ff784b943f5a9d164ee7cdc001465502ce4 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/gossip/GossipContainer.java
 @@ -8,6 +8,7 @@ import com.mojang.serialization.Dynamic;

--- a/patches/server/0483-Update-itemstack-legacy-name-and-lore.patch
+++ b/patches/server/0483-Update-itemstack-legacy-name-and-lore.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Update itemstack legacy name and lore
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 30a339f56eb1edb730e4ce72b4ce314555bc8c15..d9f832241cd8697c65bfb5add035aee1e77c6165 100644
+index 1f93ad93701339418b554eb3e1e3f74e62468f3f..e643f925623820ffa67217eb3615582c0d0ca3a5 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -168,6 +168,44 @@ public final class ItemStack {

--- a/patches/server/0487-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0487-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4f996f0216aa1255d2031bb151d2a43d61a7e42b..cda994992814109f4fac8f031ec82e98c482c0ad 100644
+index b6a36706846a3106f7e747ce761aa2064a934d05..8a0722455bf303f50b2955b53f9d7284a20f672e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3359,7 +3359,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -941,7 +941,7 @@ index d94241bcca4f2fd5e464a860bd356af504dc68b7..1cc4e0a1f3d8235ef88b48e01ca8b78a
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index c28eda68d744c0a1c9229790af3a89dfac94ae22..f72ef5a0f97119732babc0ea353658cef52d6fe0 100644
+index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10ab89b3ce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -446,6 +446,26 @@ public class ServerChunkCache extends ChunkSource {
@@ -1101,7 +1101,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index ecb22bd5f7ed3e5969b2fe8dc6bfb404c05f0f7c..99cc9b89e1c271bc4a128f7fedccc0998aa04010 100644
+index 9b04ce1b82e954eca6e59360e606438695dd3bb4..ae65830c10888993e0a4c7863abf91f560313da1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1545,6 +1545,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0490-Optimize-NetworkManager-Exception-Handling.patch
+++ b/patches/server/0490-Optimize-NetworkManager-Exception-Handling.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimize NetworkManager Exception Handling
 
 
 diff --git a/src/main/java/net/minecraft/network/ConnectionProtocol.java b/src/main/java/net/minecraft/network/ConnectionProtocol.java
-index e722cf3a8e816b0c7405e6282591d9fa8d5bfa61..22d1758e52f56b39a2c110f123bdbf80898c4d92 100644
+index 6611aebafb14b83bce3eeb87701e2edc8a0828ab..bb3b450c7e81ba47e1e8b2244d331f2ce44a7ee1 100644
 --- a/src/main/java/net/minecraft/network/ConnectionProtocol.java
 +++ b/src/main/java/net/minecraft/network/ConnectionProtocol.java
 @@ -275,6 +275,7 @@ public enum ConnectionProtocol {

--- a/patches/server/0495-Optimize-Light-Engine.patch
+++ b/patches/server/0495-Optimize-Light-Engine.patch
@@ -126,7 +126,7 @@ index d3d6651eb51c852ed1d1eeb5689569d5308b246d..c2d36600a0081c78425868154bdcf7f4
                          m = Long.MAX_VALUE;
                      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index f72ef5a0f97119732babc0ea353658cef52d6fe0..89b484170bc1c4bbd1bcd1e283dcd97c4d1129cd 100644
+index 5734a127fece27cbd20fdc31b18b9c10ab89b3ce..677aaeab867f1f4159b6fa023ce84e3dca4795fc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -1069,7 +1069,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0501-Incremental-player-saving.patch
+++ b/patches/server/0501-Incremental-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Incremental player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b67ba8f75e4a3358d7c2462918b85b0bf9b5a922..fdbd8b89bb8bf3b61f60b812b90483c98a3d5ccb 100644
+index 99879e8a14eeef80c082bc7c0fbadc02d7368485..3a3874dc04e9b0ea3c3f0fda96dce8b3fed3199f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -440,4 +440,15 @@ public class PaperConfig {

--- a/patches/server/0505-Do-not-let-the-server-load-chunks-from-newer-version.patch
+++ b/patches/server/0505-Do-not-let-the-server-load-chunks-from-newer-version.patch
@@ -9,7 +9,7 @@ the game, immediately stop the server to prevent data corruption.
 You can override this functionality at your own peril.
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
-index e9043403c0bd3edc11f8a4f55f3a512a630ec08b..f4c8b6485bd36241e1f0413140f04d7398848063 100644
+index f4cecd000ba4c4595c8db45524ec9d899193abe6..9ee2321150d3de7bf1a11c212951bc69872f4dd8 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/ChunkSerializer.java
 @@ -98,10 +98,25 @@ public class ChunkSerializer {

--- a/patches/server/0507-Add-setMaxPlayers-API.patch
+++ b/patches/server/0507-Add-setMaxPlayers-API.patch
@@ -18,7 +18,7 @@ index 13f1b62e6f3adce54f82d6d131dd60976dc6f548..f2b139d565662fca1bbad46e50b5ccb0
      private boolean allowCheatsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2b8fa52a7a80ce48673cfcae3bb6c1f1de004372..3572d362aa0773ea27353bfd0e11b591190a7908 100644
+index f93b9a1d0f3600fa1c8b9a9881465c73a965862b..f20829fdad6239f61baccd5f671a9139422f35f0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -612,6 +612,13 @@ public final class CraftServer implements Server {

--- a/patches/server/0514-Add-zombie-targets-turtle-egg-config.patch
+++ b/patches/server/0514-Add-zombie-targets-turtle-egg-config.patch
@@ -21,7 +21,7 @@ index 77e90a6b7d29ad989fd961e00a6fd97c7e5ec4fe..2252b9f36ea22a655592c6f176d18b70
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 299dc59535d2cd73de346618731c65bc01063b66..15f445e7d7250f274351cc5e46cc952d3630de5a 100644
+index 05a62a5d115d709ec1c29b36b09dfd8ce9626256..7731c11c2cb28225fc2465f4b5ea6a182e28d59e 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -109,7 +109,7 @@ public class Zombie extends Monster {

--- a/patches/server/0515-Buffer-joins-to-world.patch
+++ b/patches/server/0515-Buffer-joins-to-world.patch
@@ -8,7 +8,7 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index faa1b775e45563b93ac1d5b904938b1f5ad8d80c..545948f20efd6c8dd42140b565af94cd6b52b661 100644
+index 2678e4517570cbeafca7a9a4e54d4518cba75e69..8f702f1e80776259015a48cc4649b995198c7bfb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -457,4 +457,9 @@ public class PaperConfig {
@@ -22,7 +22,7 @@ index faa1b775e45563b93ac1d5b904938b1f5ad8d80c..545948f20efd6c8dd42140b565af94cd
 +    }
  }
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 34c642a9439faec095c58c6017a0dfd4b35a2401..01b9c360c6d687c6a774bf3375802be487cb0e0c 100644
+index 3faf9bc694016f3f46576a549814ff8e6070598a..7f6405ac44fef423dc8b21f3dbeaae26a1005077 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -37,6 +37,7 @@ import net.minecraft.network.protocol.Packet;

--- a/patches/server/0517-Fix-hex-colors-not-working-in-some-kick-messages.patch
+++ b/patches/server/0517-Fix-hex-colors-not-working-in-some-kick-messages.patch
@@ -43,7 +43,7 @@ index c09d3cdb3acb04b6a833c30a619ff2af5e8b6b18..2384ae5082afd01c4f28fe2f3f782cdc
                              this.connection.disconnect(chatmessage);
                              return;
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 195f5d1519c3fc2fdd03ecd0d49d7fba74037692..b8fb3f99e4af5768d8afc1b143e5585f08cc21a9 100644
+index bd1203a5b58bac7cccf1f81337fa2967a0e9eb40..7da88bc52161dc32da22451077a4dfd8facb2de1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -106,14 +106,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0518-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/patches/server/0518-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PortalCreateEvent needs to know its entity
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 41de19cc0cf5d4a2e5963a4226d08585d396fe42..aa0680291d042b9b4510008965d80cfd075f277c 100644
+index e643f925623820ffa67217eb3615582c0d0ca3a5..ae6638e44b5562436e8d3ad89167663c6f3961b1 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -407,7 +407,7 @@ public final class ItemStack {

--- a/patches/server/0521-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/patches/server/0521-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -21,7 +21,7 @@ index 64c304cab8c7c4c9c29f73465f99c11f224a72bd..b31eaa1459690d7f54989ba7a01f96a3
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index d18f8d7c699893740fa709ef1f0caa4390e7eb20..736cbdc118b7a19b724a3afd433927e8e8316d23 100644
+index 6b79b1ea43b713105f37de517019c033477f9835..135749c789d44f0af1ad11ccd1b208f1e28853eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -43,6 +43,7 @@ import org.bukkit.Registry;

--- a/patches/server/0524-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0524-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 00ce5bfdae67befdb72b01c152ab403fe60ab663..118580de630408472727b99fbca92695d95e5eec 100644
+index c7f18e142b0294291d7c47cf95943cb3cbc10a11..55e824f0b0258b8bde6d9f453256edf32b2e4a32 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -681,7 +681,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0525-Add-additional-open-container-api-to-HumanEntity.patch
+++ b/patches/server/0525-Add-additional-open-container-api-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add additional open container api to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 36ea76bfe0bd96ead82ed1ad34f25de10b7fa30e..021394a0e668d2cfccd8617d4aee79147181fa22 100644
+index 1dec5e2d11888a8684a198d9951d7e9bdd729898..13b3ac88e6ef436edf55e752fe2ded7844967c36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -458,6 +458,70 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {

--- a/patches/server/0528-Don-t-mark-dirty-in-invalid-locations-SPIGOT-6086.patch
+++ b/patches/server/0528-Don-t-mark-dirty-in-invalid-locations-SPIGOT-6086.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't mark dirty in invalid locations (SPIGOT-6086)
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index e5f2b9286cd2a4764894029a4cb982eddde3c8da..5f5e4366c88ce6b0fdb92cd88917757de21829af 100644
+index e649e6a8b354be45eed808ee02082ca7c826b59b..f542998d3aac3b5f3039b906b8dadd636c1fb164 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -379,6 +379,7 @@ public class ChunkHolder {

--- a/patches/server/0530-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0530-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,7 +14,7 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 545948f20efd6c8dd42140b565af94cd6b52b661..7d50aded88f5b7dfebaea1aebc86231f7b5c4e25 100644
+index 8f702f1e80776259015a48cc4649b995198c7bfb..3e486376a49a61d52cdcd32ea877996d81186a73 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -462,4 +462,9 @@ public class PaperConfig {

--- a/patches/server/0533-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
+++ b/patches/server/0533-Fix-CME-on-adding-a-passenger-in-CreatureSpawnEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix CME on adding a passenger in CreatureSpawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a8d000717a52e3896c0c81e8cf754d8cfbeadf52..6d49bd2693b30441d426c2a33399e0017edafe99 100644
+index 477b6102361f0ae03541402578e1d053572e52d3..144b5774077eb756df28c72b8cda78972ccf120e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3436,7 +3436,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0536-Fix-for-large-move-vectors-crashing-server.patch
+++ b/patches/server/0536-Fix-for-large-move-vectors-crashing-server.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix for large move vectors crashing server
 Check movement distance also based on current position.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 118580de630408472727b99fbca92695d95e5eec..fc0b50ff8a0b648b056d5393e68eee4006e32a45 100644
+index 55e824f0b0258b8bde6d9f453256edf32b2e4a32..650793ec3d9f2d30845aff1ddf1067da36ee8004 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -506,19 +506,24 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0537-Optimise-getType-calls.patch
+++ b/patches/server/0537-Optimise-getType-calls.patch
@@ -80,7 +80,7 @@ index 6dc8f9f269db6971b8b46819e017357899ccd118..7f49c7c7048b5778f20ddce1d844d4b3
  
      public BlockState getState() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-index 24a2e88d083f90375c46cf948c7c89dccc6e4aa0..53a0edfff9b8a5417461aa253ee6df4f592fd5d8 100644
+index 4645303efa716442b14e5c1e767b0d94dbb50170..d2ce92a8dea9f6e3d6262dfe7c599cc82b6028ce 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 @@ -77,7 +77,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {

--- a/patches/server/0543-Player-elytra-boost-API.patch
+++ b/patches/server/0543-Player-elytra-boost-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 56155f59c9a8ce6dd0e60e23bf346e6ab6312886..46b36ab9dee6fbb2ab8bbbe605c358d5edf76241 100644
+index 5a7f6ba01167784894e549e1b04193bf9c9db89c..a8ecfbf334f13f6ba986b170de712ad8b8f0b4ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -539,6 +539,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0546-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0546-Add-getOfflinePlayerIfCached-String.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f6fd414e639f2880f1abc2e4c4ef0fbe05a562db..5412c537fa3c3c1e4613a3b3b0ebfdf983a6902a 100644
+index f20829fdad6239f61baccd5f671a9139422f35f0..091824ee0cc45292988906d8004ecd472e5d772c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1608,6 +1608,28 @@ public final class CraftServer implements Server {

--- a/patches/server/0547-Add-ignore-discounts-API.patch
+++ b/patches/server/0547-Add-ignore-discounts-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add ignore discounts API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index cad80978510b50a3061cc5c898d6e7cb2b62b3b0..4a7de0ae19d49d868a5e6696e1a01871b654bf48 100644
+index cbec6decd12dae4f1b9f05f863b493d7379f46ed..25bc1f56e884e8fd9fc900d05dc82712e2f6e9d4 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -474,6 +474,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler

--- a/patches/server/0549-Fix-client-lag-on-advancement-loading.patch
+++ b/patches/server/0549-Fix-client-lag-on-advancement-loading.patch
@@ -15,7 +15,7 @@ manually reload the advancement data for all players, which
 normally takes place as a part of the datapack reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index a6250143baced61e87900181f8b37cfd89c717ff..9cbe97686394a5c4ae7b401d846b1a3525602d46 100644
+index 8c1ac43cf5510a14d1d41ec45d189ad9711024da..58193c1f62f2ef68e6e0b99aa6008b00b833ee42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -307,7 +307,13 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0553-Add-API-for-quit-reason.patch
+++ b/patches/server/0553-Add-API-for-quit-reason.patch
@@ -37,7 +37,7 @@ index 8c5445f845c5a1d30a4046ef78ea930d684e1942..979c3c08024f398997cd9f27bdff3639
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 85d6f50dd7394e20eeb0383b0d7d5e6653c29dda..fdf4a8078112ccef9087d5fa3e9b189bc5154561 100644
+index 650793ec3d9f2d30845aff1ddf1067da36ee8004..b804a29dc0c3538f5f14d6276247f8f7a299e481 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -443,6 +443,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0554-Seed-based-feature-search.patch
+++ b/patches/server/0554-Seed-based-feature-search.patch
@@ -40,7 +40,7 @@ index a03b835320bb99c38ec5f23f0c23284c08bd4171..45e65d1c56b693d8f7c5c12da7774849
      private void maxEntityCollision() {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
-index 3878a7f6402a1dff1e019e16dd8772ec7303ebe7..ef77b7e54c9ce3379b3bd6991aebcb4889029907 100644
+index d7129f3379f2edecbcfd85f83d75e4d7064ce71d..7705ad4460ddf5166d922888f3a1368c50bb11ca 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/feature/StructureFeature.java
 @@ -171,7 +171,24 @@ public abstract class StructureFeature<C extends FeatureConfiguration> {

--- a/patches/server/0559-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0559-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 46b36ab9dee6fbb2ab8bbbe605c358d5edf76241..ce437d0fd3194342bb660ff47f35d087522bc935 100644
+index a8ecfbf334f13f6ba986b170de712ad8b8f0b4ca..6a262955e0523db99d2b38cd7815968e8d6b41d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2062,7 +2062,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0563-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0563-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -21,7 +21,7 @@ index 935bb237f8ecd63ca4cec64a7c7a341c9d3358e5..208690ceca2485b54acde5123ba494d7
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index d857359e315f56afd9218e29bc43b898f41d22e5..3fb8a99fceaf7d271737046b9411b9a536e38ab6 100644
+index 144b5774077eb756df28c72b8cda78972ccf120e..db2ca58064000ac73c054d51590ccbcb9151d596 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1723,6 +1723,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -61,7 +61,7 @@ index 8fb89326395a7e70982c0d757b506565e98b12a4..a060cca08631fb42041e3a79a9abc422
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cda994992814109f4fac8f031ec82e98c482c0ad..515e551c365d799bebac3997f85c99243667caf5 100644
+index 8a0722455bf303f50b2955b53f9d7284a20f672e..e159d6c77860790c20ca7b531ed23ffda0380810 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3277,7 +3277,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0567-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0567-Fix-curing-zombie-villager-discount-exploit.patch
@@ -24,7 +24,7 @@ index 208690ceca2485b54acde5123ba494d71367791b..561976466cae6e4df63433c4631c516c
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 4a7de0ae19d49d868a5e6696e1a01871b654bf48..2ad93ff0bb46a282df706438b7c039c46323979a 100644
+index 25bc1f56e884e8fd9fc900d05dc82712e2f6e9d4..eaefa4f5f86f1c836aa29dd64ea786baced4b34d 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 @@ -1056,6 +1056,15 @@ public class Villager extends AbstractVillager implements ReputationEventHandler

--- a/patches/server/0574-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0574-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7159d63c7708cebda60da33eefc8a492d8de6219..ef4efe95bfa9058b9f9a6736e111b7cddfee4fbd 100644
+index a26ac24817f2480326cb9140625c82335d90c9a2..f9dfee7b1a4382002805b68d88b9c19476b66a66 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -257,6 +257,10 @@ public class CraftEventFactory {

--- a/patches/server/0582-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/patches/server/0582-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -21,7 +21,7 @@ index 561976466cae6e4df63433c4631c516c32a80bca..0079b4423c022a68aa9bee5b81910714
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/item/SpawnEggItem.java b/src/main/java/net/minecraft/world/item/SpawnEggItem.java
-index dd69c9b132fb52c60c44b3e029924412ecc28133..32a9a752e1afdcdaffa5198f3577856f742c9136 100644
+index 88d33491e858a25a53872b49311e7a5a97c1f67c..b16f338a001254c700fe4e10a5cec0d6dc7bd127 100644
 --- a/src/main/java/net/minecraft/world/item/SpawnEggItem.java
 +++ b/src/main/java/net/minecraft/world/item/SpawnEggItem.java
 @@ -61,7 +61,7 @@ public class SpawnEggItem extends Item {

--- a/patches/server/0595-Added-PlayerLoomPatternSelectEvent.patch
+++ b/patches/server/0595-Added-PlayerLoomPatternSelectEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added PlayerLoomPatternSelectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/LoomMenu.java b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
-index 7e8b6e0e69876cb7bfd444a8dd72edf8289e6dd1..51579f642859fc99c715dfcd286482995012d84a 100644
+index 9bcab01324612a905b21623a09109d404f8dadf7..fbe481faa504e9504bde5ed7b5098eaf847f647a 100644
 --- a/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/LoomMenu.java
 @@ -166,7 +166,22 @@ public class LoomMenu extends AbstractContainerMenu {

--- a/patches/server/0596-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0596-Configurable-door-breaking-difficulty.patch
@@ -72,7 +72,7 @@ index fafc4c4c7f5d6c4c03671bceec269250117ec472..51082fb81477b96c778796e8daf288b3
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 6c4c5756def8eb368cbc6e9319ae6f7ddccf0499..bb3b932c57fd1e5b1517940c7602c7f4aeeaf17e 100644
+index bcf80e22c815cf851a86e6cc9865c3cb5e89a143..ddda5d1e85864030db0cfecbf7a5fe134d7013a1 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -100,7 +100,7 @@ public class Zombie extends Monster {

--- a/patches/server/0597-Empty-commands-shall-not-be-dispatched.patch
+++ b/patches/server/0597-Empty-commands-shall-not-be-dispatched.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Empty commands shall not be dispatched
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index 7156dea53be828acd01734fa1f9f7b9accf30ff6..dc5d21693237ebb0b2a1ee45e92d0f191c547637 100644
+index f9b37c873b6b02f14bb7a7225197c552a7f7c5b9..5574c19d32bb8a0c08011be9ebb9105886459ec0 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
 @@ -230,6 +230,7 @@ public class Commands {

--- a/patches/server/0601-Add-sendOpLevel-API.patch
+++ b/patches/server/0601-Add-sendOpLevel-API.patch
@@ -46,7 +46,7 @@ index 6ac6d05390359bd858673c4941e7d90f4cf98a02..f80e4e2d8311ccfb62b7a61a71d8ae43
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ce437d0fd3194342bb660ff47f35d087522bc935..bdb4e47bb4fe23842abf583d25e0fc043499b675 100644
+index 6a262955e0523db99d2b38cd7815968e8d6b41d1..0c04869f9859ad0ee6885b8a26964804bb9ea930 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -553,6 +553,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0602-Add-StructureLocateEvent.patch
+++ b/patches/server/0602-Add-StructureLocateEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add StructureLocateEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
-index 6a93d3b3798b15fd75ca797665b442dcc634b89a..c2b0b1adcff5baf169901710d492317d44b93846 100644
+index 57ee9023c265504e07647cd9dd8997600c84594f..4a40fa5f7c71481ef0b275955bbd81a737889781 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkGenerator.java
 @@ -2,6 +2,7 @@ package net.minecraft.world.level.chunk;

--- a/patches/server/0603-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0603-Collision-option-for-requiring-a-player-participant.patch
@@ -28,7 +28,7 @@ index 4227e7fc46e22265316b42bbdb166d60e5aed94e..3d16e4a6bf842a209c760fd89f8edf99
      public int wanderingTraderSpawnDayTicks = 24000;
      public int wanderingTraderSpawnChanceFailureIncrement = 25;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 879cadfd1fe96059e621c625adef1673a41ac5dc..c696beff4211266e93026464ba9af5a5d4342e4f 100644
+index f744bf2d19291991ffa9c7b13fc62a479702d201..9b4bbdec896fa8c37d68604f095cc3cd54c8cab2 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1606,6 +1606,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0609-Added-Vanilla-Entity-Tags.patch
+++ b/patches/server/0609-Added-Vanilla-Entity-Tags.patch
@@ -39,7 +39,7 @@ index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d6ac063c78768fe8cc30e47b69795a740772e5e..52a13a702043a4cc97d650056ac8faae7bbe2afa 100644
+index 091824ee0cc45292988906d8004ecd472e5d772c..cbf97c2d69ef0ca68f4d9df81db5364599a4ae02 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2227,6 +2227,11 @@ public final class CraftServer implements Server {
@@ -55,7 +55,7 @@ index 6d6ac063c78768fe8cc30e47b69795a740772e5e..52a13a702043a4cc97d650056ac8faae
                  throw new IllegalArgumentException();
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 9cbe97686394a5c4ae7b401d846b1a3525602d46..75240802d17ff6b032c8708700cb2407cca3e56f 100644
+index 58193c1f62f2ef68e6e0b99aa6008b00b833ee42..21c1d6b7e97a1dee372ea1fa8eb95a712db63418 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -116,8 +116,17 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0610-added-Wither-API.patch
+++ b/patches/server/0610-added-Wither-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] added Wither API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index 03263689479d0f163fceb834bda07e7be13b798d..1e479853ec239b5e970b478adb3419e400d2f1d6 100644
+index 2f849b21e39d04a27ef88f8c76275f10bf55db3b..40b7f71c1aa561462f7551ae6f7c36b18b41b93a 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -83,6 +83,11 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob

--- a/patches/server/0611-Added-firing-of-PlayerChangeBeaconEffectEvent.patch
+++ b/patches/server/0611-Added-firing-of-PlayerChangeBeaconEffectEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added firing of PlayerChangeBeaconEffectEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
-index 4c76ef8ac18c538f97fd33cf5de47441c17b9181..91118c5d7d1414cacb80aad753c44c90f5812cf2 100644
+index 6647cda859006f7afc9aae14f5c305e428b3c5c6..6a198f2590563577877ec8510bbdbab72c359aa7 100644
 --- a/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/BeaconMenu.java
 @@ -160,9 +160,15 @@ public class BeaconMenu extends AbstractContainerMenu {

--- a/patches/server/0616-Skip-distance-map-update-when-spawning-disabled.patch
+++ b/patches/server/0616-Skip-distance-map-update-when-spawning-disabled.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Skip distance map update when spawning disabled.
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 89b484170bc1c4bbd1bcd1e283dcd97c4d1129cd..c5a73dee1c1c4724f01be44399f52cd2f711256c 100644
+index 677aaeab867f1f4159b6fa023ce84e3dca4795fc..6daf49a951fe7fdb04e8b71f00922e1d457b4e84 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -811,7 +811,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0617-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0617-Reset-shield-blocking-on-dimension-change.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4f97ddea0317d51b09da1a6b7de899c749e35bd5..cfa63b5f90869dd3af88684a4dfc633cb0c5127d 100644
+index 3fce21f8a7a48099dd6c2cce6b96fcae7975ac96..2b8be9b9af1ee571343b0a837eee3a57e7e31edd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1142,6 +1142,11 @@ public class ServerPlayer extends Player {

--- a/patches/server/0622-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0622-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4991ee6671f73b446e5dff958427b10aac78c63a..a59a449c0a7b76527f009031aee2d11d6b43cadf 100644
+index 1ab0c25dabd19dd53f255b76b2a5c85399cffaaf..21471cec1c8403b2b18744210ffe59a729d48105 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -390,13 +390,30 @@ public class CraftEventFactory {

--- a/patches/server/0623-Add-getMainThreadExecutor-to-BukkitScheduler.patch
+++ b/patches/server/0623-Add-getMainThreadExecutor-to-BukkitScheduler.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getMainThreadExecutor to BukkitScheduler
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-index 33480893ddee34a1983c5f1c4b14db98ff438528..d20438fcfc2baf7c826d1723738dbad3fdd123ee 100644
+index a423970cf7c927ea8a1bf842aaa236d3cf2d54c2..cdefb2025eedea7e204d70d568adaf1c1ec4c03c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scheduler/CraftScheduler.java
-@@ -635,4 +635,15 @@ public class CraftScheduler implements BukkitScheduler {
+@@ -655,4 +655,15 @@ public class CraftScheduler implements BukkitScheduler {
      public BukkitTask runTaskTimerAsynchronously(Plugin plugin, BukkitRunnable task, long delay, long period) throws IllegalArgumentException {
          throw new UnsupportedOperationException("Use BukkitRunnable#runTaskTimerAsynchronously(Plugin, long, long)");
      }

--- a/patches/server/0627-misc-debugging-dumps.patch
+++ b/patches/server/0627-misc-debugging-dumps.patch
@@ -74,7 +74,7 @@ index 7da88bc52161dc32da22451077a4dfd8facb2de1..f4cff18afa816aa7efb2f80e0af51216
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c1517da9414f2aaf00ccfe3554d2a8d177cb82e2..b27ba6026ffeadafddace294679a0b47088976f1 100644
+index cbf97c2d69ef0ca68f4d9df81db5364599a4ae02..f30ab74020f3b766242bcb81c480009e72fbdb2c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -931,6 +931,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0628-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0628-Add-support-for-hex-color-codes-in-console.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add support for hex color codes in console
 Converts upstream's hex color code legacy format into actual hex color codes in the console.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ecd2a9cd422e67d5aeebf9abf2998452515fad80..03521590dfcbb09416097e793fae5951c1ae3cc0 100644
+index b898690863be9753910bb4af3be13c2e73db7b00..ac8d8342094158d83e179b8b4906c96cb12b488b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -30,6 +30,7 @@ dependencies {

--- a/patches/server/0629-Expose-Tracked-Players.patch
+++ b/patches/server/0629-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bdb4e47bb4fe23842abf583d25e0fc043499b675..c5aa6f3edab0dbb6a9121200c46e31e5e5f39293 100644
+index 0c04869f9859ad0ee6885b8a26964804bb9ea930..418aa0d31fae7c5fa9c0826ef99ac00729c2de71 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2355,6 +2355,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0631-MC-29274-Fix-Wither-hostility-towards-players.patch
+++ b/patches/server/0631-MC-29274-Fix-Wither-hostility-towards-players.patch
@@ -21,7 +21,7 @@ index 0eba516110b82d917c3374a9fe5bbf337b83fad6..20eb4aea24cc6699747b18b2c00e5b01
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
-index 1e479853ec239b5e970b478adb3419e400d2f1d6..1c8f6863b976cfcb559de9b3e3cf9292831166ee 100644
+index 40b7f71c1aa561462f7551ae6f7c36b18b41b93a..6e3bd5146c687922e7b4680d59a1ae2d1480ad40 100644
 --- a/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 +++ b/src/main/java/net/minecraft/world/entity/boss/wither/WitherBoss.java
 @@ -105,6 +105,7 @@ public class WitherBoss extends Monster implements PowerableMob, RangedAttackMob

--- a/patches/server/0638-Prevent-grindstones-from-overstacking-items.patch
+++ b/patches/server/0638-Prevent-grindstones-from-overstacking-items.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent grindstones from overstacking items
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
-index b260216460b0bbf75edc631bb69e3e4fc94d459a..4414f59b17d3a5232dc2def1816964610fe03b68 100644
+index dda6c4948b903221fa8020c76d109216d2dd82bf..51f3650bc19bddc71731c0cb36e600cc8d16a495 100644
 --- a/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/GrindstoneMenu.java
 @@ -199,13 +199,13 @@ public class GrindstoneMenu extends AbstractContainerMenu {

--- a/patches/server/0644-Item-Rarity-API.patch
+++ b/patches/server/0644-Item-Rarity-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Item Rarity API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 75240802d17ff6b032c8708700cb2407cca3e56f..36cb7e974ed78074ac82ec7d2a4d86d91504872c 100644
+index 21c1d6b7e97a1dee372ea1fa8eb95a712db63418..e606c246f486eb0775a577ee7ccc87a8a4f313a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -470,6 +470,20 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0649-Don-t-ignore-result-of-PlayerEditBookEvent.patch
+++ b/patches/server/0649-Don-t-ignore-result-of-PlayerEditBookEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Don't ignore result of PlayerEditBookEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b77cd074a287d9db21819d950b1f158b8efcfd05..9aa08fffa6b01b77a0875fcaaa5416fabc92e276 100644
+index 373edbfde76af6733911e40ff343faccf9f6df99..1e75796a5cbad7bdb8250fddcde092786ec45f90 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1171,7 +1171,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0651-fix-cancelling-block-falling-causing-client-desync.patch
+++ b/patches/server/0651-fix-cancelling-block-falling-causing-client-desync.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix cancelling block falling causing client desync
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 5d89acffe7df54b79733bebba342ea694339ac4b..edc6126d45b0cf1918c5722c34ea6fea977ed293 100644
+index 15ec064cb9336924e16a7c9b3f76a9b6ef18d947..8336ea928faa92c6f58f8cdfb9faf1d8e26c9ccf 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -119,8 +119,18 @@ public class FallingBlockEntity extends Entity {

--- a/patches/server/0653-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
+++ b/patches/server/0653-Allow-for-Component-suggestion-tooltips-in-AsyncTabC.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow for Component suggestion tooltips in
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 5969d66ba88b4509b03f315721c8b2d8a1f07d43..6a0bda9711fedac3662ebe86d3b592935536694f 100644
+index 1e75796a5cbad7bdb8250fddcde092786ec45f90..89867d1dce38400a70efa0758b46397dcb3f64f9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -757,12 +757,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0654-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0654-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Enhance console tab completions for brigadier commands
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c56e7fb18f9a56c8025eb70a524f028b5942da37..efc1e42d606e1c9feb1a4871c0714933ae92a1b2 100644
+index ea4fa458113d68dc2ed3187e19b11d72fc05d36c..458412d66f392fe5736f68126180b0a039dde785 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -479,4 +479,11 @@ public class PaperConfig {

--- a/patches/server/0655-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0655-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,7 +9,7 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a0861a9c97c8cd300485dfd8b528092ad4ed17ba..9f57ebcf4f1fafe38ebdf9b78f186e244853101d 100644
+index fdf0c39111059d7030cfc1eddfdcdda375bd2640..99b33003c97bb86b2cfc4a77298ac52efad6e78f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3702,6 +3702,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0658-add-isDeeplySleeping-to-HumanEntity.patch
+++ b/patches/server/0658-add-isDeeplySleeping-to-HumanEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add isDeeplySleeping to HumanEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
-index 021394a0e668d2cfccd8617d4aee79147181fa22..3ab8bd503a599a11c0d50017826cebf6765197f3 100644
+index 13b3ac88e6ef436edf55e752fe2ded7844967c36..9ae925e02698fdfd2f77ab40268b9ac0635f9bd2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
 @@ -121,6 +121,13 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {

--- a/patches/server/0661-add-get-set-drop-chance-to-EntityEquipment.patch
+++ b/patches/server/0661-add-get-set-drop-chance-to-EntityEquipment.patch
@@ -27,7 +27,7 @@ index 5a22c089f8c2c58f577ee32caa9985fff112de3c..1a88eafcba718f0c307ef6fcde72f156
      private void setDropChance(net.minecraft.world.entity.EquipmentSlot slot, float chance) {
          Preconditions.checkArgument(this.entity.getHandle() instanceof Mob, "Cannot set drop chance for non-Mob entity");
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
-index 5ae4f2b6cfa4067a0589d6f909ac6a7d9b48fd6f..3354d13f657cecfc3cc756a99accd5d481e8b1dd 100644
+index 8bca88f7b7d310b29bdc851125e4cd03718a4fb9..d6a228473ca6f425757683a4b17b035a53ab117f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
 @@ -354,4 +354,15 @@ public class CraftInventoryPlayer extends CraftInventory implements org.bukkit.i

--- a/patches/server/0662-fix-PigZombieAngerEvent-cancellation.patch
+++ b/patches/server/0662-fix-PigZombieAngerEvent-cancellation.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] fix PigZombieAngerEvent cancellation
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/monster/ZombifiedPiglin.java b/src/main/java/net/minecraft/world/entity/monster/ZombifiedPiglin.java
-index 7853fbad01bea710e06bdf3198895f2492bdbd10..233b390541acddcf815db4a8f299496eaea4f758 100644
+index 214a17f00eec7a59c89ab5799491c7a7315eb72f..025d53ab0787d596f4c486b15d286b9547838e16 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/ZombifiedPiglin.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/ZombifiedPiglin.java
 @@ -51,6 +51,7 @@ public class ZombifiedPiglin extends Zombie implements NeutralMob {

--- a/patches/server/0663-Fix-checkReach-check-for-Shulker-boxes.patch
+++ b/patches/server/0663-Fix-checkReach-check-for-Shulker-boxes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix checkReach check for Shulker boxes
 
 
 diff --git a/src/main/java/net/minecraft/world/inventory/ShulkerBoxMenu.java b/src/main/java/net/minecraft/world/inventory/ShulkerBoxMenu.java
-index b6235e4fe95ba5f19d5897010bf74245336d372d..4739515ca5c8d88283f24214c74ebf4fbd203677 100644
+index fdf04f3834a2a58073a642f4d0bfef7c8d1a6888..087da4c5774e01b05612153e4e2e2bb588404f3d 100644
 --- a/src/main/java/net/minecraft/world/inventory/ShulkerBoxMenu.java
 +++ b/src/main/java/net/minecraft/world/inventory/ShulkerBoxMenu.java
 @@ -66,6 +66,7 @@ public class ShulkerBoxMenu extends AbstractContainerMenu {

--- a/patches/server/0665-Added-PlayerDeepSleepEvent.patch
+++ b/patches/server/0665-Added-PlayerDeepSleepEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added PlayerDeepSleepEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 183b621cbf6fbe7cec144af69fd74461b2471142..d286d88a3c3f93dbfa92de9421e320c92cd96350 100644
+index 48c7b81b320b5b4da07dbbefcc0d29f8b8a506d7..d197a63bac1238020cd6cacf209bc7c1b463040d 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -247,6 +247,11 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0670-Introduce-beacon-activation-deactivation-events.patch
+++ b/patches/server/0670-Introduce-beacon-activation-deactivation-events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Introduce beacon activation/deactivation events
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
-index 1df7a4a937729fc402f80021434ddf3481facd94..c1a0b0d77b8783fd127b68449a209ec0e62e6005 100644
+index 11740e6a312cf8ab10b52461f455feba0e1b2788..3281448bf37da8a1b4b7b44f10f4b2438b4a4f29 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BeaconBlockEntity.java
 @@ -206,6 +206,15 @@ public class BeaconBlockEntity extends BlockEntity implements MenuProvider {

--- a/patches/server/0673-Send-empty-commands-if-tab-completion-is-disabled.patch
+++ b/patches/server/0673-Send-empty-commands-if-tab-completion-is-disabled.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Send empty commands if tab completion is disabled
 
 
 diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
-index dc5d21693237ebb0b2a1ee45e92d0f191c547637..ff4f48f6646060b398e8bf90a078e7fbf84beada 100644
+index 5574c19d32bb8a0c08011be9ebb9105886459ec0..a6f10d47bc4e2cadcc3e06cffa011ed7fb97c68d 100644
 --- a/src/main/java/net/minecraft/commands/Commands.java
 +++ b/src/main/java/net/minecraft/commands/Commands.java
 @@ -334,7 +334,12 @@ public class Commands {

--- a/patches/server/0677-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0677-Add-raw-address-to-AsyncPlayerPreLoginEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add raw address to AsyncPlayerPreLoginEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 17a171f531c356e2c8abe2f26c012e9bdcfa9879..5d26417b5d4e182fdefdf1ef5c81a0b7d7f2d4c1 100644
+index f4cff18afa816aa7efb2f80e0af51216129963a4..45e77d96f673ce68cf15ce3d45fd1eeffed4d8d8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -351,12 +351,13 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener

--- a/patches/server/0679-call-PortalCreateEvent-players-and-end-platform.patch
+++ b/patches/server/0679-call-PortalCreateEvent-players-and-end-platform.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] call PortalCreateEvent players and end platform
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index cfa63b5f90869dd3af88684a4dfc633cb0c5127d..eef88ba763edfc6515c5e0f8c0b3e13145bea822 100644
+index 2b8be9b9af1ee571343b0a837eee3a57e7e31edd..91a03f4ed215c882d2ae930402220e4cbbf1ea00 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1169,15 +1169,21 @@ public class ServerPlayer extends Player {

--- a/patches/server/0680-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
+++ b/patches/server/0680-Add-a-should-burn-in-sunlight-API-for-Phantoms-and-S.patch
@@ -110,7 +110,7 @@ index c9dab70b0b284fe1c1daafd3c1f5bd08b14fa35d..dce23f3878b1588c26b6116d80e597d0
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
-index 7a73ada3d8b8085591308275ece4a9ce617314d3..823e922a049719c4cfd57b0108df3bc2144d9975 100644
+index 78f736ed3abaab4cc8bf8b7b163e25c806f79f3c..61e2841fea6603e3e5fbd004de7ffdfb79fc9981 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
 @@ -51,4 +51,16 @@ public class CraftSkeleton extends CraftAbstractSkeleton implements Skeleton {

--- a/patches/server/0682-Add-basic-Datapack-API.patch
+++ b/patches/server/0682-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dda910b0135cc285365c03630e57867ff0a2a6ab..b483289bf016317d6ccb8baad2504e9091d72c5b 100644
+index aaf176deb2f28b02f474efdbce40f9db9f70dad9..f9d148fce42b146e5e1921221020341edbe7c1ec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -266,6 +266,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0684-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0684-additions-to-PlayerGameModeChangeEvent.patch
@@ -91,7 +91,7 @@ index 91a03f4ed215c882d2ae930402220e4cbbf1ea00..8e2bccc3a9ddb17a4978596056189eb7
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
-index cc2d2f4885ba0946f93f08aba2b2ec828bb83d85..9ace6b067b46831ee381ee6b40dedd952d3c7562 100644
+index 5ef649dec31ba6d6b74a7bd757727ffd2a79d71e..1c83fbc96a074c85a3e349e936ff1f3198596709 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayerGameMode.java
 @@ -74,18 +74,24 @@ public class ServerPlayerGameMode {

--- a/patches/server/0686-ItemStack-repair-check-API.patch
+++ b/patches/server/0686-ItemStack-repair-check-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack repair check API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index fa3c5f2b24dc89b07991fae5e463ea53abdd78b4..0c720f3a75cff8e62802b1fe6e3c5f594c5cc1a8 100644
+index 7cf7e838867aed87fec2319cd84be7466b57e09f..24f5f6c7b1ca21515cdeb053f8e1f56004c800d0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -485,6 +485,14 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0688-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0688-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,7 +7,7 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b483289bf016317d6ccb8baad2504e9091d72c5b..21f64f879ab71fd40d3f5bb1d0ded4e5802ae373 100644
+index f9d148fce42b146e5e1921221020341edbe7c1ec..69489893e648e72e95d8522a5990f27535fc3c0d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -385,8 +385,13 @@ public final class CraftServer implements Server {
@@ -46,7 +46,7 @@ index b483289bf016317d6ccb8baad2504e9091d72c5b..21f64f879ab71fd40d3f5bb1d0ded4e5
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index daa881823f9a0757211e4fece8ebd9225f8b41bb..d92a7e8e4f5a6e794ae4563f17a817ace36da73e 100644
+index f197d63c618b25c139852809c0b0a6e313c83f18..ea7df53656766a8dc4ab5fe66de894301db634e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -153,6 +153,12 @@ public class Main {

--- a/patches/server/0689-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0689-Fix-and-optimise-world-force-upgrading.patch
@@ -352,7 +352,7 @@ index 43510774d489bfdd30f10d521e424fa1363b8919..6496108953effae82391b5c1ea6fdec8
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 85f2feec921184d2c20aac740d3d4328a730ae8a..9f2cc053cc0262405dc377716688e0c97f63b30f 100644
+index 69489893e648e72e95d8522a5990f27535fc3c0d..dd435909ad16a7f732fd0a2056f986dd9b24c0d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1138,14 +1138,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0692-Add-EntityInsideBlockEvent.patch
+++ b/patches/server/0692-Add-EntityInsideBlockEvent.patch
@@ -149,7 +149,7 @@ index f0a3ef0529951e7732602d358ddea1782001db7e..6588b207d93d96934e72176874ba60c8
              entity.lavaHurt();
          }
 diff --git a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
-index 033b4e342d6c3978be084e65a2a7a3b23d6a7851..058f55c68ea788719b369efbe78a02dfadfcd960 100644
+index a22676495796784e59a0dd11343c966ec7ea6bc6..d06a20f12a4c0d7d561141ca004a965751a68f9e 100644
 --- a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 @@ -59,6 +59,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {

--- a/patches/server/0693-Attributes-API-for-item-defaults.patch
+++ b/patches/server/0693-Attributes-API-for-item-defaults.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Attributes API for item defaults
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 0c720f3a75cff8e62802b1fe6e3c5f594c5cc1a8..edf7e8d65d7f67f2f34490fdb766eca7d3b17aee 100644
+index 24f5f6c7b1ca21515cdeb053f8e1f56004c800d0..7a8db8d481e9487ea83a640af208242f4987ad28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -493,6 +493,19 @@ public final class CraftMagicNumbers implements UnsafeValues {

--- a/patches/server/0696-More-Lidded-Block-API.patch
+++ b/patches/server/0696-More-Lidded-Block-API.patch
@@ -21,7 +21,7 @@ index dcae26b698d31a8b0107b0f9757efa34f53b030a..c0e7ae7ae38d55088e1b6ae6c80b849f
 +    // Paper end - More Lidded Block API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index f48b830a9ae8160388cb0d0220a44b1ec9f0d214..5045507871db402305a43430194b4c5e965300ad 100644
+index 79edaefe8f6c027b5ad67c6bdcc0bb84a0582887..3b90bee227ebfc1b6436319d002b5fd35e4eeda8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 @@ -79,4 +79,11 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest

--- a/patches/server/0706-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0706-Fix-dangerous-end-portal-logic.patch
@@ -11,7 +11,7 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9bff440ed2063d9663da96fa45ec49c1d80606e2..4fd030ef9537d9b31c6167d73349f4c4a6b33a15 100644
+index 9b4bbdec896fa8c37d68604f095cc3cd54c8cab2..a11507c630248b98153275f78c15ebee59a6b0a3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -361,6 +361,37 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0708-Make-item-validations-configurable.patch
+++ b/patches/server/0708-Make-item-validations-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index efc1e42d606e1c9feb1a4871c0714933ae92a1b2..7acf077bc131af718c7548cc29deef558c04e463 100644
+index 458412d66f392fe5736f68126180b0a039dde785..ffdacd1946c73e762b89b35c55a2e60eb7cd195b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -486,4 +486,19 @@ public class PaperConfig {

--- a/patches/server/0717-Ensure-disconnect-for-book-edit-is-called-on-main.patch
+++ b/patches/server/0717-Ensure-disconnect-for-book-edit-is-called-on-main.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure disconnect for book edit is called on main
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 784fc77a5b98f1e085edc4aea3c6bed524b1fb0e..6c6e5b7562d9051709f76bf968060de7212dc182 100644
+index c4c3c9c19ce0d35c8d7937f5d166412872fbdf1b..439c86b2661bc22844d17a16e7ccf68f875b4268 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1093,7 +1093,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0721-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0721-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -21,7 +21,7 @@ index 4b582ae2a11864bfde7fb6a45e51a9938d9d4c08..c2e0417ee15018ec31c4aa8eec3dff7a
  
      // Paper start - Asynchronous IO
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6c6e5b7562d9051709f76bf968060de7212dc182..6ff04fc7202a7eb1f2b5978a2e2a573945d9dde1 100644
+index 439c86b2661bc22844d17a16e7ccf68f875b4268..98a77dfce1f24751b77b6a1dc6f2b040819f2a6d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1298,7 +1298,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0726-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0726-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26e18a08a7f0bd704ff3055ce3a7814191450c85..b07368ed5b8fcacd617988d09d5d27904315cf27 100644
+index 33d7a5da8764c5f6b8e911faecb6b4282443a60b..857ef2377d2e6fd84d70e301860692e670983f0c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -648,6 +648,21 @@ public class PaperWorldConfig {

--- a/patches/server/0727-Fix-incorrect-message-for-outdated-client.patch
+++ b/patches/server/0727-Fix-incorrect-message-for-outdated-client.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix incorrect message for outdated client
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
-index e0cd786f130e34b3401d40663e1548fc0076f74a..6de604675a5f41a12f6daa093fc15f22732dba58 100644
+index e0cd786f130e34b3401d40663e1548fc0076f74a..451ca1a1d84227274fd59fc5d46654a441561710 100644
 --- a/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerHandshakePacketListenerImpl.java
 @@ -81,7 +81,7 @@ public class ServerHandshakePacketListenerImpl implements ServerHandshakePacketL


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
eec4aab0 SPIGOT-6657: Add getPlayer to SheepDyeWoolEvent
205213c6 SPIGOT-6656: CauldronLevelChangeEvent is not fired correctly when dripstone fills the cauldron

CraftBukkit Changes:
b8c522d5 SPIGOT-6657: Add getPlayer to SheepDyeWoolEvent
f04a77dc SPIGOT-6656: CauldronLevelChangeEvent is not fired correctly when dripstone fills the cauldron
d1dbcebc SPIGOT-6653: Canceling snow bucket placement removes snow from bucket
4f34a67b #891: Fix scheduler task ID overflow and duplication issues

Spigot Changes:
d03d7f12 BUILDTOOLS-604: Rebuild patches