### PR TITLE
Correct handling of invalid maps

### DIFF
--- a/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
+++ b/patches/server/0090-Improve-Maps-in-item-frames-performance-and-bug-fixe.patch
@@ -25,7 +25,7 @@ index 4291492dc5cf0c845af30f62e2dcb15826842d12..160da347ed52739e930044fe456a4dd3
                                  }
                              }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 484b1bf43b897c5ffe47baa340957e3293c7bf92..c825ad2d04b964561355cb0564f9f5507848217f 100644
+index 484b1bf43b897c5ffe47baa340957e3293c7bf92..928595ff46287e92759bbf0ef3d64d4a39ab135d 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -88,6 +88,7 @@ import net.minecraft.world.item.ElytraItem;
@@ -44,19 +44,34 @@ index 484b1bf43b897c5ffe47baa340957e3293c7bf92..c825ad2d04b964561355cb0564f9f550
  import net.minecraft.world.phys.AABB;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -732,6 +734,12 @@ public abstract class Player extends LivingEntity {
+@@ -732,6 +734,14 @@ public abstract class Player extends LivingEntity {
                  return null;
              }
              // CraftBukkit end
 +            // Paper start - remove player from map on drop
 +            if (stack.getItem() == Items.FILLED_MAP) {
 +                MapItemSavedData worldmap = MapItem.getSavedData(stack, this.level);
-+                worldmap.tickCarriedBy(this, stack);
++                if (worldmap != null) {
++                    worldmap.tickCarriedBy(this, stack);
++                }
 +            }
 +            // Paper end
  
              return entityitem;
          }
