### PR TITLE
Add back link detection on non-chat event messages

### DIFF
--- a/patches/server/0731-Add-back-link-detection-on-non-chat-event-messages.patch
+++ b/patches/server/0731-Add-back-link-detection-on-non-chat-event-messages.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 22 Jul 2021 21:43:20 -0700
+Subject: [PATCH] Add back link detection on non-chat event messages
+
+
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..8dbfcfdad1037b2a0a17eda7dcb159dd43b8840a 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -1402,7 +1402,7 @@ public abstract class PlayerList {
+         while (iterator.hasNext()) {
+             ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+ 
+-            entityplayer.sendMessage(message, type, sender);
++            entityplayer.sendMessage(CraftChatMessage.fixComponent(message), type, sender); // Paper - add back URL detection
+         }
+ 
+     }


### PR DESCRIPTION
Fixes #6141

upstream removed this for some reason. I think this is the right place to put it back based on its use in 1.16.5