### PR TITLE
Respect legacy colour code in more paper messages

### DIFF
--- a/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace351305790 100644
+index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..b020a5d69c2d6a55577c0fdcfc2a3ab1e35bcf36 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,18 +16,26 @@ index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace3
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -273,4 +274,9 @@ public class PaperConfig {
+@@ -17,6 +18,7 @@ import java.util.regex.Pattern;
+ import com.google.common.collect.Lists;
+ import net.minecraft.server.MinecraftServer;
+ import org.bukkit.Bukkit;
++import org.bukkit.ChatColor;
+ import org.bukkit.command.Command;
+ import org.bukkit.configuration.ConfigurationSection;
+ import org.bukkit.configuration.InvalidConfigurationException;
+@@ -273,4 +275,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }
 +
 +    public static String authenticationServersDownKickMessage = ""; // empty = use translatable message
 +    private static void authenticationServersDownKickMessage() {
-+        authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
++        authenticationServersDownKickMessage = Strings.emptyToNull(ChatColor.translateAlternateColorCodes('&', getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage)));
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index ab3409dd3a7671b46cba210cfa326311d10a7ef4..82d0979e3239dddf3951df4a8b65ae7319d3d5b5 100644
+index ab3409dd3a7671b46cba210cfa326311d10a7ef4..b812034decb5ec68d048cddc8d432f9dd3884d8d 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -297,6 +297,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -36,7 +44,7 @@ index ab3409dd3a7671b46cba210cfa326311d10a7ef4..82d0979e3239dddf3951df4a8b65ae73
                      } else {
 +                            // Paper start
 +                            if (com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage != null) {
-+                                ServerLoginPacketListenerImpl.this.disconnect(new TextComponent(com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage));
++                                ServerLoginPacketListenerImpl.this.disconnect(PaperAdventure.asVanilla(PaperAdventure.LEGACY_SECTION_UXRC.deserialize(com.destroystokyo.paper.PaperConfig.authenticationServersDownKickMessage)));
 +                            } else // Paper end
                          ServerLoginPacketListenerImpl.this.disconnect(new TranslatableComponent("multiplayer.disconnect.authservers_down"));
                          ServerLoginPacketListenerImpl.LOGGER.error("Couldn't verify username because servers are unavailable");

--- a/patches/server/0188-Make-player-data-saving-configurable.patch
+++ b/patches/server/0188-Make-player-data-saving-configurable.patch
@@ -8,12 +8,12 @@ however, we should still migrate our configuration back upstream,
 to prevent unexpected situations
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 52954fc3bf932cfc9d5ce63e3d3cace351305790..05a5abb951abe37f30a719cb75376d2d43c0d252 100644
+index b020a5d69c2d6a55577c0fdcfc2a3ab1e35bcf36..2e90709bdd42b4dd5394c977b45b427047713ba5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -279,4 +279,13 @@ public class PaperConfig {
+@@ -280,4 +280,13 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
-         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+         authenticationServersDownKickMessage = Strings.emptyToNull(ChatColor.translateAlternateColorCodes('&', getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage)));
      }
 +
 +    private static void savePlayerData() {

--- a/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 05a5abb951abe37f30a719cb75376d2d43c0d252..77a03abd59db4a43f6f2d59d4c7ef176e782f205 100644
+index 2e90709bdd42b4dd5394c977b45b427047713ba5..8d361fa6199a32be72ded0c4d5491fb25c954fc0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -288,4 +288,12 @@ public class PaperConfig {
+@@ -289,4 +289,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }

--- a/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 77a03abd59db4a43f6f2d59d4c7ef176e782f205..bd508025b771424c942fd856c31d520b6f548082 100644
+index 8d361fa6199a32be72ded0c4d5491fb25c954fc0..fc0d7301d5e1de89f63796da96b358173082f28e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -296,4 +296,18 @@ public class PaperConfig {
+@@ -297,4 +297,18 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,10 +9,10 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2786328e5 100644
+index fc0d7301d5e1de89f63796da96b358173082f28e..dd907995ea1c39c24f9a130a86285965bc0fe774 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
+@@ -26,6 +26,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
  import co.aikar.timings.Timings;
  import co.aikar.timings.TimingsManager;
  import org.spigotmc.SpigotConfig;
@@ -20,7 +20,7 @@ index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2
  
  public class PaperConfig {
  
-@@ -297,6 +298,14 @@ public class PaperConfig {
+@@ -298,6 +299,14 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -159,7 +159,7 @@ index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c
  
      public static Timing getTickList(ServerLevel worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 62621562137cba4804f0465c58d25ca2786328e5..ee8ead249d89bc81f87bfff6a1f594a9aeb21250 100644
+index dd907995ea1c39c24f9a130a86285965bc0fe774..98ed6efa1c9b377828a0b254b01c82f829fef6e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -169,7 +169,7 @@ index 62621562137cba4804f0465c58d25ca2786328e5..ee8ead249d89bc81f87bfff6a1f594a9
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -319,4 +320,54 @@ public class PaperConfig {
+@@ -320,4 +321,54 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }

--- a/patches/server/0273-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0273-Configurable-connection-throttle-kick-message.patch
@@ -5,16 +5,16 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ee8ead249d89bc81f87bfff6a1f594a9aeb21250..585be2fcbd63a59f911df69136eae07ce665053c 100644
+index 98ed6efa1c9b377828a0b254b01c82f829fef6e3..289143ed52c40d561e7df5d0b9ee671955942c15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -282,6 +282,11 @@ public class PaperConfig {
-         authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
+@@ -283,6 +283,11 @@ public class PaperConfig {
+         authenticationServersDownKickMessage = Strings.emptyToNull(ChatColor.translateAlternateColorCodes('&', getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage)));
      }
  
 +    public static String connectionThrottleKickMessage = "Connection throttled! Please wait before reconnecting.";
 +    private static void connectionThrottleKickMessage() {
-+        connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
++        connectionThrottleKickMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.kick.connection-throttle", connectionThrottleKickMessage));
 +    }
 +
      private static void savePlayerData() {

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c57773216 100644
+index 289143ed52c40d561e7df5d0b9ee671955942c15..394bc4f9e60cbadb9bbbf54c79afa5b5d8b8f0aa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -9,6 +9,7 @@ import java.io.IOException;
@@ -25,7 +25,7 @@ index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c
  import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
-@@ -253,7 +254,7 @@ public class PaperConfig {
+@@ -254,7 +255,7 @@ public class PaperConfig {
      }
  
      public static boolean isProxyOnlineMode() {
@@ -34,7 +34,7 @@ index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -326,6 +327,20 @@ public class PaperConfig {
+@@ -327,6 +328,20 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  
@@ -128,7 +128,7 @@ index 0000000000000000000000000000000000000000..41d73aa91fb401612e087aa1b7278ba6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 39bdda56aaa5503efc15207261634127b462c3e7..3fd913f3e963cf2da849a52364356e3b2da11eee 100644
+index 0dbe8dc5054a3f2540a9cee7b3aad54e8aff904e..477c4e727adf225e3a42209797a7d767b9e697e1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -18,6 +18,7 @@ import javax.crypto.Cipher;

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -6,19 +6,11 @@ Subject: [PATCH] Make the default permission message configurable
 TODO: Change the message in PaperCommand
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23ad753b18e 100644
+index 394bc4f9e60cbadb9bbbf54c79afa5b5d8b8f0aa..f0ea45cf31fcf0d708c0950da1dffa694e98cd2a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
- import com.google.common.collect.Lists;
- import net.minecraft.server.MinecraftServer;
- import org.bukkit.Bukkit;
-+import org.bukkit.ChatColor;
- import org.bukkit.command.Command;
- import org.bukkit.configuration.ConfigurationSection;
- import org.bukkit.configuration.InvalidConfigurationException;
-@@ -288,6 +289,11 @@ public class PaperConfig {
-         connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
+@@ -289,6 +289,11 @@ public class PaperConfig {
+         connectionThrottleKickMessage = ChatColor.translateAlternateColorCodes('&', getString("messages.kick.connection-throttle", connectionThrottleKickMessage));
      }
  
 +    public static String noPermissionMessage = "&cI'm sorry, but you do not have permission to perform this command. Please contact the server administrators if you believe that this is in error.";


### PR DESCRIPTION
To match the current behaviour of spigots configuration file, this
commit allows the usage of the '&' colour code in the two paper
messages:
 - 'messages.kick.connection-throttle'
 - 'messages.kick.authentication-servers-down'

As of right now, feedback on the deserialization of `messages.kick.authentication-servers-down` is very welcome. I don't know if there is a faster way to convert legacy string text into vanilla components using adventure deserializers.