### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -3377,10 +3377,10 @@ index 2a145d851ce30360aa39549745bd87590c034584..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7d2e96fa96f5c4c5dbe97113a5e1b9cb59e09ac6..edf4623a831442e1f06daabc402a3f32610dd519 100644
+index 7d5236e39a74fd76b626e5f9c8f76c8fbb99439f..6c910e09eda6f4f08226ccc75189171015a72b85 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1395,7 +1395,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1414,7 +1414,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           */
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -1352,10 +1352,18 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..d7a4cfed4f46b34f83fb2c07bdab5a71
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb8823e02d 100644
+index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2ac18ac691 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -33,7 +33,28 @@ import org.jetbrains.annotations.Nullable;
+@@ -1,6 +1,7 @@
+ package org.bukkit.entity;
+ 
+ import java.net.InetSocketAddress;
++import java.util.List; // Paper
+ import java.util.UUID;
+ import org.bukkit.DyeColor;
+ import org.bukkit.Effect;
+@@ -33,7 +34,28 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */
@@ -1385,7 +1393,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
  
      /**
       * Gets the "friendly" name to display of this player. This may include
-@@ -43,7 +64,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -43,7 +65,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @return the friendly name
@@ -1395,7 +1403,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      @NotNull
      public String getDisplayName();
  
-@@ -55,15 +78,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -55,15 +79,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @param name The new display name.
@@ -1446,7 +1454,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      public String getPlayerListName();
  
      /**
-@@ -72,14 +130,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -72,14 +131,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * If the value is null, the name will be identical to {@link #getName()}.
       *
       * @param name new player list name
@@ -1465,7 +1473,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      @Nullable
      public String getPlayerListHeader();
  
-@@ -87,7 +149,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -87,7 +150,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gets the currently displayed player list footer for this player.
       *
       * @return player list header or null
@@ -1475,7 +1483,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      @Nullable
      public String getPlayerListFooter();
  
-@@ -95,14 +159,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -95,14 +160,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Sets the currently displayed player list header for this player.
       *
       * @param header player list header, null for empty
@@ -1494,7 +1502,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      public void setPlayerListFooter(@Nullable String footer);
  
      /**
-@@ -111,7 +179,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -111,7 +180,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param header player list header, null for empty
       * @param footer player list footer, null for empty
@@ -1504,7 +1512,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      public void setPlayerListHeaderFooter(@Nullable String header, @Nullable String footer);
  
      /**
-@@ -149,9 +219,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -149,9 +220,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Kicks player with custom kick message.
       *
       * @param message kick message
@@ -1525,19 +1533,11 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      /**
       * Says a message (or runs a command).
       *
-@@ -475,6 +556,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -475,6 +557,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated
      public boolean sendChunkChange(@NotNull Location loc, int sx, int sy, int sz, @NotNull byte[] data);
  
 +    // Paper start
-     /**
-      * Send a sign change. This fakes a sign change packet for a user at
-      * a certain location. This will not actually change the world in any way.
-@@ -490,6 +572,43 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-      * @throws IllegalArgumentException if location is null
-      * @throws IllegalArgumentException if lines is non-null and has a length less than 4
-      */
-+    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines) throws IllegalArgumentException;
 +    /**
 +     * Send a sign change. This fakes a sign change packet for a user at
 +     * a certain location. This will not actually change the world in any way.
@@ -1550,13 +1550,72 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
 +     *
 +     * @param loc the location of the sign
 +     * @param lines the new text on the sign or null to clear it
-+     * @param  dyeColor the color of the sign
++     * @throws IllegalArgumentException if location is null
++     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     */
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines) throws IllegalArgumentException {
++        this.sendSignChange(loc, lines, DyeColor.BLACK);
++    }
++
+     /**
+      * Send a sign change. This fakes a sign change packet for a user at
+      * a certain location. This will not actually change the world in any way.
+@@ -487,9 +589,75 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *
+      * @param loc the location of the sign
+      * @param lines the new text on the sign or null to clear it
++     * @param dyeColor the color of the sign
+      * @throws IllegalArgumentException if location is null
++     * @throws IllegalArgumentException if dyeColor is null
+      * @throws IllegalArgumentException if lines is non-null and has a length less than 4
+      */
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException {
++        this.sendSignChange(loc, lines, dyeColor, false);
++    }
++
++    /**
++     * Send a sign change. This fakes a sign change packet for a user at
++     * a certain location. This will not actually change the world in any way.
++     * This method will use a sign at the location's block or a faked sign
++     * sent via
++     * {@link #sendBlockChange(org.bukkit.Location, org.bukkit.Material, byte)}.
++     * <p>
++     * If the client does not have a sign at the given location it will
++     * display an error message to the user.
++     *
++     * @param loc the location of the sign
++     * @param lines the new text on the sign or null to clear it
++     * @param hasGlowingText whether the text of the sign should glow as if dyed with a glowing ink sac
 +     * @throws IllegalArgumentException if location is null
 +     * @throws IllegalArgumentException if dyeColor is null
 +     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
 +     */
-+    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
++    default void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, boolean hasGlowingText) throws IllegalArgumentException {
++        this.sendSignChange(loc, lines, DyeColor.BLACK, hasGlowingText);
++    }
++
++    /**
++     * Send a sign change. This fakes a sign change packet for a user at
++     * a certain location. This will not actually change the world in any way.
++     * This method will use a sign at the location's block or a faked sign
++     * sent via
++     * {@link #sendBlockChange(org.bukkit.Location, org.bukkit.Material, byte)}.
++     * <p>
++     * If the client does not have a sign at the given location it will
++     * display an error message to the user.
++     *
++     * @param loc the location of the sign
++     * @param lines the new text on the sign or null to clear it
++     * @param dyeColor the color of the sign
++     * @param hasGlowingText whether the text of the sign should glow as if dyed with a glowing ink sac
++     * @throws IllegalArgumentException if location is null
++     * @throws IllegalArgumentException if dyeColor is null
++     * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     */
++    void sendSignChange(@NotNull Location loc, @Nullable java.util.List<net.kyori.adventure.text.Component> lines, @NotNull DyeColor dyeColor, boolean hasGlowingText)
++        throws IllegalArgumentException;
 +    // Paper end
