### PR TITLE
Move `getTrackedPlayers` up from Player to Entity

### DIFF
--- a/patches/api/0275-Expose-Tracked-Players.patch
+++ b/patches/api/0275-Expose-Tracked-Players.patch
@@ -4,30 +4,20 @@ Date: Fri, 26 Feb 2021 16:24:25 -0600
 Subject: [PATCH] Expose Tracked Players
 
 
-diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index c79183e6499808af04962df48b05846f9c764682..38c4fbe41d964b9404e79ebd7cb3ea8c2f514935 100644
---- a/src/main/java/org/bukkit/entity/Player.java
-+++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1,6 +1,7 @@
- package org.bukkit.entity;
- 
- import java.net.InetSocketAddress;
-+import java.util.Set; // Paper
- import java.util.UUID;
- import com.destroystokyo.paper.ClientOption; // Paper
- import com.destroystokyo.paper.Title; // Paper
-@@ -2143,6 +2144,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
-     void sendOpLevel(byte level);
-     // Paper end
- 
-+    // Paper start
-+    /**
-+     * @return Returns a set of Players within this player's tracking range (that the player's client can "see")
-+     */
-+    @NotNull
-+    Set<Player> getTrackedPlayers();
-+    // Paper end
+diff --git a/src/main/java/org/bukkit/entity/Entity.java b/src/main/java/org/bukkit/entity/Entity.java
+index b02704b0535522c5535b560105eec2885fdd3e77..d515de1c316f14165ee327bc81f0be98b60db3bf 100644
+--- a/src/main/java/org/bukkit/entity/Entity.java
++++ b/src/main/java/org/bukkit/entity/Entity.java
+@@ -760,5 +760,12 @@ public interface Entity extends Metadatable, CommandSender, Nameable, Persistent
+      * Check if entity is inside a ticking chunk
+      */
+     public boolean isTicking();
 +
-     // Spigot start
-     public class Spigot extends Entity.Spigot {
- 
++    /**
++     * Returns a set of {@link Player Players} within this entity's tracking range (players that can "see" this entity).
++     *
++     * @return players in tracking range
++     */
++    @NotNull Set<Player> getTrackedPlayers();
+     // Paper end
+ }

--- a/patches/api/0313-Add-PlayerKickEvent-causes.patch
+++ b/patches/api/0313-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6503bb08731fb2dcfc4f771e802c41be7f3fd4cb..3e8cd3971ac8256a40d9b85cd7514998c965512c 100644
+index c79183e6499808af04962df48b05846f9c764682..9a6e410206852029f1fea0c4409352d5743dcf64 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -240,6 +240,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -239,6 +239,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param message kick message
       */
      void kick(final @Nullable net.kyori.adventure.text.Component message);

--- a/patches/server/0624-Expose-Tracked-Players.patch
+++ b/patches/server/0624-Expose-Tracked-Players.patch
@@ -4,29 +4,26 @@ Date: Fri, 26 Feb 2021 16:24:25 -0600
 Subject: [PATCH] Expose Tracked Players
 
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ff9ef9741ccd561f8bf1c517f5c9671874e0a083..660fea802abee79414815f73e079a05b5be1b72a 100644
---- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2403,6 +2403,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+index 986f045a2e6a040c6e2aab7420c8cb2d4ac3a726..ee50ea695585639d0ff184b675f3fb3b205b9f86 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
+@@ -1263,5 +1263,18 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     public boolean isTicking() {
+         return getHandle().isTicking();
      }
-     // Paper end
- 
-+    // Paper start
++
 +    @Override
-+    public Set<Player> getTrackedPlayers() {
-+        if (entity.tracker == null) {
++    public Set<org.bukkit.entity.Player> getTrackedPlayers() {
++        if (this.entity.tracker == null) {
 +            return java.util.Collections.emptySet();
 +        }
 +
-+        Set<Player> set = new HashSet<>(entity.tracker.seenBy.size());
-+        for (net.minecraft.server.network.ServerPlayerConnection connection : entity.tracker.seenBy) {
++        Set<org.bukkit.entity.Player> set = new java.util.HashSet<>(this.entity.tracker.seenBy.size());
++        for (net.minecraft.server.network.ServerPlayerConnection connection : this.entity.tracker.seenBy) {
 +            set.add(connection.getPlayer().getBukkitEntity().getPlayer());
 +        }
 +        return set;
 +    }
-+    // Paper end
-+
-     // Spigot start
-     private final Player.Spigot spigot = new Player.Spigot()
-     {
+     // Paper end
+ }


### PR DESCRIPTION
This moves the getTrackedPlayers method to the Entity class as all entities can contain trackers.