### PR TITLE
Fix unreliable entities pushed by pistons

### DIFF
--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -124,26 +124,28 @@ index ae2606215a43a49b5e65052c407df715f260e400..60de95d72ca4e4b2e12a2b3363c59a08
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1d8eb407c892e4c635f11070036013587a9264cb..3c5724251f64c5960f2c4cba2223c5ef55970775 100644
+index 1d8eb407c892e4c635f11070036013587a9264cb..4510c7da6dcc07a11904579f70dab80151acb80e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -326,6 +326,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -326,6 +326,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public final org.spigotmc.ActivationRange.ActivationType activationType = org.spigotmc.ActivationRange.initializeEntityActivationType(this);
      public final boolean defaultActivationState;
      public long activatedTick = Integer.MIN_VALUE;
++    public long activatedImmunityTick = Integer.MIN_VALUE; // Paper
 +    public boolean isTemporarilyActive = false; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
-@@ -767,6 +768,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -767,6 +769,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
-+                this.activatedTick = MinecraftServer.currentTick + 20; // Paper
++                this.activatedTick = Math.max(this.activatedTick, MinecraftServer.currentTick + 20); // Paper
++                this.activatedImmunityTick = Math.max(this.activatedImmunityTick, MinecraftServer.currentTick + 20);   // Paper
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -779,6 +781,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -779,6 +783,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }
@@ -333,8 +335,23 @@ index af0dd46e352115d1984f07fff746c7ad41486ac2..fb6da4bccd33b9e079f4bcf84f8ff59a
      public boolean populating;
      public final org.spigotmc.SpigotWorldConfig spigotConfig; // Spigot
  
+diff --git a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
+index 9b631698d1c736f61e07a5a1253127f4081dc90d..f18b20f94b4d2d7f07a70414834b3b284f65da78 100644
+--- a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
+@@ -140,6 +140,10 @@ public class PistonMovingBlockEntity extends BlockEntity {
+                                 }
+ 
+                                 entity.setDeltaMovement(e, g, h);
++                                // Paper - EAR items stuck in in slime pushed by a piston
++                                entity.activatedTick = Math.max(entity.activatedTick, net.minecraft.server.MinecraftServer.currentTick + 10); 
++                                entity.activatedImmunityTick = Math.max(entity.activatedImmunityTick, net.minecraft.server.MinecraftServer.currentTick + 10); 
++                                // Paper end
+                                 break;
+                             }
+                         }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d734cd7beaa 100644
+index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2574ccd92c43f56e8be71f1bf6857c761a72a510 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -1,39 +1,51 @@
@@ -509,7 +526,7 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
  
              world.getEntities().get(maxBB, ActivationRange::activateEntity);
          }
-@@ -162,56 +238,105 @@ public class ActivationRange
+@@ -162,56 +238,108 @@ public class ActivationRange
       * @param entity
       * @return
       */
@@ -524,6 +541,9 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
 +        }
 +        if (entity.remainingFireTicks > 0) {
 +            return 2;
++        }
++        if (entity.activatedImmunityTick >= MinecraftServer.currentTick) {
++            return 1;
 +        }
 +        long inactiveFor = MinecraftServer.currentTick - entity.activatedTick;
 +        // Paper end
@@ -562,7 +582,8 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
              {
 -                return true;
 +                return 20; // Paper
-+            }
+             }
+-            if ( entity instanceof Villager && ( (Villager) entity ).canBreed() )
 +            // Paper start
 +            if (entity instanceof Bee) {
 +                Bee bee = (Bee)entity;
@@ -590,8 +611,7 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
 +                        return config.villagersWorkImmunityFor;
 +                    }
 +                }
