### PR TITLE
clone itemstack to return remaining stack

### DIFF
--- a/patches/server/0741-Make-hoppers-respect-inventory-max-stack-size.patch
+++ b/patches/server/0741-Make-hoppers-respect-inventory-max-stack-size.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make hoppers respect inventory max stack size
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-index 3b1442bf4c83650369e925d76f07dc67c6cbbc83..8ba57e133a9b800b8f291dd9cb8f46de0492f639 100644
+index 3b1442bf4c83650369e925d76f07dc67c6cbbc83..a3f0e2ab3eeebeb7c43fda3ddb1f16f8696255d3 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/HopperBlockEntity.java
-@@ -588,13 +588,21 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
+@@ -588,13 +588,22 @@ public class HopperBlockEntity extends RandomizableContainerBlockEntity implemen
              boolean flag1 = to.isEmpty();
  
              if (itemstack1.isEmpty()) {
@@ -21,6 +21,7 @@ index 3b1442bf4c83650369e925d76f07dc67c6cbbc83..8ba57e133a9b800b8f291dd9cb8f46de
                  stack = ItemStack.EMPTY;
 +                // Paper start
 +                } else {
++                    stack = stack.copy(); // Paper - copy stack to return leftover stack
 +                    stack.setCount(originalCount - stack.getCount());
 +                }
 +                // Paper end


### PR DESCRIPTION
Per @Brokkonaut's comment on the commit, I did further testing and found this clone necessary to not change the stack already moved to the other inventory.