### PR TITLE
Implement Adventure's pointer system

### DIFF
--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 17fd7162ab32785252bf2579daae8d47aec21684..f3018c133440e2f6d1bcdf1adb060dfc6db1a866 100644
+index ccf5b30fa48e641fc8d04f185f9ffca55d4e2154..0ed6d9e6619db7559dc5b65a8da6e54e6e15d31c 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -10,6 +10,19 @@ java {
@@ -1076,7 +1076,7 @@ index efb97712cc9dc7c1e12a59f5b94e4f2ad7c6b7d8..3024468af4c073324e536c1cb26beffb
                  return warning == null || warning.value();
              }
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index bc4417d8ffa92a78f690bfa5705d3e42cdc11fd2..d3519fa5b99e2888a194c6382415537785fbeef0 100644
+index df938699524dcba4e5dc247df618bffea7d993e2..3dc19b4af1e6e5c54e110720668454da5768a98a 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -38,7 +38,7 @@ import org.jetbrains.annotations.Nullable;
@@ -3538,6 +3538,45 @@ index 4dba721aefe4fc6699b3b4bfa7ecb0b19c2a2a1a..01dec2c877df58c9dc22445e8b1f9ce2
 +    @Deprecated
 +    public @NotNull MapCursor addCursor(int x, int y, byte direction, byte type, boolean visible, @Nullable net.kyori.adventure.text.Component caption) {
 +        return addCursor(new MapCursor((byte) x, (byte) y, direction, type, visible, caption));
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/permissions/Permissible.java b/src/main/java/org/bukkit/permissions/Permissible.java
+index 228421154913116069c20323afb519bdde2134df..c0c58024a8213863184964d58eeffc3d06c0eb54 100644
+--- a/src/main/java/org/bukkit/permissions/Permissible.java
++++ b/src/main/java/org/bukkit/permissions/Permissible.java
+@@ -126,4 +126,34 @@ public interface Permissible extends ServerOperator {
+      */
+     @NotNull
+     public Set<PermissionAttachmentInfo> getEffectivePermissions();
++
++    // Paper start - add TriState permission checks
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.@NotNull TriState checkPermission(final @NotNull Permission permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
++    }
++
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.@NotNull TriState checkPermission(final @NotNull String permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
 +    }
 +    // Paper end
  }

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1844,14 +1844,14 @@ index 02d8cfeaea105d42a437b08c3ba59c50eda5a452..6ba6e88174644cfea81445f1e8483e81
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6dbe186ed897a5c829ef56f70185c1f8749476cc..8ded509267326d6298ed361af9359955927f3114 100644
+index 6dbe186ed897a5c829ef56f70185c1f8749476cc..5db8e54cfcef415ab046264a50941dc80e55fccf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -272,6 +272,7 @@ public class CraftWorld implements World {
      private int waterAnimalSpawn = -1;
      private int waterAmbientSpawn = -1;
      private int ambientSpawn = -1;
-+    private net.kyori.adventure.pointer.Pointers adventure$pointers;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
      private static final Random rand = new Random();
  
@@ -2226,18 +2226,10 @@ index 042691349dd5659e8db526199641cbcfa21c6005..841dbf4a86b19d7c8ea41930ecb1f88c
          player.initMenu(container);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03ccc3cb67 100644
+index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..6e25d7ebb54017a3ecbb850741b5b57d3d7f675d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -127,6 +127,7 @@ import org.bukkit.plugin.messaging.StandardMessenger;
- import org.bukkit.scoreboard.Scoreboard;
- 
- import net.md_5.bungee.api.chat.BaseComponent; // Spigot
-+import org.jetbrains.annotations.NotNull;
- 
- @DelegateDeserialization(CraftOfflinePlayer.class)
- public class CraftPlayer extends CraftHumanEntity implements Player {
-@@ -141,6 +142,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -141,6 +141,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private double health = 20;
      private boolean scaledHealth = false;
      private double healthScale = 20;
@@ -2245,7 +2237,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -244,14 +246,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -244,14 +245,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -2285,7 +2277,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -270,42 +297,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -270,42 +296,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2337,7 +2329,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
          this.getHandle().connection.send(packet);
      }
  
-@@ -337,6 +364,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -337,6 +363,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -2355,7 +2347,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -571,6 +609,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -571,6 +608,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2389,7 +2381,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -598,14 +663,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -598,14 +662,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2407,7 +2399,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
      }
  
      @Override
-@@ -1705,6 +1771,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1705,6 +1770,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2420,7 +2412,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1733,6 +1805,174 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1733,6 +1804,174 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2578,7 +2570,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03
 +    }
 +
 +    @Override
-+    public net.kyori.adventure.pointer.@NotNull Pointers pointers() {
++    public net.kyori.adventure.pointer.@org.jetbrains.annotations.NotNull Pointers pointers() {
 +        if (this.adventure$pointers == null) {
 +            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
 +                .withDynamic(net.kyori.adventure.identity.Identity.DISPLAY_NAME, this::displayName)

--- a/patches/server/0010-Adventure.patch
+++ b/patches/server/0010-Adventure.patch
@@ -1843,8 +1843,39 @@ index 02d8cfeaea105d42a437b08c3ba59c50eda5a452..6ba6e88174644cfea81445f1e8483e81
 +    }
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 6dbe186ed897a5c829ef56f70185c1f8749476cc..8ded509267326d6298ed361af9359955927f3114 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -272,6 +272,7 @@ public class CraftWorld implements World {
+     private int waterAnimalSpawn = -1;
+     private int waterAmbientSpawn = -1;
+     private int ambientSpawn = -1;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers;
+ 
+     private static final Random rand = new Random();
+ 
+@@ -2433,4 +2434,18 @@ public class CraftWorld implements World {
+         return this.spigot;
+     }
+     // Spigot end
++
++    // Paper start - implement pointers
++    @Override
++    public net.kyori.adventure.pointer.@org.jetbrains.annotations.NotNull Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUID)
++                .build();
++        }
++
++        return this.adventure$pointers;
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
-index 5944e75b9501a3f9f25be5efe11351dd337158c5..e4cd36cf6626ad702ee654587b2f8c5442e4fe2b 100644
+index 11d1bc56439ff867224ef1c2058aee67ba0ee332..52f78b8a3d4588f9aba10c8aea4d36cb02f1f54f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
 +++ b/src/main/java/org/bukkit/craftbukkit/Main.java
 @@ -19,6 +19,12 @@ public class Main {
@@ -2065,6 +2096,39 @@ index f3cb4102ab223f379f60dac317df7da1fab812a8..b41452c3ed833f0e6c3b03a56fe5773e
 +    }
 +    // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
+index 8107ed0d248ff2a1cf8e556b7610a68f6c197691..e3dffa7ee5b00dc71e5603838b2e5543b21bf725 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
+@@ -14,6 +14,7 @@ import org.bukkit.plugin.Plugin;
+ public abstract class ServerCommandSender implements CommandSender {
+     private static PermissibleBase blockPermInst;
+     private final PermissibleBase perm;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     public ServerCommandSender() {
+         if (this instanceof CraftBlockCommandSender) {
+@@ -100,6 +101,20 @@ public abstract class ServerCommandSender implements CommandSender {
+         this.sendMessage(messages); // ServerCommandSenders have no use for senders
+     }
+ 
++    // Paper start - implement pointers
++    @Override
++    public net.kyori.adventure.pointer.@org.jetbrains.annotations.NotNull Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::checkPermission)
++                .build();
++        }
++
++        return this.adventure$pointers;
++    }
++    // Paper end
++
+     // Spigot start
+     private final org.bukkit.command.CommandSender.Spigot spigot = new org.bukkit.command.CommandSender.Spigot()
+     {
 diff --git a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
 index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6e31d7465 100644
 --- a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
@@ -2083,10 +2147,18 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 3aecaf187b0360eb0e5dc9a8948c834cf3401ad8..8d7d256fa33635807d187d493e71b6b4e17fa2e8 100644
+index 3aecaf187b0360eb0e5dc9a8948c834cf3401ad8..0cdc2d66092fd17fe20db551db125ca87c943216 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -810,6 +810,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -189,6 +189,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     protected Entity entity;
+     private EntityDamageEvent lastDamageEvent;
+     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     public CraftEntity(final CraftServer server, final Entity entity) {
+         this.server = server;
+@@ -810,6 +811,32 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getVehicle().getBukkitEntity();
      }
  
@@ -2100,6 +2172,19 @@ index 3aecaf187b0360eb0e5dc9a8948c834cf3401ad8..8d7d256fa33635807d187d493e71b6b4
 +    @Override
 +    public void customName(final net.kyori.adventure.text.Component customName) {
 +        this.getHandle().setCustomName(customName != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(customName) : null);
++    }
++
++    @Override
++    public net.kyori.adventure.pointer.@org.jetbrains.annotations.NotNull Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUniqueId)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::checkPermission)
++                .build();
++        }
++
++        return this.adventure$pointers;
 +    }
 +    // Paper end
 +
@@ -2141,10 +2226,26 @@ index 042691349dd5659e8db526199641cbcfa21c6005..841dbf4a86b19d7c8ea41930ecb1f88c
          player.initMenu(container);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48eaf556df94 100644
