### PR TITLE
Add EntityFormWitherRoseEvent

### DIFF
--- a/patches/api/0332-Add-EntityFormWitherRoseEvent.patch
+++ b/patches/api/0332-Add-EntityFormWitherRoseEvent.patch
@@ -1,0 +1,77 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sun, 5 Sep 2021 22:31:38 +0200
+Subject: [PATCH] Add EntityFormWitherRoseEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityFormWitherRoseEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityFormWitherRoseEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..1a6bafd7be3af7ed022fb756da91820490febd30
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityFormWitherRoseEvent.java
+@@ -0,0 +1,65 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.block.Block;
++import org.bukkit.block.BlockState;
++import org.bukkit.entity.Entity;
++import org.bukkit.entity.Wither;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.block.EntityBlockFormEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity dies and forms a wither rose.
++ */
++public class EntityFormWitherRoseEvent extends EntityBlockFormEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean cancelled;
++
++    private final Wither wither;
++
++    public EntityFormWitherRoseEvent(@NotNull Entity entity, @NotNull Wither wither, @NotNull Block block, @NotNull BlockState blockstate) {
++        super(entity, block, blockstate);
++        this.wither = wither;
++    }
++
++    /**
++     * Get the entity that forms the wither rose.
++     * @return the entity that forms the wither rose
++     */
++    @Override
++    @NotNull
++    public Entity getEntity() {
++        return super.getEntity();
++    }
++
++    /**
++     * Get the wither that killed the entity.
++     * @return the wither that killed the entity
++     */
++    @NotNull
++    public Wither getWither() {
++        return this.wither;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancelled) {
++        this.cancelled = cancelled;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++
++}

--- a/patches/server/0804-Add-EntityFormWitherRoseEvent.patch
+++ b/patches/server/0804-Add-EntityFormWitherRoseEvent.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sun, 5 Sep 2021 22:51:52 +0200
+Subject: [PATCH] Add EntityFormWitherRoseEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+index 6175360eb2b19c8197cc5b82a09030211afd838b..8a29743960f6322bae5f1aa54638c2e45e671fa7 100644
+--- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
++++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
+@@ -1668,7 +1668,14 @@ public abstract class LivingEntity extends Entity {
+                     BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
+ 
+                     if (this.level.getBlockState(blockposition).isAir() && iblockdata.canSurvive(this.level, blockposition)) {
+-                        this.level.setBlock(blockposition, iblockdata, 3);
++                        // Paper start - EntityFormWitherRoseEvent
++                        org.bukkit.craftbukkit.block.CraftBlockState bs = org.bukkit.craftbukkit.block.CraftBlockState.getBlockState(level, blockposition);
++                        bs.setData(iblockdata);
++                        io.papermc.paper.event.entity.EntityFormWitherRoseEvent entityFormWitherRoseEvent = new io.papermc.paper.event.entity.EntityFormWitherRoseEvent(this.getBukkitEntity(), (org.bukkit.entity.Wither) adversary.getBukkitEntity(), org.bukkit.craftbukkit.block.CraftBlock.at(this.level, blockposition), bs);
++                        if (entityFormWitherRoseEvent.callEvent()) {
++                            this.level.setBlock(blockposition, iblockdata, 3);
++                        }
++                        // Paper end
+                         flag = true;
+                     }
+                 }


### PR DESCRIPTION
Fixes #6564. Implementation is largely inspired by the [DragonEggFormEvent](https://github.com/PaperMC/Paper/pull/5112). We considered extending the EntityBlockChangeEvent, but felt like EntityBlockFormEvent was a better fit here since the block forms out of thin air. 