### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index fa576096e908f8fbdbef53e1bd91215ac9e73ed6..98263d896f316983609432c45b85401a2692432d 100644
+index 9c06b9c3a4ebb2bd5dae63b337779e3e7ca90862..50ef424e74b6f92fcc61a293fb92a0b9f88eb8cd 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index fa576096e908f8fbdbef53e1bd91215ac9e73ed6..98263d896f316983609432c45b85401a
  import org.bukkit.block.Block;
  import org.bukkit.block.BlockState;
  import org.bukkit.block.data.BlockData;
-@@ -103,13 +105,36 @@ public interface Chunk extends PersistentDataHolder {
+@@ -104,13 +106,36 @@ public interface Chunk extends PersistentDataHolder {
      @NotNull
      Entity[] getEntities();
  

--- a/patches/api/0318-Add-more-LimitedRegion-API.patch
+++ b/patches/api/0318-Add-more-LimitedRegion-API.patch
@@ -355,13 +355,13 @@ index 0667315e2bd10254aef59c2a6bcceee9d927b6d5..e96d8877f73de12a56a2b36e32381a0b
       * Gets a fixed spawn location to use for a given world.
       * <p>
 diff --git a/src/main/java/org/bukkit/generator/LimitedRegion.java b/src/main/java/org/bukkit/generator/LimitedRegion.java
-index 0428f210866587997d3e73dbb6ae4770f3c44ed5..3bd9f092d9ae38c2d91abdc522d6a8d94b4b8212 100644
+index 85faeeeef908243aa5f172284784e7e67995ebfb..e0b249d328f7671894cea94bc00d54ab54aacd36 100644
 --- a/src/main/java/org/bukkit/generator/LimitedRegion.java
 +++ b/src/main/java/org/bukkit/generator/LimitedRegion.java
-@@ -2,6 +2,12 @@ package org.bukkit.generator;
- 
+@@ -4,6 +4,12 @@ import java.util.List;
  import org.bukkit.Location;
  import org.bukkit.RegionAccessor;
+ import org.bukkit.block.BlockState;
 +// Paper start
 +import org.bukkit.World;
 +import org.bukkit.block.BlockState;
@@ -371,10 +371,11 @@ index 0428f210866587997d3e73dbb6ae4770f3c44ed5..3bd9f092d9ae38c2d91abdc522d6a8d9
  import org.jetbrains.annotations.NotNull;
  
  /**
-@@ -42,4 +48,136 @@ public interface LimitedRegion extends RegionAccessor {
-      * @return true if the coordinates are in the region, otherwise false.
+@@ -53,4 +59,137 @@ public interface LimitedRegion extends RegionAccessor {
       */
-     boolean isInRegion(int x, int y, int z);
+     @NotNull
+     List<BlockState> getTileEntities();
++
 +
 +    // Paper start
 +    /**

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -2481,10 +2481,10 @@ index 1a6cca634d6b40a6d5f30eda98be3aa72c2569ad..32f555a846d34e086e75c027a92a48ea
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ded90f10b0034e7982c426b40d2e399dc95e24d4..0f7aa47de024cf8e7c33efd688bd34447ec2a702 100644
+index a4c436ca7b05726df9a8e18f79022b76de5d4a1d..30b00d4c3824749c991084e69cd2bf33ff674ad6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -802,9 +802,9 @@ public class CraftEventFactory {
+@@ -806,9 +806,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2496,7 +2496,7 @@ index ded90f10b0034e7982c426b40d2e399dc95e24d4..0f7aa47de024cf8e7c33efd688bd3444
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -829,7 +829,7 @@ public class CraftEventFactory {
+@@ -833,7 +833,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0110-Add-EntityZapEvent.patch
+++ b/patches/server/0110-Add-EntityZapEvent.patch
@@ -44,10 +44,10 @@ index c5a8edf426e79b8746c7a5a5a5de3e3df1708740..f030c8d7c28039fde273e6b30c63ea79
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0f7aa47de024cf8e7c33efd688bd34447ec2a702..c5146ccf0dfc979306d9e4401c9b053ed040e777 100644
+index 30b00d4c3824749c991084e69cd2bf33ff674ad6..f7dfc549dce8cd96656c80b0a2fe5a79796128a9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1116,6 +1116,14 @@ public class CraftEventFactory {
+@@ -1120,6 +1120,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0114-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 8b8181cfdd8d826dd132eb9475f6ff8e04afa465..4000480a14d2ba52149f4fa47f824abf
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c5146ccf0dfc979306d9e4401c9b053ed040e777..32bd705a44acb8b2fef1759e72cc47bde8f1e764 100644
+index f7dfc549dce8cd96656c80b0a2fe5a79796128a9..aaac6afc2e80149b128321b1ae62295b0dc323eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1075,6 +1075,17 @@ public class CraftEventFactory {
+@@ -1079,6 +1079,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0116-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0116-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index f81be1c6a5efc5090fbb8832f44dbb2ae6aa2f4a..8e81b19706a14c21b5ffdc4f12818fe7
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 32bd705a44acb8b2fef1759e72cc47bde8f1e764..0e1cdea5ba4b01ee5c64b74ebff466e6f5d9045f 100644
+index aaac6afc2e80149b128321b1ae62295b0dc323eb..4c135327c7d9acd0dc210bcef33241a2e6201044 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1219,6 +1219,16 @@ public class CraftEventFactory {
+@@ -1223,6 +1223,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0221-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0221-InventoryCloseEvent-Reason-API.patch
@@ -187,10 +187,10 @@ index 1ad37b47a64700f9fd895afb26f8b07c0cad72d5..067a3990825dd17d2843a5f8d215d19d
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0e1cdea5ba4b01ee5c64b74ebff466e6f5d9045f..e7ae70313146fa779395c5b00d61bcee397f95a5 100644
+index 4c135327c7d9acd0dc210bcef33241a2e6201044..6bb94a7c712996555d290d0c556ff490db30b489 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1188,7 +1188,7 @@ public class CraftEventFactory {
+@@ -1192,7 +1192,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index 0e1cdea5ba4b01ee5c64b74ebff466e6f5d9045f..e7ae70313146fa779395c5b00d61bcee
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1354,8 +1354,18 @@ public class CraftEventFactory {
+@@ -1358,8 +1358,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0234-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0234-Vanished-players-don-t-have-rights.patch
@@ -99,10 +99,10 @@ index d49ce298219dd2144ca1357ab9f158455187c985..17f596e6059334114ce3ee17fbde1ce3
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e7ae70313146fa779395c5b00d61bcee397f95a5..b7fbbe39bc36f5315abe658b00704836a40d34ca 100644
+index 6bb94a7c712996555d290d0c556ff490db30b489..e6f2dff4e581535047136b398aca023cd46cf4b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1224,6 +1224,14 @@ public class CraftEventFactory {
+@@ -1228,6 +1228,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0240-Add-hand-to-bucket-events.patch
+++ b/patches/server/0240-Add-hand-to-bucket-events.patch
@@ -139,10 +139,10 @@ index 17f596e6059334114ce3ee17fbde1ce3d14c5ca1..96c685ffbf6058b69f0c573a1255a9e8
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b7fbbe39bc36f5315abe658b00704836a40d34ca..732a6f247e25e245909829d9fa784fced1d3cca2 100644
+index e6f2dff4e581535047136b398aca023cd46cf4b4..fb17ab47d45b1cb2aa48ba28c452a683ce8a1568 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -222,7 +222,7 @@ public class CraftEventFactory {
+@@ -226,7 +226,7 @@ public class CraftEventFactory {
      public static Entity entityDamage; // For use in EntityDamageByEntityEvent
  
      // helper methods
@@ -151,7 +151,7 @@ index b7fbbe39bc36f5315abe658b00704836a40d34ca..732a6f247e25e245909829d9fa784fce
          int spawnSize = Bukkit.getServer().getSpawnRadius();
  
          if (world.dimension() != Level.OVERWORLD) return true;
-@@ -416,6 +416,20 @@ public class CraftEventFactory {
+@@ -420,6 +420,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
@@ -172,7 +172,7 @@ index b7fbbe39bc36f5315abe658b00704836a40d34ca..732a6f247e25e245909829d9fa784fce
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -428,10 +442,10 @@ public class CraftEventFactory {
+@@ -432,10 +446,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/patches/server/0250-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/server/0250-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 6437644d384c1057a5d4f458fefc31fa45002211..17c2f2dca587b350dc3e48f01dc62025a12d83c0 100644
+index 026992056716c11606bd334dd0be178b7e8fb020..7690252c08785906e721ba09834c1a64e32b2880 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -3,8 +3,10 @@ package org.bukkit.craftbukkit;
@@ -16,10 +16,10 @@ index 6437644d384c1057a5d4f458fefc31fa45002211..17c2f2dca587b350dc3e48f01dc62025
  import java.util.Arrays;
  import java.util.Collection;
 +import java.util.List;
+ import java.util.Objects;
  import java.util.function.Predicate;
  import net.minecraft.core.BlockPos;
- import net.minecraft.core.Registry;
-@@ -117,6 +119,13 @@ public class CraftChunk implements Chunk {
+@@ -149,6 +151,13 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -33,7 +33,7 @@ index 6437644d384c1057a5d4f458fefc31fa45002211..17c2f2dca587b350dc3e48f01dc62025
          if (!this.isLoaded()) {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
-@@ -131,7 +140,29 @@ public class CraftChunk implements Chunk {
+@@ -163,7 +172,29 @@ public class CraftChunk implements Chunk {
              }
  
              BlockPos position = (BlockPos) obj;

--- a/patches/server/0264-Improve-death-events.patch
+++ b/patches/server/0264-Improve-death-events.patch
@@ -297,10 +297,10 @@ index 30357dd7b527c40f9aa42a5873ad21c46d3c2311..6fac6afd5ea4e35f6bb0e9b859fb9b4c
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 732a6f247e25e245909829d9fa784fced1d3cca2..736e308dff475623fd44370f3ea76e51b582d1dd 100644
+index fb17ab47d45b1cb2aa48ba28c452a683ce8a1568..aa652bfcd0e60784afc36a800a0278c3baa32221 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -802,9 +802,16 @@ public class CraftEventFactory {
+@@ -806,9 +806,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -317,7 +317,7 @@ index 732a6f247e25e245909829d9fa784fced1d3cca2..736e308dff475623fd44370f3ea76e51
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -821,8 +828,15 @@ public class CraftEventFactory {
+@@ -825,8 +832,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -333,7 +333,7 @@ index 732a6f247e25e245909829d9fa784fced1d3cca2..736e308dff475623fd44370f3ea76e51
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -839,6 +853,31 @@ public class CraftEventFactory {
+@@ -843,6 +857,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0353-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0353-Duplicate-UUID-Resolve-Option.patch
@@ -165,10 +165,10 @@ index 4ab3f694dda4d766d0421977d270f7b71b2db217..68997cc0b534c46c33c0f137738fbaca
          ChunkPos chunkcoordintpair = holder.getPos();
          CompletableFuture<Either<List<ChunkAccess>, ChunkHolder.ChunkLoadingFailure>> completablefuture = this.getChunkRangeFuture(chunkcoordintpair, 1, (i) -> {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 96b070a1fd4a3948609ba47614c81cc231084f5c..d9b82aea11dda1d6b45a66f2b7ca1524b7a3c369 100644
+index 02767e831301b9112a77e9c2eb786ddbd95edfbd..59c3f1263f6418736e207786bc50448ed5dde32a 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -64,7 +64,21 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -74,7 +74,21 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
  
      private boolean addEntityUuid(T entity) {
          if (!this.knownUuids.add(entity.getUUID())) {

--- a/patches/server/0368-Anti-Xray.patch
+++ b/patches/server/0368-Anti-Xray.patch
@@ -1405,10 +1405,10 @@ index 670e4f65680ca36fba1c84cb334c470ea8fa9b60..79f2b3942a3ccccd8fe8719db12de458
                  chunksection.getStates().read(nbttagcompound2.getList("Palette", 10), nbttagcompound2.getLongArray("BlockStates"));
                  chunksection.recalcBlockCounts();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 17c2f2dca587b350dc3e48f01dc62025a12d83c0..1ba393e2b47cca45bfa8e4ff4ef2438f273fd467 100644
+index 7690252c08785906e721ba09834c1a64e32b2880..fd5462aa51199f294dda203bd4c313df2608c0c0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -46,7 +46,7 @@ public class CraftChunk implements Chunk {
+@@ -47,7 +47,7 @@ public class CraftChunk implements Chunk {
      private final ServerLevel worldServer;
      private final int x;
      private final int z;
@@ -1417,7 +1417,7 @@ index 17c2f2dca587b350dc3e48f01dc62025a12d83c0..1ba393e2b47cca45bfa8e4ff4ef2438f
      private static final byte[] emptyLight = new byte[2048];
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
-@@ -275,7 +275,7 @@ public class CraftChunk implements Chunk {
+@@ -307,7 +307,7 @@ public class CraftChunk implements Chunk {
                  CompoundTag data = new CompoundTag();
                  cs[i].getStates().write(data, "Palette", "BlockStates");
  

--- a/patches/server/0383-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0383-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 736e308dff475623fd44370f3ea76e51b582d1dd..0cdcb8adf6879c08c88615023446acaf2282fbce 100644
+index aa652bfcd0e60784afc36a800a0278c3baa32221..794f8cbcf7072b10fa06c26a122739b37fe0430c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -339,13 +339,18 @@ public class CraftEventFactory {
+@@ -343,13 +343,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0389-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0389-Optimise-TickListServer-by-rewriting-it.patch
@@ -1118,13 +1118,13 @@ index 3b8c04f6ffd7e6c197465aa1caf633ba92529472..1007bfc9c19641f42afd5526cfe7bdb6
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index d9b82aea11dda1d6b45a66f2b7ca1524b7a3c369..10bc96bb33c5f292adb6383fdda73f90d43b090b 100644
+index 59c3f1263f6418736e207786bc50448ed5dde32a..e9d455736a2ff7a87f319615af4a090ddc943641 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -281,6 +281,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
-                 this.addEntity(entityaccess, true);
-             });
-             this.chunkLoadStatuses.put(chunkentities.getPos().toLong(), PersistentEntitySectionManager.ChunkLoadStatus.LOADED);
+@@ -303,6 +303,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+             List<Entity> entities = this.getEntities(chunkentities.getPos()); // PAIL rename getChunkPos
+             CraftEventFactory.callEntitiesLoadEvent(((EntityStorage) this.permanentStorage).level, chunkentities.getPos(), entities);
+             // CraftBukkit end
 +            // Paper start - rewrite ServerTickList
 +            final net.minecraft.server.level.ServerLevel level = ((net.minecraft.world.level.chunk.storage.EntityStorage) this.permanentStorage).level;
 +            if (level.chunkSource.isPositionTickingReady(chunkentities.getPos().longKey)) {

--- a/patches/server/0422-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0422-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -102,10 +102,10 @@ index bbde9b758643c087733064a126d90689d71830cf..069cdfce085909991a69ebec3004d407
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0cdcb8adf6879c08c88615023446acaf2282fbce..d49627866c9151ffe4be3eef3d944f0a7b3e8ffe 100644
+index 794f8cbcf7072b10fa06c26a122739b37fe0430c..09e0b2fface050699872341215c257d4b8f403c2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -822,7 +822,8 @@ public class CraftEventFactory {
+@@ -826,7 +826,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/patches/server/0433-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0433-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -22,10 +22,10 @@ index e146dad0d90fee216630eb3df6a34e2a0f6441a6..eb30ec087b90835aba281580b0563d02
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d49627866c9151ffe4be3eef3d944f0a7b3e8ffe..6c17e7696d39f49aa6dde4f8cc352eb1ac78373b 100644
+index 09e0b2fface050699872341215c257d4b8f403c2..bb80d9840fd9448bf18df00c205a93a623b45ba9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -625,16 +625,30 @@ public class CraftEventFactory {
+@@ -629,16 +629,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0434-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0434-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6c17e7696d39f49aa6dde4f8cc352eb1ac78373b..d5588bca58d999b7242041127fac3809aa9e2ddd 100644
+index bb80d9840fd9448bf18df00c205a93a623b45ba9..0cb910df23ed963b70b28be26a30460b7882c112 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -635,7 +635,7 @@ public class CraftEventFactory {
+@@ -639,7 +639,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0445-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0445-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -47,10 +47,10 @@ index 439f82a48e6f6ce7b4773505ced32324cacb302d..2a99aa989ac5c19d99bb3cbc0934425e
  
      public static int getX(long pos) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 10bc96bb33c5f292adb6383fdda73f90d43b090b..b93ed663a565056adc902bb6263c9014fda6a9d2 100644
+index e9d455736a2ff7a87f319615af4a090ddc943641..cb6fc8bab2bf4d4b6293ce6e3e62aedadf04b771 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -362,6 +362,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -384,6 +384,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      public LevelEntityGetter<T> getEntityGetter() {
          return this.entityGetter;
      }

--- a/patches/server/0477-Optimize-NibbleArray-to-use-pooled-buffers.patch
+++ b/patches/server/0477-Optimize-NibbleArray-to-use-pooled-buffers.patch
@@ -299,10 +299,10 @@ index 24030bcb3303d0419c7859ded7613608c5f82308..ec3837a64e8ac6892028611d57a111a7
                              int k = SectionPos.sectionToBlockCoord(SectionPos.y(l));
                              int m = SectionPos.sectionToBlockCoord(SectionPos.z(l));
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 1ba393e2b47cca45bfa8e4ff4ef2438f273fd467..591a66dcdb717ad041120ab27de8f2f3a1975358 100644
+index fd5462aa51199f294dda203bd4c313df2608c0c0..e317a1d4b463ac1f17cb282260279e92b32087d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -286,14 +286,14 @@ public class CraftChunk implements Chunk {
+@@ -318,14 +318,14 @@ public class CraftChunk implements Chunk {
                      sectionSkyLights[i] = CraftChunk.emptyLight;
                  } else {
                      sectionSkyLights[i] = new byte[2048];

--- a/patches/server/0483-Add-PrepareResultEvent.patch
+++ b/patches/server/0483-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 3df5031ec2c50dc6eb2533318cf8a98f21b03d2a..c971a534ded962e3be92c71059c75cc1
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index d5588bca58d999b7242041127fac3809aa9e2ddd..c96953ab3f358c7c67297532cd6740ff3ff61aa3 100644
+index 0cb910df23ed963b70b28be26a30460b7882c112..c1ae63dfd9ad7519ba538b60f6c254f791d53600 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1551,19 +1551,44 @@ public class CraftEventFactory {
+@@ -1555,19 +1555,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0570-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0570-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c96953ab3f358c7c67297532cd6740ff3ff61aa3..2cab0a3eb489f1f36bb7eaae2706e3b4518668ce 100644
+index c1ae63dfd9ad7519ba538b60f6c254f791d53600..caf747d2a9079b5161c1b3a5be1e66e29146e56f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -257,6 +257,10 @@ public class CraftEventFactory {
+@@ -261,6 +261,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0589-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0589-Implemented-BlockFailedDispenseEvent.patch
@@ -32,12 +32,12 @@ index 51723c8f740c7b0bbd15acc0f1c848790c2ff299..5a95b550c767284563c124df1ff45322
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2cab0a3eb489f1f36bb7eaae2706e3b4518668ce..f960ee7644ed792c4136cbcb75cc12e8dbed65c4 100644
+index caf747d2a9079b5161c1b3a5be1e66e29146e56f..133a4a00d74a719881bca47d9d5efc850c7fa4bf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1814,4 +1814,12 @@ public class CraftEventFactory {
+@@ -1829,4 +1829,12 @@ public class CraftEventFactory {
+         EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
-         return event;
      }
 +
 +    // Paper start

--- a/patches/server/0594-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0594-Implement-API-to-expose-exact-interaction-point.patch
@@ -18,10 +18,10 @@ index 2fb45e48cc5845c71cca21c43bb012f3eb6a0b53..5ef649dec31ba6d6b74a7bd757727ffd
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f960ee7644ed792c4136cbcb75cc12e8dbed65c4..00426ffa3da994aed445f0767a99b83154773e10 100644
+index 133a4a00d74a719881bca47d9d5efc850c7fa4bf..18f929e0adf011671ad0dec2e7dedbc88bcd667e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -55,7 +55,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
+@@ -56,7 +56,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
  import net.minecraft.world.phys.BlockHitResult;
  import net.minecraft.world.phys.EntityHitResult;
  import net.minecraft.world.phys.HitResult;
@@ -31,7 +31,7 @@ index f960ee7644ed792c4136cbcb75cc12e8dbed65c4..00426ffa3da994aed445f0767a99b831
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -477,7 +479,13 @@ public class CraftEventFactory {
+@@ -481,7 +483,13 @@ public class CraftEventFactory {
          return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index f960ee7644ed792c4136cbcb75cc12e8dbed65c4..00426ffa3da994aed445f0767a99b831
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -503,7 +511,10 @@ public class CraftEventFactory {
+@@ -507,7 +515,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/patches/server/0604-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0604-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 501a5483160dba050261bb3448317a097cdb7ef2..2dcac4b638073aa1748f26f61219dbf9
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 00426ffa3da994aed445f0767a99b83154773e10..b06d92fa7c1d7cb7a9637e9c435f95b8c18d0581 100644
+index 18f929e0adf011671ad0dec2e7dedbc88bcd667e..b3d218a1a1bd52dfe00062ef82779cf81157e74b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1832,5 +1832,11 @@ public class CraftEventFactory {
+@@ -1847,5 +1847,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0610-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0610-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index b9b67134f02fd7484ed19905c9ae1f9b8a26ce26..c05f173b7642380900fdd77ce5d2c020
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b06d92fa7c1d7cb7a9637e9c435f95b8c18d0581..7c68b15c432084adf069797cfccb0526055796cb 100644
+index b3d218a1a1bd52dfe00062ef82779cf81157e74b..0deb6fd786ffdb2f3a2b51f487288d6917b1229f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1484,8 +1484,10 @@ public class CraftEventFactory {
+@@ -1488,8 +1488,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0617-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0617-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 7c68b15c432084adf069797cfccb0526055796cb..db6c0917824b9127abd9f9250dc195a9f1d56f4f 100644
+index 0deb6fd786ffdb2f3a2b51f487288d6917b1229f..31bbf018e3b7cafb1e186c7d00b421fb133331a3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -390,13 +390,30 @@ public class CraftEventFactory {
+@@ -394,13 +394,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0645-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0645-Entity-load-save-limit-per-chunk.patch
@@ -9,7 +9,7 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f21534b43fa7f8349f49246c310b102cb5a28f53..4b2a86c2190368b0c2250e70be7263e3d3a01e76 100644
+index 1da69d56f0b58708d4c85e76307b725221f9caed..5eeb09c7cbc743c4273a6d02d9f0c357c2724ba2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,9 +1,12 @@
@@ -90,13 +90,13 @@ index 8c829066939a4069953097fd268f7c214a555779..1c446dba5de89698397041ee38a2e1a0
                          return entity;
                      });
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-index 9b0b3affdbdf831f0d3d61c59bdb99555bc0bed7..396c34c0866bf395b4d86361d96fe103c5d9ae7e 100644
+index 50afe31798664b2e0ac7546d775ecea534e351e2..0e13a1f898a793799416056bd468851013f9c5cb 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-@@ -90,7 +90,18 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {
- 
+@@ -107,7 +107,18 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {
          } else {
-             ListTag listTag = new ListTag();
+             ListTag nbttaglist = new ListTag();
+ 
 +            final java.util.Map<net.minecraft.world.entity.EntityType<?>, Integer> savedEntityCounts = new java.util.HashMap<>(); // Paper
              dataList.getEntities().forEach((entity) -> {
 +                // Paper start
@@ -109,6 +109,6 @@ index 9b0b3affdbdf831f0d3d61c59bdb99555bc0bed7..396c34c0866bf395b4d86361d96fe103
 +                    savedEntityCounts.merge(entityType, 1, Integer::sum);
 +                }
 +                // Paper end
-                 CompoundTag compoundTag = new CompoundTag();
-                 if (entity.save(compoundTag)) {
-                     listTag.add(compoundTag);
+                 CompoundTag nbttagcompound = new CompoundTag();
+ 
+                 if (entity.save(nbttagcompound)) {

--- a/patches/server/0707-Add-more-LimitedRegion-API.patch
+++ b/patches/server/0707-Add-more-LimitedRegion-API.patch
@@ -127,18 +127,10 @@ index 0000000000000000000000000000000000000000..ccb6b20b5f56c3bacdc6bd384931986c
 +}
 +
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-index 8f968ed09b960c2e4aca2fa6aba20aae00456ea8..0d23d2be7829b62391dc1313b0f20762002c1d34 100644
+index d91c88d7bdfd954fa81fbf1c9ad92161d70993a6..f5ef7e026061351590f1ce77694e2d8fb8521048 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CraftLimitedRegion.java
-@@ -6,6 +6,7 @@ import java.util.ArrayList;
- import java.util.Collection;
- import java.util.List;
- import java.util.Random;
-+import net.minecraft.core.BlockPos; // Paper
- import net.minecraft.nbt.CompoundTag;
- import net.minecraft.server.level.WorldGenRegion;
- import net.minecraft.world.entity.EntityType;
-@@ -134,7 +135,10 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -151,7 +151,10 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      @Override
      public BlockState getBlockState(int x, int y, int z) {
          Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
@@ -150,7 +142,7 @@ index 8f968ed09b960c2e4aca2fa6aba20aae00456ea8..0d23d2be7829b62391dc1313b0f20762
      }
  
      @Override
-@@ -152,7 +156,7 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -169,7 +172,7 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      @Override
      public void setBlockData(int x, int y, int z, BlockData blockData) {
          Preconditions.checkArgument(this.isInRegion(x, y, z), "Coordinates %s, %s, %s are not in the region", x, y, z);
@@ -159,7 +151,7 @@ index 8f968ed09b960c2e4aca2fa6aba20aae00456ea8..0d23d2be7829b62391dc1313b0f20762
      }
  
      @Override
-@@ -182,4 +186,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
+@@ -199,4 +202,45 @@ public class CraftLimitedRegion extends CraftRegionAccessor implements LimitedRe
      public void addEntityToWorld(net.minecraft.world.entity.Entity entity, CreatureSpawnEvent.SpawnReason reason) {
          this.entities.add(entity);
      }

--- a/patches/server/0763-Add-more-async-catchers.patch
+++ b/patches/server/0763-Add-more-async-catchers.patch
@@ -31,10 +31,10 @@ index f01182a0ac8a14bcd5b1deb778306e7bf1bf70ed..b27c8db914cca3ff0ea8a24acddb9cb9
              throw new UnsupportedOperationException("Only one concurrent iteration supported");
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index b93ed663a565056adc902bb6263c9014fda6a9d2..e4e4b48250d32d9e6c034d62e13ac2277bffda8f 100644
+index cb6fc8bab2bf4d4b6293ce6e3e62aedadf04b771..0c4ffc0049679b911cc1e1bea36eb21ff6324c46 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -151,6 +151,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -161,6 +161,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void updateChunkStatus(ChunkPos chunkPos, ChunkHolder.FullChunkStatus levelType) {

--- a/patches/server/0765-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0765-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1210,10 +1210,10 @@ index a7485746417e0dddb392c89a5a1d467c0bc83fbe..82da0f2226f71a5081e24c17a8a39be2
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8fb665f75a 100644
+index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729efd013009 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -45,8 +45,10 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -49,8 +49,10 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      private final Long2ObjectMap<PersistentEntitySectionManager.ChunkLoadStatus> chunkLoadStatuses = new Long2ObjectOpenHashMap();
      private final LongSet chunksToUnload = new LongOpenHashSet();
      private final Queue<ChunkEntities<T>> loadingInbox = Queues.newConcurrentLinkedQueue();
@@ -1225,7 +1225,7 @@ index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8f
          this.sectionStorage = new EntitySectionStorage<>(entityClass, this.chunkVisibility);
          this.chunkVisibility.defaultReturnValue(Visibility.HIDDEN);
          this.chunkLoadStatuses.defaultReturnValue(PersistentEntitySectionManager.ChunkLoadStatus.FRESH);
-@@ -97,6 +99,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -107,6 +109,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              EntitySection<T> entitysection = this.sectionStorage.getOrCreateSection(i);
  
              entitysection.add(entity); // CraftBukkit - decompile error
@@ -1233,7 +1233,7 @@ index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8f
              entity.setLevelCallback(new PersistentEntitySectionManager.Callback(entity, i, entitysection));
              if (!existing) {
                  this.callbacks.onCreated(entity);
-@@ -154,6 +157,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -164,6 +167,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          io.papermc.paper.util.TickThread.ensureTickThread("Asynchronous chunk ticking status update"); // Paper
          Visibility visibility = Visibility.fromFullChunkStatus(levelType);
  
@@ -1241,7 +1241,7 @@ index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8f
          this.updateChunkStatus(chunkPos, visibility);
      }
  
-@@ -434,6 +438,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -456,6 +460,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              long i = SectionPos.asLong(blockposition);
  
              if (i != this.currentSectionKey) {
@@ -1249,7 +1249,7 @@ index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8f
                  Visibility visibility = this.currentSection.getStatus();
  
                  if (!this.currentSection.remove(this.entity)) {
-@@ -482,6 +487,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -504,6 +509,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              if (!this.currentSection.remove(this.entity)) {
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", this.entity, SectionPos.of(this.currentSectionKey), reason);
              }
@@ -1258,19 +1258,28 @@ index e4e4b48250d32d9e6c034d62e13ac2277bffda8f..a0dd49d17e1a83edbb0bf5cfbaba3f8f
              Visibility visibility = PersistentEntitySectionManager.getEffectiveStatus(this.entity, this.currentSection.getStatus());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 591a66dcdb717ad041120ab27de8f2f3a1975358..b27945cc7beb36a10bb9f3503b060f6c2ad18b77 100644
+index e317a1d4b463ac1f17cb282260279e92b32087d7..2db015b975077f0bd9514a164d4857a5e05bd701 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -110,11 +110,7 @@ public class CraftChunk implements Chunk {
-             this.getWorld().getChunkAt(x, z); // Transient load for this tick
+@@ -122,9 +122,7 @@ public class CraftChunk implements Chunk {
+         long pair = ChunkPos.asLong(x, z);
+ 
+         if (entityManager.areEntitiesLoaded(pair)) { // PAIL rename isEntitiesLoaded
+-            return entityManager.getEntities(new ChunkPos(this.x, this.z)).stream()
+-                    .map(net.minecraft.world.entity.Entity::getBukkitEntity)
+-                    .filter(Objects::nonNull).toArray(Entity[]::new);
++            return getCraftWorld().getHandle().getChunkEntities(this.x, this.z); // Paper - optimise this
          }
  
--        Location location = new Location(null, 0, 0, 0);
--        return this.getWorld().getEntities().stream().filter((entity) -> {
--            entity.getLocation(location);
--            return location.getBlockX() >> 4 == this.x && location.getBlockZ() >> 4 == this.z;
--        }).toArray(Entity[]::new);
-+        return ((CraftWorld)this.getWorld()).getHandle().getChunkEntities(this.x, this.z); // Paper - optimise this
+         entityManager.ensureChunkQueuedForLoad(pair); // Start entity loading
+@@ -144,9 +142,7 @@ public class CraftChunk implements Chunk {
+             return entityManager.areEntitiesLoaded(pair);
+         });
+ 
+-        return entityManager.getEntities(new ChunkPos(this.x, this.z)).stream()
+-                .map(net.minecraft.world.entity.Entity::getBukkitEntity)
+-                .filter(Objects::nonNull).toArray(Entity[]::new);
++        return getCraftWorld().getHandle().getChunkEntities(this.x, this.z); // Paper - optimise this
      }
  
      @Override

--- a/patches/server/0796-Optimise-WorldServer-notify.patch
+++ b/patches/server/0796-Optimise-WorldServer-notify.patch
@@ -214,12 +214,12 @@ index e605daac0c90f5d0b9315d1499938feb0e478d0e..b5c385aeb86ac267cae9726354c896ee
              Vec3 vec3 = new Vec3(((double)node.x + this.mob.getX()) / 2.0D, ((double)node.y + this.mob.getY()) / 2.0D, ((double)node.z + this.mob.getZ()) / 2.0D);
              if (pos.closerThan(vec3, (double)(this.path.getNodeCount() - this.path.getNextNodeIndex()))) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index a0dd49d17e1a83edbb0bf5cfbaba3f8fb665f75a..90427b7ee0ad69afa498ce6accd369d28a55427d 100644
+index dbb78ee61a6a3a7336f0656414cd729efd013009..1ed6573e0ca6b353d1de3b4486e199a5db9aa447 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -57,6 +57,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
-         this.entityGetter = new LevelEntityGetterAdapter<>(this.visibleEntityStorage, this.sectionStorage);
+@@ -67,6 +67,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
+     // CraftBukkit end
  
 +    // Paper start - optimise notify()
 +    public final void removeNavigatorsFromData(Entity entity, final int chunkX, final int chunkZ) {
@@ -283,7 +283,7 @@ index a0dd49d17e1a83edbb0bf5cfbaba3f8fb665f75a..90427b7ee0ad69afa498ce6accd369d2
      void removeSectionIfEmpty(long sectionPos, EntitySection<T> section) {
          if (section.isEmpty()) {
              this.sectionStorage.remove(sectionPos);
-@@ -435,11 +494,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -457,11 +516,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          @Override
          public void onMove() {
              BlockPos blockposition = this.entity.blockPosition();
@@ -311,7 +311,7 @@ index a0dd49d17e1a83edbb0bf5cfbaba3f8fb665f75a..90427b7ee0ad69afa498ce6accd369d2
  
                  if (!this.currentSection.remove(this.entity)) {
                      PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (moving to {})", this.entity, SectionPos.of(this.currentSectionKey), i);
-@@ -451,6 +524,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -473,6 +546,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
                  entitysection.add(this.entity); // CraftBukkit - decompile error
                  this.currentSection = entitysection;
                  this.currentSectionKey = i;

--- a/patches/server/0798-Rewrite-dataconverter-system.patch
+++ b/patches/server/0798-Rewrite-dataconverter-system.patch
@@ -19598,13 +19598,13 @@ index b889dbad607b6508fb4987d21d3be691a5b37072..747e2a31f055d84d4321c8241e1b6c29
              nbttagcompound.putInt("DataVersion", SharedConstants.getCurrentVersion().getWorldVersion());
          }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-index 396c34c0866bf395b4d86361d96fe103c5d9ae7e..05af8f292a598a242a396afe4c2ddb2aa2c6b42e 100644
+index 0e13a1f898a793799416056bd468851013f9c5cb..916f93b097a65f95e830fe5e1567c85d304f808f 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-@@ -128,7 +128,7 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {
- 
+@@ -148,7 +148,7 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {
      private CompoundTag upgradeChunkTag(CompoundTag chunkTag) {
-         int i = getVersion(chunkTag);
+         int i = EntityStorage.getVersion(chunkTag);
+ 
 -        return NbtUtils.update(this.fixerUpper, DataFixTypes.ENTITY_CHUNK, chunkTag, i);
 +        return ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ENTITY_CHUNK, chunkTag, i, SharedConstants.getCurrentVersion().getWorldVersion()); // Paper - route to new converter system
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
ed7bba95 SPIGOT-6547: Chunk#getEntities() doesn't return all entities immediately after chunk load
d99a585c SPIGOT-6719: Add getTileEntities() to LimitedRegion

CraftBukkit Changes:
422cec08 Rebuild patch
15f27fc7 SPIGOT-6547: Chunk#getEntities() doesn't return all entities immediately after chunk load
cbd747af SPIGOT-6719: Add getTileEntities() to LimitedRegion

Spigot Changes:
6c1c1b26 Rebuild patches