++
 +    /**
 +     * Send a sign change. This fakes a sign change packet for a user at
 +     * a certain location. This will not actually change the world in any way.
@@ -1576,8 +1635,8 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
 +    @Deprecated // Paper
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
- 
-@@ -509,7 +628,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     /**
+@@ -508,7 +676,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1587,7 +1646,17 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -1247,6 +1368,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -528,7 +698,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @throws IllegalArgumentException if location is null
+      * @throws IllegalArgumentException if dyeColor is null
+      * @throws IllegalArgumentException if lines is non-null and has a length less than 4
++     * @deprecated Deprecated in favour of {@link #sendSignChange(Location, List, DyeColor, boolean)}
+      */
++    @Deprecated // Paper
+     public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
+ 
+     /**
+@@ -1266,6 +1438,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -1602,7 +1671,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1272,8 +1401,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1291,8 +1471,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -1613,7 +1682,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      public String getLocale();
  
      /**
-@@ -1291,6 +1422,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1310,6 +1492,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void openBook(@NotNull ItemStack book);
  
@@ -1628,7 +1697,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1345,11 +1484,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1364,11 +1554,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -1642,7 +1711,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1360,7 +1501,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1379,7 +1571,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -1652,7 +1721,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1370,7 +1513,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1389,7 +1583,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -1662,7 +1731,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1381,7 +1526,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1400,7 +1596,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -1672,7 +1741,7 @@ index edf4623a831442e1f06daabc402a3f32610dd519..8ed69c4be84db742f2ff53adfd40f9eb
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1392,7 +1539,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1411,7 +1609,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -1352,18 +1352,10 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..d7a4cfed4f46b34f83fb2c07bdab5a71
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2ac18ac691 100644
+index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955dfa653edb3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1,6 +1,7 @@
- package org.bukkit.entity;
- 
- import java.net.InetSocketAddress;
-+import java.util.List; // Paper
- import java.util.UUID;
- import org.bukkit.DyeColor;
- import org.bukkit.Effect;
-@@ -33,7 +34,28 @@ import org.jetbrains.annotations.Nullable;
+@@ -33,7 +33,28 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */
@@ -1393,7 +1385,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
  
      /**
       * Gets the "friendly" name to display of this player. This may include
-@@ -43,7 +65,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -43,7 +64,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @return the friendly name
@@ -1403,7 +1395,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      @NotNull
      public String getDisplayName();
  
-@@ -55,15 +79,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -55,15 +78,50 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * places defined by plugins.
       *
       * @param name The new display name.
@@ -1454,7 +1446,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public String getPlayerListName();
  
      /**
-@@ -72,14 +131,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -72,14 +130,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * If the value is null, the name will be identical to {@link #getName()}.
       *
       * @param name new player list name
@@ -1473,7 +1465,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      @Nullable
      public String getPlayerListHeader();
  
-@@ -87,7 +150,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -87,7 +149,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Gets the currently displayed player list footer for this player.
       *
       * @return player list header or null
@@ -1483,7 +1475,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      @Nullable
      public String getPlayerListFooter();
  
-@@ -95,14 +160,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -95,14 +159,18 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Sets the currently displayed player list header for this player.
       *
       * @param header player list header, null for empty
@@ -1502,7 +1494,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public void setPlayerListFooter(@Nullable String footer);
  
      /**
-@@ -111,7 +180,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -111,7 +179,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param header player list header, null for empty
       * @param footer player list footer, null for empty
@@ -1512,7 +1504,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public void setPlayerListHeaderFooter(@Nullable String header, @Nullable String footer);
  
      /**
-@@ -149,9 +220,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -149,9 +219,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Kicks player with custom kick message.
       *
       * @param message kick message
@@ -1533,7 +1525,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      /**
       * Says a message (or runs a command).
       *
-@@ -475,6 +557,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -475,6 +556,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated
      public boolean sendChunkChange(@NotNull Location loc, int sx, int sy, int sz, @NotNull byte[] data);
  
@@ -1560,7 +1552,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -487,9 +589,75 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -487,9 +588,75 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param loc the location of the sign
       * @param lines the new text on the sign or null to clear it
@@ -1636,7 +1628,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -508,7 +676,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -508,7 +675,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1646,17 +1638,17 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -528,7 +698,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -528,7 +697,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
-+     * @deprecated Deprecated in favour of {@link #sendSignChange(Location, List, DyeColor, boolean)}
++     * @deprecated Deprecated in favour of {@link #sendSignChange(Location, java.util.List, DyeColor, boolean)}
       */
 +    @Deprecated // Paper
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1266,6 +1438,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1266,6 +1437,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -1671,7 +1663,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1291,8 +1471,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1291,8 +1470,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -1682,7 +1674,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      public String getLocale();
  
      /**
-@@ -1310,6 +1492,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1310,6 +1491,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void openBook(@NotNull ItemStack book);
  
@@ -1697,7 +1689,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1364,11 +1554,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1364,11 +1553,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -1711,7 +1703,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1379,7 +1571,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1379,7 +1570,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -1721,7 +1713,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1389,7 +1583,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1389,7 +1582,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -1731,7 +1723,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1400,7 +1596,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1400,7 +1595,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -1741,7 +1733,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..fd5e85e2b20a88ab245eba113fe67f2a
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1411,7 +1609,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1411,7 +1608,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0008-Player-affects-spawning-API.patch
+++ b/patches/api/0008-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fd5e85e2b20a88ab245eba113fe67f2ac18ac691..35b4669a40ad2277d058207028c3143bf010dd9b 100644
+index d68b2c6044db7740ef4d737e1b2955dfa653edb3..1786b6c230cabaf962b27f9d95c49b42e2b5cc67 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1477,6 +1477,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1476,6 +1476,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0008-Player-affects-spawning-API.patch
+++ b/patches/api/0008-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 8ed69c4be84db742f2ff53adfd40f9eb8823e02d..f7975a9146a1e21127ede13630f6d63d7a0285d7 100644
+index fd5e85e2b20a88ab245eba113fe67f2ac18ac691..35b4669a40ad2277d058207028c3143bf010dd9b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1407,6 +1407,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1477,6 +1477,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0013-Add-player-view-distance-API.patch
+++ b/patches/api/0013-Add-player-view-distance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player view distance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f7975a9146a1e21127ede13630f6d63d7a0285d7..f41d6a76f768c9ffa6c2ba9379564d07163f60c3 100644
+index 35b4669a40ad2277d058207028c3143bf010dd9b..54affc99338908e1af4537d4d6935c78300447d0 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1421,6 +1421,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1491,6 +1491,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0013-Add-player-view-distance-API.patch
+++ b/patches/api/0013-Add-player-view-distance-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player view distance API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 35b4669a40ad2277d058207028c3143bf010dd9b..54affc99338908e1af4537d4d6935c78300447d0 100644
+index 1786b6c230cabaf962b27f9d95c49b42e2b5cc67..28ef62e9e04501dbf4fe7b0fec52b1435621cffb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1491,6 +1491,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1490,6 +1490,28 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Graduate bungeecord chat API from spigot subclasses
 Change Javadoc to be accurate
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index f01fca5854b161278f448788e4b391e764107490..914a435bc3651f1153dd4e8128abcdec779be97e 100644
+index 0a3ae145c5406999eecbf0983cff8790ce42388e..d2c98a9e670bb5202b6db0a1be8aa2b78328da91 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -309,6 +309,30 @@ public final class Bukkit {
@@ -41,7 +41,7 @@ index f01fca5854b161278f448788e4b391e764107490..914a435bc3651f1153dd4e8128abcdec
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/Server.java b/src/main/java/org/bukkit/Server.java
-index 019dcabdd21783cd4d14d407d4dcae739afcaadd..25d6c59728c616f47dea4254a9317807ed6863be 100644
+index 53455bbe675bdfd424d8cebeb057c1d8defd0dd5..5ae4b3c4a20fd8fd727efbfe7b721c9b365b87a6 100644
 --- a/src/main/java/org/bukkit/Server.java
 +++ b/src/main/java/org/bukkit/Server.java
 @@ -254,6 +254,30 @@ public interface Server extends PluginMessageRecipient, net.kyori.adventure.audi
@@ -76,10 +76,10 @@ index 019dcabdd21783cd4d14d407d4dcae739afcaadd..25d6c59728c616f47dea4254a9317807
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f41d6a76f768c9ffa6c2ba9379564d07163f60c3..d3d412fc75ad0a849e8c81f0ba73ba980754c12e 100644
+index 54affc99338908e1af4537d4d6935c78300447d0..5fb7d1243ba103766cfe362de09e504bbf5cebf3 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -641,6 +641,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -711,6 +711,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -76,10 +76,10 @@ index 53455bbe675bdfd424d8cebeb057c1d8defd0dd5..5ae4b3c4a20fd8fd727efbfe7b721c9b
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 54affc99338908e1af4537d4d6935c78300447d0..5fb7d1243ba103766cfe362de09e504bbf5cebf3 100644
+index 28ef62e9e04501dbf4fe7b0fec52b1435621cffb..bd652a0c20335be67aae67ea663a23ea215d237a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -711,6 +711,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -710,6 +710,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
@@ -432,18 +432,18 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5fb7d1243ba103766cfe362de09e504bbf5cebf3..c5bb58e0bafaf89a8e83ce5452e623ad90c9ae0b 100644
+index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd822a01ca3c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3,6 +3,7 @@ package org.bukkit.entity;
+@@ -2,6 +2,7 @@ package org.bukkit.entity;
+ 
  import java.net.InetSocketAddress;
- import java.util.List; // Paper
  import java.util.UUID;
 +import com.destroystokyo.paper.Title; // Paper
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -745,6 +746,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -744,6 +745,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
@@ -432,18 +432,18 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d3d412fc75ad0a849e8c81f0ba73ba980754c12e..1a5d42d27299191f60fa1fd380dd0827dff4f7b1 100644
+index 5fb7d1243ba103766cfe362de09e504bbf5cebf3..c5bb58e0bafaf89a8e83ce5452e623ad90c9ae0b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
- 
+@@ -3,6 +3,7 @@ package org.bukkit.entity;
  import java.net.InetSocketAddress;
+ import java.util.List; // Paper
  import java.util.UUID;
 +import com.destroystokyo.paper.Title; // Paper
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -675,6 +676,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -745,6 +746,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0024-Complete-resource-pack-API.patch
+++ b/patches/api/0024-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1a5d42d27299191f60fa1fd380dd0827dff4f7b1..b30d00f26da93688cc81c522d4a032a72194bd63 100644
+index c5bb58e0bafaf89a8e83ce5452e623ad90c9ae0b..91e2f81b39ff421a7e6e1bef5f431e693679e073 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1151,7 +1151,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1221,7 +1221,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index 1a5d42d27299191f60fa1fd380dd0827dff4f7b1..b30d00f26da93688cc81c522d4a032a7
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -1628,6 +1630,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1698,6 +1700,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0024-Complete-resource-pack-API.patch
+++ b/patches/api/0024-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c5bb58e0bafaf89a8e83ce5452e623ad90c9ae0b..91e2f81b39ff421a7e6e1bef5f431e693679e073 100644
+index 9c9c9e504cb4db80e760207f6a27fd822a01ca3c..ea119d5f6f29cdb93a5586357375b476caec5655 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1221,7 +1221,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1220,7 +1220,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index c5bb58e0bafaf89a8e83ce5452e623ad90c9ae0b..91e2f81b39ff421a7e6e1bef5f431e69
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -1698,6 +1700,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1697,6 +1699,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0044-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0044-Add-String-based-Action-Bar-API.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 91e2f81b39ff421a7e6e1bef5f431e693679e073..c41bb4edffda834a596e323f0ab1f191d5d5a4d1 100644
+index ea119d5f6f29cdb93a5586357375b476caec5655..9d5c5b5f7d7ae4f0278410833d9d385242872498 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
- import java.util.List; // Paper
+@@ -3,6 +3,7 @@ package org.bukkit.entity;
+ import java.net.InetSocketAddress;
  import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
 +import net.kyori.adventure.text.Component;
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -713,6 +714,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -712,6 +713,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -56,7 +56,7 @@ index 91e2f81b39ff421a7e6e1bef5f431e693679e073..c41bb4edffda834a596e323f0ab1f191
      /**
       * Sends the component to the player
       *
-@@ -740,9 +774,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -739,9 +773,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *
@@ -68,7 +68,7 @@ index 91e2f81b39ff421a7e6e1bef5f431e693679e073..c41bb4edffda834a596e323f0ab1f191
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1889,6 +1925,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1888,6 +1924,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index 91e2f81b39ff421a7e6e1bef5f431e693679e073..c41bb4edffda834a596e323f0ab1f191
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -1901,6 +1938,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1900,6 +1937,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0044-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0044-Add-String-based-Action-Bar-API.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b30d00f26da93688cc81c522d4a032a72194bd63..2ab6ca203428fffe7f04beb0b3d14157d2896617 100644
+index 91e2f81b39ff421a7e6e1bef5f431e693679e073..c41bb4edffda834a596e323f0ab1f191d5d5a4d1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3,6 +3,7 @@ package org.bukkit.entity;
- import java.net.InetSocketAddress;
+@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
+ import java.util.List; // Paper
  import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
 +import net.kyori.adventure.text.Component;
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -643,6 +644,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -713,6 +714,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -56,7 +56,7 @@ index b30d00f26da93688cc81c522d4a032a72194bd63..2ab6ca203428fffe7f04beb0b3d14157
      /**
       * Sends the component to the player
       *
-@@ -670,9 +704,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -740,9 +774,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *
@@ -68,7 +68,7 @@ index b30d00f26da93688cc81c522d4a032a72194bd63..2ab6ca203428fffe7f04beb0b3d14157
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1819,6 +1855,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1889,6 +1925,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index b30d00f26da93688cc81c522d4a032a72194bd63..2ab6ca203428fffe7f04beb0b3d14157
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -1831,6 +1868,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1901,6 +1938,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
+++ b/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadoc warnings and errors
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2ab6ca203428fffe7f04beb0b3d14157d2896617..c7b3f8799a41c455b49bb601a48f6b5d33e68c08 100644
+index c41bb4edffda834a596e323f0ab1f191d5d5a4d1..c3d84c7a178fc4d34de40ccb3b3c0319bfcfe4fb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -661,7 +661,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -731,7 +731,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *

--- a/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
+++ b/patches/api/0053-Fix-upstream-javadoc-warnings-and-errors.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix upstream javadoc warnings and errors
 Upstream still refuses to use Java 8 with the API so they are likely unaware these are even issues.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c41bb4edffda834a596e323f0ab1f191d5d5a4d1..c3d84c7a178fc4d34de40ccb3b3c0319bfcfe4fb 100644
+index 9d5c5b5f7d7ae4f0278410833d9d385242872498..2301a5c6ada86b63b1c0207a6d89b0da4c167bbb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -731,7 +731,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -730,7 +730,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *

--- a/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..7b2af1bd72dfbcf4e962a982940fc49b
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c7b3f8799a41c455b49bb601a48f6b5d33e68c08..7434899dec25777b699022b4cb20266efd16289e 100644
+index c3d84c7a178fc4d34de40ccb3b3c0319bfcfe4fb..2dc16a03701fc4e8a74c5d750a58388924f98498 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */

