### PR TITLE
Optimize entity tracker passenger checks

### DIFF
--- a/patches/server/0742-Optimize-entity-tracker-passenger-checks.patch
+++ b/patches/server/0742-Optimize-entity-tracker-passenger-checks.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Sun, 8 Aug 2021 00:52:54 -0400
+Subject: [PATCH] Optimize entity tracker passenger checks
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
+index 2f3e69ad809199ffc2661d524bb627ec8dbc2e80..e5cae2fb67541785072324e5434820ee4b169556 100644
+--- a/src/main/java/net/minecraft/server/level/ServerEntity.java
++++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
+@@ -74,7 +74,7 @@ public class ServerEntity {
+         this.trackedPlayers = trackedPlayers;
+         // CraftBukkit end
+         this.ap = Vec3.ZERO;
+-        this.lastPassengers = Collections.emptyList();
++        this.lastPassengers = com.google.common.collect.ImmutableList.of(); // Paper - optimize passenger checks
+         this.level = worldserver;
+         this.broadcast = consumer;
+         this.entity = entity;


### PR DESCRIPTION
When a `ServerEntity` instance is first constructed, it uses a pre-Java 9 empty collection, but passengers use Guava `ImmutableList`. When comparing the two collections via `Object#equals`, we miss out on an opportunity to reduce the check to little more than a reference equality check (which is very fast).

Noticed this while working on Krypton.