### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -2782,7 +2782,7 @@ index 0000000000000000000000000000000000000000..5989ee21297935651b0edd44b8239e65
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 94089c0a616b06a7b4bb5e720fcebeab8636291e..05595fea641dbbc3d5eefb262731faad5bdb7965 100644
+index de23baef8a0902956ef4f35dd74744fca8dc6fce..1d54b48250cd8313719c301a2770358a61d9d152 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -673,7 +673,6 @@ public final class Bukkit {
@@ -2794,10 +2794,10 @@ index 94089c0a616b06a7b4bb5e720fcebeab8636291e..05595fea641dbbc3d5eefb262731faad
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0bd32af41e4965ce317d5781b092e8f5b641a8a2..bc4c4b6a10726347649a9232ee8ede28c967b8f4 100644
+index c43f40f699818032511714cd468e894a432a35bd..f549bac30ea5e42d99a8920d305fe33748dc84a9 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1364,6 +1364,26 @@ public interface Server extends PluginMessageRecipient {
+@@ -1415,6 +1415,26 @@ public interface Server extends PluginMessageRecipient {
              throw new UnsupportedOperationException("Not supported yet.");
          }
  

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -447,7 +447,7 @@ index 0000000000000000000000000000000000000000..77db592d05b754f879f8d1790642e9d9
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6cb2fd0de 100644
+index 1d54b48250cd8313719c301a2770358a61d9d152..241d6179347a3eedbab537e6e596f18a1a39cee3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -302,7 +302,9 @@ public final class Bukkit {
@@ -460,7 +460,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      public static int broadcastMessage(@NotNull String message) {
          return server.broadcastMessage(message);
      }
-@@ -860,6 +862,19 @@ public final class Bukkit {
+@@ -915,6 +917,19 @@ public final class Bukkit {
          server.shutdown();
      }
  
@@ -480,7 +480,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      /**
       * Broadcasts the specified message to every user with the given
       * permission name.
-@@ -869,6 +884,21 @@ public final class Bukkit {
+@@ -924,6 +939,21 @@ public final class Bukkit {
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
       */
@@ -502,7 +502,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      public static int broadcast(@NotNull String message, @NotNull String permission) {
          return server.broadcast(message, permission);
      }
-@@ -1068,6 +1098,7 @@ public final class Bukkit {
+@@ -1123,6 +1153,7 @@ public final class Bukkit {
          return server.createInventory(owner, type);
      }
  
@@ -510,7 +510,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -1093,6 +1124,38 @@ public final class Bukkit {
+@@ -1148,6 +1179,38 @@ public final class Bukkit {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -549,7 +549,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      public static Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title) {
          return server.createInventory(owner, type, title);
      }
-@@ -1111,6 +1174,7 @@ public final class Bukkit {
+@@ -1166,6 +1229,7 @@ public final class Bukkit {
          return server.createInventory(owner, size);
      }
  
@@ -557,7 +557,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -1123,10 +1187,30 @@ public final class Bukkit {
+@@ -1178,10 +1242,30 @@ public final class Bukkit {
       * @throws IllegalArgumentException if the size is not a multiple of 9
       */
      @NotNull
@@ -588,7 +588,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      /**
       * Creates an empty merchant.
       *
-@@ -1134,7 +1218,20 @@ public final class Bukkit {
+@@ -1189,7 +1273,20 @@ public final class Bukkit {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -609,7 +609,7 @@ index 05595fea641dbbc3d5eefb262731faad5bdb7965..cc208227301b30c3717516ceb9529ca6
      public static Merchant createMerchant(@Nullable String title) {
          return server.createMerchant(title);
      }
-@@ -1205,22 +1302,47 @@ public final class Bukkit {
+@@ -1260,22 +1357,47 @@ public final class Bukkit {
          return server.isPrimaryThread();
      }
  
@@ -731,7 +731,7 @@ index 803fa0019869127ee8c7e4fb1777a59c43e66f8a..c65f0d6569c130b4920a9e71ad24af64
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea4028cac876 100644
+index f549bac30ea5e42d99a8920d305fe33748dc84a9..6f87dec0e0b1625e1628e8a1a8357ddf03db123c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -55,13 +55,13 @@ import org.jetbrains.annotations.Nullable;
@@ -769,7 +769,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      public int broadcastMessage(@NotNull String message);
  
      /**
-@@ -723,8 +725,33 @@ public interface Server extends PluginMessageRecipient {
+@@ -774,8 +776,33 @@ public interface Server extends PluginMessageRecipient {
       * @param permission the required permission {@link Permissible
       *     permissibles} must have to receive the broadcast
       * @return number of message recipients
@@ -803,7 +803,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
  
      /**
       * Gets the player by the given name, regardless if they are offline or
-@@ -889,6 +916,7 @@ public interface Server extends PluginMessageRecipient {
+@@ -940,6 +967,7 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type);
  
@@ -811,7 +811,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      /**
       * Creates an empty inventory with the specified type and title. If the type
       * is {@link InventoryType#CHEST}, the new inventory has a size of 27;
-@@ -914,6 +942,36 @@ public interface Server extends PluginMessageRecipient {
+@@ -965,6 +993,36 @@ public interface Server extends PluginMessageRecipient {
       * @see InventoryType#isCreatable()
       */
      @NotNull
@@ -848,7 +848,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      Inventory createInventory(@Nullable InventoryHolder owner, @NotNull InventoryType type, @NotNull String title);
  
      /**
-@@ -928,6 +986,22 @@ public interface Server extends PluginMessageRecipient {
+@@ -979,6 +1037,22 @@ public interface Server extends PluginMessageRecipient {
      @NotNull
      Inventory createInventory(@Nullable InventoryHolder owner, int size) throws IllegalArgumentException;
  
@@ -871,7 +871,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      /**
       * Creates an empty inventory of type {@link InventoryType#CHEST} with the
       * specified size and title.
-@@ -938,10 +1012,13 @@ public interface Server extends PluginMessageRecipient {
+@@ -989,10 +1063,13 @@ public interface Server extends PluginMessageRecipient {
       *     viewed
       * @return a new inventory
       * @throws IllegalArgumentException if the size is not a multiple of 9
@@ -885,7 +885,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      /**
       * Creates an empty merchant.
       *
-@@ -949,7 +1026,18 @@ public interface Server extends PluginMessageRecipient {
+@@ -1000,7 +1077,18 @@ public interface Server extends PluginMessageRecipient {
       * when the merchant inventory is viewed
       * @return a new merchant
       */
@@ -904,7 +904,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      Merchant createMerchant(@Nullable String title);
  
      /**
-@@ -1006,20 +1094,41 @@ public interface Server extends PluginMessageRecipient {
+@@ -1057,20 +1145,41 @@ public interface Server extends PluginMessageRecipient {
       */
      boolean isPrimaryThread();
  
@@ -946,7 +946,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
      String getShutdownMessage();
  
      /**
-@@ -1388,7 +1497,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1439,7 +1548,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends the component to the player
           *
           * @param component the components to send
@@ -956,7 +956,7 @@ index bc4c4b6a10726347649a9232ee8ede28c967b8f4..cb0f365c4829f382a8fef8c176b7ea40
          public void broadcast(@NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1397,7 +1508,9 @@ public interface Server extends PluginMessageRecipient {
+@@ -1448,7 +1559,9 @@ public interface Server extends PluginMessageRecipient {
           * Sends an array of components as a single message to the player
           *
           * @param components the components to send
@@ -1161,7 +1161,7 @@ index ab6b0ec328e94bf65a0dafd0403e5ee3b870296c..c8d37184d8e882a4084a1bfef85faa33
  
      /**
 diff --git a/src/main/java/org/bukkit/command/CommandSender.java b/src/main/java/org/bukkit/command/CommandSender.java
-index ac772bf349e0ffe9cab1df165d9460b387f2fe69..c88418c7aa19b4fecdfa9af3d18ff202a5dc5763 100644
+index 284be63a125624a8ae43d2c164aede810ce6bfe5..511746ef9576e4c219e9ab35da3ab0727cb7ee7c 100644
 --- a/src/main/java/org/bukkit/command/CommandSender.java
 +++ b/src/main/java/org/bukkit/command/CommandSender.java
 @@ -6,12 +6,13 @@ import org.bukkit.permissions.Permissible;
@@ -1185,7 +1185,7 @@ index ac772bf349e0ffe9cab1df165d9460b387f2fe69..c88418c7aa19b4fecdfa9af3d18ff202
       * @param messages An array of messages to be displayed
 +     * @see #sendMessage(net.kyori.adventure.text.Component)
       */
-     public void sendMessage(@NotNull String[] messages);
+     public void sendMessage(@NotNull String... messages);
  
 @@ -27,6 +29,7 @@ public interface CommandSender extends Permissible {
       *
@@ -1201,7 +1201,7 @@ index ac772bf349e0ffe9cab1df165d9460b387f2fe69..c88418c7aa19b4fecdfa9af3d18ff202
       * @param sender The sender of this message
 +     * @see #sendMessage(net.kyori.adventure.identity.Identified, net.kyori.adventure.text.Component)
       */
-     public void sendMessage(@Nullable UUID sender, @NotNull String[] messages);
+     public void sendMessage(@Nullable UUID sender, @NotNull String... messages);
  
 @@ -61,7 +65,9 @@ public interface CommandSender extends Permissible {
           * Sends this sender a chat component.

--- a/patches/api/0009-Add-getTPS-method.patch
+++ b/patches/api/0009-Add-getTPS-method.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getTPS method
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index cc208227301b30c3717516ceb9529ca6cb2fd0de..43d35945a5c315fc324a7f6c2eef69d34be0dc45 100644
+index 241d6179347a3eedbab537e6e596f18a1a39cee3..357536ffc82e2adb220a3069fa2e76fa28f215e4 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1567,6 +1567,17 @@ public final class Bukkit {
+@@ -1622,6 +1622,17 @@ public final class Bukkit {
          return server.getEntity(uuid);
      }
  
@@ -27,10 +27,10 @@ index cc208227301b30c3717516ceb9529ca6cb2fd0de..43d35945a5c315fc324a7f6c2eef69d3
       * Get the advancement specified by this key.
       *
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index cb0f365c4829f382a8fef8c176b7ea4028cac876..0e0fd990e09619d89c1dcb645c22c6e4e73a7139 100644
+index 6f87dec0e0b1625e1628e8a1a8357ddf03db123c..f3102fdbb4caab2d58a8f5e305ac80fa36d10d8d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1321,6 +1321,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1372,6 +1372,16 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @Nullable
      Entity getEntity(@NotNull UUID uuid);
  

--- a/patches/api/0017-Expose-server-CommandMap.patch
+++ b/patches/api/0017-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 43d35945a5c315fc324a7f6c2eef69d34be0dc45..f01fca5854b161278f448788e4b391e764107490 100644
+index 357536ffc82e2adb220a3069fa2e76fa28f215e4..0a3ae145c5406999eecbf0983cff8790ce42388e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1741,6 +1741,19 @@ public final class Bukkit {
+@@ -1796,6 +1796,19 @@ public final class Bukkit {
          return server.getUnsafe();
      }
  
@@ -29,10 +29,10 @@ index 43d35945a5c315fc324a7f6c2eef69d34be0dc45..f01fca5854b161278f448788e4b391e7
      public static Server.Spigot spigot() {
          return server.spigot();
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 0e0fd990e09619d89c1dcb645c22c6e4e73a7139..019dcabdd21783cd4d14d407d4dcae739afcaadd 100644
+index f3102fdbb4caab2d58a8f5e305ac80fa36d10d8d..53455bbe675bdfd424d8cebeb057c1d8defd0dd5 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1331,6 +1331,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1382,6 +1382,15 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      public double[] getTPS();
      // Paper end
  

--- a/patches/api/0028-Add-command-to-reload-permissions.yml-and-require-co.patch
+++ b/patches/api/0028-Add-command-to-reload-permissions.yml-and-require-co.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add command to reload permissions.yml and require confirm to
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 914a435bc3651f1153dd4e8128abcdec779be97e..03db21881383b52d5afd9c8fa00bbd533bdd609e 100644
+index d2c98a9e670bb5202b6db0a1be8aa2b78328da91..9ba12077dfbdd99cbb269dfcffc09dc9e325bae3 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1776,6 +1776,13 @@ public final class Bukkit {
+@@ -1831,6 +1831,13 @@ public final class Bukkit {
      public static org.bukkit.command.CommandMap getCommandMap() {
          return server.getCommandMap();
      }
@@ -24,10 +24,10 @@ index 914a435bc3651f1153dd4e8128abcdec779be97e..03db21881383b52d5afd9c8fa00bbd53
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 25d6c59728c616f47dea4254a9317807ed6863be..f1b7d99eca33b9a4d193cdf589e1533c1f89b82e 100644
+index 5ae4b3c4a20fd8fd727efbfe7b721c9b365b87a6..414a24197256c5a27e9e854a96428ed2aa81f60c 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1569,4 +1569,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1620,4 +1620,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      Spigot spigot();
      // Spigot end

--- a/patches/api/0041-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/api/0041-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 03db21881383b52d5afd9c8fa00bbd533bdd609e..1f9dcd8cc63c050ccb654a9818b8be372185db19 100644
+index 9ba12077dfbdd99cbb269dfcffc09dc9e325bae3..fd7ac75f545810c5c85b231639483b30da373e6e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1783,6 +1783,15 @@ public final class Bukkit {
+@@ -1838,6 +1838,15 @@ public final class Bukkit {
      public static void reloadPermissions() {
          server.reloadPermissions();
      }
@@ -26,10 +26,10 @@ index 03db21881383b52d5afd9c8fa00bbd533bdd609e..1f9dcd8cc63c050ccb654a9818b8be37
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index f1b7d99eca33b9a4d193cdf589e1533c1f89b82e..e5b66aaf0124a236b6353d4689c54865e7430652 100644
+index 414a24197256c5a27e9e854a96428ed2aa81f60c..075573b2ba144752cdee270c9d599b8bc0972df0 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1571,4 +1571,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1622,4 +1622,6 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      // Spigot end
  
      void reloadPermissions(); // Paper

--- a/patches/api/0052-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/api/0052-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1f9dcd8cc63c050ccb654a9818b8be372185db19..4ff85202a61f43b175ba7b3c2191f0a5b9f6a59b 100644
+index fd7ac75f545810c5c85b231639483b30da373e6e..02045103fc776a149cd05a779461acb6164b656f 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1792,6 +1792,16 @@ public final class Bukkit {
+@@ -1847,6 +1847,16 @@ public final class Bukkit {
      public static boolean reloadCommandAliases() {
          return server.reloadCommandAliases();
      }
@@ -27,10 +27,10 @@ index 1f9dcd8cc63c050ccb654a9818b8be372185db19..4ff85202a61f43b175ba7b3c2191f0a5
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index e5b66aaf0124a236b6353d4689c54865e7430652..1a6142822eb3530649da564272fb40c9aab53ba8 100644
+index 075573b2ba144752cdee270c9d599b8bc0972df0..1d13a4c289e6a764b3b080455a86e17a5e60929e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1573,4 +1573,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1624,4 +1624,14 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      void reloadPermissions(); // Paper
  
      boolean reloadCommandAliases(); // Paper

--- a/patches/api/0057-Basic-PlayerProfile-API.patch
+++ b/patches/api/0057-Basic-PlayerProfile-API.patch
@@ -267,10 +267,10 @@ index 0000000000000000000000000000000000000000..7b3b6ef533d32169fbeca389bd61cfc6
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 4ff85202a61f43b175ba7b3c2191f0a5b9f6a59b..a903cc8e0fd6f44dc31b8b3998767d24a18f59b6 100644
+index 02045103fc776a149cd05a779461acb6164b656f..fc29c3982b80f70ba7eb37262f3ba3b9dcdfdbcd 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1802,6 +1802,40 @@ public final class Bukkit {
+@@ -1857,6 +1857,40 @@ public final class Bukkit {
      public static boolean suggestPlayerNamesWhenNullTabCompletions() {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
@@ -312,10 +312,10 @@ index 4ff85202a61f43b175ba7b3c2191f0a5b9f6a59b..a903cc8e0fd6f44dc31b8b3998767d24
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 1a6142822eb3530649da564272fb40c9aab53ba8..d1554849a8a0e698d6106487fea44ad8e8b438da 100644
+index 1d13a4c289e6a764b3b080455a86e17a5e60929e..e1123bd39196c5ca81b4e0b7da633f41d9485091 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1582,5 +1582,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1633,5 +1633,33 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if player names should be suggested
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();

--- a/patches/api/0164-Make-the-default-permission-message-configurable.patch
+++ b/patches/api/0164-Make-the-default-permission-message-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make the default permission message configurable
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 85cb12d2719ca42c04abcd63726059767bba6fe7..1d586d7308d8b17e007dac6fabb53d7dffc660e9 100644
+index 922431356145b3abb154812c4593ed87d5383b06..6aabf764231d29b0d9c83c0c40e1088c34d6f168 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1817,6 +1817,15 @@ public final class Bukkit {
+@@ -1872,6 +1872,15 @@ public final class Bukkit {
          return server.suggestPlayerNamesWhenNullTabCompletions();
      }
  
@@ -25,10 +25,10 @@ index 85cb12d2719ca42c04abcd63726059767bba6fe7..1d586d7308d8b17e007dac6fabb53d7d
       * Creates a PlayerProfile for the specified uuid, with name as null
       * @param uuid UUID to create profile for
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d2fce537c80c73bd1711854fd4b86fb4730e6fe4..c9b792870f8329079ee7fb07e922f066d7832e81 100644
+index 9a44e497ae0c027acd39566681833b992e4e274b..f5f41fb37fd8dbdcffe47eefa939aecdad8210c0 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1595,6 +1595,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1646,6 +1646,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      boolean suggestPlayerNamesWhenNullTabCompletions();
  

--- a/patches/api/0178-Flip-some-Spigot-API-null-annotations.patch
+++ b/patches/api/0178-Flip-some-Spigot-API-null-annotations.patch
@@ -9,10 +9,10 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 1d586d7308d8b17e007dac6fabb53d7dffc660e9..bec68e0eff61e4d81b9723db601e37a9e1d47c42 100644
+index 6aabf764231d29b0d9c83c0c40e1088c34d6f168..228a7874bc8c280c43971a89ba9cbb14f7d10cb0 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1413,7 +1413,7 @@ public final class Bukkit {
+@@ -1468,7 +1468,7 @@ public final class Bukkit {
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -21,7 +21,7 @@ index 1d586d7308d8b17e007dac6fabb53d7dffc660e9..bec68e0eff61e4d81b9723db601e37a9
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
      }
-@@ -1710,7 +1710,7 @@ public final class Bukkit {
+@@ -1765,7 +1765,7 @@ public final class Bukkit {
       * @param clazz the class of the tag entries
       * @return the tag or null
       */
@@ -62,10 +62,10 @@ index 88b3e0323dbc4f0fce31b147c7aaa08d65745852..1835d39f6259732e56d51fa746faf1e4
          if (this.world == null) {
              return null;
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index c9b792870f8329079ee7fb07e922f066d7832e81..d7c73eaf5d3075c2f983c31feb303b853fa744b8 100644
+index f5f41fb37fd8dbdcffe47eefa939aecdad8210c0..a09513f74b3fb9790958f40a7ebef952f9e304f2 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1191,7 +1191,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1242,7 +1242,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       *
       * @return the scoreboard manager or null if no worlds are loaded.
       */
@@ -74,7 +74,7 @@ index c9b792870f8329079ee7fb07e922f066d7832e81..d7c73eaf5d3075c2f983c31feb303b85
      ScoreboardManager getScoreboardManager();
  
      /**
-@@ -1461,7 +1461,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1512,7 +1512,7 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @param clazz the class of the tag entries
       * @return the tag or null
       */

--- a/patches/api/0186-Expose-the-internal-current-tick.patch
+++ b/patches/api/0186-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index bec68e0eff61e4d81b9723db601e37a9e1d47c42..5a74cce889b1c41701e862f854b3c45f4970828c 100644
+index 228a7874bc8c280c43971a89ba9cbb14f7d10cb0..a99486ee6bedd9743ee8aa34f32b73aebab74bc7 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1859,6 +1859,10 @@ public final class Bukkit {
+@@ -1914,6 +1914,10 @@ public final class Bukkit {
      public static com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name) {
          return server.createProfile(uuid, name);
      }
@@ -20,10 +20,10 @@ index bec68e0eff61e4d81b9723db601e37a9e1d47c42..5a74cce889b1c41701e862f854b3c45f
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index d7c73eaf5d3075c2f983c31feb303b853fa744b8..cadea9bc73eeb15be32505709caf0e9a99c04967 100644
+index a09513f74b3fb9790958f40a7ebef952f9e304f2..14838cf97760b3b4de07bad24e30dfa851cb468f 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1629,5 +1629,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1680,5 +1680,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.profile.PlayerProfile createProfile(@Nullable UUID uuid, @Nullable String name);

--- a/patches/api/0193-Add-tick-times-API.patch
+++ b/patches/api/0193-Add-tick-times-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add tick times API
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5a74cce889b1c41701e862f854b3c45f4970828c..17c38075b1ac435d2f4446e759548a744e657eed 100644
+index a99486ee6bedd9743ee8aa34f32b73aebab74bc7..00bdd2f71f3ccde3fa64b597dc9c926319b96519 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1614,6 +1614,25 @@ public final class Bukkit {
+@@ -1669,6 +1669,25 @@ public final class Bukkit {
      public static double[] getTPS() {
          return server.getTPS();
      }
@@ -35,10 +35,10 @@ index 5a74cce889b1c41701e862f854b3c45f4970828c..17c38075b1ac435d2f4446e759548a74
  
      /**
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index cadea9bc73eeb15be32505709caf0e9a99c04967..5cfb1905a5e4b8812aa7128ebdab9ac32644bfa4 100644
+index 14838cf97760b3b4de07bad24e30dfa851cb468f..d7b4d1deda0d02deb96e33917f1b013c6dbee98d 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1365,6 +1365,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1416,6 +1416,21 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      public double[] getTPS();

--- a/patches/api/0194-Expose-MinecraftServer-isRunning.patch
+++ b/patches/api/0194-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 17c38075b1ac435d2f4446e759548a744e657eed..152ba4281d730643957ead601a91beefce7893da 100644
+index 00bdd2f71f3ccde3fa64b597dc9c926319b96519..96039e4f17dd2860bf78ccfca4656da1129ef5af 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1882,6 +1882,15 @@ public final class Bukkit {
+@@ -1937,6 +1937,15 @@ public final class Bukkit {
      public static int getCurrentTick() {
          return server.getCurrentTick();
      }
@@ -26,10 +26,10 @@ index 17c38075b1ac435d2f4446e759548a744e657eed..152ba4281d730643957ead601a91beef
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 5cfb1905a5e4b8812aa7128ebdab9ac32644bfa4..b45551e606369f69a3777d15c35ffa5af3dfdf67 100644
+index d7b4d1deda0d02deb96e33917f1b013c6dbee98d..6ee70b7be4cf04d74f8941c321e08105d86d4edf 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1651,5 +1651,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1702,5 +1702,12 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return Current tick
       */
      int getCurrentTick();

--- a/patches/api/0203-Add-Mob-Goal-API.patch
+++ b/patches/api/0203-Add-Mob-Goal-API.patch
@@ -520,10 +520,10 @@ index 0000000000000000000000000000000000000000..659193fc0596084031c09aa47fbb428a
 +    @Deprecated GoalKey<Mob> UNIVERSAL_ANGER_RESET = GoalKey.of(Mob.class, NamespacedKey.minecraft("universal_anger_reset"));
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 152ba4281d730643957ead601a91beefce7893da..f9f9a3f0689e6494bd56f288319930018052c38b 100644
+index 96039e4f17dd2860bf78ccfca4656da1129ef5af..eef5770b5167844bf07c65a4e870db576161cf13 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1891,6 +1891,16 @@ public final class Bukkit {
+@@ -1946,6 +1946,16 @@ public final class Bukkit {
      public static boolean isStopping() {
          return server.isStopping();
      }
@@ -541,10 +541,10 @@ index 152ba4281d730643957ead601a91beefce7893da..f9f9a3f0689e6494bd56f28831993001
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index b45551e606369f69a3777d15c35ffa5af3dfdf67..e0b79d23f4c16505cf54afb822b2f6c370560931 100644
+index 6ee70b7be4cf04d74f8941c321e08105d86d4edf..7284a2898ff5f6160787278396e16223eff41831 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1658,5 +1658,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1709,5 +1709,13 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       * @return true if server is in the process of being shutdown
       */
      boolean isStopping();

--- a/patches/api/0217-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/api/0217-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 5bbb9e858253d31dc58d1eda1c88c8a84d2fb65a..191fbd4441b9287dd0ae30e2a636c1f95e382572 100644
+index 8553330a96d5902110b904da79a91c9900162adf..14200e67d00679eed47402d3789614e31e1b5514 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1514,6 +1514,22 @@ public final class Bukkit {
+@@ -1569,6 +1569,22 @@ public final class Bukkit {
          return server.createChunkData(world);
      }
  
@@ -32,10 +32,10 @@ index 5bbb9e858253d31dc58d1eda1c88c8a84d2fb65a..191fbd4441b9287dd0ae30e2a636c1f9
       * Creates a boss bar instance to display to players. The progress
       * defaults to 1.0
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 00904a803418865521c52088bf6fe9db2eb28b31..c8798700fbb3885c7522e1170242cba573826358 100644
+index dbfe95698deb1a6bfcc5cebf5916f5a974b293e0..bcb584a244a7e56586571f51baa5cab35780a59e 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1276,6 +1276,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1327,6 +1327,20 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public ChunkGenerator.ChunkData createChunkData(@NotNull World world);
  

--- a/patches/api/0233-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/api/0233-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index c6648e84f762ae4b2d06e2a5cd08ff1f7739f49a..cf7138a9251e92065fef8b0090eaaf779064e2fc 100644
+index e94e8df18b5e2f10de6f4ece5bd55899d4972830..bf6895b6040097f411dcbc24454735af4d585a74 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -986,6 +986,27 @@ public final class Bukkit {
+@@ -1041,6 +1041,27 @@ public final class Bukkit {
          return server.getOfflinePlayer(name);
      }
  
@@ -37,10 +37,10 @@ index c6648e84f762ae4b2d06e2a5cd08ff1f7739f49a..cf7138a9251e92065fef8b0090eaaf77
       * Gets the player by the given UUID, regardless if they are offline or
       * online.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index bc7bfb56bd0291c3ab1d74970057d4b0c52b3075..724a32e4a4861f9f9a8ffc5b5a497b458efffc0f 100644
+index 63f5cbb8d292fbcefde32375c67ae8eed3f63d9c..3badf646e25b457435d3cba4b64c8a94423f91af 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -828,6 +828,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -879,6 +879,25 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
      @NotNull
      public OfflinePlayer getOfflinePlayer(@NotNull String name);
  

--- a/patches/api/0302-Add-basic-Datapack-API.patch
+++ b/patches/api/0302-Add-basic-Datapack-API.patch
@@ -70,10 +70,10 @@ index 0000000000000000000000000000000000000000..58f78d5e91beacaf710f62461cf869f7
 +
 +}
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index 4bd7fee100800d0ede600afcde2277b1de9e52f2..071a0013ac4bad6483c1400e8eb7b842fa1b7496 100644
+index 6bec329379971532eaa44cc8d231c2244ed84975..85a6687be7d26215680054af1524dc946960b75a 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
-@@ -1973,6 +1973,14 @@ public final class Bukkit {
+@@ -2028,6 +2028,14 @@ public final class Bukkit {
      public static com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return server.getMobGoals();
      }
@@ -89,10 +89,10 @@ index 4bd7fee100800d0ede600afcde2277b1de9e52f2..071a0013ac4bad6483c1400e8eb7b842
  
      @NotNull
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index dcdd0c3f3d03e4a3043909cf051faeb665115c34..f05edac8cdd33daaf1d15a526be4d2ac2b08846d 100644
+index dccd769cdd63f78b51caa09aaf6931a4c1882fb9..024da3febe3fd6c54aa30e99cb08300bc38ddb92 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
-@@ -1729,5 +1729,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
+@@ -1780,5 +1780,11 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
       */
      @NotNull
      com.destroystokyo.paper.entity.ai.MobGoals getMobGoals();

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -681,10 +681,10 @@ index 7f81dd05ec8945a851b6501854dc894cad240a66..d6b2e7d643f907ddd81d394d9b613e9c
          this.world = new CraftWorld((ServerLevel) this, gen, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6c1a641f57011f3443e022758e37660034aa240f..a3f27b2e766e0477410e14e55a0c800ab307984c 100644
+index ace054af2d4f1ab026ee6a5d96e35e7cc7fd53f8..7964acaef50a1786c0510e04723e1ec8dc682757 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -805,6 +805,7 @@ public final class CraftServer implements Server {
+@@ -814,6 +814,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -692,7 +692,7 @@ index 6c1a641f57011f3443e022758e37660034aa240f..a3f27b2e766e0477410e14e55a0c800a
          for (ServerLevel world : this.console.getAllLevels()) {
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
-@@ -838,12 +839,14 @@ public final class CraftServer implements Server {
+@@ -847,12 +848,14 @@ public final class CraftServer implements Server {
                  world.ticksPerAmbientSpawns = this.getTicksPerAmbientSpawns();
              }
              world.spigotConfig.init(); // Spigot
@@ -707,7 +707,7 @@ index 6c1a641f57011f3443e022758e37660034aa240f..a3f27b2e766e0477410e14e55a0c800a
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2111,4 +2114,35 @@ public final class CraftServer implements Server {
+@@ -2188,4 +2191,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -3447,10 +3447,10 @@ index e6d003701426a823768966d944384c69b9701967..3b09f76805053802bb779e227749d814
      @Override
      public float getBukkitYaw() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 014a95cac1ad21637c21e2c0c9e189ff9e3b319d..6b4e78af38fe5b2567597d6267ddecd252585b5a 100644
+index 3a830166b65e81b970b0e9930bd79cb3e4eafc74..9d9d7990c49fd37c660efcb2c87a6c3495d648a6 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -231,6 +231,7 @@ public abstract class Mob extends LivingEntity {
+@@ -235,6 +235,7 @@ public abstract class Mob extends LivingEntity {
          return this.target;
      }
  

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -1444,7 +1444,7 @@ index 8c4744b3a3ebf73d31f59d1566320031550aa3bb..c731f22390773bcd43d392b86ae5b42b
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0b13a1464a9e6c4912e737879b00ae14da99fbf5..e21f83ca4520da2e518950de5f8bc84d666158e6 100644
+index 01a5c95c40b39ba71add80f65359e390b9079f4e..11f9be795dc622f84866acf461cf3b3190b3d62c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -126,7 +126,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1817,10 +1817,10 @@ index b645a2fc839dbf922ce73b23b7d53e9a5fe1a2ee..1b478ebfe6792a157772a5812d0daa1a
  
      private static CompoundTag packStructureData(ServerLevel world, ChunkPos chunkcoordintpair, Map<StructureFeature<?>, StructureStart<?>> map, Map<StructureFeature<?>, LongSet> map1) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a3f27b2e766e0477410e14e55a0c800ab307984c..bf26a5175e672b51561a6c5a32a32068541ae656 100644
+index 7964acaef50a1786c0510e04723e1ec8dc682757..02d8cfeaea105d42a437b08c3ba59c50eda5a452 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2083,12 +2083,31 @@ public final class CraftServer implements Server {
+@@ -2160,12 +2160,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  
@@ -2022,7 +2022,7 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 73556aa988cdd969642bad89345637c534f753b6..d4836d251eeca4c550bf2e7e0d5c039fb1529e9a 100644
+index f1a5257ba8e626cc55bbdd755af23de2326e92f8..7274657daecdaaf961f5bbd69e05fc5b7f0c2fda 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1819,6 +1819,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1699,10 +1699,10 @@ index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d1801dcb2d5 100644
+index 02d8cfeaea105d42a437b08c3ba59c50eda5a452..6ba6e88174644cfea81445f1e8483e8118744027 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -564,8 +564,10 @@ public final class CraftServer implements Server {
+@@ -573,8 +573,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1713,7 +1713,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      }
  
      @Override
-@@ -1305,7 +1307,15 @@ public final class CraftServer implements Server {
+@@ -1382,7 +1384,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1729,7 +1729,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1422,7 +1432,20 @@ public final class CraftServer implements Server {
+@@ -1499,7 +1509,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1750,7 +1750,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1430,14 +1453,14 @@ public final class CraftServer implements Server {
+@@ -1507,14 +1530,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1767,7 +1767,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1673,6 +1696,14 @@ public final class CraftServer implements Server {
+@@ -1750,6 +1773,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1782,7 +1782,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1685,13 +1716,28 @@ public final class CraftServer implements Server {
+@@ -1762,13 +1793,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1811,7 +1811,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1735,6 +1781,12 @@ public final class CraftServer implements Server {
+@@ -1812,6 +1858,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1824,7 +1824,7 @@ index bf26a5175e672b51561a6c5a32a32068541ae656..d096bd229ee581bd8fe40a4e02705d18
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2163,5 +2215,15 @@ public final class CraftServer implements Server {
+@@ -2240,5 +2292,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }
@@ -2047,7 +2047,7 @@ index 2509a39bec5edd38b54709fec241c7c18e0d1c26..6e89b039479a034d98d1ec183b06d541
          Component[] components = new Component[4];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
-index 8bf9dd8f83c5e17447d8603fa5551e1fea06705d..a885eb537d6475eefe7d06f8312ecf0a278c5a00 100644
+index f3cb4102ab223f379f60dac317df7da1fab812a8..1a8b02e9e4cf6fb27d6bcdf0350bdfc24e6bdee3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 @@ -80,4 +80,11 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
@@ -2080,7 +2080,7 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f337cae2f34ddd5412136bb2a2df4f6a12c5a0f4..ee7c920a5a3154927c675b2e1cd0c16f99d0e9a2 100644
+index 3aecaf187b0360eb0e5dc9a8948c834cf3401ad8..8d7d256fa33635807d187d493e71b6b4e17fa2e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -810,6 +810,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -2138,7 +2138,7 @@ index 042691349dd5659e8db526199641cbcfa21c6005..841dbf4a86b19d7c8ea41930ecb1f88c
          player.initMenu(container);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d4836d251eeca4c550bf2e7e0d5c039fb1529e9a..cc97a1fb78037e4b09ebe825b5135702f2f19e00 100644
+index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1de87a77e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2482,7 +2482,7 @@ index d4836d251eeca4c550bf2e7e0d5c039fb1529e9a..cc97a1fb78037e4b09ebe825b5135702
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 606f6b790c3680e3cf4e4bb31b98f1684c72a50f..631a2e301d4940486a401c427b7b2db44bd68e3c 100644
+index e2c30e2073f6e4d667d91c9ca29bd6e91900aa97..23f894528daa01010c133366a63ac10779603b6e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -802,9 +802,9 @@ public class CraftEventFactory {

--- a/patches/server/0014-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0014-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -19,7 +19,7 @@ index 78948c42b13194005bdbbbc69c2b7ae0732a78c5..b41e7922dd96c3358eb849ab39982a75
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e21f83ca4520da2e518950de5f8bc84d666158e6..04f2cee8045ba74993e10230c3ad7ca80fb048d6 100644
+index 11f9be795dc622f84866acf461cf3b3190b3d62c..8369238dd8042310b8e2aa10e463a3a9f9f7ec64 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1264,6 +1264,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -31,7 +31,7 @@ index e21f83ca4520da2e518950de5f8bc84d666158e6..04f2cee8045ba74993e10230c3ad7ca8
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 6b4e78af38fe5b2567597d6267ddecd252585b5a..8e2f3ffae0071be4f44c9b04269913d9daed2a4d 100644
+index 9d9d7990c49fd37c660efcb2c87a6c3495d648a6..5c01a30ccdcf05f516700fb95a46606f2c4cfc6b 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -104,6 +104,7 @@ public abstract class Mob extends LivingEntity {
@@ -42,7 +42,7 @@ index 6b4e78af38fe5b2567597d6267ddecd252585b5a..8e2f3ffae0071be4f44c9b04269913d9
      public GoalSelector targetSelector;
      private LivingEntity target;
      private final Sensing sensing;
-@@ -795,7 +796,17 @@ public abstract class Mob extends LivingEntity {
+@@ -799,7 +800,17 @@ public abstract class Mob extends LivingEntity {
      @Override
      protected final void serverAiStep() {
          ++this.noActionTime;

--- a/patches/server/0015-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0015-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -30,10 +30,10 @@ index b41e7922dd96c3358eb849ab39982a75736e3476..2f0d582baf0eb2bb477944d0cb1369db
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 8e2f3ffae0071be4f44c9b04269913d9daed2a4d..f8dcd9cb5e6d223f4f5445a4172cc6c4ea160313 100644
+index 5c01a30ccdcf05f516700fb95a46606f2c4cfc6b..78813a0efcab432c8c8c869da13ea49c93874cbf 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -774,16 +774,16 @@ public abstract class Mob extends LivingEntity {
+@@ -778,16 +778,16 @@ public abstract class Mob extends LivingEntity {
                  int i = this.getType().getCategory().getDespawnDistance();
                  int j = i * i;
  

--- a/patches/server/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0018-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -32,10 +32,10 @@ index fcc775723bcef7c6b740ee332c21ef70e591c77e..0ee92562ef7c6ac99f5bea0b6d0751d0
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d096bd229ee581bd8fe40a4e02705d1801dcb2d5..e0a50b7d71d0ddee905e3799264dfb978d1ed0b1 100644
+index 6ba6e88174644cfea81445f1e8483e8118744027..fdf877a717f07187eeee98f0203e70d71e1706c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -227,7 +227,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -236,7 +236,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {

--- a/patches/server/0021-Player-affects-spawning-API.patch
+++ b/patches/server/0021-Player-affects-spawning-API.patch
@@ -21,10 +21,10 @@ index 195989667c7d844399a72787819f62a3fd0d9c78..d17b75ad13bbc8a38cdc2f2d77ee5d88
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f8dcd9cb5e6d223f4f5445a4172cc6c4ea160313..78e2d0165f6f6da4d7d1e1dad76e5edcbe48df9e 100644
+index 78813a0efcab432c8c8c869da13ea49c93874cbf..01f88d647032820e19418c3d97e40dfaf1a7e482 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -767,7 +767,7 @@ public abstract class Mob extends LivingEntity {
+@@ -771,7 +771,7 @@ public abstract class Mob extends LivingEntity {
          if (this.level.getDifficulty() == Difficulty.PEACEFUL && this.shouldDespawnInPeaceful()) {
              this.discard();
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {

--- a/patches/server/0023-Further-improve-server-tick-loop.patch
+++ b/patches/server/0023-Further-improve-server-tick-loop.patch
@@ -143,10 +143,10 @@ index 0ee92562ef7c6ac99f5bea0b6d0751d0add50f16..6225e9391ddff28d8f71a9f643ef2c41
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e0a50b7d71d0ddee905e3799264dfb978d1ed0b1..200fd7bdd0e1ea45f77932ef16a9ddc4e73b75eb 100644
+index fdf877a717f07187eeee98f0203e70d71e1706c4..5e5163d180742c33fc6f045530906d76df758c96 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2131,6 +2131,17 @@ public final class CraftServer implements Server {
+@@ -2208,6 +2208,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0044-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0044-Ensure-commands-are-not-ran-async.patch
@@ -48,10 +48,10 @@ index da9f4b3337b49597c17b50964656457cd629a0b7..22c2c121bbcc7b0e15d73d20c9cc83d5
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 200fd7bdd0e1ea45f77932ef16a9ddc4e73b75eb..c5b0bd10906a5da569dc6465e2b1913fd9513d51 100644
+index 5e5163d180742c33fc6f045530906d76df758c96..747cdfbbd5d22094dcc43208036accff70356c7e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -758,6 +758,28 @@ public final class CraftServer implements Server {
+@@ -767,6 +767,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0046-Expose-server-CommandMap.patch
+++ b/patches/server/0046-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c5b0bd10906a5da569dc6465e2b1913fd9513d51..6d5567fde20508a060a7c13e54e1cfa3924f4d0d 100644
+index 747cdfbbd5d22094dcc43208036accff70356c7e..a493f3ae60f2b2f4397a0b81f25a014d9edc805d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1769,6 +1769,7 @@ public final class CraftServer implements Server {
+@@ -1846,6 +1846,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0051-Add-velocity-warnings.patch
+++ b/patches/server/0051-Add-velocity-warnings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d5567fde20508a060a7c13e54e1cfa3924f4d0d..2e479cd5f7effeadc1ea41f91f5019e42ece0ac1 100644
+index a493f3ae60f2b2f4397a0b81f25a014d9edc805d..ea8ed9c3d83e7038c334779b7bd3739286101f73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -263,6 +263,7 @@ public final class CraftServer implements Server {
+@@ -272,6 +272,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -17,7 +17,7 @@ index 6d5567fde20508a060a7c13e54e1cfa3924f4d0d..2e479cd5f7effeadc1ea41f91f5019e4
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 1c6473b496ca05e9e0fcd505caaa18b5546d1d3c..db430d20186fc8d307fd4e521778316845cd8581 100644
+index 3510448dd6964981cd9aa64c24c85c310eb75971..99bd0df1351c356b0ff9f5d864ba5dad89c90acf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -435,10 +435,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
@@ -30,10 +30,10 @@ index 429b74474ced04d8dd8f038b8590b8dfe178bf4d..716f285e67019b8a62922d09c15883c9
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2e479cd5f7effeadc1ea41f91f5019e42ece0ac1..47f9993c632ff0d8b1f1692b88efc4127be996b4 100644
+index ea8ed9c3d83e7038c334779b7bd3739286101f73..14d50ebcf9b229bf0664d200117d027983cbf1a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -400,6 +400,7 @@ public final class CraftServer implements Server {
+@@ -409,6 +409,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -41,7 +41,7 @@ index 2e479cd5f7effeadc1ea41f91f5019e42ece0ac1..47f9993c632ff0d8b1f1692b88efc412
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -419,7 +420,7 @@ public final class CraftServer implements Server {
+@@ -428,7 +429,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0060-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 47f9993c632ff0d8b1f1692b88efc4127be996b4..bd3c7de5ab0b81ef83ead5a0710240dd52b19728 100644
+index 14d50ebcf9b229bf0664d200117d027983cbf1a2..71e5640c9416d95412638f2bceeb901b9188ac58 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2261,5 +2261,23 @@ public final class CraftServer implements Server {
+@@ -2338,5 +2338,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0061-Remove-Metadata-on-reload.patch
+++ b/patches/server/0061-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bd3c7de5ab0b81ef83ead5a0710240dd52b19728..6c372692eb6ac813ed071337d6ea98e604133510 100644
+index 71e5640c9416d95412638f2bceeb901b9188ac58..0f30b58e047c1bc034b2e34ed8fc3823cddaaf7f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -868,8 +868,16 @@ public final class CraftServer implements Server {
+@@ -877,8 +877,16 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index f6cb864c45f960811acc02829d1f7883b916de29..8703f97dc2f392b136c6851aa09b607c
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6c372692eb6ac813ed071337d6ea98e604133510..94fe09fdf6e477eca467287c68d7a8b5a6fbaee0 100644
+index 0f30b58e047c1bc034b2e34ed8fc3823cddaaf7f..e83a8e5c190d3d9906c343b14d44af47f23b3414 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1512,7 +1512,7 @@ public final class CraftServer implements Server {
+@@ -1589,7 +1589,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 94fe09fdf6e477eca467287c68d7a8b5a6fbaee0..9847c5d18fc9a6d1689341ea8a989a99880a5581 100644
+index e83a8e5c190d3d9906c343b14d44af47f23b3414..98622d2bb3a491e973bac914604124f7133a62e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2287,5 +2287,24 @@ public final class CraftServer implements Server {
+@@ -2364,5 +2364,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9847c5d18fc9a6d1689341ea8a989a99880a5581..9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b 100644
+index 98622d2bb3a491e973bac914604124f7133a62e9..98b8027f57c8c68621957652823e0994c2a19219 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2306,5 +2306,10 @@ public final class CraftServer implements Server {
+@@ -2383,5 +2383,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -244,10 +244,10 @@ index 24add1cd1f865012c5382548e415218d481ecefe..31dccb0b4ab60d6cedf236fc7d51a363
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b..c904c969b7a64f1b90f570d76ac5eb542eff9ba6 100644
+index 98b8027f57c8c68621957652823e0994c2a19219..d516f012ffbb5d12f698101efe91baff78c4a57e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -46,7 +46,6 @@ import java.util.function.Consumer;
+@@ -47,7 +47,6 @@ import java.util.function.Consumer;
  import java.util.logging.Level;
  import java.util.logging.Logger;
  import javax.imageio.ImageIO;
@@ -255,7 +255,7 @@ index 9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b..c904c969b7a64f1b90f570d76ac5eb54
  import net.minecraft.advancements.Advancement;
  import net.minecraft.commands.CommandSourceStack;
  import net.minecraft.commands.Commands;
-@@ -60,6 +59,7 @@ import net.minecraft.resources.RegistryReadOps;
+@@ -61,6 +60,7 @@ import net.minecraft.resources.RegistryReadOps;
  import net.minecraft.resources.ResourceKey;
  import net.minecraft.resources.ResourceLocation;
  import net.minecraft.server.ConsoleInput;
@@ -263,7 +263,7 @@ index 9a21554ae88d8ddf0ebe8dcaa40663fbdfacf75b..c904c969b7a64f1b90f570d76ac5eb54
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.bossevents.CustomBossEvent;
  import net.minecraft.server.commands.ReloadCommand;
-@@ -1200,9 +1200,13 @@ public final class CraftServer implements Server {
+@@ -1209,9 +1209,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0139-Item-canEntityPickup.patch
+++ b/patches/server/0139-Item-canEntityPickup.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Item#canEntityPickup
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 78e2d0165f6f6da4d7d1e1dad76e5edcbe48df9e..6b18d4dd869b442f06a7e9ae690edd5ff5227cbb 100644
+index 01f88d647032820e19418c3d97e40dfaf1a7e482..ebdd1c2f9c73b484df62bb20825324cf8e339248 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -615,6 +615,11 @@ public abstract class Mob extends LivingEntity {
+@@ -619,6 +619,11 @@ public abstract class Mob extends LivingEntity {
                  ItemEntity entityitem = (ItemEntity) iterator.next();
  
                  if (!entityitem.isRemoved() && !entityitem.getItem().isEmpty() && !entityitem.hasPickUpDelay() && this.wantsToPickUp(entityitem.getItem())) {

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c904c969b7a64f1b90f570d76ac5eb542eff9ba6..8667373de82ce335fb0c55e39e6c1e1e791d70ce 100644
+index d516f012ffbb5d12f698101efe91baff78c4a57e..01c10ee7f4a1568a35101dd73c0049e24bfb3e00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -788,7 +788,13 @@ public final class CraftServer implements Server {
+@@ -797,7 +797,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -491,10 +491,10 @@ index 6e1b7d5b20e9f6ed1b650eb9d6ac9f8c4867b4b7..61405c2b53e03a4b83e2c70c6e4d3739
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8667373de82ce335fb0c55e39e6c1e1e791d70ce..df03db15e0a7d90ada2ae2a7990472ec2ca72806 100644
+index 01c10ee7f4a1568a35101dd73c0049e24bfb3e00..472c466c8257bcd696184ac71019acd491eca714 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -226,6 +226,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -235,6 +235,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -504,7 +504,7 @@ index 8667373de82ce335fb0c55e39e6c1e1e791d70ce..df03db15e0a7d90ada2ae2a7990472ec
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2321,5 +2324,24 @@ public final class CraftServer implements Server {
+@@ -2398,5 +2401,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -58,10 +58,10 @@ index 77645019c88d61dde28b7598d8a29b7d0c23c209..8a079ee3ed243fd19b1dd7eed2de1dd3
          return null;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 923948e7fc63a778ca126c99e1189357bb490dee..bf12cb6a1f991372206e462e46f2686decff11a6 100644
+index 4a61ce62ffe75622583bbb2d83e6d46f1e769d59..d8136ba1aacf55f710365a9171033f743ce2775b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -316,7 +316,21 @@ public class CraftBlock implements Block {
+@@ -311,7 +311,21 @@ public class CraftBlock implements Block {
  
      @Override
      public BlockState getState() {

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index cf42d59254f2786bfe8785249ad270d35996417a..8c2242d7e443bee26741608c65d314d8
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index df03db15e0a7d90ada2ae2a7990472ec2ca72806..c9bc580b1fb274ea2af31adab0440132e3775ba6 100644
+index 472c466c8257bcd696184ac71019acd491eca714..f3461229c19ad011e33b2d0e2675622e1f339bcb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1856,7 +1856,7 @@ public final class CraftServer implements Server {
+@@ -1933,7 +1933,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0187-getPlayerUniqueId-API.patch
+++ b/patches/server/0187-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c9bc580b1fb274ea2af31adab0440132e3775ba6..096caeab9813d59e4b086c379e100d8b22713194 100644
+index f3461229c19ad011e33b2d0e2675622e1f339bcb..ac431c5b9a05a9aa65351092534298141f506fb8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1514,6 +1514,25 @@ public final class CraftServer implements Server {
+@@ -1591,6 +1591,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
@@ -56,10 +56,10 @@ index 0a954a83e29f2ffc622675f671416bdadc1d3f6a..91a0699ba30fa1e9c8172e07f034ea1f
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 6b18d4dd869b442f06a7e9ae690edd5ff5227cbb..e9e89608c4b77868fed92717c837db76d6bb5a54 100644
+index ebdd1c2f9c73b484df62bb20825324cf8e339248..2ced732bd024caa0aa282bc23d536accba28b032 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1533,7 +1533,7 @@ public abstract class Mob extends LivingEntity {
+@@ -1537,7 +1537,7 @@ public abstract class Mob extends LivingEntity {
  
          if (flag) {
              if (f1 > 0.0F && target instanceof LivingEntity) {

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -48,10 +48,10 @@ index 2bbed2eb8f992764deac2cd5e08471aa0f967606..d0d524bfe7ae90f6d2edefa4063bf009
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 096caeab9813d59e4b086c379e100d8b22713194..6338f32acb10fdb8a6cf8004e78096db33ce1aec 100644
+index ac431c5b9a05a9aa65351092534298141f506fb8..f1e50f3f6d0e4876aa54b72dd474d238cd91f9b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -806,6 +806,7 @@ public final class CraftServer implements Server {
+@@ -815,6 +815,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index 096caeab9813d59e4b086c379e100d8b22713194..6338f32acb10fdb8a6cf8004e78096db
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -921,6 +922,7 @@ public final class CraftServer implements Server {
+@@ -930,6 +931,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -225,10 +225,10 @@ index 39bdda56aaa5503efc15207261634127b462c3e7..3fd913f3e963cf2da849a52364356e3b
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6338f32acb10fdb8a6cf8004e78096db33ce1aec..5775b1656d636479f269f3863c04fcaa4027fd8b 100644
+index f1e50f3f6d0e4876aa54b72dd474d238cd91f9b6..e388a319a311e81dcddf83d3984af35b55f0c6ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -679,7 +679,7 @@ public final class CraftServer implements Server {
+@@ -688,7 +688,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -30,10 +30,10 @@ index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23a
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5775b1656d636479f269f3863c04fcaa4027fd8b..b044a4ab4f95476666f8b0c41bd5e63e9d02ffea 100644
+index e388a319a311e81dcddf83d3984af35b55f0c6ab..bdaf6f35df2066b1626c6c52683c5468d9948aec 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2346,6 +2346,11 @@ public final class CraftServer implements Server {
+@@ -2423,6 +2423,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index 8908b61dc601dc8fd16976df350197ff1d3e3bd7..85477d81a38aefa09f95671951cd06da
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b044a4ab4f95476666f8b0c41bd5e63e9d02ffea..f8e979d9e4b177bffa2b1357fcdce5fbf04aeac0 100644
+index bdaf6f35df2066b1626c6c52683c5468d9948aec..4279eb8c20b546247c27a3a7fd4713e26d91ed5b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1845,7 +1845,7 @@ public final class CraftServer implements Server {
+@@ -1922,7 +1922,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0332-Implement-CraftBlockSoundGroup.patch
+++ b/patches/server/0332-Implement-CraftBlockSoundGroup.patch
@@ -49,17 +49,17 @@ index 0000000000000000000000000000000000000000..9a516520d975f52169e346adc4ec6d9d
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index bf12cb6a1f991372206e462e46f2686decff11a6..75dd8cbadae9a2d18931dd49f49f8f1e14b50da5 100644
+index d8136ba1aacf55f710365a9171033f743ce2775b..f84edce88a9631c9a2a5a75c963fb6abf9e1a88c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -764,4 +764,10 @@ public class CraftBlock implements Block {
+@@ -759,4 +759,10 @@ public class CraftBlock implements Block {
          VoxelShape shape = this.getNMS().getCollisionShape(world, position);
          return new CraftVoxelShape(shape);
      }
 +    // Paper start
 +    @Override
 +    public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
-+        return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMSBlock().defaultBlockState().getSoundType());
++        return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
 +    }
 +    // Paper end
  }

--- a/patches/server/0335-Expose-the-internal-current-tick.patch
+++ b/patches/server/0335-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f8e979d9e4b177bffa2b1357fcdce5fbf04aeac0..ab6518d8caf00c99a2c49c69a62923da98170cad 100644
+index 4279eb8c20b546247c27a3a7fd4713e26d91ed5b..ddc8b381e28b2e22630fd058970bae0bc413beaa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2369,5 +2369,10 @@ public final class CraftServer implements Server {
+@@ -2446,5 +2446,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0363-Add-effect-to-block-break-naturally.patch
+++ b/patches/server/0363-Add-effect-to-block-break-naturally.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 75dd8cbadae9a2d18931dd49f49f8f1e14b50da5..64c304cab8c7c4c9c29f73465f99c11f224a72bd 100644
+index 2cf063a3f934aba9ce7bcec23feb0ac022feb022..ec107a4a30abc777798c18952b633b54a7efc661 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -635,6 +635,13 @@ public class CraftBlock implements Block {
+@@ -630,6 +630,13 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean breakNaturally(ItemStack item) {
@@ -22,7 +22,7 @@ index 75dd8cbadae9a2d18931dd49f49f8f1e14b50da5..64c304cab8c7c4c9c29f73465f99c11f
          // Order matters here, need to drop before setting to air so skulls can get their data
          net.minecraft.world.level.block.state.BlockState iblockdata = this.getNMS();
          net.minecraft.world.level.block.Block block = iblockdata.getBlock();
-@@ -644,6 +651,7 @@ public class CraftBlock implements Block {
+@@ -639,6 +646,7 @@ public class CraftBlock implements Block {
          // Modelled off EntityHuman#hasBlock
          if (block != Blocks.AIR && (item == null || !iblockdata.requiresCorrectToolForDrops() || nmsItem.isCorrectToolForDrops(iblockdata))) {
              net.minecraft.world.level.block.Block.dropResources(iblockdata, this.world.getMinecraftWorld(), position, this.world.getBlockEntity(position), null, nmsItem);

--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -124,7 +124,7 @@ index ae2606215a43a49b5e65052c407df715f260e400..60de95d72ca4e4b2e12a2b3363c59a08
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index a8a91ed20c1b97368acdbb6ed7cd73ddaf7e1ea0..6ce232c623d86af20b74d7ee1e7b258cd7342d24 100644
+index 1d8eb407c892e4c635f11070036013587a9264cb..3c5724251f64c5960f2c4cba2223c5ef55970775 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -326,6 +326,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -158,10 +158,10 @@ index a8a91ed20c1b97368acdbb6ed7cd73ddaf7e1ea0..6ce232c623d86af20b74d7ee1e7b258c
              movement = this.maybeBackOffFromEdge(movement, movementType);
              Vec3 vec3d1 = this.collide(movement);
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index e9e89608c4b77868fed92717c837db76d6bb5a54..eec836e5e66a7255a31f1e9311cdb4e9819c84b2 100644
+index 2ced732bd024caa0aa282bc23d536accba28b032..2e9ce7cbf45198a7ac7d9062fcbe71dae6b7c1e8 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -199,6 +199,19 @@ public abstract class Mob extends LivingEntity {
+@@ -203,6 +203,19 @@ public abstract class Mob extends LivingEntity {
          return this.lookControl;
      }
  

--- a/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0399-Add-tick-times-API-and-mspt-command.patch
@@ -146,10 +146,10 @@ index 0115ffe84356468ddc254d8d5bdd719bc5e7e3f8..def1edb961ba41819ce30c427b161657
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ab6518d8caf00c99a2c49c69a62923da98170cad..48e1f49f6ada1a1a2a5e85ab3e12fe9816cb577a 100644
+index ddc8b381e28b2e22630fd058970bae0bc413beaa..4c374bf69ebec859aa4d415c3200b1dac40620dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2207,6 +2207,16 @@ public final class CraftServer implements Server {
+@@ -2284,6 +2284,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0400-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0400-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 48e1f49f6ada1a1a2a5e85ab3e12fe9816cb577a..796decb4d6a011fae263d6bced59d2399a61a60b 100644
+index 4c374bf69ebec859aa4d415c3200b1dac40620dd..42a1187f78b5d48ab931b78c5d4f2d1a706a8552 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2384,5 +2384,10 @@ public final class CraftServer implements Server {
+@@ -2461,5 +2461,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0404-Improved-Watchdog-Support.patch
+++ b/patches/server/0404-Improved-Watchdog-Support.patch
@@ -323,10 +323,10 @@ index 016c2302d8bcf121eafd1be7eb4f3b206dbdbeec..1de1566b76c73ddfaf7e022296068db0
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 796decb4d6a011fae263d6bced59d2399a61a60b..fc1b0fe8c45f133715488f02f41e0c078c4b6803 100644
+index 42a1187f78b5d48ab931b78c5d4f2d1a706a8552..57e37048e896eec47fdd9585d40cb1b82a3775a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1845,7 +1845,7 @@ public final class CraftServer implements Server {
+@@ -1922,7 +1922,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0428-Expose-game-version.patch
+++ b/patches/server/0428-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fc1b0fe8c45f133715488f02f41e0c078c4b6803..238901696feb8de28c8d543535b578decd146334 100644
+index 57e37048e896eec47fdd9585d40cb1b82a3775a2..1a1d4f6deadd2faf811ad16d5548c94786ecc84d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -517,6 +517,13 @@ public final class CraftServer implements Server {
+@@ -526,6 +526,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0431-Implement-Mob-Goal-API.patch
+++ b/patches/server/0431-Implement-Mob-Goal-API.patch
@@ -895,10 +895,10 @@ index 8c2ec30a35e86f2b30863045b586a67e485c624b..9cb5ccf4815b56169b63b34da88e7394
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 238901696feb8de28c8d543535b578decd146334..644373b23cf228505dd23ba07bd9cacbdc365c6c 100644
+index 1a1d4f6deadd2faf811ad16d5548c94786ecc84d..464cf287cf2bad787207f29946c97c9709a699e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2396,5 +2396,11 @@ public final class CraftServer implements Server {
+@@ -2473,5 +2473,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0440-Wait-for-Async-Tasks-during-shutdown.patch
@@ -22,10 +22,10 @@ index 736cbb3430ba1d8c00ea43a80c978949108d8b6c..d285967a60903a73608a1f9cdc306e63
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 644373b23cf228505dd23ba07bd9cacbdc365c6c..610dab96b6dcb5bf5dbd19a7f075241b8bd3e50f 100644
+index 464cf287cf2bad787207f29946c97c9709a699e9..9dc9153bd53b0d1e63d0367498a99271821217e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -932,6 +932,35 @@ public final class CraftServer implements Server {
+@@ -941,6 +941,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 610dab96b6dcb5bf5dbd19a7f075241b8bd3e50f..49a907e0761cea917db3aa7cfbc6ed237acc59f6 100644
+index 9dc9153bd53b0d1e63d0367498a99271821217e0..5285a5b16b0b706d9e1728a23628ff12e6b3b55d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -345,7 +345,7 @@ public final class CraftServer implements Server {
+@@ -354,7 +354,7 @@ public final class CraftServer implements Server {
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 610dab96b6dcb5bf5dbd19a7f075241b8bd3e50f..49a907e0761cea917db3aa7cfbc6ed23
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -830,7 +830,7 @@ public final class CraftServer implements Server {
+@@ -839,7 +839,7 @@ public final class CraftServer implements Server {
          this.waterAmbientSpawn = this.configuration.getInt("spawn-limits.water-ambient");
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 49a907e0761cea917db3aa7cfbc6ed237acc59f6..f93b9a1d0f3600fa1c8b9a9881465c73a965862b 100644
+index 5285a5b16b0b706d9e1728a23628ff12e6b3b55d..df20ac811d673c205695d563f84382d1bf1e82e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2038,6 +2038,32 @@ public final class CraftServer implements Server {
+@@ -2115,6 +2115,32 @@ public final class CraftServer implements Server {
          return new CraftChunkData(world);
      }
  

--- a/patches/server/0507-Add-setMaxPlayers-API.patch
+++ b/patches/server/0507-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index 13f1b62e6f3adce54f82d6d131dd60976dc6f548..f2b139d565662fca1bbad46e50b5ccb0
      private boolean allowCheatsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f93b9a1d0f3600fa1c8b9a9881465c73a965862b..f20829fdad6239f61baccd5f671a9139422f35f0 100644
+index df20ac811d673c205695d563f84382d1bf1e82e1..c664c4fc1280fd57c3b7e8580294b3823b98eae9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -612,6 +612,13 @@ public final class CraftServer implements Server {
+@@ -621,6 +621,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0521-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
+++ b/patches/server/0521-Add-a-way-to-get-translation-keys-for-blocks-entitie.patch
@@ -6,12 +6,12 @@ Subject: [PATCH] Add a way to get translation keys for blocks, entities and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 64c304cab8c7c4c9c29f73465f99c11f224a72bd..b31eaa1459690d7f54989ba7a01f96a3f0d8d3b9 100644
+index f17fa8223dcb0e6a90e7745117029af0fa0aa70e..a9b4277855ed3536bd00a03b85b0ae3336336c2b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -777,5 +777,10 @@ public class CraftBlock implements Block {
+@@ -772,5 +772,10 @@ public class CraftBlock implements Block {
      public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
-         return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMSBlock().defaultBlockState().getSoundType());
+         return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
      }
 +
 +    @Override

--- a/patches/server/0537-Optimise-getType-calls.patch
+++ b/patches/server/0537-Optimise-getType-calls.patch
@@ -41,10 +41,10 @@ index e2e6652fc227173b69580dba74855c3ed8884a3b..2c23712aadfe32439ae014c62aa16f1b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index b31eaa1459690d7f54989ba7a01f96a3f0d8d3b9..aa81c0a4c02fd6f2ab900983fd8c9668fada802e 100644
+index 75863778df4b6988452ff27a1ba8a4e1733b3b7e..2f8ab6660c8a0cf208fc59e2d8a3f94c07bdd482 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -214,7 +214,7 @@ public class CraftBlock implements Block {
+@@ -209,7 +209,7 @@ public class CraftBlock implements Block {
  
      @Override
      public Material getType() {

--- a/patches/server/0546-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0546-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f20829fdad6239f61baccd5f671a9139422f35f0..091824ee0cc45292988906d8004ecd472e5d772c 100644
+index c664c4fc1280fd57c3b7e8580294b3823b98eae9..192c8651882286d6e1d2c7be021d2bd4d60e88cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1608,6 +1608,28 @@ public final class CraftServer implements Server {
+@@ -1685,6 +1685,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0558-Add-Destroy-Speed-API.patch
+++ b/patches/server/0558-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index aa81c0a4c02fd6f2ab900983fd8c9668fada802e..2209587fbc4240561aeea6e525fbf22f5041e145 100644
+index 62d8b9a174fa33136a4091652856b2efd8aa6245..28c455f3e9452e988b35c632cabfb47a2b6b09e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -782,5 +782,23 @@ public class CraftBlock implements Block {
+@@ -777,5 +777,23 @@ public class CraftBlock implements Block {
      public String getTranslationKey() {
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }
@@ -22,7 +22,7 @@ index aa81c0a4c02fd6f2ab900983fd8c9668fada802e..2209587fbc4240561aeea6e525fbf22f
 +        } else {
 +            nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
 +        }
-+        float speed = nmsItemStack.getItem().getDestroySpeed(nmsItemStack, this.getNMSBlock().defaultBlockState());
++        float speed = nmsItemStack.getItem().getDestroySpeed(nmsItemStack, this.getNMS().getBlock().defaultBlockState());
 +        if (speed > 1.0F && considerEnchants) {
 +            int enchantLevel = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_EFFICIENCY, nmsItemStack);
 +            if (enchantLevel > 0) {

--- a/patches/server/0578-Additional-Block-Material-API-s.patch
+++ b/patches/server/0578-Additional-Block-Material-API-s.patch
@@ -9,10 +9,10 @@ process to do this in the Bukkit API
 Adds API for buildable, replaceable, burnable too.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 2209587fbc4240561aeea6e525fbf22f5041e145..2379b61fff76fa39a37348a740ca5ad18fadff4f 100644
+index dbb1e219be66e37829ec5be585a9881d589cf6e6..aa1ef5bb1e27e8c45710299febb2d6c6b122ff15 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -623,6 +623,25 @@ public class CraftBlock implements Block {
+@@ -618,6 +618,25 @@ public class CraftBlock implements Block {
          return this.getNMS().getMaterial().isLiquid();
      }
  

--- a/patches/server/0609-Added-Vanilla-Entity-Tags.patch
+++ b/patches/server/0609-Added-Vanilla-Entity-Tags.patch
@@ -39,10 +39,10 @@ index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 091824ee0cc45292988906d8004ecd472e5d772c..cbf97c2d69ef0ca68f4d9df81db5364599a4ae02 100644
+index 192c8651882286d6e1d2c7be021d2bd4d60e88cb..016299cc9e7327f5b29fd51df571fa23b45df6aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2227,6 +2227,11 @@ public final class CraftServer implements Server {
+@@ -2304,6 +2304,11 @@ public final class CraftServer implements Server {
                  Preconditions.checkArgument(clazz == org.bukkit.Fluid.class, "Fluid namespace must have fluid type");
  
                  return (org.bukkit.Tag<T>) new CraftFluidTag(FluidTags.getAllTags(), key);

--- a/patches/server/0614-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0614-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index eec836e5e66a7255a31f1e9311cdb4e9819c84b2..0ce0e7a923da812a02d9ab83607d3cc9c87047df 100644
+index 2e9ce7cbf45198a7ac7d9062fcbe71dae6b7c1e8..4dfba7069fed54b44822b0790b8513c8ece2d4b7 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1209,12 +1209,15 @@ public abstract class Mob extends LivingEntity {
+@@ -1213,12 +1213,15 @@ public abstract class Mob extends LivingEntity {
              return InteractionResult.PASS;
          } else if (this.getLeashHolder() == player) {
              // CraftBukkit start - fire PlayerUnleashEntityEvent
@@ -26,7 +26,7 @@ index eec836e5e66a7255a31f1e9311cdb4e9819c84b2..0ce0e7a923da812a02d9ab83607d3cc9
              return InteractionResult.sidedSuccess(this.level.isClientSide);
          } else {
              InteractionResult enuminteractionresult = this.checkAndHandleImportantInteractions(player, hand);
-@@ -1372,8 +1375,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1376,8 +1379,11 @@ public abstract class Mob extends LivingEntity {
  
          if (this.leashHolder != null) {
              if (!this.isAlive() || !this.leashHolder.isAlive()) {
@@ -40,7 +40,7 @@ index eec836e5e66a7255a31f1e9311cdb4e9819c84b2..0ce0e7a923da812a02d9ab83607d3cc9
              }
  
          }
-@@ -1436,8 +1442,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1440,8 +1446,11 @@ public abstract class Mob extends LivingEntity {
          boolean flag1 = super.startRiding(entity, force);
  
          if (flag1 && this.isLeashed()) {
@@ -54,7 +54,7 @@ index eec836e5e66a7255a31f1e9311cdb4e9819c84b2..0ce0e7a923da812a02d9ab83607d3cc9
          }
  
          return flag1;
-@@ -1607,8 +1616,11 @@ public abstract class Mob extends LivingEntity {
+@@ -1611,8 +1620,11 @@ public abstract class Mob extends LivingEntity {
      @Override
      protected void removeAfterChangingDimensions() {
          super.removeAfterChangingDimensions();
@@ -122,7 +122,7 @@ index b9b67134f02fd7484ed19905c9ae1f9b8a26ce26..c05f173b7642380900fdd77ce5d2c020
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c8c3a8d8e4e5e7df66b69011ad95bb6bd6d3b6ee..1ab0c25dabd19dd53f255b76b2a5c85399cffaaf 100644
+index 77d53272dc856972f05576d55d51d00f6cc33fec..279ef7337cbe523fc354b8f47cbccefd90b42759 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1481,8 +1481,10 @@ public class CraftEventFactory {

--- a/patches/server/0626-misc-debugging-dumps.patch
+++ b/patches/server/0626-misc-debugging-dumps.patch
@@ -74,10 +74,10 @@ index 7da88bc52161dc32da22451077a4dfd8facb2de1..f4cff18afa816aa7efb2f80e0af51216
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cbf97c2d69ef0ca68f4d9df81db5364599a4ae02..f30ab74020f3b766242bcb81c480009e72fbdb2c 100644
+index 016299cc9e7327f5b29fd51df571fa23b45df6aa..cfad79b859abfeb9bd83843b04bff3fd5d2e0ac3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -931,6 +931,7 @@ public final class CraftServer implements Server {
+@@ -940,6 +940,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0639-Add-Block-isValidTool.patch
+++ b/patches/server/0639-Add-Block-isValidTool.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 2379b61fff76fa39a37348a740ca5ad18fadff4f..4270431061b5a52d709b7db4ebc8c322bdd7cfdb 100644
+index aa1ef5bb1e27e8c45710299febb2d6c6b122ff15..0c27c7edad34cf9baf42d3782c5ccdb1c4bed3b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -819,5 +819,9 @@ public class CraftBlock implements Block {
+@@ -814,5 +814,9 @@ public class CraftBlock implements Block {
          }
          return speed;
      }

--- a/patches/server/0641-Implement-Keyed-on-World.patch
+++ b/patches/server/0641-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f30ab74020f3b766242bcb81c480009e72fbdb2c..aaf176deb2f28b02f474efdbce40f9db9f70dad9 100644
+index cfad79b859abfeb9bd83843b04bff3fd5d2e0ac3..210032209b3cdd2cda0e7463e3ee0e0228aa2c93 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1150,7 +1150,7 @@ public final class CraftServer implements Server {
+@@ -1159,7 +1159,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index f30ab74020f3b766242bcb81c480009e72fbdb2c..aaf176deb2f28b02f474efdbce40f9db
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1241,6 +1241,15 @@ public final class CraftServer implements Server {
+@@ -1250,6 +1250,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0681-Add-basic-Datapack-API.patch
+++ b/patches/server/0681-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index aaf176deb2f28b02f474efdbce40f9db9f70dad9..f9d148fce42b146e5e1921221020341edbe7c1ec 100644
+index 210032209b3cdd2cda0e7463e3ee0e0228aa2c93..45ae98058d4207ccf9cc85fe27021356438a08fa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -266,6 +266,7 @@ public final class CraftServer implements Server {
+@@ -275,6 +275,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index aaf176deb2f28b02f474efdbce40f9db9f70dad9..f9d148fce42b146e5e1921221020341e
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -348,6 +349,7 @@ public final class CraftServer implements Server {
+@@ -357,6 +358,7 @@ public final class CraftServer implements Server {
          TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
@@ -111,7 +111,7 @@ index aaf176deb2f28b02f474efdbce40f9db9f70dad9..f9d148fce42b146e5e1921221020341e
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2501,5 +2503,11 @@ public final class CraftServer implements Server {
+@@ -2578,5 +2580,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0687-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0687-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f9d148fce42b146e5e1921221020341edbe7c1ec..69489893e648e72e95d8522a5990f27535fc3c0d 100644
+index 45ae98058d4207ccf9cc85fe27021356438a08fa..85d078f7c0e5338315ba8290dd4981e59dbc7956 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -385,8 +385,13 @@ public final class CraftServer implements Server {
+@@ -394,8 +394,13 @@ public final class CraftServer implements Server {
  
          File pluginFolder = (File) console.options.valueOf("plugins");
  
@@ -26,7 +26,7 @@ index f9d148fce42b146e5e1921221020341edbe7c1ec..69489893e648e72e95d8522a5990f275
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -401,6 +406,18 @@ public final class CraftServer implements Server {
+@@ -410,6 +415,18 @@ public final class CraftServer implements Server {
          }
      }
  

--- a/patches/server/0688-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0688-Fix-and-optimise-world-force-upgrading.patch
@@ -352,10 +352,10 @@ index 43510774d489bfdd30f10d521e424fa1363b8919..6496108953effae82391b5c1ea6fdec8
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 69489893e648e72e95d8522a5990f27535fc3c0d..dd435909ad16a7f732fd0a2056f986dd9b24c0d5 100644
+index 85d078f7c0e5338315ba8290dd4981e59dbc7956..9954e45c32a4b6d80fe912ed9d55cd4fc8c4e98b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1138,14 +1138,7 @@ public final class CraftServer implements Server {
+@@ -1147,14 +1147,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().isPresent());
@@ -371,7 +371,7 @@ index 69489893e648e72e95d8522a5990f27535fc3c0d..dd435909ad16a7f732fd0a2056f986dd
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1162,6 +1155,14 @@ public final class CraftServer implements Server {
+@@ -1171,6 +1164,14 @@ public final class CraftServer implements Server {
              chunkgenerator = worlddimension.generator();
          }
  

--- a/patches/server/0708-Line-Of-Sight-Changes.patch
+++ b/patches/server/0708-Line-Of-Sight-Changes.patch
@@ -42,7 +42,7 @@ index fea56803b648bdda9ba8ead14816b1b4fa6cd73a..39f8ff65ae06a072ad37e80769244895
  
      private static final Random rand = new Random();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 526beeac806d65c53c117be7702ce6cc3c6ec1c1..eed0abb13b4f27a55db577f1005193c81744d247 100644
+index e91b055e46a2884d91a896366916de140d5ec20c..f9110f682ddc356299ff94e1e536f8e5024378d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -29,6 +29,9 @@ import net.minecraft.world.entity.projectile.ThrownEgg;
@@ -73,4 +73,4 @@ index 526beeac806d65c53c117be7702ce6cc3c6ec1c1..eed0abb13b4f27a55db577f1005193c8
 +
      @Override
      public boolean getRemoveWhenFarAway() {
-         return this.getHandle() instanceof Mob && !((Mob) this.getHandle()).persistenceRequired;
+         return this.getHandle() instanceof Mob && !((Mob) this.getHandle()).isPersistenceRequired();

--- a/patches/server/0719-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
+++ b/patches/server/0719-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix return value of Block#applyBoneMeal always being false
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4270431061b5a52d709b7db4ebc8c322bdd7cfdb..e119df73fea9dff0ae5830e438f8fcbda0dddf2e 100644
+index 0c27c7edad34cf9baf42d3782c5ccdb1c4bed3b1..6e09db89fa7da4dd56f465af3b89b87bc9d593b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -682,7 +682,7 @@ public class CraftBlock implements Block {
+@@ -677,7 +677,7 @@ public class CraftBlock implements Block {
          Direction direction = CraftBlock.blockFaceToNotch(face);
          UseOnContext context = new UseOnContext(this.getCraftWorld().getHandle(), null, InteractionHand.MAIN_HAND, Items.BONE_MEAL.getDefaultInstance(), new BlockHitResult(Vec3.ZERO, direction, this.getPosition(), false));
  

--- a/patches/server/0730-Add-a-bunch-of-missing-forceDrop-toggles.patch
+++ b/patches/server/0730-Add-a-bunch-of-missing-forceDrop-toggles.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add a bunch of missing forceDrop toggles
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index b366c47cc53f195d8ad6ce281fc8145ca588947a..ed5ea221cb273c77848b773924193e06dc30f66f 100644
+index c375081e02925da6085a2d433bfc2c3719770f78..a8e5be1c941755b3e5b335d8211ca70a6c6fc32f 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -1470,7 +1470,9 @@ public abstract class Mob extends LivingEntity {
+@@ -1474,7 +1474,9 @@ public abstract class Mob extends LivingEntity {
              }
  
              if (this.tickCount > 100) {
@@ -42,20 +42,6 @@ index 851ee58e52c6003d6ae7b58c9b6b9a9a9795fa85..12ed864bedf2201fad68e2aeba249c3c
          if (!this.level.isClientSide() && this.random.nextInt(700) == 0 && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
 +            this.forceDrops = true; // Paper
              this.spawnAtLocation((ItemLike) Items.SLIME_BALL);
-+            this.forceDrops = false; // Paper
-         }
- 
-     }
-diff --git a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java b/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
-index 2631f08496c8e45874b22760b559a91b7b2bf415..7f3dc582276a00120d4d6a1e829da2e7908e87cf 100644
---- a/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
-+++ b/src/main/java/net/minecraft/world/entity/animal/SnowGolem.java
-@@ -174,7 +174,9 @@ public class SnowGolem extends AbstractGolem implements Shearable, RangedAttackM
-         this.level.playSound((Player) null, (Entity) this, SoundEvents.SNOW_GOLEM_SHEAR, shearedSoundCategory, 1.0F, 1.0F);
-         if (!this.level.isClientSide()) {
-             this.setPumpkin(false);
-+            this.forceDrops = true; // Paper
-             this.spawnAtLocation(new ItemStack(Items.CARVED_PUMPKIN), 1.7F);
 +            this.forceDrops = false; // Paper
          }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
e7b0f8d6 #⁠642: Add Crafting methods to API
9e58831e SPIGOT-6641: Use varargs in sendMessage
e409fe49 SPIGOT-6545: Unable to set Guardian target via API while awareness is disabled
6997c726 SPIGOT-6661: Fix missing radius from GenericGameEvent
02d03f35 SPIGOT-6369: Add ItemStack to HangingPlaceEvent

CraftBukkit Changes:
0abf420c SPIGOT-6665: Shearing a Snowman does not drop a carved pumpkin
e8e3cbcc #⁠893: Add Crafting methods to API
879acfee Fix missing varargs from previous commit
6572b9c3 SPIGOT-6641: Use varargs in sendMessage
9e06bb2a SPIGOT-6663: Chicken Jockeys chickens don't despawn
699f2d36 SPIGOT-6545: Unable to set Guardian target via API while awareness is disabled
8ffa54ba SPIGOT-6369: Add ItemStack to HangingPlaceEvent
c851639c SPIGOT-6645: Call EntityChangeBlockEvent before PlayerHarvestBlockEvent
8d244b0b SPIGOT-3725, SPIGOT-6638, MC-136917: Properly clear tile entities before replacing

Spigot Changes:
18c71bf4 Rebuild patches