--- a/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/api/0075-Expose-client-protocol-version-and-virtual-host.patch
@@ -57,10 +57,10 @@ index 0000000000000000000000000000000000000000..7b2af1bd72dfbcf4e962a982940fc49b
 +
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c3d84c7a178fc4d34de40ccb3b3c0319bfcfe4fb..2dc16a03701fc4e8a74c5d750a58388924f98498 100644
+index 2301a5c6ada86b63b1c0207a6d89b0da4c167bbb..4dc4811d608e51aea3cd2c26beaebc7c25f4b69b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -36,7 +36,7 @@ import org.jetbrains.annotations.Nullable;
+@@ -35,7 +35,7 @@ import org.jetbrains.annotations.Nullable;
  /**
   * Represents a player, connected or not
   */

--- a/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2dc16a03701fc4e8a74c5d750a58388924f98498..f858be54eb7659d4c320e305b82aea6647dcb721 100644
+index 4dc4811d608e51aea3cd2c26beaebc7c25f4b69b..30e7cd8e35549022d68e9ca206e55a2537694b14 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -989,12 +989,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -988,12 +988,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7434899dec25777b699022b4cb20266efd16289e..5d1f8bea2b1af036a3c5d869f8c20838ed19a8ae 100644
+index 2dc16a03701fc4e8a74c5d750a58388924f98498..f858be54eb7659d4c320e305b82aea6647dcb721 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -919,12 +919,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -989,12 +989,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/patches/api/0090-Player.setPlayerProfile-API.patch
+++ b/patches/api/0090-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5d1f8bea2b1af036a3c5d869f8c20838ed19a8ae..7ab92fce37eae47985345c9c0b610b808df98111 100644
+index f858be54eb7659d4c320e305b82aea6647dcb721..d16a606a3752d6ef3a6438eb4d870ae8d410cf24 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
+@@ -5,6 +5,7 @@ import java.util.List; // Paper
  import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
