### PR TITLE
Set AsyncAppender dispatch thread to be a daemon thread

### DIFF
--- a/patches/server/0748-Set-AsyncAppender-dispatch-thread-to-be-a-daemon-thr.patch
+++ b/patches/server/0748-Set-AsyncAppender-dispatch-thread-to-be-a-daemon-thr.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Wed, 18 Aug 2021 12:02:02 -0500
+Subject: [PATCH] Set AsyncAppender dispatch thread to be a daemon thread
+
+This diff will be included in the not yet released Log4j 2.14.2. When Log4j 2.14.2 is released this patch should be dropped in favor of bumping Log4j.
+
+diff --git a/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java b/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
+index a01f68db840b6e953fa6908ad10cd25744be6471..d406c3d38059b1e4012ca5ebd938b8a6f8ce152f 100644
+--- a/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
++++ b/src/main/java/org/apache/logging/log4j/core/appender/AsyncAppenderEventDispatcher.java
+@@ -50,6 +50,7 @@ class AsyncAppenderEventDispatcher extends Log4jThread {
+             final List<AppenderControl> appenders,
+             final BlockingQueue<LogEvent> queue) {
+         super("AsyncAppenderEventDispatcher-" + THREAD_COUNTER.incrementAndGet() + "-" + name);
++        this.setDaemon(true); // Paper - Backport change from not yet released Log4j 2.14.2
+         this.errorAppender = errorAppender;
+         this.appenders = appenders;
+         this.queue = queue;


### PR DESCRIPTION
This diff will be included in the not yet released Log4j 2.14.2 (https://github.com/apache/logging-log4j2/commit/e24e2e8901ccfff1b7e6c5b8d40b707bfc91c843#diff-4024f348bc64d36c3d1d1a7ff91e60af17a1369fe21d012ea14b71892af311d8). When Log4j 2.14.2 is released this patch should be dropped in favor of bumping Log4j.

Fixes #6422 and #6423