### PR TITLE
Add download link to the /version command

### DIFF
--- a/patches/server/0020-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0020-Implement-Paper-VersionChecker.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b24b68898c
+index 0000000000000000000000000000000000000000..54a43041eb9a91b43cb87d9ee145fa96750433a1
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -0,0 +1,122 @@
+@@ -0,0 +1,129 @@
 +package com.destroystokyo.paper;
 +
 +import com.destroystokyo.paper.util.VersionFetcher;
@@ -17,6 +17,7 @@ index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b2
 +import com.google.common.io.Resources;
 +import com.google.gson.*;
 +import net.kyori.adventure.text.Component;
++import net.kyori.adventure.text.event.ClickEvent;
 +import net.kyori.adventure.text.format.NamedTextColor;
 +
 +import javax.annotation.Nonnull;
@@ -29,6 +30,7 @@ index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b2
 +public class PaperVersionFetcher implements VersionFetcher {
 +    private static final java.util.regex.Pattern VER_PATTERN = java.util.regex.Pattern.compile("^([0-9\\.]*)\\-.*R"); // R is an anchor, will always give '-R' at end
 +    private static final String GITHUB_BRANCH_NAME = "master";
++    private static final String DOWNLOAD_PAGE = "https://papermc.io/downloads";
 +    private static @Nullable String mcVer;
 +
 +    @Override
@@ -77,7 +79,12 @@ index 0000000000000000000000000000000000000000..1a1b50e475b9ede544b2f6d0d36632b2
 +            case -2:
 +                return Component.text("Unknown version", NamedTextColor.YELLOW);
 +            default:
-+                return Component.text("You are " + distance + " version(s) behind", NamedTextColor.YELLOW);
++                return Component.text("You are " + distance + " version(s) behind", NamedTextColor.YELLOW)
++                        .append(Component.newline())
++                        .append(Component.text("Download the new version at: ", NamedTextColor.YELLOW)
++                                .append(Component.text(DOWNLOAD_PAGE)
++                                        .hoverEvent(Component.text("Click to open", NamedTextColor.WHITE))
++                                        .clickEvent(ClickEvent.openUrl(DOWNLOAD_PAGE))));
 +        }
 +    }
 +

--- a/patches/server/0020-Implement-Paper-VersionChecker.patch
+++ b/patches/server/0020-Implement-Paper-VersionChecker.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement Paper VersionChecker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..54a43041eb9a91b43cb87d9ee145fa96750433a1
+index 0000000000000000000000000000000000000000..91d7afc710a2d52b4f429e0381cf64176ecb6415
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 @@ -0,0 +1,129 @@
@@ -81,8 +81,8 @@ index 0000000000000000000000000000000000000000..54a43041eb9a91b43cb87d9ee145fa96
 +            default:
 +                return Component.text("You are " + distance + " version(s) behind", NamedTextColor.YELLOW)
 +                        .append(Component.newline())
-+                        .append(Component.text("Download the new version at: ", NamedTextColor.YELLOW)
-+                                .append(Component.text(DOWNLOAD_PAGE)
++                        .append(Component.text("Download the new version at: ")
++                                .append(Component.text(DOWNLOAD_PAGE, NamedTextColor.GOLD)
 +                                        .hoverEvent(Component.text("Click to open", NamedTextColor.WHITE))
 +                                        .clickEvent(ClickEvent.openUrl(DOWNLOAD_PAGE))));
 +        }

--- a/patches/server/0021-Add-version-history-to-version-command.patch
+++ b/patches/server/0021-Add-version-history-to-version-command.patch
@@ -5,20 +5,19 @@ Subject: [PATCH] Add version history to version command
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-index 1a1b50e475b9ede544b2f6d0d36632b24b68898c..580bae0d414d371a07a6bfeefc41fdd989dc0083 100644
+index 54a43041eb9a91b43cb87d9ee145fa96750433a1..3daeebb5ce4df012e6cb6683697c9179eebf6b35 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperVersionFetcher.java
-@@ -5,7 +5,9 @@ import com.google.common.base.Charsets;
- import com.google.common.io.Resources;
- import com.google.gson.*;
+@@ -7,6 +7,8 @@ import com.google.gson.*;
  import net.kyori.adventure.text.Component;
-+import net.kyori.adventure.text.TextComponent;
+ import net.kyori.adventure.text.event.ClickEvent;
  import net.kyori.adventure.text.format.NamedTextColor;
 +import net.kyori.adventure.text.format.TextDecoration;
++import net.kyori.adventure.text.TextComponent;
  
  import javax.annotation.Nonnull;
  import javax.annotation.Nullable;
-@@ -28,7 +30,10 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -30,7 +32,10 @@ public class PaperVersionFetcher implements VersionFetcher {
      @Override
      public Component getVersionMessage(@Nonnull String serverVersion) {
          String[] parts = serverVersion.substring("git-Paper-".length()).split("[-\\s]");
@@ -30,7 +29,7 @@ index 1a1b50e475b9ede544b2f6d0d36632b24b68898c..580bae0d414d371a07a6bfeefc41fdd9
      }
  
      private static @Nullable String getMinecraftVersion() {
-@@ -119,4 +124,19 @@ public class PaperVersionFetcher implements VersionFetcher {
+@@ -126,4 +131,19 @@ public class PaperVersionFetcher implements VersionFetcher {
              return -1;
          }
      }


### PR DESCRIPTION
Adds a link to https://papermc.io/downloads on the /version output when there is a newer version available for download, can be easily changed for any forks.

Features a clickable link: https://i.imgur.com/VwL3MlA.jpg
Old copy behaviour is still working as well.

Hopefully will encourage users to update when given a direct link and avoids inexperienced users from potentially navigating to a malware/mirror site.