### PR TITLE
Fix GlobalPalette serialized size

### DIFF
--- a/patches/server/0807-Fix-GlobalPalette-serialized-size.patch
+++ b/patches/server/0807-Fix-GlobalPalette-serialized-size.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
+Date: Thu, 16 Sep 2021 19:32:23 +0200
+Subject: [PATCH] Fix GlobalPalette serialized size
+
+
+diff --git a/src/main/java/net/minecraft/world/level/chunk/GlobalPalette.java b/src/main/java/net/minecraft/world/level/chunk/GlobalPalette.java
+index ebca8dd8828767a71e06fcd1cf54ebb993c3feb0..72a8fb1007b298834c4d53ef78bb23b9388e7ee1 100644
+--- a/src/main/java/net/minecraft/world/level/chunk/GlobalPalette.java
++++ b/src/main/java/net/minecraft/world/level/chunk/GlobalPalette.java
+@@ -41,7 +41,7 @@ public class GlobalPalette<T> implements Palette<T> {
+ 
+     @Override
+     public int getSerializedSize() {
+-        return FriendlyByteBuf.getVarIntSize(0);
++        return 0; // Paper - fix serialized size
+     }
+ 
+     @Override


### PR DESCRIPTION
Within chunk packets, there is a new ByteBuf allocated with pre-calculated size based on the chunk section's non-air blocks and their block palettes. The global palette size returns 1 instead of 0 bytes and the buffer is needlessly extended - which doesn't cause any issues or warnings, since this is a special allocated buf inside of a packet, but still causes the mismatch in expected length and actual content (= being left with readableBytes > 0 despite all actual data having ended), annoying in custom protocol reading