### PR TITLE
Prevent NPE when removing enchantment with no ItemMeta

### DIFF
--- a/patches/server/0062-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0062-Handle-Item-Meta-Inconsistencies.patch
@@ -79,7 +79,7 @@ index ddf0889b20b42c17edc2678d809bddf3dacf4c8f..7f44e9e382aa87ad9be94394d05bbcac
  
      public boolean isEnchanted() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index b89292f10e254616bfe3da4700eb12a9fd41f25d..379612cb78d275fa61125390c7429fcb2920ab33 100644
+index b89292f10e254616bfe3da4700eb12a9fd41f25d..45d61dbe785155501d9fa23e33b1954c5ad1c0e4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 @@ -6,7 +6,6 @@ import java.util.Map;
@@ -124,7 +124,7 @@ index b89292f10e254616bfe3da4700eb12a9fd41f25d..379612cb78d275fa61125390c7429fcb
      }
  
      static boolean makeTag(net.minecraft.world.item.ItemStack item) {
-@@ -215,66 +197,33 @@ public final class CraftItemStack extends ItemStack {
+@@ -215,66 +197,34 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean containsEnchantment(Enchantment ench) {
@@ -183,6 +183,7 @@ index b89292f10e254616bfe3da4700eb12a9fd41f25d..379612cb78d275fa61125390c7429fcb
 -            }
 +        // Paper start - replace entire method
 +        final ItemMeta itemMeta = this.getItemMeta();
++        if (itemMeta == null) return 0;
 +        int level = itemMeta.getEnchantLevel(ench);
 +        if (level > 0) {
 +            itemMeta.removeEnchant(ench);

--- a/patches/server/0236-Don-t-call-getItemMeta-on-hasItemMeta.patch
+++ b/patches/server/0236-Don-t-call-getItemMeta-on-hasItemMeta.patch
@@ -11,10 +11,10 @@ Returns true if getDamage() == 0 or has damage tag or other tag is set.
 Check the `ItemMetaTest#testTaggedButNotMeta` method to see how this method behaves.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-index efdcccac85626835ff29ed00976978d5bb900356..b3acc23d54c593b599517a481ad6ac86e5661fa2 100644
+index 3cf23bc0a28ac5f4ac7b51f427f17365eaff8cc1..f02bbc2e927ea2d8e861597da4dbe4d199e48799 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
-@@ -574,7 +574,7 @@ public final class CraftItemStack extends ItemStack {
+@@ -575,7 +575,7 @@ public final class CraftItemStack extends ItemStack {
  
      @Override
      public boolean hasItemMeta() {


### PR DESCRIPTION
The other enchantment-related methods on CraftItemStack check for the existence of ItemMeta except this one so it throws an NPE if you try to remove an enchantment from an item that doesnt have any meta. 0 is the appropriate return value for an enchantment that doesn't exist.