### PR TITLE
Remove unneeded @ throws from team javadocs

### DIFF
--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -3667,10 +3667,10 @@ index d283f6947d775a3bc3a9b2f75db9ab733d819a06..93089ce61d2e1888df13b7c9629a79cd
  
      /**
 diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
-index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff894f7c79f 100644
+index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..d5b39fb4fc16a342b5661e08df1506858168d20d 100644
 --- a/src/main/java/org/bukkit/scoreboard/Team.java
 +++ b/src/main/java/org/bukkit/scoreboard/Team.java
-@@ -22,14 +22,95 @@ public interface Team {
+@@ -22,14 +22,93 @@ public interface Team {
       */
      @NotNull
      String getName() throws IllegalStateException;
@@ -3706,7 +3706,6 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
 +     *
 +     * @param prefix New prefix
 +     * @throws IllegalArgumentException if prefix is null
-+     * @throws IllegalArgumentException if prefix is longer than 64
 +     *     characters
 +     * @throws IllegalStateException if this team has been unregistered
 +     */
@@ -3725,7 +3724,6 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
 +     *
 +     * @param suffix the new suffix for this team.
 +     * @throws IllegalArgumentException if suffix is null
-+     * @throws IllegalArgumentException if suffix is longer than 64
 +     *     characters
 +     * @throws IllegalStateException if this team has been unregistered
 +     */
@@ -3766,7 +3764,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      String getDisplayName() throws IllegalStateException;
  
      /**
-@@ -39,7 +120,9 @@ public interface Team {
+@@ -39,7 +118,9 @@ public interface Team {
       * @throws IllegalArgumentException if displayName is longer than 128
       *     characters.
       * @throws IllegalStateException if this team has been unregistered
@@ -3776,7 +3774,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      void setDisplayName(@NotNull String displayName) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -47,8 +130,10 @@ public interface Team {
+@@ -47,8 +128,10 @@ public interface Team {
       *
       * @return Team prefix
       * @throws IllegalStateException if this team has been unregistered
@@ -3787,7 +3785,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      String getPrefix() throws IllegalStateException;
  
      /**
-@@ -59,7 +144,9 @@ public interface Team {
+@@ -59,7 +142,9 @@ public interface Team {
       * @throws IllegalArgumentException if prefix is longer than 64
       *     characters
       * @throws IllegalStateException if this team has been unregistered
@@ -3797,7 +3795,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      void setPrefix(@NotNull String prefix) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -67,8 +154,10 @@ public interface Team {
+@@ -67,8 +152,10 @@ public interface Team {
       *
       * @return the team's current suffix
       * @throws IllegalStateException if this team has been unregistered
@@ -3808,7 +3806,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      String getSuffix() throws IllegalStateException;
  
      /**
-@@ -79,7 +168,9 @@ public interface Team {
+@@ -79,7 +166,9 @@ public interface Team {
       * @throws IllegalArgumentException if suffix is longer than 64
       *     characters
       * @throws IllegalStateException if this team has been unregistered
@@ -3818,7 +3816,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      void setSuffix(@NotNull String suffix) throws IllegalStateException, IllegalArgumentException;
  
      /**
-@@ -90,8 +181,10 @@ public interface Team {
+@@ -90,8 +179,10 @@ public interface Team {
       *
       * @return team color, defaults to {@link ChatColor#RESET}
       * @throws IllegalStateException if this team has been unregistered
@@ -3829,7 +3827,7 @@ index 0db7fe1b9fe5621ceed3f4f046691e359f5949dd..30fce0df75494eb9b7409f08ea3d6ff8
      ChatColor getColor() throws IllegalStateException;
  
      /**
-@@ -102,7 +195,9 @@ public interface Team {
+@@ -102,7 +193,9 @@ public interface Team {
       *
       * @param color new color, must be non-null. Use {@link ChatColor#RESET} for
       * no color


### PR DESCRIPTION
There is no length limit on team prefixes and suffixes