-             }
--            if ( entity instanceof Villager && ( (Villager) entity ).canBreed() )
++            }
 +            if ( entity instanceof Llama && ( (Llama) entity ).inCaravan() )
              {
 -                return true;
@@ -631,7 +651,7 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
      }
  
      /**
-@@ -226,8 +351,19 @@ public class ActivationRange
+@@ -226,8 +354,19 @@ public class ActivationRange
          if ( entity instanceof FireworkRocketEntity ) {
              return true;
          }
@@ -652,7 +672,7 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2ab585a018290996e7fa9ca6f3ad7d73
  
          // Should this entity tick?
          if ( !isActive )
-@@ -235,15 +371,19 @@ public class ActivationRange
+@@ -235,15 +374,19 @@ public class ActivationRange
              if ( ( MinecraftServer.currentTick - entity.activatedTick - 1 ) % 20 == 0 )
              {
                  // Check immunities every 20 ticks.

--- a/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3c5724251f64c5960f2c4cba2223c5ef55970775..ad9098cf2e12d400f2e4ae0a9740c497423f8de3 100644
+index 4510c7da6dcc07a11904579f70dab80151acb80e..9a96db211fe19e92f4fae8b007e8be2d899d8f09 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3007,6 +3007,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3009,6 +3009,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              BlockPos blockposition1;
  
              if (flag1) {

--- a/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -21,18 +21,18 @@ index f2e4939c8144b9bc7441130302ab3e2358c42063..3d14a7dbcc6bc46141596a7e04f790bf
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ad9098cf2e12d400f2e4ae0a9740c497423f8de3..7ce969911723d34c0027c063c184fa392d09fc12 100644
+index 9a96db211fe19e92f4fae8b007e8be2d899d8f09..8ac6bf93ab35062a1325b099a695fea1ba154a1d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -328,6 +328,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
-     public long activatedTick = Integer.MIN_VALUE;
+@@ -329,6 +329,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+     public long activatedImmunityTick = Integer.MIN_VALUE; // Paper
      public boolean isTemporarilyActive = false; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
 +    public boolean fromNetherPortal; // Paper
      protected int numCollisions = 0; // Paper
      public void inactiveTick() { }
      // Spigot end
-@@ -1884,6 +1885,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1886,6 +1887,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -42,7 +42,7 @@ index ad9098cf2e12d400f2e4ae0a9740c497423f8de3..7ce969911723d34c0027c063c184fa39
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2025,6 +2029,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2027,6 +2031,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
+++ b/patches/server/0418-Load-Chunks-for-Login-Asynchronously.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e81aeb4811064a8868f29e854635b3ba62509eea..7424def8aa625d1a11c3fdc4f6f4128e579c108b 100644
+index 73dc7394a7209a8cd1eec40115cb6e7828f1dbd6..30f8f4a8314c849a66143a545c1af3440965c6aa 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -178,6 +178,7 @@ public class ServerPlayer extends Player {
@@ -244,10 +244,10 @@ index 9609579e6d61c3975740d07a394680aeef952516..6b23b9389ff92ae8016d4adb289ac2a0
          Iterator iterator = list.iterator();
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c3f5a6b688873fa416408dd50935ba10d9cc594c..0d8092357a442fb113d53320a7a66c9fb87b5567 100644
+index 079e8f0f7ec5c3566b6778f5d518061a08699872..ebf7a58c6af5f5573d97c730c50c69a9f8140a6d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1511,7 +1511,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1513,7 +1513,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          this.yo = y;
          this.zo = d4;
          this.setPos(d3, y, d4);

--- a/patches/server/0419-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0419-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0d8092357a442fb113d53320a7a66c9fb87b5567..9f2428e6e878d596cb1a1188665b9159abddb57b 100644
+index ebf7a58c6af5f5573d97c730c50c69a9f8140a6d..a6e90cfaae38b9e4db812b7338dd0738608cae27 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2002,9 +2002,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2004,9 +2004,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
                      bworld = server.getWorld(worldName);
                  }
  

--- a/patches/server/0424-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0424-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9f2428e6e878d596cb1a1188665b9159abddb57b..75abebd72ec4bb67e1e8112fcc5c05a7acc0383e 100644
+index a6e90cfaae38b9e4db812b7338dd0738608cae27..9c5a475c221261482bcfe6495a53d76ffa7c1e5c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2151,11 +2151,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2153,11 +2153,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index 9f2428e6e878d596cb1a1188665b9159abddb57b..75abebd72ec4bb67e1e8112fcc5c05a7
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -2897,6 +2898,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2899,6 +2900,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, BlockPos location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index 9f2428e6e878d596cb1a1188665b9159abddb57b..75abebd72ec4bb67e1e8112fcc5c05a7
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -2917,6 +2924,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2919,6 +2926,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index 9f2428e6e878d596cb1a1188665b9159abddb57b..75abebd72ec4bb67e1e8112fcc5c05a7
                  Entity entity = this.getType().create((Level) worldserver);
  
                  if (entity != null) {
-@@ -2930,10 +2942,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2932,10 +2944,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index 9f2428e6e878d596cb1a1188665b9159abddb57b..75abebd72ec4bb67e1e8112fcc5c05a7
                      // CraftBukkit end
                  }
  
-@@ -3058,7 +3066,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3060,7 +3068,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      public boolean canChangeDimensions() {
@@ -102,7 +102,7 @@ index bbde9b758643c087733064a126d90689d71830cf..069cdfce085909991a69ebec3004d407
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8e63b18f455e57ba4ccd4a73ee9be1cb14857b61..771632c9bc5c352e894dc6cb99fd73bc07c3a9e7 100644
+index 0cdcb8adf6879c08c88615023446acaf2282fbce..d49627866c9151ffe4be3eef3d944f0a7b3e8ffe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -822,7 +822,8 @@ public class CraftEventFactory {

--- a/patches/server/0432-Use-distance-map-to-optimise-entity-tracker.patch
+++ b/patches/server/0432-Use-distance-map-to-optimise-entity-tracker.patch
@@ -288,7 +288,7 @@ index e7c78106aa34d948a77cf72d5716e17d10beae72..073aa637fcaf14a5ae8b203604d75b74
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 75abebd72ec4bb67e1e8112fcc5c05a7acc0383e..65d91af42196d51e28afb9c20b87ac9a73f751b1 100644
+index 9c5a475c221261482bcfe6495a53d76ffa7c1e5c..e07011898143b04090cb7ea4b3f4fd9c255209de 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -50,6 +50,7 @@ import net.minecraft.network.syncher.EntityDataSerializers;
@@ -299,7 +299,7 @@ index 75abebd72ec4bb67e1e8112fcc5c05a7acc0383e..65d91af42196d51e28afb9c20b87ac9a
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
-@@ -343,6 +344,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -344,6 +345,21 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
      // CraftBukkit end
  

--- a/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0459-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -81,10 +81,10 @@ index 4eac07022a7d896ee8921afa6d35cba7f0c89941..dd50a29d47a62df8cdfd69358218d155
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-index 9b631698d1c736f61e07a5a1253127f4081dc90d..87bedba9ab495edcce289c6665271d92b7165944 100644
+index f18b20f94b4d2d7f07a70414834b3b284f65da78..7b987071405229678f10a75e49786f5055026521 100644
 --- a/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/piston/PistonMovingBlockEntity.java
-@@ -281,7 +281,7 @@ public class PistonMovingBlockEntity extends BlockEntity {
+@@ -285,7 +285,7 @@ public class PistonMovingBlockEntity extends BlockEntity {
                  if (blockEntity.movedState != null && world.getBlockState(pos).is(Blocks.MOVING_PISTON)) {
                      BlockState blockState = Block.updateFromNeighbourShapes(blockEntity.movedState, world, pos);
                      if (blockState.isAir()) {

--- a/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0467-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 65d91af42196d51e28afb9c20b87ac9a73f751b1..0a4e6317178c3a2c96d945c014c54a1fcab4e2ae 100644
+index e07011898143b04090cb7ea4b3f4fd9c255209de..dbaa4167eab3aa21089c55e866e24efec9577f6f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -559,8 +559,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -560,8 +560,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      public void setPos(double x, double y, double z) {
@@ -19,7 +19,7 @@ index 65d91af42196d51e28afb9c20b87ac9a73f751b1..0a4e6317178c3a2c96d945c014c54a1f
      }
  
      protected AABB makeBoundingBox() {
-@@ -3740,6 +3740,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3742,6 +3742,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index 65d91af42196d51e28afb9c20b87ac9a73f751b1..0a4e6317178c3a2c96d945c014c54a1f
          if (this.position.x != x || this.position.y != y || this.position.z != z) {
              this.position = new Vec3(x, y, z);
              int i = Mth.floor(x);
-@@ -3758,6 +3763,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3760,6 +3765,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              }
          }
  

--- a/patches/server/0468-Optimize-WorldBorder-collision-checks-and-air.patch
+++ b/patches/server/0468-Optimize-WorldBorder-collision-checks-and-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize WorldBorder collision checks and air
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 0a4e6317178c3a2c96d945c014c54a1fcab4e2ae..5bd575b776d2df5a84259508a62aa97eabb2b7d4 100644
+index dbaa4167eab3aa21089c55e866e24efec9577f6f..7ac6a5fa2401dab160881a6c2d8cea09d0653ade 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1044,7 +1044,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1046,7 +1046,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          AABB axisalignedbb = this.getBoundingBox();
          CollisionContext voxelshapecollision = CollisionContext.of(this);
          VoxelShape voxelshape = this.level.getWorldBorder().getCollisionShape();

--- a/patches/server/0482-Add-entity-liquid-API.patch
+++ b/patches/server/0482-Add-entity-liquid-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add entity liquid API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5bd575b776d2df5a84259508a62aa97eabb2b7d4..3e951522169fcb071cc578e8bd9a78baa10f4e4d 100644
+index 7ac6a5fa2401dab160881a6c2d8cea09d0653ade..4e1ebc2e40e65925f7b65a65107f14516b58b0ba 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1339,7 +1339,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1341,7 +1341,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
          return this.isInWater() || this.isInRain();
      }
  

--- a/patches/server/0523-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0523-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index b7454592b9cee09f41631db6664cb18e2f890479..b45f79e83fc033424472b4044ab15a8c
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3e951522169fcb071cc578e8bd9a78baa10f4e4d..c94cbd22e465e22cfd66f24c2b0c3858a630f5a4 100644
+index 4e1ebc2e40e65925f7b65a65107f14516b58b0ba..bdcdf3fc5f471d0a5db7f892537cfb596bf83136 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -152,6 +152,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -42,7 +42,7 @@ index 3e951522169fcb071cc578e8bd9a78baa10f4e4d..c94cbd22e465e22cfd66f24c2b0c3858
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1542,6 +1543,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1544,6 +1545,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0528-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0528-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c94cbd22e465e22cfd66f24c2b0c3858a630f5a4..1183406a0c69bb79a51d31480cc5ed17ca317444 100644
+index bdcdf3fc5f471d0a5db7f892537cfb596bf83136..6e0e4ff1ed9594d7f4fb9c78f7c02975c8741806 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3932,4 +3932,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3934,4 +3934,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0530-Entity-isTicking.patch
+++ b/patches/server/0530-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1183406a0c69bb79a51d31480cc5ed17ca317444..60acf347cb5f4fc2e0cab18c5d9b5f4c2dd5121d 100644
+index 6e0e4ff1ed9594d7f4fb9c78f7c02975c8741806..33eb15d2b42331808334bd584de7b15b035ae7ed 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -52,6 +52,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 1183406a0c69bb79a51d31480cc5ed17ca317444..60acf347cb5f4fc2e0cab18c5d9b5f4c
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -3937,5 +3938,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3939,5 +3940,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0561-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0561-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -21,10 +21,10 @@ index 935bb237f8ecd63ca4cec64a7c7a341c9d3358e5..208690ceca2485b54acde5123ba494d7
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 60acf347cb5f4fc2e0cab18c5d9b5f4c2dd5121d..41ee12693e87383a0fc1c95b3d68daf22e3545cf 100644
+index 33eb15d2b42331808334bd584de7b15b035ae7ed..025d4922142a5b24d69b93e7f5e0aaf7d2ec5719 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1723,6 +1723,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1725,6 +1725,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      public boolean isPushable() {

--- a/patches/server/0568-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0568-MC-4-Fix-item-position-desync.patch
@@ -41,10 +41,10 @@ index b30c08bfb8c55161543a4ef09f2e462e0a1fe4ae..ec93f5300cc7d423ec0d292f0f8443f9
  
      public Vec3 updateEntityPosition(Vec3 orig) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 41ee12693e87383a0fc1c95b3d68daf22e3545cf..37589ece33e787720e9f6bd4c403ac6366893d2d 100644
+index 025d4922142a5b24d69b93e7f5e0aaf7d2ec5719..7177f6af0f05ed35a6fec1cabdf10fc3512b97fa 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3759,6 +3759,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3761,6 +3761,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
      public final void setPosRaw(double x, double y, double z, boolean forceBoundingBoxUpdate) {
          // Paper end

--- a/patches/server/0601-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0601-Collision-option-for-requiring-a-player-participant.patch
@@ -28,10 +28,10 @@ index 4227e7fc46e22265316b42bbdb166d60e5aed94e..3d16e4a6bf842a209c760fd89f8edf99
      public int wanderingTraderSpawnDayTicks = 24000;
      public int wanderingTraderSpawnChanceFailureIncrement = 25;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 37589ece33e787720e9f6bd4c403ac6366893d2d..9a59bec7878902a174ce8b2a45de6b2191dc96ac 100644
+index 7177f6af0f05ed35a6fec1cabdf10fc3512b97fa..9468b39f8c6a138aa345fd505124d5e79553a4dc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1606,6 +1606,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -1608,6 +1608,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0703-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0703-Fix-dangerous-end-portal-logic.patch
@@ -11,10 +11,10 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9a59bec7878902a174ce8b2a45de6b2191dc96ac..7c6bd61ebb87960c2d769f30c6f1543cee63ddf0 100644
+index 9468b39f8c6a138aa345fd505124d5e79553a4dc..f9b88b9d157af8ba7a3501e09ee27631d901407d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -361,6 +361,37 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -362,6 +362,37 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
      // Paper end - optimise entity tracking
  
@@ -52,7 +52,7 @@ index 9a59bec7878902a174ce8b2a45de6b2191dc96ac..7c6bd61ebb87960c2d769f30c6f1543c
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
          this.passengers = ImmutableList.of();
-@@ -2511,6 +2542,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -2513,6 +2544,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
              }
  
              this.processPortalCooldown();

--- a/patches/server/0741-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0741-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7c6bd61ebb87960c2d769f30c6f1543cee63ddf0..23ca6c3c59de9da965154a1c987d7dc0f960a67f 100644
+index f9b88b9d157af8ba7a3501e09ee27631d901407d..cdec0668ecbf9dea2551101cc3054dcc398d282a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3475,26 +3475,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+@@ -3477,26 +3477,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
      }
  
      private Stream<Entity> getIndirectPassengersStream() {


### PR DESCRIPTION
[resubmission of a corrected pull as I accidentally closed the previous #6301]

This patch solves #5189 where entities in slime blocks are unreliable
in PaperMC. This is known to break some contraptions like the ice road
maker mentionend there.

The removal of 1/4 of all ticks for an entity that takes place in
ActivationRange.checkIfActive() results in an entity like e.g.
an armor stand not noticing that it has had setDeltaMovement() called.
The result is that an armor stand inside a slime block gets left behind
1/4 of the pushes.

There were already some hard coded logic in checkIfActive to not apply
the culling in some circumstances. The attach patch takes a slightly
different approach and adds a general mechanism where the entity knows
how many ticks into the future that it has to be fully ticked and
ActivationRange queries that.

Another approach would be to just have a "wasMovedByPiston" memory in
the entity and have the timing logic in ActivationRange. I prepared a
patch for that as well in case that is preferable. All things being
equal I thought it better to submit the more general patch if more cases
of needing to temporarily override the tick culling.

As dicussed on the discord channel this patch does not affect the
configration option to not tick armor stands as that is handled
in ArmorStand.tick().