### PR TITLE
Undeprecate Enchantment#isCursed

### DIFF
--- a/patches/api/0305-More-Enchantment-API.patch
+++ b/patches/api/0305-More-Enchantment-API.patch
@@ -35,10 +35,22 @@ index 0000000000000000000000000000000000000000..e6a40c1fcea761bd66743b50e3da3d14
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
-index b277034fee2d4f38c40713842d14a8f6dde757aa..05f516eb488124a86dcd31a52ffa1f4b847545ac 100644
+index b277034fee2d4f38c40713842d14a8f6dde757aa..1e1c5a9d9a769018c4604e6e44fc5ed2312981e9 100644
 --- a/src/main/java/org/bukkit/enchantments/Enchantment.java
 +++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
-@@ -306,6 +306,46 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
+@@ -268,11 +268,7 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
+      * Cursed enchantments are found the same way treasure enchantments are
+      *
+      * @return true if the enchantment is cursed
+-     * @deprecated cursed enchantments are no longer special. Will return true
+-     * only for {@link Enchantment#BINDING_CURSE} and
+-     * {@link Enchantment#VANISHING_CURSE}.
+      */
+-    @Deprecated
+     public abstract boolean isCursed();
+ 
+     /**
+@@ -306,6 +302,46 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
       * @return the name of the enchantment with {@code level} applied
       */
      public abstract @NotNull net.kyori.adventure.text.Component displayName(int level);


### PR DESCRIPTION
https://github.com/PaperMC/Paper/pull/6521 was closed for some reason

We fix the implementation of this method to check isCurse on the Mojang enchant: https://github.com/PaperMC/Paper/blob/cf27619809e34d26ec07608b3e060247c8ee9d95/patches/server/0683-More-Enchantment-API.patch#L13-L17

Seems like it was just forgotten to remove the deprecation when making this change