### PR TITLE
[ci skip] adjust upstreamCommit script to not mention paper issues

### DIFF
--- a/scripts/upstreamCommit.sh
+++ b/scripts/upstreamCommit.sh
@@ -5,7 +5,7 @@ PS1="$"
 
 function changelog() {
     base=$(git ls-tree HEAD $1  | cut -d' ' -f3 | cut -f1)
-    cd $1 && git log --oneline ${base}...HEAD
+    cd $1 && git log --oneline ${base}...HEAD | sed 's/\(^[0-9a-f]\{8\}\s\|Revert\s"\)#\([0-9]\+\)/\1PR-\2/'
 }
 bukkit=$(changelog work/Bukkit)
 cb=$(changelog work/CraftBukkit)


### PR DESCRIPTION
Prevents those nasty mentions of old issues from commit msgs from upstream repos