### PR TITLE
Fix PaperTickList ticking before entities are loaded

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -113,6 +113,7 @@ public net.minecraft.server.level.ChunkMap mainThreadMailbox # todo one of these
 
 # Optimise TickListServer
 public net.minecraft.world.level.ServerTickList saveTickList(Ljava/util/function/Function;Ljava/lang/Iterable;J)Lnet/minecraft/nbt/ListTag;
+public net.minecraft.world.level.chunk.storage.EntityStorage level
 
 # Don't move existing players to world spawn
 public net.minecraft.server.level.ServerPlayer fudgeSpawnLocation(Lnet/minecraft/server/level/ServerLevel;)V

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -889,7 +889,7 @@ index 0000000000000000000000000000000000000000..118988c39e58f28e8a2851792b9c014f
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..8104b9be5a8e8d57f6f50475788aec6a762a0f7e 100644
+index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..bbb94e8a5e3585701849e025b534a69a6e67949f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -86,6 +86,19 @@ public class ChunkHolder {
@@ -912,37 +912,44 @@ index 1dd1b9afaee38fdc994ad0a069bd63b02eedf55c..8104b9be5a8e8d57f6f50475788aec6a
  
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
          this.futures = new AtomicReferenceArray(ChunkHolder.CHUNK_STATUSES.size());
-@@ -538,6 +551,10 @@ public class ChunkHolder {
+@@ -538,6 +551,12 @@ public class ChunkHolder {
                  either.ifLeft(chunk -> {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      ChunkHolder.this.isTickingReady = true;
 +
 +                    // Paper start - rewrite ticklistserver
-+                    ChunkHolder.this.chunkMap.level.onChunkSetTicking(ChunkHolder.this.pos.x, ChunkHolder.this.pos.z);
++                    if (ChunkHolder.this.chunkMap.level.entityManager.areEntitiesLoaded(this.pos.longKey)) {
++                        ChunkHolder.this.chunkMap.level.onChunkSetTicking(ChunkHolder.this.pos.x, ChunkHolder.this.pos.z);
++                    }
 +                    // Paper end - rewrite ticklistserver
                  });
              });
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 550338a7170437415342df7bc1b0a5c445480300..34174c3cdcb69c96e8601e28ecaf01df9b8c0f37 100644
+index 550338a7170437415342df7bc1b0a5c445480300..5e4de1ffb1ed3161022fde4fd1bc8b9f2b314ec7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -219,6 +219,13 @@ public class ServerChunkCache extends ChunkSource {
+@@ -219,6 +219,18 @@ public class ServerChunkCache extends ChunkSource {
          }, this.mainThreadProcessor);
      }
      // Paper end
 +    // Paper start - rewrite ticklistserver
