### PR TITLE
Improve EntityTransformEvent cancellation handling

### DIFF
--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/ma
 index 18ba4b9d9b68088afd48d1f12cec6b155ea84159..dfc67cd0ef52939be5e5a9952cfcdb4d87bf0d82 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -837,10 +837,17 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -837,10 +837,18 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
      @Override
      public void thunderHit(ServerLevel world, LightningBolt lightning) {
          if (world.getDifficulty() != Difficulty.PEACEFUL) {
@@ -19,6 +19,7 @@ index 18ba4b9d9b68088afd48d1f12cec6b155ea84159..dfc67cd0ef52939be5e5a9952cfcdb4d
              if (entitywitch != null) {
 +                // Paper start
 +                if (org.bukkit.craftbukkit.event.CraftEventFactory.callEntityZapEvent(this, lightning, entitywitch).isCancelled()) {
++                    super.thunderHit(world, lightning);
 +                    return;
 +                }
 +                if (org.spigotmc.SpigotConfig.logVillagerDeaths) Villager.LOGGER.info("Villager {} was struck by lightning {}.", this, lightning); // Move down

--- a/patches/server/0173-PreCreatureSpawnEvent.patch
+++ b/patches/server/0173-PreCreatureSpawnEvent.patch
@@ -87,7 +87,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/ma
 index bbbb26550b0c5b36d9c7204f075aa90b79b85ff0..bc778aadb2604756b783d4d024e3154576ab3236 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -951,7 +951,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -952,7 +952,7 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
              }).limit(5L).collect(Collectors.toList());
  
              if (list1.size() >= requiredCount) {

--- a/patches/server/0515-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0515-Fix-curing-zombie-villager-discount-exploit.patch
@@ -11,7 +11,7 @@ diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/ma
 index e3db573f10b7a3f8f605a11dc886859c68168467..105f8fcbbc5c7c384b77ca8eb768f1147d6ce4b2 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -980,6 +980,15 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -981,6 +981,15 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
      @Override
      public void onReputationEventFrom(ReputationEventType interaction, Entity entity) {
          if (interaction == ReputationEventType.ZOMBIE_VILLAGER_CURED) {

--- a/patches/server/0927-More-vanilla-friendly-methods-to-update-trades.patch
+++ b/patches/server/0927-More-vanilla-friendly-methods-to-update-trades.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More vanilla friendly methods to update trades
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-index 105f8fcbbc5c7c384b77ca8eb768f1147d6ce4b2..18eac340386a396c9850f53f30d20a41c1437788 100644
+index a7dac1af41456e55baa35f38ac7fce69b83117c2..60e4b98cac3545cfb647fccd44c1378a1e8452ba 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
 +++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
-@@ -923,6 +923,12 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -924,6 +924,12 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
  
      @Override
      protected void updateTrades() {
@@ -21,7 +21,7 @@ index 105f8fcbbc5c7c384b77ca8eb768f1147d6ce4b2..18eac340386a396c9850f53f30d20a41
          VillagerData villagerdata = this.getVillagerData();
          Int2ObjectMap<VillagerTrades.ItemListing[]> int2objectmap = (Int2ObjectMap) VillagerTrades.TRADES.get(villagerdata.getProfession());
  
-@@ -932,9 +938,11 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+@@ -933,9 +939,11 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
              if (avillagertrades_imerchantrecipeoption != null) {
                  MerchantOffers merchantrecipelist = this.getOffers();
  

--- a/patches/server/0951-Improve-EntityTransformEvent-cancellation-handling.patch
+++ b/patches/server/0951-Improve-EntityTransformEvent-cancellation-handling.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 21 Aug 2021 21:15:38 -0700
+Subject: [PATCH] Improve EntityTransformEvent cancellation handling
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/animal/Pig.java b/src/main/java/net/minecraft/world/entity/animal/Pig.java
+index fc29107ee256af2b5f2e481f17ade6cfcaa101ae..b5de4963ea04b9243ba20ca58c217c316403c307 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/Pig.java
++++ b/src/main/java/net/minecraft/world/entity/animal/Pig.java
+@@ -255,6 +255,7 @@ public class Pig extends Animal implements ItemSteerable, Saddleable {
+                 entitypigzombie.setPersistenceRequired();
+                 // CraftBukkit start
+                 if (CraftEventFactory.callPigZapEvent(this, lightning, entitypigzombie).isCancelled()) {
++                    super.thunderHit(world, lightning); // Paper - fallback on old behavior
+                     return;
+                 }
+                 // CraftBukkit - added a reason for spawning this creature
+diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+index 60e4b98cac3545cfb647fccd44c1378a1e8452ba..922b508e7a058780db4d48c733fc13f6a9e5a4ec 100644
+--- a/src/main/java/net/minecraft/world/entity/npc/Villager.java
++++ b/src/main/java/net/minecraft/world/entity/npc/Villager.java
+@@ -861,7 +861,6 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+                     super.thunderHit(world, lightning);
+                     return;
+                 }
+-                if (org.spigotmc.SpigotConfig.logVillagerDeaths) Villager.LOGGER.info("Villager {} was struck by lightning {}.", this, lightning); // Move down
+                 // Paper end
+ 
+                 entitywitch.moveTo(this.getX(), this.getY(), this.getZ(), this.getYRot(), this.getXRot());
+@@ -875,8 +874,10 @@ public class Villager extends AbstractVillager implements ReputationEventHandler
+                 entitywitch.setPersistenceRequired();
+                 // CraftBukkit start
+                 if (CraftEventFactory.callEntityTransformEvent(this, entitywitch, EntityTransformEvent.TransformReason.LIGHTNING).isCancelled()) {
++                    super.thunderHit(world, lightning); // Paper - didn't cancel the lighting, just the transformation
+                     return;
+                 }
++                if (org.spigotmc.SpigotConfig.logVillagerDeaths) Villager.LOGGER.info("Villager {} was struck by lightning {}.", this, lightning); // Paper - move even further down because if transformation is cancelled, the entity won't die
+                 world.addFreshEntityWithPassengers(entitywitch, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.LIGHTNING);
+                 // CraftBukkit end
+                 this.releaseAllPois();


### PR DESCRIPTION
Saw the [spigot issue](https://hub.spigotmc.org/jira/browse/SPIGOT-6713), and decided to look around elsewhere for oddities with cancelling EntityTransformEvent, and as usual, there was an issue where Villager's deaths would be logged if it was cancelled, and they wouldn't take lightning damage if it was cancelled.