### PR TITLE
Add the default tick rate of the sensor to the timings

### DIFF
--- a/patches/server/0729-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0729-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -9,7 +9,7 @@ This adds config options to specify the tick rate for sensors
  ones might need tweaking.
 
 diff --git a/src/main/java/co/aikar/timings/MinecraftTimings.java b/src/main/java/co/aikar/timings/MinecraftTimings.java
-index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092c25a3645 100644
+index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..e873b23527cc4e56580c3c7dc5b52ecc3f2a9e31 100644
 --- a/src/main/java/co/aikar/timings/MinecraftTimings.java
 +++ b/src/main/java/co/aikar/timings/MinecraftTimings.java
 @@ -114,6 +114,14 @@ public final class MinecraftTimings {
@@ -20,8 +20,8 @@ index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..fe225310e4b62e7bded3521d3ddf4092
 +        return Timings.ofSafe("Behavior - " + type);
 +    }
 +
-+    public static Timing getSensorTimings(String type) {
-+        return Timings.ofSafe("Sensor - " + type);
++    public static Timing getSensorTimings(String type, int rate) {
++        return Timings.ofSafe("Sensor - " + type + " (Default rate: " + rate + ")");
 +    }
 +
      /**
@@ -111,7 +111,7 @@ index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..f65e3b51e876f7a3d30710eed56fdca4
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
-index b1212e162ba938b3abe0df747a633ba9cbbe57c8..b1928807851a4fca53e117573b25c62a6deeb8e1 100644
+index 0982ff2bac359fe10d55c12f7c7cdcf69ae6bf57..0610a0f587d012f15f264513b308e92cc62b5991 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/behavior/Behavior.java
 @@ -14,6 +14,10 @@ public abstract class Behavior<E extends LivingEntity> {
@@ -183,7 +183,7 @@ index b1212e162ba938b3abe0df747a633ba9cbbe57c8..b1928807851a4fca53e117573b25c62a
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
-index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..ef0677e8a09800a5eeb30ae6575fbd5acf181a7c 100644
+index f8bdebe49704a7d8acad17acca1698fa3a11a3c9..e679eddd8d6e1a0355cb2d4996409d25288010e6 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/sensing/Sensor.java
 @@ -19,8 +19,28 @@ public abstract class Sensor<E extends LivingEntity> {
@@ -210,7 +210,7 @@ index f94aa5147c52d2e36d6018f51b85e9dac7a6208a..ef0677e8a09800a5eeb30ae6575fbd5a
 +            }
 +        }
 +        this.configKey = key.toLowerCase(java.util.Locale.ROOT);
-+        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey);
++        this.timing = co.aikar.timings.MinecraftTimings.getSensorTimings(configKey, senseInterval);
 +        // Paper end
          this.scanRate = senseInterval;
          this.timeToTick = (long)RANDOM.nextInt(senseInterval);


### PR DESCRIPTION
This adds the default tick rate of the sensor to the timings page to simplify the adjusting of those.

In order to not have to query the timings object each time this is done with the default rate, not the actual configured one but it should be good enough to give users a feeling for the default values as those aren't accessible at all otherwise.

This is not necessary for behaviours as they don't have a rate by default and can activate every tick.