### PR TITLE
Update Upstream (CraftBukkit)

### DIFF
--- a/patches/server/0466-Add-permission-for-command-blocks.patch
+++ b/patches/server/0466-Add-permission-for-command-blocks.patch
@@ -18,7 +18,7 @@ index 3f7919f4e8f5a5b79bf4e541ea5f4ce482965fa1..81275857101522b2bb88243131597440
                  return false;
              } else if (this.player.blockActionRestricted((Level) this.level, pos, this.gameModeForPlayer)) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d6fc3ed5339f974b826123d4833045527007ae6e..70c9cfa62af326ee030c4e70fc3d120c82a82a4c 100644
+index d6fc3ed5339f974b826123d4833045527007ae6e..15b16f94736b250e1e4207498a42043901dd8f1b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -787,7 +787,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -26,7 +26,7 @@ index d6fc3ed5339f974b826123d4833045527007ae6e..70c9cfa62af326ee030c4e70fc3d120c
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);
 -        } else if (!this.player.canUseGameMasterBlocks()) {
-+        } else if (!this.player.canUseGameMasterBlocks() && !this.player.isCreative() && !this.player.getBukkitEntity().hasPermission("minecraft.commandblock")) { // Paper - command block permission
++        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
              this.player.sendMessage(new TranslatableComponent("advMode.notAllowed"), Util.NIL_UUID);
          } else {
              BaseCommandBlock commandblocklistenerabstract = null;
@@ -35,12 +35,12 @@ index d6fc3ed5339f974b826123d4833045527007ae6e..70c9cfa62af326ee030c4e70fc3d120c
          if (!this.server.isCommandBlockEnabled()) {
              this.player.sendMessage(new TranslatableComponent("advMode.notEnabled"), Util.NIL_UUID);
 -        } else if (!this.player.canUseGameMasterBlocks()) {
-+        } else if (!this.player.canUseGameMasterBlocks() && !this.player.isCreative() && !this.player.getBukkitEntity().hasPermission("minecraft.commandblock")) { // Paper - command block permission
++        } else if (!this.player.canUseGameMasterBlocks() && (!this.player.isCreative() || !this.player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
              this.player.sendMessage(new TranslatableComponent("advMode.notAllowed"), Util.NIL_UUID);
          } else {
              BaseCommandBlock commandblocklistenerabstract = packet.getCommandBlock(this.player.level);
 diff --git a/src/main/java/net/minecraft/world/level/BaseCommandBlock.java b/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
-index 2e6172930526efc536a214e420e690a5ea42ac3e..c0dd148d08abf064b5f3c261046cf41d0d1bcf06 100644
+index 2e6172930526efc536a214e420e690a5ea42ac3e..a71cd95291e593a54c66f5672554f91b0f1470fa 100644
 --- a/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
 +++ b/src/main/java/net/minecraft/world/level/BaseCommandBlock.java
 @@ -200,7 +200,7 @@ public abstract class BaseCommandBlock implements CommandSource {
@@ -48,7 +48,7 @@ index 2e6172930526efc536a214e420e690a5ea42ac3e..c0dd148d08abf064b5f3c261046cf41d
  
      public InteractionResult usedBy(Player player) {
 -        if (!player.canUseGameMasterBlocks()) {
-+        if (!player.canUseGameMasterBlocks() && !player.isCreative() && !player.getBukkitEntity().hasPermission("minecraft.commandblock")) { // Paper - command block permission
++        if (!player.canUseGameMasterBlocks() && (!player.isCreative() || !player.getBukkitEntity().hasPermission("minecraft.commandblock"))) { // Paper - command block permission
              return InteractionResult.PASS;
          } else {
              if (player.getCommandSenderWorld().isClientSide) {

--- a/patches/server/0485-Add-PrepareResultEvent.patch
+++ b/patches/server/0485-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 3df5031ec2c50dc6eb2533318cf8a98f21b03d2a..c971a534ded962e3be92c71059c75cc1
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6fcef73d07432bedf73861f35426719e11a8623d..a26ac24817f2480326cb9140625c82335d90c9a2 100644
+index be7a9b0d8f65c884c0ff183041c20b7a99c30e2a..69a4795266b40c3cd113b13300bb7bbdcf842496 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1544,19 +1544,44 @@ public class CraftEventFactory {
+@@ -1548,19 +1548,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0593-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0593-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 51723c8f740c7b0bbd15acc0f1c848790c2ff299..5a95b550c767284563c124df1ff45322
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f9dfee7b1a4382002805b68d88b9c19476b66a66..e6474142eb8f7f19f083d1ad8797b662eca27565 100644
+index 8818a2d971615234a29710eb3cff2153f5896518..f5e83d82940602ef7733fbc61077c42c72da74bd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1807,4 +1807,12 @@ public class CraftEventFactory {
+@@ -1811,4 +1811,12 @@ public class CraftEventFactory {
          Bukkit.getPluginManager().callEvent(event);
          return event;
      }

--- a/patches/server/0608-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0608-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 501a5483160dba050261bb3448317a097cdb7ef2..2dcac4b638073aa1748f26f61219dbf9
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 5e030bddc8e9fe9cbe16a53242b6be8f2232fbc1..c8c3a8d8e4e5e7df66b69011ad95bb6bd6d3b6ee 100644
+index 67c3405264fda2f7ce2b9822f8e0a8da71998677..c96f598089ae441ee737b26705c2c1e5e9dcd326 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1825,5 +1825,11 @@ public class CraftEventFactory {
+@@ -1829,5 +1829,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
6788550f SPIGOT-6678: ChunkSnapshot#isSectionEmpty() not working as intended.
3ad0fb1c #901: Fix PlayerStatisticIncrementEvent spam