### PR TITLE
Update PlayerPostRespawnEvent to check for anchor respawn

### DIFF
--- a/patches/api/0176-Add-PlayerPostRespawnEvent.patch
+++ b/patches/api/0176-Add-PlayerPostRespawnEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerPostRespawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f1ad0c997
+index 0000000000000000000000000000000000000000..a947676d1e2c3a0aca35d0616b5ffb1c2ee665b8
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerPostRespawnEvent.java
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,68 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import org.bukkit.Location;
@@ -25,11 +25,18 @@ index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f
 +    private final static HandlerList handlers = new HandlerList();
 +    private final Location respawnedLocation;
 +    private final boolean isBedSpawn;
++    private final boolean isAnchorSpawn;
 +
++    @Deprecated
 +    public PlayerPostRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnedLocation, final boolean isBedSpawn) {
++        this(respawnPlayer, respawnedLocation, isBedSpawn, false);
++    }
++
++    public PlayerPostRespawnEvent(@NotNull final Player respawnPlayer, @NotNull final Location respawnedLocation, final boolean isBedSpawn, final boolean isAnchorSpawn) {
 +        super(respawnPlayer);
 +        this.respawnedLocation = respawnedLocation;
 +        this.isBedSpawn = isBedSpawn;
++        this.isAnchorSpawn = isAnchorSpawn;
 +    }
 +
 +    /**
@@ -49,6 +56,15 @@ index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f
 +     */
 +    public boolean isBedSpawn() {
 +        return isBedSpawn;
++    }
++
++    /**
++     * Checks if the player respawned to their anchor
++     *
++     * @return whether the player respawned to their anchor
++     */
++    public boolean isAnchorSpawn() {
++        return isAnchorSpawn;
 +    }
 +
 +    @Override