@@ -17,7 +17,7 @@ index 5d1f8bea2b1af036a3c5d869f8c20838ed19a8ae..7ab92fce37eae47985345c9c0b610b80
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1805,6 +1806,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1875,6 +1876,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0090-Player.setPlayerProfile-API.patch
+++ b/patches/api/0090-Player.setPlayerProfile-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index f858be54eb7659d4c320e305b82aea6647dcb721..d16a606a3752d6ef3a6438eb4d870ae8d410cf24 100644
+index 30e7cd8e35549022d68e9ca206e55a2537694b14..d12d7e421eb634a9a3b5e35f8970995ec7786055 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -5,6 +5,7 @@ import java.util.List; // Paper
+@@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
  import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
@@ -17,7 +17,7 @@ index f858be54eb7659d4c320e305b82aea6647dcb721..d16a606a3752d6ef3a6438eb4d870ae8
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1875,6 +1876,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1874,6 +1875,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,10 +74,10 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d16a606a3752d6ef3a6438eb4d870ae8d410cf24..4264802e21c715f1922fe362a37c28f9287ed303 100644
+index d12d7e421eb634a9a3b5e35f8970995ec7786055..09d7ce67f711d48e63d71b6b8f19047aaa09d24d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -6,6 +6,10 @@ import java.util.UUID;
+@@ -5,6 +5,10 @@ import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
@@ -88,7 +88,7 @@ index d16a606a3752d6ef3a6438eb4d870ae8d410cf24..4264802e21c715f1922fe362a37c28f9
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -715,6 +719,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -714,6 +718,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,10 +74,10 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7ab92fce37eae47985345c9c0b610b808df98111..54cb4de5f4f48924ad89b4a757255fce243d1187 100644
+index d16a606a3752d6ef3a6438eb4d870ae8d410cf24..4264802e21c715f1922fe362a37c28f9287ed303 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -5,6 +5,10 @@ import java.util.UUID;
+@@ -6,6 +6,10 @@ import java.util.UUID;
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
@@ -88,7 +88,7 @@ index 7ab92fce37eae47985345c9c0b610b808df98111..54cb4de5f4f48924ad89b4a757255fce
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -645,6 +649,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -715,6 +719,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4264802e21c715f1922fe362a37c28f9287ed303..4a950df42c71cb336732807e422ddcacb981e44a 100644
+index 09d7ce67f711d48e63d71b6b8f19047aaa09d24d..f42bf3bd0423850e7b7cba75b6c0d1d2c8421de0 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2050,6 +2050,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2049,6 +2049,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 54cb4de5f4f48924ad89b4a757255fce243d1187..14457e5ba8809273362b3cab9fc3a9c3e05edf8a 100644
+index 4264802e21c715f1922fe362a37c28f9287ed303..4a950df42c71cb336732807e422ddcacb981e44a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1980,6 +1980,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2050,6 +2050,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0198-Add-Player-Client-Options-API.patch
+++ b/patches/api/0198-Add-Player-Client-Options-API.patch
@@ -176,18 +176,18 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 4a950df42c71cb336732807e422ddcacb981e44a..935fbfc776e723b2f4a6dd9a49828827d0f59d70 100644
+index f42bf3bd0423850e7b7cba75b6c0d1d2c8421de0..768eca64aba4446fc341b71c12ff538169399f76 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -3,6 +3,7 @@ package org.bukkit.entity;
+@@ -2,6 +2,7 @@ package org.bukkit.entity;
+ 
  import java.net.InetSocketAddress;
