### PR TITLE
Add deepslate as xray engine 2 replacement default

### DIFF
--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a91a7d8f56a068b18d50a8b987b71510b0a19d5b..b8ca1f73b2451307c3711076eaa43e2adb34d92e 100644
+index a91a7d8f56a068b18d50a8b987b71510b0a19d5b..9e16c9e6b6e84d84028821f2ade103dbced66470 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -42,7 +42,7 @@ index a91a7d8f56a068b18d50a8b987b71510b0a19d5b..b8ca1f73b2451307c3711076eaa43e2a
 +        hiddenBlocks = getList("anti-xray.hidden-blocks", Arrays.asList("copper_ore", "deepslate_copper_ore", "gold_ore", "deepslate_gold_ore", "iron_ore", "deepslate_iron_ore",
 +            "coal_ore", "deepslate_coal_ore", "lapis_ore", "deepslate_lapis_ore", "mossy_cobblestone", "obsidian", "chest", "diamond_ore", "deepslate_diamond_ore",
 +            "redstone_ore", "deepslate_redstone_ore", "clay", "emerald_ore", "deepslate_emerald_ore", "ender_chest"));
-+        replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList("stone", "oak_planks"));
++        replacementBlocks = getList("anti-xray.replacement-blocks", Arrays.asList("stone", "oak_planks", "deepslate"));
 +        if (PaperConfig.version < 19) {
 +            hiddenBlocks.remove("lit_redstone_ore");
 +            int index = replacementBlocks.indexOf("planks");


### PR DESCRIPTION
With the addition of deepslate in 1.17, the anti xray configuration was
updated to include the deepslate variants of the ores in regards to
hiding them.
During this change, the fact that most surrounding blocks are deepslate
was overlooked and hence anti-xray engine 2 did not have any blocks to
obfuscate the ores with.

This commit fixes that by adding the deepslate block to the default
values on config generation.

Notably, this will not forceably add the deepslate default to existing
configs, hence old config files will need to be manually edited.

Resolves: #6350