### PR TITLE
Prevent AFK kick while watching end credits (#6239).

### DIFF
--- a/patches/server/0731-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0731-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 24 Jul 2021 16:54:11 +0200
+Subject: [PATCH] Prevent AFK kick while watching end credits.
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index 68c3d744717cef8eeb16d640877157340a45e81c..219e93937b7f8f6e8f77e8f1ba221409352df3fc 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -151,6 +151,7 @@ import net.minecraft.world.level.block.entity.SignBlockEntity;
+ import net.minecraft.world.level.block.entity.StructureBlockEntity;
+ import net.minecraft.world.level.block.state.BlockBehaviour;
+ import net.minecraft.world.level.block.state.BlockState;
++import net.minecraft.world.level.dimension.DimensionType;
+ import net.minecraft.world.phys.AABB;
+ import net.minecraft.world.phys.BlockHitResult;
+ import net.minecraft.world.phys.HitResult;
+@@ -389,7 +390,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+             --this.dropSpamTickCount;
+         }
+ 
+-        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60)) {
++        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !(this.player.isChangingDimension && this.player.getLevel().getTypeKey() == DimensionType.END_LOCATION)) { // Paper - Prevent AFK kick while watching end credits.
+             this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
+             this.disconnect(new TranslatableComponent("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
+         }

--- a/patches/server/0731-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0731-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -5,23 +5,15 @@ Subject: [PATCH] Prevent AFK kick while watching end credits.
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 68c3d744717cef8eeb16d640877157340a45e81c..219e93937b7f8f6e8f77e8f1ba221409352df3fc 100644
+index 68c3d744717cef8eeb16d640877157340a45e81c..1addc9030d5e23859e21b7f8066d85e426f473d3 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-@@ -151,6 +151,7 @@ import net.minecraft.world.level.block.entity.SignBlockEntity;
- import net.minecraft.world.level.block.entity.StructureBlockEntity;
- import net.minecraft.world.level.block.state.BlockBehaviour;
- import net.minecraft.world.level.block.state.BlockState;
-+import net.minecraft.world.level.dimension.DimensionType;
- import net.minecraft.world.phys.AABB;
- import net.minecraft.world.phys.BlockHitResult;
- import net.minecraft.world.phys.HitResult;
-@@ -389,7 +390,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+@@ -389,7 +389,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
              --this.dropSpamTickCount;
          }
  
 -        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60)) {
-+        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !(this.player.isChangingDimension && this.player.getLevel().getTypeKey() == DimensionType.END_LOCATION)) { // Paper - Prevent AFK kick while watching end credits.
++        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !(this.player.isChangingDimension && this.player.getLevel().getTypeKey() == net.minecraft.world.level.dimension.DimensionType.END_LOCATION)) { // Paper - Prevent AFK kick while watching end credits.
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
              this.disconnect(new TranslatableComponent("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
          }

--- a/patches/server/0736-Improve-boat-collision-performance.patch
+++ b/patches/server/0736-Improve-boat-collision-performance.patch
@@ -54,13 +54,14 @@ index 24c629d5f26bc5aadebcf39a63930b3448525242..2b7eeb5659b1083ef550eb9feb0b7ba8
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
-index aa7c022c4faade23bd9061311d4152cf845d3331..95ccf785fd8a4fb4903807840c2fe41d58658354 100644
+index aa7c022c4faade23bd9061311d4152cf845d3331..99124b70d82140b108d424a5206657efe94f184e 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/Boat.java
-@@ -689,7 +689,7 @@ public class Boat extends Entity {
+@@ -688,8 +688,7 @@ public class Boat extends Entity {
+         this.invFriction = 0.05F;
          if (this.oldStatus == Boat.Status.IN_AIR && this.status != Boat.Status.IN_AIR && this.status != Boat.Status.ON_LAND) {
              this.waterLevel = this.getY(1.0D);
-             this.setPos(this.getX(), (double) (this.getWaterLevelAbove() - this.getBbHeight()) + 0.101D, this.getZ());
+-            this.setPos(this.getX(), (double) (this.getWaterLevelAbove() - this.getBbHeight()) + 0.101D, this.getZ());
 -            this.setDeltaMovement(this.getDeltaMovement().multiply(1.0D, 0.0D, 1.0D));
 +            this.setDeltaMovement(this.getDeltaMovement().multiply(1.0D, 0.0D, 1.0D).add(0.0, ((double) (this.getWaterLevelAbove() - this.getBbHeight()) + 0.101D) - this.getY(), 0.0)); // Paper
              this.lastYd = 0.0D;

--- a/patches/server/0737-Prevent-AFK-kick-while-watching-end-credits.patch
+++ b/patches/server/0737-Prevent-AFK-kick-while-watching-end-credits.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent AFK kick while watching end credits.
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 68c3d744717cef8eeb16d640877157340a45e81c..1addc9030d5e23859e21b7f8066d85e426f473d3 100644
+index 064aecb28f05fcf572ee7d29f611a31cc7b6e49a..ad1a9c6c354d40d5fa589666b1b00792d9cd6161 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -389,7 +389,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -13,7 +13,7 @@ index 68c3d744717cef8eeb16d640877157340a45e81c..1addc9030d5e23859e21b7f8066d85e4
          }
  
 -        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60)) {
-+        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !(this.player.isChangingDimension && this.player.getLevel().getTypeKey() == net.minecraft.world.level.dimension.DimensionType.END_LOCATION)) { // Paper - Prevent AFK kick while watching end credits.
++        if (this.player.getLastActionTime() > 0L && this.server.getPlayerIdleTimeout() > 0 && Util.getMillis() - this.player.getLastActionTime() > (long) (this.server.getPlayerIdleTimeout() * 1000 * 60) && !this.player.wonGame) { // Paper - Prevent AFK kick while watching end credits.
              this.player.resetLastActionTime(); // CraftBukkit - SPIGOT-854
              this.disconnect(new TranslatableComponent("multiplayer.disconnect.idling"), org.bukkit.event.player.PlayerKickEvent.Cause.IDLING); // Paper - kick event cause
          }


### PR DESCRIPTION
This PR implements #6239 by preventing an AFK kick if the player is switching dimensions and in the end.