- import java.util.List; // Paper
  import java.util.UUID;
 +import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2070,6 +2071,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2069,6 +2070,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0198-Add-Player-Client-Options-API.patch
+++ b/patches/api/0198-Add-Player-Client-Options-API.patch
@@ -176,18 +176,18 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 14457e5ba8809273362b3cab9fc3a9c3e05edf8a..9fdaec602522dbf261f0d91eed69284cea930d9a 100644
+index 4a950df42c71cb336732807e422ddcacb981e44a..935fbfc776e723b2f4a6dd9a49828827d0f59d70 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
- 
+@@ -3,6 +3,7 @@ package org.bukkit.entity;
  import java.net.InetSocketAddress;
+ import java.util.List; // Paper
  import java.util.UUID;
 +import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2000,6 +2001,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2070,6 +2071,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0223-Brand-support.patch
+++ b/patches/api/0223-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9fdaec602522dbf261f0d91eed69284cea930d9a..e70e96139d88529e7a1156f61df3da3278da0b07 100644
+index 935fbfc776e723b2f4a6dd9a49828827d0f59d70..368d14d6ca1ace90f2c999304243b36e204c799b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2135,6 +2135,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2205,6 +2205,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0223-Brand-support.patch
+++ b/patches/api/0223-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 935fbfc776e723b2f4a6dd9a49828827d0f59d70..368d14d6ca1ace90f2c999304243b36e204c799b 100644
+index 768eca64aba4446fc341b71c12ff538169399f76..95bc3af2b14126caaf2394941ea6cbb60afeac0d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2205,6 +2205,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2204,6 +2204,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0232-Player-elytra-boost-API.patch
+++ b/patches/api/0232-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index e70e96139d88529e7a1156f61df3da3278da0b07..c7e4a2c45c2183f1c9f96340a52f9ba0b30c5d5b 100644
+index 368d14d6ca1ace90f2c999304243b36e204c799b..04a3630c80da1bfb986fce9b5ff84faa61511bbb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2007,6 +2007,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2077,6 +2077,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0232-Player-elytra-boost-API.patch
+++ b/patches/api/0232-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 368d14d6ca1ace90f2c999304243b36e204c799b..04a3630c80da1bfb986fce9b5ff84faa61511bbb 100644
+index 95bc3af2b14126caaf2394941ea6cbb60afeac0d..046476fdfcd9ceecb6e0f314228c3f81ad46ec80 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2077,6 +2077,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2076,6 +2076,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0261-Add-sendOpLevel-API.patch
+++ b/patches/api/0261-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 04a3630c80da1bfb986fce9b5ff84faa61511bbb..83758e7bd4210056769a8b91a2eb53f28a8aa7fd 100644
+index 046476fdfcd9ceecb6e0f314228c3f81ad46ec80..bb3c29cc5121232e93ec8d5a5c308b1f85071f0c 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2090,6 +2090,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2089,6 +2089,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0261-Add-sendOpLevel-API.patch
+++ b/patches/api/0261-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c7e4a2c45c2183f1c9f96340a52f9ba0b30c5d5b..58c05bf819fc8b4427a4f07452a5ec18f5e3b445 100644
+index 04a3630c80da1bfb986fce9b5ff84faa61511bbb..83758e7bd4210056769a8b91a2eb53f28a8aa7fd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2020,6 +2020,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2090,6 +2090,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0276-Expose-Tracked-Players.patch
+++ b/patches/api/0276-Expose-Tracked-Players.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 58c05bf819fc8b4427a4f07452a5ec18f5e3b445..69b1cd6d504e30b5c638882aa925033930d45964 100644
+index 83758e7bd4210056769a8b91a2eb53f28a8aa7fd..58aabad5eaa2af4b3db03450c7266e8f7d793a55 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1,6 +1,7 @@
- package org.bukkit.entity;
+@@ -2,6 +2,7 @@ package org.bukkit.entity;
  
  import java.net.InetSocketAddress;
+ import java.util.List; // Paper
 +import java.util.Set; // Paper
  import java.util.UUID;
  import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
-@@ -2033,6 +2034,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2103,6 +2104,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end
  

--- a/patches/api/0276-Expose-Tracked-Players.patch
+++ b/patches/api/0276-Expose-Tracked-Players.patch
@@ -5,18 +5,18 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 83758e7bd4210056769a8b91a2eb53f28a8aa7fd..58aabad5eaa2af4b3db03450c7266e8f7d793a55 100644
+index bb3c29cc5121232e93ec8d5a5c308b1f85071f0c..97ace842faa16d02d10181bc4ec3a382bc7e4e65 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2,6 +2,7 @@ package org.bukkit.entity;
+@@ -1,6 +1,7 @@
+ package org.bukkit.entity;
  
  import java.net.InetSocketAddress;
- import java.util.List; // Paper
 +import java.util.Set; // Paper
  import java.util.UUID;
  import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
-@@ -2103,6 +2104,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2102,6 +2103,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end
  

--- a/patches/api/0314-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0314-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 69b1cd6d504e30b5c638882aa925033930d45964..5e8814cc317a705eaf8bdd9f3876a5366c0a0226 100644
+index 58aabad5eaa2af4b3db03450c7266e8f7d793a55..446db64cef0dd583f5f2be9d76142eb8ebf81673 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -240,6 +240,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -241,6 +241,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param message kick message
       */
      void kick(final @Nullable net.kyori.adventure.text.Component message);

--- a/patches/api/0314-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0314-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 58aabad5eaa2af4b3db03450c7266e8f7d793a55..446db64cef0dd583f5f2be9d76142eb8ebf81673 100644
+index 97ace842faa16d02d10181bc4ec3a382bc7e4e65..3ec1be36b90dbedb8631135555da4b69110e4791 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -241,6 +241,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -240,6 +240,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param message kick message
       */
      void kick(final @Nullable net.kyori.adventure.text.Component message);

--- a/patches/server/0009-Timings-v2.patch
+++ b/patches/server/0009-Timings-v2.patch
@@ -2028,10 +2028,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f1a5257ba8e626cc55bbdd755af23de2326e92f8..7274657daecdaaf961f5bbd69e05fc5b7f0c2fda 100644
+index da4296ecdc5b37224bc9fd9be426b613f0ec9586..1a6cca634d6b40a6d5f30eda98be3aa72c2569ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1819,6 +1819,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1825,6 +1825,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -2142,7 +2142,7 @@ index 042691349dd5659e8db526199641cbcfa21c6005..841dbf4a86b19d7c8ea41930ecb1f88c
          player.initMenu(container);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1de87a77e9 100644
+index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48eaf556df94 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2255,17 +2255,13 @@ index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1d
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -571,6 +607,36 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -571,6 +607,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
 +    // Paper start
 +    @Override
