### PR TITLE
Don't fire entitymovevent for players.

### DIFF
--- a/patches/server/0616-EntityMoveEvent.patch
+++ b/patches/server/0616-EntityMoveEvent.patch
@@ -29,7 +29,7 @@ index 4223d4610b4fec588980dba2ea5ec4f04c45d945..fd2b301bda95438bc7e48173bbe74aec
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3227ce58391b93c12dd01e2b73a3a6c5d6062827..f0a2e27c21b0fd9df236a0a145c7cbf37661fa7d 100644
+index 3227ce58391b93c12dd01e2b73a3a6c5d6062827..25aa83e2d63edffa4a30c2563341ee4d82e4f3bd 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3223,6 +3223,20 @@ public abstract class LivingEntity extends Entity {
@@ -37,7 +37,7 @@ index 3227ce58391b93c12dd01e2b73a3a6c5d6062827..f0a2e27c21b0fd9df236a0a145c7cbf3
          this.pushEntities();
          this.level.getProfiler().pop();
 +        // Paper start
-+        if (((ServerLevel) this.level).hasEntityMoveEvent) {
++        if (((ServerLevel) this.level).hasEntityMoveEvent && !(this instanceof net.minecraft.world.entity.player.Player)) {
 +            if (this.xo != getX() || this.yo != this.getY() || this.zo != this.getZ() || this.yRotO != this.getYRot() || this.xRotO != this.getXRot()) {
 +                Location from = new Location(this.level.getWorld(), this.xo, this.yo, this.zo, this.yRotO, this.xRotO);
 +                Location to = new Location (this.level.getWorld(), this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());


### PR DESCRIPTION
Closes #6401.

EntityMoveEvent doesn't look like it should fire for players, as it's fired in `LivingEntity#aiStep`. Players jumping still fired this event. This PR checks if the entity isn't a player before firing the event.