### PR TITLE
Mark fish and axolotls from buckets as persistent

### DIFF
--- a/patches/server/0807-Mark-fish-and-axolotls-from-buckets-as-persistent.patch
+++ b/patches/server/0807-Mark-fish-and-axolotls-from-buckets-as-persistent.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 13 Aug 2021 16:38:08 -0700
+Subject: [PATCH] Mark fish and axolotls from buckets as persistent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/AbstractFish.java b/src/main/java/net/minecraft/world/entity/animal/AbstractFish.java
+index fc0cd86397b12e42756273a0317164d79ac51937..76cb5ba6023a8d019b5f4c8c2cedbc8e0fd04886 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/AbstractFish.java
++++ b/src/main/java/net/minecraft/world/entity/animal/AbstractFish.java
+@@ -90,7 +90,7 @@ public abstract class AbstractFish extends WaterAnimal implements Bucketable {
+     @Override
+     public void setFromBucket(boolean fromBucket) {
+         this.entityData.set(AbstractFish.FROM_BUCKET, fromBucket);
+-        this.setPersistenceRequired(this.isPersistenceRequired()); // CraftBukkit - SPIGOT-4106 update persistence
++        this.setPersistenceRequired(fromBucket); // CraftBukkit - SPIGOT-4106 update persistence // Paper - actually set as persistent
+     }
+ 
+     @Override
+diff --git a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+index fa365420a4593bc7d652b0d92f4750602fcb334b..d041e6f9c01549bb15f3d68ff1fd3bcc3458482b 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
++++ b/src/main/java/net/minecraft/world/entity/animal/axolotl/Axolotl.java
+@@ -236,7 +236,7 @@ public class Axolotl extends Animal implements LerpingModel, Bucketable {
+     @Override
+     public void setFromBucket(boolean fromBucket) {
+         this.entityData.set(Axolotl.FROM_BUCKET, fromBucket);
+-        this.setPersistenceRequired(this.isPersistenceRequired()); // CraftBukkit - SPIGOT-4106 update persistence
++        this.setPersistenceRequired(fromBucket); // CraftBukkit - SPIGOT-4106 update persistence // Paper - actually set as persistent
+     }
+ 
+     @Nullable


### PR DESCRIPTION
Fixes [SPIGOT-6618](https://hub.spigotmc.org/jira/browse/SPIGOT-6618).

This doesn't actually change any behavior on the server side of things because Paper only counts mobs that have a `NATURAL` SpawnReason and fish/axolotls from buckets have a `SPAWNER_EGG` reason, but it does affect what is returned by the api method `LivingEntity#getRemoveWhenFarAway` which would've returned false for fish/axolotls without this change.