### PR TITLE
Don't count named piglins and hoglins towards mob cap

### DIFF
--- a/patches/server/0814-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
+++ b/patches/server/0814-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 20 Aug 2021 18:36:02 -0700
+Subject: [PATCH] Dont count named piglins and hoglins towards mob cap
+
+
+diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
+index 0b228b8bcae5ed2840ab244b6de35732f737504d..f316585ccf6baf5e7e514ba3a68b4344e781a82d 100644
+--- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
++++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
+@@ -83,7 +83,7 @@ public final class NaturalSpawner {
+                 Mob entityinsentient = (Mob) entity;
+ 
+                 // CraftBukkit - Split out persistent check, don't apply it to special persistent mobs
+-                if (entityinsentient.removeWhenFarAway(0) && entityinsentient.isPersistenceRequired()) {
++                if ((entityinsentient instanceof net.minecraft.world.entity.monster.piglin.Piglin || entityinsentient instanceof net.minecraft.world.entity.monster.hoglin.Hoglin || entityinsentient.removeWhenFarAway(0)) && entityinsentient.isPersistenceRequired()) { // Paper - what a jank fix, CBs like totally tried to change what removeWhenFarAway does, that method isnt even called here in vanilla, idk wtf is going on
+                     continue;
+                 }
+             }


### PR DESCRIPTION
Fixes #6446

This ridiculous change is needed because of the following jank:  


Both `Piglin` and `Hoglin` override `Mob`s removeWhenFarAway(double) method  
```java
    @Override
    public boolean removeWhenFarAway(double distanceSquared) {
        return !this.isPersistenceRequired();
    }
```

Now one of the reasons entities aren't counted towards the mob caps is this  
```java
if (entityinsentient.removeWhenFarAway(0) && entityinsentient.isPersistenceRequired()) {
	continue;
}
```

So for piglins and hoglins, that conditional will only ever be, if (true && false) or if (false && true).

EDIT: Tested with breakpoints, with this patch, the continue is called and the mob is not counted.