### PR TITLE
Add STRUCTURE_TYPE registry entry

### DIFF
--- a/patches/api/0363-Expand-the-Registry-API.patch
+++ b/patches/api/0363-Expand-the-Registry-API.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 14 Aug 2021 16:19:03 -0700
+Subject: [PATCH] Expand the Registry API
+
+
+diff --git a/src/main/java/org/bukkit/Registry.java b/src/main/java/org/bukkit/Registry.java
+index 6242336de18fdd708cc3d7b745cbbace13140bc0..661d424c609a01ad9bee837b4069d9e4e98d20c0 100644
+--- a/src/main/java/org/bukkit/Registry.java
++++ b/src/main/java/org/bukkit/Registry.java
+@@ -209,6 +209,25 @@ public interface Registry<T extends Keyed> extends Iterable<T> {
+             return Arrays.stream(org.bukkit.potion.PotionEffectType.values()).iterator();
+         }
+     };
++
++    /**
++     * Structure types.
++     *
++     * @see StructureType
++     */
++    Registry<StructureType> STRUCTURE_TYPE = new Registry<StructureType>() {
++
++        @Override
++        public @Nullable StructureType get(@NotNull NamespacedKey key) {
++            return StructureType.getStructureTypes().get(key.getKey());
++        }
++
++        @NotNull
++        @Override
++        public Iterator<StructureType> iterator() {
++            return StructureType.getStructureTypes().values().iterator();
++        }
++    };
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/StructureType.java b/src/main/java/org/bukkit/StructureType.java
+index 8acb2b9de398ab5f4b18c46e9ab9eb964df8be3f..5558daa9512212a4b05f174b64c4c998ebbccfcc 100644
+--- a/src/main/java/org/bukkit/StructureType.java
++++ b/src/main/java/org/bukkit/StructureType.java
+@@ -19,7 +19,7 @@ import org.jetbrains.annotations.Nullable;
+  * The registration of new {@link StructureType}s is case-sensitive.
+  */
+ // Order is retrieved from WorldGenFactory
+-public final class StructureType {
++public final class StructureType implements Keyed { // Paper - implement keyed
+ 
+     private static final Map<String, StructureType> structureTypeMap = new HashMap<>();
+ 
+@@ -244,4 +244,10 @@ public final class StructureType {
+     public static Map<String, StructureType> getStructureTypes() {
+         return ImmutableMap.copyOf(structureTypeMap);
+     }
++    // Paper start
++    @Override
++    public @NotNull NamespacedKey getKey() {
++        return NamespacedKey.minecraft(this.name);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Noticed this was missing when I went looking for it for a thing. I created a PaperRegistry interface for putting ones Paper adds cause its not unreasonable that upstream will add them, and if there's a slightly different name, I **really** wouldn't want both in the same class. Can deprecate these if upstream ever adds any. 

More can be added to this patch when needed.