### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/api/0137-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/Chunk.java b/src/main/java/org/bukkit/Chunk.java
-index 9c06b9c3a4ebb2bd5dae63b337779e3e7ca90862..50ef424e74b6f92fcc61a293fb92a0b9f88eb8cd 100644
+index 40ddeb7abd49eeece531a8e90b4508f3831cc3e9..5a4884db36d448c885e49c965ae329a0638dd628 100644
 --- a/src/main/java/org/bukkit/Chunk.java
 +++ b/src/main/java/org/bukkit/Chunk.java
 @@ -1,6 +1,8 @@
@@ -17,7 +17,7 @@ index 9c06b9c3a4ebb2bd5dae63b337779e3e7ca90862..50ef424e74b6f92fcc61a293fb92a0b9
  import org.bukkit.block.Block;
  import org.bukkit.block.BlockState;
  import org.bukkit.block.data.BlockData;
-@@ -104,13 +106,36 @@ public interface Chunk extends PersistentDataHolder {
+@@ -111,13 +113,36 @@ public interface Chunk extends PersistentDataHolder {
      @NotNull
      Entity[] getEntities();
  

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1537,7 +1537,7 @@ index 7f3d83d3d071f6b441ad119b1c93be035e911e70..28f1a53a2b9ebe9948509dabbf1a4ae8
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8f44b9465 100644
+index 7ac8bac2f538616de0c4ef59c9ac2ec86aa62b43..9255134d9cdbeeb9529b4f962ea32c230c6c4403 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -140,7 +140,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1549,7 +1549,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
  
  public abstract class LivingEntity extends Entity {
  
-@@ -2761,7 +2761,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2762,7 +2762,6 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void tick() {
@@ -1557,7 +1557,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
          super.tick();
          this.updatingUsingItem();
          this.updateSwimAmount();
-@@ -2802,9 +2801,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2803,9 +2802,7 @@ public abstract class LivingEntity extends Entity {
              }
          }
  
@@ -1567,7 +1567,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
          double d0 = this.getX() - this.xo;
          double d1 = this.getZ() - this.zo;
          float f = (float) (d0 * d0 + d1 * d1);
-@@ -2884,8 +2881,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2885,8 +2882,6 @@ public abstract class LivingEntity extends Entity {
          if (this.isSleeping()) {
              this.setXRot(0.0F);
          }
@@ -1576,7 +1576,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
      }
  
      public void detectEquipmentUpdates() {
-@@ -3067,7 +3062,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3068,7 +3063,6 @@ public abstract class LivingEntity extends Entity {
  
          this.setDeltaMovement(d4, d5, d6);
          this.level.getProfiler().push("ai");
@@ -1584,7 +1584,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
          if (this.isImmobile()) {
              this.jumping = false;
              this.xxa = 0.0F;
-@@ -3077,7 +3071,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3078,7 +3072,6 @@ public abstract class LivingEntity extends Entity {
              this.serverAiStep();
              this.level.getProfiler().pop();
          }
@@ -1592,7 +1592,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
  
          this.level.getProfiler().pop();
          this.level.getProfiler().push("jump");
-@@ -3112,9 +3105,9 @@ public abstract class LivingEntity extends Entity {
+@@ -3113,9 +3106,9 @@ public abstract class LivingEntity extends Entity {
          this.updateFallFlying();
          AABB axisalignedbb = this.getBoundingBox();
  
@@ -1604,7 +1604,7 @@ index 2473816c70c05662d75f6b875b46a4e53d7b76fa..914f69157ac5e5e9e77de968c4e328d8
          this.level.getProfiler().pop();
          this.level.getProfiler().push("freezing");
          boolean flag1 = this.getType().is((Tag) EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
-@@ -3143,9 +3136,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3144,9 +3137,7 @@ public abstract class LivingEntity extends Entity {
              this.checkAutoSpinAttack(axisalignedbb, this.getBoundingBox());
          }
  

--- a/patches/server/0066-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0066-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 200aca8237dd7fbb0e4959831bda877c58ec37fb..8d9c6cebd22e453024716b9fb88786e8ec95fccb 100644
+index 1ebfd0c77a5337a5ff8665f24655b8f2bc16a229..41fce2aeb130c970702a95f0fb37dcd07e566fa9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3563,9 +3563,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3564,9 +3564,10 @@ public abstract class LivingEntity extends Entity {
                  this.triggerItemUseEffects(this.useItem, 16);
                  // CraftBukkit start - fire PlayerItemConsumeEvent
                  ItemStack itemstack;
@@ -20,7 +20,7 @@ index 200aca8237dd7fbb0e4959831bda877c58ec37fb..8d9c6cebd22e453024716b9fb88786e8
                      level.getCraftServer().getPluginManager().callEvent(event);
  
                      if (event.isCancelled()) {
-@@ -3579,6 +3580,13 @@ public abstract class LivingEntity extends Entity {
+@@ -3580,6 +3581,13 @@ public abstract class LivingEntity extends Entity {
                  } else {
                      itemstack = this.useItem.finishUsingItem(this.level, this);
                  }
@@ -34,7 +34,7 @@ index 200aca8237dd7fbb0e4959831bda877c58ec37fb..8d9c6cebd22e453024716b9fb88786e8
                  // CraftBukkit end
  
                  if (itemstack != this.useItem) {
-@@ -3586,6 +3594,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3587,6 +3595,11 @@ public abstract class LivingEntity extends Entity {
                  }
  
                  this.stopUsingItem();

--- a/patches/server/0067-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0067-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8d9c6cebd22e453024716b9fb88786e8ec95fccb..dcf12a35a5a4e0682db81c58ad115687ad5ae7cc 100644
+index 41fce2aeb130c970702a95f0fb37dcd07e566fa9..41b5b04d8609ff7172579313be4ae9933778f81e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -764,7 +764,13 @@ public abstract class LivingEntity extends Entity {
@@ -34,7 +34,7 @@ index 8d9c6cebd22e453024716b9fb88786e8ec95fccb..dcf12a35a5a4e0682db81c58ad115687
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3398,7 +3408,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3399,7 +3409,7 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void setAbsorptionAmount(float amount) {

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,10 +129,10 @@ index 41556294841b2c280ba4eff861405ccb6aee19e5..5220e3ee9fab4c4cbc95e0cf19283923
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a5e47e581a79546e10ad2f5bdabcd92607384867..a69b8ef71b2ee216cb22f4079352d41ab1417e1f 100644
+index 5c227131bad75515fe678a6f32ebddd8d30b8f85..b71b611f3b4506a68ab6c9195c67ba0f52c84ed2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1703,7 +1703,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1704,7 +1704,8 @@ public abstract class LivingEntity extends Entity {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
          if (true) {

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -39,10 +39,10 @@ index 6211a425e81f9ba9718af6c30e534d35b10bad02..bf52f5f9b13e8b4eb3c7ee19b0e57bb8
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a69b8ef71b2ee216cb22f4079352d41ab1417e1f..d9503597b2c2707bf28b31db9c1099fd326d2451 100644
+index b71b611f3b4506a68ab6c9195c67ba0f52c84ed2..290cf1289cdbe344d4009f8012309fc1f7875100 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3227,8 +3227,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3228,8 +3228,11 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  

--- a/patches/server/0164-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0164-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d9503597b2c2707bf28b31db9c1099fd326d2451..2c68fb49040dcb1b6acead188fa9094180577aa7 100644
+index 290cf1289cdbe344d4009f8012309fc1f7875100..ba5003e8ea8c5fd239bf5e430446ad5b813e9829 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@
@@ -15,7 +15,7 @@ index d9503597b2c2707bf28b31db9c1099fd326d2451..2c68fb49040dcb1b6acead188fa90941
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
  import com.google.common.collect.ImmutableMap;
-@@ -2940,6 +2941,13 @@ public abstract class LivingEntity extends Entity {
+@@ -2941,6 +2942,13 @@ public abstract class LivingEntity extends Entity {
              ItemStack itemstack1 = this.getItemBySlot(enumitemslot);
  
              if (!ItemStack.matches(itemstack1, itemstack)) {

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -19,10 +19,10 @@ index 10f7437d62bfa774309d6334ca791505254bcaf7..6d2d82c24c9f43fab2cddee03960325c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2c68fb49040dcb1b6acead188fa9094180577aa7..3be95347badafc35990f5fbb1c0be77b8702bc64 100644
+index ba5003e8ea8c5fd239bf5e430446ad5b813e9829..f7b849548f5d21886898df316114b34fd3033bde 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3668,12 +3668,24 @@ public abstract class LivingEntity extends Entity {
+@@ -3669,12 +3669,24 @@ public abstract class LivingEntity extends Entity {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0214-Implement-EntityKnockbackByEntityEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Implement EntityKnockbackByEntityEvent
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3be95347badafc35990f5fbb1c0be77b8702bc64..bfec0ae49c74ec5f6762140199cbfaf9e87a047c 100644
+index f7b849548f5d21886898df316114b34fd3033bde..96866aaa40a8c20384941b1619faa61f2f71d250 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1437,7 +1437,7 @@ public abstract class LivingEntity extends Entity {
@@ -27,7 +27,7 @@ index 3be95347badafc35990f5fbb1c0be77b8702bc64..bfec0ae49c74ec5f6762140199cbfaf9
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1737,6 +1737,11 @@ public abstract class LivingEntity extends Entity {
+@@ -1738,6 +1738,11 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void knockback(double strength, double x, double z) {
@@ -39,7 +39,7 @@ index 3be95347badafc35990f5fbb1c0be77b8702bc64..bfec0ae49c74ec5f6762140199cbfaf9
          strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
          if (strength > 0.0D) {
              this.hasImpulse = true;
-@@ -1744,6 +1749,15 @@ public abstract class LivingEntity extends Entity {
+@@ -1745,6 +1750,15 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
  
              this.setDeltaMovement(vec3d.x / 2.0D - vec3d1.x, this.onGround ? Math.min(0.4D, vec3d.y / 2.0D + strength) : vec3d.y, vec3d.z / 2.0D - vec3d1.z);

--- a/patches/server/0249-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/server/0249-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 026992056716c11606bd334dd0be178b7e8fb020..7690252c08785906e721ba09834c1a64e32b2880 100644
+index b135f07389bafe9f0a107f8d4115824662fd20b0..1bf64e7961f794b2da7ab81b4afe162fb48a48cc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -3,8 +3,10 @@ package org.bukkit.craftbukkit;
@@ -19,7 +19,7 @@ index 026992056716c11606bd334dd0be178b7e8fb020..7690252c08785906e721ba09834c1a64
  import java.util.Objects;
  import java.util.function.Predicate;
  import net.minecraft.core.BlockPos;
-@@ -149,6 +151,13 @@ public class CraftChunk implements Chunk {
+@@ -154,6 +156,13 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -33,7 +33,7 @@ index 026992056716c11606bd334dd0be178b7e8fb020..7690252c08785906e721ba09834c1a64
          if (!this.isLoaded()) {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
-@@ -163,7 +172,29 @@ public class CraftChunk implements Chunk {
+@@ -168,7 +177,29 @@ public class CraftChunk implements Chunk {
              }
  
              BlockPos position = (BlockPos) obj;

--- a/patches/server/0261-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0261-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -28,10 +28,10 @@ index 49fd3486a6c595749f33bbe1c1bec0454e4725c5..5c290f263fc2b643987c96ea75729bf1
          switch (enumDirection) {
              case DOWN:
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index bfec0ae49c74ec5f6762140199cbfaf9e87a047c..4bc467f5c0fd261a01fd4ecc49015b6e7d6b6ef9 100644
+index 96866aaa40a8c20384941b1619faa61f2f71d250..fd92591e563529c5ef8099df934c413218c1a611 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3689,6 +3689,23 @@ public abstract class LivingEntity extends Entity {
+@@ -3690,6 +3690,23 @@ public abstract class LivingEntity extends Entity {
      }
  
      // Paper start

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -70,7 +70,7 @@ index b34f9c039a3ac198ae450794b5486d5197d2cfea..4cfbb920abad262d42553270455f0cd0
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4bc467f5c0fd261a01fd4ecc49015b6e7d6b6ef9..82d6d56d6e1bc6f98811a4a9b2a9d80a62c61292 100644
+index fd92591e563529c5ef8099df934c413218c1a611..44b9eb9fefae81201f51f24937c09d6993370eb9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -261,6 +261,7 @@ public abstract class LivingEntity extends Entity {
@@ -167,7 +167,7 @@ index 4bc467f5c0fd261a01fd4ecc49015b6e7d6b6ef9..82d6d56d6e1bc6f98811a4a9b2a9d80a
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1662,7 +1688,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1663,7 +1689,7 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
@@ -176,7 +176,7 @@ index 4bc467f5c0fd261a01fd4ecc49015b6e7d6b6ef9..82d6d56d6e1bc6f98811a4a9b2a9d80a
          Entity entity = source.getEntity();
          int i;
  
-@@ -1680,15 +1706,18 @@ public abstract class LivingEntity extends Entity {
+@@ -1681,15 +1707,18 @@ public abstract class LivingEntity extends Entity {
              this.dropCustomDeathLoot(source, i, flag);
          }
          // CraftBukkit start - Call death event
@@ -196,7 +196,7 @@ index 4bc467f5c0fd261a01fd4ecc49015b6e7d6b6ef9..82d6d56d6e1bc6f98811a4a9b2a9d80a
  
      // CraftBukkit start
      public int getExpReward() {
-@@ -1766,6 +1795,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1767,6 +1796,7 @@ public abstract class LivingEntity extends Entity {
          return SoundEvents.GENERIC_HURT;
      }
  

--- a/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0276-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 82d6d56d6e1bc6f98811a4a9b2a9d80a62c61292..1c97ba35c9588b98d66e82ca83e4c48615b9e01b 100644
+index 44b9eb9fefae81201f51f24937c09d6993370eb9..182351530dfbbbeb39338425886bd3fd04aa0364 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -116,6 +116,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 82d6d56d6e1bc6f98811a4a9b2a9d80a62c61292..1c97ba35c9588b98d66e82ca83e4c486
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3736,6 +3737,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3737,6 +3738,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0297-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0297-force-entity-dismount-during-teleportation.patch
@@ -93,10 +93,10 @@ index b4f2b969ad30be38c0a9e3f8efd2a57c3e0f7df0..3c7e75b8fc1bfbe08e232fcba412c83f
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1c97ba35c9588b98d66e82ca83e4c48615b9e01b..04a979eb45b903eb0411b996ef4fc9d889983b5d 100644
+index 182351530dfbbbeb39338425886bd3fd04aa0364..aecb662a8e9e803b619a88d1d1637386fb39c679 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3335,11 +3335,13 @@ public abstract class LivingEntity extends Entity {
+@@ -3336,11 +3336,13 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 4) != 0;
      }
  

--- a/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0343-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 04a979eb45b903eb0411b996ef4fc9d889983b5d..8e07212a0e943ed698e5c7dc32ce17ffe90cd38e 100644
+index aecb662a8e9e803b619a88d1d1637386fb39c679..bb0b7da2e6bfd35bf3f937af928d515ef59401fb 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3554,15 +3554,18 @@ public abstract class LivingEntity extends Entity {
+@@ -3555,15 +3555,18 @@ public abstract class LivingEntity extends Entity {
          this.entityData.set(LivingEntity.DATA_LIVING_ENTITY_FLAGS, (byte) j);
      }
  
@@ -31,7 +31,7 @@ index 04a979eb45b903eb0411b996ef4fc9d889983b5d..8e07212a0e943ed698e5c7dc32ce17ff
              }
  
          }
-@@ -3635,6 +3638,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3636,6 +3639,7 @@ public abstract class LivingEntity extends Entity {
              this.releaseUsingItem();
          } else {
              if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -39,7 +39,7 @@ index 04a979eb45b903eb0411b996ef4fc9d889983b5d..8e07212a0e943ed698e5c7dc32ce17ff
                  this.triggerItemUseEffects(this.useItem, 16);
                  // CraftBukkit start - fire PlayerItemConsumeEvent
                  ItemStack itemstack;
-@@ -3669,8 +3673,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3670,8 +3674,8 @@ public abstract class LivingEntity extends Entity {
                  }
  
                  this.stopUsingItem();

--- a/patches/server/0360-Lag-compensate-eating.patch
+++ b/patches/server/0360-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 8e07212a0e943ed698e5c7dc32ce17ffe90cd38e..9f108e1327f09d5c4876b096b50c62866c2fd6d4 100644
+index bb0b7da2e6bfd35bf3f937af928d515ef59401fb..833c1b02e382f01ecfd1fabf26a520a80642f92d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3498,6 +3498,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3499,6 +3499,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index 8e07212a0e943ed698e5c7dc32ce17ffe90cd38e..9f108e1327f09d5c4876b096b50c6286
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3515,8 +3520,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3516,8 +3521,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index 8e07212a0e943ed698e5c7dc32ce17ffe90cd38e..9f108e1327f09d5c4876b096b50c6286
              this.completeUsingItem();
          }
  
-@@ -3562,7 +3571,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3563,7 +3572,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index 8e07212a0e943ed698e5c7dc32ce17ffe90cd38e..9f108e1327f09d5c4876b096b50c6286
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, enumhand == InteractionHand.OFF_HAND);
-@@ -3586,7 +3598,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3587,7 +3599,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index 8e07212a0e943ed698e5c7dc32ce17ffe90cd38e..9f108e1327f09d5c4876b096b50c6286
              }
          }
  
-@@ -3712,7 +3727,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3713,7 +3728,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1405,7 +1405,7 @@ index 670e4f65680ca36fba1c84cb334c470ea8fa9b60..79f2b3942a3ccccd8fe8719db12de458
                  chunksection.getStates().read(nbttagcompound2.getList("Palette", 10), nbttagcompound2.getLongArray("BlockStates"));
                  chunksection.recalcBlockCounts();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 7690252c08785906e721ba09834c1a64e32b2880..fd5462aa51199f294dda203bd4c313df2608c0c0 100644
+index 1bf64e7961f794b2da7ab81b4afe162fb48a48cc..cce7250ebeaeeaedfd0cb0147526f4ce2dd34b73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -47,7 +47,7 @@ public class CraftChunk implements Chunk {
@@ -1417,7 +1417,7 @@ index 7690252c08785906e721ba09834c1a64e32b2880..fd5462aa51199f294dda203bd4c313df
      private static final byte[] emptyLight = new byte[2048];
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
-@@ -307,7 +307,7 @@ public class CraftChunk implements Chunk {
+@@ -312,7 +312,7 @@ public class CraftChunk implements Chunk {
                  CompoundTag data = new CompoundTag();
                  cs[i].getStates().write(data, "Palette", "BlockStates");
  

--- a/patches/server/0379-Entity-Jump-API.patch
+++ b/patches/server/0379-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 9f108e1327f09d5c4876b096b50c62866c2fd6d4..36592baae26dce299980060d941730e6dd853cef 100644
+index 833c1b02e382f01ecfd1fabf26a520a80642f92d..2a81568c59545689a392f461abd23675341c911e 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3165,8 +3165,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3166,8 +3166,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid((Tag) FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {

--- a/patches/server/0409-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0409-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 36592baae26dce299980060d941730e6dd853cef..a377d73bb2b2c292aeaefa2d60be27366713fd7c 100644
+index 2a81568c59545689a392f461abd23675341c911e..90c018758e0817566390cdd0f3946b21cf5e3017 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3262,10 +3262,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3263,10 +3263,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0418-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0418-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a377d73bb2b2c292aeaefa2d60be27366713fd7c..44df201abb930b455d9de8f36260ec5e4f20f5c2 100644
+index 90c018758e0817566390cdd0f3946b21cf5e3017..9bc6df403ce49dd13bfec25483b89ea75dd57672 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2040,7 +2040,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2041,7 +2041,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0476-Optimize-NibbleArray-to-use-pooled-buffers.patch
+++ b/patches/server/0476-Optimize-NibbleArray-to-use-pooled-buffers.patch
@@ -299,10 +299,10 @@ index 24030bcb3303d0419c7859ded7613608c5f82308..ec3837a64e8ac6892028611d57a111a7
                              int k = SectionPos.sectionToBlockCoord(SectionPos.y(l));
                              int m = SectionPos.sectionToBlockCoord(SectionPos.z(l));
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index fd5462aa51199f294dda203bd4c313df2608c0c0..e317a1d4b463ac1f17cb282260279e92b32087d7 100644
+index cce7250ebeaeeaedfd0cb0147526f4ce2dd34b73..9292db5ebf706d89a69dff9ac1e26e06e4ea7cba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -318,14 +318,14 @@ public class CraftChunk implements Chunk {
+@@ -323,14 +323,14 @@ public class CraftChunk implements Chunk {
                      sectionSkyLights[i] = CraftChunk.emptyLight;
                  } else {
                      sectionSkyLights[i] = new byte[2048];

--- a/patches/server/0484-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0484-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 44df201abb930b455d9de8f36260ec5e4f20f5c2..0c7ed53964675c81185644549898369cdda80377 100644
+index 9bc6df403ce49dd13bfec25483b89ea75dd57672..aa94f0053f2f3151170be420a8d7d92dea5c97fa 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3359,7 +3359,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3360,7 +3360,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0558-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0558-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -61,10 +61,10 @@ index 8fb89326395a7e70982c0d757b506565e98b12a4..a060cca08631fb42041e3a79a9abc422
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0c7ed53964675c81185644549898369cdda80377..3227ce58391b93c12dd01e2b73a3a6c5d6062827 100644
+index aa94f0053f2f3151170be420a8d7d92dea5c97fa..8b06b2c22ca6d22468340207f178906c744f6d75 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3277,7 +3277,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3278,7 +3278,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index 0c7ed53964675c81185644549898369cdda80377..3227ce58391b93c12dd01e2b73a3a6c5
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3444,9 +3444,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3445,9 +3445,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0613-EntityMoveEvent.patch
+++ b/patches/server/0613-EntityMoveEvent.patch
@@ -29,10 +29,10 @@ index aedb1d7a0b60fba72a952fa140569b72795660e4..d5c7180376562cd576d832d44ab11c9c
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3227ce58391b93c12dd01e2b73a3a6c5d6062827..25aa83e2d63edffa4a30c2563341ee4d82e4f3bd 100644
+index 8b06b2c22ca6d22468340207f178906c744f6d75..6c6c4922e922f5475086752382350a6a2ad9ab6f 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3223,6 +3223,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3224,6 +3224,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0649-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0649-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 25aa83e2d63edffa4a30c2563341ee4d82e4f3bd..6539cd1a63f2d987bda2b91555b94df896089d1f 100644
+index 6c6c4922e922f5475086752382350a6a2ad9ab6f..702b166e032f1aedc8e1faa1e04738e768b40aa9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3702,6 +3702,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3703,6 +3703,7 @@ public abstract class LivingEntity extends Entity {
                      level.getCraftServer().getPluginManager().callEvent(event);
  
                      if (event.isCancelled()) {

--- a/patches/server/0702-Line-Of-Sight-Changes.patch
+++ b/patches/server/0702-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 6539cd1a63f2d987bda2b91555b94df896089d1f..429c229d7c88060c76b143ff4aa1bea88b2be786 100644
+index 702b166e032f1aedc8e1faa1e04738e768b40aa9..928fe7bb4ef959b7c8ab1f7d421612b98b1db038 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3430,7 +3430,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3431,7 +3431,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0728-Improve-boat-collision-performance.patch
+++ b/patches/server/0728-Improve-boat-collision-performance.patch
@@ -17,7 +17,7 @@ index 81f4f26a6b83079d36acd1fd86dede0eb1116c01..59437f04911662f06596ef61b91017ca
  
      public static <K, V> Collector<Entry<? extends K, ? extends V>, ?, Map<K, V>> toMap() {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2c49851c2113692d666ccdde6043c82370725010..6175360eb2b19c8197cc5b82a09030211afd838b 100644
+index 57a6c61a979f72f1270041bcf72e83bd8f0c2504..1149a15486016ac101c5976b45b7d1c1109244ce 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1321,7 +1321,7 @@ public abstract class LivingEntity extends Entity {
@@ -44,7 +44,7 @@ index 2c49851c2113692d666ccdde6043c82370725010..6175360eb2b19c8197cc5b82a0903021
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2086,7 +2087,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2087,7 +2088,7 @@ public abstract class LivingEntity extends Entity {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0764-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0764-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1258,10 +1258,10 @@ index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729e
              Visibility visibility = PersistentEntitySectionManager.getEffectiveStatus(this.entity, this.currentSection.getStatus());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index e317a1d4b463ac1f17cb282260279e92b32087d7..2db015b975077f0bd9514a164d4857a5e05bd701 100644
+index 9292db5ebf706d89a69dff9ac1e26e06e4ea7cba..87368816fdb23f804752351de502126f2cd062c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -122,9 +122,7 @@ public class CraftChunk implements Chunk {
+@@ -127,9 +127,7 @@ public class CraftChunk implements Chunk {
          long pair = ChunkPos.asLong(x, z);
  
          if (entityManager.areEntitiesLoaded(pair)) { // PAIL rename isEntitiesLoaded
@@ -1272,7 +1272,7 @@ index e317a1d4b463ac1f17cb282260279e92b32087d7..2db015b975077f0bd9514a164d4857a5
          }
  
          entityManager.ensureChunkQueuedForLoad(pair); // Start entity loading
-@@ -144,9 +142,7 @@ public class CraftChunk implements Chunk {
+@@ -149,9 +147,7 @@ public class CraftChunk implements Chunk {
              return entityManager.areEntitiesLoaded(pair);
          });
  

--- a/patches/server/0802-Do-not-process-entity-loads-in-CraftChunk-getEntitie.patch
+++ b/patches/server/0802-Do-not-process-entity-loads-in-CraftChunk-getEntitie.patch
@@ -16,10 +16,10 @@ of a chance that we're about to eat a dirtload of chunk load callbacks, thus
 making this issue much more of an issue
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 2db015b975077f0bd9514a164d4857a5e05bd701..8946a5607864524b31975f9d3dfaf5881e20a9c3 100644
+index 87368816fdb23f804752351de502126f2cd062c7..3eefcae565ced131ad2924290423fd0b3249ccde 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -118,30 +118,6 @@ public class CraftChunk implements Chunk {
+@@ -123,30 +123,6 @@ public class CraftChunk implements Chunk {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
7da4c0be SPIGOT-6729: Add Chunk.isEntitiesLoaded()

CraftBukkit Changes:
9217b523 #929: Call EntityBlockFormEvent for Wither Rose placed by dead entity
757d42ae SPIGOT-6729: Add Chunk.isEntitiesLoaded()