### PR TITLE
Fixed layers from V2550 not being added to list

### DIFF
--- a/patches/server/0798-Rewrite-dataconverter-system.patch
+++ b/patches/server/0798-Rewrite-dataconverter-system.patch
@@ -13649,10 +13649,10 @@ index 0000000000000000000000000000000000000000..9648299bb96c20c783bb7c7010173a0f
 +}
 diff --git a/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2550.java b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2550.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..19d900f5198982eb22a9fbc7639d333be9800fe2
+index 0000000000000000000000000000000000000000..b9a50d44982abe228c5e7d58a4b917d0fbfda6b9
 --- /dev/null
 +++ b/src/main/java/ca/spottedleaf/dataconverter/minecraft/versions/V2550.java
-@@ -0,0 +1,341 @@
+@@ -0,0 +1,342 @@
 +package ca.spottedleaf.dataconverter.minecraft.versions;
 +
 +import ca.spottedleaf.dataconverter.converters.DataConverter;
@@ -13739,6 +13739,7 @@ index 0000000000000000000000000000000000000000..19d900f5198982eb22a9fbc7639d333b
 +                                    final MapType<String> layer = Types.NBT.createEmptyMap();
 +                                    layer.setInt("height", heights[i]);
 +                                    layer.setString("block", blocks[i]);
++                                    layers.addMap(layer);
 +                                }
 +                            }
 +


### PR DESCRIPTION
Note from Spottedleaf:
Please note that this doesn't fix any problems using dataconverter
because dataconverter does not re-route world gen settings conversion.