### PR TITLE
Fix vanilla command ignore permissions on tab complete

### DIFF
--- a/patches/server/0748-Fix-vanilla-command-ignore-permissions-on-tab-comple.patch
+++ b/patches/server/0748-Fix-vanilla-command-ignore-permissions-on-tab-comple.patch
@@ -1,0 +1,25 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: LemonCaramel <admin@caramel.moe>
+Date: Thu, 19 Aug 2021 03:51:01 +0900
+Subject: [PATCH] Fix vanilla command ignore permissions on tab complete
+
+
+diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
+index a6f10d47bc4e2cadcc3e06cffa011ed7fb97c68d..54af37a2b6ca1c7c5f5a20260284e8ee1b2e6852 100644
+--- a/src/main/java/net/minecraft/commands/Commands.java
++++ b/src/main/java/net/minecraft/commands/Commands.java
+@@ -393,11 +393,13 @@ public class Commands {
+     private void fillUsableCommands(CommandNode<CommandSourceStack> tree, CommandNode<SharedSuggestionProvider> result, CommandSourceStack source, Map<CommandNode<CommandSourceStack>, CommandNode<SharedSuggestionProvider>> resultNodes) {
+         Iterator iterator = tree.getChildren().iterator();
+ 
++        Collection<CommandNode<CommandSourceStack>> vanillaCommands = source.getServer().vanillaCommandDispatcher.getDispatcher().getRoot().getChildren(); // Paper
+         while (iterator.hasNext()) {
+             CommandNode<CommandSourceStack> commandnode2 = (CommandNode) iterator.next();
+             if ( !org.spigotmc.SpigotConfig.sendNamespaced && commandnode2.getName().contains( ":" ) ) continue; // Spigot
+ 
+-            if (commandnode2.canUse(source)) {
++            boolean isVanillaCommand = vanillaCommands.contains(commandnode2) || commandnode2.getName().startsWith("minecraft:"); // Paper
++            if (commandnode2.canUse(source) && (!isVanillaCommand || (source.getEntity() instanceof ServerPlayer && source.getBukkitSender().hasPermission(org.bukkit.craftbukkit.command.VanillaCommandWrapper.getPermission(commandnode2))))) { // Paper
+                 ArgumentBuilder argumentbuilder = commandnode2.createBuilder(); // CraftBukkit - decompile error
+ 
+                 argumentbuilder.requires((icompletionprovider) -> {


### PR DESCRIPTION
Close #6085

This resolves the issue of vanilla command tabcomplete, but problems occur when the namespace of a non-vanilla command is "minecraft". _(ex. [CommandAPI plugin](https://github.com/JorelAli/CommandAPI))_

there may be a better way to solve this issue.
Feedback welcome