### PR TITLE
Suppress deprecation registration warnings for brigadier events

### DIFF
--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/AsyncPlayerSendCommandsEvent.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/AsyncPlayerSendCommandsEvent.java
@@ -3,6 +3,7 @@ package com.destroystokyo.paper.event.brigadier;
 import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
 import com.mojang.brigadier.tree.RootCommandNode;
 import org.bukkit.Bukkit;
+import org.bukkit.Warning;
 import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.player.PlayerEvent;
@@ -28,6 +29,7 @@ import org.jetbrains.annotations.NotNull;
  * @deprecated Draft API - Subject to change until confirmed solves desired use cases
  */
 @Deprecated
+@Warning(false)
 public class AsyncPlayerSendCommandsEvent <S extends BukkitBrigadierCommandSource> extends PlayerEvent {
 
     private static final HandlerList handlers = new HandlerList();

--- a/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
+++ b/Paper-MojangAPI/src/main/java/com/destroystokyo/paper/event/brigadier/CommandRegisteredEvent.java
@@ -5,6 +5,7 @@ import com.destroystokyo.paper.brigadier.BukkitBrigadierCommandSource;
 import com.mojang.brigadier.tree.ArgumentCommandNode;
 import com.mojang.brigadier.tree.LiteralCommandNode;
 import com.mojang.brigadier.tree.RootCommandNode;
+import org.bukkit.Warning;
 import org.bukkit.command.Command;
 import org.bukkit.event.Cancellable;
 import org.bukkit.event.HandlerList;
@@ -22,6 +23,7 @@ import org.jetbrains.annotations.NotNull;
  * @deprecated Draft API - Subject to change until confirmed solves desired use cases
  */
 @Deprecated
+@Warning(false)
 public class CommandRegisteredEvent <S extends BukkitBrigadierCommandSource> extends ServerEvent implements Cancellable {
 
     private static final HandlerList handlers = new HandlerList();


### PR DESCRIPTION
This solves the issue that since https://github.com/PaperMC/Paper/pull/6264, the usage of these draft API's results in deprecation warnings when registering listeners for these events