### PR TITLE
Expose tracked entities

### DIFF
--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKooks <superkooks@superkooks.com>
+Date: Wed, 4 Aug 2021 18:05:01 +1000
+Subject: [PATCH] Expose tracked entities
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
+index 42fd259f4492e539112b5bcb310aaaadab58a443..eb412fac2e4ad7e292eaf9fee39acdfd87c2d775 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
+@@ -2279,7 +2279,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+ 
+         final ServerEntity serverEntity;
+         final Entity entity;
+-        private final int range;
++        public final int range; // Paper - expose range to entities
+         SectionPos lastSectionPos;
+         public final Set<ServerPlayerConnection> seenBy = Sets.newIdentityHashSet();
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..7b29369b7972488ca6bf68d2625bf3e9183632f9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2375,6 +2375,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // Paper start
++    @Override
++    public <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(Class<T> entityClass) {
++        if (entityClass.equals(Player.class)) {
++            return (Set<T>) getTrackedPlayers();
++        }
++
++        if (entity.tracker == null) {
++            return java.util.Collections.<T>emptySet();
++        }
++
++        Collection<org.bukkit.entity.Entity> entities = getLocation().getWorld().getNearbyEntities(getLocation(),
++            entity.tracker.range, entity.tracker.range, entity.tracker.range);
++
++        Set<T> output = new HashSet<>();
++        for (org.bukkit.entity.Entity e : entities) {
++            if (entityClass.isInstance(e)) {
++                output.add((T)entity);
++            }
++        }
++
++        return output;
++    }
++    // Paper end
++
+     // Spigot start
+     private final Player.Spigot spigot = new Player.Spigot()
+     {


### PR DESCRIPTION
Provides a method for getting entities within the tracking range of a player. The results can be filtered by class. Resolves #5300.