### PR TITLE
Optimize indirect passenger iteration

### DIFF
--- a/patches/server/0745-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0745-Optimize-indirect-passenger-iteration.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Andrew Steinborn <git@steinborn.me>
+Date: Mon, 9 Aug 2021 00:38:37 -0400
+Subject: [PATCH] Optimize indirect passenger iteration
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 896d892237b29eb404398db07264eb6f04786754..895c8d8c676bfd3e11cd8371b2ac115b6a2e52b4 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -3475,26 +3475,41 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+     }
+ 
+     private Stream<Entity> getIndirectPassengersStream() {
++        if (this.passengers.isEmpty()) { return Stream.of(); } // Paper
+         return ImmutableList.copyOf(this.passengers).stream().flatMap(Entity::getSelfAndPassengers); // Paper
+     }
+ 
+     @Override
+     public Stream<Entity> getSelfAndPassengers() {
++        if (this.passengers.isEmpty()) { return Stream.of(this); } // Paper
+         return Stream.concat(Stream.of(this), this.getIndirectPassengersStream());
+     }
+ 
+     @Override
+     public Stream<Entity> getPassengersAndSelf() {
++        if (this.passengers.isEmpty()) { return Stream.of(this); } // Paper
+         return Stream.concat(this.passengers.stream().flatMap(Entity::getPassengersAndSelf), Stream.of(this));
+     }
+ 
+     public Iterable<Entity> getIndirectPassengers() {
++        // Paper start - rewrite this method
++        if (this.passengers.isEmpty()) { return ImmutableList.of(); }
++        ImmutableList.Builder<Entity> indirectPassengers = ImmutableList.builder();
++        for (Entity passenger : this.passengers) {
++            indirectPassengers.add(passenger);
++            indirectPassengers.addAll(passenger.getIndirectPassengers());
++        }
++        return indirectPassengers.build();
++    }
++    private Iterable<Entity> getIndirectPassengers_old() {
++        // Paper end
+         return () -> {
+             return this.getIndirectPassengersStream().iterator();
+         };
+     }
+ 
+     public boolean hasExactlyOnePlayerPassenger() {
++        if (this.passengers.isEmpty()) { return false; } // Paper
+         return this.getIndirectPassengersStream().filter((entity) -> {
+             return entity instanceof Player;
+         }).count() == 1L;


### PR DESCRIPTION
[Partially inspired by a similar Lithium optimization](https://github.com/CaffeineMC/lithium-fabric/commit/5aaed7b9a5d079aab489dcf113702bfb0d030f21) but more tailored, focusing on `Entity#getIndirectPassengers()` which is invoked at least as many times as there are entities being tracked in the entity tracker.