### PR TITLE
Add configurable height for slime spawn per world

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -49,4 +49,5 @@ MeFisto94 <MeFisto94@users.noreply.github.com>
 Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 LemonCaramel <admin@caramel.moe>
 Noah van der Aa <ndvdaa@gmail.com>
+Doc <nachito94@msn.com>
 ```

--- a/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Doc <nachito94@msn.com>
+Date: Mon, 2 Aug 2021 11:24:39 -0400
+Subject: [PATCH] Add configurable height for slime spawn
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index c334f29c69c1e6e3fe55cd6695e7df400cf36058..d8b917a0f81476b23a03052ae086fbe92996d886 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -345,6 +345,16 @@ public class PaperWorldConfig {
+         allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
+     }
+ 
++    public double slimeMaxSpawnHeightInSwamp;
++    public double slimeMinSpawnHeightInSwamp;
++    public double slimeMaxSpawnHeightInSlimeChunks;
++    private void slimeSpawnHeight() {
++        slimeMaxSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.maximum", 0.0D);
++        slimeMinSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.minimum", 0.0D);
++        slimeMaxSpawnHeightInSlimeChunks = getDouble("slime-spawn-height.slime-chunk.maximum", 0.0D);
++    }
++
++
+     public int portalSearchRadius;
+     public int portalCreateRadius;
+     public boolean portalSearchVanillaDimensionScaling;
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+index e1a593b464c35f68b22e84a09f99ee72af73da32..ae3c267429dac53c955b248bfc4dc5e4120cb527 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
+@@ -326,9 +326,13 @@ public class Slime extends Mob implements Enemy {
+ 
+     public static boolean checkSlimeSpawnRules(EntityType<Slime> type, LevelAccessor world, MobSpawnType spawnReason, BlockPos pos, Random random) {
+         if (world.getDifficulty() != Difficulty.PEACEFUL) {
+-            if (Objects.equals(world.getBiomeName(pos), Optional.of(Biomes.SWAMP)) && pos.getY() > 50 && pos.getY() < 70 && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
++            // Paper start - Replace rules for Height in Swamp Biome
++            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp > 0 ? world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp : 70;
++            final double minHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp > 0 ? world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp : 50;
++            if (Objects.equals(world.getBiomeName(pos), Optional.of(Biomes.SWAMP)) && pos.getY() > minHeightSwamp && pos.getY() < maxHeightSwamp && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
+                 return checkMobSpawnRules(type, world, spawnReason, pos, random);
+             }
++            // Paper end
+ 
+             if (!(world instanceof WorldGenLevel)) {
+                 return false;
+@@ -337,9 +341,12 @@ public class Slime extends Mob implements Enemy {
+             ChunkPos chunkcoordintpair = new ChunkPos(pos);
+             boolean flag = world.getMinecraftWorld().paperConfig.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(chunkcoordintpair.x, chunkcoordintpair.z, ((WorldGenLevel) world).getSeed(), world.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Spigot // Paper
+ 
+-            if (random.nextInt(10) == 0 && flag && pos.getY() < 40) {
++            // Paper start - Replace rules for Height in Slime Chunks
++            final double maxHeightSlimeChunk = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks > 0 ? world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks : 40;
++            if (random.nextInt(10) == 0 && flag && pos.getY() < maxHeightSlimeChunk) {
+                 return checkMobSpawnRules(type, world, spawnReason, pos, random);
+             }
++            // Paper end
+         }
+ 
+         return false;

--- a/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
@@ -38,9 +38,9 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee1
 +            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp;
 +            final double minHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp;
 +            if (Objects.equals(world.getBiomeName(pos), Optional.of(Biomes.SWAMP)) && pos.getY() > minHeightSwamp && pos.getY() < maxHeightSwamp && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
++            // Paper end
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }
-+            // Paper end
  
              if (!(world instanceof WorldGenLevel)) {
                  return false;
@@ -52,9 +52,9 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee1
 +            // Paper start - Replace rules for Height in Slime Chunks
 +            final double maxHeightSlimeChunk = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks;
 +            if (random.nextInt(10) == 0 && flag && pos.getY() < maxHeightSlimeChunk) {
++            // Paper end
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }
-+            // Paper end
          }
  
          return false;

--- a/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0738-Add-configurable-height-for-slime-spawn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add configurable height for slime spawn
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c334f29c69c1e6e3fe55cd6695e7df400cf36058..d8b917a0f81476b23a03052ae086fbe92996d886 100644
+index c334f29c69c1e6e3fe55cd6695e7df400cf36058..ab50da2a07dff960a73d0fb47849624f302cb09c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -345,6 +345,16 @@ public class PaperWorldConfig {
@@ -16,9 +16,9 @@ index c334f29c69c1e6e3fe55cd6695e7df400cf36058..d8b917a0f81476b23a03052ae086fbe9
 +    public double slimeMinSpawnHeightInSwamp;
 +    public double slimeMaxSpawnHeightInSlimeChunks;
 +    private void slimeSpawnHeight() {
-+        slimeMaxSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.maximum", 0.0D);
-+        slimeMinSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.minimum", 0.0D);
-+        slimeMaxSpawnHeightInSlimeChunks = getDouble("slime-spawn-height.slime-chunk.maximum", 0.0D);
++        slimeMaxSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.maximum", 70);
++        slimeMinSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.minimum", 50);
++        slimeMaxSpawnHeightInSlimeChunks = getDouble("slime-spawn-height.slime-chunk.maximum", 40);
 +    }
 +
 +
@@ -26,7 +26,7 @@ index c334f29c69c1e6e3fe55cd6695e7df400cf36058..d8b917a0f81476b23a03052ae086fbe9
      public int portalCreateRadius;
      public boolean portalSearchVanillaDimensionScaling;
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index e1a593b464c35f68b22e84a09f99ee72af73da32..ae3c267429dac53c955b248bfc4dc5e4120cb527 100644
+index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee169a70fb3 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
 @@ -326,9 +326,13 @@ public class Slime extends Mob implements Enemy {
@@ -35,8 +35,8 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..ae3c267429dac53c955b248bfc4dc5e4
          if (world.getDifficulty() != Difficulty.PEACEFUL) {
 -            if (Objects.equals(world.getBiomeName(pos), Optional.of(Biomes.SWAMP)) && pos.getY() > 50 && pos.getY() < 70 && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
 +            // Paper start - Replace rules for Height in Swamp Biome
-+            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp > 0 ? world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp : 70;
-+            final double minHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp > 0 ? world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp : 50;
++            final double maxHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSwamp;
++            final double minHeightSwamp = world.getMinecraftWorld().paperConfig.slimeMinSpawnHeightInSwamp;
 +            if (Objects.equals(world.getBiomeName(pos), Optional.of(Biomes.SWAMP)) && pos.getY() > minHeightSwamp && pos.getY() < maxHeightSwamp && random.nextFloat() < 0.5F && random.nextFloat() < world.getMoonBrightness() && world.getMaxLocalRawBrightness(pos) <= random.nextInt(8)) {
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }
@@ -50,7 +50,7 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..ae3c267429dac53c955b248bfc4dc5e4
  
 -            if (random.nextInt(10) == 0 && flag && pos.getY() < 40) {
 +            // Paper start - Replace rules for Height in Slime Chunks
-+            final double maxHeightSlimeChunk = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks > 0 ? world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks : 40;
++            final double maxHeightSlimeChunk = world.getMinecraftWorld().paperConfig.slimeMaxSpawnHeightInSlimeChunks;
 +            if (random.nextInt(10) == 0 && flag && pos.getY() < maxHeightSlimeChunk) {
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }

--- a/patches/server/0849-Add-configurable-height-for-slime-spawn.patch
+++ b/patches/server/0849-Add-configurable-height-for-slime-spawn.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable height for slime spawn
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c334f29c69c1e6e3fe55cd6695e7df400cf36058..ab50da2a07dff960a73d0fb47849624f302cb09c 100644
+index cd5a7bac92a1e733d69340f09bc35906138a6ce3..c6aa0bef1e7b9c30c0bd2d466d368ab38690246c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -345,6 +345,16 @@ public class PaperWorldConfig {
+@@ -423,6 +423,16 @@ public class PaperWorldConfig {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
  
@@ -16,9 +16,9 @@ index c334f29c69c1e6e3fe55cd6695e7df400cf36058..ab50da2a07dff960a73d0fb47849624f
 +    public double slimeMinSpawnHeightInSwamp;
 +    public double slimeMaxSpawnHeightInSlimeChunks;
 +    private void slimeSpawnHeight() {
-+        slimeMaxSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.maximum", 70);
-+        slimeMinSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.minimum", 50);
-+        slimeMaxSpawnHeightInSlimeChunks = getDouble("slime-spawn-height.slime-chunk.maximum", 40);
++        slimeMaxSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.maximum", this.slimeMaxSpawnHeightInSwamp);
++        slimeMinSpawnHeightInSwamp = getDouble("slime-spawn-height.swamp-biome.minimum", this.slimeMinSpawnHeightInSwamp);
++        slimeMaxSpawnHeightInSlimeChunks = getDouble("slime-spawn-height.slime-chunk.maximum", this.slimeMaxSpawnHeightInSlimeChunks);
 +    }
 +
 +
@@ -26,10 +26,10 @@ index c334f29c69c1e6e3fe55cd6695e7df400cf36058..ab50da2a07dff960a73d0fb47849624f
      public int portalCreateRadius;
      public boolean portalSearchVanillaDimensionScaling;
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Slime.java b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee169a70fb3 100644
+index 5722d9b30223fb229b80f54d7fb9edf41254a7f7..9c440625ce89686b2c250e6aaa62ed83b7015412 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Slime.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Slime.java
-@@ -326,9 +326,13 @@ public class Slime extends Mob implements Enemy {
+@@ -327,7 +327,11 @@ public class Slime extends Mob implements Enemy {
  
      public static boolean checkSlimeSpawnRules(EntityType<Slime> type, LevelAccessor world, MobSpawnType spawnReason, BlockPos pos, Random random) {
          if (world.getDifficulty() != Difficulty.PEACEFUL) {
@@ -42,9 +42,7 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee1
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }
  
-             if (!(world instanceof WorldGenLevel)) {
-                 return false;
-@@ -337,9 +341,12 @@ public class Slime extends Mob implements Enemy {
+@@ -338,7 +342,10 @@ public class Slime extends Mob implements Enemy {
              ChunkPos chunkcoordintpair = new ChunkPos(pos);
              boolean flag = world.getMinecraftWorld().paperConfig.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(chunkcoordintpair.x, chunkcoordintpair.z, ((WorldGenLevel) world).getSeed(), world.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Spigot // Paper
  
@@ -56,5 +54,3 @@ index e1a593b464c35f68b22e84a09f99ee72af73da32..9c95c5e8550b48baad84be9e97be7ee1
                  return checkMobSpawnRules(type, world, spawnReason, pos, random);
              }
          }
- 
-         return false;


### PR DESCRIPTION
This PR (resolve #6305) allow configure height limits to the slime spawn based in the current rules from vanilla:

- Min height in Swamp Biomes
- Max height in Swamp Biomes
- Max height  in Slime Chunks

Docs: PaperMC/PaperDocs#106