### PR TITLE
Fix tick rates map being stored with upper case values instead of lower case

### DIFF
--- a/patches/server/0721-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0721-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..055f0de420fd3603b4e2580b29746c127bb1a104 100644
+index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..34d3ca57acd3aa37a37d44cd81bdd10967f12aaa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,14 +3,19 @@ package com.destroystokyo.paper;
@@ -82,7 +82,7 @@ index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..055f0de420fd3603b4e2580b29746c12
 +                    for (String typeName : entitySection.getKeys(false)) {
 +                        if (entitySection.isInt(typeName)) {
 +                            int tickRate = entitySection.getInt(typeName);
-+                            table.put(entity.toUpperCase(Locale.ROOT), typeName.toUpperCase(Locale.ROOT), tickRate);
++                            table.put(entity.toLowerCase(Locale.ROOT), typeName.toLowerCase(Locale.ROOT), tickRate);
 +                            log("      " + typeName + ": " + tickRate);
 +                        }
 +                    }


### PR DESCRIPTION
The key being used to access sensorTickRates and behaviorTickRates in the PaperWorldConfig is lower case as shown in:
```java
this.configKey = key.toLowerCase(java.util.Locale.ROOT);
int tickRate = world.paperConfig.getBehaviorTickRate(this.configKey, entity.getType().id, -1);
this.timeToTick = world.paperConfig.getSensorTickRate(this.configKey, entity.getType().id, this.scanRate);
```

However, these keys were being stored into these tables as upper case:
```java
table.put(entity.toUpperCase(Locale.ROOT), typeName.toUpperCase(Locale.ROOT), tickRate);
```

This caused the tick rates value to always be the default valye no matter what you set it as in the config.

This pull request fixes this by storing the keys as lower case instead.

### Example of this being fixed with the following paper.yml config options:
```yaml
    tick-rates:
      sensor:
        villager:
          secondarypoisensor: 40
      behavior:
        villager:
          validatenearbypoi: 100
          yieldjobsite: 100
          acquirepoi: 100
          poicompetitorscan: 100
```

Before the fix, poicompetitorscan was being run 363 times per tick as seen in [https://timings.aikar.co/?id=8cdfb64f26db4d288f2bdec2e4a5a2b6](https://timings.aikar.co/?id=8cdfb64f26db4d288f2bdec2e4a5a2b6)

After the fix, poicompetitorscan is only being run 6 times per tick as seen in [https://timings.aikar.co/?id=3f57d7ffc2e54849951df5a90d35e6ad](https://timings.aikar.co/?id=3f57d7ffc2e54849951df5a90d35e6ad)