### PR TITLE
Allow skipping writing of comments to server.properties

### DIFF
--- a/patches/server/0738-Allow-skipping-writing-of-comments-to-server.propert.patch
+++ b/patches/server/0738-Allow-skipping-writing-of-comments-to-server.propert.patch
@@ -1,0 +1,95 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Professor Bloodstone <git@bloodstone.dev>
+Date: Fri, 23 Jul 2021 02:32:04 +0200
+Subject: [PATCH] Allow skipping writing of comments to server.properties
+
+Makes less git noise, as it won't update the date every single time
+
+Use -DPaper.skipServerPropertiesComments=true flag to disable writing it
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/Settings.java b/src/main/java/net/minecraft/server/dedicated/Settings.java
+index 745a6735fba8343329ec31723da914fad16ae134..2713d9acc51c6c5cc51bdbbe63477343ecb29154 100644
+--- a/src/main/java/net/minecraft/server/dedicated/Settings.java
++++ b/src/main/java/net/minecraft/server/dedicated/Settings.java
+@@ -1,9 +1,11 @@
+ package net.minecraft.server.dedicated;
+ 
+ import com.google.common.base.MoreObjects;
++import java.io.BufferedWriter; // Paper
+ import java.io.IOException;
+ import java.io.InputStream;
+ import java.io.OutputStream;
++import java.io.OutputStreamWriter; // Paper
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+ import java.util.Objects;
+@@ -18,11 +20,13 @@ import org.apache.logging.log4j.Logger;
+ 
+ import joptsimple.OptionSet; // CraftBukkit
+ import net.minecraft.core.RegistryAccess;
++import org.jetbrains.annotations.NotNull; // Paper
+ 
+ public abstract class Settings<T extends Settings<T>> {
+ 
+     private static final Logger LOGGER = LogManager.getLogger();
+     public final Properties properties;
++    private static final boolean skipComments = Boolean.getBoolean("Paper.skipServerPropertiesComments"); // Paper - allow skipping server.properties comments
+     // CraftBukkit start
+     private OptionSet options = null;
+ 
+@@ -79,9 +83,54 @@ public abstract class Settings<T extends Settings<T>> {
+             }
+             // CraftBukkit end
+             OutputStream outputstream = Files.newOutputStream(path);
++            // Paper start - disable writing comments to properties file
++            OutputStreamWriter outputStreamWriter = new OutputStreamWriter(outputstream);
++            BufferedWriter bufferedwriter = !skipComments ? new BufferedWriter(outputStreamWriter) : new BufferedWriter(outputStreamWriter) {
++                private boolean isRightAfterNewline = true; // If last written char was newline
++                private boolean isComment = false; // Are we writing comment currently?
++
++                @Override
++                public void write(@NotNull String str) throws IOException {
++                    char[] ch = str.toCharArray();
++                    this.write(ch);
++                }
++
++                @Override
++                public void write(@NotNull char[] cbuf) throws IOException {
++                    this.write(cbuf, 0, cbuf.length);
++                }
++
++                @Override
++                public void write(@NotNull char[] cbuf, int off, int len) throws IOException {
++                    int latest_offset = off; // The latest offset, updated when comment ends
++                    for (int index = off; index < off + len; ++index ) {
++                        char c = cbuf[index];
++                        boolean isNewline = (c == '\n' || c == '\r');
++                        if (isNewline && isComment) {
++                            // Comment has ended
++                            isComment = false;
++                            latest_offset = index+1;
++                        }
++                        if (c == '#' && isRightAfterNewline) {
++                            isComment = true;
++                            if (index != latest_offset) {
++                                // We got some non-comment data earlier
++                                super.write(cbuf, latest_offset, index-latest_offset);
++                            }
++                        }
++                        isRightAfterNewline = isNewline; // Store for next iteration
++
++                    }
++                    if (latest_offset < off+len && !isComment) {
++                        // We have some unwritten data, that isn't part of a comment
++                        super.write(cbuf, latest_offset, (off + len) - latest_offset);
++                    }
++                }
++            };
++            // Paper end
+ 
+             try {
+-                this.properties.store(outputstream, "Minecraft server properties");
++                this.properties.store(bufferedwriter, "Minecraft server properties"); // Paper - use bufferedwriter
+             } catch (Throwable throwable) {
+                 if (outputstream != null) {
+                     try {


### PR DESCRIPTION
Makes less git noise, as it won't update the date every damn single time.

Use `-DPaper.skipServerPropertiesComments=true` flag to disable writing comments

The issue was date being constantly updated. I saw 3 possible solutions:
1. Create `BufferedWriter` where I override the `write` method(s) and make it drop second line starting with `#`
2. Make `DedicatedServerProperties` override `store0` method of `java.util.Properties`, copy-pasting the code, just adding if on the line adding date
3. Just make the flag disable writing the file completely

While the third solution is the simplest, its not ideal given that one would need to remember to disable it periodically to update the entries added/changed/deleted. That's why I decided to opt for the first option (dropping all comments instead of only second line), which takes most work, but also should be maintenance-free.

I tried to optimize it and document as I could, open to questions and suggestions how to improve it :)