### PR TITLE
Fix block drops position losing precision millions of blocks out

### DIFF
--- a/patches/server/0746-Fix-block-drops-position-losing-precision-millions-o.patch
+++ b/patches/server/0746-Fix-block-drops-position-losing-precision-millions-o.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Thu, 12 Aug 2021 21:15:38 -0700
+Subject: [PATCH] Fix block drops position losing precision millions of blocks
+ out
+
+
+diff --git a/src/main/java/net/minecraft/world/level/block/Block.java b/src/main/java/net/minecraft/world/level/block/Block.java
+index d6a3f3a2edae806b0ebf5bf5ac445116c0d64535..1a5605b11170dfe1bd37165de886bad0f2e38ecd 100644
+--- a/src/main/java/net/minecraft/world/level/block/Block.java
++++ b/src/main/java/net/minecraft/world/level/block/Block.java
+@@ -344,9 +344,11 @@ public class Block extends BlockBehaviour implements ItemLike {
+ 
+     public static void popResource(Level world, BlockPos pos, ItemStack stack) {
+         float f = EntityType.ITEM.getHeight() / 2.0F;
+-        double d0 = (double) ((float) pos.getX() + 0.5F) + Mth.nextDouble(world.random, -0.25D, 0.25D);
+-        double d1 = (double) ((float) pos.getY() + 0.5F) + Mth.nextDouble(world.random, -0.25D, 0.25D) - (double) f;
+-        double d2 = (double) ((float) pos.getZ() + 0.5F) + Mth.nextDouble(world.random, -0.25D, 0.25D);
++        // Paper start - don't convert potentially massive numbers to floats
++        double d0 = pos.getX() + 0.5D + Mth.nextDouble(world.random, -0.25D, 0.25D);
++        double d1 = pos.getY() + 0.5D + Mth.nextDouble(world.random, -0.25D, 0.25D) - (double) f;
++        double d2 = pos.getZ() + 0.5D + Mth.nextDouble(world.random, -0.25D, 0.25D);
++        // Paper end
+ 
+         Block.popResource(world, () -> {
+             return new ItemEntity(world, d0, d1, d2, stack);
+@@ -359,9 +361,11 @@ public class Block extends BlockBehaviour implements ItemLike {
+         int k = direction.getStepZ();
+         float f = EntityType.ITEM.getWidth() / 2.0F;
+         float f1 = EntityType.ITEM.getHeight() / 2.0F;
+-        double d0 = (double) ((float) pos.getX() + 0.5F) + (i == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) i * (0.5F + f)));
+-        double d1 = (double) ((float) pos.getY() + 0.5F) + (j == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) j * (0.5F + f1))) - (double) f1;
+-        double d2 = (double) ((float) pos.getZ() + 0.5F) + (k == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) k * (0.5F + f)));
++        // Paper start - don't convert potentially massive numbers to floats
++        double d0 = pos.getX() + 0.5D + (i == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) i * (0.5F + f)));
++        double d1 = pos.getY() + 0.5D + (j == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) j * (0.5F + f1))) - (double) f1;
++        double d2 = pos.getZ() + 0.5D + (k == 0 ? Mth.nextDouble(world.random, -0.25D, 0.25D) : (double) ((float) k * (0.5F + f)));
++        // Paper end
+         double d3 = i == 0 ? Mth.nextDouble(world.random, -0.1D, 0.1D) : (double) i * 0.1D;
+         double d4 = j == 0 ? Mth.nextDouble(world.random, 0.0D, 0.1D) : (double) j * 0.1D + 0.1D;
+         double d5 = k == 0 ? Mth.nextDouble(world.random, -0.1D, 0.1D) : (double) k * 0.1D;


### PR DESCRIPTION
Fixes the issue shown in [this video](https://www.youtube.com/watch?v=jfAkBd4kMHQ) where drops from breaking blocks lose precision in their position and end up 1-2 blocks in the wrong direction, sometimes inside of walls, when the block pos is in the tens of millions.