### PR TITLE
Fix incorrect colors in ConsoleCommandSender messages with TranslatableComponents

### DIFF
--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2051,7 +2051,7 @@ index 2509a39bec5edd38b54709fec241c7c18e0d1c26..6e89b039479a034d98d1ec183b06d541
          Component[] components = new Component[4];
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
-index f3cb4102ab223f379f60dac317df7da1fab812a8..1a8b02e9e4cf6fb27d6bcdf0350bdfc24e6bdee3 100644
+index f3cb4102ab223f379f60dac317df7da1fab812a8..b41452c3ed833f0e6c3b03a56fe5773e7b68a8e6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 @@ -80,4 +80,11 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
@@ -2062,7 +2062,7 @@ index f3cb4102ab223f379f60dac317df7da1fab812a8..1a8b02e9e4cf6fb27d6bcdf0350bdfc2
 +    // Paper start
 +    @Override
 +    public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component message, final net.kyori.adventure.audience.MessageType type) {
-+        this.sendRawMessage(org.bukkit.craftbukkit.util.CraftChatMessage.fromComponent(io.papermc.paper.adventure.PaperAdventure.asVanilla(message)));
++        this.sendRawMessage(io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.serialize(message));
 +    }
 +    // Paper end
  }
@@ -2486,7 +2486,7 @@ index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1d
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e2c30e2073f6e4d667d91c9ca29bd6e91900aa97..23f894528daa01010c133366a63ac10779603b6e 100644
+index eef4726c754eee963b3c3cb4f812ffeab24181c4..7103eed119a1a802476d08daca2ec36543d9bd6b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -802,9 +802,9 @@ public class CraftEventFactory {

--- a/patches/server/0446-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0446-Add-option-for-console-having-all-permissions.patch
@@ -19,12 +19,12 @@ index ef9e4515260ec92a6a0d6ab77d6492574d70a3f9..3b4b7dca3d109f72aa12f8ac79fb46bf
 +
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
-index 1a8b02e9e4cf6fb27d6bcdf0350bdfc24e6bdee3..dfea570dfbe227d1b902b5cb0f6d870383392e3b 100644
+index b41452c3ed833f0e6c3b03a56fe5773e7b68a8e6..9383e2fd8469d3203e0fe91dfbb05eb8192bc082 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
 @@ -86,5 +86,15 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
      public void sendMessage(final net.kyori.adventure.identity.Identity identity, final net.kyori.adventure.text.Component message, final net.kyori.adventure.audience.MessageType type) {
-         this.sendRawMessage(org.bukkit.craftbukkit.util.CraftChatMessage.fromComponent(io.papermc.paper.adventure.PaperAdventure.asVanilla(message)));
+         this.sendRawMessage(io.papermc.paper.adventure.PaperAdventure.LEGACY_SECTION_UXRC.serialize(message));
      }
 +
 +    @Override


### PR DESCRIPTION
Applies the same "temporary" workaround as #5609 but for ConsoleCommandSender methods accept take a component which may contain TranslatableComponents