-+    public void sendSignChange(Location loc, List<net.kyori.adventure.text.Component> lines) {
-+        this.sendSignChange(loc, lines, org.bukkit.DyeColor.BLACK);
-+    }
-+    @Override
-+    public void sendSignChange(Location loc, List<net.kyori.adventure.text.Component> lines, DyeColor dyeColor) {
++    public void sendSignChange(Location loc, @Nullable List<net.kyori.adventure.text.Component> lines, DyeColor dyeColor, boolean hasGlowingText) {
 +        if (getHandle().connection == null) {
 +            return;
 +        }
@@ -2278,12 +2274,13 @@ index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1d
 +            throw new IllegalArgumentException("Must have at least 4 lines");
 +        }
 +        Component[] components = CraftSign.sanitizeLines(lines);
-+        this.sendSignChange0(components, loc, dyeColor);
++        this.sendSignChange0(components, loc, dyeColor, hasGlowingText);
 +    }
 +
-+    private void sendSignChange0(Component[] components, Location loc, DyeColor dyeColor) {
++    private void sendSignChange0(Component[] components, Location loc, DyeColor dyeColor, boolean hasGlowingText) {
 +        SignBlockEntity sign = new SignBlockEntity(new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), Blocks.OAK_SIGN.defaultBlockState());
 +        sign.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
++        sign.setHasGlowingText(hasGlowingText);
 +        System.arraycopy(components, 0, sign.messages, 0, sign.messages.length);
 +
 +        getHandle().connection.send(sign.getUpdatePacket());
@@ -2291,27 +2288,26 @@ index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1d
 +    // Paper end
      @Override
      public void sendSignChange(Location loc, String[] lines) {
-        this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -593,13 +659,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+         this.sendSignChange(loc, lines, DyeColor.BLACK);
+@@ -598,14 +661,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
 -        SignBlockEntity sign = new SignBlockEntity(new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), Blocks.OAK_SIGN.defaultBlockState());
--        sign.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
--        for (int i = 0; i < components.length; i++) {
--            sign.setMessage(i, components[i]);
--        }
 +        /*SignBlockEntity sign = new SignBlockEntity(new BlockPos(loc.getBlockX(), loc.getBlockY(), loc.getBlockZ()), Blocks.OAK_SIGN.defaultBlockState());
-+        sign.setColor(EnumColor.fromColorIndex(dyeColor.getWoolData()));
-+        System.arraycopy(components, 0, sign.lines, 0, sign.lines.length);
+         sign.setColor(net.minecraft.world.item.DyeColor.byId(dyeColor.getWoolData()));
+         sign.setHasGlowingText(hasGlowingText);
+         for (int i = 0; i < components.length; i++) {
+             sign.setMessage(i, components[i]);
+         }
  
 -        this.getHandle().connection.send(sign.getUpdatePacket());
 +        this.getHandle().connection.send(sign.getUpdatePacket());*/ // Paper
-+        this.sendSignChange0(components, loc, dyeColor); // Paper
++        this.sendSignChange0(components, loc, dyeColor, hasGlowingText); // Paper
      }
  
      @Override
-@@ -1699,6 +1764,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1705,6 +1769,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2324,7 +2320,7 @@ index 7274657daecdaaf961f5bbd69e05fc5b7f0c2fda..62e773ed5ec894bcd213ba046070cb1d
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1727,6 +1798,160 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1733,6 +1803,160 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  

--- a/patches/server/0021-Player-affects-spawning-API.patch
+++ b/patches/server/0021-Player-affects-spawning-API.patch
@@ -21,7 +21,7 @@ index 195989667c7d844399a72787819f62a3fd0d9c78..d17b75ad13bbc8a38cdc2f2d77ee5d88
      public static Predicate<Entity> withinDistance(double x, double y, double z, double max) {
          double d4 = max * max;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 78813a0efcab432c8c8c869da13ea49c93874cbf..01f88d647032820e19418c3d97e40dfaf1a7e482 100644
+index c9a9a4c6ba930dedb227c1f1d4ca4bb520983854..5dbc90cf67ee88d2f7043c38eaad4fc5874606b5 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -771,7 +771,7 @@ public abstract class Mob extends LivingEntity {
@@ -117,10 +117,10 @@ index 389985e022b82c675fb21f363422471bd15b84b0..849616d9ad140285f7aa4d2ffafd6371
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cc97a1fb78037e4b09ebe825b5135702f2f19e00..ff239a739ec8c72da82b142a3ecb7f55772e6e0d 100644
+index 32f555a846d34e086e75c027a92a48eaf556df94..6de88d1ea0ff50dddb65a65fa53fba6ee475e886 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1778,8 +1778,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1783,8 +1783,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0024-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0024-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ff239a739ec8c72da82b142a3ecb7f55772e6e0d..4178dc224e3cbff004a55e1e84512ae345d7ec9c 100644
+index 6de88d1ea0ff50dddb65a65fa53fba6ee475e886..2685ebf77191a797bc1835a3da13a238ce9432a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1447,12 +1447,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1452,12 +1452,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a1b816bc32adb4085c5d5457ed24996e0c5f3bc5..3a45ad211e5e35a87270b35725693d13f1fdd720 100644
+index e1c3472c15a85d47d8abd24ddb69fd99c8a6b3e2..e9d03d4540fa39b783f808c81f397e25f653bec2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -885,7 +885,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -890,7 +890,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0057-Complete-resource-pack-API.patch
+++ b/patches/server/0057-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3a45ad211e5e35a87270b35725693d13f1fdd720..6ee60169ecb5c04b27a4037b44d4d927bd39b5c2 100644
+index e9d03d4540fa39b783f808c81f397e25f653bec2..ada3e4af93c96221355b5ad777527ae16cfa866d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -45,7 +45,7 @@ index 3a45ad211e5e35a87270b35725693d13f1fdd720..6ee60169ecb5c04b27a4037b44d4d927
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1896,6 +1901,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1901,6 +1906,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index a492f0b8393c185f0464f0fb0e5d5dce4d0e3824..bcf7fc1bdee10baaff7ec15ad2572061
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6ee60169ecb5c04b27a4037b44d4d927bd39b5c2..b08c99fc99266eb2dbca8e5c863864d7752fbc76 100644
+index ada3e4af93c96221355b5ad777527ae16cfa866d..b3d49b652790a98f1426498a555c6826f8657c63 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1703,6 +1703,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1708,6 +1708,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b08c99fc99266eb2dbca8e5c863864d7752fbc76..c1f8f0d616a480078abb83eff1c2ccf5b3488f45 100644
+index b3d49b652790a98f1426498a555c6826f8657c63..77dd225e6cc20b4faa55aab2b52af77298639e0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -895,6 +895,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -900,6 +900,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 68bc585a446585bfc3922db8e4539a25f846e308..2903f3d98949b5a582bf7996b73083f1
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a027b08d34993d920ded7e94e278314431c182ce..e9fd0737fb122e2beb12898a2d082aebd11604ed 100644
+index 77dd225e6cc20b4faa55aab2b52af77298639e0e..90ab0a3967aaa5394e2b09c4c9879b84e82ece76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1900,8 +1900,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1905,8 +1905,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,7 +28,7 @@ index 6f25e9f41d93a225acaa6575954967438a6cabbf..d439e8ce87bf7da03683a336941c7673
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 284772518ecb00d9e83a9e22480842deeba47dd0..18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f 100644
+index 8abce60db2bfd99aa5bb188dc231edcbde870e92..df9508e3f2272e63a4902687e69df631671584e7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -61,11 +61,14 @@ import net.minecraft.server.level.ServerPlayer;
@@ -46,7 +46,7 @@ index 284772518ecb00d9e83a9e22480842deeba47dd0..18f061f96d5c4da2c0dbd4bce1f1a7f1
  import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.SignBlockEntity;
-@@ -1203,8 +1206,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1208,8 +1211,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
      }
  

--- a/patches/server/0186-Player.setPlayerProfile-API.patch
+++ b/patches/server/0186-Player.setPlayerProfile-API.patch
@@ -26,7 +26,7 @@ index 261ebb134a5ff40406e74237f730aad1c78a8215..39bdda56aaa5503efc15207261634127
                              uniqueId = gameProfile.getId();
                              // Paper end
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index da0176ed9d51aef76d9c439a03718c1635c35333..f9593486e5382c629e0febd43b3d7464481f0045 100644
+index 3c8de1d70714a021dbd58894f3fd986bf5d6bde7..cc6f1f94c1a01992dfe29399b346c972f114a38d 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -173,7 +173,7 @@ public abstract class Player extends LivingEntity {
@@ -39,7 +39,7 @@ index da0176ed9d51aef76d9c439a03718c1635c35333..f9593486e5382c629e0febd43b3d7464
      private ItemStack lastItemInMainHand;
      private final ItemCooldowns cooldowns;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f..b24fa0876a3573b9000689fa540709f08d529f64 100644
+index df9508e3f2272e63a4902687e69df631671584e7..f006b9ba8ebad98b3e679d7049bd9244f72a9348 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -71,6 +71,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -50,7 +50,7 @@ index 18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f..b24fa0876a3573b9000689fa540709f0
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1334,8 +1335,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1339,8 +1340,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -65,7 +65,7 @@ index 18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f..b24fa0876a3573b9000689fa540709f0
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1376,8 +1382,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1381,8 +1387,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenPlayers.remove(player.getUniqueId());
  
@@ -80,7 +80,7 @@ index 18f061f96d5c4da2c0dbd4bce1f1a7f1ee1cd62f..b24fa0876a3573b9000689fa540709f0
  
          this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.ADD_PLAYER, other));
  
