### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -141,6 +141,7 @@ public net.minecraft.world.entity.Entity isInBubbleColumn()Z
 
 # Allow delegation to vanilla chunk gen
 public org.bukkit.craftbukkit.generator.CustomChunkGenerator delegate
+private-f org.bukkit.craftbukkit.generator.CraftChunkData sections
 
 # Optimize redstone algorithm
 public net.minecraft.world.level.block.RedStoneWireBlock shouldSignal

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1427,13 +1427,13 @@ index 245d764d3dcc549fa8acbd7c9024a3c88d2d2a74..1c49512c4b9c1b187e555312fe937f2a
  
                  sectionBlockIDs[i] = blockids;
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-index 3d905c98704da64cefd009b2c796b24e729396a5..c4d5349f515d5c0ffad4db15ecca1431c830b824 100644
+index c587007de724f165c031a18ab59edd0623a045f3..45e5dfeef92e9756b0fa63d8fc66a4cf96ae7d9a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-@@ -22,9 +22,11 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
-     private final int maxHeight;
-     private final LevelChunkSection[] sections;
+@@ -23,9 +23,11 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+     private LevelChunkSection[] sections;
      private Set<BlockPos> tiles;
+     private final Set<BlockPos> lights = new HashSet<>();
 +    private World world; // Paper - Anti-Xray - Add parameters
  
      public CraftChunkData(World world) {
@@ -1442,7 +1442,7 @@ index 3d905c98704da64cefd009b2c796b24e729396a5..c4d5349f515d5c0ffad4db15ecca1431
      }
  
      /* pp for tests */ CraftChunkData(int minHeight, int maxHeight) {
-@@ -162,7 +164,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+@@ -170,7 +172,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
          int offset = (y - this.minHeight) >> 4;
          LevelChunkSection section = this.sections[offset];
          if (create && section == null) {

--- a/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0486-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -42,19 +42,10 @@ index 5285a5b16b0b706d9e1728a23628ff12e6b3b55d..df20ac811d673c205695d563f84382d1
      public BossBar createBossBar(String title, BarColor color, BarStyle style, BarFlag... flags) {
          return new CraftBossBar(title, color, style, flags);
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-index c4d5349f515d5c0ffad4db15ecca1431c830b824..4645303efa716442b14e5c1e767b0d94dbb50170 100644
+index 45e5dfeef92e9756b0fa63d8fc66a4cf96ae7d9a..4dc68ff7d2c9775e370e3854e5a8a7eee4e261aa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-@@ -20,7 +20,7 @@ import org.bukkit.material.MaterialData;
- public final class CraftChunkData implements ChunkGenerator.ChunkData {
-     private final int minHeight;
-     private final int maxHeight;
--    private final LevelChunkSection[] sections;
-+    private LevelChunkSection[] sections; // Paper - remove final
-     private Set<BlockPos> tiles;
-     private World world; // Paper - Anti-Xray - Add parameters
- 
-@@ -173,6 +173,12 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+@@ -181,6 +181,12 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
          return this.sections;
      }
  

--- a/patches/server/0537-Optimise-getType-calls.patch
+++ b/patches/server/0537-Optimise-getType-calls.patch
@@ -41,7 +41,7 @@ index e2e6652fc227173b69580dba74855c3ed8884a3b..2c23712aadfe32439ae014c62aa16f1b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 75863778df4b6988452ff27a1ba8a4e1733b3b7e..2f8ab6660c8a0cf208fc59e2d8a3f94c07bdd482 100644
+index a9b4277855ed3536bd00a03b85b0ae3336336c2b..62d8b9a174fa33136a4091652856b2efd8aa6245 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 @@ -209,7 +209,7 @@ public class CraftBlock implements Block {
@@ -80,10 +80,10 @@ index 6dc8f9f269db6971b8b46819e017357899ccd118..7f49c7c7048b5778f20ddce1d844d4b3
  
      public BlockState getState() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-index 4645303efa716442b14e5c1e767b0d94dbb50170..d2ce92a8dea9f6e3d6262dfe7c599cc82b6028ce 100644
+index 4dc68ff7d2c9775e370e3854e5a8a7eee4e261aa..e1735e5c82019005b8019ce8ed2f4089967351a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftChunkData.java
-@@ -77,7 +77,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
+@@ -78,7 +78,7 @@ public final class CraftChunkData implements ChunkGenerator.ChunkData {
  
      @Override
      public Material getType(int x, int y, int z) {

--- a/patches/server/0606-Make-schedule-command-per-world.patch
+++ b/patches/server/0606-Make-schedule-command-per-world.patch
@@ -5,33 +5,24 @@ Subject: [PATCH] Make schedule command per-world
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/ScheduleCommand.java b/src/main/java/net/minecraft/server/commands/ScheduleCommand.java
-index 018923e519544561747240618bce5df60475cdc6..7f5d249502e9b2fb9e5811cfeb43122b47f7b111 100644
+index 3f2a4e2399759cdd5aebe0b87c9d72f50cf6a72d..fb1f94acb3e848fa2a21a258145f3b4cb42fe562 100644
 --- a/src/main/java/net/minecraft/server/commands/ScheduleCommand.java
 +++ b/src/main/java/net/minecraft/server/commands/ScheduleCommand.java
-@@ -29,7 +29,7 @@ public class ScheduleCommand {
-         return new TranslatableComponent("commands.schedule.cleared.failure", eventName);
+@@ -32,7 +32,7 @@ public class ScheduleCommand {
+         return new TranslatableComponent("commands.schedule.cleared.failure", new Object[]{object});
      });
-     private static final SuggestionProvider<CommandSourceStack> SUGGEST_SCHEDULE = (context, builder) -> {
--        return SharedSuggestionProvider.suggest(context.getSource().getServer().getWorldData().overworldData().getScheduledEvents().getEventsIds(), builder);
-+        return SharedSuggestionProvider.suggest(context.getSource().getLevel().serverLevelData.overworldData().getScheduledEvents().getEventsIds(), builder); // Paper
+     private static final SuggestionProvider<CommandSourceStack> SUGGEST_SCHEDULE = (commandcontext, suggestionsbuilder) -> {
+-        return SharedSuggestionProvider.suggest((Iterable) ((CommandSourceStack) commandcontext.getSource()).getServer().getWorldData().overworldData().getScheduledEvents().getEventsIds(), suggestionsbuilder);
++        return SharedSuggestionProvider.suggest((Iterable) ((net.minecraft.commands.CommandSourceStack) commandcontext.getSource()).getLevel().serverLevelData.getScheduledEvents().getEventsIds(), suggestionsbuilder); // Paper
      };
  
-     public static void register(CommandDispatcher<CommandSourceStack> dispatcher) {
-@@ -52,7 +52,7 @@ public class ScheduleCommand {
-         } else {
-             long l = source.getLevel().getGameTime() + (long)time;
-             ResourceLocation resourceLocation = function.getFirst();
--            TimerQueue<MinecraftServer> timerQueue = source.getServer().getWorldData().overworldData().getScheduledEvents();
-+            TimerQueue<MinecraftServer> timerQueue = source.getLevel().serverLevelData.getScheduledEvents(); // Paper
-             function.getSecond().ifLeft((functionx) -> {
-                 String string = resourceLocation.toString();
-                 if (replace) {
-@@ -75,7 +75,7 @@ public class ScheduleCommand {
+     public ScheduleCommand() {}
+@@ -83,7 +83,7 @@ public class ScheduleCommand {
      }
  
      private static int remove(CommandSourceStack source, String eventName) throws CommandSyntaxException {
 -        int i = source.getServer().getWorldData().overworldData().getScheduledEvents().remove(eventName);
 +        int i = source.getLevel().serverLevelData.getScheduledEvents().remove(eventName); // Paper
+ 
          if (i == 0) {
-             throw ERROR_CANT_REMOVE.create(eventName);
-         } else {
+             throw ScheduleCommand.ERROR_CANT_REMOVE.create(eventName);

--- a/patches/server/0712-Add-Feature-Generation-API.patch
+++ b/patches/server/0712-Add-Feature-Generation-API.patch
@@ -126,10 +126,10 @@ index 0000000000000000000000000000000000000000..69b17fe56f28f8978abc3f363a9e805d
 +}
 +
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
-index bc25c0f466f8cc5662f01f38a38713570c1e5bfc..eff743042c9b6536f1d5001260ab04b42dfd21bd 100644
+index 6450dbe4e4e9a5f2b5dc3d783aa97e69e296033d..cffb0586bf6c98e90588185c10e8f5dd76bc489b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
-@@ -191,6 +191,12 @@ public class CustomChunkGenerator extends InternalChunkGenerator {
+@@ -196,6 +196,12 @@ public class CustomChunkGenerator extends InternalChunkGenerator {
          if (this.generator.shouldGenerateDecorations()) {
              this.delegate.applyBiomeDecoration(region, accessor);
          }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
64d149a5 SPIGOT-1753: ChunkGenerator lighting updates
82f0955b SPIGOT-6666: NPE when deserializing bundle
8dfa97af SPIGOT-6669: Shearing a Mooshroom does not fire EntityDropItemEvent
629cc539 SPIGOT-6667: /schedule function not working correctly in other dimensions