### PR TITLE
Add force getter to ParticleBuilder

### DIFF
--- a/patches/api/0099-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/api/0099-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -10,10 +10,10 @@ This adds a new Builder API which is much friendlier to use.
 
 diff --git a/src/main/java/com/destroystokyo/paper/ParticleBuilder.java b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..06f1602f5b327705f726d0a99dd6b95e1554d382
+index 0000000000000000000000000000000000000000..f45b8cfd1611345e8d81ecb8297a586f05eb5dc6
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ParticleBuilder.java
-@@ -0,0 +1,478 @@
+@@ -0,0 +1,485 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.collect.Lists;
@@ -427,6 +427,13 @@ index 0000000000000000000000000000000000000000..06f1602f5b327705f726d0a99dd6b95e
 +    public <T> ParticleBuilder data(@Nullable T data) {
 +        this.data = data;
 +        return this;
++    }
++
++    /**
++     * @return whether the particle is forcefully shown to players.
++     */
++    public boolean force() {
++        return force;
 +    }
 +
 +    /**


### PR DESCRIPTION
Hello,

I saw ParticleBuilder class didn't have any getter for the `force` private field. So I added one with the same logic than other fields : same name for getter and setter methods but parameters and return value change, that's why the method I added is called `force()` and not `hasForce()` or something like that.

That's my first pull request with patches, let me know if I did something wrong but I think it's okay.

Thank you !