### PR TITLE
Send game events to a world

### DIFF
--- a/patches/api/0291-More-World-API.patch
+++ b/patches/api/0291-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index e149ab9b4ccd1b98791c3ebe5e9c7eb97de853af..145780fc900531687036003d3eec2057f205679c 100644
+index e149ab9b4ccd1b98791c3ebe5e9c7eb97de853af..4d8be6f200dbe2bd534a7f62152074dca59f9db4 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
-@@ -3564,6 +3564,105 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
+@@ -3564,6 +3564,114 @@ public interface World extends PluginMessageRecipient, Metadatable, net.kyori.ad
      @Nullable
      public Location locateNearestStructure(@NotNull Location origin, @NotNull StructureType structureType, int radius, boolean findUnexplored);
  
@@ -109,6 +109,15 @@ index e149ab9b4ccd1b98791c3ebe5e9c7eb97de853af..145780fc900531687036003d3eec2057
 +     */
 +    @NotNull
 +    Collection<Material> getInfiniburn();
++
++    /**
++     * Posts a specified game event at a location
++     *
++     * @param sourceEntity optional source entity
++     * @param gameEvent the game event to post
++     * @param position the position in the world where to post the event to listeners
++     */
++    void sendGameEvent(@Nullable Entity sourceEntity, @NotNull GameEvent gameEvent, @NotNull Vector position);
 +    // Paper end
 +
      // Spigot start

--- a/patches/server/0663-More-World-API.patch
+++ b/patches/server/0663-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4717bd703d3a8bb87c71d14eb851db09c264046e..b825673fdd7c8c8dd9e05fe6b317006a64ba913e 100644
+index 4717bd703d3a8bb87c71d14eb851db09c264046e..48052de8a7a495743845f1610ed00cafb535bb89 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2579,6 +2579,60 @@ public class CraftWorld implements World {
+@@ -2579,6 +2579,65 @@ public class CraftWorld implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  
@@ -64,8 +64,31 @@ index 4717bd703d3a8bb87c71d14eb851db09c264046e..b825673fdd7c8c8dd9e05fe6b317006a
 +    public Collection<org.bukkit.Material> getInfiniburn() {
 +        return com.google.common.collect.Sets.newHashSet(com.google.common.collect.Iterators.transform(getHandle().dimensionType().infiniburn().getValues().iterator(), CraftMagicNumbers::getMaterial));
 +    }
++
++    @Override
++    public void sendGameEvent(Entity sourceEntity, org.bukkit.GameEvent gameEvent, Vector position) {
++        getHandle().gameEvent(sourceEntity != null ? ((CraftEntity) sourceEntity).getHandle(): null, net.minecraft.core.Registry.GAME_EVENT.get(org.bukkit.craftbukkit.util.CraftNamespacedKey.toMinecraft(gameEvent.getKey())), org.bukkit.craftbukkit.util.CraftVector.toBlockPos(position));
++    }
 +    // Paper end
 +
      @Override
      public Raid locateNearestRaid(Location location, int radius) {
          Validate.notNull(location, "Location cannot be null");
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftVector.java b/src/main/java/org/bukkit/craftbukkit/util/CraftVector.java
+index 3071ac1ac0e733d73dade49597a39f7d156bbc04..60c4afd5cad66ffb0cfb5c1fa9857def593813ae 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftVector.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftVector.java
+@@ -12,4 +12,13 @@ public final class CraftVector {
+     public static net.minecraft.world.phys.Vec3 toNMS(org.bukkit.util.Vector bukkit) {
+         return new net.minecraft.world.phys.Vec3(bukkit.getX(), bukkit.getY(), bukkit.getZ());
+     }
++    // Paper start
++    public static org.bukkit.util.Vector toBukkit(net.minecraft.core.BlockPos blockPosition) {
++        return new org.bukkit.util.Vector(blockPosition.getX(), blockPosition.getY(), blockPosition.getZ());
++    }
++
++    public static net.minecraft.core.BlockPos toBlockPos(org.bukkit.util.Vector bukkit) {
++        return new net.minecraft.core.BlockPos(bukkit.getX(), bukkit.getY(), bukkit.getZ());
++    }
++    // Paper end
+ }


### PR DESCRIPTION
This is another thing that would cause an event because of what a plugin does, like changing the world time, or weather, or teleporting an entity, or a number of other things. It can be made to bypass the event, or maybe have a bool param for calling the event, I don't know. Maybe a Reason enum for the GenericGameEvent or something.