### PR TITLE
Fix CB lib relocation

### DIFF
--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -28,10 +28,10 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..bb338269c9e3bef4c274157c490d8b8f
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9
+index 0000000000000000000000000000000000000000..6f084d7500d9de76604440bdcc582be1af04fc8c
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,172 @@
+@@ -0,0 +1,173 @@
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Log4j2PluginsCacheFileTransformer
 +import com.github.jengelman.gradle.plugins.shadow.transformers.Transformer
 +import io.papermc.paperweight.util.Git
@@ -105,6 +105,7 @@ index 0000000000000000000000000000000000000000..fd7d8208587a1f92b7a928cde0bb4b2d
 +}
 +
 +relocation {
++    // Order matters here - e.g. craftbukkit proper must be relocated before any of the libs are relocated into the cb package
 +    val packageVersion = "1_17_R1"
 +    relocate("org.bukkit.craftbukkit" to "org.bukkit.craftbukkit.v$packageVersion") {
 +        exclude("org.bukkit.craftbukkit.Main*")

--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -28,7 +28,7 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..bb338269c9e3bef4c274157c490d8b8f
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..71f781083f2f81d064605b2a652181f22b98733d
+index 0000000000000000000000000000000000000000..fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9
 --- /dev/null
 +++ b/build.gradle.kts
 @@ -0,0 +1,172 @@
@@ -105,6 +105,11 @@ index 0000000000000000000000000000000000000000..71f781083f2f81d064605b2a652181f2
 +}
 +
 +relocation {
++    val packageVersion = "1_17_R1"
++    relocate("org.bukkit.craftbukkit" to "org.bukkit.craftbukkit.v$packageVersion") {
++        exclude("org.bukkit.craftbukkit.Main*")
++    }
++
 +    fun cb(pack: String) = "org.bukkit.craftbukkit.libs.$pack"
 +
 +    sequenceOf(
@@ -128,11 +133,6 @@ index 0000000000000000000000000000000000000000..71f781083f2f81d064605b2a652181f2
 +        "org.eclipse.sisu"
 +    ).forEach { pack ->
 +        relocate(pack to cb(pack))
-+    }
-+
-+    val packageVersion = "1_17_R1"
-+    relocate("org.bukkit.craftbukkit" to "org.bukkit.craftbukkit.v$packageVersion") {
-+        exclude("org.bukkit.craftbukkit.Main*")
 +    }
 +}
 +

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9..7543b976ed605fab205edd08589a897664c2720f 100644
+index 6f084d7500d9de76604440bdcc582be1af04fc8c..d97e9ba4432fc87c84f9f128820ff741464e1e25 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,21 +18,24 @@ repositories {
@@ -45,7 +45,7 @@ index fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9..7543b976ed605fab205edd08589a8976
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -82,7 +86,7 @@ relocation {
+@@ -83,7 +87,7 @@ relocation {
          "org.jline:jline-terminal-jansi" to "jline",
          "commons-codec:commons-codec" to "org.apache.commons.codec",
          "commons-io:commons-io" to "org.apache.commons.io",
@@ -54,7 +54,7 @@ index fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9..7543b976ed605fab205edd08589a8976
          "org.apache.commons:commons-lang3" to "org.apache.commons.lang3",
          "org.ow2.asm:asm" to "org.objectweb.asm"
      ).forEach { (owner, pack) ->
-@@ -102,9 +106,17 @@ relocation {
+@@ -103,9 +107,17 @@ relocation {
      }
  }
  

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 71f781083f2f81d064605b2a652181f22b98733d..bacfd25d2fa07d2b0441494a39fe3830b7e4d1f0 100644
+index fd7d8208587a1f92b7a928cde0bb4b2d0efc61a9..7543b976ed605fab205edd08589a897664c2720f 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -18,21 +18,24 @@ repositories {
@@ -45,7 +45,7 @@ index 71f781083f2f81d064605b2a652181f22b98733d..bacfd25d2fa07d2b0441494a39fe3830
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)
-@@ -77,7 +81,7 @@ relocation {
+@@ -82,7 +86,7 @@ relocation {
          "org.jline:jline-terminal-jansi" to "jline",
          "commons-codec:commons-codec" to "org.apache.commons.codec",
          "commons-io:commons-io" to "org.apache.commons.io",

--- a/patches/server/0712-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0712-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 7933b1594253ca13ad50ebca077c2e98f3021fa3..805820262d075728dc2a85e47bb32b19f5f5abfa 100644
+index 5ee1e44647cfd7dff08ba7ce17d4b04246b7ab57..dc17410ac88e9f069a48ce7eb94b7cbec8e61c74 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,8 +1,12 @@
@@ -46,7 +46,7 @@ index 7933b1594253ca13ad50ebca077c2e98f3021fa3..805820262d075728dc2a85e47bb32b19
      testImplementation("io.github.classgraph:classgraph:4.8.47") // Paper - mob goal test
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
-@@ -142,6 +156,44 @@ tasks.shadowJar {
+@@ -143,6 +157,44 @@ tasks.shadowJar {
      transform(ModifiedLog4j2PluginsCacheFileTransformer::class.java)
  }
  


### PR DESCRIPTION
Fixes #5864 

need to relocate craftbukkit *before* the libs or stuff might get messed up, like  
`META-INF/services/javax.annotation.processing.Processor`  
containing
`org.bukkit.craftbukkit.v1_17_R1.libs.org.eclipse.sisu.space.SisuIndexAPT6`  
which is incorrect, libs aren't in the v1_17_R1 package.