### PR TITLE
ci: update setup-java action to v2.3.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
               uses: actions/setup-java@v2.3.0
               with:
                   java-version: ${{ matrix.java }}
-                  distribution: 'adopt'
+                  distribution: 'temurin'
                   cache: 'gradle'
             - name: Patch and build
               run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,20 +18,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - name: JDK ${{ matrix.java }}
-              uses: actions/setup-java@v2
+              uses: actions/setup-java@v2.3.0
               with:
                   java-version: ${{ matrix.java }}
                   distribution: 'adopt'
-            - name: Cache gradle
-              uses: actions/cache@v2
-              with:
-                  path: |
-                    ~/.gradle/caches
-                    ~/.gradle/jdks
-                    ~/.gradle/native
-                    ~/.gradle/wrapper
-                  key: ${{ runner.os }}-paper-2-${{ hashFiles('**/*.gradle*', 'gradle/**', 'gradle.properties') }}
-                  restore-keys: ${{ runner.os }}-paper-2
+                  cache: 'gradle'
             - name: Patch and build
               run: |
                   git config --global user.email "no-reply@github.com"


### PR DESCRIPTION
Updates the setup-java action to v2.3.0 for cache option.

We can cache gradle dependencies by setup-java action now!
https://github.com/actions/setup-java/releases/tag/v2.3.0