### PR TITLE
Expose tracked entities

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -235,4 +235,4 @@ public net.minecraft.world.level.entity.PersistentEntitySectionManager sectionSt
 public-f net.minecraft.world.level.chunk.DataLayer
 
 # Expose tracked entities
-public net.minecraft.server.level.ChunkMap.TrackedEntity range
+public net.minecraft.server.level.ChunkMap$TrackedEntity range

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -235,4 +235,4 @@ public net.minecraft.world.level.entity.PersistentEntitySectionManager sectionSt
 public-f net.minecraft.world.level.chunk.DataLayer
 
 # Expose tracked entities
-public-f net.minecraft.server.level.ChunkMap.TrackedEntity range
+public net.minecraft.server.level.ChunkMap.TrackedEntity range

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -235,4 +235,4 @@ public net.minecraft.world.level.entity.PersistentEntitySectionManager sectionSt
 public-f net.minecraft.world.level.chunk.DataLayer
 
 # Expose tracked entities
-public net.minecraft.server.level.ChunkMap.TrackedEntity range
+public-f net.minecraft.server.level.ChunkMap.TrackedEntity range

--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -233,3 +233,6 @@ public net.minecraft.world.level.entity.PersistentEntitySectionManager sectionSt
 
 # Optimize light engine
 public-f net.minecraft.world.level.chunk.DataLayer
+
+# Expose tracked entities
+public net.minecraft.server.level.ChunkMap.TrackedEntity range

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -5,18 +5,10 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..cf07aa6aa23cdbc893b23e1acfe0bf420c49931e 100644
+index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..521edf8201d074acf9703391180d1a606989efcf 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
- 
- import java.net.InetSocketAddress;
- import java.util.Set; // Paper
-+import java.util.Collection; // Paper
- import java.util.UUID;
- import com.destroystokyo.paper.ClientOption; // Paper
- import com.destroystokyo.paper.Title; // Paper
-@@ -2050,6 +2051,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2050,6 +2050,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      Set<Player> getTrackedPlayers();
      // Paper end
  
@@ -27,7 +19,7 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..cf07aa6aa23cdbc893b23e1acfe0bf42
 +     * @return The filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(@NotNull Class<T> entityClass);
