### PR TITLE
Vanilla command permission fixes (fixes #6085)

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -237,3 +237,6 @@ public-f net.minecraft.world.level.chunk.DataLayer
 # Add methods to get translation keys
 public org.bukkit.craftbukkit.inventory.CraftMetaFirework
 public org.bukkit.craftbukkit.inventory.CraftMetaFirework getNBT(Lorg/bukkit/FireworkEffect$Type;)I
+
+# Vanilla command permission fixes
+public-f com.mojang.brigadier.tree.CommandNode requirement

--- a/patches/server/0438-Optimize-brigadier-child-sorting-performance.patch
+++ b/patches/server/0438-Optimize-brigadier-child-sorting-performance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Optimize brigadier child sorting performance
 
 
 diff --git a/src/main/java/com/mojang/brigadier/tree/CommandNode.java b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
-index b8d646864a24bba376661cfd87901012416c669d..aa3a1795850a419f624f14bd7c4daab0020779d0 100644
+index 2dd09c97e00d877f5f3beed9583d3fdabc88e181..74af1b6158394d66fe470f9b7db741871f2bb534 100644
 --- a/src/main/java/com/mojang/brigadier/tree/CommandNode.java
 +++ b/src/main/java/com/mojang/brigadier/tree/CommandNode.java
 @@ -26,7 +26,7 @@ import java.util.stream.Collectors;
@@ -16,7 +16,7 @@ index b8d646864a24bba376661cfd87901012416c669d..aa3a1795850a419f624f14bd7c4daab0
 +    private Map<String, CommandNode<S>> children = Maps.newTreeMap(); //Paper - Switch to tree map for automatic sorting
      private Map<String, LiteralCommandNode<S>> literals = Maps.newLinkedHashMap();
      private Map<String, ArgumentCommandNode<S, ?>> arguments = Maps.newLinkedHashMap();
-     private final Predicate<S> requirement;
+     public Predicate<S> requirement;
 @@ -107,7 +107,7 @@ public abstract class CommandNode<S> implements Comparable<CommandNode<S>> {
              }
          }

--- a/patches/server/0752-Vanilla-command-permission-fixes.patch
+++ b/patches/server/0752-Vanilla-command-permission-fixes.patch
@@ -1,0 +1,78 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Wed, 25 Aug 2021 13:19:53 -0700
+Subject: [PATCH] Vanilla command permission fixes
+
+Fixes permission checks for vanilla commands which don't have a
+requirement, as well as for namespaced vanilla commands.
+
+diff --git a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+index 899008b2980d13f1be6280cd8cb959c53a29bebf..f875507241ac6769545e91cd3285232b75b892f0 100644
+--- a/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
++++ b/src/main/java/com/mojang/brigadier/builder/ArgumentBuilder.java
+@@ -14,9 +14,17 @@ import java.util.Collections;
+ import java.util.function.Predicate;
+ 
+ public abstract class ArgumentBuilder<S, T extends ArgumentBuilder<S, T>> {
++    // Paper start
++    private static final Predicate<Object> DEFAULT_REQUIREMENT = s -> true;
++
++    @SuppressWarnings("unchecked")
++    public static <S> Predicate<S> defaultRequirement() {
++        return (Predicate<S>) DEFAULT_REQUIREMENT;
++    }
++    // Paper end
+     private final RootCommandNode<S> arguments = new RootCommandNode<>();
+     private Command<S> command;
+-    private Predicate<S> requirement = s -> true;
++    private Predicate<S> requirement = defaultRequirement(); // Paper
+     private CommandNode<S> target;
+     private RedirectModifier<S> modifier = null;
+     private boolean forks;
+diff --git a/src/main/java/net/minecraft/commands/Commands.java b/src/main/java/net/minecraft/commands/Commands.java
+index a6f10d47bc4e2cadcc3e06cffa011ed7fb97c68d..cc0aff09e03586f97d79c8db6e1e52d9f192b4b1 100644
+--- a/src/main/java/net/minecraft/commands/Commands.java
++++ b/src/main/java/net/minecraft/commands/Commands.java
+@@ -204,6 +204,13 @@ public class Commands {
+             PublishCommand.register(this.dispatcher);
+         }
+ 
++        // Paper start
++        for (final CommandNode<CommandSourceStack> node : this.dispatcher.getRoot().getChildren()) {
++            if (node.getRequirement() == com.mojang.brigadier.builder.ArgumentBuilder.<CommandSourceStack>defaultRequirement()) {
++                node.requirement = stack -> stack.getBukkitSender().hasPermission(org.bukkit.craftbukkit.command.VanillaCommandWrapper.getPermission(node));
++            }
++        }
++        // Paper end
+         this.dispatcher.findAmbiguities((commandnode, commandnode1, commandnode2, collection) -> {
+             // CommandDispatcher.LOGGER.warn("Ambiguity between arguments {} and {} with inputs: {}", this.b.getPath(commandnode1), this.b.getPath(commandnode2), collection); // CraftBukkit
+         });
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+index 0377c706c9aec6f367e83f859f9a3432ad5bba4a..e9d1fb479855194da5a05e86861848158736cbb4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+@@ -87,7 +87,23 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+     }
+ 
+     public static String getPermission(CommandNode<CommandSourceStack> vanillaCommand) {
+-        return "minecraft.command." + ((vanillaCommand.getRedirect() == null) ? vanillaCommand.getName() : vanillaCommand.getRedirect().getName());
++        // Paper start
++        final String commandName;
++        if (vanillaCommand.getRedirect() == null) {
++            commandName = vanillaCommand.getName();
++        } else {
++            commandName = vanillaCommand.getRedirect().getName();
++        }
++        return "minecraft.command." + stripDefaultNamespace(commandName);
++    }
++
++    private static String stripDefaultNamespace(final String maybeNamespaced) {
++        final String prefix = "minecraft:";
++        if (maybeNamespaced.startsWith(prefix)) {
++            return maybeNamespaced.substring(prefix.length());
++        }
++        return maybeNamespaced;
++        // Paper end
+     }
+ 
+     private String toDispatcher(String[] args, String name) {


### PR DESCRIPTION
Fixes permission checks for vanilla commands which don't have a
requirement, as well as for namespaced vanilla commands.

Compared to #6426 this is a larger diff, but I think it's the more proper fix, as it actually addresses the issues with the existing checks rather than adding an additional check.

Fixes #6085