### PR TITLE
Use mapped names for sensor and behavior timings/config

### DIFF
--- a/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -159,10 +159,10 @@ index 0000000000000000000000000000000000000000..d019802a36dbaca4bf299a55d28381e4
 +}
 diff --git a/src/main/java/io/papermc/paper/util/StacktraceDeobfuscator.java b/src/main/java/io/papermc/paper/util/StacktraceDeobfuscator.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..281fd2dbc7f1281ba882020be2a3481fe8909685
+index 0000000000000000000000000000000000000000..b43edcb54a50cf53b4e8b365555385d026a7061f
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/StacktraceDeobfuscator.java
-@@ -0,0 +1,223 @@
+@@ -0,0 +1,227 @@
 +package io.papermc.paper.util;
 +
 +import com.destroystokyo.paper.PaperConfig;
@@ -372,18 +372,22 @@ index 0000000000000000000000000000000000000000..281fd2dbc7f1281ba882020be2a3481f
 +        return rootClassName + ".java";
 +    }
 +
-+    private record ClassMapping(
++    public record ClassMapping(
 +        String obfName,
 +        String mojangName,
 +        Map<Pair<String, String>, MethodMapping> methodMappings
 +    ) {
 +    }
 +
-+    private record MethodMapping(
++    public record MethodMapping(
 +        String obfName,
 +        String mojangName,
 +        String descriptor
 +    ) {
++    }
++
++    public @Nullable Map<String, ClassMapping> mappings() {
++        return mappings;
 +    }
 +}
 diff --git a/src/main/java/io/papermc/paper/util/TraceUtil.java b/src/main/java/io/papermc/paper/util/TraceUtil.java

--- a/patches/server/0730-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0730-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..eb99eed57d45e680f2ae3eea62e5eee72e4dffaa 100644
+index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..f65e3b51e876f7a3d30710eed56fdca4daa620c9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,14 +3,19 @@ package com.destroystokyo.paper;
@@ -59,8 +59,8 @@ index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..eb99eed57d45e680f2ae3eea62e5eee7
 +    private Table<String, String, Integer> sensorTickRates;
 +    private Table<String, String, Integer> behaviorTickRates;
 +    private void tickRates() {
-+        config.addDefault("world-settings.default.tick-rates.sensor.villager.secondaryplaces", 40);
-+        config.addDefault("world-settings.default.tick-rates.behavior.villager.positionvalidate", 20);
++        config.addDefault("world-settings.default.tick-rates.sensor.villager.secondarypoisensor", 40);
++        config.addDefault("world-settings.default.tick-rates.behavior.villager.validatenearbypoi", -1); // Example
 +        log("Tick rates:");
 +        sensorTickRates = loadTickRates("sensor");
 +        behaviorTickRates = loadTickRates("behavior");
@@ -111,7 +111,7 @@ index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..eb99eed57d45e680f2ae3eea62e5eee7
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570a70c4cf2 100644
+index b1212e162ba938b3abe0df747a633ba9cbbe57c8..40a575cfa7670f24578f603a3e445f763e2279b5 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 @@ -14,6 +14,10 @@ public abstract class Behavior<E extends LivingEntity> {
@@ -125,23 +125,29 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570
  
      public Behavior(Map<MemoryModuleType<?>, MemoryStatus> requiredMemoryState) {
          this(requiredMemoryState, 60);
-@@ -27,6 +31,15 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -27,6 +31,21 @@ public abstract class Behavior<E extends LivingEntity> {
          this.minDuration = minRunTime;
          this.maxDuration = maxRunTime;
          this.entryCondition = requiredMemoryState;
 +        // Paper start - configurable behavior tick rate and timings
-+        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
-+        key = key.toLowerCase(java.util.Locale.ROOT);
-+        if (key.startsWith("behavior")) {
-+            key = key.substring("behavior".length());
++        Map<String, io.papermc.paper.util.StacktraceDeobfuscator.ClassMapping> mappings = io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.mappings();
++        String key;
++        if (mappings != null) {
++            key = mappings.get(getClass().getName()).mojangName();
++            int lastSeparator = key.lastIndexOf('.');
++            if (lastSeparator != -1) {
++                key = key.substring(lastSeparator + 1);
++            }
++        } else {
++            key = getClass().getSimpleName();
 +        }
-+        this.configKey = key;
++        this.configKey = key.toLowerCase(java.util.Locale.ROOT);
 +        this.timing = co.aikar.timings.MinecraftTimings.getBehaviorTimings(configKey);
 +        // Paper end
      }
  
      public Behavior.Status getStatus() {
-@@ -34,11 +47,19 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -34,11 +53,19 @@ public abstract class Behavior<E extends LivingEntity> {
      }
  
      public final boolean tryStart(ServerLevel world, E entity, long time) {
@@ -161,7 +167,7 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570
              return true;
          } else {
              return false;
-@@ -49,11 +70,13 @@ public abstract class Behavior<E extends LivingEntity> {
+@@ -49,11 +76,13 @@ public abstract class Behavior<E extends LivingEntity> {
      }
  
      public final void tickOrStop(ServerLevel world, E entity, long time) {
@@ -176,10 +182,10 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..fe2aa0165be6b9d9a82a799b7096a570
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..d9fc867c6414d36d76411ad012d1aff9a6cf6772 100644
+index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..188dc5bf48d5c1f624ac117db5e79101a441370b 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-@@ -19,8 +19,21 @@ public abstract class Sensor<E extends LivingEntity> {
+@@ -19,8 +19,27 @@ public abstract class Sensor<E extends LivingEntity> {
      private static final TargetingConditions ATTACK_TARGET_CONDITIONS_IGNORE_INVISIBILITY_AND_LINE_OF_SIGHT = TargetingConditions.forCombat().range(16.0D).ignoreLineOfSight().ignoreInvisibilityTesting();
      private final int scanRate;
      private long timeToTick;
@@ -190,18 +196,24 @@ index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..d9fc867c6414d36d76411ad012d1aff9
  
      public Sensor(int senseInterval) {
 +        // Paper start - configurable sensor tick rate and timings
-+        String key = getClass().getName().startsWith("net.minecraft.") ? getClass().getSimpleName() : getClass().getName();
-+        key = key.toLowerCase(java.util.Locale.ROOT);
-+        if (key.startsWith("sensor")) {
-+            key = key.substring("sensor".length());
++        java.util.Map<String, io.papermc.paper.util.StacktraceDeobfuscator.ClassMapping> mappings = io.papermc.paper.util.StacktraceDeobfuscator.INSTANCE.mappings();
++        String key;
++        if (mappings != null) {
++            key = mappings.get(getClass().getName()).mojangName();
++            int lastSeparator = key.lastIndexOf('.');
++            if (lastSeparator != -1) {
++                key = key.substring(lastSeparator + 1);
++            }
++        } else {
++            key = getClass().getSimpleName();
 +        }
-+        this.configKey = key;
++        this.configKey = key.toLowerCase(java.util.Locale.ROOT);
 +        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey);
 +        // Paper end
          this.scanRate = senseInterval;
          this.timeToTick = (long)RANDOM.nextInt(senseInterval);
      }
-@@ -31,8 +44,12 @@ public abstract class Sensor<E extends LivingEntity> {
+@@ -31,8 +50,12 @@ public abstract class Sensor<E extends LivingEntity> {
  
      public final void tick(ServerLevel world, E entity) {
          if (--this.timeToTick <= 0L) {


### PR DESCRIPTION
Uses StackTraceObfuscator for now, but jmp will move that out into its own utility at a later date.
Also removes the validatenearbypoi change since the delay doesn't make all too much of a difference in performance usually, but will likely annoy more often than it helps (but kept as -1 as an example).