++    public final boolean isPositionTickingReady(long pos) {
++        final ChunkHolder chunkHolder = this.chunkMap.getUpdatingChunkIfPresent(pos);
++        return chunkHolder != null && chunkHolder.isTickingReady();
++    }
++
 +    public final boolean isPositionTickingWithEntitiesLoaded(BlockPos pos) {
-+        long position = net.minecraft.server.MCUtil.getCoordinateKey(pos);
-+        ChunkHolder chunkHolder = this.chunkMap.getUpdatingChunkIfPresent(position);
-+        return chunkHolder != null && chunkHolder.isTickingReady() /* && this.level.entityManager.areEntitiesLoaded(position) */; // TODO Needs to wait for entities, but has to be manually marked as ready
++        final long position = net.minecraft.server.MCUtil.getCoordinateKey(pos);
++        final ChunkHolder chunkHolder = this.chunkMap.getUpdatingChunkIfPresent(position);
++        return chunkHolder != null && chunkHolder.isTickingReady() && this.level.entityManager.areEntitiesLoaded(position);
 +    }
 +    // Paper end - rewrite ticklistserver
  
      public ServerChunkCache(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor workerExecutor, ChunkGenerator chunkGenerator, int viewDistance, boolean flag, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkstatusupdatelistener, Supplier<DimensionDataStorage> supplier) {
          this.level = world;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 00a064305dd8c671566dc32b8cd85f593ad139a3..e51a393a31af71c18465b460dcf8d6d80a7f1c0f 100644
+index 00a064305dd8c671566dc32b8cd85f593ad139a3..4e654eda235d05ba96bacc6d9c14ce6428e60d07 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -291,6 +291,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -950,7 +957,7 @@ index 00a064305dd8c671566dc32b8cd85f593ad139a3..e51a393a31af71c18465b460dcf8d6d8
      // Paper end
  
 +    // Paper start - rewrite ticklistserver
-+    void onChunkSetTicking(int chunkX, int chunkZ) {
++    public void onChunkSetTicking(int chunkX, int chunkZ) {
 +        if (com.destroystokyo.paper.PaperConfig.useOptimizedTickList) {
 +            ((com.destroystokyo.paper.server.ticklist.PaperTickList) this.blockTicks).onChunkSetTicking(chunkX, chunkZ);
 +            ((com.destroystokyo.paper.server.ticklist.PaperTickList) this.liquidTicks).onChunkSetTicking(chunkX, chunkZ);
@@ -1111,3 +1118,20 @@ index 3b8c04f6ffd7e6c197465aa1caf633ba92529472..1007bfc9c19641f42afd5526cfe7bdb6
      }
  
      @Override
+diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
+index a56cfcf5ac735147f3f2bd029a2b1a4e889d5b4f..790594b970c03c340d0c4ca7b5ce315f5ffe571d 100644
+--- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
++++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
+@@ -264,6 +264,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+                 this.addEntity(entity, true);
+             });
+             this.chunkLoadStatuses.put(chunkEntities.getPos().toLong(), PersistentEntitySectionManager.ChunkLoadStatus.LOADED);
++            // Paper start - rewrite ServerTickList
++            final net.minecraft.server.level.ServerLevel level = ((net.minecraft.world.level.chunk.storage.EntityStorage) this.permanentStorage).level;
++            if (level.chunkSource.isPositionTickingReady(chunkEntities.getPos().longKey)) {
++                level.onChunkSetTicking(chunkEntities.getPos().x, chunkEntities.getPos().z);
++            }
++            // Paper end
+         }
+ 
+     }

--- a/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -233,10 +233,10 @@ index 2b291296821dc6d6a8437bd977eeba517cdb5003..962028a58ee54b99be20905c1fd16cfe
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 34174c3cdcb69c96e8601e28ecaf01df9b8c0f37..1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314 100644
+index a10c8df3061ebc20c32346462cf2dfccd85ad722..ac077d88e0102b50edce094a6ac4c63546915e88 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -767,7 +767,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -772,7 +772,7 @@ public class ServerChunkCache extends ChunkSource {
              };
              // Paper end
              this.level.timings.chunkTicks.startTiming(); // Paper