+index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..aff4700608211f5f071953fffb4d8a03ccc3cb67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -127,6 +127,7 @@ import org.bukkit.plugin.messaging.StandardMessenger;
+ import org.bukkit.scoreboard.Scoreboard;
+ 
+ import net.md_5.bungee.api.chat.BaseComponent; // Spigot
++import org.jetbrains.annotations.NotNull;
+ 
+ @DelegateDeserialization(CraftOfflinePlayer.class)
+ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -141,6 +142,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+     private double health = 20;
+     private boolean scaledHealth = false;
+     private double healthScale = 20;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     public CraftPlayer(CraftServer server, ServerPlayer entity) {
+         super(server, entity);
+@@ -244,14 +246,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getDisplayName() {
@@ -2184,7 +2285,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      @Override
      public String getPlayerListName() {
          return this.getHandle().listName == null ? getName() : CraftChatMessage.fromComponent(this.getHandle().listName);
-@@ -270,42 +295,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -270,42 +297,42 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  
@@ -2236,7 +2337,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
          this.getHandle().connection.send(packet);
      }
  
-@@ -337,6 +362,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -337,6 +364,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.disconnect(message == null ? "" : message);
      }
  
@@ -2254,7 +2355,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -571,6 +607,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -571,6 +609,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2288,7 +2389,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -598,14 +661,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -598,14 +663,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2306,7 +2407,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      }
  
      @Override
-@@ -1705,6 +1769,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1705,6 +1771,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2319,7 +2420,7 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1733,6 +1803,160 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1733,6 +1805,174 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2474,6 +2575,20 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, item));
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundOpenBookPacket(net.minecraft.world.InteractionHand.MAIN_HAND));
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, inventory.getSelected()));
++    }
++
++    @Override
++    public net.kyori.adventure.pointer.@NotNull Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.DISPLAY_NAME, this::displayName)
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUniqueId)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::checkPermission)
++                .build();
++        }
++
++        return this.adventure$pointers;
 +    }
 +    // Paper end
 +

--- a/patches/server/0021-Player-affects-spawning-API.patch
+++ b/patches/server/0021-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 389985e022b82c675fb21f363422471bd15b84b0..849616d9ad140285f7aa4d2ffafd6371
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 32f555a846d34e086e75c027a92a48eaf556df94..6de88d1ea0ff50dddb65a65fa53fba6ee475e886 100644
+index aff4700608211f5f071953fffb4d8a03ccc3cb67..4a92ec971318c271741a091ce3b5f9732531fb73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1783,8 +1783,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1785,8 +1785,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0021-Player-affects-spawning-API.patch
+++ b/patches/server/0021-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 389985e022b82c675fb21f363422471bd15b84b0..849616d9ad140285f7aa4d2ffafd6371
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aff4700608211f5f071953fffb4d8a03ccc3cb67..4a92ec971318c271741a091ce3b5f9732531fb73 100644
+index 6e25d7ebb54017a3ecbb850741b5b57d3d7f675d..62d13e154f7a59f9c4d5d16c3da0281afe4feea6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1785,8 +1785,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1784,8 +1784,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0024-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0024-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6de88d1ea0ff50dddb65a65fa53fba6ee475e886..2685ebf77191a797bc1835a3da13a238ce9432a7 100644
+index 4a92ec971318c271741a091ce3b5f9732531fb73..df946d6187fe18c4fb2ed75dd7fd68103b3a5fb3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1452,12 +1452,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1454,12 +1454,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0024-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0024-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4a92ec971318c271741a091ce3b5f9732531fb73..df946d6187fe18c4fb2ed75dd7fd68103b3a5fb3 100644
+index 62d13e154f7a59f9c4d5d16c3da0281afe4feea6..4b3fc4f2ddef3752ad006350ab12c2e1c5477f14 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1454,12 +1454,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1453,12 +1453,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0025-Entity-Origin-API.patch
+++ b/patches/server/0025-Entity-Origin-API.patch
@@ -25,7 +25,7 @@ index 253d62b0da6bd59363a85139a5a5d5f11169466a..d721d05841d9557583045ab3adc347c2
  
          public void onTrackingEnd(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 04f2cee8045ba74993e10230c3ad7ca80fb048d6..fe08d13e0d25119c48a8872fac6fd2a6ce0170be 100644
+index 8369238dd8042310b8e2aa10e463a3a9f9f7ec64..ade73dadb857593c793aaddc613b3bf4e0d0b168 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -280,6 +280,27 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -132,10 +132,10 @@ index 394164f50256ad9a167e15531a9202875abb6cb6..8ad1b3cb16533d62deda643ce0cdda30
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index ee7c920a5a3154927c675b2e1cd0c16f99d0e9a2..1c6473b496ca05e9e0fcd505caaa18b5546d1d3c 100644
+index 0cdc2d66092fd17fe20db551db125ca87c943216..dfb632b931ae47e96438ec5d6130175d3f34b4a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1116,4 +1116,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1130,4 +1130,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
@@ -20,10 +20,10 @@ index 65ef47b59f9096e7ae4358cf417d73327f9d91a4..b8ae3fbb8fda72906a6e108abbbbe744
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index df946d6187fe18c4fb2ed75dd7fd68103b3a5fb3..6952e3162f67bb4d1ea2b9883709d759eeeb352d 100644
+index 4b3fc4f2ddef3752ad006350ab12c2e1c5477f14..3cdb1ef3b3dc7c06cad336b59d07d87edbb1d413 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -373,6 +373,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -372,6 +372,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
+++ b/patches/server/0037-Per-Player-View-Distance-API-placeholders.patch
@@ -7,7 +7,7 @@ I hope to look at this more in-depth soon. It appears doable.
 However this should not block the update.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 094228ff071218f49d07f8e5343e1544c98e14d1..505cf31d1cc89d463c1b61fdf9b2247ce2743dc8 100644
+index 65ef47b59f9096e7ae4358cf417d73327f9d91a4..b8ae3fbb8fda72906a6e108abbbbe74455a9d016 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -171,6 +171,8 @@ import org.bukkit.inventory.MainHand;
@@ -20,10 +20,10 @@ index 094228ff071218f49d07f8e5343e1544c98e14d1..505cf31d1cc89d463c1b61fdf9b2247c
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_XZ = 32;
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4178dc224e3cbff004a55e1e84512ae345d7ec9c..b2d17fa187d8de8ff99923fef0485209338f2783 100644
+index df946d6187fe18c4fb2ed75dd7fd68103b3a5fb3..6952e3162f67bb4d1ea2b9883709d759eeeb352d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -371,6 +371,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -373,6 +373,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              connection.disconnect(message == null ? net.kyori.adventure.text.Component.empty() : message);
          }
      }

--- a/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6952e3162f67bb4d1ea2b9883709d759eeeb352d..17837b9685c9319fc32d0219dd696ebba9e07734 100644
+index 3cdb1ef3b3dc7c06cad336b59d07d87edbb1d413..cb3f63d6352f97817af6297089d8eb0369fc2e82 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index 6952e3162f67bb4d1ea2b9883709d759eeeb352d..17837b9685c9319fc32d0219dd696ebb
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -244,6 +245,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -243,6 +244,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/server/0048-Player-Tab-List-and-Title-APIs.patch
@@ -63,7 +63,7 @@ index bd808eb312ade7122973a47f4b96505829511da5..bf0f9cab7c66c089f35b851e799ba4a4
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b2d17fa187d8de8ff99923fef0485209338f2783..a1b816bc32adb4085c5d5457ed24996e0c5f3bc5 100644
+index 6952e3162f67bb4d1ea2b9883709d759eeeb352d..17837b9685c9319fc32d0219dd696ebba9e07734 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1,5 +1,6 @@
@@ -73,7 +73,7 @@ index b2d17fa187d8de8ff99923fef0485209338f2783..a1b816bc32adb4085c5d5457ed24996e
  import com.google.common.base.Preconditions;
  import com.google.common.collect.ImmutableSet;
  import com.google.common.io.BaseEncoding;
