### PR TITLE
Fix server not shutting down when exiting early.

### DIFF
--- a/patches/server/0224-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0224-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -17,7 +17,7 @@ index 49acf558413ddfe6569ff83054ae654c9205d61a..af212392d7758aef9d9974b74000f980
      runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.1")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.0")
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f63919922 100644
+index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..4c9e7243e1c9ccfa64ef96892e8a68f4c1f548b9 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -112,6 +112,8 @@ public class Main {
@@ -25,7 +25,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f
              if (optionset.has("initSettings")) { // CraftBukkit
                  Main.LOGGER.info("Initialized '{}' and '{}'", path.toAbsolutePath(), path1.toAbsolutePath());
 +                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
-+                Process.exit(0); // Paper - workaround until Log4J is updated.
++                System.exit(0); // Paper - workaround until Log4J is updated.
                  return;
              }
  
@@ -34,7 +34,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f
              if (!eula.hasAgreedToEULA() && !eulaAgreed) { // Spigot
                  Main.LOGGER.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
 +                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
-+                Process.exit(0); // Paper - workaround until Log4J is updated.
++                System.exit(0); // Paper - workaround until Log4J is updated.
                  return;
              }
  
@@ -43,7 +43,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f
              if (worldinfo != null && worldinfo.isIncompatibleWorldHeight()) {
                  Main.LOGGER.info("Loading of worlds with extended height is disabled.");
 +                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
-+                Process.exit(0); // Paper - workaround until Log4J is updated.
++                System.exit(0); // Paper - workaround until Log4J is updated.
                  return;
              }
  
@@ -52,7 +52,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f
                  Main.LOGGER.warn("Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode", exception);
                  resourcepackrepository.close();
 +                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
-+                Process.exit(0); // Paper - workaround until Log4J is updated.
++                System.exit(0); // Paper - workaround until Log4J is updated.
                  return;
              }
  

