### PR TITLE
Add per-player chunk send rate

### DIFF
--- a/patches/api/9999-Add-per-player-chunk-send-rate.patch
+++ b/patches/api/9999-Add-per-player-chunk-send-rate.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MartijnMuijsers <martijnmuijsers@live.nl>
+Date: Thu, 16 Sep 2021 22:00:39 +0200
+Subject: [PATCH] Add per-player chunk send rate
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index afa245018192a63e5db8bc568ddea2790bf5b8a2..bd608f097dc52a1fe878bb3b608aa34650cd100f 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -1938,6 +1938,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param viewDistance view distance in [2, 32] or -1
+      */
+     public void setSendViewDistance(int viewDistance);
++
++    /**
++     * Gets the target chunk send rate (in chunks per second) for this player.
++     * <p>
++     * The maximum chunk send rate an individual player will ever have. A value of -1 means the limit is disabled.
++     * </p>
++     * @return The target chunk send rate for this player, always either -1 (to indicate an unlimited chunk send rate) or a positive value >= 1
++     */
++    public double getTargetChunkSendRate();
++
++    /**
++     * Sets the target chunk send rate (in chunks per second) for this player.
++     * <p>
++     * The maximum chunk send rate an individual player will ever have. A value of -1 means the limit is disabled.
++     * <br>
++     * Any negative value given will be treated as -1 (disabling the limit). Any value in the range [0, 1] will be treated as 1. If given null, this method acts as unsetting the value for this player: instead, the value in the Paper configuration will be used.
++     * </p>
++     * @param chunkSendRate The target chunk send rate for this player, or null to defer to the value in the Paper configuration.
++     */
++    public void setTargetChunkSendRate(@Nullable Double chunkSendRate);
+     // Paper end
+ 
+     /**

--- a/patches/server/9999-Add-per-player-chunk-send-rate.patch
+++ b/patches/server/9999-Add-per-player-chunk-send-rate.patch
@@ -1,0 +1,85 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MartijnMuijsers <martijnmuijsers@live.nl>
+Date: Thu, 16 Sep 2021 22:00:02 +0200
+Subject: [PATCH] Add per-player chunk send rate
+
+
+diff --git a/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
+index b3da5ec6701448a4b273c86aff9c64e3d75e5885..4feed4d081dd1da9beb69c4e19e4e3c74fb8626d 100644
+--- a/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
++++ b/src/main/java/io/papermc/paper/chunk/PlayerChunkLoader.java
+@@ -304,8 +304,10 @@ public final class PlayerChunkLoader {
+         return (int)Math.ceil(Math.min(config * MinecraftServer.getServer().getPlayerCount(), max <= 1.0 ? Double.MAX_VALUE : max));
+     }
+ 
+-    protected long getTargetSendPerPlayerAddend() {
+-        return PaperConfig.playerTargetChunkSendRate <= 1.0 ? 0L : (long)Math.round(1.0e9 / PaperConfig.playerTargetChunkSendRate);
++    protected long getTargetSendPerPlayerAddend(ServerPlayer player) {
++        final double chunkSendRate = player.getBukkitEntity().getTargetChunkSendRate();
++        // disable the limit for any given negative rate (with -1 the intended value to denote this)
++        return chunkSendRate < 0 ? 0L : (long) Math.round(1.0e9 / chunkSendRate);
+     }
+ 
+     protected long getMaxSendAddend() {
+@@ -456,7 +458,6 @@ public final class PlayerChunkLoader {
+         }
+ 
+         final int maxSends = this.getMaxConcurrentChunkSends();
+-        final long nextPlayerDeadline = this.getTargetSendPerPlayerAddend() + time;
+         for (;;) {
+             if (this.chunkSendQueue.isEmpty()) {
+                 break;
+@@ -489,6 +490,7 @@ public final class PlayerChunkLoader {
+                 throw new IllegalStateException();
+             }
+ 
++            final long nextPlayerDeadline = getTargetSendPerPlayerAddend(data.player) + time;
+             data.nextChunkSendTarget = nextPlayerDeadline;
+             this.chunkSendWaitQueue.add(data);
+ 
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index 6d2d2ba4a83d887f4d52188305a4a28c2ee2f014..de4ce4a18709f5b58c24852c06cab7fc31f174fb 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -240,6 +240,10 @@ public class ServerPlayer extends Player {
+     public final int[] mobCounts = new int[MOBCATEGORY_TOTAL_ENUMS]; // Paper
+     public final com.destroystokyo.paper.util.PooledHashSets.PooledObjectLinkedOpenHashSet<ServerPlayer> cachedSingleMobDistanceMap;
+     // Paper end
++    // Paper start - per-player chunk send rate
++    // the target chunk send rate (in chunks per second) for this player, or null if no specific value for this player is set
++    public Double targetChunkSendRate = null;
++    // Paper end
+ 
+     // CraftBukkit start
+     public String displayName;
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 1ccbdd2554073a41ca2f37deca3f1ec3e6a0665f..688c0c1a91261581f9b7a06fa6d44fc5478b7513 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.craftbukkit.entity;
+ 
++import com.destroystokyo.paper.PaperConfig;
+ import com.destroystokyo.paper.Title;
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.ImmutableSet;
+@@ -580,6 +581,19 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+         data.setTargetTickViewDistance(viewDistance);
+     }
++
++    @Override
++    public double getTargetChunkSendRate() {
++        final Double playerTargetChunkSendRate = this.getHandle().targetChunkSendRate;
++        final double effectiveTargetChunkSendRate = playerTargetChunkSendRate == null ? PaperConfig.playerTargetChunkSendRate : playerTargetChunkSendRate;
++        // Make sure the returned rate is -1, or >= 1
++        return effectiveTargetChunkSendRate < 0 ? -1 : (effectiveTargetChunkSendRate <= 1 ? 1 : effectiveTargetChunkSendRate);
++    }
++
++    @Override
++    public void setTargetChunkSendRate(Double chunkSendRate) {
++        this.getHandle().targetChunkSendRate = chunkSendRate;
++    }
+     // Paper end - implement view distances
+ 
+     @Override


### PR DESCRIPTION
Closes #6610 and fixes #6616.

Changes:
* Add per-player chunk send rate: added chunk send rate field per player, that when given overrides the configured value in paper.yml
* Fix chunk send rate of 1.0 disabling the limit: instead, any negative value will disable the limit (as matches the documentation which indicates a value of -1 to disable the limit), and any nonnegative value of at most 1.0 sets the chunk send rate to 1.0.