### PR TITLE
Add fireball to default max load config

### DIFF
--- a/patches/server/0649-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0649-Entity-load-save-limit-per-chunk.patch
@@ -9,7 +9,7 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index acd61a9033fdfb91e29a5fa6a10b8983ed94baa5..c94579d5db6802ef27c6c64cde1cdfdff5040ed2 100644
+index acd61a9033fdfb91e29a5fa6a10b8983ed94baa5..3e9f288ee310c7c79664e69b99698fdd179ae77f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,9 +1,12 @@
@@ -25,7 +25,7 @@ index acd61a9033fdfb91e29a5fa6a10b8983ed94baa5..c94579d5db6802ef27c6c64cde1cdfdf
  import net.minecraft.world.entity.monster.Vindicator;
  import net.minecraft.world.entity.monster.Zombie;
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
-@@ -123,6 +126,20 @@ public class PaperWorldConfig {
+@@ -123,6 +126,22 @@ public class PaperWorldConfig {
          );
      }
  
@@ -35,6 +35,8 @@ index acd61a9033fdfb91e29a5fa6a10b8983ed94baa5..c94579d5db6802ef27c6c64cde1cdfdf
 +        getInt("entity-per-chunk-save-limit.snowball", -1);
 +        getInt("entity-per-chunk-save-limit.ender_pearl", -1);
 +        getInt("entity-per-chunk-save-limit.arrow", -1);
++        getInt("entity-per-chunk-save-limit.fireball", -1);
++        getInt("entity-per-chunk-save-limit.small_fireball", -1);
 +        EntityType.getEntityNameList().forEach(name -> {
 +            final EntityType<?> type = EntityType.byString(name.getPath()).orElseThrow(() -> new IllegalStateException("Unknown Entity Type: " + name.toString()));
 +            final String path = ".entity-per-chunk-save-limit." + name.getPath();
@@ -72,7 +74,7 @@ index b50bf044a3cb05b811fd06796a351e6b15b352ad..ac99265aacd4a28490705e3079ed0402
                          return entity;
                      });
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-index b35c1c2cb2bbe489ccd3fe64049c3af11bfd26f4..69ac9ed94b1890f9bd5ba21cdfe31e42529274e1 100644
+index 9b0b3affdbdf831f0d3d61c59bdb99555bc0bed7..396c34c0866bf395b4d86361d96fe103c5d9ae7e 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 @@ -90,7 +90,18 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {

--- a/patches/server/0696-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0696-Limit-item-frame-cursors-on-maps.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c94579d5db6802ef27c6c64cde1cdfdff5040ed2..05c1aa7c49134e099e3d14a244252173e6755401 100644
+index 3e9f288ee310c7c79664e69b99698fdd179ae77f..c0e733d839f4c86bdcd6e1ca0b40b082fc6eb86e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -792,5 +792,10 @@ public class PaperWorldConfig {
+@@ -794,5 +794,10 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }

--- a/patches/server/0701-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0701-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 05c1aa7c49134e099e3d14a244252173e6755401..258d54e450ff5aec06eaeb1d57c049d9b0b3ea48 100644
+index c0e733d839f4c86bdcd6e1ca0b40b082fc6eb86e..579bd433e1f680c2273cd048b304c1276016e6cc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -797,5 +797,10 @@ public class PaperWorldConfig {
+@@ -799,5 +799,10 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0703-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0703-Fix-invulnerable-end-crystals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 258d54e450ff5aec06eaeb1d57c049d9b0b3ea48..417cf3d8988f28fa1e0b05f11b89ef2c02d59ed9 100644
+index 579bd433e1f680c2273cd048b304c1276016e6cc..97a1ca789eb606b263ebabad188baefe4df69b85 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -802,5 +802,10 @@ public class PaperWorldConfig {
+@@ -804,5 +804,10 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0709-add-per-world-spawn-limits.patch
+++ b/patches/server/0709-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 417cf3d8988f28fa1e0b05f11b89ef2c02d59ed9..26e18a08a7f0bd704ff3055ce3a7814191450c85 100644
+index 97a1ca789eb606b263ebabad188baefe4df69b85..435558eb9f3ce277c14ff5e368d489d1df4da8e1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -658,6 +658,19 @@ public class PaperWorldConfig {
+@@ -660,6 +660,19 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  

--- a/patches/server/0722-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0722-Fix-commands-from-signs-not-firing-command-events.patch
@@ -10,10 +10,10 @@ This patch changes sign command logic so that `run_command` click events:
   - sends failure messages to the player who clicked the sign
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 26e18a08a7f0bd704ff3055ce3a7814191450c85..33d7a5da8764c5f6b8e911faecb6b4282443a60b 100644
+index 435558eb9f3ce277c14ff5e368d489d1df4da8e1..b8a2406d847051442485691c91dcd82d40258424 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -820,5 +820,10 @@ public class PaperWorldConfig {
+@@ -822,5 +822,10 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }

--- a/patches/server/0725-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0725-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 33d7a5da8764c5f6b8e911faecb6b4282443a60b..857ef2377d2e6fd84d70e301860692e670983f0c 100644
+index b8a2406d847051442485691c91dcd82d40258424..6ff53e138ea17c3e8283a52251c81d5cdf91ebac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -648,6 +648,21 @@ public class PaperWorldConfig {
+@@ -650,6 +650,21 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  

--- a/patches/server/0728-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0728-Don-t-apply-cramming-damage-to-players.patch
@@ -11,10 +11,10 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 857ef2377d2e6fd84d70e301860692e670983f0c..171321d4f1b73a25266175dfb5529dfc5cb8a5ca 100644
+index 6ff53e138ea17c3e8283a52251c81d5cdf91ebac..0e7d29dbbdb862dd5876adee26fbba02267e5276 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -840,5 +840,10 @@ public class PaperWorldConfig {
+@@ -842,5 +842,10 @@ public class PaperWorldConfig {
      private void showSignClickCommandFailureMessagesToPlayer() {
          showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }

--- a/patches/server/0729-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0729-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b9cdbf8acccfd6b207a0116f068168f3b8c8e17d..e873b23527cc4e56580c3c7dc5b52ecc
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..f65e3b51e876f7a3d30710eed56fdca4daa620c9 100644
+index 0e7d29dbbdb862dd5876adee26fbba02267e5276..c334f29c69c1e6e3fe55cd6695e7df400cf36058 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,14 +3,19 @@ package com.destroystokyo.paper;
@@ -51,7 +51,7 @@ index 171321d4f1b73a25266175dfb5529dfc5cb8a5ca..f65e3b51e876f7a3d30710eed56fdca4
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -845,5 +850,58 @@ public class PaperWorldConfig {
+@@ -847,5 +852,58 @@ public class PaperWorldConfig {
      private void playerCrammingDamage() {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }


### PR DESCRIPTION
This is commonly used to access chunks that crash upon load due to fireballs, and having this in here by default would lead to a lot less confusion when people could just change the number.