-@@ -242,6 +243,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -244,6 +245,100 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0051-Add-velocity-warnings.patch
+++ b/patches/server/0051-Add-velocity-warnings.patch
@@ -17,10 +17,10 @@ index a493f3ae60f2b2f4397a0b81f25a014d9edc805d..ea8ed9c3d83e7038c334779b7bd37392
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 3510448dd6964981cd9aa64c24c85c310eb75971..99bd0df1351c356b0ff9f5d864ba5dad89c90acf 100644
+index dfb632b931ae47e96438ec5d6130175d3f34b4a7..3a938d001a791f9aeb93e4fd639695a44f8d2699 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -435,10 +435,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -436,10 +436,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public void setVelocity(Vector velocity) {
          Preconditions.checkArgument(velocity != null, "velocity");
          velocity.checkFinite();

--- a/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 17837b9685c9319fc32d0219dd696ebba9e07734..395f1aeb0eee194325259e97a60ae81957e54586 100644
+index cb3f63d6352f97817af6297089d8eb0369fc2e82..bf633e77feac29673d3eaa0986ffff3a89faab0e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -892,7 +892,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -891,7 +891,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0052-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index 670efbe53241a0ae32d618c83da601ccc1f26e37..abbbe1786eb68af02f9d39650aad730a
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e1c3472c15a85d47d8abd24ddb69fd99c8a6b3e2..e9d03d4540fa39b783f808c81f397e25f653bec2 100644
+index 17837b9685c9319fc32d0219dd696ebba9e07734..395f1aeb0eee194325259e97a60ae81957e54586 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -890,7 +890,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -892,7 +892,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0057-Complete-resource-pack-API.patch
+++ b/patches/server/0057-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e9d03d4540fa39b783f808c81f397e25f653bec2..ada3e4af93c96221355b5ad777527ae16cfa866d 100644
+index 395f1aeb0eee194325259e97a60ae81957e54586..8ad49f2dbe7d39fe1d115b401c5b81020ef1f844 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -33,11 +33,11 @@ index e9d03d4540fa39b783f808c81f397e25f653bec2..ada3e4af93c96221355b5ad777527ae1
 +import org.jetbrains.annotations.NotNull;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
- 
-@@ -142,6 +143,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-     private double health = 20;
+ import org.jetbrains.annotations.NotNull;
+@@ -144,6 +145,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private boolean scaledHealth = false;
      private double healthScale = 20;
+     private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
 +    // Paper start
 +    private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
 +    private String resourcePackHash;
@@ -45,7 +45,7 @@ index e9d03d4540fa39b783f808c81f397e25f653bec2..ada3e4af93c96221355b5ad777527ae1
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1901,6 +1906,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1903,6 +1908,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0057-Complete-resource-pack-API.patch
+++ b/patches/server/0057-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 395f1aeb0eee194325259e97a60ae81957e54586..8ad49f2dbe7d39fe1d115b401c5b81020ef1f844 100644
+index bf633e77feac29673d3eaa0986ffff3a89faab0e..230146ff6e8b2d31404019c9007a5baceadbb7db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -33,8 +33,8 @@ index 395f1aeb0eee194325259e97a60ae81957e54586..8ad49f2dbe7d39fe1d115b401c5b8102
 +import org.jetbrains.annotations.NotNull;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
- import org.jetbrains.annotations.NotNull;
-@@ -144,6 +145,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+@@ -143,6 +144,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private boolean scaledHealth = false;
      private double healthScale = 20;
      private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
@@ -45,7 +45,7 @@ index 395f1aeb0eee194325259e97a60ae81957e54586..8ad49f2dbe7d39fe1d115b401c5b8102
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1903,6 +1908,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1902,6 +1907,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a492f0b8393c185f0464f0fb0e5d5dce4d0e3824..bcf7fc1bdee10baaff7ec15ad2572061c2c800ec 100644
+index 8d9c6cebd22e453024716b9fb88786e8ec95fccb..dcf12a35a5a4e0682db81c58ad115687ad5ae7cc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -764,7 +764,13 @@ public abstract class LivingEntity extends Entity {
@@ -44,10 +44,10 @@ index a492f0b8393c185f0464f0fb0e5d5dce4d0e3824..bcf7fc1bdee10baaff7ec15ad2572061
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ada3e4af93c96221355b5ad777527ae16cfa866d..b3d49b652790a98f1426498a555c6826f8657c63 100644
+index 8ad49f2dbe7d39fe1d115b401c5b81020ef1f844..cbe64c9462409bc2df8508a30f50afd67743a4d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1708,6 +1708,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1710,6 +1710,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0066-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -44,10 +44,10 @@ index 8d9c6cebd22e453024716b9fb88786e8ec95fccb..dcf12a35a5a4e0682db81c58ad115687
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8ad49f2dbe7d39fe1d115b401c5b81020ef1f844..cbe64c9462409bc2df8508a30f50afd67743a4d7 100644
+index 230146ff6e8b2d31404019c9007a5baceadbb7db..87741d1b78a562e19ba3ff85c210880e0070cedd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1710,6 +1710,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1709,6 +1709,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cbe64c9462409bc2df8508a30f50afd67743a4d7..5858ce56723941fd244c7fca98bdf923337d37d6 100644
+index 87741d1b78a562e19ba3ff85c210880e0070cedd..57770607e03c586b01d5f1d5ad165ecd989257df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -902,6 +902,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -901,6 +901,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0082-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3d49b652790a98f1426498a555c6826f8657c63..77dd225e6cc20b4faa55aab2b52af77298639e0e 100644
+index cbe64c9462409bc2df8508a30f50afd67743a4d7..5858ce56723941fd244c7fca98bdf923337d37d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -900,6 +900,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -902,6 +902,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 36edbdf8717f8cf4611da2e304c9aac0b9f44b49..2b13aec562182ce56a2fe16b70f20af3
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 77dd225e6cc20b4faa55aab2b52af77298639e0e..90ab0a3967aaa5394e2b09c4c9879b84e82ece76 100644
+index 5858ce56723941fd244c7fca98bdf923337d37d6..de3e7787acf81ff5610223cd5d54e10c6f473263 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1905,8 +1905,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1907,8 +1907,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0086-Implement-PlayerLocaleChangeEvent.patch
@@ -30,10 +30,10 @@ index 36edbdf8717f8cf4611da2e304c9aac0b9f44b49..2b13aec562182ce56a2fe16b70f20af3
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 5858ce56723941fd244c7fca98bdf923337d37d6..de3e7787acf81ff5610223cd5d54e10c6f473263 100644
+index 57770607e03c586b01d5f1d5ad165ecd989257df..92495717677f0106f2548a400006df04ddbf0263 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1907,8 +1907,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1906,8 +1906,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 596ef79ea50c7c01a87ab37962195deb5327ccb5..76c749566b9cd41dea3c4520f6773620f7caedf2 100644
+index de3e7787acf81ff5610223cd5d54e10c6f473263..acc6910b584b499dce0105322844afe2c58fddf6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -249,6 +249,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -251,6 +251,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0122-String-based-Action-Bar-API.patch
+++ b/patches/server/0122-String-based-Action-Bar-API.patch
@@ -26,10 +26,10 @@ index 32ef3edebe94a2014168b7e438752a80b2687e5f..ab6c58eed6707ab7b0aa3e7549a871ad
          // Paper end
          buf.writeComponent(this.text);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index de3e7787acf81ff5610223cd5d54e10c6f473263..acc6910b584b499dce0105322844afe2c58fddf6 100644
+index 92495717677f0106f2548a400006df04ddbf0263..1d19b803732e09a2c022d82a5776772725eaf6b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -251,6 +251,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -250,6 +250,26 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      // Paper start

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,12 +20,12 @@ index 05f94017546f3bb326f445d06add401498524d4d..43febeede5fcc9d52e6682f94afb26c1
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8ded509267326d6298ed361af9359955927f3114..85ae0b4468b5b67369b699832a7534e687908cf2 100644
+index 5db8e54cfcef415ab046264a50941dc80e55fccf..fc7640196c0e14e4c551e035e04f9baddba2eee6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -274,6 +274,57 @@ public class CraftWorld implements World {
      private int ambientSpawn = -1;
-     private net.kyori.adventure.pointer.Pointers adventure$pointers;
+     private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
 +    // Paper start - Provide fast information methods
 +    @Override

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,12 +20,12 @@ index 05f94017546f3bb326f445d06add401498524d4d..43febeede5fcc9d52e6682f94afb26c1
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2889ac5f94787b1af65c8a691c227fbddb638c2e..e228a59166c6e492d96ebf72890f8925e96c4575 100644
+index 8ded509267326d6298ed361af9359955927f3114..85ae0b4468b5b67369b699832a7534e687908cf2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -273,6 +273,57 @@ public class CraftWorld implements World {
-     private int waterAmbientSpawn = -1;
+@@ -274,6 +274,57 @@ public class CraftWorld implements World {
      private int ambientSpawn = -1;
+     private net.kyori.adventure.pointer.Pointers adventure$pointers;
  
 +    // Paper start - Provide fast information methods
 +    @Override

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,7 +129,7 @@ index 4000480a14d2ba52149f4fa47f824abfa2e0e5f8..ea01f84448693ca740b5f3381a9c500e
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fe74e130309fbef3f763d875310cbd7a5d9b74fd..9fb669c0199a73136bf5b5a86fa60036dc67bd3e 100644
+index a5e47e581a79546e10ad2f5bdabcd92607384867..a69b8ef71b2ee216cb22f4079352d41ab1417e1f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1703,7 +1703,8 @@ public abstract class LivingEntity extends Entity {
@@ -143,7 +143,7 @@ index fe74e130309fbef3f763d875310cbd7a5d9b74fd..9fb669c0199a73136bf5b5a86fa60036
          }
          // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Animal.java b/src/main/java/net/minecraft/world/entity/animal/Animal.java
-index b8163a04f5aad326e78416b270dc64ffc913ccc5..5a503a255b4e7e684a8f42d8190430397ca81683 100644
+index c955f34e9c92f3310d2ead4eb887b5fe94180619..43841b5c77beb73169e2ff1645afe1234d8f74c7 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Animal.java
 +++ b/src/main/java/net/minecraft/world/entity/animal/Animal.java
 @@ -264,7 +264,7 @@ public abstract class Animal extends AgeableMob {
@@ -301,10 +301,10 @@ index 61ab07be21759df7b92ba71e31c537860f4e5dc2..265fa3cb96b7d39194a7e83b8b77b811
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e228a59166c6e492d96ebf72890f8925e96c4575..49ef818c6601855924472e655d3419d82c28e339 100644
+index 85ae0b4468b5b67369b699832a7534e687908cf2..299f89b8fd757e3271a9315e79e6c4120fc7c40d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1839,7 +1839,7 @@ public class CraftWorld implements World {
+@@ -1840,7 +1840,7 @@ public class CraftWorld implements World {
          } else if (TNTPrimed.class.isAssignableFrom(clazz)) {
              entity = new PrimedTnt(this.world, x, y, z, null);
          } else if (ExperienceOrb.class.isAssignableFrom(clazz)) {

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 01cfa488e7b25b7c65e71908bb6f5e6b7b61ca89..b0422e655fa836b5ff44f56a2ba9b4318e56e93e 100644
+index e459001142435ad11da2b7b17273243db3fe5858..ea9f165a958c507ef57523e7cfbccbea77aef6d9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -321,6 +321,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -49,10 +49,10 @@ index 037dafb59e54047d1d54474c44897d35b8f46c98..e310c1eb1108780bcff4d7ba9d49cefa
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index db430d20186fc8d307fd4e521778316845cd8581..2840228aa6aa8f1559b976d396aa9d1f8f4d6a40 100644
+index 3a938d001a791f9aeb93e4fd639695a44f8d2699..92fb9f3323bcbc2fc14febba27aede211e8ba020 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1162,5 +1162,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1176,5 +1176,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          //noinspection ConstantConditions
          return originVector.toLocation(world);
      }

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index c4ba069f5124ec151e05813beddf293fddc3b804..484221e5a9c246aa91e0eacef3911b0e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 76c749566b9cd41dea3c4520f6773620f7caedf2..284772518ecb00d9e83a9e22480842deeba47dd0 100644
+index acc6910b584b499dce0105322844afe2c58fddf6..cbd1931d65c72927cda231c9c2c6612107aa5454 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -193,6 +193,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -195,6 +195,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
+++ b/patches/server/0161-Expose-client-protocol-version-and-virtual-host.patch
@@ -90,10 +90,10 @@ index c4ba069f5124ec151e05813beddf293fddc3b804..484221e5a9c246aa91e0eacef3911b0e
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index acc6910b584b499dce0105322844afe2c58fddf6..cbd1931d65c72927cda231c9c2c6612107aa5454 100644
+index 1d19b803732e09a2c022d82a5776772725eaf6b6..2756c84b3f6514fb72f799ad6523b646e3ebd2c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -195,6 +195,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -194,6 +194,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
      }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,7 +28,7 @@ index 6f25e9f41d93a225acaa6575954967438a6cabbf..d439e8ce87bf7da03683a336941c7673
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8abce60db2bfd99aa5bb188dc231edcbde870e92..df9508e3f2272e63a4902687e69df631671584e7 100644
+index cbd1931d65c72927cda231c9c2c6612107aa5454..6d575289599d2a277a23c46a889d5d832c8856b6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -61,11 +61,14 @@ import net.minecraft.server.level.ServerPlayer;
@@ -46,7 +46,7 @@ index 8abce60db2bfd99aa5bb188dc231edcbde870e92..df9508e3f2272e63a4902687e69df631
  import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.SignBlockEntity;
-@@ -1208,8 +1211,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1210,8 +1213,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
      }
  

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,7 +28,7 @@ index 6f25e9f41d93a225acaa6575954967438a6cabbf..d439e8ce87bf7da03683a336941c7673
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cbd1931d65c72927cda231c9c2c6612107aa5454..6d575289599d2a277a23c46a889d5d832c8856b6 100644
+index 2756c84b3f6514fb72f799ad6523b646e3ebd2c2..4a7ad9652780f2ff039bb332fd9aee7eef6b99e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -61,11 +61,14 @@ import net.minecraft.server.level.ServerPlayer;
@@ -46,7 +46,7 @@ index cbd1931d65c72927cda231c9c2c6612107aa5454..6d575289599d2a277a23c46a889d5d83
  import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.SignBlockEntity;
-@@ -1210,8 +1213,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1209,8 +1212,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
      }
  

--- a/patches/server/0186-Player.setPlayerProfile-API.patch
+++ b/patches/server/0186-Player.setPlayerProfile-API.patch
@@ -39,7 +39,7 @@ index 3c8de1d70714a021dbd58894f3fd986bf5d6bde7..cc6f1f94c1a01992dfe29399b346c972
      private ItemStack lastItemInMainHand;
      private final ItemCooldowns cooldowns;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6d575289599d2a277a23c46a889d5d832c8856b6..fac712a16e9e57e1b44f29fceb28fc25b006d43f 100644
+index 4a7ad9652780f2ff039bb332fd9aee7eef6b99e1..7b61424098513a0991980986d09bdcae7d7ec88e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -71,6 +71,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -50,7 +50,7 @@ index 6d575289599d2a277a23c46a889d5d832c8856b6..fac712a16e9e57e1b44f29fceb28fc25
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1341,8 +1342,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1340,8 +1341,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -65,7 +65,7 @@ index 6d575289599d2a277a23c46a889d5d832c8856b6..fac712a16e9e57e1b44f29fceb28fc25
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1383,8 +1389,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1382,8 +1388,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenPlayers.remove(player.getUniqueId());
  
@@ -80,7 +80,7 @@ index 6d575289599d2a277a23c46a889d5d832c8856b6..fac712a16e9e57e1b44f29fceb28fc25
  
          this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.ADD_PLAYER, other));
  
-@@ -1393,6 +1404,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1392,6 +1403,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0186-Player.setPlayerProfile-API.patch
+++ b/patches/server/0186-Player.setPlayerProfile-API.patch
@@ -39,7 +39,7 @@ index 3c8de1d70714a021dbd58894f3fd986bf5d6bde7..cc6f1f94c1a01992dfe29399b346c972
      private ItemStack lastItemInMainHand;
      private final ItemCooldowns cooldowns;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index df9508e3f2272e63a4902687e69df631671584e7..f006b9ba8ebad98b3e679d7049bd9244f72a9348 100644
+index 6d575289599d2a277a23c46a889d5d832c8856b6..fac712a16e9e57e1b44f29fceb28fc25b006d43f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -71,6 +71,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -50,7 +50,7 @@ index df9508e3f2272e63a4902687e69df631671584e7..f006b9ba8ebad98b3e679d7049bd9244
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1339,8 +1340,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1341,8 +1342,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -65,7 +65,7 @@ index df9508e3f2272e63a4902687e69df631671584e7..f006b9ba8ebad98b3e679d7049bd9244
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1381,8 +1387,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1383,8 +1389,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenPlayers.remove(player.getUniqueId());
  
@@ -80,7 +80,7 @@ index df9508e3f2272e63a4902687e69df631671584e7..f006b9ba8ebad98b3e679d7049bd9244
  
          this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.ADD_PLAYER, other));
  
