### PR TITLE
Update JavaPluginLoader to match Bukkit behavior

### DIFF
--- a/patches/api/0101-Close-Plugin-Class-Loaders-on-Disable.patch
+++ b/patches/api/0101-Close-Plugin-Class-Loaders-on-Disable.patch
@@ -53,14 +53,14 @@ index 41e26451fe12d8e6e0ef73c85731b24b4e3f200c..86cc5025ad98f7a752c51713b7cd6a39
       * Gets a {@link Permission} from its fully qualified name
       *
 diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
-index 2d27dfb859c312d46a14d0356c7c3f227e965a67..892ec4b43cc97a235df0819d30391a8a3770cbcb 100644
+index 2d27dfb859c312d46a14d0356c7c3f227e965a67..56c47badd92169a4886b80e38a1ba9257327c11e 100644
 --- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 +++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
 @@ -492,17 +492,28 @@ public final class SimplePluginManager implements PluginManager {
  
      @Override
      public void disablePlugins() {
-+        disablePlugins(false);
++        disablePlugins(true);
 +    }
 +
 +    public void disablePlugins(boolean closeClassloaders) {
@@ -74,7 +74,7 @@ index 2d27dfb859c312d46a14d0356c7c3f227e965a67..892ec4b43cc97a235df0819d30391a8a
  
      @Override
      public void disablePlugin(@NotNull final Plugin plugin) {
-+        disablePlugin(plugin, false);
++        disablePlugin(plugin, true);
 +    }
 +
 +    @Override
@@ -97,7 +97,7 @@ index 2d27dfb859c312d46a14d0356c7c3f227e965a67..892ec4b43cc97a235df0819d30391a8a
              lookupNames.clear();
              dependencyGraph = GraphBuilder.directed().build();
 diff --git a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
-index 79ac529017aac059d13fe342f279e9c8faeba599..816c2b1797447ab315ceb6eda89d25f27d2bce98 100644
+index 79ac529017aac059d13fe342f279e9c8faeba599..e354bb8b4929b4443d1a6d2664ec9a8e01813730 100644
 --- a/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/JavaPluginLoader.java
 @@ -322,7 +322,7 @@ public final class JavaPluginLoader implements PluginLoader {
@@ -114,7 +114,7 @@ index 79ac529017aac059d13fe342f279e9c8faeba599..816c2b1797447ab315ceb6eda89d25f2
      @Override
      public void disablePlugin(@NotNull Plugin plugin) {
 +    // Paper start - close Classloader on disable
-+        disablePlugin(plugin, false); // Retain old behavior unless requested
++        disablePlugin(plugin, true);
 +    }
 +
 +    public void disablePlugin(@NotNull Plugin plugin, boolean closeClassloader) {
@@ -122,20 +122,18 @@ index 79ac529017aac059d13fe342f279e9c8faeba599..816c2b1797447ab315ceb6eda89d25f2
          Validate.isTrue(plugin instanceof JavaPlugin, "Plugin is not associated with this PluginLoader");
  
          if (plugin.isEnabled()) {
-@@ -367,6 +373,16 @@ public final class JavaPluginLoader implements PluginLoader {
+@@ -363,9 +369,14 @@ public final class JavaPluginLoader implements PluginLoader {
+                 }
+ 
+                 try {
++                    if (closeClassloader) // Paper - close Class Loader on disable
+                     loader.close();
                  } catch (IOException ex) {
                      //
-                 }
-+                // Paper start - close Class Loader on disable
-+                try {
-+                    if (closeClassloader) {
-+                        loader.close();
-+                    }
-+                } catch (IOException e) {
++                    // Paper start - close Class Loader on disable
 +                    server.getLogger().log(Level.WARNING, "Error closing the Plugin Class Loader for " + plugin.getDescription().getFullName());
-+                    e.printStackTrace();
-+                }
-+                // Paper end
++                    ex.printStackTrace();
++                    // Paper end
+                 }
              }
          }
-     }


### PR DESCRIPTION
not sure how updating from upstream works so I don't know if not changing this was intentional so this PR might be useless
but Bukkit by default closes plugin jars while disabling so I think it is strange that the closeClassloader parameter is just practically ignored