### PR TITLE
Add helpers for left/right hand to Action

### DIFF
--- a/patches/api/0332-Add-helpers-for-left-right-hand-to-Action.patch
+++ b/patches/api/0332-Add-helpers-for-left-right-hand-to-Action.patch
@@ -1,11 +1,11 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Madeline Miller <mnmiller1@me.com>
-Date: Sun, 29 Aug 2021 16:16:04 +1000
+Date: Sun, 29 Aug 2021 16:22:46 +1000
 Subject: [PATCH] Add helpers for left/right hand to Action
 
 
 diff --git a/src/main/java/org/bukkit/event/block/Action.java b/src/main/java/org/bukkit/event/block/Action.java
-index 25d26e3fe713311e66d7e634a6c32af61f4cef59..ea87a8e499e5ef23c72e5ea144dd65dd07ab067b 100644
+index 25d26e3fe713311e66d7e634a6c32af61f4cef59..839dd6765c7b3338d5fc55d6f336cf7f22bfa959 100644
 --- a/src/main/java/org/bukkit/event/block/Action.java
 +++ b/src/main/java/org/bukkit/event/block/Action.java
 @@ -29,5 +29,25 @@ public enum Action {
@@ -13,9 +13,9 @@ index 25d26e3fe713311e66d7e634a6c32af61f4cef59..ea87a8e499e5ef23c72e5ea144dd65dd
       * </ul>
       */
 -    PHYSICAL,
++    // Paper start
 +    PHYSICAL;
 +
-+    // Paper start
 +    /**
 +     * Gets whether this action is a result of a left-hand click.
 +     *

--- a/patches/api/0332-Add-helpers-for-left-right-hand-to-Action.patch
+++ b/patches/api/0332-Add-helpers-for-left-right-hand-to-Action.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Madeline Miller <mnmiller1@me.com>
+Date: Sun, 29 Aug 2021 16:16:04 +1000
+Subject: [PATCH] Add helpers for left/right hand to Action
+
+
+diff --git a/src/main/java/org/bukkit/event/block/Action.java b/src/main/java/org/bukkit/event/block/Action.java
+index 25d26e3fe713311e66d7e634a6c32af61f4cef59..ea87a8e499e5ef23c72e5ea144dd65dd07ab067b 100644
+--- a/src/main/java/org/bukkit/event/block/Action.java
++++ b/src/main/java/org/bukkit/event/block/Action.java
+@@ -29,5 +29,25 @@ public enum Action {
+      * <li>Triggering tripwire
+      * </ul>
+      */
+-    PHYSICAL,
++    PHYSICAL;
++
++    // Paper start
++    /**
++     * Gets whether this action is a result of a left-hand click.
++     *
++     * @return Whether it's a left-hand click
++     */
++    public boolean isLeftHand() {
++        return this == LEFT_CLICK_AIR || this == LEFT_CLICK_BLOCK;
++    }
++
++    /**
++     * Gets whether this action is a result of a right-hand click.
++     *
++     * @return Whether it's a right-hand click
++     */
++    public boolean isRightHand() {
++        return this == RIGHT_CLICK_AIR || this == RIGHT_CLICK_BLOCK;
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Whenever I want to check for a right-click, this massively annoys me. Just adds helper functions to the enum to check if it's the right hand or the left hand