++    <T extends org.bukkit.entity.Entity> java.util.Collection<? extends T> getTrackedEntities(@NotNull Class<T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -16,7 +16,7 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c1
 +    /**
 +     * Gets entities within this player's tracking range (that the player's client can "see")
 +     * @param entityClass The class of entities to filter for
-+     * @return Returns the filtered set of entities
++     * @return The filtered set of entities
 +     */
 +    @NotNull
 +    <T extends org.bukkit.entity.Entity> Set<? extends T> getTrackedEntities(@Nullable Class<? extends T> entityClass);

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..1a63144cd001a6b9d1ddf37ba795d7fb2e94c9ee 100644
+index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..cf07aa6aa23cdbc893b23e1acfe0bf420c49931e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -27,7 +27,7 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..1a63144cd001a6b9d1ddf37ba795d7fb
 +     * @return The filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(@NotNull Class<? extends T> entityClass);
++    <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(@NotNull Class<T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKooks <superkooks@superkooks.com>
+Date: Wed, 4 Aug 2021 18:18:52 +1000
+Subject: [PATCH] Expose tracked entities
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c16215d77c 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2050,6 +2050,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     Set<Player> getTrackedPlayers();
+     // Paper end
+ 
++    // Paper start
++    /**
++     * Gets entities within this player's tracking range (that the player's client can "see")
++     * @param entityClass The class of entities to filter for
++     * @return Returns the filtered set of entities
++     */
++    @NotNull
++    <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(@Nullable Class<T> entityClass);
++    // Paper end
++
+     // Spigot start
+     public class Spigot extends Entity.Spigot {
+ 

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -19,7 +19,7 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c1
 +     * @return Returns the filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(@Nullable Class<T> entityClass);
++    <T extends org.bukkit.entity.Entity> Set<? extends T> getTrackedEntities(@Nullable Class<? extends T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..8c1368e09c590cd80f7c6829728bc7d329086ec4 100644
+index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..1a63144cd001a6b9d1ddf37ba795d7fb2e94c9ee 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -27,7 +27,7 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..8c1368e09c590cd80f7c6829728bc7d3
 +     * @return The filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Collection<T> getTrackedEntities(@NotNull Class<T> entityClass);
++    <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(@NotNull Class<? extends T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -16,10 +16,10 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c1
 +    /**
 +     * Gets entities within this player's tracking range (that the player's client can "see")
 +     * @param entityClass The class of entities to filter for
-+     * @return The filtered set of entities
++     * @return Returns the filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Set<? extends T> getTrackedEntities(@Nullable Class<? extends T> entityClass);
++    <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(@Nullable Class<T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/api/0327-Expose-tracked-entities.patch
+++ b/patches/api/0327-Expose-tracked-entities.patch
@@ -5,10 +5,18 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c16215d77c 100644
+index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..8c1368e09c590cd80f7c6829728bc7d329086ec4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2050,6 +2050,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2,6 +2,7 @@ package org.bukkit.entity;
+ 
+ import java.net.InetSocketAddress;
+ import java.util.Set; // Paper
++import java.util.Collection; // Paper
+ import java.util.UUID;
+ import com.destroystokyo.paper.ClientOption; // Paper
+ import com.destroystokyo.paper.Title; // Paper
+@@ -2050,6 +2051,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      Set<Player> getTrackedPlayers();
      // Paper end
  
@@ -16,10 +24,10 @@ index 5e8814cc317a705eaf8bdd9f3876a5366c0a0226..22749f6c83f60c2038b5f7ba14d0e6c1
 +    /**
 +     * Gets entities within this player's tracking range (that the player's client can "see")
 +     * @param entityClass The class of entities to filter for
-+     * @return Returns the filtered set of entities
++     * @return The filtered set of entities
 +     */
 +    @NotNull
-+    <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(@Nullable Class<T> entityClass);
++    <T extends org.bukkit.entity.Entity> Collection<T> getTrackedEntities(@NotNull Class<T> entityClass);
 +    // Paper end
 +
      // Spigot start

--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: SuperKooks <superkooks@superkooks.com>
+Date: Wed, 4 Aug 2021 18:05:01 +1000
+Subject: [PATCH] Expose tracked entities
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
+index 42fd259f4492e539112b5bcb310aaaadab58a443..eb412fac2e4ad7e292eaf9fee39acdfd87c2d775 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
+@@ -2279,7 +2279,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
+ 
+         final ServerEntity serverEntity;
+         final Entity entity;
+-        private final int range;
++        public final int range; // Paper - expose range to entities
+         SectionPos lastSectionPos;
+         public final Set<ServerPlayerConnection> seenBy = Sets.newIdentityHashSet();
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..7b29369b7972488ca6bf68d2625bf3e9183632f9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -2375,6 +2375,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     }
+     // Paper end
+ 
++    // Paper start
++    @Override
++    public <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(Class<T> entityClass) {
++        if (entityClass.equals(Player.class)) {
++            return (Set<T>) getTrackedPlayers();
++        }
++
++        if (entity.tracker == null) {
++            return java.util.Collections.<T>emptySet();
++        }
++
++        Collection<org.bukkit.entity.Entity> entities = getLocation().getWorld().getNearbyEntities(getLocation(),
++            entity.tracker.range, entity.tracker.range, entity.tracker.range);
++
++        Set<T> output = new HashSet<>();
++        for (org.bukkit.entity.Entity e : entities) {
++            if (entityClass.isInstance(e)) {
++                output.add((T)entity);
++            }
++        }
++
++        return output;
++    }
++    // Paper end
++
+     // Spigot start
+     private final Player.Spigot spigot = new Player.Spigot()
+     {

--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -5,17 +5,18 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e8918d03b8213e5f6689fc93030138fd704aca9..2a376cb1c4883db02257099ef07c826393ef72d0 100644
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..33dcfe769d7261835842153a99c9c077297b2e14 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2375,6 +2375,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2375,6 +2375,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
 +    // Paper start
 +    @Override
-+    public <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(Class<? extends T> entityClass) {
-+        if (entityClass.equals(Player.class)) {
++    @SuppressWarnings("unchecked")
++    public <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(Class<T> entityClass) {
++        if (entityClass == Player.class) {
 +            return (Set<T>) getTrackedPlayers();
 +        }
 +

--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -4,19 +4,6 @@ Date: Wed, 4 Aug 2021 18:05:01 +1000
 Subject: [PATCH] Expose tracked entities
 
 
-diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 42fd259f4492e539112b5bcb310aaaadab58a443..eb412fac2e4ad7e292eaf9fee39acdfd87c2d775 100644
---- a/src/main/java/net/minecraft/server/level/ChunkMap.java
-+++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -2279,7 +2279,7 @@ Sections go from 0..16. Now whenever a section is not empty, it can potentially
- 
-         final ServerEntity serverEntity;
-         final Entity entity;
--        private final int range;
-+        public final int range; // Paper - expose range to entities
-         SectionPos lastSectionPos;
-         public final Set<ServerPlayerConnection> seenBy = Sets.newIdentityHashSet();
- 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 index 9e8918d03b8213e5f6689fc93030138fd704aca9..d0f472cb1ebc26e13abea855221414b976909476 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java

--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -18,35 +18,21 @@ index 42fd259f4492e539112b5bcb310aaaadab58a443..eb412fac2e4ad7e292eaf9fee39acdfd
          public final Set<ServerPlayerConnection> seenBy = Sets.newIdentityHashSet();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e8918d03b8213e5f6689fc93030138fd704aca9..7b29369b7972488ca6bf68d2625bf3e9183632f9 100644
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..d0f472cb1ebc26e13abea855221414b976909476 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2375,6 +2375,31 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2375,6 +2375,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  
 +    // Paper start
 +    @Override
-+    public <T extends org.bukkit.entity.Entity> Set<T> getTrackedEntities(Class<T> entityClass) {
++    public <T extends org.bukkit.entity.Entity> Collection<T> getTrackedEntities(Class<T> entityClass) {
 +        if (entityClass.equals(Player.class)) {
 +            return (Set<T>) getTrackedPlayers();
 +        }
 +
-+        if (entity.tracker == null) {
-+            return java.util.Collections.<T>emptySet();
-+        }
-+
-+        Collection<org.bukkit.entity.Entity> entities = getLocation().getWorld().getNearbyEntities(getLocation(),
-+            entity.tracker.range, entity.tracker.range, entity.tracker.range);
-+
-+        Set<T> output = new HashSet<>();
-+        for (org.bukkit.entity.Entity e : entities) {
-+            if (entityClass.isInstance(e)) {
-+                output.add((T)entity);
-+            }
-+        }
-+
-+        return output;
++        return getWorld().getNearbyEntitiesByType(entityClass, getLocation(), entity.tracker.range);
 +    }
 +    // Paper end
 +

--- a/patches/server/0738-Expose-tracked-entities.patch
+++ b/patches/server/0738-Expose-tracked-entities.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose tracked entities
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e8918d03b8213e5f6689fc93030138fd704aca9..d0f472cb1ebc26e13abea855221414b976909476 100644
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..2a376cb1c4883db02257099ef07c826393ef72d0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -2375,6 +2375,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -14,7 +14,7 @@ index 9e8918d03b8213e5f6689fc93030138fd704aca9..d0f472cb1ebc26e13abea855221414b9
  
 +    // Paper start
 +    @Override
-+    public <T extends org.bukkit.entity.Entity> Collection<T> getTrackedEntities(Class<T> entityClass) {
++    public <T extends org.bukkit.entity.Entity> Collection<? extends T> getTrackedEntities(Class<? extends T> entityClass) {
 +        if (entityClass.equals(Player.class)) {
 +            return (Set<T>) getTrackedPlayers();
 +        }


### PR DESCRIPTION
Provides a method for getting and filtering all entities within the tracking range of a Player. Resolves #5300 