### PR TITLE
Log when the async catcher is tripped

### DIFF
--- a/patches/server/0762-Log-when-the-async-catcher-is-tripped.patch
+++ b/patches/server/0762-Log-when-the-async-catcher-is-tripped.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+Date: Wed, 25 Aug 2021 20:17:12 -0700
+Subject: [PATCH] Log when the async catcher is tripped
+
+The chunk system can swallow the exception given it's all
+built with completablefuture, so ensure it is at least printed.
+
+diff --git a/src/main/java/org/spigotmc/AsyncCatcher.java b/src/main/java/org/spigotmc/AsyncCatcher.java
+index 7a23b56752f6733ee626a8b1e4c3b78591855c4e..54bd77934f58bed162574356d8e2b71dd01d6c9b 100644
+--- a/src/main/java/org/spigotmc/AsyncCatcher.java
++++ b/src/main/java/org/spigotmc/AsyncCatcher.java
+@@ -12,6 +12,7 @@ public class AsyncCatcher
+     {
+         if ( AsyncCatcher.enabled && Thread.currentThread() != MinecraftServer.getServer().serverThread )
+         {
++            MinecraftServer.LOGGER.fatal("Thread " + Thread.currentThread().getName() + " failed main thread check: " + reason, new Throwable()); // Paper
+             throw new IllegalStateException( "Asynchronous " + reason + "!" );
+         }
+     }


### PR DESCRIPTION
The chunk system can swallow the exception given it's all
built with completablefuture, so ensure it is at least printed.