### PR TITLE
Use null for null resource pack prompts

### DIFF
--- a/patches/server/0058-Complete-resource-pack-API.patch
+++ b/patches/server/0058-Complete-resource-pack-API.patch
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 50cce9e9a67dc2e6722f87b06907b37402158700..90317fef5ebfb44e0f200a75569edfec7a5d9b1a 100644
+index 50cce9e9a67dc2e6722f87b06907b37402158700..d526d80631088ad80b1fb7e5e3e42e9d8d8d8bcf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -66,7 +66,7 @@ index 50cce9e9a67dc2e6722f87b06907b37402158700..90317fef5ebfb44e0f200a75569edfec
 +        Validate.notNull(hash, "Hash cannot be null");
 +        net.minecraft.network.chat.Component promptComponent = resourcePackPrompt != null ?
 +                            io.papermc.paper.adventure.PaperAdventure.asVanilla(resourcePackPrompt) :
-+                           new net.minecraft.network.chat.TextComponent("");
++                           null;
 +        this.getHandle().sendTexturePack(url, hash, required, promptComponent);
 +    }
 +


### PR DESCRIPTION
if someone agrees with my idea in #6571 I would put it in this PR as well

the packet for a resource pack defines whether or not a custom prompt is attached
if we use a "" TextComponent, then it will show that an empty custom prompt is attached when really we meant to attach no prompt at all
using null instead will indicate on the client that no prompt is present