### PR TITLE
Add CompostItemEvent and EntityCompostItemEvent

### DIFF
--- a/patches/api/0419-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/api/0419-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -1,0 +1,126 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sat, 7 Aug 2021 15:11:27 +0200
+Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java b/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..150c6c1468a36bf51f53b6227c50ab517b10f5ce
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/block/CompostItemEvent.java
+@@ -0,0 +1,65 @@
++package io.papermc.paper.event.block;
++
++import org.bukkit.block.Block;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.BlockEvent;
++import org.bukkit.event.inventory.InventoryMoveItemEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an item is about to be composted by a hopper.
++ * To prevent hoppers from moving items into composters, cancel the {@link InventoryMoveItemEvent}.
++ */
++public class CompostItemEvent extends BlockEvent {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private final ItemStack item;
++    private boolean willRaiseLevel;
++
++    public CompostItemEvent(@NotNull Block composter, @NotNull ItemStack item, boolean willRaiseLevel) {
++        super(composter);
++        this.item = item;
++        this.willRaiseLevel = willRaiseLevel;
++    }
++
++    /**
++     * Gets the item that was used on the composter.
++     *
++     * @return the item
++     */
++    @NotNull
++    public ItemStack getItem() {
++        return this.item;
++    }
++
++    /**
++     * Gets whether the composter will rise a level.
++     *
++     * @return true if successful
++     */
++    public boolean willRaiseLevel() {
++        return this.willRaiseLevel;
++    }
++
++    /**
++     * Sets whether the composter will rise a level.
++     *
++     * @param willRaiseLevel true if the composter should rise a level
++     */
++    public void setWillRaiseLevel(boolean willRaiseLevel) {
++        this.willRaiseLevel = willRaiseLevel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++}
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..fd94caaece9629df859cab85b98218ab3c8f22af
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityCompostItemEvent.java
+@@ -0,0 +1,43 @@
++package io.papermc.paper.event.entity;
++
++import io.papermc.paper.event.block.CompostItemEvent;
++import org.bukkit.block.Block;
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an item is about to be composted by an entity.
++ */
++public class EntityCompostItemEvent extends CompostItemEvent implements Cancellable {
++
++    private final Entity who;
++    private boolean cancelled;
++
++    public EntityCompostItemEvent(@NotNull Entity who, @NotNull Block composter, @NotNull ItemStack item, boolean willRaiseLevel) {
++        super(composter, item, willRaiseLevel);
++        this.who = who;
++    }
++
++    /**
++     * Gets the entity that interacted with the composter.
++     *
++     * @return the entity that composted an item.
++     */
++    @NotNull
++    public Entity getEntity() {
++        return this.who;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return this.cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++}

--- a/patches/server/0966-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
+++ b/patches/server/0966-Add-CompostItemEvent-and-EntityCompostItemEvent.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sun, 8 Aug 2021 19:56:02 +0200
+Subject: [PATCH] Add CompostItemEvent and EntityCompostItemEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
+index 564822911c25238900b361d564c5db3103900fb3..f6268231e39f50bb6adedd85e3c18d746ae3792d 100644
+--- a/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/ComposterBlock.java
+@@ -227,7 +227,10 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+                 if (state != dummyBlockState && org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(player, pos, dummyBlockState).isCancelled()) { // if block state will change and event cancelled
+                     return InteractionResult.sidedSuccess(world.isClientSide);
+                 }
+-                BlockState iblockdata1 = ComposterBlock.addItem(state, world, pos, itemstack, rand);
++                BlockState iblockdata1 = ComposterBlock.addItem(state, world, pos, itemstack, player);
++                if (iblockdata1 == null) {
++                    return InteractionResult.PASS;
++                }
+                 // Paper end
+ 
+                 world.levelEvent(1500, pos, state != iblockdata1 ? 1 : 0);
+@@ -252,11 +255,16 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+         if (i < 7 && ComposterBlock.COMPOSTABLES.containsKey(itemstack.getItem())) {
+             // CraftBukkit start
+             double rand = worldserver.getRandom().nextDouble();
+-            BlockState iblockdata1 = ComposterBlock.addItem(iblockdata, DummyGeneratorAccess.INSTANCE, blockposition, itemstack, rand);
++            BlockState iblockdata1 = ComposterBlock.addItem(iblockdata, DummyGeneratorAccess.INSTANCE, blockposition, itemstack, rand, entity); // Paper
+             if (iblockdata == iblockdata1 || org.bukkit.craftbukkit.event.CraftEventFactory.callEntityChangeBlockEvent(entity, blockposition, iblockdata1).isCancelled()) {
+                 return iblockdata;
+             }
+-            iblockdata1 = ComposterBlock.addItem(iblockdata, (LevelAccessor) worldserver, blockposition, itemstack, rand);
++            // Paper start
++            iblockdata1 = ComposterBlock.addItem(iblockdata, (LevelAccessor) worldserver, blockposition, itemstack, rand, entity);
++            if (iblockdata1 == null) {
++                return iblockdata;
++            }
++            // Paper end
+             // CraftBukkit end
+ 
+             itemstack.shrink(1);
+@@ -303,13 +311,39 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+         // CraftBukkit start
+         return ComposterBlock.addItem(state, world, pos, item, world.getRandom().nextDouble());
+     }
++    // Paper start
++    static BlockState addItem(BlockState state, LevelAccessor world, BlockPos pos, ItemStack item, @Nullable Entity entity) {
++        return ComposterBlock.addItem(state, world, pos, item, world.getRandom().nextDouble(), entity);
++    }
++    // Paper end
+ 
+     static BlockState addItem(BlockState iblockdata, LevelAccessor generatoraccess, BlockPos blockposition, ItemStack itemstack, double rand) {
++        // Paper start
++        return ComposterBlock.addItem(iblockdata, generatoraccess, blockposition, itemstack, rand, null);
++    }
++
++    @Nullable
++    static BlockState addItem(BlockState iblockdata, LevelAccessor generatoraccess, BlockPos blockposition, ItemStack itemstack, double rand, @Nullable Entity entity) {
++        // Paper end
+         // CraftBukkit end
+         int i = (Integer) iblockdata.getValue(ComposterBlock.LEVEL);
+         float f = ComposterBlock.COMPOSTABLES.getFloat(itemstack.getItem());
+ 
+-        if ((i != 0 || f <= 0.0F) && rand >= (double) f) {
++        // Paper start
++        io.papermc.paper.event.block.CompostItemEvent event;
++        boolean willRaiseLevel = !((i != 0 || f <= 0.0F) && rand >= (double) f);
++        if (entity == null) {
++            event = new io.papermc.paper.event.block.CompostItemEvent(org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
++        } else {
++            event = new io.papermc.paper.event.entity.EntityCompostItemEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(generatoraccess, blockposition), itemstack.getBukkitStack(), willRaiseLevel);
++        }
++
++        if (!event.callEvent()) {
++            return null;
++        }
++
++        if (!event.willRaiseLevel()) {
++            // Paper end
+             return iblockdata;
+         } else {
+             int j = i + 1;
+@@ -453,6 +487,11 @@ public class ComposterBlock extends Block implements WorldlyContainerHolder {
+                 this.changed = true;
+                 BlockState iblockdata = ComposterBlock.addItem(this.state, this.level, this.pos, itemstack);
+ 
++                // Paper start
++                if (iblockdata == null) {
++                    return;
++                }
++                // Paper end
+                 this.level.levelEvent(1500, this.pos, iblockdata != this.state ? 1 : 0);
+                 this.removeItemNoUpdate(0);
+             }


### PR DESCRIPTION
Adds #6349 . The event exposes the player who composted, the composter block, the item stack used, whether or not the level will be raised (settable), the level the composter currently has and it is of course cancellable.