### PR TITLE
Offset spigot item optimizations instead of Mojang's

### DIFF
--- a/patches/server/0352-Fix-items-not-falling-correctly.patch
+++ b/patches/server/0352-Fix-items-not-falling-correctly.patch
@@ -11,11 +11,11 @@ optimization which skips ticking active entities every fourth tick.
 This can result in a state where an item will never properly fall
 due to its move method never being called.
 
-This patch resolves the conflict by offsetting checking an item's
-move method from Spigot's entity activation range check.
+This patch resolves the conflict by offsetting checking Spigot's entity
+activation range check from an item's move method.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 1da634eacccff884d50b7f1298bc8e44b0b8b6f2..abe72b940b21376571e6a0598e847e3e9ed0f061 100644
+index 1da634eacccff884d50b7f1298bc8e44b0b8b6f2..b73198444747e6f8865ad9694c0b11ee95746dae 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -134,7 +134,7 @@ public class ItemEntity extends Entity {
@@ -23,7 +23,20 @@ index 1da634eacccff884d50b7f1298bc8e44b0b8b6f2..abe72b940b21376571e6a0598e847e3e
              }
  
 -            if (!this.onGround || this.getDeltaMovement().horizontalDistanceSqr() > 9.999999747378752E-6D || (this.tickCount + this.getId()) % 4 == 0) {
-+            if (!this.onGround || this.getDeltaMovement().horizontalDistanceSqr() > 9.999999747378752E-6D || this.tickCount % 4 == 0) { // Paper - Ensure checking item movement is always offset from Spigot's entity activation range check
++            if (!this.onGround || this.getDeltaMovement().horizontalDistanceSqr() > 9.999999747378752E-6D || (this.tickCount + this.getId()) % 4 == 0) { // Paper - Diff on change
                  this.move(MoverType.SELF, this.getDeltaMovement());
                  float f1 = 0.98F;
  
+diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
+index 07e5ece37af6b02210920ce6cc31738274d447a9..7bae24598218dcf0012dd21e619e6f5f984bd6f0 100644
+--- a/src/main/java/org/spigotmc/ActivationRange.java
++++ b/src/main/java/org/spigotmc/ActivationRange.java
+@@ -251,7 +251,7 @@ public class ActivationRange
+                 isActive = true;
+             }
+             // Add a little performance juice to active entities. Skip 1/4 if not immune.
+-        } else if ( !entity.defaultActivationState && entity.tickCount % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) )
++        } else if ( !entity.defaultActivationState && entity.tickCount + entity.getId() + 1 % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
+         {
+             isActive = false;
+         }

--- a/patches/server/0357-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0357-Entity-Activation-Range-2.0.patch
@@ -108,7 +108,7 @@ index 367e074dd5f85f824b7c4f5506d0ccac60580c1b..83c5b111b98e52f52b7e4cf607aac07b
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index aa5fdc74a3b06b8d8b82b86fb4f1469ddd4c629e..ae454b12a0671f6698ff2b889988348e3a518b36 100644
+index 71de08f60b9d9d0f132e2d3c60cd7b70e9ec3759..8b1e6961e2a60e17aa12ec949e3166e461d4fed7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -313,6 +313,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -335,7 +335,7 @@ index 6b29f66aec8a82b367a979b5b04857416b697c14..78d252b829e5c1f19532656a72862085
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 07e5ece37af6b02210920ce6cc31738274d447a9..84880151abd193be5f02b5e9abb3fa78f2aa2cac 100644
+index 7bae24598218dcf0012dd21e619e6f5f984bd6f0..88c3022abc5edde312573de4fe499f1f5ee9eeae 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -1,39 +1,52 @@
@@ -681,8 +681,8 @@ index 07e5ece37af6b02210920ce6cc31738274d447a9..84880151abd193be5f02b5e9abb3fa78
 +
              }
              // Add a little performance juice to active entities. Skip 1/4 if not immune.
