### PR TITLE
Don't expose ASM in API

### DIFF
--- a/patches/api/0025-Use-ASM-for-event-executors.patch
+++ b/patches/api/0025-Use-ASM-for-event-executors.patch
@@ -6,18 +6,19 @@ Subject: [PATCH] Use ASM for event executors.
 Uses method handles for private or static methods.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 479d4e3b91e902e9b30d351aa65c8b079555d7e0..58b7df30d050156998aa88fb7e2b1973492294db 100644
+index 479d4e3b91e902e9b30d351aa65c8b079555d7e0..c12636f01b233c2436b7d5cdd4c04ac91389247b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -26,6 +26,8 @@ dependencies {
-     api("net.kyori:adventure-text-serializer-gson")
+@@ -27,6 +27,9 @@ dependencies {
      api("net.kyori:adventure-text-serializer-legacy")
      api("net.kyori:adventure-text-serializer-plain")
-+    api("org.ow2.asm:asm:9.0")
-+    api("org.ow2.asm:asm-commons:9.0")
  
++    implementation("org.ow2.asm:asm:9.1")
++    implementation("org.ow2.asm:asm-commons:9.1")
++
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.1")
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.0")
+     compileOnly("org.apache.maven.resolver:maven-resolver-transport-http:1.7.0")
 diff --git a/src/main/java/com/destroystokyo/paper/event/executor/MethodHandleEventExecutor.java b/src/main/java/com/destroystokyo/paper/event/executor/MethodHandleEventExecutor.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..5b28e9b1daba7834af67dbc193dd656bedd9a994

--- a/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,17 +14,17 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 58b7df30d050156998aa88fb7e2b1973492294db..7ad3e5153718f6d4ce8293a9790bc3c1158aeb8e 100644
+index c12636f01b233c2436b7d5cdd4c04ac91389247b..15b8f4708887535383bb74bd922f893231737599 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -28,6 +28,7 @@ dependencies {
+@@ -26,6 +26,7 @@ dependencies {
+     api("net.kyori:adventure-text-serializer-gson")
+     api("net.kyori:adventure-text-serializer-legacy")
      api("net.kyori:adventure-text-serializer-plain")
-     api("org.ow2.asm:asm:9.0")
-     api("org.ow2.asm:asm-commons:9.0")
 +    api("org.apache.logging.log4j:log4j-api:2.14.1") // Paper
  
-     compileOnly("org.apache.maven:maven-resolver-provider:3.8.1")
-     compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.0")
+     implementation("org.ow2.asm:asm:9.1")
+     implementation("org.ow2.asm:asm-commons:9.1")
 diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
 index febfec6efafd76bb59b4b43aa223af16f73339b4..79890c68f1ad31f951dfdbd9a16dac500ec58c40 100644
 --- a/src/main/java/org/bukkit/plugin/Plugin.java

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -20,17 +20,15 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..3e05459f27c4c5697ae65da504d67a6a
  /.project
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..f99a9702fe9282a1982c25cd0c003d8df80e97de
+index 0000000000000000000000000000000000000000..8d27de2c9da08ca32ff18fc4b8b02ea583edfc1c
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,146 @@
+@@ -0,0 +1,144 @@
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 +import io.papermc.paperweight.util.Git
 +import io.papermc.paperweight.util.path
 +import shadow.org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE
-+import java.text.SimpleDateFormat
-+import java.util.Date
 +import java.util.Locale
 +
 +plugins {

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f99a9702fe9282a1982c25cd0c003d8df80e97de..f06e7871780e863f5dd34338b008b739a471709a 100644
+index 8d27de2c9da08ca32ff18fc4b8b02ea583edfc1c..31343d49cf38063976e0f8c93264a4f3897f06fb 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -20,21 +20,23 @@ repositories {
+@@ -18,21 +18,24 @@ repositories {
  dependencies {
      implementation(project(":Paper-API"))
      implementation("jline:jline:2.12.1")
@@ -18,6 +18,7 @@ index f99a9702fe9282a1982c25cd0c003d8df80e97de..f06e7871780e863f5dd34338b008b739
 +    implementation("org.apache.logging.log4j:log4j-iostreams:2.14.1") // Paper
 +    implementation("org.apache.logging.log4j:log4j-api:2.14.1") // Paper
      implementation("org.ow2.asm:asm:9.1")
++    implementation("org.ow2.asm:asm-commons:9.1") // Paper - ASM event executor generation
      implementation("com.googlecode.json-simple:json-simple:1.1.1") {
          // This includes junit transitively for whatever reason
          isTransitive = false
@@ -36,7 +37,7 @@ index f99a9702fe9282a1982c25cd0c003d8df80e97de..f06e7871780e863f5dd34338b008b739
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
  }
-@@ -55,6 +57,7 @@ tasks.jar {
+@@ -53,6 +56,7 @@ tasks.jar {
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
@@ -44,7 +45,7 @@ index f99a9702fe9282a1982c25cd0c003d8df80e97de..f06e7871780e863f5dd34338b008b739
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -72,15 +75,23 @@ publishing {
+@@ -70,15 +74,23 @@ publishing {
      }
  }
  

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,10 +19,10 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index f06e7871780e863f5dd34338b008b739a471709a..eaf938718764cae71f35077623796084ac0308d4 100644
+index 31343d49cf38063976e0f8c93264a4f3897f06fb..af867b39253f49f5dcf927d8659bc84cab0e26f0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -19,7 +19,17 @@ repositories {
+@@ -17,7 +17,17 @@ repositories {
  
  dependencies {
      implementation(project(":Paper-API"))

--- a/patches/server/0157-Handle-plugin-prefixes-using-Log4J-configuration.patch
+++ b/patches/server/0157-Handle-plugin-prefixes-using-Log4J-configuration.patch
@@ -15,10 +15,10 @@ This may cause additional prefixes to be disabled for plugins bypassing
 the plugin logger.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index eaf938718764cae71f35077623796084ac0308d4..3360889a8a067a5f1cb703df88484b4f5f87c8ce 100644
+index af867b39253f49f5dcf927d8659bc84cab0e26f0..34a0d6b54a15c8aa0c706541316c5d448e3d94b9 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -28,7 +28,7 @@ dependencies {
+@@ -26,7 +26,7 @@ dependencies {
            all its classes to check if they are plugins.
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */

--- a/patches/server/0224-Use-asynchronous-Log4j-2-loggers.patch
+++ b/patches/server/0224-Use-asynchronous-Log4j-2-loggers.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Use asynchronous Log4j 2 loggers
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 3360889a8a067a5f1cb703df88484b4f5f87c8ce..03a37d0429b6e1f18d90f0fa8268071965f6bae3 100644
+index 34a0d6b54a15c8aa0c706541316c5d448e3d94b9..514633e01a1b5c85a4bc62bf1c3e096f4eaa5e98 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -39,6 +39,7 @@ dependencies {
+@@ -38,6 +38,7 @@ dependencies {
      }
      runtimeOnly("org.xerial:sqlite-jdbc:3.34.0")
      runtimeOnly("mysql:mysql-connector-java:8.0.23") // Paper

--- a/patches/server/0425-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0425-Implement-Brigadier-Mojang-API.patch
@@ -10,10 +10,10 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 03a37d0429b6e1f18d90f0fa8268071965f6bae3..8d08c4f2bedddc737dbefb89fa2f99fba2b66e4a 100644
+index 514633e01a1b5c85a4bc62bf1c3e096f4eaa5e98..702ccd405ebe5d3b1f2525a475c81caadc04a0f0 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -19,6 +19,7 @@ repositories {
+@@ -17,6 +17,7 @@ repositories {
  
  dependencies {
      implementation(project(":Paper-API"))

--- a/patches/server/0431-Implement-Mob-Goal-API.patch
+++ b/patches/server/0431-Implement-Mob-Goal-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 8d08c4f2bedddc737dbefb89fa2f99fba2b66e4a..b898690863be9753910bb4af3be13c2e73db7b00 100644
+index 702ccd405ebe5d3b1f2525a475c81caadc04a0f0..59f034c2bc0db9e918e6ecc422021ea82bae9f29 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -49,6 +49,7 @@ dependencies {
+@@ -48,6 +48,7 @@ dependencies {
      implementation("co.aikar:cleaner:1.0-SNAPSHOT") // Paper
      implementation("io.netty:netty-all:4.1.65.Final") // Paper
  

--- a/patches/server/0628-Add-support-for-hex-color-codes-in-console.patch
+++ b/patches/server/0628-Add-support-for-hex-color-codes-in-console.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add support for hex color codes in console
 Converts upstream's hex color code legacy format into actual hex color codes in the console.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index b898690863be9753910bb4af3be13c2e73db7b00..ac8d8342094158d83e179b8b4906c96cb12b488b 100644
+index 59f034c2bc0db9e918e6ecc422021ea82bae9f29..9c1698df7e31c467ddb43c3989a0aeabebb88e94 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -30,6 +30,7 @@ dependencies {
+@@ -28,6 +28,7 @@ dependencies {
            Scanning takes about 1-2 seconds so adding this speeds up the server start.
       */
      implementation("org.apache.logging.log4j:log4j-core:2.14.1") // Paper - implementation

--- a/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0715-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ac8d8342094158d83e179b8b4906c96cb12b488b..88694b73f7c9d02c8d0d4f38ef0533b9eb9e3497 100644
+index 9c1698df7e31c467ddb43c3989a0aeabebb88e94..864f67f57b92bc66208ff632250863484c8ab295 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,8 +1,12 @@
@@ -19,10 +19,10 @@ index ac8d8342094158d83e179b8b4906c96cb12b488b..88694b73f7c9d02c8d0d4f38ef0533b9
  import io.papermc.paperweight.util.path
  import shadow.org.apache.logging.log4j.core.config.plugins.processor.PluginProcessor.PLUGIN_CACHE_FILE
 +import java.nio.file.Files
- import java.text.SimpleDateFormat
- import java.util.Date
  import java.util.Locale
-@@ -15,6 +19,14 @@ plugins {
+ 
+ plugins {
+@@ -13,6 +17,14 @@ plugins {
  
  repositories {
      maven("https://libraries.minecraft.net/")
@@ -37,7 +37,7 @@ index ac8d8342094158d83e179b8b4906c96cb12b488b..88694b73f7c9d02c8d0d4f38ef0533b9
  }
  
  dependencies {
-@@ -50,6 +62,8 @@ dependencies {
+@@ -49,6 +61,8 @@ dependencies {
      implementation("co.aikar:cleaner:1.0-SNAPSHOT") // Paper
      implementation("io.netty:netty-all:4.1.65.Final") // Paper
  
@@ -46,7 +46,7 @@ index ac8d8342094158d83e179b8b4906c96cb12b488b..88694b73f7c9d02c8d0d4f38ef0533b9
      testImplementation("io.github.classgraph:classgraph:4.8.47") // Paper - mob goal test
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
-@@ -115,6 +129,44 @@ tasks.shadowJar {
+@@ -114,6 +128,44 @@ tasks.shadowJar {
      transform(ModifiedLog4j2PluginsCacheFileTransformer::class.java)
  }
  

--- a/patches/server/0718-Add-git-branch-and-commit-to-manifest.patch
+++ b/patches/server/0718-Add-git-branch-and-commit-to-manifest.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add git branch and commit to manifest
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 88694b73f7c9d02c8d0d4f38ef0533b9eb9e3497..682935762008602ca214f68147766792cbedeea9 100644
+index 864f67f57b92bc66208ff632250863484c8ab295..b50463c2356301a1b47a0bf4f50dc1f121d363a1 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -77,6 +77,7 @@ tasks.jar {
+@@ -76,6 +76,7 @@ tasks.jar {
          val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
          val implementationVersion = System.getenv("BUILD_NUMBER") ?: "\"$gitHash\""
          val date = git("show", "-s", "--format=%ci", gitHash).getText().trim() // Paper
@@ -16,7 +16,7 @@ index 88694b73f7c9d02c8d0d4f38ef0533b9eb9e3497..682935762008602ca214f68147766792
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
-@@ -86,6 +87,8 @@ tasks.jar {
+@@ -85,6 +86,8 @@ tasks.jar {
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
              "Multi-Release" to "true", // Paper


### PR DESCRIPTION
ASM was not meant to exposed to API consumers in the first place, and for the duration of time it has been exposed, it has also been relocated.