### PR TITLE
fix: promote slf4j-api to api scope

### DIFF
--- a/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0068-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,14 +14,15 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c12636f01b233c2436b7d5cdd4c04ac91389247b..15b8f4708887535383bb74bd922f893231737599 100644
+index c12636f01b233c2436b7d5cdd4c04ac91389247b..d69d367a7527d677661ea56453b95417748b70a9 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -26,6 +26,7 @@ dependencies {
+@@ -26,6 +26,8 @@ dependencies {
      api("net.kyori:adventure-text-serializer-gson")
      api("net.kyori:adventure-text-serializer-legacy")
      api("net.kyori:adventure-text-serializer-plain")
 +    api("org.apache.logging.log4j:log4j-api:2.14.1") // Paper
++    api("org.slf4j:slf4j-api:1.7.30") // Paper
  
      implementation("org.ow2.asm:asm:9.1")
      implementation("org.ow2.asm:asm-commons:9.1")


### PR DESCRIPTION
`slf4j-api` was previously brought in via an `implementation`, which obviously won't expose it.