### PR TITLE
Apply furnace cook speed multiplier through event

### DIFF
--- a/patches/api/0154-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/api/0154-Implement-furnace-cook-speed-multiplier-API.patch
@@ -36,3 +36,27 @@ index c5a8c96fa2204d6b4d2409b1bfc97697d39d964e..9063cf370a0fe66c2a27086e125f9111
      @NotNull
      @Override
      public FurnaceInventory getInventory();
+diff --git a/src/main/java/org/bukkit/event/inventory/FurnaceStartSmeltEvent.java b/src/main/java/org/bukkit/event/inventory/FurnaceStartSmeltEvent.java
+index 533a33dbd4c4c3c07fe759206dc288efec5cd531..f13f1b4daa99fb86b60acc94d0406dcd8cb4d98b 100644
+--- a/src/main/java/org/bukkit/event/inventory/FurnaceStartSmeltEvent.java
++++ b/src/main/java/org/bukkit/event/inventory/FurnaceStartSmeltEvent.java
+@@ -13,11 +13,18 @@ public class FurnaceStartSmeltEvent extends BlockEvent {
+     private final CookingRecipe<?> recipe;
+     private int totalCookTime;
+ 
++    @Deprecated // Paper - furnace cook speed multiplier
+     public FurnaceStartSmeltEvent(@NotNull final Block furnace, @NotNull ItemStack source, @NotNull final CookingRecipe<?> recipe) {
++        // Paper start - furnace cook speed multiplier
++        this(furnace, source, recipe, recipe.getCookingTime());
++    }
++
++    public FurnaceStartSmeltEvent(@NotNull final Block furnace, @NotNull ItemStack source, @NotNull CookingRecipe<?> recipe, int cookingTime) {
++        // Paper end
+         super(furnace);
+         this.source = source;
+         this.recipe = recipe;
+-        this.totalCookTime = recipe.getCookingTime();
++        this.totalCookTime = cookingTime; // Paper - furnace cook speed multiplier
+     }
+ 
+     /**

--- a/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
@@ -11,7 +11,7 @@ to the nearest Integer when updating its current cook time.
 Modified by: Eric Su <ericsu@alumni.usc.edu>
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
-index 265fa3cb96b7d39194a7e83b8b77b811bc3e8b40..348196524eb3770541966e7e842ff0ae7afd94ad 100644
+index 265fa3cb96b7d39194a7e83b8b77b811bc3e8b40..02ded982bc36ce6530c92e18a079dc0bec729273 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/AbstractFurnaceBlockEntity.java
 @@ -73,6 +73,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
@@ -42,6 +42,15 @@ index 265fa3cb96b7d39194a7e83b8b77b811bc3e8b40..348196524eb3770541966e7e842ff0ae
          ContainerHelper.saveAllItems(nbt, this.items);
          CompoundTag nbttagcompound1 = new CompoundTag();
  
+@@ -346,7 +353,7 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
+                     CraftItemStack source = CraftItemStack.asCraftMirror(blockEntity.items.get(0));
+                     CookingRecipe<?> recipe = (CookingRecipe<?>) irecipe.toBukkitRecipe();
+ 
+-                    FurnaceStartSmeltEvent event = new FurnaceStartSmeltEvent(CraftBlock.at(world, pos), source, recipe);
++                    FurnaceStartSmeltEvent event = new FurnaceStartSmeltEvent(CraftBlock.at(world, pos), source, recipe, AbstractFurnaceBlockEntity.getTotalCookTime(world, blockEntity.recipeType, blockEntity, blockEntity.cookSpeedMultiplier)); // Paper - cook speed multiplier API
+                     world.getCraftServer().getPluginManager().callEvent(event);
+ 
+                     blockEntity.cookingTotalTime = event.getTotalCookTime();
 @@ -354,9 +361,9 @@ public abstract class AbstractFurnaceBlockEntity extends BaseContainerBlockEntit
                  // CraftBukkit end
  


### PR DESCRIPTION
Previously the upstream FurnaceStartSmeltEvent would default to the
recipes cooking time, ignoring any modifications from the furnace speed
multiplier.
While this works correctly for upstream, paper introduces the speed
multiplier API, which allows a different cook time from the one provided
by the recipe.

This commit now passes the modified cooktime to the furnace start smelt
event explicitly, instead of allowing the event to default to the
recipes cooking time, thus ensuring that the speed modifier is
respected.

Resolves: #6376

----------------------------------------------------------------------------------

### Alternatives
Another possible solution to this issue was proposed by @NoahvdAa in #6376 which shifts the calculation logic into the event constructor:
```patch
-        this.totalCookTime = recipe.getCookingTime();
+        this.totalCookTime = (int) Math.ceil(recipe.getCookingTime() / ((org.bukkit.block.Furnace) furnace.getState()).getCookSpeedMultiplier());
```
