### PR TITLE
Added and implemented OP level API.

### DIFF
--- a/patches/api/0327-Added-OP-level-API.patch
+++ b/patches/api/0327-Added-OP-level-API.patch
@@ -1,0 +1,75 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MCMDEV <john-m.1@gmx.de>
+Date: Thu, 5 Aug 2021 17:00:29 +0200
+Subject: [PATCH] Added OP level API
+
+
+diff --git a/src/main/java/org/bukkit/command/MessageCommandSender.java b/src/main/java/org/bukkit/command/MessageCommandSender.java
+index a7ef1f51c2b96617a32e6e7b1723e8770ba8a6a8..d7484f5c7c14ce68e280d10950b99b027e7b6fac 100644
+--- a/src/main/java/org/bukkit/command/MessageCommandSender.java
++++ b/src/main/java/org/bukkit/command/MessageCommandSender.java
+@@ -60,6 +60,18 @@ public interface MessageCommandSender extends CommandSender {
+         throw new NotImplementedException();
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    default int getOpLevel()    {
++        throw new NotImplementedException();
++    }
++
++    @Override
++    default void setOpLevel(int value)  {
++        throw new NotImplementedException();
++    }
++    //Paper end
++
+     @Override
+     default boolean isPermissionSet(@NotNull String name) {
+         throw new NotImplementedException();
+diff --git a/src/main/java/org/bukkit/permissions/PermissibleBase.java b/src/main/java/org/bukkit/permissions/PermissibleBase.java
+index c94e4cdb5785d5dfcb704c4adabda0b19a20ec7d..d738b3b49449cb8b5e8694000b9285fc2a8f1a57 100644
+--- a/src/main/java/org/bukkit/permissions/PermissibleBase.java
++++ b/src/main/java/org/bukkit/permissions/PermissibleBase.java
+@@ -49,6 +49,26 @@ public class PermissibleBase implements Permissible {
+         }
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        if (opable == null) {
++            return 0;
++        } else {
++            return opable.getOpLevel();
++        }
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        if (opable == null) {
++            throw new UnsupportedOperationException("Cannot change op value as no ServerOperator is set");
++        } else {
++            opable.setOpLevel(value);
++        }
++    }
++    //Paper end
++
+     @Override
+     public boolean isPermissionSet(@NotNull String name) {
+         if (name == null) {
+diff --git a/src/main/java/org/bukkit/permissions/ServerOperator.java b/src/main/java/org/bukkit/permissions/ServerOperator.java
+index 26ed24307b0c84e8946cf9f276012ea6d5219b9d..3762492c5bfedb4487197c7dffaa4d1d46411b2a 100644
+--- a/src/main/java/org/bukkit/permissions/ServerOperator.java
++++ b/src/main/java/org/bukkit/permissions/ServerOperator.java
+@@ -21,4 +21,10 @@ public interface ServerOperator {
+      * @param value New operator value
+      */
+     public void setOp(boolean value);
++
++    //Paper start - OP level API
++    public int getOpLevel();
++
++    public void setOpLevel(int value);
++    //Paper end
+ }

--- a/patches/api/0327-Added-OP-level-API.patch
+++ b/patches/api/0327-Added-OP-level-API.patch
@@ -59,17 +59,28 @@ index c94e4cdb5785d5dfcb704c4adabda0b19a20ec7d..d738b3b49449cb8b5e8694000b9285fc
      public boolean isPermissionSet(@NotNull String name) {
          if (name == null) {
 diff --git a/src/main/java/org/bukkit/permissions/ServerOperator.java b/src/main/java/org/bukkit/permissions/ServerOperator.java
-index 26ed24307b0c84e8946cf9f276012ea6d5219b9d..3762492c5bfedb4487197c7dffaa4d1d46411b2a 100644
+index 26ed24307b0c84e8946cf9f276012ea6d5219b9d..1e0f6b22fdefe515be046b7eee67124eed31106b 100644
 --- a/src/main/java/org/bukkit/permissions/ServerOperator.java
 +++ b/src/main/java/org/bukkit/permissions/ServerOperator.java
-@@ -21,4 +21,10 @@ public interface ServerOperator {
+@@ -21,4 +21,21 @@ public interface ServerOperator {
       * @param value New operator value
       */
      public void setOp(boolean value);
 +
 +    //Paper start - OP level API
-+    public int getOpLevel();
 +
-+    public void setOpLevel(int value);
++    /**
++     * Gets the op permission level of this object
++     *
++     * @return The current op permission level
++     */
++    int getOpLevel();
++
++    /**
++     * Sets the current op permission level of this object
++     *
++     * @param value New op permission level
++     */
++    void setOpLevel(int value);
 +    //Paper end
  }

--- a/patches/server/0739-Implemented-OP-level-API.patch
+++ b/patches/server/0739-Implemented-OP-level-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implemented OP level API
 
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
-index 918f5221e94cbc867349c69c83563e225d2fef1d..734e5305d2a059738df20ea9a72dad6ca6c5b810 100644
+index 918f5221e94cbc867349c69c83563e225d2fef1d..790357efd87f9c77597bcb97e79e7b61580aca82 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
 @@ -52,6 +52,17 @@ public class DedicatedPlayerList extends PlayerList {
@@ -13,11 +13,11 @@ index 918f5221e94cbc867349c69c83563e225d2fef1d..734e5305d2a059738df20ea9a72dad6c
      }
  
 +    // Paper start - OP level API
-+    public int getOperatorLevel(GameProfile profile)    {
++    public int getOperatorLevel(GameProfile profile)  {
 +        return this.getServer().getProfilePermissions(profile);
 +    }
 +
-+    public void setOperatorLevel(GameProfile profile, int value)    {
++    public void setOperatorLevel(GameProfile profile, int value)  {
 +        super.op(profile, value);
 +        this.saveOps();
 +    }
@@ -27,20 +27,21 @@ index 918f5221e94cbc867349c69c83563e225d2fef1d..734e5305d2a059738df20ea9a72dad6c
      public void reloadWhiteList() {
          this.loadWhiteList();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..03934348739d31cd41bf74992e59f344adf86669 100644
+index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..d9a572efe0298647755fb6e3a0e49be10dc745e0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -1124,15 +1124,20 @@ public abstract class PlayerList {
          return this.ipBans;
      }
  
-+    // Paper start - OP level API
-     public void op(GameProfile profile) {
+-    public void op(GameProfile profile) {
 -        this.ops.add(new ServerOpListEntry(profile, this.server.getOperatorUserPermissionLevel(), this.ops.canBypassPlayerLimit(profile)));
++    // Paper start - OP level API
++    public void op(GameProfile profile)  {
 +        this.op(profile, this.server.getOperatorUserPermissionLevel());
 +    }
 +
-+    public void op(GameProfile profile, int permissionLevel)    {
++    public void op(GameProfile profile, int permissionLevel)  {
 +        this.ops.add(new ServerOpListEntry(profile, permissionLevel, this.ops.canBypassPlayerLimit(profile)));
          ServerPlayer entityplayer = this.getPlayer(profile.getId());
  
@@ -54,7 +55,7 @@ index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..03934348739d31cd41bf74992e59f344
      public void deop(GameProfile profile) {
          this.ops.remove(profile);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
-index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..896fb655c7c0d24d6f6a85d319862eef4fde7317 100644
+index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..8147e7ffd278dd02419492666042309ff20ae2cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 @@ -96,6 +96,18 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
@@ -63,12 +64,12 @@ index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..896fb655c7c0d24d6f6a85d319862eef
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return this.server.getHandle().getOperatorLevel(profile);
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        this.server.getHandle().setOperatorLevel(profile, value);
 +    }
 +    //Paper end
@@ -77,7 +78,7 @@ index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..896fb655c7c0d24d6f6a85d319862eef
      public boolean isBanned() {
          if (this.getName() == null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
-index 83efca7144b4ce9cf7bd6bbbbf9c4426d2472315..657e7ca37dcc286210784d4f819e4e7203fafe84 100644
+index 83efca7144b4ce9cf7bd6bbbbf9c4426d2472315..1f9fbaa9b67ffd8554b8732f6677e6e711fc4079 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
 @@ -56,6 +56,18 @@ public class CraftBlockCommandSender extends ServerCommandSender implements Bloc
@@ -86,12 +87,12 @@ index 83efca7144b4ce9cf7bd6bbbbf9c4426d2472315..657e7ca37dcc286210784d4f819e4e72
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return 2;
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        throw new UnsupportedOperationException("Cannot change operator level of a block");
 +    }
 +    //Paper end
@@ -121,7 +122,7 @@ index 9383e2fd8469d3203e0fe91dfbb05eb8192bc082..740993519fab9c5837f6a11d78a57171
      public boolean beginConversation(Conversation conversation) {
          return this.conversationTracker.beginConversation(conversation);
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
-index a3194c8a425d1d808c76ebef9997478f4d399fe0..9e581483b9fadb3d24a20ebabb70d5d4d843383a 100644
+index a3194c8a425d1d808c76ebef9997478f4d399fe0..5e9c7a3bf9d54471aaf76361f32c13d2d6e0694a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
 @@ -40,6 +40,18 @@ public class CraftRemoteConsoleCommandSender extends ServerCommandSender impleme
@@ -130,12 +131,12 @@ index a3194c8a425d1d808c76ebef9997478f4d399fe0..9e581483b9fadb3d24a20ebabb70d5d4
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return 4;
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        throw new UnsupportedOperationException("Cannot change operator level of remote controller.");
 +    }
 +    //Paper end
@@ -144,7 +145,7 @@ index a3194c8a425d1d808c76ebef9997478f4d399fe0..9e581483b9fadb3d24a20ebabb70d5d4
      @Override
      public boolean hasPermission(String name) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
-index 53d6950ad270ba901de5226b9daecb683248ad05..50cbe53bad542d3a969a4e4b5e8a5c4d0208397a 100644
+index 53d6950ad270ba901de5226b9daecb683248ad05..f806b2e51e63a51072e2f916cb31190278f160ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
 @@ -132,6 +132,18 @@ public class ProxiedNativeCommandSender implements ProxiedCommandSender {
@@ -153,12 +154,12 @@ index 53d6950ad270ba901de5226b9daecb683248ad05..50cbe53bad542d3a969a4e4b5e8a5c4d
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return this.caller.getOpLevel();
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        this.caller.setOpLevel(value);
 +    }
 +    //Paper end
@@ -167,7 +168,7 @@ index 53d6950ad270ba901de5226b9daecb683248ad05..50cbe53bad542d3a969a4e4b5e8a5c4d
      @Override
      public org.bukkit.command.CommandSender.Spigot spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 85ca30aef0703db6859e66c62781ecfd334426e7..0761a26f877e7ae43410e170b39d537cefb9a2ab 100644
+index 85ca30aef0703db6859e66c62781ecfd334426e7..21029884c3158bced5707576508a89b5c23f127a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -998,6 +998,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -176,12 +177,12 @@ index 85ca30aef0703db6859e66c62781ecfd334426e7..0761a26f877e7ae43410e170b39d537c
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return CraftEntity.getPermissibleBase().getOpLevel();
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        CraftEntity.getPermissibleBase().setOpLevel(value);
 +    }
 +    //Paper end
@@ -196,12 +197,12 @@ index 85ca30aef0703db6859e66c62781ecfd334426e7..0761a26f877e7ae43410e170b39d537c
 +
 +                //Paper start - OP level API
 +                @Override
-+                public int getOpLevel() {
++                public int getOpLevel()  {
 +                    return 0;
 +                }
 +
 +                @Override
-+                public void setOpLevel(int value) {
++                public void setOpLevel(int value)  {
 +
 +                }
 +                //Paper end
@@ -209,7 +210,7 @@ index 85ca30aef0703db6859e66c62781ecfd334426e7..0761a26f877e7ae43410e170b39d537c
          }
          return CraftEntity.perm;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
-index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..de840350ac9af1d6e760f6f3197134f74ed64913 100644
+index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..45667da757e01232e96bcbf0e105de75bf58440d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
 @@ -75,6 +75,18 @@ public class CraftMinecartCommand extends CraftMinecart implements CommandMineca
@@ -218,12 +219,12 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..de840350ac9af1d6e760f6f3197134f7
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return 2;
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        throw new UnsupportedOperationException("Cannot change operator level of a block");
 +    }
 +    //Paper end
@@ -232,7 +233,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..de840350ac9af1d6e760f6f3197134f7
      public boolean isPermissionSet(String name) {
          return this.perm.isPermissionSet(name);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e8918d03b8213e5f6689fc93030138fd704aca9..9ed99298d3a204924a0c85fea6d8116b89963df4 100644
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..4d3f9e65184dfe93f524bc969b669e98c051c3fc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -182,6 +182,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -241,12 +242,12 @@ index 9e8918d03b8213e5f6689fc93030138fd704aca9..9ed99298d3a204924a0c85fea6d8116b
  
 +    //Paper start - OP level API
 +    @Override
-+    public int getOpLevel() {
++    public int getOpLevel()  {
 +        return server.getHandle().getOperatorLevel(this.getProfile());
 +    }
 +
 +    @Override
-+    public void setOpLevel(int value) {
++    public void setOpLevel(int value)  {
 +        server.getHandle().setOperatorLevel(this.getProfile(), value);
 +    }
 +    //Paper end

--- a/patches/server/0739-Implemented-OP-level-API.patch
+++ b/patches/server/0739-Implemented-OP-level-API.patch
@@ -5,10 +5,26 @@ Subject: [PATCH] Implemented OP level API
 
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
-index 918f5221e94cbc867349c69c83563e225d2fef1d..790357efd87f9c77597bcb97e79e7b61580aca82 100644
+index 918f5221e94cbc867349c69c83563e225d2fef1d..d3464011db58266bf6381ea7ef3d6bab2365cf57 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
-@@ -52,6 +52,17 @@ public class DedicatedPlayerList extends PlayerList {
+@@ -40,11 +40,13 @@ public class DedicatedPlayerList extends PlayerList {
+         this.getServer().storeUsingWhiteList(whitelistEnabled);
+     }
+ 
++    // Paper start - OP level API
+     @Override
+-    public void op(GameProfile profile) {
+-        super.op(profile);
++    public void op(GameProfile profile, int permissionLevel) {
++        super.op(profile, permissionLevel);
+         this.saveOps();
+     }
++    // Paper end
+ 
+     @Override
+     public void deop(GameProfile profile) {
+@@ -52,6 +54,17 @@ public class DedicatedPlayerList extends PlayerList {
          this.saveOps();
      }
  

--- a/patches/server/0739-Implemented-OP-level-API.patch
+++ b/patches/server/0739-Implemented-OP-level-API.patch
@@ -1,0 +1,252 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MCMDEV <john-m.1@gmx.de>
+Date: Thu, 5 Aug 2021 17:00:10 +0200
+Subject: [PATCH] Implemented OP level API
+
+
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
+index 918f5221e94cbc867349c69c83563e225d2fef1d..afc9c3f0550053126640f570ca4a31b5e3584459 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
+@@ -52,6 +52,17 @@ public class DedicatedPlayerList extends PlayerList {
+         this.saveOps();
+     }
+ 
++    //Paper start - OP level API
++    public int getOperatorLevel(GameProfile profile)    {
++        return super.getOperatorLevel(profile);
++    }
++
++    public void setOperatorLevel(GameProfile profile, int value)    {
++        super.setOperatorLevel(profile, value);
++        this.saveOps();
++    }
++    //Paper end
++
+     @Override
+     public void reloadWhiteList() {
+         this.loadWhiteList();
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..7a6d9a037bcc47f19768e6a716a1aa918d82aeb1 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -1144,6 +1144,18 @@ public abstract class PlayerList {
+ 
+     }
+ 
++    //Paper start - OP level API
++    public int getOperatorLevel(GameProfile profile)   {
++        return this.getServer().getProfilePermissions(profile);
++    }
++
++    public void setOperatorLevel(GameProfile profile, int permissionLevel)  {
++        ServerOpListEntry entry = this.ops.get(profile);
++        entry = new ServerOpListEntry(profile, permissionLevel, entry == null ? this.ops.canBypassPlayerLimit(profile) : entry.getBypassesPlayerLimit());
++        this.ops.add(entry);
++    }
++    //Paper end
++
+     private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
+         // Paper start - add recalculatePermissions parameter
+         this.sendPlayerOperatorStatus(player, permissionLevel, true);
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..896fb655c7c0d24d6f6a85d319862eef4fde7317 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+@@ -96,6 +96,18 @@ public class CraftOfflinePlayer implements OfflinePlayer, ConfigurationSerializa
+         }
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return this.server.getHandle().getOperatorLevel(profile);
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        this.server.getHandle().setOperatorLevel(profile, value);
++    }
++    //Paper end
++
+     @Override
+     public boolean isBanned() {
+         if (this.getName() == null) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
+index 83efca7144b4ce9cf7bd6bbbbf9c4426d2472315..657e7ca37dcc286210784d4f819e4e7203fafe84 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftBlockCommandSender.java
+@@ -56,6 +56,18 @@ public class CraftBlockCommandSender extends ServerCommandSender implements Bloc
+         throw new UnsupportedOperationException("Cannot change operator status of a block");
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return 2;
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        throw new UnsupportedOperationException("Cannot change operator level of a block");
++    }
++    //Paper end
++
+     public CommandSourceStack getWrapper() {
+         return this.block;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+index 9383e2fd8469d3203e0fe91dfbb05eb8192bc082..740993519fab9c5837f6a11d78a57171d38eaaf4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftConsoleCommandSender.java
+@@ -56,6 +56,16 @@ public class CraftConsoleCommandSender extends ServerCommandSender implements Co
+         throw new UnsupportedOperationException("Cannot change operator status of server console");
+     }
+ 
++    @Override
++    public int getOpLevel() {
++        return 4;
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        throw new UnsupportedOperationException("Cannot change operator level of server console");
++    }
++
+     @Override
+     public boolean beginConversation(Conversation conversation) {
+         return this.conversationTracker.beginConversation(conversation);
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
+index a3194c8a425d1d808c76ebef9997478f4d399fe0..9e581483b9fadb3d24a20ebabb70d5d4d843383a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/CraftRemoteConsoleCommandSender.java
+@@ -40,6 +40,18 @@ public class CraftRemoteConsoleCommandSender extends ServerCommandSender impleme
+         throw new UnsupportedOperationException("Cannot change operator status of remote controller.");
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return 4;
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        throw new UnsupportedOperationException("Cannot change operator level of remote controller.");
++    }
++    //Paper end
++
+     // Paper start
+     @Override
+     public boolean hasPermission(String name) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
+index 53d6950ad270ba901de5226b9daecb683248ad05..50cbe53bad542d3a969a4e4b5e8a5c4d0208397a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/ProxiedNativeCommandSender.java
+@@ -132,6 +132,18 @@ public class ProxiedNativeCommandSender implements ProxiedCommandSender {
+         this.getCaller().setOp(value);
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return this.caller.getOpLevel();
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        this.caller.setOpLevel(value);
++    }
++    //Paper end
++
+     // Spigot start
+     @Override
+     public org.bukkit.command.CommandSender.Spigot spigot()
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 85ca30aef0703db6859e66c62781ecfd334426e7..0761a26f877e7ae43410e170b39d537cefb9a2ab 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -998,6 +998,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+         CraftEntity.getPermissibleBase().setOp(value);
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return CraftEntity.getPermissibleBase().getOpLevel();
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        CraftEntity.getPermissibleBase().setOpLevel(value);
++    }
++    //Paper end
++
+     @Override
+     public void setGlowing(boolean flag) {
+         this.getHandle().setGlowingTag(flag);
+@@ -1135,6 +1147,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+                 public void setOp(boolean value) {
+ 
+                 }
++
++                //Paper start - OP level API
++                @Override
++                public int getOpLevel() {
++                    return 0;
++                }
++
++                @Override
++                public void setOpLevel(int value) {
++
++                }
++                //Paper end
+             });
+         }
+         return CraftEntity.perm;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
+index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..de840350ac9af1d6e760f6f3197134f74ed64913 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartCommand.java
+@@ -75,6 +75,18 @@ public class CraftMinecartCommand extends CraftMinecart implements CommandMineca
+         throw new UnsupportedOperationException("Cannot change operator status of a minecart");
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return 2;
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        throw new UnsupportedOperationException("Cannot change operator level of a block");
++    }
++    //Paper end
++
+     @Override
+     public boolean isPermissionSet(String name) {
+         return this.perm.isPermissionSet(name);
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 9e8918d03b8213e5f6689fc93030138fd704aca9..9ed99298d3a204924a0c85fea6d8116b89963df4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -182,6 +182,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         perm.recalculatePermissions();
+     }
+ 
++    //Paper start - OP level API
++    @Override
++    public int getOpLevel() {
++        return server.getHandle().getOperatorLevel(this.getProfile());
++    }
++
++    @Override
++    public void setOpLevel(int value) {
++        server.getHandle().setOperatorLevel(this.getProfile(), value);
++    }
++    //Paper end
++
+     @Override
+     public boolean isOnline() {
+         return server.getPlayer(getUniqueId()) != null;

--- a/patches/server/0739-Implemented-OP-level-API.patch
+++ b/patches/server/0739-Implemented-OP-level-API.patch
@@ -5,50 +5,54 @@ Subject: [PATCH] Implemented OP level API
 
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
-index 918f5221e94cbc867349c69c83563e225d2fef1d..afc9c3f0550053126640f570ca4a31b5e3584459 100644
+index 918f5221e94cbc867349c69c83563e225d2fef1d..734e5305d2a059738df20ea9a72dad6ca6c5b810 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedPlayerList.java
 @@ -52,6 +52,17 @@ public class DedicatedPlayerList extends PlayerList {
          this.saveOps();
      }
  
-+    //Paper start - OP level API
++    // Paper start - OP level API
 +    public int getOperatorLevel(GameProfile profile)    {
-+        return super.getOperatorLevel(profile);
++        return this.getServer().getProfilePermissions(profile);
 +    }
 +
 +    public void setOperatorLevel(GameProfile profile, int value)    {
-+        super.setOperatorLevel(profile, value);
++        super.op(profile, value);
 +        this.saveOps();
 +    }
-+    //Paper end
++    // Paper end
 +
      @Override
      public void reloadWhiteList() {
          this.loadWhiteList();
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..7a6d9a037bcc47f19768e6a716a1aa918d82aeb1 100644
+index 48045993c8ad4b014cf4a67f7c4db42e014d1c81..03934348739d31cd41bf74992e59f344adf86669 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1144,6 +1144,18 @@ public abstract class PlayerList {
- 
+@@ -1124,15 +1124,20 @@ public abstract class PlayerList {
+         return this.ipBans;
      }
  
-+    //Paper start - OP level API
-+    public int getOperatorLevel(GameProfile profile)   {
-+        return this.getServer().getProfilePermissions(profile);
++    // Paper start - OP level API
+     public void op(GameProfile profile) {
+-        this.ops.add(new ServerOpListEntry(profile, this.server.getOperatorUserPermissionLevel(), this.ops.canBypassPlayerLimit(profile)));
++        this.op(profile, this.server.getOperatorUserPermissionLevel());
 +    }
 +
-+    public void setOperatorLevel(GameProfile profile, int permissionLevel)  {
-+        ServerOpListEntry entry = this.ops.get(profile);
-+        entry = new ServerOpListEntry(profile, permissionLevel, entry == null ? this.ops.canBypassPlayerLimit(profile) : entry.getBypassesPlayerLimit());
-+        this.ops.add(entry);
-+    }
-+    //Paper end
-+
-     private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {
-         // Paper start - add recalculatePermissions parameter
-         this.sendPlayerOperatorStatus(player, permissionLevel, true);
++    public void op(GameProfile profile, int permissionLevel)    {
++        this.ops.add(new ServerOpListEntry(profile, permissionLevel, this.ops.canBypassPlayerLimit(profile)));
+         ServerPlayer entityplayer = this.getPlayer(profile.getId());
+ 
+         if (entityplayer != null) {
+             this.sendPlayerPermissionLevel(entityplayer);
+         }
+-
+     }
++    // Paper end
+ 
+     public void deop(GameProfile profile) {
+         this.ops.remove(profile);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
 index b20bfe5ab165bf86985e5ff2f93f415d9710e0e4..896fb655c7c0d24d6f6a85d319862eef4fde7317 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java


### PR DESCRIPTION
Adds API functionality for changing and getting a ServerOperator's OP permission level.

Can be used to protect commands especially sensitive commands.
For example, from players who has operator status on a single server, but isn't supposed to be able to give themselves a permission group on the entire network.