### PR TITLE
Configurable item frame map cursor interval

### DIFF
--- a/patches/server/0745-Configurable-item-frame-map-cursor-interval.patch
+++ b/patches/server/0745-Configurable-item-frame-map-cursor-interval.patch
@@ -1,0 +1,36 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
+Date: Fri, 13 Aug 2021 01:14:38 +0200
+Subject: [PATCH] Configurable item frame map cursor interval
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index cad6b4479ad3ab9e2e4bb3a733a66e4a2598dc90..f3d37d519f0b6a5eeb7dece82c2da0ccc81b96f3 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -838,6 +838,12 @@ public class PaperWorldConfig {
+         mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
+     }
+ 
++    public int itemFrameMapCursorUpdateInterval = 10;
++    private void itemFrameCursorUpdateInterval() {
++        itemFrameMapCursorUpdateInterval = getInt("item-frame-map-cursor-update-interval", 10);
++    }
++
++
+     public boolean fixItemsMergingThroughWalls;
+     private void fixItemsMergingThroughWalls() {
+         fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
+diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
+index e5cae2fb67541785072324e5434820ee4b169556..a0a8d7043eac26433fef8264a17359e08d4d3156 100644
+--- a/src/main/java/net/minecraft/server/level/ServerEntity.java
++++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
+@@ -99,7 +99,7 @@ public class ServerEntity {
+             ItemFrame entityitemframe = (ItemFrame) this.entity;
+             ItemStack itemstack = entityitemframe.getItem();
+ 
+-            if (this.tickCount % 10 == 0 && itemstack.getItem() instanceof MapItem) { // CraftBukkit - Moved this.tickCounter % 10 logic here so item frames do not enter the other blocks
++            if (this.level.paperConfig.itemFrameMapCursorUpdateInterval >= 0 && this.tickCount % this.level.paperConfig.itemFrameMapCursorUpdateInterval == 0 && itemstack.getItem() instanceof MapItem) { // Paper - Make item frame map cursor update interval configurable
+                 Integer integer = MapItem.getMapId(itemstack);
+                 MapItemSavedData worldmap = MapItem.getSavedData(integer, (Level) this.level);
+ 

--- a/patches/server/0745-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0745-Configurable-item-frame-map-cursor-update-interval.patch
@@ -1,28 +1,27 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Warrior <50800980+Warriorrrr@users.noreply.github.com>
 Date: Fri, 13 Aug 2021 01:14:38 +0200
-Subject: [PATCH] Configurable item frame map cursor interval
+Subject: [PATCH] Configurable item frame map cursor update interval
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cad6b4479ad3ab9e2e4bb3a733a66e4a2598dc90..f3d37d519f0b6a5eeb7dece82c2da0ccc81b96f3 100644
+index cad6b4479ad3ab9e2e4bb3a733a66e4a2598dc90..af06e87191b2a04dc8e7c7555ab98bef17021b9f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -838,6 +838,12 @@ public class PaperWorldConfig {
+@@ -838,6 +838,11 @@ public class PaperWorldConfig {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }
  
-+    public int itemFrameMapCursorUpdateInterval = 10;
++    public int mapItemFrameCursorUpdateInterval = 10;
 +    private void itemFrameCursorUpdateInterval() {
-+        itemFrameMapCursorUpdateInterval = getInt("item-frame-map-cursor-update-interval", 10);
++        mapItemFrameCursorUpdateInterval = getInt("map-item-frame-cursor-update-interval", mapItemFrameCursorUpdateInterval);
 +    }
-+
 +
      public boolean fixItemsMergingThroughWalls;
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index e5cae2fb67541785072324e5434820ee4b169556..a0a8d7043eac26433fef8264a17359e08d4d3156 100644
+index e5cae2fb67541785072324e5434820ee4b169556..fe62ec1a888a93d90f40d86908f83faaed907ba6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -99,7 +99,7 @@ public class ServerEntity {
@@ -30,7 +29,7 @@ index e5cae2fb67541785072324e5434820ee4b169556..a0a8d7043eac26433fef8264a17359e0
              ItemStack itemstack = entityitemframe.getItem();
  
 -            if (this.tickCount % 10 == 0 && itemstack.getItem() instanceof MapItem) { // CraftBukkit - Moved this.tickCounter % 10 logic here so item frames do not enter the other blocks
-+            if (this.level.paperConfig.itemFrameMapCursorUpdateInterval >= 0 && this.tickCount % this.level.paperConfig.itemFrameMapCursorUpdateInterval == 0 && itemstack.getItem() instanceof MapItem) { // Paper - Make item frame map cursor update interval configurable
++            if (this.level.paperConfig.mapItemFrameCursorUpdateInterval >= 0 && this.tickCount % this.level.paperConfig.mapItemFrameCursorUpdateInterval == 0 && itemstack.getItem() instanceof MapItem) { // CraftBukkit - Moved this.tickCounter % 10 logic here so item frames do not enter the other blocks // Paper - Make item frame map cursor update interval configurable
                  Integer integer = MapItem.getMapId(itemstack);
                  MapItemSavedData worldmap = MapItem.getSavedData(integer, (Level) this.level);
  


### PR DESCRIPTION
Adds a config option in order to make the interval at which the green arrows maps in item frames sometimes have are updated. The aim of this patch is to improve performance in situations where there are a lot of maps in item frames, while keeping maps functionally the same.