### PR TITLE
Improve ItemStack#editMeta

### DIFF
--- a/patches/api/0308-ItemStack-editMeta.patch
+++ b/patches/api/0308-ItemStack-editMeta.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] ItemStack#editMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 86bd9f14de5c1ff3d797955be1af56e5efcac884..59a026d80b0a0a4890becf98efdbe5325b2c622a 100644
+index 86bd9f14de5c1ff3d797955be1af56e5efcac884..d86a697bffd411036e9c6c15fb19040dfb1a030a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
-@@ -543,6 +543,31 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
+@@ -543,6 +543,50 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
          return result.ensureServerConversions(); // Paper
      }
  
@@ -27,9 +27,28 @@ index 86bd9f14de5c1ff3d797955be1af56e5efcac884..59a026d80b0a0a4890becf98efdbe532
 +     * @return {@code true} if the edit was successful, {@code false} otherwise
 +     */
 +    public boolean editMeta(final @NotNull java.util.function.Consumer<? super ItemMeta> consumer) {
++        return editMeta(ItemMeta.class, consumer);
++    }
++
++    /**
++     * Edits the {@link ItemMeta} of this stack if the meta is of the specified type.
++     * <p>
++     * The {@link java.util.function.Consumer} must only interact
++     * with this stack's {@link ItemMeta} through the provided {@link ItemMeta} instance.
++     * Calling this method or any other meta-related method of the {@link ItemStack} class
++     * (such as {@link #getItemMeta()}, {@link #addItemFlags(ItemFlag...)}, {@link #lore()}, etc.)
++     * from inside the consumer is disallowed and will produce undefined results or exceptions.
++     * </p>
++     *
++     * @param metaClass the type of meta to edit
++     * @param consumer the meta consumer
++     * @param <M> the meta type
++     * @return {@code true} if the edit was successful, {@code false} otherwise
++     */
++    public <M extends ItemMeta> boolean editMeta(Class<M> metaClass, final @NotNull java.util.function.Consumer<? super M> consumer) {
 +        final ItemMeta meta = this.getItemMeta();
-+        if (meta != null) {
-+            consumer.accept(meta);
++        if (meta != null && metaClass.isInstance(meta)) {
++            consumer.accept((M) meta);
 +            this.setItemMeta(meta);
 +            return true;
 +        }

--- a/patches/api/0308-ItemStack-editMeta.patch
+++ b/patches/api/0308-ItemStack-editMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] ItemStack#editMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 86bd9f14de5c1ff3d797955be1af56e5efcac884..d86a697bffd411036e9c6c15fb19040dfb1a030a 100644
+index 86bd9f14de5c1ff3d797955be1af56e5efcac884..56072cb4d32ca8a09023be08a5a832c2c108379a 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -543,6 +543,50 @@ public class ItemStack implements Cloneable, ConfigurationSerializable, net.kyor
@@ -45,9 +45,9 @@ index 86bd9f14de5c1ff3d797955be1af56e5efcac884..d86a697bffd411036e9c6c15fb19040d
 +     * @param <M> the meta type
 +     * @return {@code true} if the edit was successful, {@code false} otherwise
 +     */
-+    public <M extends ItemMeta> boolean editMeta(Class<M> metaClass, final @NotNull java.util.function.Consumer<? super M> consumer) {
-+        final ItemMeta meta = this.getItemMeta();
-+        if (meta != null && metaClass.isInstance(meta)) {
++    public <M extends ItemMeta> boolean editMeta(final @NotNull Class<M> metaClass, final @NotNull java.util.function.Consumer<@NotNull ? super M> consumer) {
++        final @Nullable ItemMeta meta = this.getItemMeta();
++        if (metaClass.isInstance(meta)) {
 +            consumer.accept((M) meta);
 +            this.setItemMeta(meta);
 +            return true;


### PR DESCRIPTION
I think some people might find this handy, I think someone mentioned something similar in discord today, and I thought I'd make it happen. Should preserve existing behavior of ItemStack#editMeta because all meta is an instance of ItemMeta.