--- a/patches/server/0319-Implement-PlayerPostRespawnEvent.patch
+++ b/patches/server/0319-Implement-PlayerPostRespawnEvent.patch
@@ -5,15 +5,16 @@ Subject: [PATCH] Implement PlayerPostRespawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index abba62b7252c6d6ee92a4b1a9b23df7758ab6a77..7dd874c6aa1268665d4a64dfc41013c304991273 100644
+index abba62b7252c6d6ee92a4b1a9b23df7758ab6a77..b0fb156f02185f6866e56ad024056982e82545ab 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -723,9 +723,14 @@ public abstract class PlayerList {
+@@ -723,9 +723,15 @@ public abstract class PlayerList {
  
          boolean flag2 = false;
  
 +        // Paper start
 +        boolean isBedSpawn = false;
++        boolean isAnchorSpawn = false;
 +        boolean isRespawn = false;
 +        // Paper end
 +
@@ -24,7 +25,15 @@ index abba62b7252c6d6ee92a4b1a9b23df7758ab6a77..7dd874c6aa1268665d4a64dfc41013c3
              ServerLevel worldserver1 = this.server.getLevel(entityplayer.getRespawnDimension());
              if (worldserver1 != null) {
                  Optional optional;
-@@ -776,6 +781,7 @@ public abstract class PlayerList {
+@@ -739,6 +745,7 @@ public abstract class PlayerList {
+                 if (optional.isPresent()) {
+                     BlockState iblockdata = worldserver1.getBlockState(blockposition);
+                     boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
++                    isAnchorSpawn = flag3;
+                     Vec3 vec3d = (Vec3) optional.get();
+                     float f1;
+ 
+@@ -776,6 +783,7 @@ public abstract class PlayerList {
  
              location = respawnEvent.getRespawnLocation();
              if (!flag) entityplayer.reset(); // SPIGOT-4785
@@ -32,14 +41,14 @@ index abba62b7252c6d6ee92a4b1a9b23df7758ab6a77..7dd874c6aa1268665d4a64dfc41013c3
          } else {
              location.setWorld(worldserver.getWorld());
          }
-@@ -833,6 +839,13 @@ public abstract class PlayerList {
+@@ -833,6 +841,13 @@ public abstract class PlayerList {
          if (entityplayer.connection.isDisconnected()) {
              this.save(entityplayer);
          }
 +
 +        // Paper start
 +        if (isRespawn) {
-+            cserver.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerPostRespawnEvent(entityplayer.getBukkitEntity(), location, isBedSpawn));
++            cserver.getPluginManager().callEvent(new com.destroystokyo.paper.event.player.PlayerPostRespawnEvent(entityplayer.getBukkitEntity(), location, isBedSpawn, isAnchorSpawn));
 +        }
 +        // Paper end
 +

--- a/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
+++ b/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
@@ -18,10 +18,10 @@ index 8537d010fa698c05c227f71b83b1e743f8578d84..8eac8e0898ffe621024daf3a1250e9c9
                  PlayerChangedWorldEvent changeEvent = new PlayerChangedWorldEvent(this.getBukkitEntity(), worldserver1.getWorld());
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 993f31b9106b5e20c62bfd405daa9fe55046840f..4ba978af436cb114aa5274df5cd8bd25ff7be2c9 100644
+index 680c9ece3a69b8048109576651db6949c08416bf..5a44820589246fa13f99a68418ee99d95b8d4c90 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -828,6 +828,8 @@ public abstract class PlayerList {
+@@ -830,6 +830,8 @@ public abstract class PlayerList {
              entityplayer.connection.send(new ClientboundUpdateMobEffectPacket(entityplayer.getId(), mobEffect));
          }
  

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -23,7 +23,7 @@ index ee53453440177537fc653ea156785d7591498614..cfe293881f68c8db337c3a48948362bb
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b8ca1f73b2451307c3711076eaa43e2adb34d92e..45e30c0d78b7625a6a55e6d7d60a823b674b75db 100644
+index 9e16c9e6b6e84d84028821f2ade103dbced66470..fd1064b08e61c0547cad092e009635ab708b8962 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -487,6 +487,11 @@ public class PaperWorldConfig {
@@ -532,7 +532,7 @@ index cd5394a0f1b46946b4f1575412c01bfcd86e782f..d234f08782b1a0c50714b8911d048699
      public ServerPlayer(MinecraftServer server, ServerLevel world, GameProfile profile) {
          super(world, world.getSharedSpawnPos(), world.getSharedSpawnAngle(), profile);
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 4ba978af436cb114aa5274df5cd8bd25ff7be2c9..10eb562d2089dc20c9ec33956c3e2f98084de748 100644
+index 5a44820589246fa13f99a68418ee99d95b8d4c90..9819f1e67d18d8272ea33fd5a1c8e59f70c918b2 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -244,7 +244,7 @@ public abstract class PlayerList {
@@ -544,7 +544,7 @@ index 4ba978af436cb114aa5274df5cd8bd25ff7be2c9..10eb562d2089dc20c9ec33956c3e2f98
          player.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
          playerconnection.send(new ClientboundCustomPayloadPacket(ClientboundCustomPayloadPacket.BRAND, (new FriendlyByteBuf(Unpooled.buffer())).writeUtf(this.getServer().getServerModName())));
          playerconnection.send(new ClientboundChangeDifficultyPacket(worlddata.getDifficulty(), worlddata.isDifficultyLocked()));
-@@ -797,7 +797,7 @@ public abstract class PlayerList {
+@@ -799,7 +799,7 @@ public abstract class PlayerList {
          // CraftBukkit start
          LevelData worlddata = worldserver1.getLevelData();
          entityplayer1.connection.send(new ClientboundRespawnPacket(worldserver1.dimensionType(), worldserver1.dimension(), BiomeManager.obfuscateSeed(worldserver1.getSeed()), entityplayer1.gameMode.getGameModeForPlayer(), entityplayer1.gameMode.getPreviousGameModeForPlayer(), worldserver1.isDebug(), worldserver1.isFlat(), flag));
@@ -553,7 +553,7 @@ index 4ba978af436cb114aa5274df5cd8bd25ff7be2c9..10eb562d2089dc20c9ec33956c3e2f98
          entityplayer1.setLevel(worldserver1);
          entityplayer1.unsetRemoved();
          entityplayer1.connection.teleport(new Location(worldserver1.getWorld(), entityplayer1.getX(), entityplayer1.getY(), entityplayer1.getZ(), entityplayer1.getYRot(), entityplayer1.getXRot()));
-@@ -1282,7 +1282,7 @@ public abstract class PlayerList {
+@@ -1284,7 +1284,7 @@ public abstract class PlayerList {
  
      public void setViewDistance(int viewDistance) {
          this.viewDistance = viewDistance;
@@ -703,7 +703,7 @@ index b57e5ffca725b10570aa10a870b992e6b767c2ec..4c439246f476225e6a1c6a2e758cf6d6
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
      {
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 2ab585a018290996e7fa9ca6f3ad7d734cd7beaa..a08583863f9fa08016bdfc7949a273eaa4429927 100644
+index 2574ccd92c43f56e8be71f1bf6857c761a72a510..951e8ba1e05436aa0afcd0a72358550422afa791 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -188,7 +188,7 @@ public class ActivationRange

--- a/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
@@ -14,10 +14,10 @@ movement will load only the chunk the player enters anyways and avoids loading
 massive amounts of surrounding chunks due to large AABB lookups.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 10eb562d2089dc20c9ec33956c3e2f98084de748..b828d6b2ce20a058acbabba5594e743d91df3060 100644
+index 9819f1e67d18d8272ea33fd5a1c8e59f70c918b2..acd4092a5b8bae0fd8e393c2efd2dc6a20c32880 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -791,6 +791,7 @@ public abstract class PlayerList {
+@@ -793,6 +793,7 @@ public abstract class PlayerList {
          entityplayer1.forceSetPositionRotation(location.getX(), location.getY(), location.getZ(), location.getYaw(), location.getPitch());
          // CraftBukkit end
  
@@ -26,7 +26,7 @@ index 10eb562d2089dc20c9ec33956c3e2f98084de748..b828d6b2ce20a058acbabba5594e743d
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7ce969911723d34c0027c063c184fa392d09fc12..c3f5a6b688873fa416408dd50935ba10d9cc594c 100644
+index 8ac6bf93ab35062a1325b099a695fea1ba154a1d..079e8f0f7ec5c3566b6778f5d518061a08699872 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -172,6 +172,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0449-Optimize-sending-packets-to-nearby-locations-sounds-.patch
+++ b/patches/server/0449-Optimize-sending-packets-to-nearby-locations-sounds-.patch
@@ -11,10 +11,10 @@ This will drastically cut down on packet sending cost for worlds with
 lots of players in them.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6b23b9389ff92ae8016d4adb289ac2a097670be5..f5334be5d9c799da16198ecb0f69f17a2bf4a1eb 100644
+index fbbdb3773912be0b4f2747b83c9d42b4b897ec2a..4e5c2011db99d71bf3f19387db361ea80a12329b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1137,16 +1137,40 @@ public abstract class PlayerList {
+@@ -1139,16 +1139,40 @@ public abstract class PlayerList {
      }
  
      public void broadcast(@Nullable net.minecraft.world.entity.player.Player player, double x, double y, double z, double distance, ResourceKey<Level> worldKey, Packet<?> packet) {

--- a/patches/server/0495-Fix-SPIGOT-5989.patch
+++ b/patches/server/0495-Fix-SPIGOT-5989.patch
@@ -10,7 +10,7 @@ This fixes that by checking if the modified spawn location is
 still at a respawn anchor.
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index e0c9857a922d8a3f421d7df0f056b82c4775390e..82a646365b5b0619825995c722cf773bf23b64ae 100644
+index 3206888f64bbcaa7543dc1bc22ea85506b4c2fb3..95bf45405c839d98f6bfacd41a227a691000ed50 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -79,6 +79,7 @@ import net.minecraft.world.level.GameRules;
@@ -21,15 +21,15 @@ index e0c9857a922d8a3f421d7df0f056b82c4775390e..82a646365b5b0619825995c722cf773b
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.border.BorderChangeListener;
  import net.minecraft.world.level.border.WorldBorder;
-@@ -829,6 +830,7 @@ public abstract class PlayerList {
-         // Paper start
+@@ -830,6 +831,7 @@ public abstract class PlayerList {
          boolean isBedSpawn = false;
+         boolean isAnchorSpawn = false;
          boolean isRespawn = false;
 +        boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
          // Paper end
  
          // CraftBukkit start - fire PlayerRespawnEvent
-@@ -839,7 +841,7 @@ public abstract class PlayerList {
+@@ -840,7 +842,7 @@ public abstract class PlayerList {
                  Optional optional;
  
                  if (blockposition != null) {
@@ -38,7 +38,7 @@ index e0c9857a922d8a3f421d7df0f056b82c4775390e..82a646365b5b0619825995c722cf773b
                  } else {
                      optional = Optional.empty();
                  }
-@@ -882,7 +884,12 @@ public abstract class PlayerList {
+@@ -884,7 +886,12 @@ public abstract class PlayerList {
              }
              // Spigot End
  
@@ -52,7 +52,7 @@ index e0c9857a922d8a3f421d7df0f056b82c4775390e..82a646365b5b0619825995c722cf773b
              if (!flag) entityplayer.reset(); // SPIGOT-4785
              isRespawn = true; // Paper
          } else {
-@@ -919,8 +926,12 @@ public abstract class PlayerList {
+@@ -921,8 +928,12 @@ public abstract class PlayerList {
          }
          // entityplayer1.syncInventory();
          entityplayer1.setHealth(entityplayer1.getHealth());

--- a/patches/server/0500-Incremental-player-saving.patch
+++ b/patches/server/0500-Incremental-player-saving.patch
@@ -67,7 +67,7 @@ index cf09bd17b9d2be04f79edef6debdd815b5f7f86c..7c05dd7489e686af3ce9c0d63cff3082
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 82a646365b5b0619825995c722cf773bf23b64ae..e990c9d936b9b2b510dd9c7f5a507b4ba9e79965 100644
+index 95bf45405c839d98f6bfacd41a227a691000ed50..44ad2b6fba813f44793dfb5816337cf84f52c1fb 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -569,6 +569,7 @@ public abstract class PlayerList {
@@ -78,7 +78,7 @@ index 82a646365b5b0619825995c722cf773bf23b64ae..e990c9d936b9b2b510dd9c7f5a507b4b
          this.playerIo.save(player);
          ServerStatsCounter serverstatisticmanager = (ServerStatsCounter) player.getStats(); // CraftBukkit
  
-@@ -1206,10 +1207,21 @@ public abstract class PlayerList {
+@@ -1208,10 +1209,21 @@ public abstract class PlayerList {
      }
  
      public void saveAll() {

--- a/patches/server/0555-Expose-world-spawn-angle.patch
+++ b/patches/server/0555-Expose-world-spawn-angle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose world spawn angle
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 5188f62a581276847695cc457f6fe86d47ec2af5..523a6163c9ac3eadebdd185d291aad21c33caae8 100644
+index d153fd8152d97c0d3dd28903d58df9e565c4a5c2..3bf47be1c9c1103230de4ea6214c7067e48b6ca9 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -873,7 +873,7 @@ public abstract class PlayerList {
+@@ -875,7 +875,7 @@ public abstract class PlayerList {
              if (location == null) {
                  worldserver1 = this.server.getLevel(Level.OVERWORLD);
                  blockposition = entityplayer1.getSpawnPoint(worldserver1);

--- a/patches/server/0599-Add-sendOpLevel-API.patch
+++ b/patches/server/0599-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6c167952102548c5f766eaa8e022e213cc20bd74..9a7b635e2a962f4e1ae689ec7a3bc471d9d940cc 100644
+index 3625a1287ab93cd7a1c96ef835a699b85f387695..ee62a9086e5a534b8cf6c9f5fb64154d85732dda 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -1121,22 +1121,29 @@ public abstract class PlayerList {
+@@ -1123,22 +1123,29 @@ public abstract class PlayerList {
      }
  
      private void sendPlayerPermissionLevel(ServerPlayer player, int permissionLevel) {

--- a/patches/server/0666-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
+++ b/patches/server/0666-Fix-anchor-respawn-acting-as-a-bed-respawn-from-the-.patch
@@ -6,26 +6,19 @@ Subject: [PATCH] Fix anchor respawn acting as a bed respawn from the end
 
 
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c0b4b4827c03a466752db32734a60813ec98c863..29aab99e686702eba9885b440d5755a4e59116f6 100644
+index 63c221c98c7a3ef5eeb493bdbddf30dd65f4ef19..af59b4f5e47aa5701fadbce3983b69a0b13e8de3 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -848,6 +848,7 @@ public abstract class PlayerList {
- 
-         // Paper start
-         boolean isBedSpawn = false;
-+        boolean isAnchorSpawn = false;
-         boolean isRespawn = false;
-         boolean isLocAltered = false; // Paper - Fix SPIGOT-5989
-         // Paper end
-@@ -868,6 +869,7 @@ public abstract class PlayerList {
+@@ -869,7 +869,7 @@ public abstract class PlayerList {
                  if (optional.isPresent()) {
                      BlockState iblockdata = worldserver1.getBlockState(blockposition);
                      boolean flag3 = iblockdata.is(Blocks.RESPAWN_ANCHOR);
+-                    isAnchorSpawn = flag3;
 +                    isAnchorSpawn = flag3; // Paper - Fix anchor respawn acting as a bed respawn from the end portal
                      Vec3 vec3d = (Vec3) optional.get();
                      float f1;
  
-@@ -895,7 +897,7 @@ public abstract class PlayerList {
+@@ -897,7 +897,7 @@ public abstract class PlayerList {
              }
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();


### PR DESCRIPTION
This PR adds a new method to the PlayerPostRespawnEvent event, isAnchorSpawn(), to check if the respawn was due to an anchor.