--        } else if ( !entity.defaultActivationState && entity.tickCount % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) )
-+        } else if ( entity.tickCount % 4 == 0 && ActivationRange.checkEntityImmunities( entity ) < 0 ) // Paper
+-        } else if ( !entity.defaultActivationState && entity.tickCount + entity.getId() + 1 % 4 == 0 && !ActivationRange.checkEntityImmunities( entity ) ) // Paper - Ensure checking item movement is offset from Spigot's entity activation range check
++        } else if ( entity.tickCount + entity.getId() + 1 % 4 == 0 && ActivationRange.checkEntityImmunities( entity ) < 0 ) // Paper
          {
              isActive = false;
          }

--- a/patches/server/0360-Anti-Xray.patch
+++ b/patches/server/0360-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 723adafaf82a664b8bfff9d7d11e43e3eafafa6e..1cdfba84abcee02c0ac49367c97544bc4758715b 100644
+index d9c59ea6faa7155d415c89228c22da3311855c9d..a17bf0ebe4d60effc72ea71ba4a7eba001875e19 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,11 +1,13 @@
@@ -1126,7 +1126,7 @@ index 7825d6f0fdcfda6212cff8033ec55fb7db236154..2072aa8710f6e285f7c8f76c63b7bcf8
  
      public ClientboundLevelChunkWithLightPacket(FriendlyByteBuf buf) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index cb050e658c5c99feb4586c1fba9a57ee3c0d6052..1112ffdaa13c6f0ca41b32127c3fed69f828d6fe 100644
+index 66c9cbf383e1b6333e46162b8a97e0a9cc05f419..882a960c97b5f298049ea38ef1208b437e2e02a8 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -938,7 +938,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1179,7 +1179,7 @@ index cb050e658c5c99feb4586c1fba9a57ee3c0d6052..1112ffdaa13c6f0ca41b32127c3fed69
          List<Entity> list = Lists.newArrayList();
          List<Entity> list1 = Lists.newArrayList();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index daeb483b7aa0356447381aec8d92f5dfa500d5b1..6a0eb9313ae62549f2e9220ca00a7ef27d3b2fca 100644
