### PR TITLE
fix per-player-mob-spawns cause total limit cap by Bukkit's spawn limit

### DIFF
--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -697,7 +697,7 @@ index 95e5660e6cb1afb5ebdb3dbbe59a07c879bddb4b..88145f04989c71a686aae1b486087ecd
 +            // Paper end
 +
 +            // Paper start - per player mob spawning
-+            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (rareSpawn || !enumcreaturetype.isPersistent()) && info.canSpawnForCategory(enumcreaturetype, limit) && difference > 0) {
++            if ((spawnAnimals || !enumcreaturetype.isFriendly()) && (spawnMonsters || enumcreaturetype.isFriendly()) && (rareSpawn || !enumcreaturetype.isPersistent()) && difference > 0) {
                  // CraftBukkit end
                  Objects.requireNonNull(info);
                  NaturalSpawner.SpawnPredicate spawnercreature_c = info::canSpawn;


### PR DESCRIPTION
We had calculate  `difference` for per-player-mob-spawns from Bukkit's spawn limit `info.getSpawnableChunkCount()`,
but we check spawn limit again with for whole world,
this cause the total limit still cap by Bukkit's spawn limit.
These lines are same equation as Bukkit's `info.canSpawnForCategory(enumcreaturetype, limit)`:
https://github.com/PaperMC/Paper/blob/master/patches/server/0372-implement-optional-per-player-mob-spawns.patch#L686-L688

Current world's entities must < per-player-limit && < Bukkit's limit, otherwise not spawn.
Not sure this is desired to or just a bug?
If is desired to,
I think we should add another config for a total limit per world, which should >= Bukkit's spawn limit.

for example, if we had config:
 * Bukkit's spawn limit: 70
 *  per-player-mob-spawns: true
 * player A & B > `ViewDistance`

before this patch:
 * player A: 20/70 => `difference` = 50
 * player B: 50/70 => `difference` = 20
 * all in world: 70
 * `info.canSpawnForCategory(enumcreaturetype, limit)` (`limit` == 70) => false
 * result: not spawn

after this patch:
 * player A: 20/70 -> `difference` = 50
 * player B: 50/70 -> `difference` = 20
  * all in world: 70
 * ~~`info.canSpawnForCategory(enumcreaturetype, limit)`~~  (`limit` == 70)
 * result: spawn with `difference` 50 and 20 for player A and B

Sorry for my bad English, I can not describe very clearly, I will try my best.