--- a/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -147,10 +147,10 @@ index ce438760cbc92c08c079d06a8b97eaeda1018491..0115ffe84356468ddc254d8d5bdd719b
                  // Spigot Start
                  CrashReport crashreport;
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a8d75ae42 100644
+index ac077d88e0102b50edce094a6ac4c63546915e88..7cc8a898b5a6349da91b34b8be6ec00707183589 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -704,6 +704,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -709,6 +709,7 @@ public class ServerChunkCache extends ChunkSource {
          this.level.getProfiler().push("purge");
          this.level.timings.doChunkMap.startTiming(); // Spigot
          this.distanceManager.purgeStaleTickets();
@@ -158,7 +158,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
          this.runDistanceManagerUpdates();
          this.level.timings.doChunkMap.stopTiming(); // Spigot
          this.level.getProfiler().popPush("chunks");
-@@ -713,6 +714,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -718,6 +719,7 @@ public class ServerChunkCache extends ChunkSource {
          this.level.timings.doChunkUnload.startTiming(); // Spigot
          this.level.getProfiler().popPush("unload");
          this.chunkMap.tick(booleansupplier);
@@ -166,7 +166,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
          this.level.timings.doChunkUnload.stopTiming(); // Spigot
          this.level.getProfiler().pop();
          this.clearCache();
-@@ -767,7 +769,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -772,7 +774,7 @@ public class ServerChunkCache extends ChunkSource {
              };
              // Paper end
              this.level.timings.chunkTicks.startTiming(); // Paper
@@ -175,7 +175,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
                  Optional<LevelChunk> optional = ((Either) playerchunk.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK)).left();
  
                  if (optional.isPresent()) {
-@@ -778,6 +780,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -783,6 +785,7 @@ public class ServerChunkCache extends ChunkSource {
                          chunk.setInhabitedTime(chunk.getInhabitedTime() + j);
                          if (flag1 && (this.spawnEnemies || this.spawnFriendlies) && this.level.getWorldBorder().isWithinBounds(chunk.getPos()) && !this.chunkMap.isOutsideOfRange(chunkcoordintpair, true)) { // Spigot
                              NaturalSpawner.spawnForChunk(this.level, chunk, spawnercreature_d, this.spawnFriendlies, this.spawnEnemies, flag2);
@@ -183,7 +183,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
                          }
  
                          // this.level.timings.doTickTiles.startTiming(); // Spigot // Paper
-@@ -795,7 +798,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -800,7 +803,7 @@ public class ServerChunkCache extends ChunkSource {
              }
  
              this.level.getProfiler().popPush("broadcast");
@@ -192,7 +192,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
                  Optional<LevelChunk> optional = ((Either) playerchunk.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK)).left(); // CraftBukkit - decompile error
  
                  Objects.requireNonNull(playerchunk);
-@@ -959,6 +962,41 @@ public class ServerChunkCache extends ChunkSource {
+@@ -964,6 +967,41 @@ public class ServerChunkCache extends ChunkSource {
              super.doRunTask(task);
          }
  
@@ -235,7 +235,7 @@ index 1b55d1bfc0ebab40dc74a801aa0ad95b6ed22314..a376fa2456607337d3eec007abd5622a
          // CraftBukkit start - process pending Chunk loadCallback() and unloadCallback() after each run task
          public boolean pollTask() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index bc467846e98e9c8e8e060939ef8795c7a7845c0a..b31271a50740a77bc97ab47fdfe23f11a2a76618 100644
+index 3d2aa5c3832a2d3ed42303edde2d0d8528c4570a..bfc855adc411269b63b44157266d6ef7945aa7e0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -544,6 +544,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0414-Fix-Chunk-Post-Processing-deadlock-risk.patch
+++ b/patches/server/0414-Fix-Chunk-Post-Processing-deadlock-risk.patch
@@ -46,10 +46,10 @@ index 6d810cdb538d078dbf7ccd2ef84a4be27eb1f3e7..aa9846c7d6b8499e01bf0ffeece6a940
  
          completablefuture1.thenAcceptAsync((either) -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index a376fa2456607337d3eec007abd5622a8d75ae42..e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00 100644
+index 7cc8a898b5a6349da91b34b8be6ec00707183589..3e7469032d38b9432bb36d37214524ca2df11098 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -1009,6 +1009,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1014,6 +1014,7 @@ public class ServerChunkCache extends ChunkSource {
                  return super.pollTask() || execChunkTask; // Paper
              }
          } finally {

--- a/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
+++ b/patches/server/0433-Optimize-isOutsideRange-to-use-distance-maps.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Optimize isOutsideRange to use distance maps
 Use a distance map to find the players in range quickly
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 8104b9be5a8e8d57f6f50475788aec6a762a0f7e..e6883cad6c604673535deacc19463aeeb060199a 100644
+index bf641519ce1592737feac6eaf1d155d8fd126ec7..4569788773c8a9dc072d5ae5239c17c4f50e9ab0 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -100,6 +100,18 @@ public class ChunkHolder {
@@ -291,10 +291,10 @@ index b49d380ef088aed3204ec71abc437c348ef004fa..577b391dcba1db712c1e2c83296e1c87
  
      public String getDebugStatus() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00..58b4d6a2c07a283d9077b23aaef2aeef9153dd4b 100644
+index 3e7469032d38b9432bb36d37214524ca2df11098..b85a85fbb12802c355e8f458077b4b124380813b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -730,6 +730,37 @@ public class ServerChunkCache extends ChunkSource {
+@@ -735,6 +735,37 @@ public class ServerChunkCache extends ChunkSource {
          boolean flag1 = this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBSPAWNING) && !this.level.players().isEmpty(); // CraftBukkit
  
          if (!flag) {
@@ -332,7 +332,7 @@ index e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00..58b4d6a2c07a283d9077b23aaef2aeef
              this.level.getProfiler().push("pollingChunks");
              int k = this.level.getGameRules().getInt(GameRules.RULE_RANDOMTICKING);
              boolean flag2 = level.ticksPerAnimalSpawns != 0L && worlddata.getGameTime() % level.ticksPerAnimalSpawns == 0L; // CraftBukkit
-@@ -759,15 +790,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -764,15 +795,7 @@ public class ServerChunkCache extends ChunkSource {
              this.level.getProfiler().pop();
              //List<PlayerChunk> list = Lists.newArrayList(this.playerChunkMap.f()); // Paper
              //Collections.shuffle(list); // Paper
@@ -349,7 +349,7 @@ index e9ea16a953cff7c980cd0c1e5c2a4dcdada55f00..58b4d6a2c07a283d9077b23aaef2aeef
              this.level.timings.chunkTicks.startTiming(); // Paper
              final int[] chunksTicked = {0}; this.chunkMap.forEachVisibleChunk((playerchunk) -> { // Paper - safe iterator incase chunk loads, also no wrapping
                  Optional<LevelChunk> optional = ((Either) playerchunk.getTickingChunkFuture().getNow(ChunkHolder.UNLOADED_LEVEL_CHUNK)).left();
-@@ -776,9 +799,9 @@ public class ServerChunkCache extends ChunkSource {
+@@ -781,9 +804,9 @@ public class ServerChunkCache extends ChunkSource {
                      LevelChunk chunk = (LevelChunk) optional.get();
                      ChunkPos chunkcoordintpair = chunk.getPos();
  

--- a/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0447-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -8,7 +8,7 @@ so inline where possible, and avoid the abstraction of the
 Either class.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index b31271a50740a77bc97ab47fdfe23f11a2a76618..79338bd6349b1e454f190e4daab030859d5fdf47 100644
+index bfc855adc411269b63b44157266d6ef7945aa7e0..6fc4b479dcb40b7f6f018731956bc003e95ea05b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2034,15 +2034,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -47,10 +47,10 @@ index 439f82a48e6f6ce7b4773505ced32324cacb302d..2a99aa989ac5c19d99bb3cbc0934425e
  
      public static int getX(long pos) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index a56cfcf5ac735147f3f2bd029a2b1a4e889d5b4f..5a0a1b01e89b122811b0b567e1ee27081953e638 100644
+index 75e9350d2dcb2669107a938a8cff2e537488f88f..c1e17b0d7c0b9a55e9061fa4d0bb1805d8f86ba2 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -327,6 +327,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -333,6 +333,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      public LevelEntityGetter<T> getEntityGetter() {
          return this.entityGetter;
      }

--- a/patches/server/0456-incremental-chunk-saving.patch
+++ b/patches/server/0456-incremental-chunk-saving.patch
@@ -72,7 +72,7 @@ index d285967a60903a73608a1f9cdc306e63066824ab..a36fa61313baf9ab260b8805860ac4bc
          this.profiler.push("snooper");
          if (((DedicatedServer) this).getProperties().snooperEnabled && !this.snooper.isStarted() && this.tickCount > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index e6883cad6c604673535deacc19463aeeb060199a..e26b65c3b2594ae45b68bcbd135152130663be7f 100644
+index 4569788773c8a9dc072d5ae5239c17c4f50e9ab0..d5ff572f41d6efc82294e11db0952a39d6ac801e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -111,6 +111,8 @@ public class ChunkHolder {
@@ -104,7 +104,7 @@ index e6883cad6c604673535deacc19463aeeb060199a..e26b65c3b2594ae45b68bcbd13515213
          if (!flag2 && flag3) {
              int expectCreateCount = ++this.fullChunkCreateCount; // Paper
              this.fullChunkFuture = chunkStorage.prepareAccessibleChunk(this);
-@@ -645,9 +659,33 @@ public class ChunkHolder {
+@@ -647,9 +661,33 @@ public class ChunkHolder {
      }
  
      public void refreshAccessibility() {
@@ -240,10 +240,10 @@ index a1529fef41543486d29271b1de62a6246d07d384..f518fc7a39a807bff2e141fd238ab1bf
              ChunkPos chunkcoordintpair = chunk.getPos();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 58b4d6a2c07a283d9077b23aaef2aeef9153dd4b..1255b1806dabf1417cfdd195ee331a35edc059c7 100644
+index b85a85fbb12802c355e8f458077b4b124380813b..4807807466c3cf04960392ff776b0999e667de56 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -672,6 +672,15 @@ public class ServerChunkCache extends ChunkSource {
+@@ -677,6 +677,15 @@ public class ServerChunkCache extends ChunkSource {
          } // Paper - Timings
      }
  
@@ -260,7 +260,7 @@ index 58b4d6a2c07a283d9077b23aaef2aeef9153dd4b..1255b1806dabf1417cfdd195ee331a35
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 79338bd6349b1e454f190e4daab030859d5fdf47..15d27aa11594b668ca7715ed1c465c6003d6e9bf 100644
+index 6fc4b479dcb40b7f6f018731956bc003e95ea05b..ac9020467cef648c72ccb350d26f90545f5afb56 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -964,6 +964,37 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -80,7 +80,7 @@ index 2d5b8e35d52b0dfd075af81a3a936d8a21053b31..9ddedd310eb0323a5a09f51a61bfb7b3
                  chunkData.addProperty("queued-for-unload", chunkMap.toDrop.contains(playerChunk.pos.longKey));
                  chunkData.addProperty("status", status == null ? "unloaded" : status.toString());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index e26b65c3b2594ae45b68bcbd135152130663be7f..3e004f391668865c0e6f1c38cef9661f7372fffe 100644
+index d5ff572f41d6efc82294e11db0952a39d6ac801e..c71905aeed2a39fc5be58540ca506b5660d3f0db 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -60,7 +60,7 @@ public class ChunkHolder {
@@ -269,7 +269,7 @@ index e26b65c3b2594ae45b68bcbd135152130663be7f..3e004f391668865c0e6f1c38cef9661f
                  either.ifLeft(chunk -> {
                      // note: Here is a very good place to add callbacks to logic waiting on this.
                      ChunkHolder.this.isTickingReady = true;
-@@ -604,7 +734,7 @@ public class ChunkHolder {
+@@ -606,7 +736,7 @@ public class ChunkHolder {
              this.entityTickingChunkFuture = chunkStorage.prepareEntityTickingChunk(this.pos);
              this.scheduleFullChunkPromotion(chunkStorage, this.entityTickingChunkFuture, executor, ChunkHolder.FullChunkStatus.ENTITY_TICKING);
              // Paper start - cache ticking ready status
@@ -278,7 +278,7 @@ index e26b65c3b2594ae45b68bcbd135152130663be7f..3e004f391668865c0e6f1c38cef9661f
                  either.ifLeft(chunk -> {
                      ChunkHolder.this.isEntityTickingReady = true;
                  });
-@@ -622,12 +752,30 @@ public class ChunkHolder {
+@@ -624,12 +754,30 @@ public class ChunkHolder {
              this.demoteFullChunk(chunkStorage, playerchunk_state1);
          }
  
@@ -941,10 +941,10 @@ index d94241bcca4f2fd5e464a860bd356af504dc68b7..1cc4e0a1f3d8235ef88b48e01ca8b78a
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10ab89b3ce 100644
+index 4807807466c3cf04960392ff776b0999e667de56..f4f6124c20c31224312070c5e95be00a62e89897 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -446,6 +446,26 @@ public class ServerChunkCache extends ChunkSource {
+@@ -451,6 +451,26 @@ public class ServerChunkCache extends ChunkSource {
      public <T> void removeTicketAtLevel(TicketType<T> ticketType, ChunkPos chunkPos, int ticketLevel, T identifier) {
          this.distanceManager.removeTicketAtLevel(ticketType, chunkPos, ticketLevel, identifier);
      }
@@ -971,7 +971,7 @@ index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10
      // Paper end - async chunk io
  
      @Nullable
-@@ -486,6 +506,8 @@ public class ServerChunkCache extends ChunkSource {
+@@ -491,6 +511,8 @@ public class ServerChunkCache extends ChunkSource {
              Objects.requireNonNull(completablefuture);
              if (!completablefuture.isDone()) { // Paper
                  // Paper start - async chunk io/loading
@@ -980,7 +980,7 @@ index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10
                  this.level.asyncChunkTaskManager.raisePriority(x1, z1, com.destroystokyo.paper.io.PrioritizedTaskQueue.HIGHEST_PRIORITY);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.pushChunkWait(this.level, x1, z1);
                  // Paper end
-@@ -494,6 +516,8 @@ public class ServerChunkCache extends ChunkSource {
+@@ -499,6 +521,8 @@ public class ServerChunkCache extends ChunkSource {
              chunkproviderserver_a.managedBlock(completablefuture::isDone);
                  com.destroystokyo.paper.io.chunk.ChunkTaskManager.popChunkWait(); // Paper - async chunk debug
                  this.level.timings.syncChunkLoad.stopTiming(); // Paper
@@ -989,7 +989,7 @@ index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10
              } // Paper
              ichunkaccess = (ChunkAccess) ((Either) completablefuture.join()).map((ichunkaccess1) -> {
                  return ichunkaccess1;
-@@ -567,10 +591,12 @@ public class ServerChunkCache extends ChunkSource {
+@@ -572,10 +596,12 @@ public class ServerChunkCache extends ChunkSource {
          if (flag && !currentlyUnloading) {
              // CraftBukkit end
              this.distanceManager.addTicket(TicketType.UNKNOWN, chunkcoordintpair, l, chunkcoordintpair);
@@ -1002,7 +1002,7 @@ index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10
                  this.runDistanceManagerUpdates();
                  playerchunk = this.getVisibleChunkIfPresent(k);
                  gameprofilerfiller.pop();
-@@ -579,8 +605,13 @@ public class ServerChunkCache extends ChunkSource {
+@@ -584,8 +610,13 @@ public class ServerChunkCache extends ChunkSource {
                  }
              }
          }
@@ -1018,7 +1018,7 @@ index 1255b1806dabf1417cfdd195ee331a35edc059c7..5734a127fece27cbd20fdc31b18b9c10
      }
  
      private boolean chunkAbsent(@Nullable ChunkHolder holder, int maxLevel) {
-@@ -632,6 +663,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -637,6 +668,7 @@ public class ServerChunkCache extends ChunkSource {
      }
  
      public boolean runDistanceManagerUpdates() {

--- a/patches/server/0495-Optimize-Light-Engine.patch
+++ b/patches/server/0495-Optimize-Light-Engine.patch
@@ -25,10 +25,10 @@ Massive update to light to improve performance and chunk loading/generation.
 8) Fix NPE risk that crashes server in getting nibble data
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 4114c0fa58e41383b5469cbc6abb44416a7af247..e649e6a8b354be45eed808ee02082ca7c826b59b 100644
+index 90115430d7b068b1d92f92dee73214dd8dc0053e..a076829f21afaffd5c281f4c16ce0889a8c38a5e 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-@@ -771,6 +771,7 @@ public class ChunkHolder {
+@@ -773,6 +773,7 @@ public class ChunkHolder {
                  ioPriority = com.destroystokyo.paper.io.PrioritizedTaskQueue.HIGH_PRIORITY;
              }
              chunkMap.level.asyncChunkTaskManager.raisePriority(pos.x, pos.z, ioPriority);
@@ -126,10 +126,10 @@ index d3d6651eb51c852ed1d1eeb5689569d5308b246d..c2d36600a0081c78425868154bdcf7f4
                          m = Long.MAX_VALUE;
                      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 5734a127fece27cbd20fdc31b18b9c10ab89b3ce..677aaeab867f1f4159b6fa023ce84e3dca4795fc 100644
+index f4f6124c20c31224312070c5e95be00a62e89897..a24790b798d733976db4de430164d648b739158b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -1069,7 +1069,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1074,7 +1074,7 @@ public class ServerChunkCache extends ChunkSource {
              if (ServerChunkCache.this.runDistanceManagerUpdates()) {
                  return true;
              } else {

--- a/patches/server/0616-Skip-distance-map-update-when-spawning-disabled.patch
+++ b/patches/server/0616-Skip-distance-map-update-when-spawning-disabled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Skip distance map update when spawning disabled.
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 677aaeab867f1f4159b6fa023ce84e3dca4795fc..6daf49a951fe7fdb04e8b71f00922e1d457b4e84 100644
+index a24790b798d733976db4de430164d648b739158b..f6b624948493d6ba2c04bebef93045ea686f027e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -811,7 +811,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -816,7 +816,7 @@ public class ServerChunkCache extends ChunkSource {
              int l = this.distanceManager.getNaturalSpawnChunkCount();
              // Paper start - per player mob spawning
              NaturalSpawner.SpawnState spawnercreature_d; // moved down


### PR DESCRIPTION
Co-authored-by: Jason Penilla <11360596+jpenilla@users.noreply.github.com>

The issue is outlined in https://github.com/PaperMC/Paper/pull/6216, and as for the checks before setting as ready:
In `ChunkHolder` it now checks if entities are loaded before setting, and in `PersistentEntitySectionManager` it checks for isTickingReady, otherwise the tick might immediately be added to the unready list again (since the counterpart has not finished), before then being added again by the other part respectively. That isn't inherently bad, but is an unnecessary de- and re-queueing.