+index 83c5b111b98e52f52b7e4cf607aac07be7043709..be75691d91b3559788365da2b813ea3c010b6637 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -394,7 +394,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0361-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0361-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1cdfba84abcee02c0ac49367c97544bc4758715b..619f5c11ae8e21b060b52b60d681db6dd9cb5816 100644
+index a17bf0ebe4d60effc72ea71ba4a7eba001875e19..68ae6664541d1dbc611520e7e8612b4f5162c696 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -565,5 +565,52 @@ public class PaperWorldConfig {
@@ -63,7 +63,7 @@ index 1cdfba84abcee02c0ac49367c97544bc4758715b..619f5c11ae8e21b060b52b60d681db6d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index abe72b940b21376571e6a0598e847e3e9ed0f061..37d9788c1d4eb40ccdc0ec946bfd648822e486a0 100644
+index b73198444747e6f8865ad9694c0b11ee95746dae..995172d8f271520ffa09e919f2a4890a4a1ccd89 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -174,7 +174,7 @@ public class ItemEntity extends Entity {

--- a/patches/server/0364-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0364-implement-optional-per-player-mob-spawns.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] implement optional per player mob spawns
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 619f5c11ae8e21b060b52b60d681db6dd9cb5816..88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f 100644
+index 68ae6664541d1dbc611520e7e8612b4f5162c696..6b0391743cd9e249c66796e7fe7a4da8c6b81b2e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -613,4 +613,12 @@ public class PaperWorldConfig {
@@ -269,7 +269,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 0c82b270c7095c7e4666a8078ecc7142503795c4..2d7f0eb7df62d1c26ccf19cf61595227e19aa562 100644
+index 75381712377c1b77289a6b5877a657af8eb39a41..056e35b00bd840d8c62c4dc978cbbe5bb8c37887 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -151,6 +151,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0378-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0378-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,7 +8,7 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e0ebea2f62db5d0723aa353db49cdc3854aa5dd7..5fee3bdea651fcdd7ea01df4cfb8288a231f9236 100644
+index 4c49a7a686ad1ff386999c21fa25acd30a615abf..c9d9461695d95e227f41b894b42b8be8d9d198cd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -536,6 +536,11 @@ public class PaperWorldConfig {

--- a/patches/server/0409-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0409-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7f09e1178b73b3c436aea9059162628bfa8a6911..1ea83baba79254e11fc770a6a1c7fb740ac43d82 100644
+index e2b71ffd6057dcc84e4e0910fddd24c50ef9d38d..e7cbdc75d7fd1252024c450ff0ec3b1ebdd17b93 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -646,4 +646,11 @@ public class PaperWorldConfig {

--- a/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0420-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1ea83baba79254e11fc770a6a1c7fb740ac43d82..65fcdbc5c1f637f809d3033b83e5b1c807472911 100644
+index e7cbdc75d7fd1252024c450ff0ec3b1ebdd17b93..bc880a78381b9c30e4ec92bdf17c9eca1ded41f2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -653,4 +653,10 @@ public class PaperWorldConfig {
@@ -20,7 +20,7 @@ index 1ea83baba79254e11fc770a6a1c7fb740ac43d82..65fcdbc5c1f637f809d3033b83e5b1c8
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d74db5ac46314683b8c8713b8e6f6450ef7eb1b1..d62b1f22ee5679b0f223320db0db9c53b2120c91 100644
+index de5f5856875fc4bfb051c7535344f18ded360ad3..618be6243225c82c3f7e039a00c43cf3c2ef1dbf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -630,16 +630,30 @@ public class CraftEventFactory {

--- a/patches/server/0435-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0435-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,7 +17,7 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 65fcdbc5c1f637f809d3033b83e5b1c807472911..d6d549df6e8920c936dd0d1b7ba828dbebc60b32 100644
+index bc880a78381b9c30e4ec92bdf17c9eca1ded41f2..eae27a641ee69f3383f1200f8c8ab8dd7a4105a4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -659,4 +659,13 @@ public class PaperWorldConfig {
@@ -35,7 +35,7 @@ index 65fcdbc5c1f637f809d3033b83e5b1c807472911..d6d549df6e8920c936dd0d1b7ba828db
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 95f195980e28bb59f43e5ca1d5e79ebe8c3ddaea..84dc1e94b4f7b8315d8422634dd49b1f85044d18 100644
+index 3865146697051e01a778414064425ea0e5162b8d..cd81e7844c985d7d0f0930faa96478af6a7f6cd4 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -197,6 +197,27 @@ public abstract class DistanceManager {

--- a/patches/server/0568-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0568-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8df810594156944a2cb149af35863caf10edbb83..63d0971379f96e000ab9e7939f626c216cb6d12c 100644
+index f61e0c14db835a6b79f7c4b1f68a1005d5b3e913..ab52e655d16dc565cfb890ec8fdb07ce7f68e4cf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -720,6 +720,14 @@ public class PaperWorldConfig {

--- a/patches/server/0587-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0587-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add toggle for always placing the dragon egg
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 671ca20b02097332ef98d2be2e7aaafeadaf2a2c..a17dc48e0bddea3272120f4a129278b755834d40 100644
+index 7b771d8467027b9ec898efe96b423a98556e54c3..e6b8f71c81daf1e886a9d46a2bed18d4d414e18d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -750,6 +750,11 @@ public class PaperWorldConfig {

--- a/patches/server/0593-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0593-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a17dc48e0bddea3272120f4a129278b755834d40..83d5bbf0a819d6a75d148de5a7f3679e3faad9ec 100644
+index e6b8f71c81daf1e886a9d46a2bed18d4d414e18d..59675e523625b95169236bd0ead063cf0d87847e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -755,6 +755,11 @@ public class PaperWorldConfig {
@@ -21,7 +21,7 @@ index a17dc48e0bddea3272120f4a129278b755834d40..83d5bbf0a819d6a75d148de5a7f3679e
      public boolean phantomOnlyAttackInsomniacs = true;
      private void phantomSettings() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 2b6444711c39f042c21d374fc0dc507f1577fa1a..277f9c00c305a1e8b832bb48d9764a9d014612a6 100644
+index 558a202fb147f4c466d5c8b958105cbf43be0788..d76668ab79d6afa0972fd54408a8475781b1c928 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1400,6 +1400,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0612-Allow-using-signs-inside-spawn-protection.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83d5bbf0a819d6a75d148de5a7f3679e3faad9ec..f372caad76d5f59f37d073bb245fca3a037c2bef 100644
+index 59675e523625b95169236bd0ead063cf0d87847e..bdd531806a4f006085be113c34b5780cb1a06fb7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -789,4 +789,9 @@ public class PaperWorldConfig {

--- a/patches/server/0665-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0665-Limit-item-frame-cursors-on-maps.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1fc750c1f33d8f25a65cf286fd88fd21ab46c0ef..9b9b2a70a33639c7e24ec8fee68b20a979bea37d 100644
+index 502d7cbff05c9fd6ef64d6e6483b7c7d5cebfb22..eff5a39968c8a4ff49ca9a7de5e2bf2a20ea7fd8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -828,4 +828,9 @@ public class PaperWorldConfig {

--- a/patches/server/0670-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0670-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b9b2a70a33639c7e24ec8fee68b20a979bea37d..04c91116d88b7c7b8a5886cc54f21be645998e38 100644
+index eff5a39968c8a4ff49ca9a7de5e2bf2a20ea7fd8..0059c837ab3b1223c56aa9fbc96dd2aedd13e0eb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -833,4 +833,9 @@ public class PaperWorldConfig {
@@ -19,7 +19,7 @@ index 9b9b2a70a33639c7e24ec8fee68b20a979bea37d..04c91116d88b7c7b8a5886cc54f21be6
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 37d9788c1d4eb40ccdc0ec946bfd648822e486a0..f63502307fce7d3721b368d81af5a121b7dd9744 100644
+index 995172d8f271520ffa09e919f2a4890a4a1ccd89..0a1ef65c7199939035f2d548525b72bd0e40704d 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -240,6 +240,14 @@ public class ItemEntity extends Entity {

--- a/patches/server/0672-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0672-Fix-invulnerable-end-crystals.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04c91116d88b7c7b8a5886cc54f21be645998e38..478c93a4eae18047df037958720e56e94a131f1c 100644
+index 0059c837ab3b1223c56aa9fbc96dd2aedd13e0eb..d980e31884ea70493628e4934e19fa68314ba8e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -838,4 +838,9 @@ public class PaperWorldConfig {

--- a/patches/server/0678-add-per-world-spawn-limits.patch
+++ b/patches/server/0678-add-per-world-spawn-limits.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 478c93a4eae18047df037958720e56e94a131f1c..feaabc6d65845b81a3a184dc332d115200bdcca3 100644
+index d980e31884ea70493628e4934e19fa68314ba8e2..54a1fb5b6d1dee73761851c55c6bdc1c30d9934a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -53,6 +53,11 @@ public class PaperWorldConfig {

--- a/patches/server/0686-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0686-Fix-commands-from-signs-not-firing-command-events.patch
@@ -10,7 +10,7 @@ This patch changes sign command logic so that `run_command` click events:
   - sends failure messages to the player who clicked the sign
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index feaabc6d65845b81a3a184dc332d115200bdcca3..3a83320bae86ba1acb189b9b2cf934ad0393c353 100644
+index 54a1fb5b6d1dee73761851c55c6bdc1c30d9934a..047d2b47b5af22087359e76362d84dc69ae26707 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -863,4 +863,9 @@ public class PaperWorldConfig {

--- a/patches/server/0691-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0691-Don-t-apply-cramming-damage-to-players.patch
@@ -11,7 +11,7 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index be7b7f9345a42007d6ccea6a31c93a4c874647b6..a374112dc1ecb55dc921d2a2202f6eab47be0d35 100644
+index 36730b851203602a49d5a76b25a9e3a11c005033..e3551edd1693c388f22436db1c2bee22385962de 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -883,4 +883,9 @@ public class PaperWorldConfig {

--- a/patches/server/0692-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0692-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a374112dc1ecb55dc921d2a2202f6eab47be0d35..9e31046c1e6f1138e75aee11647b0ff9bf45503d 100644
+index e3551edd1693c388f22436db1c2bee22385962de..45a317c46bbe05dfaf5b555d9a8c281ff8d9103d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -9,8 +9,10 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;

--- a/patches/server/0709-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0709-Configurable-item-frame-map-cursor-update-interval.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable item frame map cursor update interval
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e85835f3ec7bb5e5ef5a827a4cb6614780255326..f0073bafac729f018ad3264f673c158c1ed5b0d7 100644
+index b33a8e15153375316b9c8e856c14669667599225..848169bdab0a20e41cfb917cd6ec1abc771c1a7d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -876,6 +876,11 @@ public class PaperWorldConfig {

--- a/patches/server/0792-Preserve-overstacked-loot.patch
+++ b/patches/server/0792-Preserve-overstacked-loot.patch
@@ -10,7 +10,7 @@ chunk bans via the large amount of NBT created by unstacking the items.
 Fixes GH-5140 and GH-4748.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0073bafac729f018ad3264f673c158c1ed5b0d7..ea67eb1099e6ec34426d80c95e9999f4aa8793b9 100644
+index 848169bdab0a20e41cfb917cd6ec1abc771c1a7d..e5eeab49d167a9a151301ca910e1421550e14245 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -901,6 +901,11 @@ public class PaperWorldConfig {

--- a/patches/server/0799-Configurable-feature-seeds.patch
+++ b/patches/server/0799-Configurable-feature-seeds.patch
@@ -19,7 +19,7 @@ index ee53453440177537fc653ea156785d7591498614..5e3b7fb2e0b7608610555cd23e7ad25a
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ea67eb1099e6ec34426d80c95e9999f4aa8793b9..8150330bc55a010c7d0f96421586226631eb72f7 100644
+index e5eeab49d167a9a151301ca910e1421550e14245..0a70dfd7880f5fcf1292dd2fdae2964bc2f51d61 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -946,6 +946,55 @@ public class PaperWorldConfig {

--- a/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Hide unnecessary itemmeta from clients
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8150330bc55a010c7d0f96421586226631eb72f7..d71cd626bcbefc576f9c05b8885acc9fb2a33cd5 100644
+index 0a70dfd7880f5fcf1292dd2fdae2964bc2f51d61..365c907efc100bbb5cf9223a10f6b56e3d7846ec 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -916,6 +916,13 @@ public class PaperWorldConfig {

--- a/patches/server/0833-Configurable-max-block-light-for-monster-spawning.patch
+++ b/patches/server/0833-Configurable-max-block-light-for-monster-spawning.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable max block light for monster spawning
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d71cd626bcbefc576f9c05b8885acc9fb2a33cd5..5a5db15493cd9b83815c36487c2f38cb8ac76f3a 100644
+index 365c907efc100bbb5cf9223a10f6b56e3d7846ec..c9eefc9455e3db248216a38cd6120cdfa27c1eab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1014,4 +1014,9 @@ public class PaperWorldConfig {


### PR DESCRIPTION
This PR allows server owners to use Mojang's implementation of tick skipping for items, instead of the one provided by Spigot. There are several situations where Mojang's system, which is based on the entity id and entity age, is preferred over the one Spigot uses, which only uses entity age. For example, the [wireless redstone system](https://www.youtube.com/watch?v=FLynwXDnETI) mentioned in #6277. These types of systems need the item id based implementation to function correctly. This change brings back something that could be considered a vanilla mechanic, and should be easy to maintain.

_Small sidenote:_ I'm not 100% sure I rebased the patches correctly, please let me know if anything needs changing.