### PR TITLE
Add EntityFireTickChangeEvent

### DIFF
--- a/patches/api/0333-Add-EntityFireTickChangeEvent.patch
+++ b/patches/api/0333-Add-EntityFireTickChangeEvent.patch
@@ -1,0 +1,94 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sun, 19 Sep 2021 23:41:47 +0200
+Subject: [PATCH] Add EntityFireTickChangeEvent
+
+
+diff --git a/src/main/java/io/papermc/paper/event/entity/EntityFireTickChangeEvent.java b/src/main/java/io/papermc/paper/event/entity/EntityFireTickChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..469479731defe144436504bc1b46e8e2d21f7d7c
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/entity/EntityFireTickChangeEvent.java
+@@ -0,0 +1,82 @@
++package io.papermc.paper.event.entity;
++
++import org.bukkit.entity.Entity;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.entity.EntityEvent;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when an entity's amount of remaining fire ticks change.
++ */
++public class EntityFireTickChangeEvent extends EntityEvent implements Cancellable {
++    private static final HandlerList handlers = new HandlerList();
++    private boolean canceled;
++
++    private final int previousTicks;
++    private int newTicks;
++    private final boolean combusted;
++
++    public EntityFireTickChangeEvent(@NotNull Entity what, int previousTicks, int newTicks, boolean combusted) {
++        super(what);
++        this.previousTicks = previousTicks;
++        this.newTicks = newTicks;
++        this.combusted = combusted;
++    }
++
++    /**
++     * Gets the old amount of remaining fire ticks.
++     *
++     * @return the amount of remaining fire ticks before the even was fired
++     */
++    public int getPreviousTicks() {
++        return previousTicks;
++    }
++
++    /**
++     * Gets the new amount of remaining fire ticks.
++     *
++     * @return the new amount of remaining fire ticks
++     */
++    public int getNewTicks() {
++        return newTicks;
++    }
++
++    /**
++     * Sets the new amount of remaining fire ticks.
++     *
++     * @param newTicks the new amount of remaining fire ticks
++     */
++    public void setNewTicks(int newTicks) {
++        this.newTicks = newTicks;
++    }
++
++    /**
++     * Gets whether the entity was burning before.
++     *
++     * @return true if the entity was already burning
++     */
++    public boolean hasCombusted() {
++        return combusted;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return canceled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        canceled = cancel;
++    }
++
++    @Override
++    public @NotNull HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/0807-Add-EntityFireTickChangeEvent.patch
+++ b/patches/server/0807-Add-EntityFireTickChangeEvent.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Sun, 19 Sep 2021 23:42:02 +0200
+Subject: [PATCH] Add EntityFireTickChangeEvent
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
+index 94857a736d2a16e8ade286c6f2ddf8bd798008eb..aeedc48608f470bc68f919cd150da69653817150 100644
+--- a/src/main/java/net/minecraft/world/entity/Entity.java
++++ b/src/main/java/net/minecraft/world/entity/Entity.java
+@@ -857,7 +857,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
+     }
+ 
+     public void setRemainingFireTicks(int ticks) {
+-        this.remainingFireTicks = ticks;
++        // Paper start
++        if (this.remainingFireTicks != ticks) {
++            io.papermc.paper.event.entity.EntityFireTickChangeEvent tickEvent = new io.papermc.paper.event.entity.EntityFireTickChangeEvent(this.getBukkitEntity(), this.remainingFireTicks, ticks, this.remainingFireTicks <= 0);
++            if (!tickEvent.callEvent()) {
++                return;
++            }
++            this.remainingFireTicks = tickEvent.getNewTicks();
++        }
++        // Paper end
+     }
+ 
+     public int getRemainingFireTicks() {


### PR DESCRIPTION
Fixes #5517. I'm not entirely sure if this event should have some sort of pre-fire check, similar to [EntityMoveEvent](https://github.com/PaperMC/Paper/blob/f75636b55fa3c0a29c91931f6c44db2da7d1cefb/patches/server/0615-EntityMoveEvent.patch#L15), since the event is fired pretty often (or maybe some sort of fire condition).