--- a/patches/server/0224-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
+++ b/patches/server/0224-Use-AsyncAppender-to-keep-logging-IO-off-main-thread.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Use AsyncAppender to keep logging IO off main thread
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 34a0d6b54a15c8aa0c706541316c5d448e3d94b9..76a8db5ff623b0a3b83a0861f642da67ad2be3aa 100644
+index 49acf558413ddfe6569ff83054ae654c9205d61a..af212392d7758aef9d9974b74000f9804132d929 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -38,6 +38,7 @@ dependencies {
@@ -16,6 +16,46 @@ index 34a0d6b54a15c8aa0c706541316c5d448e3d94b9..76a8db5ff623b0a3b83a0861f642da67
  
      runtimeOnly("org.apache.maven:maven-resolver-provider:3.8.1")
      runtimeOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.0")
+diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
+index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..1537e1b54564295acf0c0466156b4a1f63919922 100644
+--- a/src/main/java/net/minecraft/server/Main.java
++++ b/src/main/java/net/minecraft/server/Main.java
+@@ -112,6 +112,8 @@ public class Main {
+ 
+             if (optionset.has("initSettings")) { // CraftBukkit
+                 Main.LOGGER.info("Initialized '{}' and '{}'", path.toAbsolutePath(), path1.toAbsolutePath());
++                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
++                Process.exit(0); // Paper - workaround until Log4J is updated.
+                 return;
+             }
+ 
+@@ -126,6 +128,8 @@ public class Main {
+             // Spigot End
+             if (!eula.hasAgreedToEULA() && !eulaAgreed) { // Spigot
+                 Main.LOGGER.info("You need to agree to the EULA in order to run the server. Go to eula.txt for more info.");
++                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
++                Process.exit(0); // Paper - workaround until Log4J is updated.
+                 return;
+             }
+ 
+@@ -144,6 +148,8 @@ public class Main {
+ 
+             if (worldinfo != null && worldinfo.isIncompatibleWorldHeight()) {
+                 Main.LOGGER.info("Loading of worlds with extended height is disabled.");
++                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
++                Process.exit(0); // Paper - workaround until Log4J is updated.
+                 return;
+             }
+ 
+@@ -182,6 +188,8 @@ public class Main {
+             } catch (Exception exception) {
+                 Main.LOGGER.warn("Failed to load datapacks, can't proceed with server load. You can either fix your datapacks or reset to vanilla with --safeMode", exception);
+                 resourcepackrepository.close();
++                LogManager.shutdown(); // Paper - workaround until Log4J is updated.
++                Process.exit(0); // Paper - workaround until Log4J is updated.
+                 return;
+             }
+ 
 diff --git a/src/main/resources/log4j2.xml b/src/main/resources/log4j2.xml
 index 476f4a5cbe664ddd05474cb88553018bd334a5b8..3dc317e466e1b93dff030794dd7f29ca1b266778 100644
 --- a/src/main/resources/log4j2.xml

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -2287,10 +2287,10 @@ index 966f0951832040c38fdd2caa58f7eae372aa0f59..49fd3486a6c595749f33bbe1c1bec045
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..7ce854edba32ffcafaa5268d4bb2822a5233e40b 100644
+index 1537e1b54564295acf0c0466156b4a1f63919922..00275c20e6e45650b57877a71d40bce79f1dfbcd 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -217,6 +217,7 @@ public class Main {
+@@ -225,6 +225,7 @@ public class Main {
  
              convertable_conversionsession.a((IRegistryCustom) iregistrycustom_dimension, (SaveData) object);
              */

--- a/patches/server/0496-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
+++ b/patches/server/0496-Fix-SPIGOT-5824-Bukkit-world-container-is-not-used.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5824 Bukkit world-container is not used
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 7ce854edba32ffcafaa5268d4bb2822a5233e40b..3d6e09a3f028e50c08cbbb6b426f5b044c7b9e67 100644
+index 00275c20e6e45650b57877a71d40bce79f1dfbcd..c07823a45fe95fac3e45dd549e4cac4a37dc3de4 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -129,11 +129,20 @@ public class Main {
+@@ -133,11 +133,20 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0497-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
+++ b/patches/server/0497-Fix-SPIGOT-5885-Unable-to-disable-advancements.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix SPIGOT-5885 Unable to disable advancements
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 3d6e09a3f028e50c08cbbb6b426f5b044c7b9e67..ea136b9ad3a2a07076e12b8656c68f63aa4718c8 100644
+index c07823a45fe95fac3e45dd549e4cac4a37dc3de4..a0eea5ebd15cdc98579f9471b5f4b1e37a3bb12a 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -129,6 +129,7 @@ public class Main {
+@@ -133,6 +133,7 @@ public class Main {
                  return;
              }
  

--- a/patches/server/0680-Add-environment-variable-to-disable-server-gui.patch
+++ b/patches/server/0680-Add-environment-variable-to-disable-server-gui.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add environment variable to disable server gui
 
 
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index ea136b9ad3a2a07076e12b8656c68f63aa4718c8..cf0a74b8a1c31d4bc493eb09a69ee2bd94cb6485 100644
+index a0eea5ebd15cdc98579f9471b5f4b1e37a3bb12a..f5d12d35412087a379de200dec756951c7b6ce85 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
-@@ -239,6 +239,7 @@ public class Main {
+@@ -247,6 +247,7 @@ public class Main {
                  */
                  boolean flag1 = !optionset.has("nogui") && !optionset.nonOptionArguments().contains("nogui");
  

--- a/patches/server/0686-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0686-Fix-and-optimise-world-force-upgrading.patch
@@ -237,7 +237,7 @@ index 0000000000000000000000000000000000000000..389faf099ff64bb2845222600552c8fc
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index cf0a74b8a1c31d4bc493eb09a69ee2bd94cb6485..cfd43069ee2b6f79afb12e10d223f6bf75100034 100644
+index f5d12d35412087a379de200dec756951c7b6ce85..b006067ba3ed7466f0e7916ffc4517a7c4ecd861 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -15,6 +15,7 @@ import java.nio.file.Paths;
@@ -248,7 +248,7 @@ index cf0a74b8a1c31d4bc493eb09a69ee2bd94cb6485..cfd43069ee2b6f79afb12e10d223f6bf
  import joptsimple.NonOptionArgumentSpec;
  import joptsimple.OptionParser;
  import joptsimple.OptionSet;
-@@ -283,6 +284,15 @@ public class Main {
+@@ -291,6 +292,15 @@ public class Main {
      }
      // Paper end
  


### PR DESCRIPTION
Fixes #6422 with a workaround until a Log4J update is released.