### PR TITLE
Undeprecated Enchantment#isCursed

### DIFF
--- a/patches/api/0333-Undeprecated-Enchantment-isCursed.patch
+++ b/patches/api/0333-Undeprecated-Enchantment-isCursed.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Auxilor <william.favierparsons1@gmail.com>
+Date: Sun, 29 Aug 2021 21:56:05 +0100
+Subject: [PATCH] Undeprecated Enchantment#isCursed
+
+
+diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
+index 05f516eb488124a86dcd31a52ffa1f4b847545ac..16a33660bb07e553d51e95661f79f11fe2260a14 100644
+--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
++++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
+@@ -272,7 +272,7 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
+      * only for {@link Enchantment#BINDING_CURSE} and
+      * {@link Enchantment#VANISHING_CURSE}.
+      */
+-    @Deprecated
++    //@Deprecated // Paper
+     public abstract boolean isCursed();
+ 
+     /**


### PR DESCRIPTION
Very minor change, but Enchantment#isCursed has valid applications, especially considering custom enchantment plugins that may add new curses, that may not contain 'curse' in the enchantment key, which is the other way of checking if an enchantment is a curse (other than hardcoding a list).

(Take 2 on this one, screwed up the first time)