+diff --git a/src/main/java/net/minecraft/world/item/MapItem.java b/src/main/java/net/minecraft/world/item/MapItem.java
+index 2ac84599cd9c71c1a32d70e447b014dc6711cda7..7d7acad622a3c04163308434b8a3cfd877039ad1 100644
+--- a/src/main/java/net/minecraft/world/item/MapItem.java
++++ b/src/main/java/net/minecraft/world/item/MapItem.java
+@@ -58,7 +58,7 @@ public class MapItem extends ComplexItem {
+ 
+     @Nullable
+     public static MapItemSavedData getSavedData(@Nullable Integer id, Level world) {
+-        return id == null ? null : world.getMapData(MapItem.makeKey(id));
++        return id == null || id < 0 ? null : world.getMapData(MapItem.makeKey(id)); // Paper - map ids under 0 are invalid
+     }
+ 
+     @Nullable
 diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 index 6859fafa42527d45366018f737c19e6c3777d152..15c6f9d1c43fbedac70526a84a010be83b4cae86 100644
 --- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java

--- a/patches/server/0144-Shoulder-Entities-Release-API.patch
+++ b/patches/server/0144-Shoulder-Entities-Release-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 273bb051c3f19e388ccea367ef6b46b509015abd..789a42f997d5f0abf50171db7d747092653817fa 100644
+index eee7ac657dcf21f3f365ab43eaebf878a552fc27..b4ec8fc67ba99a632581913931e9107b329b521b 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1949,20 +1949,44 @@ public abstract class Player extends LivingEntity {
+@@ -1951,20 +1951,44 @@ public abstract class Player extends LivingEntity {
  
      }
  

--- a/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d34b7ab0a 100644
+index b4ec8fc67ba99a632581913931e9107b329b521b..2a8bcee1422805e29512e791c52d0787c05e1e61 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -30,6 +30,7 @@ import net.minecraft.network.chat.MutableComponent;
@@ -17,7 +17,7 @@ index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d
  import net.minecraft.network.syncher.EntityDataAccessor;
  import net.minecraft.network.syncher.EntityDataSerializers;
  import net.minecraft.network.syncher.SynchedEntityData;
-@@ -1179,7 +1180,7 @@ public abstract class Player extends LivingEntity {
+@@ -1181,7 +1182,7 @@ public abstract class Player extends LivingEntity {
                      int i = b0 + EnchantmentHelper.getKnockbackBonus((LivingEntity) this);
  
                      if (this.isSprinting() && flag) {
@@ -26,7 +26,7 @@ index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d
                          ++i;
                          flag1 = true;
                      }
-@@ -1254,7 +1255,7 @@ public abstract class Player extends LivingEntity {
+@@ -1256,7 +1257,7 @@ public abstract class Player extends LivingEntity {
                                  }
                              }
  
@@ -35,7 +35,7 @@ index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d
                              this.sweepAttack();
                          }
  
-@@ -1282,15 +1283,15 @@ public abstract class Player extends LivingEntity {
+@@ -1284,15 +1285,15 @@ public abstract class Player extends LivingEntity {
                          }
  
                          if (flag2) {
@@ -54,7 +54,7 @@ index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d
                              }
                          }
  
-@@ -1342,7 +1343,7 @@ public abstract class Player extends LivingEntity {
+@@ -1344,7 +1345,7 @@ public abstract class Player extends LivingEntity {
  
                          this.applyExhaustion(level.spigotConfig.combatExhaustion, EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value
                      } else {
@@ -63,7 +63,7 @@ index 789a42f997d5f0abf50171db7d747092653817fa..615ed6c07a3c20f0bd6b58f7d260e12d
                          if (flag4) {
                              target.clearFire();
                          }
-@@ -1789,6 +1790,14 @@ public abstract class Player extends LivingEntity {
+@@ -1791,6 +1792,14 @@ public abstract class Player extends LivingEntity {
      public int getXpNeededForNextLevel() {
          return this.experienceLevel >= 30 ? 112 + (this.experienceLevel - 30) * 9 : (this.experienceLevel >= 15 ? 37 + (this.experienceLevel - 15) * 5 : 7 + this.experienceLevel * 2);
      }

--- a/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -21,10 +21,10 @@ index 3577100f850975020b74f077d688f59dbca78962..da4a110809eee691c1d5b072de335d75
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 615ed6c07a3c20f0bd6b58f7d260e12d34b7ab0a..da0176ed9d51aef76d9c439a03718c1635c35333 100644
+index 2a8bcee1422805e29512e791c52d0787c05e1e61..3c8de1d70714a021dbd58894f3fd986bf5d6bde7 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1187,6 +1187,7 @@ public abstract class Player extends LivingEntity {
+@@ -1189,6 +1189,7 @@ public abstract class Player extends LivingEntity {
  
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.onClimbable() && !this.isInWater() && !this.hasEffect(MobEffects.BLINDNESS) && !this.isPassenger() && target instanceof LivingEntity;
  

--- a/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
@@ -20,10 +20,10 @@ index da4a110809eee691c1d5b072de335d75e1516eae..9225372cb9ef51a8cfbd4cee543c250a
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index f9593486e5382c629e0febd43b3d7464481f0045..28b1d0291d5ffce2606b42394ea22de7a382f9fd 100644
+index cc6f1f94c1a01992dfe29399b346c972f114a38d..220a1c4ecf9bc95c804a831fb661aa28f00059b1 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1236,7 +1236,11 @@ public abstract class Player extends LivingEntity {
+@@ -1238,7 +1238,11 @@ public abstract class Player extends LivingEntity {
                              }
  
                              this.setDeltaMovement(this.getDeltaMovement().multiply(0.6D, 1.0D, 0.6D));

--- a/patches/server/0213-PlayerReadyArrowEvent.patch
+++ b/patches/server/0213-PlayerReadyArrowEvent.patch
@@ -7,10 +7,10 @@ Called when a player is firing a bow and the server is choosing an arrow to use.
 Plugins can skip selection of certain arrows and control which is used.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 28b1d0291d5ffce2606b42394ea22de7a382f9fd..ce8b5394f418583608bb8965c058660264ddf66c 100644
+index 220a1c4ecf9bc95c804a831fb661aa28f00059b1..157abba796981cf2d1b0b17ccd376de10c782a30 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -2182,6 +2182,17 @@ public abstract class Player extends LivingEntity {
+@@ -2184,6 +2184,17 @@ public abstract class Player extends LivingEntity {
          return ImmutableList.of(Pose.STANDING, Pose.CROUCHING, Pose.SWIMMING);
      }
  
@@ -28,7 +28,7 @@ index 28b1d0291d5ffce2606b42394ea22de7a382f9fd..ce8b5394f418583608bb8965c0586602
      @Override
      public ItemStack getProjectile(ItemStack stack) {
          if (!(stack.getItem() instanceof ProjectileWeaponItem)) {
-@@ -2198,7 +2209,7 @@ public abstract class Player extends LivingEntity {
+@@ -2200,7 +2211,7 @@ public abstract class Player extends LivingEntity {
                  for (int i = 0; i < this.inventory.getContainerSize(); ++i) {
                      ItemStack itemstack2 = this.inventory.getItem(i);
  

--- a/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
@@ -82,10 +82,10 @@ index f6fd39823f04f8071c616d40a838b01e7159c5a1..e1cdf3ce38404d3f40be59e4cd3ad2b9
              serverLevel.playSound((Player)null, pathfinderMob, this.getImpactSound.apply(pathfinderMob), SoundSource.HOSTILE, 1.0F, 1.0F);
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index ce8b5394f418583608bb8965c058660264ddf66c..3db5b3adb9fe4a1682b0a4e75ae3e1f6febb7822 100644
+index 157abba796981cf2d1b0b17ccd376de10c782a30..72b7c6654c68daa2591d55ff62d4a6ba7ae25618 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1230,7 +1230,7 @@ public abstract class Player extends LivingEntity {
+@@ -1232,7 +1232,7 @@ public abstract class Player extends LivingEntity {
                      if (flag5) {
                          if (i > 0) {
                              if (target instanceof LivingEntity) {
@@ -94,7 +94,7 @@ index ce8b5394f418583608bb8965c058660264ddf66c..3db5b3adb9fe4a1682b0a4e75ae3e1f6
                              } else {
                                  target.push((double) (-Mth.sin(this.getYRot() * 0.017453292F) * (float) i * 0.5F), 0.1D, (double) (Mth.cos(this.getYRot() * 0.017453292F) * (float) i * 0.5F));
                              }
-@@ -1254,7 +1254,7 @@ public abstract class Player extends LivingEntity {
+@@ -1256,7 +1256,7 @@ public abstract class Player extends LivingEntity {
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo(entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
                                      if (entityliving.hurt(DamageSource.playerAttack(this).sweep(), f4)) {

--- a/patches/server/0297-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0297-force-entity-dismount-during-teleportation.patch
@@ -41,7 +41,7 @@ index 635aa1cf7343a242fb01a49f2215d2af25a09760..efb759fe76540b51509029d40884eb85
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 35f83b559002886b8728297eb9fecc7588bdc950..dbf002a6967812fd58ed9bcfa615dc525586c1a0 100644
+index 103a0eb2580384d50eda74da83fbc64f5e6dd7cd..70f18293c5b6f6a8f9e83048a393cb21dbb04164 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2239,12 +2239,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -114,10 +114,10 @@ index ef3b47c30e9fa0a41268b61d3008507587999aa6..f6ed1ec062eef635b8e629b0e2001850
              this.dismountVehicle(entity);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 5dc5c12f341282f296082ce9c972808b8f155b1d..4ce8bdb30e24822273d6c608c8a2002877fa99fc 100644
+index 744d8c049e753c0e07cf064597a086ccf6d3f3ea..22ca888f0ec650616c098c8ffedfde5ea32ea4cb 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1092,9 +1092,11 @@ public abstract class Player extends LivingEntity {
+@@ -1094,9 +1094,11 @@ public abstract class Player extends LivingEntity {
          return -0.35D;
      }
  

--- a/patches/server/0395-Dead-Player-s-shouldn-t-be-able-to-move.patch
+++ b/patches/server/0395-Dead-Player-s-shouldn-t-be-able-to-move.patch
@@ -7,10 +7,10 @@ This fixes a lot of game state issues where packets were delayed for processing
 due to 1.15's new queue but processed while dead.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 4ce8bdb30e24822273d6c608c8a2002877fa99fc..d8f4dc4b6b923e70c70e9c607cda2c19c372fa75 100644
+index 22ca888f0ec650616c098c8ffedfde5ea32ea4cb..4a49c06bdae9f2dd684743f434d96817d472de06 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1102,7 +1102,7 @@ public abstract class Player extends LivingEntity {
+@@ -1104,7 +1104,7 @@ public abstract class Player extends LivingEntity {
  
      @Override
      protected boolean isImmobile() {


### PR DESCRIPTION
There's two fixes here:

1. A NPE which can be triggered by a creative player giving themselves a map with no id.
2. Unnecessary map lookup when the id is less than 0, which CraftBukkit conveniently returns instead of null in getMapId.