### PR TITLE
Correct Remaining Items For Non-Recipe Crafting

### DIFF
--- a/patches/server/0748-Correct-Remaining-Items-For-Non-Recipe-Crafting.patch
+++ b/patches/server/0748-Correct-Remaining-Items-For-Non-Recipe-Crafting.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: thamid-gamer <60953955+thamid-gamer@users.noreply.github.com>
+Date: Wed, 18 Aug 2021 00:54:32 -0400
+Subject: [PATCH] Correct Remaining Items For Non-Recipe Crafting
+
+
+diff --git a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+index 057b92a2948543644618c63abd3f61d1120db4dd..de2db75862d15c2755d62431e4b4f589c8bee43d 100644
+--- a/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
++++ b/src/main/java/net/minecraft/world/item/crafting/RecipeManager.java
+@@ -134,7 +134,12 @@ public class RecipeManager extends SimpleJsonResourceReloadListener {
+             NonNullList<ItemStack> nonnulllist = NonNullList.withSize(inventory.getContainerSize(), ItemStack.EMPTY);
+ 
+             for (int i = 0; i < nonnulllist.size(); ++i) {
+-                nonnulllist.set(i, inventory.getItem(i));
++                // Paper start - use remaining items for non-recipe crafting (copied from default Recipe#getRemainingItems(Container))
++                net.minecraft.world.item.Item item = inventory.getItem(i).getItem();
++                if (item.hasCraftingRemainingItem()) {
++                    nonnulllist.set(i, new ItemStack(item.getCraftingRemainingItem()));
++                }
++                // Paper end
+             }
+ 
+             return nonnulllist;


### PR DESCRIPTION
Fixes #1822 (kind of)

from what I understand, the client has a RecipeManager as well which expects the item stack to follow the doubling behavior. that being said I think it's fine to deviate here since stacks should never be greater than 64. however, this will cause a slight flicker sometimes, doubling the stack and until the server later sets the amount it should really be at. the same flickering occurs when we set the remaining item.