-@@ -1391,6 +1402,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1393,6 +1404,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0191-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0191-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fac712a16e9e57e1b44f29fceb28fc25b006d43f..8d8e3a55a9dce9c1cf440ef77854ef13216d8a04 100644
+index 7b61424098513a0991980986d09bdcae7d7ec88e..c1abbcd219a7a4899ffa8f4c323dc1166965a3fb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -152,6 +152,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -151,6 +151,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index fac712a16e9e57e1b44f29fceb28fc25b006d43f..8d8e3a55a9dce9c1cf440ef77854ef13
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1610,7 +1611,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1609,7 +1610,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/patches/server/0191-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0191-Flag-to-disable-the-channel-limit.patch
@@ -9,10 +9,10 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index f006b9ba8ebad98b3e679d7049bd9244f72a9348..1ad37b47a64700f9fd895afb26f8b07c0cad72d5 100644
+index fac712a16e9e57e1b44f29fceb28fc25b006d43f..8d8e3a55a9dce9c1cf440ef77854ef13216d8a04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -150,6 +150,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -152,6 +152,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      // Paper start
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
@@ -20,7 +20,7 @@ index f006b9ba8ebad98b3e679d7049bd9244f72a9348..1ad37b47a64700f9fd895afb26f8b07c
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1608,7 +1609,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1610,7 +1611,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index 160da347ed52739e930044fe456a4dd36e561a43..d06fa20dd605e9ce0e41a4d69ffeec98
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1e96978cb4abf92eadd570bcda6a04ac76793e30..39412e473be4d138d789cabe27f4b64b00f23a97 100644
+index 299f89b8fd757e3271a9315e79e6c4120fc7c40d..79c8cf136e7b609522694cb5df49b36f416f6637 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2404,11 +2404,17 @@ public class CraftWorld implements World {
+@@ -2405,11 +2405,17 @@ public class CraftWorld implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0203-Allow-spawning-Item-entities-with-World.spawnEntity.patch
+++ b/patches/server/0203-Allow-spawning-Item-entities-with-World.spawnEntity.patch
@@ -8,10 +8,10 @@ This API has more capabilities than .dropItem with the Consumer function
 Item can be set inside of the Consumer pre spawn function.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 18e4c893f86cdaf816e5d88416fe3fe7be953bc5..1aab57f7eabc1acce9827017fde7daf382b46dce 100644
+index 79c8cf136e7b609522694cb5df49b36f416f6637..7aba79e35d2761e93dbf7cd1e750221128d49376 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1508,6 +1508,10 @@ public class CraftWorld implements World {
+@@ -1509,6 +1509,10 @@ public class CraftWorld implements World {
          if (Boat.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.vehicle.Boat(this.world, x, y, z);
              entity.moveTo(x, y, z, yaw, pitch);

--- a/patches/server/0208-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0208-Fix-CraftEntity-hashCode.patch
@@ -21,10 +21,10 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 2840228aa6aa8f1559b976d396aa9d1f8f4d6a40..84316ea7f1ad285009f02cdf6e501c577958a170 100644
+index 92fb9f3323bcbc2fc14febba27aede211e8ba020..48c5cb265b54eddf01db9b8e20025f4dc288635e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -786,14 +786,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -787,14 +787,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
          final CraftEntity other = (CraftEntity) obj;

--- a/patches/server/0215-Expand-Explosions-API.patch
+++ b/patches/server/0215-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1aab57f7eabc1acce9827017fde7daf382b46dce..9b9dc5b8e5c2ce6ab4876067374e24d6cbf2fa12 100644
+index 7aba79e35d2761e93dbf7cd1e750221128d49376..bb27e27dce534c44596bc0c1d3ca2aca1f5c1925 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -892,6 +892,12 @@ public class CraftWorld implements World {
+@@ -893,6 +893,12 @@ public class CraftWorld implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0219-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0219-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9b9dc5b8e5c2ce6ab4876067374e24d6cbf2fa12..dac119e71c53f246944b3d2072f1fa7d6c8fa828 100644
+index bb27e27dce534c44596bc0c1d3ca2aca1f5c1925..0610baa023cf560b2dc8fffb729d77f4030f4edb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1298,6 +1298,15 @@ public class CraftWorld implements World {
+@@ -1299,6 +1299,15 @@ public class CraftWorld implements World {
          return list;
      }
  

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..460828d29583ee21a7c5b716f9687a82
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1ad37b47a64700f9fd895afb26f8b07c0cad72d5..067a3990825dd17d2843a5f8d215d19dcaac6806 100644
+index 8d8e3a55a9dce9c1cf440ef77854ef13216d8a04..ca4d20d80429d368b62d5ed0a409ecefb9520b3b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -927,7 +927,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -929,7 +929,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -174,10 +174,10 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..460828d29583ee21a7c5b716f9687a82
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8d8e3a55a9dce9c1cf440ef77854ef13216d8a04..ca4d20d80429d368b62d5ed0a409ecefb9520b3b 100644
+index c1abbcd219a7a4899ffa8f4c323dc1166965a3fb..2fc587eeacfb4ab9186c3a3e112aaa6fe55e3e76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -929,7 +929,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -928,7 +928,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dac119e71c53f246944b3d2072f1fa7d6c8fa828..ce723a4340202c16eaf7544f77c1075c4f277cb9 100644
+index 0610baa023cf560b2dc8fffb729d77f4030f4edb..be61a398f1e23ca1c9d23ed37d9b800b84054bd8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -508,7 +508,7 @@ public class CraftWorld implements World {
+@@ -509,7 +509,7 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -3619,10 +3619,10 @@ index e5e138fb23d03eb63e547e74d3e14ec9d96d8107..90f7b06bd2c558be35c4577044fa033e
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9128b6db3f28f168864345ca354707e37a77faaa..8a244988f984e7cb9df7308b21aec1524fbef3f1 100644
+index be61a398f1e23ca1c9d23ed37d9b800b84054bd8..23097a578bf28b73f9e196e79dab4f9979b6da07 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2471,6 +2471,34 @@ public class CraftWorld implements World {
+@@ -2472,6 +2472,34 @@ public class CraftWorld implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }
@@ -3658,7 +3658,7 @@ index 9128b6db3f28f168864345ca354707e37a77faaa..8a244988f984e7cb9df7308b21aec152
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 50e2cbade05dd299ef60bea4f835f9bf6df88f44..7e0986e085895ad046685771acb9e4374c5cfe89 100644
+index 48c5cb265b54eddf01db9b8e20025f4dc288635e..04bdc5ee83ee950e29be05baf86563906f3738dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
@@ -3669,7 +3669,7 @@ index 50e2cbade05dd299ef60bea4f835f9bf6df88f44..7e0986e085895ad046685771acb9e437
  import net.minecraft.world.damagesource.DamageSource;
  import net.minecraft.world.entity.AreaEffectCloud;
  import net.minecraft.world.entity.Entity;
-@@ -518,6 +519,28 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -519,6 +520,28 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          this.entity.setYHeadRot(yaw);
      }
  

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 067a3990825dd17d2843a5f8d215d19dcaac6806..30357dd7b527c40f9aa42a5873ad21c46d3c2311 100644
+index ca4d20d80429d368b62d5ed0a409ecefb9520b3b..8abaedc9b45d9efd60d9b54defb52a7f21203cf4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2253,6 +2253,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-         connection.send(new net.minecraft.network.protocol.game.ClientboundOpenBookPacket(net.minecraft.world.InteractionHand.MAIN_HAND));
-         connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, inventory.getSelected()));
+@@ -2269,6 +2269,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+         return this.adventure$pointers;
      }
 +
 +    @Override

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ca4d20d80429d368b62d5ed0a409ecefb9520b3b..8abaedc9b45d9efd60d9b54defb52a7f21203cf4 100644
+index 2fc587eeacfb4ab9186c3a3e112aaa6fe55e3e76..c6bcb6e5ad72b70fc550213d54c10eab1abf2630 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2269,6 +2269,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2268,6 +2268,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -277,10 +277,10 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 30357dd7b527c40f9aa42a5873ad21c46d3c2311..6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1 100644
+index 8abaedc9b45d9efd60d9b54defb52a7f21203cf4..c290a1554c1d24e1b4d06d9be85642b6d96c3dbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1868,7 +1868,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1870,7 +1870,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -277,10 +277,10 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8abaedc9b45d9efd60d9b54defb52a7f21203cf4..c290a1554c1d24e1b4d06d9be85642b6d96c3dbe 100644
+index c6bcb6e5ad72b70fc550213d54c10eab1abf2630..230396ef38cce9cacd8a1563a82a4fab491e9109 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1870,7 +1870,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1869,7 +1869,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0275-Add-sun-related-API.patch
+++ b/patches/server/0275-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 03a7e5d61d8888e1e836bd5a69ee9443b723f72c..01e63133d769e3d5c33944907a04ce4def8bbb45 100644
+index 23097a578bf28b73f9e196e79dab4f9979b6da07..68bb2e0b03b8d6665d1e83c2d6d0dffa963ef5a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -868,6 +868,13 @@ public class CraftWorld implements World {
+@@ -869,6 +869,13 @@ public class CraftWorld implements World {
          }
      }
  

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4f93f576bbbf7e8d0217f8d30f4c578ad917477a..95690ac3b3404ebe3d2308aaee09d9ec52b8f76d 100644
+index fcbc5019e5f9a9aca56abc0f684dbb54da5c2e0a..c82f40c2b04cb139fcb559c425757aa2b7e37118 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -219,6 +219,7 @@ public class ServerPlayer extends Player {
@@ -106,10 +106,10 @@ index 93de44b05a698515457052c9c684c4ef44c5cc40..b20bfe5ab165bf86985e5ff2f93f415d
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1..baa11848b63442fed7160a94e6447d6dd63d8ac6 100644
+index c290a1554c1d24e1b4d06d9be85642b6d96c3dbe..233dd9d23a000f6e81d11a1bd3ce2aaaaa179134 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -151,6 +151,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -153,6 +153,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index 6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1..baa11848b63442fed7160a94e6447d6d
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1512,6 +1513,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1514,6 +1515,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1..baa11848b63442fed7160a94e6447d6d
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1534,6 +1547,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1536,6 +1549,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 6fac6afd5ea4e35f6bb0e9b859fb9b4c608d53a1..baa11848b63442fed7160a94e6447d6d
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1548,6 +1563,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1550,6 +1565,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -106,10 +106,10 @@ index 93de44b05a698515457052c9c684c4ef44c5cc40..b20bfe5ab165bf86985e5ff2f93f415d
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c290a1554c1d24e1b4d06d9be85642b6d96c3dbe..233dd9d23a000f6e81d11a1bd3ce2aaaaa179134 100644
+index 230396ef38cce9cacd8a1563a82a4fab491e9109..248e254985d09e22bb3d5bf99dff56c0a8a08d20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -153,6 +153,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -152,6 +152,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      private org.bukkit.event.player.PlayerResourcePackStatusEvent.Status resourcePackStatus;
      private String resourcePackHash;
      private static final boolean DISABLE_CHANNEL_LIMIT = System.getProperty("paper.disableChannelLimit") != null; // Paper - add a flag to disable the channel limit
@@ -117,7 +117,7 @@ index c290a1554c1d24e1b4d06d9be85642b6d96c3dbe..233dd9d23a000f6e81d11a1bd3ce2aaa
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1514,6 +1515,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1513,6 +1514,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index c290a1554c1d24e1b4d06d9be85642b6d96c3dbe..233dd9d23a000f6e81d11a1bd3ce2aaa
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1536,6 +1549,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1535,6 +1548,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index c290a1554c1d24e1b4d06d9be85642b6d96c3dbe..233dd9d23a000f6e81d11a1bd3ce2aaa
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1550,6 +1565,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1549,6 +1564,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index baa11848b63442fed7160a94e6447d6dd63d8ac6..bef6868a33144e0e4f44bba1ba13d6310e291523 100644
+index 233dd9d23a000f6e81d11a1bd3ce2aaaaa179134..4ee4f491dab027acfcb6ef1cbafd6a1dff11ecb3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2300,6 +2300,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2316,6 +2316,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 233dd9d23a000f6e81d11a1bd3ce2aaaaa179134..4ee4f491dab027acfcb6ef1cbafd6a1dff11ecb3 100644
+index 248e254985d09e22bb3d5bf99dff56c0a8a08d20..45b17f96c7ec606cd46b51fc3d1fef9fe874efbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2316,6 +2316,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2315,6 +2315,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -105,10 +105,10 @@ index 494174608c0c6d0e0d9820ad4f263bef90c3dfdf..fe5e691ebbe930662f8a4f00811fdd8e
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 7e0986e085895ad046685771acb9e4374c5cfe89..ec929f74405a6a1e770986474715d9dc65b951ab 100644
+index 04bdc5ee83ee950e29be05baf86563906f3738dd..1e73ca0d849b919208cf90318cb9786e35cad009 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1191,5 +1191,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1205,5 +1205,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean fromMobSpawner() {
          return getHandle().spawnedViaMobSpawner;
      }

--- a/patches/server/0324-Add-Heightmap-API.patch
+++ b/patches/server/0324-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 01e63133d769e3d5c33944907a04ce4def8bbb45..1adcb0a90fb1e8318223a51637ce83a50efe6213 100644
+index 68bb2e0b03b8d6665d1e83c2d6d0dffa963ef5a6..b9ab1a63e9e2fff9c6a058317a7d831e21205b6d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -343,6 +343,29 @@ public class CraftWorld implements World {
+@@ -344,6 +344,29 @@ public class CraftWorld implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1adcb0a90fb1e8318223a51637ce83a50efe6213..3e2ab97daf807a6cc3502214f85559ecd21c59f7 100644
+index b9ab1a63e9e2fff9c6a058317a7d831e21205b6d..a324908c9553706cc9692ce6924b3303e2878609 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -414,13 +414,13 @@ public class CraftWorld implements World {
+@@ -415,13 +415,13 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1731081399133eda9a816e91d0e3e3f9e2c122a5..bcfc4bc482981feca7b291b4fd4e1f2dac8a1f27 100644
+index a324908c9553706cc9692ce6924b3303e2878609..c91390530771d97c68cd3e3a5f9dad0cc3cb1c50 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2021,15 +2021,21 @@ public class CraftWorld implements World {
+@@ -2022,15 +2022,21 @@ public class CraftWorld implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
@@ -235,7 +235,7 @@ index 24092d3d3d234b6f1f2b90e22d90f297532358cc..43510774d489bfdd30f10d521e424fa1
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c6373fe0361bd5c77036d36ac8ebe66408335b0c..479693f9703f743c8e64bb6b949b2803109f4fa0 100644
+index c91390530771d97c68cd3e3a5f9dad0cc3cb1c50..ddd796b5c9dd2492155771853a280648e848ad56 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -20,6 +20,7 @@ import java.util.Objects;
@@ -246,7 +246,7 @@ index c6373fe0361bd5c77036d36ac8ebe66408335b0c..479693f9703f743c8e64bb6b949b2803
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -419,8 +420,22 @@ public class CraftWorld implements World {
+@@ -420,8 +421,22 @@ public class CraftWorld implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -270,7 +270,7 @@ index c6373fe0361bd5c77036d36ac8ebe66408335b0c..479693f9703f743c8e64bb6b949b2803
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -531,20 +546,48 @@ public class CraftWorld implements World {
+@@ -532,20 +547,48 @@ public class CraftWorld implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0346-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
+++ b/patches/server/0346-Fix-spawning-of-hanging-entities-that-are-not-ItemFr.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix spawning of hanging entities that are not ItemFrames and
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 479693f9703f743c8e64bb6b949b2803109f4fa0..2c4ffaa4e9ce7759e6782547300ec6f457530c3b 100644
+index ddd796b5c9dd2492155771853a280648e848ad56..56a379b5182026269c011144aa914a225c119518 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1883,7 +1883,12 @@ public class CraftWorld implements World {
+@@ -1884,7 +1884,12 @@ public class CraftWorld implements World {
                  height = 9;
              }
  

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -658,10 +658,10 @@ index 515e28eea8cbab261320352ee0db9b877807f3ed..83ed84f89a036d3768b22a36bc8a0bfc
  
                  this.postProcessing[i].clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b57e5ffca725b10570aa10a870b992e6b767c2ec..4c439246f476225e6a1c6a2e758cf6d6d0fdf7a9 100644
+index 56a379b5182026269c011144aa914a225c119518..81e0d5c2bc2d40bbfe00250f08fafe8e12801377 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2587,10 +2587,39 @@ public class CraftWorld implements World {
+@@ -2588,10 +2588,39 @@ public class CraftWorld implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
+++ b/patches/server/0396-Optimize-PlayerChunkMap-memory-use-for-visibleChunks.patch
@@ -246,10 +246,10 @@ index 6f33d4f4ca86bfcad907b451a56e71de0d4585d5..228ff4b52a017e8af987f60d84b7906c
              Collections.shuffle(list);
              //Paper start - call player naturally spawn event
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e149744237679262174 100644
+index 81e0d5c2bc2d40bbfe00250f08fafe8e12801377..3fba9c582f9e515bb8572fa10c8b769cc10bf3c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -288,6 +288,7 @@ public class CraftWorld implements World {
+@@ -289,6 +289,7 @@ public class CraftWorld implements World {
  
      @Override
      public int getTileEntityCount() {
@@ -257,7 +257,7 @@ index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e1497442376
          // We don't use the full world tile entity list, so we must iterate chunks
          Long2ObjectLinkedOpenHashMap<ChunkHolder> chunks = world.getChunkSource().chunkMap.visibleChunkMap;
          int size = 0;
-@@ -299,6 +300,7 @@ public class CraftWorld implements World {
+@@ -300,6 +301,7 @@ public class CraftWorld implements World {
              size += chunk.blockEntities.size();
          }
          return size;
@@ -265,7 +265,7 @@ index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e1497442376
      }
  
      @Override
-@@ -308,6 +310,7 @@ public class CraftWorld implements World {
+@@ -309,6 +311,7 @@ public class CraftWorld implements World {
  
      @Override
      public int getChunkCount() {
@@ -273,7 +273,7 @@ index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e1497442376
          int ret = 0;
  
          for (ChunkHolder chunkHolder : world.getChunkSource().chunkMap.visibleChunkMap.values()) {
-@@ -316,7 +319,7 @@ public class CraftWorld implements World {
+@@ -317,7 +320,7 @@ public class CraftWorld implements World {
              }
          }
  
@@ -282,7 +282,7 @@ index a4d05aeccc142808981f1ecebd001c905ae721ed..e6b7302554b2a54363d55e1497442376
      }
  
      @Override
-@@ -443,6 +446,14 @@ public class CraftWorld implements World {
+@@ -444,6 +447,14 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {

--- a/patches/server/0413-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0413-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index b84cc33b10d84e0484df52e3e8295f4cdc1f3260..992e9d3b7713a651af91fdc0f231da2f
          if (getMainArm() != packet.getMainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4ee4f491dab027acfcb6ef1cbafd6a1dff11ecb3..013380c9f10c7a1d510d07403a554fec2b7a3a90 100644
+index 45b17f96c7ec606cd46b51fc3d1fef9fe874efbb..eed8b7e73e2438c5e9b999cbc68f8f03ce1f3e8a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -523,6 +523,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -522,6 +522,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0413-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0413-Implement-Player-Client-Options-API.patch
@@ -97,10 +97,10 @@ index b84cc33b10d84e0484df52e3e8295f4cdc1f3260..992e9d3b7713a651af91fdc0f231da2f
          if (getMainArm() != packet.getMainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bef6868a33144e0e4f44bba1ba13d6310e291523..a3951039eeb1f5d3529213ca02d11c97d499be38 100644
+index 4ee4f491dab027acfcb6ef1cbafd6a1dff11ecb3..013380c9f10c7a1d510d07403a554fec2b7a3a90 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -521,6 +521,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -523,6 +523,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }

--- a/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0455-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,10 +44,10 @@ index 9dc9153bd53b0d1e63d0367498a99271821217e0..5285a5b16b0b706d9e1728a23628ff12
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b7336da11 100644
+index 3fba9c582f9e515bb8572fa10c8b769cc10bf3c1..84f8e79ceb38676f88f0b51c2eabe27b2efd041f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -406,8 +406,21 @@ public class CraftWorld implements World {
+@@ -407,8 +407,21 @@ public class CraftWorld implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -482,7 +495,7 @@ public class CraftWorld implements World {
+@@ -483,7 +496,7 @@ public class CraftWorld implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b
          }
  
          return true;
-@@ -559,9 +572,12 @@ public class CraftWorld implements World {
+@@ -560,9 +573,12 @@ public class CraftWorld implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -569,7 +585,7 @@ public class CraftWorld implements World {
+@@ -570,7 +586,7 @@ public class CraftWorld implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -595,7 +611,7 @@ public class CraftWorld implements World {
+@@ -596,7 +612,7 @@ public class CraftWorld implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 600e68ab19121c63983633587a60a2ec4dc60d6a..32c24f9e37262f2a854556787f61cd7b
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -2590,6 +2606,7 @@ public class CraftWorld implements World {
+@@ -2591,6 +2607,7 @@ public class CraftWorld implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0482-Add-entity-liquid-API.patch
+++ b/patches/server/0482-Add-entity-liquid-API.patch
@@ -17,10 +17,10 @@ index 5bd575b776d2df5a84259508a62aa97eabb2b7d4..3e951522169fcb071cc578e8bd9a78ba
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index ec929f74405a6a1e770986474715d9dc65b951ab..33bcc85c438ef3eb5310321353e1bfdc6c63ae99 100644
+index 1e73ca0d849b919208cf90318cb9786e35cad009..98b2c76565e620843860bc9920325601780d3a2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1196,5 +1196,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1210,5 +1210,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
          return getHandle().spawnReason;
      }

--- a/patches/server/0499-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0499-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 32c24f9e37262f2a854556787f61cd7b7336da11..6bcc1a7ddfcdd0da157a65d2d866b28c390e3b41 100644
+index 84f8e79ceb38676f88f0b51c2eabe27b2efd041f..3e21b24abef43051cd4b929b5873e0ed68592c42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2669,6 +2669,7 @@ public class CraftWorld implements World {
+@@ -2670,6 +2670,7 @@ public class CraftWorld implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0505-Brand-support.patch
+++ b/patches/server/0505-Brand-support.patch
@@ -72,10 +72,10 @@ index e307f8695643360289b998a8d2ad244d966f1180..b7454592b9cee09f41631db6664cb18e
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 013380c9f10c7a1d510d07403a554fec2b7a3a90..6d65ea416f602709561d2f901da2ced3350bacbe 100644
+index eed8b7e73e2438c5e9b999cbc68f8f03ce1f3e8a..81021aefa4ab002fd2466c28e918b64e6c5a63fd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2447,6 +2447,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2446,6 +2446,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0505-Brand-support.patch
+++ b/patches/server/0505-Brand-support.patch
@@ -72,10 +72,10 @@ index e307f8695643360289b998a8d2ad244d966f1180..b7454592b9cee09f41631db6664cb18e
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a3951039eeb1f5d3529213ca02d11c97d499be38..e87a08d93abd507785ac5c79f97c02236aa6f43d 100644
+index 013380c9f10c7a1d510d07403a554fec2b7a3a90..6d65ea416f602709561d2f901da2ced3350bacbe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2431,6 +2431,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2447,6 +2447,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0509-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0509-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -17,10 +17,10 @@ index ac9020467cef648c72ccb350d26f90545f5afb56..e60d2ef3482c002b082ee84f34b9e681
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6bcc1a7ddfcdd0da157a65d2d866b28c390e3b41..bf7ba6d7f1527d4bf8533c655316865f81cde75f 100644
+index 3e21b24abef43051cd4b929b5873e0ed68592c42..b7791133d0a39bc392190ea34d0828838bb3fd12 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -387,11 +387,13 @@ public class CraftWorld implements World {
+@@ -388,11 +388,13 @@ public class CraftWorld implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0510-Add-moon-phase-API.patch
+++ b/patches/server/0510-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index bf7ba6d7f1527d4bf8533c655316865f81cde75f..2bef1c8524944e0327260542a9ebed2d8aa854e0 100644
+index b7791133d0a39bc392190ea34d0828838bb3fd12..6e71862d097c49bd270ef563ab3fad3cf4474e6a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -326,6 +326,11 @@ public class CraftWorld implements World {
+@@ -327,6 +327,11 @@ public class CraftWorld implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0523-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0523-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -69,10 +69,10 @@ index b9e738542692aba7b78fc514ae8e3248df9998ea..c601b8b12756682a4cb300be8ebed431
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 33bcc85c438ef3eb5310321353e1bfdc6c63ae99..8ae4e824ecb5d039848e574d352c019935f7093f 100644
+index 98b2c76565e620843860bc9920325601780d3a2d..aec766d4f2ef42711d017c0ba551f9d63502a98d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -565,7 +565,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -566,7 +566,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          // entity.setLocation() throws no event, and so cannot be cancelled

--- a/patches/server/0530-Entity-isTicking.patch
+++ b/patches/server/0530-Entity-isTicking.patch
@@ -27,10 +27,10 @@ index 1183406a0c69bb79a51d31480cc5ed17ca317444..60acf347cb5f4fc2e0cab18c5d9b5f4c
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 8ae4e824ecb5d039848e574d352c019935f7093f..85ca30aef0703db6859e66c62781ecfd334426e7 100644
+index aec766d4f2ef42711d017c0ba551f9d63502a98d..17383ac8388dfdfb44430ad2e1349d4d657adbaa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1220,5 +1220,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1234,5 +1234,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInLava() {
          return getHandle().isInLava();
      }

--- a/patches/server/0541-Player-elytra-boost-API.patch
+++ b/patches/server/0541-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e87a08d93abd507785ac5c79f97c02236aa6f43d..65f44c7747eea49fffff678fcbfdc32195a4db5d 100644
+index 6d65ea416f602709561d2f901da2ced3350bacbe..998fdb831876c08da2d9eeda0de28066bea404d1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -539,6 +539,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -541,6 +541,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0541-Player-elytra-boost-API.patch
+++ b/patches/server/0541-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6d65ea416f602709561d2f901da2ced3350bacbe..998fdb831876c08da2d9eeda0de28066bea404d1 100644
+index 81021aefa4ab002fd2466c28e918b64e6c5a63fd..4772d414c9755497e4d3e086ed8011df669c3379 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -541,6 +541,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -540,6 +540,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0555-Expose-world-spawn-angle.patch
+++ b/patches/server/0555-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index 5188f62a581276847695cc457f6fe86d47ec2af5..523a6163c9ac3eadebdd185d291aad21
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2bef1c8524944e0327260542a9ebed2d8aa854e0..fb82c861a457c07dfef0365fa56b4e2a8d2e1650 100644
+index 6e71862d097c49bd270ef563ab3fad3cf4474e6a..5ff8e7eaf738b0fb23399566e2f4551e0756b390 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -378,7 +378,7 @@ public class CraftWorld implements World {
+@@ -379,7 +379,7 @@ public class CraftWorld implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0557-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0557-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 65f44c7747eea49fffff678fcbfdc32195a4db5d..ca479c2de83b94e30f62cfaf573e108452908930 100644
+index 998fdb831876c08da2d9eeda0de28066bea404d1..fbf5ddf0317414ac3f0df2c896ae086fc331b697 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2057,7 +2057,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2059,7 +2059,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0557-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0557-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 998fdb831876c08da2d9eeda0de28066bea404d1..fbf5ddf0317414ac3f0df2c896ae086fc331b697 100644
+index 4772d414c9755497e4d3e086ed8011df669c3379..e78eb74a7004a6b9229ed80757e3466fcf0a91eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2059,7 +2059,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2058,7 +2058,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0588-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0588-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fb82c861a457c07dfef0365fa56b4e2a8d2e1650..085c6b5252b9b7cf64ba186df72bf233c5b6a58e 100644
+index 5ff8e7eaf738b0fb23399566e2f4551e0756b390..cceef349023362c44718c930dc87303450780153 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2409,8 +2409,13 @@ public class CraftWorld implements World {
+@@ -2410,8 +2410,13 @@ public class CraftWorld implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index fb82c861a457c07dfef0365fa56b4e2a8d2e1650..085c6b5252b9b7cf64ba186df72bf233
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -2445,8 +2450,12 @@ public class CraftWorld implements World {
+@@ -2446,8 +2451,12 @@ public class CraftWorld implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0599-Add-sendOpLevel-API.patch
+++ b/patches/server/0599-Add-sendOpLevel-API.patch
@@ -46,10 +46,10 @@ index 6c167952102548c5f766eaa8e022e213cc20bd74..9a7b635e2a962f4e1ae689ec7a3bc471
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ca479c2de83b94e30f62cfaf573e108452908930..30e042a37692053d8333191487ec48eeb8c6b502 100644
+index fbf5ddf0317414ac3f0df2c896ae086fc331b697..deeeec181baa1013d167374ec8d0efc58f423e09 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -553,6 +553,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -555,6 +555,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0599-Add-sendOpLevel-API.patch
+++ b/patches/server/0599-Add-sendOpLevel-API.patch
@@ -46,10 +46,10 @@ index 6c167952102548c5f766eaa8e022e213cc20bd74..9a7b635e2a962f4e1ae689ec7a3bc471
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fbf5ddf0317414ac3f0df2c896ae086fc331b697..deeeec181baa1013d167374ec8d0efc58f423e09 100644
+index e78eb74a7004a6b9229ed80757e3466fcf0a91eb..0fe54f20910466f663ff274d88ddef11e811bb16 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -555,6 +555,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -554,6 +554,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0626-Expose-Tracked-Players.patch
+++ b/patches/server/0626-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index deeeec181baa1013d167374ec8d0efc58f423e09..9dee02ce9db54da73607e3814ebc8d6c1db1d360 100644
+index 0fe54f20910466f663ff274d88ddef11e811bb16..655af0341887b3389c46daffc124cbe89f49eaae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2366,6 +2366,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2365,6 +2365,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0626-Expose-Tracked-Players.patch
+++ b/patches/server/0626-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 30e042a37692053d8333191487ec48eeb8c6b502..4a75642cfdf5a6eda43baa76f6a2e2a543e301ce 100644
+index deeeec181baa1013d167374ec8d0efc58f423e09..9dee02ce9db54da73607e3814ebc8d6c1db1d360 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2350,6 +2350,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2366,6 +2366,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0639-Implement-Keyed-on-World.patch
+++ b/patches/server/0639-Implement-Keyed-on-World.patch
@@ -34,10 +34,10 @@ index cfad79b859abfeb9bd83843b04bff3fd5d2e0ac3..210032209b3cdd2cda0e7463e3ee0e02
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 085c6b5252b9b7cf64ba186df72bf233c5b6a58e..271811e769e196e8694e1af37206c3b1b88194e1 100644
+index cceef349023362c44718c930dc87303450780153..b9cd665f47338e5e2d212e1e1558262757a09f0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2626,6 +2626,11 @@ public class CraftWorld implements World {
+@@ -2627,6 +2627,11 @@ public class CraftWorld implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0654-Set-area-affect-cloud-rotation.patch
+++ b/patches/server/0654-Set-area-affect-cloud-rotation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Set area affect cloud rotation
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 271811e769e196e8694e1af37206c3b1b88194e1..4717bd703d3a8bb87c71d14eb851db09c264046e 100644
+index b9cd665f47338e5e2d212e1e1558262757a09f0f..03082844560968e9a089a4ecd93a3451c7c9b948 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1975,6 +1975,7 @@ public class CraftWorld implements World {
+@@ -1976,6 +1976,7 @@ public class CraftWorld implements World {
              entity = net.minecraft.world.entity.EntityType.LIGHTNING_BOLT.create(world);
          } else if (AreaEffectCloud.class.isAssignableFrom(clazz)) {
              entity = new net.minecraft.world.entity.AreaEffectCloud(this.world, x, y, z);

--- a/patches/server/0663-More-World-API.patch
+++ b/patches/server/0663-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4717bd703d3a8bb87c71d14eb851db09c264046e..b825673fdd7c8c8dd9e05fe6b317006a64ba913e 100644
+index 03082844560968e9a089a4ecd93a3451c7c9b948..51c7e93f05791f10f64502708457adf33d9dc4b5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2579,6 +2579,60 @@ public class CraftWorld implements World {
+@@ -2580,6 +2580,60 @@ public class CraftWorld implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0681-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0681-additions-to-PlayerGameModeChangeEvent.patch
@@ -137,10 +137,10 @@ index 06b46cb1182ef65fab3e330be9c8685f2bf37a37..6cb46508513a5ccf60dba357ff1a2911
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4a75642cfdf5a6eda43baa76f6a2e2a543e301ce..1f631bdf64795913b0f6e5c1c4c8522f71b40dd1 100644
+index 9dee02ce9db54da73607e3814ebc8d6c1db1d360..e21b0cec0ea5d68f664ce95a708c1e837fe49e3e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1245,7 +1245,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1247,7 +1247,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0681-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0681-additions-to-PlayerGameModeChangeEvent.patch
@@ -137,10 +137,10 @@ index 06b46cb1182ef65fab3e330be9c8685f2bf37a37..6cb46508513a5ccf60dba357ff1a2911
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9dee02ce9db54da73607e3814ebc8d6c1db1d360..e21b0cec0ea5d68f664ce95a708c1e837fe49e3e 100644
+index 655af0341887b3389c46daffc124cbe89f49eaae..384d7f22d03bdb390b16bff51cf43a32e7d322ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1247,7 +1247,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1246,7 +1246,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0692-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0692-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -104,10 +104,10 @@ index cd840dc4a8ca432868fb3e9c912ea928e5303e0d..4d0af984490b556a9911c3b8fdca1e16
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b825673fdd7c8c8dd9e05fe6b317006a64ba913e..43f8dda87654387e95c18e93c0dd8126002b1fe0 100644
+index 51c7e93f05791f10f64502708457adf33d9dc4b5..fb7eb8246ac9d2271789f4b1645023cefb97e8bb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1457,7 +1457,7 @@ public class CraftWorld implements World {
+@@ -1458,7 +1458,7 @@ public class CraftWorld implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -116,7 +116,7 @@ index b825673fdd7c8c8dd9e05fe6b317006a64ba913e..43f8dda87654387e95c18e93c0dd8126
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1479,7 +1479,7 @@ public class CraftWorld implements World {
+@@ -1480,7 +1480,7 @@ public class CraftWorld implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0696-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0696-Add-PlayerKickEvent-causes.patch
@@ -342,10 +342,10 @@ index a708080ef25bc9596fc8f2b997b534dc5787d495..047145064e95d3d9cf398e61a17bb8ea
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e21b0cec0ea5d68f664ce95a708c1e837fe49e3e..fe4e77ec857f3136ecd953ce0a67c47850839f38 100644
+index 384d7f22d03bdb390b16bff51cf43a32e7d322ca..6ff621e6fafa7a6dfe002b50009140c317e45454 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -501,16 +501,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -500,16 +500,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0696-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0696-Add-PlayerKickEvent-causes.patch
@@ -342,10 +342,10 @@ index a708080ef25bc9596fc8f2b997b534dc5787d495..047145064e95d3d9cf398e61a17bb8ea
          // CraftBukkit end
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1f631bdf64795913b0f6e5c1c4c8522f71b40dd1..ce827827b0bdec3e4928dda72393aacd2a46ba77 100644
+index e21b0cec0ea5d68f664ce95a708c1e837fe49e3e..fe4e77ec857f3136ecd953ce0a67c47850839f38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -499,16 +499,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -501,16 +501,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          org.spigotmc.AsyncCatcher.catchOp("player kick"); // Spigot
          if (this.getHandle().connection == null) return;
  

--- a/patches/server/0706-Line-Of-Sight-Changes.patch
+++ b/patches/server/0706-Line-Of-Sight-Changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index deade89dbbd1d4e548be7be1a46e36b7a9eff809..8443d1531cf361509abfacff296ce277e35c6b13 100644
+index 6539cd1a63f2d987bda2b91555b94df896089d1f..429c229d7c88060c76b143ff4aa1bea88b2be786 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3430,7 +3430,8 @@ public abstract class LivingEntity extends Entity {
@@ -19,10 +19,10 @@ index deade89dbbd1d4e548be7be1a46e36b7a9eff809..8443d1531cf361509abfacff296ce277
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 43f8dda87654387e95c18e93c0dd8126002b1fe0..54d4c7aaae20fd8792004bee0f370ac3c629c973 100644
+index fb7eb8246ac9d2271789f4b1645023cefb97e8bb..9cdb71b99c472bf474646b915df47b85cee0ed04 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -331,6 +331,18 @@ public class CraftWorld implements World {
+@@ -332,6 +332,18 @@ public class CraftWorld implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0707-add-per-world-spawn-limits.patch
+++ b/patches/server/0707-add-per-world-spawn-limits.patch
@@ -30,10 +30,10 @@ index 97a1ca789eb606b263ebabad188baefe4df69b85..435558eb9f3ce277c14ff5e368d489d1
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 54d4c7aaae20fd8792004bee0f370ac3c629c973..8a1bee6a664b8c05b0c2f633d0971cfce5dacad2 100644
+index 9cdb71b99c472bf474646b915df47b85cee0ed04..95a82dc2d816f6b661944b7b41380ced9b0528ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -352,6 +352,13 @@ public class CraftWorld implements World {
+@@ -353,6 +353,13 @@ public class CraftWorld implements World {
          this.generator = gen;
  
          this.environment = env;

--- a/patches/server/0736-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0736-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index af4eb4a8814491afef449a2874521636957d7557..0a5d563700c9f806139001181f01fa9d
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ce827827b0bdec3e4928dda72393aacd2a46ba77..bd7d5d8c03fdb836504ad733f137cb180aa1b029 100644
+index fe4e77ec857f3136ecd953ce0a67c47850839f38..a9f3759463cabfedcb065f9ddb54caee55b3dd69 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1065,9 +1065,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1067,9 +1067,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0736-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0736-Add-PlayerSetSpawnEvent.patch
@@ -93,10 +93,10 @@ index af4eb4a8814491afef449a2874521636957d7557..0a5d563700c9f806139001181f01fa9d
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fe4e77ec857f3136ecd953ce0a67c47850839f38..a9f3759463cabfedcb065f9ddb54caee55b3dd69 100644
+index 6ff621e6fafa7a6dfe002b50009140c317e45454..3c7b83adb75a518e40e923906b6e931c42e8a17c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1067,9 +1067,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1066,9 +1066,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {


### PR DESCRIPTION
This PR replaces #5708 and implements Adventure's `Pointer` system in the following classes:
- `CraftPlayer`,
- `CraftWorld`,
- `CraftEntity`, and
- `ServerCommandSender`.

Additionally, two methods are added to `Permissible` that retrieve an Adventure `TriState` for a given permission.