### PR TITLE
VanillaCommandWrapper didnt account for entity senders

### DIFF
--- a/patches/server/0823-VanillaCommandWrapper-didnt-account-for-entity-sende.patch
+++ b/patches/server/0823-VanillaCommandWrapper-didnt-account-for-entity-sende.patch
@@ -1,0 +1,23 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 10 Sep 2021 15:49:12 -0700
+Subject: [PATCH] VanillaCommandWrapper didnt account for entity senders
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+index e9d1fb479855194da5a05e86861848158736cbb4..4aa1dc543950b5de64345b3403a6d0bc41c521df 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/VanillaCommandWrapper.java
+@@ -64,8 +64,10 @@ public final class VanillaCommandWrapper extends BukkitCommand {
+     }
+ 
+     public static CommandSourceStack getListener(CommandSender sender) {
+-        if (sender instanceof Player) {
+-            return ((CraftPlayer) sender).getHandle().createCommandSourceStack();
++        // Paper start - account for other entity command senders
++        if (sender instanceof org.bukkit.craftbukkit.entity.CraftEntity craftEntity) {
++            return craftEntity.getHandle().createCommandSourceStack();
++        // Paper end
+         }
+         if (sender instanceof BlockCommandSender) {
+             return ((CraftBlockCommandSender) sender).getWrapper();


### PR DESCRIPTION
Now to be clear, you have to give permission to the entity to run most commands as they start out knowing only the default non-op commands. And you can't OP entities. (well there's a method too, but it does literally nothing).