### PR TITLE
Add config setting for logging player ip addresses.

### DIFF
--- a/patches/server/0818-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0818-Add-config-option-for-logging-player-ip-addresses.patch
@@ -1,0 +1,98 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Tue, 5 Oct 2021 20:04:21 +0200
+Subject: [PATCH] Add config option for logging player ip addresses
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index f421e6a2e43e0a673dbb8a9a2b4331387e523e02..e143e4514789f707938a67fab4d313d5c55dc870 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -486,6 +486,11 @@ public class PaperConfig {
+         }
+     }
+ 
++    public static boolean logPlayerIpAddresses = true;
++    private static void playerIpAddresses() {
++        logPlayerIpAddresses = getBoolean("settings.log-player-ip-addresses", logPlayerIpAddresses);
++    }
++
+     public static int maxJoinsPerTick;
+     private static void maxJoinsPerTick() {
+         maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
+diff --git a/src/main/java/net/minecraft/network/protocol/PacketUtils.java b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+index acc12307f61e1e055896b68fe16654c9c4a606a0..c958a00535c0f7a015a7a566b97e2c80fc9a0efd 100644
+--- a/src/main/java/net/minecraft/network/protocol/PacketUtils.java
++++ b/src/main/java/net/minecraft/network/protocol/PacketUtils.java
+@@ -58,10 +58,11 @@ public class PacketUtils {
+                     // Paper start
+                     catch (Exception e) {
+                         Connection networkmanager = listener.getConnection();
++                        String playerIP = com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? String.valueOf(networkmanager.getRemoteAddress()) : "<ip address withheld>"; // Paper
+                         if (networkmanager.getPlayer() != null) {
+-                            LOGGER.error("Error whilst processing packet {} for {}[{}]", packet, networkmanager.getPlayer().getScoreboardName(), networkmanager.getRemoteAddress(), e);
++                            LOGGER.error("Error whilst processing packet {} for {}[{}]", packet, networkmanager.getPlayer().getScoreboardName(), playerIP, e); // Paper
+                         } else {
+-                            LOGGER.error("Error whilst processing packet {} for connection from {}", packet, networkmanager.getRemoteAddress(), e);
++                            LOGGER.error("Error whilst processing packet {} for connection from {}", packet, playerIP, e); // Paper
+                         }
+                         TextComponent error = new TextComponent("Packet processing error");
+                         networkmanager.send(new ClientboundDisconnectPacket(error), (future) -> {
+diff --git a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
+index 3962e82d4e4c5f792a37e825891e6960e737452d..dddc97094f0a7847b2818e6ea3b3f6cd4eb72b38 100644
+--- a/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
++++ b/src/main/java/net/minecraft/server/network/LegacyQueryHandler.java
+@@ -185,7 +185,7 @@ public class LegacyQueryHandler extends ChannelInboundHandlerAdapter {
+         buf.release();
+         this.buf = null;
+ 
+-        LOGGER.debug("Ping: (1.6) from {}", ctx.channel().remoteAddress());
++        LOGGER.debug("Ping: (1.6) from {}", com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? ctx.channel().remoteAddress() : "<ip address withheld>"); // Paper
+ 
+         InetSocketAddress virtualHost = com.destroystokyo.paper.network.PaperNetworkClient.prepareVirtualHost(host, port);
+         com.destroystokyo.paper.event.server.PaperServerListPingEvent event = PaperLegacyStatusClient.processRequest(
+diff --git a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
+index a7046da8c097254907e01cd17f4107c8744f4a6e..43b085ee4c747a813ec5e2fa965c3369690789c5 100644
+--- a/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
++++ b/src/main/java/net/minecraft/server/network/ServerConnectionListener.java
+@@ -204,7 +204,7 @@ public class ServerConnectionListener {
+                                 throw new ReportedException(CrashReport.forThrowable(exception, "Ticking memory connection"));
+                             }
+ 
+-                            ServerConnectionListener.LOGGER.warn("Failed to handle packet for {}", networkmanager.getRemoteAddress(), exception);
++                            ServerConnectionListener.LOGGER.warn("Failed to handle packet for {}", com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? String.valueOf(networkmanager.getRemoteAddress()) : "<ip address withheld>", exception); // Paper
+                             TextComponent chatcomponenttext = new TextComponent("Internal server error");
+ 
+                             networkmanager.send(new ClientboundDisconnectPacket(chatcomponenttext), (future) -> {
+diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+index 01fee879c946b6640da34d5890d686f0152437dc..494ca8fa8c742d4eac9fb11878d3b3170d850265 100644
+--- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+@@ -223,7 +223,10 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+     }
+ 
+     public String getUserName() {
+-        return this.gameProfile != null ? this.gameProfile + " (" + this.connection.getRemoteAddress() + ")" : String.valueOf(this.connection.getRemoteAddress());
++        // Paper start
++        String ip = com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? String.valueOf(this.connection.getRemoteAddress()) : "<ip address withheld>";
++        return this.gameProfile != null ? this.gameProfile + " (" + ip + ")" : String.valueOf(ip);
++        // Paper end
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
+index ad9fb50791779a5fe7d22268b71bd10d9c9ff3f0..1fd4a3f1ee2f4ee70f215384915d3ff972e67c3a 100644
+--- a/src/main/java/net/minecraft/server/players/PlayerList.java
++++ b/src/main/java/net/minecraft/server/players/PlayerList.java
+@@ -240,6 +240,11 @@ public abstract class PlayerList {
+             s1 = connection.getRemoteAddress().toString();
+         }
+ 
++        // Paper start
++        if (!com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses) {
++            s1 = "<ip address withheld>";
++        }
++
+         // Spigot start - spawn location event
+         Player spawnPlayer = player.getBukkitEntity();
+         org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(spawnPlayer, spawnPlayer.getLocation()); // Paper use our duplicate event

--- a/patches/server/0820-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0820-Add-config-option-for-logging-player-ip-addresses.patch
@@ -81,18 +81,15 @@ index 01fee879c946b6640da34d5890d686f0152437dc..494ca8fa8c742d4eac9fb11878d3b317
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index ad9fb50791779a5fe7d22268b71bd10d9c9ff3f0..1fd4a3f1ee2f4ee70f215384915d3ff972e67c3a 100644
+index ad9fb50791779a5fe7d22268b71bd10d9c9ff3f0..84b4b900e14628fddbaae6b00300929773df43a8 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -240,6 +240,11 @@ public abstract class PlayerList {
-             s1 = connection.getRemoteAddress().toString();
+@@ -237,7 +237,7 @@ public abstract class PlayerList {
+         String s1 = "local";
+ 
+         if (connection.getRemoteAddress() != null) {
+-            s1 = connection.getRemoteAddress().toString();
++            s1 = com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses ? connection.getRemoteAddress().toString() : "<ip address withheld>"; // Paper
          }
  
-+        // Paper start
-+        if (!com.destroystokyo.paper.PaperConfig.logPlayerIpAddresses) {
-+            s1 = "<ip address withheld>";
-+        }
-+
          // Spigot start - spawn location event
-         Player spawnPlayer = player.getBukkitEntity();
-         org.spigotmc.event.player.PlayerSpawnLocationEvent ev = new com.destroystokyo.paper.event.player.PlayerInitialSpawnEvent(spawnPlayer, spawnPlayer.getLocation()); // Paper use our duplicate event


### PR DESCRIPTION
As @CubBossa mentioned in #6298, it's probably a better and easier solution to create an easy to use config option, rather than having to install a log filter plugin.

Minecraft has a few log messages where the IP address is the only identifier, right now the PR just replaces the IP with an empty string. Would it be a better idea to use something like "CENSORED IP" to indicate that there should have been an IP there? (for example the line `Failed to handle packet for {}`, where {} is the player's ip).