### PR TITLE
Add config option to specify timings url

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -1684,7 +1684,7 @@ index 0000000000000000000000000000000000000000..f7c2245a310a084367ff25db539b3c96
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsManager.java b/src/main/java/co/aikar/timings/TimingsManager.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ef824d701c97cad8b31e76ad98c94fc4367a7eda
+index 0000000000000000000000000000000000000000..a92925d41110226f7fda055b71ce7be60eedd038
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsManager.java
 @@ -0,0 +1,188 @@
@@ -1722,7 +1722,6 @@ index 0000000000000000000000000000000000000000..ef824d701c97cad8b31e76ad98c94fc4
 +import org.bukkit.plugin.java.PluginClassLoader;
 +
 +import java.util.ArrayList;
-+import java.util.Collections;
 +import java.util.List;
 +import java.util.Map;
 +import java.util.concurrent.ConcurrentHashMap;
@@ -1737,6 +1736,7 @@ index 0000000000000000000000000000000000000000..ef824d701c97cad8b31e76ad98c94fc4
 +    public static final FullServerTickHandler FULL_SERVER_TICK = new FullServerTickHandler();
 +    public static final TimingHandler TIMINGS_TICK = Timings.ofSafe("Timings Tick", FULL_SERVER_TICK);
 +    public static final Timing PLUGIN_GROUP_HANDLER = Timings.ofSafe("Plugins");
++    public static String url = "https://timings.aikar.co/";
 +    public static List<String> hiddenConfigs = new ArrayList<String>();
 +    public static boolean privacy = false;
 +

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -163,7 +163,7 @@ index 0000000000000000000000000000000000000000..b47b7dce26805badd422c1867733ff4b
 +}
 diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f27fadc15cb7f5c782e45885ec6a5a69963beade
+index 0000000000000000000000000000000000000000..ee53453440177537fc653ea156785d7591498614
 --- /dev/null
 +++ b/src/main/java/co/aikar/timings/TimingsExport.java
 @@ -0,0 +1,376 @@
