### PR TITLE
Allow plugins to use Log4J to log

### DIFF
--- a/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -26,17 +26,22 @@ index c12636f01b233c2436b7d5cdd4c04ac91389247b..15b8f4708887535383bb74bd922f8932
      implementation("org.ow2.asm:asm:9.1")
      implementation("org.ow2.asm:asm-commons:9.1")
 diff --git a/src/main/java/org/bukkit/plugin/Plugin.java b/src/main/java/org/bukkit/plugin/Plugin.java
-index febfec6efafd76bb59b4b43aa223af16f73339b4..79890c68f1ad31f951dfdbd9a16dac500ec58c40 100644
+index febfec6efafd76bb59b4b43aa223af16f73339b4..e1174ed0b0f9b77068117712a867aa28bfaa64b5 100644
 --- a/src/main/java/org/bukkit/plugin/Plugin.java
 +++ b/src/main/java/org/bukkit/plugin/Plugin.java
-@@ -166,6 +166,13 @@ public interface Plugin extends TabExecutor {
+@@ -166,6 +166,18 @@ public interface Plugin extends TabExecutor {
      @NotNull
      public Logger getLogger();
  
-+    // Paper start - Add SLF4J logger
++    // Paper start - Add SLF4J/Log4J loggers
 +    @NotNull
 +    default org.slf4j.Logger getSLF4JLogger() {
 +        return org.slf4j.LoggerFactory.getLogger(getLogger().getName());
++    }
++
++    @NotNull
++    default org.apache.logging.log4j.Logger getLog4JLogger() {
++        return org.apache.logging.log4j.LogManager.getLogger(getLogger().getName());
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
Self-explanatory, adds `Plugin#getLog4JLogger` in the same vein as `Plugin#getSlf4JLogger`. Already have Log4J, might as well expose it.