### PR TITLE
Prevent softlocked end exit portal generation

### DIFF
--- a/patches/server/0803-Prevent-softlocked-end-exit-portal-generation.patch
+++ b/patches/server/0803-Prevent-softlocked-end-exit-portal-generation.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Mon, 30 Aug 2021 15:22:18 +0200
+Subject: [PATCH] Prevent softlocked end exit portal generation
+
+
+diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
+index 93dd5a2d0b550b0373cbf59376a04e9fd6146e92..3cdd3778e8d55bc255a4b6f248b80c04ef0c5ad1 100644
+--- a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
++++ b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
+@@ -409,6 +409,12 @@ public class EndDragonFight {
+             }
+         }
+ 
++        // Paper start - Prevent "softlocked" exit portal generation
++        if (this.portalLocation.getY() <= this.level.getMinBuildHeight()) {
++            this.portalLocation.setY(this.level.getMinBuildHeight() + 1);
++        }
++        // Paper end
++
+         endPodiumFeature.configured(FeatureConfiguration.NONE).place(this.level, this.level.getChunkSource().getGenerator(), new Random(), this.portalLocation);
+     }
+ 


### PR DESCRIPTION
As shown in [this video](https://www.youtube.com/watch?v=tXujZi0wEF0), there are minecraft seeds, such as [4717237](https://www.youtube.com/watch?v=yB2Wl5erHds), where no block generates in the end at 0,0. Because of this, the exit end portal will be placed at a negative coordinate, causing the bottom two blocks of the exit portal to be cut off. When beating the dragon, the game tries to place the actual end portal blocks at Y=-1, which isn't possible. Because of this, after beating the dragon, players are stuck in the end until they kill themselves. This PR ensures the exit portal  fully spawns above Y > 0, to prevent these types of softlocks.