@@ -473,7 +473,7 @@ index 0000000000000000000000000000000000000000..f27fadc15cb7f5c782e45885ec6a5a69
 +        String response = null;
 +        String timingsURL = null;
 +        try {
-+            HttpURLConnection con = (HttpURLConnection) new URL("http://timings.aikar.co/post").openConnection();
++            HttpURLConnection con = (HttpURLConnection) new URL(TimingsManager.url + "post").openConnection();
 +            con.setDoOutput(true);
 +            String hostName = "BrokenHost";
 +            try {
@@ -669,7 +669,7 @@ index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index da922f395f0fff0881ead893c900c5b2623f48f0..1d03a79e9010bc514b72a81ba0ad4a62aeff1bb7 100644
+index da922f395f0fff0881ead893c900c5b2623f48f0..f973828da3ab56dba768fb029a271b2e55cfc24e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -14,12 +14,15 @@ import java.util.concurrent.TimeUnit;
@@ -688,7 +688,7 @@ index da922f395f0fff0881ead893c900c5b2623f48f0..1d03a79e9010bc514b72a81ba0ad4a62
  
  public class PaperConfig {
  
-@@ -188,4 +191,30 @@ public class PaperConfig {
+@@ -188,4 +191,35 @@ public class PaperConfig {
          config.addDefault(path, def);
          return config.getString(path, config.getString(path));
      }
@@ -697,6 +697,10 @@ index da922f395f0fff0881ead893c900c5b2623f48f0..1d03a79e9010bc514b72a81ba0ad4a62
 +    private static void timings() {
 +        boolean timings = getBoolean("timings.enabled", true);
 +        boolean verboseTimings = getBoolean("timings.verbose", true);
++        TimingsManager.url = getString("timings.url", "https://timings.aikar.co/");
++        if (!TimingsManager.url.endsWith("/")) {
++            TimingsManager.url += "/";
++        }
 +        TimingsManager.privacy = getBoolean("timings.server-name-privacy", false);
 +        TimingsManager.hiddenConfigs = getList("timings.hidden-config-entries", Lists.newArrayList("database", "settings.bungeecord-addresses", "settings.velocity-support.secret"));
 +        if (!TimingsManager.hiddenConfigs.contains("settings.velocity-support.secret")) {
@@ -713,6 +717,7 @@ index da922f395f0fff0881ead893c900c5b2623f48f0..1d03a79e9010bc514b72a81ba0ad4a62
 +        Timings.setHistoryLength(timingHistoryLength * 20);
 +
 +        log("Timings: " + timings +
++                " - Url: " + TimingsManager.url +
 +                " - Verbose: " + verboseTimings +
 +                " - Interval: " + timeSummary(Timings.getHistoryInterval() / 20) +
 +                " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -7,10 +7,10 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1d03a79e9010bc514b72a81ba0ad4a62aeff1bb7..429b74474ced04d8dd8f038b8590b8dfe178bf4d 100644
+index f973828da3ab56dba768fb029a271b2e55cfc24e..4030ac49ad2e4e42a7fbd2e1979876488735a9d8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -217,4 +217,9 @@ public class PaperConfig {
+@@ -222,4 +222,9 @@ public class PaperConfig {
                  " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
                  " - Server Name: " + timingsServerName);
      }

--- a/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0059-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 429b74474ced04d8dd8f038b8590b8dfe178bf4d..716f285e67019b8a62922d09c15883c99f9421aa 100644
+index 4030ac49ad2e4e42a7fbd2e1979876488735a9d8..de5d6b692e3e05fcf704c01dc602197992991386 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -222,4 +222,9 @@ public class PaperConfig {
+@@ -227,4 +227,9 @@ public class PaperConfig {
      private static void useDisplayNameInQuit() {
          useDisplayNameInQuit = getBoolean("use-display-name-in-quit-message", useDisplayNameInQuit);
      }

--- a/patches/server/0074-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/patches/server/0074-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 716f285e67019b8a62922d09c15883c99f9421aa..439dcc6effdc91830d2b7ede9063982998b37120 100644
+index de5d6b692e3e05fcf704c01dc602197992991386..1096b7462480c6c130545c03df8d8bed9c09ab79 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -227,4 +227,9 @@ public class PaperConfig {
+@@ -232,4 +232,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }

--- a/patches/server/0083-Configurable-Player-Collision.patch
+++ b/patches/server/0083-Configurable-Player-Collision.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Player Collision
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 439dcc6effdc91830d2b7ede9063982998b37120..504efea7b6f50a0d17f4f353781953dfb18bdeca 100644
+index 1096b7462480c6c130545c03df8d8bed9c09ab79..47f77ad8ef4e9a26c6a4bbc8a73b9943f7604a6a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -232,4 +232,9 @@ public class PaperConfig {
+@@ -237,4 +237,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = Math.max(getInt("settings.region-file-cache-size", 256), 4);
      }

--- a/patches/server/0092-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/patches/server/0092-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 504efea7b6f50a0d17f4f353781953dfb18bdeca..1b8e5671c9dc8c15ce33d351c1bb20f28919b9a2 100644
+index 47f77ad8ef4e9a26c6a4bbc8a73b9943f7604a6a..8cece23c90e1fc78415f2f743fc9a91b15670d75 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -237,4 +237,9 @@ public class PaperConfig {
+@@ -242,4 +242,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }

--- a/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0102-Add-setting-for-proxy-online-mode-status.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add setting for proxy online mode status
 TODO: Add isProxyOnlineMode check to Metrics
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1b8e5671c9dc8c15ce33d351c1bb20f28919b9a2..c52dc0346f93527965ef29a0ccdc4bf3debe302e 100644
+index 8cece23c90e1fc78415f2f743fc9a91b15670d75..d7a14bf8d2f8d91e3ed1eca3dce2f6b4c1a20403 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
@@ -17,7 +17,7 @@ index 1b8e5671c9dc8c15ce33d351c1bb20f28919b9a2..c52dc0346f93527965ef29a0ccdc4bf3
  
  public class PaperConfig {
  
-@@ -242,4 +243,13 @@ public class PaperConfig {
+@@ -247,4 +248,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }

--- a/patches/server/0104-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0104-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c52dc0346f93527965ef29a0ccdc4bf3debe302e..64d7c9058ee757a6d3cf3b648596092a810e105c 100644
+index d7a14bf8d2f8d91e3ed1eca3dce2f6b4c1a20403..f1b1648a5ff2724c13a82468c3bad0040d8495cd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -252,4 +252,13 @@ public class PaperConfig {
+@@ -257,4 +257,13 @@ public class PaperConfig {
      public static boolean isProxyOnlineMode() {
          return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }

--- a/patches/server/0105-Configurable-flying-kick-messages.patch
+++ b/patches/server/0105-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 64d7c9058ee757a6d3cf3b648596092a810e105c..4e2f243faa209925dcb7c3ef89df3ed875c5ff78 100644
+index f1b1648a5ff2724c13a82468c3bad0040d8495cd..c053850594e05a92a8d4a6cf2052f698bfdc3a03 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -261,4 +261,11 @@ public class PaperConfig {
+@@ -266,4 +266,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4e2f243faa209925dcb7c3ef89df3ed875c5ff78..48319aaf1c525c6fb7bdee5c2f570a0d056d4eae 100644
+index c053850594e05a92a8d4a6cf2052f698bfdc3a03..395468cdf1e2ce834f7de351efaa6a2b0915a5ea 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -268,4 +268,9 @@ public class PaperConfig {
+@@ -273,4 +273,9 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }

--- a/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace351305790 100644
+index 395468cdf1e2ce834f7de351efaa6a2b0915a5ea..ceeb011f2ae496f39a391316cb3773fdef52ee11 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index 48319aaf1c525c6fb7bdee5c2f570a0d056d4eae..52954fc3bf932cfc9d5ce63e3d3cace3
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -273,4 +274,9 @@ public class PaperConfig {
+@@ -278,4 +279,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }

--- a/patches/server/0188-Make-player-data-saving-configurable.patch
+++ b/patches/server/0188-Make-player-data-saving-configurable.patch
@@ -8,10 +8,10 @@ however, we should still migrate our configuration back upstream,
 to prevent unexpected situations
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 52954fc3bf932cfc9d5ce63e3d3cace351305790..05a5abb951abe37f30a719cb75376d2d43c0d252 100644
+index ceeb011f2ae496f39a391316cb3773fdef52ee11..49eff2eeb06ca104c379cfa0fdb393fe9c9ff956 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -279,4 +279,13 @@ public class PaperConfig {
+@@ -284,4 +284,13 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }

--- a/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 05a5abb951abe37f30a719cb75376d2d43c0d252..77a03abd59db4a43f6f2d59d4c7ef176e782f205 100644
+index 49eff2eeb06ca104c379cfa0fdb393fe9c9ff956..3c783d49166f6fd1cfd327b83da122763ba7d9d4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -288,4 +288,12 @@ public class PaperConfig {
+@@ -293,4 +293,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }

--- a/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 77a03abd59db4a43f6f2d59d4c7ef176e782f205..bd508025b771424c942fd856c31d520b6f548082 100644
+index 3c783d49166f6fd1cfd327b83da122763ba7d9d4..706e4bb5c352be78ebbcd2879b23f220900db02c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -296,4 +296,18 @@ public class PaperConfig {
+@@ -301,4 +301,18 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2786328e5 100644
+index 706e4bb5c352be78ebbcd2879b23f220900db02c..f529b625d34395ed84570a241ab74f10985bddc9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -20,7 +20,7 @@ index bd508025b771424c942fd856c31d520b6f548082..62621562137cba4804f0465c58d25ca2
  
  public class PaperConfig {
  
-@@ -297,6 +298,14 @@ public class PaperConfig {
+@@ -302,6 +303,14 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -159,7 +159,7 @@ index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c
  
      public static Timing getTickList(ServerLevel worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 62621562137cba4804f0465c58d25ca2786328e5..ee8ead249d89bc81f87bfff6a1f594a9aeb21250 100644
+index f529b625d34395ed84570a241ab74f10985bddc9..e19988ea5822026f5a81465f6a72744b8b552cc0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -169,7 +169,7 @@ index 62621562137cba4804f0465c58d25ca2786328e5..ee8ead249d89bc81f87bfff6a1f594a9
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -319,4 +320,54 @@ public class PaperConfig {
+@@ -324,4 +325,54 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
@@ -3658,7 +3658,7 @@ index ce723a4340202c16eaf7544f77c1075c4f277cb9..03a7e5d61d8888e1e836bd5a69ee9443
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 84316ea7f1ad285009f02cdf6e501c577958a170..5178cd001064c089cb2e6a78696b4702c78bc37a 100644
+index 50e2cbade05dd299ef60bea4f835f9bf6df88f44..7e0986e085895ad046685771acb9e4374c5cfe89 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;

--- a/patches/server/0273-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0273-Configurable-connection-throttle-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ee8ead249d89bc81f87bfff6a1f594a9aeb21250..585be2fcbd63a59f911df69136eae07ce665053c 100644
+index e19988ea5822026f5a81465f6a72744b8b552cc0..50d099d4c9d61bf4679d0efce8617f662e2ba971 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -282,6 +282,11 @@ public class PaperConfig {
+@@ -287,6 +287,11 @@ public class PaperConfig {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
  

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c57773216 100644
+index 50d099d4c9d61bf4679d0efce8617f662e2ba971..0e0afdea5b9d6bdd706414cf615fa826d5efb8c7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -9,6 +9,7 @@ import java.io.IOException;
@@ -25,7 +25,7 @@ index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c
  import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
-@@ -253,7 +254,7 @@ public class PaperConfig {
+@@ -258,7 +259,7 @@ public class PaperConfig {
      }
  
      public static boolean isProxyOnlineMode() {
@@ -34,7 +34,7 @@ index 585be2fcbd63a59f911df69136eae07ce665053c..9768c591e72ce2ef5fdb43e2fc63378c
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -326,6 +327,20 @@ public class PaperConfig {
+@@ -331,6 +332,20 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Make the default permission message configurable
 TODO: Change the message in PaperCommand
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23ad753b18e 100644
+index 0e0afdea5b9d6bdd706414cf615fa826d5efb8c7..95c82bdd658ed55b2e86087441d1552eb3bd38ea 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -20,6 +20,7 @@ import java.util.regex.Pattern;
@@ -17,7 +17,7 @@ index 9768c591e72ce2ef5fdb43e2fc63378c57773216..11d628869a9a6eda8bf21a4f213ff23a
  import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
-@@ -288,6 +289,11 @@ public class PaperConfig {
+@@ -293,6 +294,11 @@ public class PaperConfig {
          connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
      }
  

--- a/patches/server/0299-Book-Size-Limits.patch
+++ b/patches/server/0299-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 11d628869a9a6eda8bf21a4f213ff23ad753b18e..4c97fa63d912548324e93f366c86666d52738bfb 100644
+index 95c82bdd658ed55b2e86087441d1552eb3bd38ea..f52f1497da37d523d2d7282127aa3b3beb76cc3b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -347,6 +347,13 @@ public class PaperConfig {
+@@ -352,6 +352,13 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,10 +42,10 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4c97fa63d912548324e93f366c86666d52738bfb..bfdf4b302860d56dec485af77c69d18db22dc6f4 100644
+index f52f1497da37d523d2d7282127aa3b3beb76cc3b..b6bb9f50f44927d5212ec3a8804f7fd793d61c48 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -354,6 +354,13 @@ public class PaperConfig {
+@@ -359,6 +359,13 @@ public class PaperConfig {
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
  

--- a/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
+++ b/patches/server/0397-Mid-Tick-Chunk-Tasks-Speed-up-processing-of-chunk-lo.patch
@@ -42,10 +42,10 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b9cdbf8acccfd6b207a0116f068168f3
      public static final Timing commandFunctionsTimer = Timings.ofSafe("Command Functions");
      public static final Timing connectionTimer = Timings.ofSafe("Connection Handler");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index bfdf4b302860d56dec485af77c69d18db22dc6f4..5c67c51dd0a19357086d4ceb3ca724401e4d26b8 100644
+index b6bb9f50f44927d5212ec3a8804f7fd793d61c48..e9d0dd2a8b4d55c3009132343388706e89cb90db 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -410,4 +410,9 @@ public class PaperConfig {
+@@ -415,4 +415,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }
@@ -147,7 +147,7 @@ index ce438760cbc92c08c079d06a8b97eaeda1018491..0115ffe84356468ddc254d8d5bdd719b
                  // Spigot Start
                  CrashReport crashreport;
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index ac077d88e0102b50edce094a6ac4c63546915e88..7cc8a898b5a6349da91b34b8be6ec00707183589 100644
+index c86457b8d2e99072840f8d4f693502bc23c98b35..41c148b05771438855d157ddd0c3ab21f0267c96 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -709,6 +709,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0442-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0442-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 89a475429ede42f3a8aae16760e56bfba57bb1b5..cbb7000aec6703c195e807014de8ecc5b5ec0756 100644
+index f52c7e7800ff86abd513777fa2ce2e8b9bd9dfd5..846c4b456e4f644b5da7fc4e2cc8df7bba7fd707 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -416,4 +416,17 @@ public class PaperConfig {
+@@ -421,4 +421,17 @@ public class PaperConfig {
      private static void midTickChunkTasks() {
          midTickChunkTasks = getInt("settings.chunk-tasks-per-tick", midTickChunkTasks);
      }

--- a/patches/server/0446-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0446-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index cbb7000aec6703c195e807014de8ecc5b5ec0756..2840a6369e6532dbed93dd09ba4f7e39c3ccb258 100644
+index 846c4b456e4f644b5da7fc4e2cc8df7bba7fd707..4cb66752f3377cc419ef944cc86f4ac734c8d9e6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -429,4 +429,9 @@ public class PaperConfig {
+@@ -434,4 +434,9 @@ public class PaperConfig {
  
      }
  
@@ -19,7 +19,7 @@ index cbb7000aec6703c195e807014de8ecc5b5ec0756..2840a6369e6532dbed93dd09ba4f7e39
 +
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
-index a885eb537d6475eefe7d06f8312ecf0a278c5a00..4d95d4f4b354fc22c29c55bb70010282a4d3c5d9 100644
+index 1a8b02e9e4cf6fb27d6bcdf0350bdfc24e6bdee3..dfea570dfbe227d1b902b5cb0f6d870383392e3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 @@ -86,5 +86,15 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
@@ -39,7 +39,7 @@ index a885eb537d6475eefe7d06f8312ecf0a278c5a00..4d95d4f4b354fc22c29c55bb70010282
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
-index c2d163c078b569e3e97ee01d149c5c3e87f55513..d1ce98ca68690542c6864c189bc114f1f715b2b5 100644
+index 02a8c522a25f1c3c8eb0245560757772e627d31e..a3194c8a425d1d808c76ebef9997478f4d399fe0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
 @@ -39,4 +39,16 @@ public class CraftRemoteConsoleCommandSender extends ServerCommandSender impleme

--- a/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2840a6369e6532dbed93dd09ba4f7e39c3ccb258..99879e8a14eeef80c082bc7c0fbadc02d7368485 100644
+index 4cb66752f3377cc419ef944cc86f4ac734c8d9e6..88e8360bc2eb8cfe896fe69f969b286e59154984 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -434,4 +434,10 @@ public class PaperConfig {
+@@ -439,4 +439,10 @@ public class PaperConfig {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }
  

--- a/patches/server/0501-Incremental-player-saving.patch
+++ b/patches/server/0501-Incremental-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 99879e8a14eeef80c082bc7c0fbadc02d7368485..3a3874dc04e9b0ea3c3f0fda96dce8b3fed3199f 100644
+index 88e8360bc2eb8cfe896fe69f969b286e59154984..fa06d9a9c353815ade73fa019ac9f55b4597cc28 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -440,4 +440,15 @@ public class PaperConfig {
+@@ -445,4 +445,15 @@ public class PaperConfig {
          allowPistonDuplication = getBoolean("settings.unsupported-settings.allow-piston-duplication", config.getBoolean("settings.unsupported-settings.allow-tnt-duplication", false));
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }

--- a/patches/server/0512-Prevent-headless-pistons-from-being-created.patch
+++ b/patches/server/0512-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3a3874dc04e9b0ea3c3f0fda96dce8b3fed3199f..2678e4517570cbeafca7a9a4e54d4518cba75e69 100644
+index fa06d9a9c353815ade73fa019ac9f55b4597cc28..085ef48d8490e2d80406656a43dc751f4428a96f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -441,6 +441,12 @@ public class PaperConfig {
+@@ -446,6 +446,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/patches/server/0515-Buffer-joins-to-world.patch
+++ b/patches/server/0515-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 2678e4517570cbeafca7a9a4e54d4518cba75e69..8f702f1e80776259015a48cc4649b995198c7bfb 100644
+index 085ef48d8490e2d80406656a43dc751f4428a96f..989d83ec31160ebfcd27281fee03da6f34ad88da 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -457,4 +457,9 @@ public class PaperConfig {
+@@ -462,4 +462,9 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/patches/server/0530-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0530-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8f702f1e80776259015a48cc4649b995198c7bfb..3e486376a49a61d52cdcd32ea877996d81186a73 100644
+index 989d83ec31160ebfcd27281fee03da6f34ad88da..b9a31b8c2d9e3d3f47ed27738a59b409aec8caf7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -462,4 +462,9 @@ public class PaperConfig {
+@@ -467,4 +467,9 @@ public class PaperConfig {
      private static void maxJoinsPerTick() {
          maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
      }

--- a/patches/server/0568-Limit-recipe-packets.patch
+++ b/patches/server/0568-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3e486376a49a61d52cdcd32ea877996d81186a73..e62bb33852b0dca346aeb3cb2747d1a5686dea2d 100644
+index b9a31b8c2d9e3d3f47ed27738a59b409aec8caf7..cd8ef155d1aa4f103fb821ebf718d00efad51aba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -334,6 +334,13 @@ public class PaperConfig {
+@@ -339,6 +339,13 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/patches/server/0570-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0570-MC-4-Fix-item-position-desync.patch
@@ -9,10 +9,10 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e62bb33852b0dca346aeb3cb2747d1a5686dea2d..ea4fa458113d68dc2ed3187e19b11d72fc05d36c 100644
+index cd8ef155d1aa4f103fb821ebf718d00efad51aba..50c47c512dfc90536b28274d5715a46fd13f4e77 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -474,4 +474,9 @@ public class PaperConfig {
+@@ -479,4 +479,9 @@ public class PaperConfig {
      private static void trackPluginScoreboards() {
          trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
      }
@@ -41,7 +41,7 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index db2ca58064000ac73c054d51590ccbcb9151d596..f744bf2d19291991ffa9c7b13fc62a479702d201 100644
+index 184e88db63012cab509a52aee0245881791fa87d..bdc6a1adccc7fa29d83799609d45e03116c6d4b9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3759,6 +3759,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0653-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0653-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Enhance console tab completions for brigadier commands
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ea4fa458113d68dc2ed3187e19b11d72fc05d36c..458412d66f392fe5736f68126180b0a039dde785 100644
+index 50c47c512dfc90536b28274d5715a46fd13f4e77..71fa9e572873f5d76643d1b9f5555c3ede7016fa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -479,4 +479,11 @@ public class PaperConfig {
+@@ -484,4 +484,11 @@ public class PaperConfig {
      private static void fixEntityPositionDesync() {
          fixEntityPositionDesync = getBoolean("settings.fix-entity-position-desync", fixEntityPositionDesync);
      }

--- a/patches/server/0707-Make-item-validations-configurable.patch
+++ b/patches/server/0707-Make-item-validations-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 458412d66f392fe5736f68126180b0a039dde785..ffdacd1946c73e762b89b35c55a2e60eb7cd195b 100644
+index 71fa9e572873f5d76643d1b9f5555c3ede7016fa..9f94c4ff06962b7b947c58db93426742574431e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -486,4 +486,19 @@ public class PaperConfig {
+@@ -491,4 +491,19 @@ public class PaperConfig {
          enableBrigadierConsoleHighlighting = getBoolean("settings.console.enable-brigadier-highlighting", enableBrigadierConsoleHighlighting);
          enableBrigadierConsoleCompletions = getBoolean("settings.console.enable-brigadier-completions", enableBrigadierConsoleCompletions);
      }

--- a/patches/server/0714-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0714-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -92,10 +92,10 @@ index 9c1698df7e31c467ddb43c3989a0aeabebb88e94..864f67f57b92bc66208ff63225086348
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ffdacd1946c73e762b89b35c55a2e60eb7cd195b..98b71384508447adc80c2175f8e35e5d86b0c378 100644
+index 9f94c4ff06962b7b947c58db93426742574431e3..4f073bff5fa8350e719da648a0c15792dadeef6f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -487,6 +487,11 @@ public class PaperConfig {
+@@ -492,6 +492,11 @@ public class PaperConfig {
          enableBrigadierConsoleCompletions = getBoolean("settings.console.enable-brigadier-completions", enableBrigadierConsoleCompletions);
      }
  

--- a/patches/server/0721-Config-option-for-named-entity-death-logging.patch
+++ b/patches/server/0721-Config-option-for-named-entity-death-logging.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Config option for named entity death logging
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 98b71384508447adc80c2175f8e35e5d86b0c378..f101302892a7f95ffa0e6d63cb69d8a3ddbd67a7 100644
+index 4f073bff5fa8350e719da648a0c15792dadeef6f..f4642259a82dbc19934772eb6ddfae682c84375e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -492,6 +492,11 @@ public class PaperConfig {
+@@ -497,6 +497,11 @@ public class PaperConfig {
          deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
      }
  


### PR DESCRIPTION
This makes the URL of the timings viewer configurable in case that Aikar's goes down again or someone wants to use their own private instance to prevent exposing data, simply not put load onto the provided instance, or just for testing reasons when developing on the viewer itself.

Also it's 2021, use https for submitting it by default...