### PR TITLE
Fix merchant inventories not closing on entity removal

### DIFF
--- a/patches/server/0826-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0826-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 2 Sep 2021 00:24:06 -0700
+Subject: [PATCH] Fix merchant inventory not closing on entity removal
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 96ccf894519fc892e35fbd13ab97fe289236caca..a62abcb2e05198001516cf2402dc7ead09761905 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2421,6 +2421,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+             // Spigot end
+             // Spigot Start
+             if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {
++                // Paper start
++                if (entity.getBukkitEntity() instanceof org.bukkit.inventory.Merchant merchant && merchant.getTrader() != null) {
++                    merchant.getTrader().closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.UNLOADED);
++                }
++                // Paper end
+                 for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((org.bukkit.inventory.InventoryHolder) entity.getBukkitEntity()).getInventory().getViewers())) {
+                     h.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.UNLOADED); // Paper
+                 }


### PR DESCRIPTION
Fixes #6510

As far as I can tell, this is because the villager entity doesn't store the MerchantMenu, its container, that the code right below my additions, is trying to get the viewers of is its internal container, not the one being viewed by the player. 