### PR TITLE
Don't log debug logging being disabled

### DIFF
--- a/patches/server/0806-Don-t-log-debug-logging-being-disabled.patch
+++ b/patches/server/0806-Don-t-log-debug-logging-being-disabled.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Tue, 14 Sep 2021 16:24:45 +0200
+Subject: [PATCH] Don't log debug logging being disabled
+
+
+diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
+index ba0e8902e7205bc6da88efd28be70ece04cc1974..ec7938202e3890bccb809a8092362458d0f4ca75 100644
+--- a/src/main/java/org/spigotmc/SpigotConfig.java
++++ b/src/main/java/org/spigotmc/SpigotConfig.java
+@@ -382,7 +382,7 @@ public class SpigotConfig
+             Bukkit.getLogger().info( "Debug logging is enabled" );
+         } else
+         {
+-            Bukkit.getLogger().info( "Debug logging is disabled" );
++            // Bukkit.getLogger().info( "Debug logging is disabled" ); // Paper - Don't log if debug logging isn't enabled.
+         }
+     }
+ 


### PR DESCRIPTION
Fixes #6602. I couldn't find an existing patch to put this into, so I'm creating this as a new patch instead.