-@@ -1386,6 +1397,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1391,6 +1402,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0191-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0191-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b24fa0876a3573b9000689fa540709f08d529f64..0ce5e35d1ca59587301edba56ddcf2a4e7fbe247 100644
+index f006b9ba8ebad98b3e679d7049bd9244f72a9348..1ad37b47a64700f9fd895afb26f8b07c0cad72d5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -150,6 +150,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index b24fa0876a3573b9000689fa540709f08d529f64..0ce5e35d1ca59587301edba56ddcf2a4
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1603,7 +1604,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1608,7 +1609,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..460828d29583ee21a7c5b716f9687a82
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 90dae9fc9f048802f79153d90ef4de9b1670ae7a..cf5dabd0e3993c388f157f28f07fc8fa796d653f 100644
+index 1ad37b47a64700f9fd895afb26f8b07c0cad72d5..067a3990825dd17d2843a5f8d215d19dcaac6806 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -922,7 +922,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -927,7 +927,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9c1a2ac04facba52af09ee87a96e8911d41a3f32..886a75f2b6402ed2e8c884fa5e125f4a4750f11d 100644
+index 067a3990825dd17d2843a5f8d215d19dcaac6806..30357dd7b527c40f9aa42a5873ad21c46d3c2311 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2248,6 +2248,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2253,6 +2253,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          connection.send(new net.minecraft.network.protocol.game.ClientboundOpenBookPacket(net.minecraft.world.InteractionHand.MAIN_HAND));
          connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, inventory.getSelected()));
      }

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -19,7 +19,7 @@ maybe more (please check patch overrides for drops for more):
 - players, armor stands, foxes, chested donkeys/llamas
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2c32d7c37d7d9b9c12c5af3a9af576ac88618049..b4d2b9a25ee1c407b3803d59c4fd80f793873192 100644
+index 4b554a9556bf29334eaaf9d4f14643ee246899c9..e73046e6d322ddc0feb4979ec0038c4a56778ed9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -219,6 +219,10 @@ public class ServerPlayer extends Player {
@@ -277,10 +277,10 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 886a75f2b6402ed2e8c884fa5e125f4a4750f11d..e3e158946ceff4c383e5da46bce09554f7526a6f 100644
+index 30357dd7b527c40f9aa42a5873ad21c46d3c2311..6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1863,7 +1863,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1868,7 +1868,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {
@@ -297,7 +297,7 @@ index 886a75f2b6402ed2e8c884fa5e125f4a4750f11d..e3e158946ceff4c383e5da46bce09554
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6fd016daeab42b43bf4b1efb4f715b28c45a88c3..934ea2cf75c44e7e5f2e302a2d2fc14da54d3310 100644
+index 0ddd9de39a0d67529a8f973f5dfaf5ff53f5eb66..253075002cffb67095d010a6a4c67d9efff9d5ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -802,9 +802,16 @@ public class CraftEventFactory {

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index efb759fe76540b51509029d40884eb85a31cda86..d2667305c73821df221cf9aaca2ca494aa1836ad 100644
+index 4f93f576bbbf7e8d0217f8d30f4c578ad917477a..95690ac3b3404ebe3d2308aaee09d9ec52b8f76d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -219,6 +219,7 @@ public class ServerPlayer extends Player {
@@ -106,7 +106,7 @@ index 93de44b05a698515457052c9c684c4ef44c5cc40..b20bfe5ab165bf86985e5ff2f93f415d
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e3e158946ceff4c383e5da46bce09554f7526a6f..d98e7b91cb8e6f9369531a08887513b05ef0f96b 100644
+index 6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1..baa11848b63442fed7160a94e6447d6dd63d8ac6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -151,6 +151,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index e3e158946ceff4c383e5da46bce09554f7526a6f..d98e7b91cb8e6f9369531a08887513b0
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1507,6 +1508,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1512,6 +1513,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index e3e158946ceff4c383e5da46bce09554f7526a6f..d98e7b91cb8e6f9369531a08887513b0
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1529,6 +1542,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1534,6 +1547,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index e3e158946ceff4c383e5da46bce09554f7526a6f..d98e7b91cb8e6f9369531a08887513b0
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1543,6 +1558,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1548,6 +1563,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d98e7b91cb8e6f9369531a08887513b05ef0f96b..0a0ffdd0cb4fb2750c8b7939fb36e12190b6b085 100644
+index baa11848b63442fed7160a94e6447d6dd63d8ac6..bef6868a33144e0e4f44bba1ba13d6310e291523 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2295,6 +2295,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2300,6 +2300,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0488-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -80,7 +80,7 @@ index 2d5b8e35d52b0dfd075af81a3a936d8a21053b31..9ddedd310eb0323a5a09f51a61bfb7b3
                  chunkData.addProperty("queued-for-unload", chunkMap.toDrop.contains(playerChunk.pos.longKey));
                  chunkData.addProperty("status", status == null ? "unloaded" : status.toString());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index d5ff572f41d6efc82294e11db0952a39d6ac801e..c71905aeed2a39fc5be58540ca506b5660d3f0db 100644
+index 8245e07f6ecfd9dd997c8525b52c6eadd392e6f1..3364ff7e8a829771a84c6f2e61d37bb4c099af87 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -60,7 +60,7 @@ public class ChunkHolder {
@@ -941,7 +941,7 @@ index d94241bcca4f2fd5e464a860bd356af504dc68b7..1cc4e0a1f3d8235ef88b48e01ca8b78a
      }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 4807807466c3cf04960392ff776b0999e667de56..f4f6124c20c31224312070c5e95be00a62e89897 100644
+index ffe700489cb2d507421abfb48939808de0adc8be..c63cbb6da6f734c3a93c63af2b28a6e588f22bf2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -451,6 +451,26 @@ public class ServerChunkCache extends ChunkSource {
@@ -1027,7 +1027,7 @@ index 4807807466c3cf04960392ff776b0999e667de56..f4f6124c20c31224312070c5e95be00a
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9fab262e420ca693778c6d41a0cf7b2783875ae2..ca83d167b12422f4d7490d2ebdff401200444d42 100644
+index 89fcf88f35a071db1704c026a99625c84daf2f28..ab12bc6db7fdc865989804aa6366cdefefbc9a31 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -189,6 +189,14 @@ public class ServerPlayer extends Player {
@@ -1101,7 +1101,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 9b04ce1b82e954eca6e59360e606438695dd3bb4..ae65830c10888993e0a4c7863abf91f560313da1 100644
+index ae3465cd5be426f3bddc3552b6aad6cad8c8ee25..91df850e66aa14b13a679357e02e2f74dc653628 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1545,6 +1545,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -1144,7 +1144,7 @@ index e0c9857a922d8a3f421d7df0f056b82c4775390e..4918f89401cdf6a85d8b71f3e3a66082
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 21a3c5fe4cf0ac4f21ffda3d7c0b20f82d4cadf1..2a5f58a87cfe312d2118c1b6ba4df98b046c4db1 100644
+index 3e951522169fcb071cc578e8bd9a78baa10f4e4d..cc4b48f6c62aaccddaf81576865b56f8ece4d040 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -223,7 +223,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -1174,10 +1174,10 @@ index 8536452ccd65814b55bc78736060b387e051c3db..881af8e0b8383b25b94958b03cfdb660
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7fc48e63ac610f65475e3a8d3d6f902cc70925ed..9144fbd3754b21295248103eac8cf9ac989d4614 100644
+index a3951039eeb1f5d3529213ca02d11c97d499be38..9ce4ebc9a0ddeefdc9fb3a7bd91be77aeb075011 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -890,6 +890,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -895,6 +895,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0506-Brand-support.patch
+++ b/patches/server/0506-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 3c4eab3b562c1fb137a8cf2c64ace05bc0f92d44..c7f18e142b0294291d7c47cf95943cb3cbc10a11 100644
+index 03ad0c0365f85a1536fb35bfdf08d6d44240df80..27fc9ec7183b100dcfc755d41b3348ccc04c705b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
@@ -72,10 +72,10 @@ index 3c4eab3b562c1fb137a8cf2c64ace05bc0f92d44..c7f18e142b0294291d7c47cf95943cb3
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9144fbd3754b21295248103eac8cf9ac989d4614..5a7f6ba01167784894e549e1b04193bf9c9db89c 100644
+index 9ce4ebc9a0ddeefdc9fb3a7bd91be77aeb075011..7257c8fedb6937d925dea592a69fd56ddd05c50d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2436,6 +2436,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2441,6 +2441,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0559-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0559-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a8ecfbf334f13f6ba986b170de712ad8b8f0b4ca..6a262955e0523db99d2b38cd7815968e8d6b41d1 100644
+index 2b24575e19cd1b24c259711bfd4e6cae6492f927..77a74b47ffe9c9d02daae74a770427ec1da450a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2062,7 +2062,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2067,7 +2067,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0628-Expose-Tracked-Players.patch
+++ b/patches/server/0628-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 0c04869f9859ad0ee6885b8a26964804bb9ea930..418aa0d31fae7c5fa9c0826ef99ac00729c2de71 100644
+index e010e67c58b531d00aee7dde6a1bfa05d67aa942..f79b62c413789353af70b691792fe3abc24746dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2355,6 +2355,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2360,6 +2360,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0683-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0683-additions-to-PlayerGameModeChangeEvent.patch
@@ -137,10 +137,10 @@ index 814a937d41b7887d94fe50f670236bab224d9886..ed7f43ad0fe7baf7c968ec214f1e32b8
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 49a92f08188a22f62758f53129c352a1f5cf80a4..e2f22b8c56492722c5e7d42d1d4da32a46ab76c7 100644
+index f79b62c413789353af70b691792fe3abc24746dd..db3582808346711ad416c0a6cfd455f0538b2fa2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1250,7 +1250,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1255,7 +1255,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0739-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0739-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index af4eb4a8814491afef449a2874521636957d7557..0a5d563700c9f806139001181f01fa9d
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9e8918d03b8213e5f6689fc93030138fd704aca9..3971fed7a0d1399117366a5d7dd2e84adbfda55a 100644
+index 0587ef4783228f4e4e7f441a47453bb8c91d7f26..63aa742c505e14faa9bf5df29a8f759486fac80b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1070,9 +1070,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1075,9 +1075,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {


### PR DESCRIPTION
The new API added has been tested, and new overloads for the Adventure variants have been added, as well as a new deprecation for the new legacy Bukkit API.

---

Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
e0598aa2 SPIGOT-6692: Add sendSignChange overload with a hasGlowingText parameter

CraftBukkit Changes:
2cdc6b1e4 SPIGOT-6692: Add sendSignChange overload with a hasGlowingText parameter