### PR TITLE
Adventure 4.9.1

### DIFF
--- a/patches/api/0002-Build-system-changes.patch
+++ b/patches/api/0002-Build-system-changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Build system changes
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 6e64a444fb20aabaabfb15a30d645702c11c2da8..db6a7b2e60da0d96ef96545a781f1e056482d6ff 100644
+index fd30d2e6d3716777be7bc2f28267ab5b03131342..8cabc75b2272dbb448c1f04a0ef6b0339d9f6b17 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
-@@ -17,12 +17,14 @@ dependencies {
+@@ -17,15 +17,23 @@ dependencies {
      api("com.google.code.gson:gson:2.8.0")
      api("net.md-5:bungeecord-chat:1.16-R0.4")
      api("org.yaml:snakeyaml:1.28")
@@ -24,7 +24,16 @@ index 6e64a444fb20aabaabfb15a30d645702c11c2da8..db6a7b2e60da0d96ef96545a781f1e05
      compileOnly(annotations)
      testCompileOnly(annotations)
  
-@@ -61,7 +63,7 @@ tasks.withType<Javadoc>().configureEach {
++    // Paper start - add checker
++    val checkerAnnotations = "org.checkerframework:checker-qual:3.18.0"
++    compileOnlyApi(checkerAnnotations)
++    testCompileOnly(checkerAnnotations)
++    // Paper end
++
+     testImplementation("junit:junit:4.13.1")
+     testImplementation("org.hamcrest:hamcrest-library:1.3")
+     testImplementation("org.ow2.asm:asm-tree:9.2")
+@@ -61,7 +69,7 @@ tasks.withType<Javadoc>().configureEach {
      (options as StandardJavadocDocletOptions).links(
          "https://guava.dev/releases/21.0/api/docs/",
          "https://javadoc.io/doc/org.yaml/snakeyaml/1.28/",

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -7,14 +7,14 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index ccf5b30fa48e641fc8d04f185f9ffca55d4e2154..0ed6d9e6619db7559dc5b65a8da6e54e6e15d31c 100644
+index 3a395a44ff50a77895341bbbfb8c81deede41b8b..6ebea1d9fafb08ede7e37dfe1b145a676c7aaaf9 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -10,6 +10,19 @@ java {
      withJavadocJar()
  }
  
-+val adventureVersion = "4.8.1"
++val adventureVersion = "4.9.1"
 +val apiAndDocs by configurations.creating {
 +    attributes {
 +        attribute(Category.CATEGORY_ATTRIBUTE, objects.named(Category.DOCUMENTATION))
@@ -42,7 +42,7 @@ index ccf5b30fa48e641fc8d04f185f9ffca55d4e2154..0ed6d9e6619db7559dc5b65a8da6e54e
  
      compileOnly("org.apache.maven:maven-resolver-provider:3.8.1")
      compileOnly("org.apache.maven.resolver:maven-resolver-connector-basic:1.7.0")
-@@ -61,10 +79,17 @@ tasks.jar {
+@@ -67,10 +85,17 @@ tasks.jar {
  }
  
  tasks.withType<Javadoc>().configureEach {
@@ -1401,7 +1401,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..03d8ac1b41659540d7eb3d7e218cdfaa
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955dfa653edb3 100644
+index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999cec151168 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -33,7 +33,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1697,7 +1697,26 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1266,6 +1437,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1020,7 +1191,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      *
+      * @param title Title text
+      * @param subtitle Subtitle text
+-     * @deprecated API behavior subject to change
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
+      */
+     @Deprecated
+     public void sendTitle(@Nullable String title, @Nullable String subtitle);
+@@ -1039,7 +1210,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
+      * @param stay time in ticks for titles to stay. Defaults to 70.
+      * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
+      */
++    @Deprecated // Paper - Adventure
+     public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
+ 
+     /**
+@@ -1266,6 +1439,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -1712,7 +1731,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1291,8 +1470,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1291,8 +1472,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -1723,7 +1742,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
      public String getLocale();
  
      /**
-@@ -1310,6 +1491,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1310,6 +1493,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void openBook(@NotNull ItemStack book);
  
@@ -1738,7 +1757,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1364,11 +1553,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1364,11 +1555,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -1752,7 +1771,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1379,7 +1570,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1379,7 +1572,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -1762,7 +1781,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1389,7 +1582,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1389,7 +1584,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -1772,7 +1791,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1400,7 +1595,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1400,7 +1597,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -1782,7 +1801,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..d68b2c6044db7740ef4d737e1b2955df
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1411,7 +1608,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1411,7 +1610,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send
@@ -3570,6 +3589,45 @@ index 4dba721aefe4fc6699b3b4bfa7ecb0b19c2a2a1a..01dec2c877df58c9dc22445e8b1f9ce2
 +    @Deprecated
 +    public @NotNull MapCursor addCursor(int x, int y, byte direction, byte type, boolean visible, @Nullable net.kyori.adventure.text.Component caption) {
 +        return addCursor(new MapCursor((byte) x, (byte) y, direction, type, visible, caption));
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/permissions/Permissible.java b/src/main/java/org/bukkit/permissions/Permissible.java
+index 228421154913116069c20323afb519bdde2134df..26791db3c267670d5782f1d2b67ff7d5b55b9dac 100644
+--- a/src/main/java/org/bukkit/permissions/Permissible.java
++++ b/src/main/java/org/bukkit/permissions/Permissible.java
+@@ -126,4 +126,34 @@ public interface Permissible extends ServerOperator {
+      */
+     @NotNull
+     public Set<PermissionAttachmentInfo> getEffectivePermissions();
++
++    // Paper start - add TriState permission checks
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.@NotNull TriState permissionValue(final @NotNull Permission permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
++    }
++
++    /**
++     * Checks if this object has a permission set and, if it is set, the value of the permission.
++     *
++     * @param permission the permission to check
++     * @return a tri-state of if the permission is set and, if it is set, it's value
++     */
++    default net.kyori.adventure.util.@NotNull TriState permissionValue(final @NotNull String permission) {
++        if (this.isPermissionSet(permission)) {
++            return net.kyori.adventure.util.TriState.byBoolean(this.hasPermission(permission));
++        } else {
++            return net.kyori.adventure.util.TriState.NOT_SET;
++        }
 +    }
 +    // Paper end
  }

--- a/patches/api/0008-Player-affects-spawning-API.patch
+++ b/patches/api/0008-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d68b2c6044db7740ef4d737e1b2955dfa653edb3..1786b6c230cabaf962b27f9d95c49b42e2b5cc67 100644
+index 696bf438012fd93f38495024ca49999cec151168..210b3440518cbddd6c27a7b301b280d814404a2a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1476,6 +1476,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1478,6 +1478,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0013-Add-view-distance-API.patch
+++ b/patches/api/0013-Add-view-distance-API.patch
@@ -64,10 +64,10 @@ index 92e8b0b1ccebdc2646337114793ea9f3e7759d25..5d01ba43ead1c5d257e38645380359c8
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 1786b6c230cabaf962b27f9d95c49b42e2b5cc67..d65f35573700078a90283c37d698778a751e44a2 100644
+index 210b3440518cbddd6c27a7b301b280d814404a2a..14f35121aaeb641ac90bcadc906816f225e165ac 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1490,6 +1490,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1492,6 +1492,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
@@ -432,7 +432,7 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd822a01ca3c 100644
+index a989f63b6862123dc2b1293b9fd901bd093c84d0..adf57da082ef37c369ed327804148ff992841055 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -474,7 +474,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * @param fadeInTicks  ticks to fade-in
 +     * @param stayTicks    ticks to stay visible
 +     * @param fadeOutTicks ticks to fade-out
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} 
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void setTitleTimes(int fadeInTicks, int stayTicks, int fadeOutTicks);
@@ -483,7 +483,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * Update the subtitle of titles displayed to the player
 +     *
 +     * @param subtitle Subtitle to set
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void setSubtitle(net.md_5.bungee.api.chat.BaseComponent[] subtitle);
@@ -492,7 +492,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * Update the subtitle of titles displayed to the player
 +     *
 +     * @param subtitle Subtitle to set
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void setSubtitle(net.md_5.bungee.api.chat.BaseComponent subtitle);
@@ -501,7 +501,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * Show the given title to the player, along with the last subtitle set, using the last set times
 +     *
 +     * @param title Title to set
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void showTitle(@Nullable net.md_5.bungee.api.chat.BaseComponent[] title);
@@ -510,7 +510,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * Show the given title to the player, along with the last subtitle set, using the last set times
 +     *
 +     * @param title Title to set
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void showTitle(@Nullable net.md_5.bungee.api.chat.BaseComponent title);
@@ -523,7 +523,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * @param fadeInTicks  ticks to fade-in
 +     * @param stayTicks    ticks to stay visible
 +     * @param fadeOutTicks ticks to fade-out
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void showTitle(@Nullable net.md_5.bungee.api.chat.BaseComponent[] title, @Nullable net.md_5.bungee.api.chat.BaseComponent[] subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks);
@@ -536,7 +536,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     * @param fadeInTicks  ticks to fade-in
 +     * @param stayTicks    ticks to stay visible
 +     * @param fadeOutTicks ticks to fade-out
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    public void showTitle(@Nullable net.md_5.bungee.api.chat.BaseComponent title, @Nullable net.md_5.bungee.api.chat.BaseComponent subtitle, int fadeInTicks, int stayTicks, int fadeOutTicks);
@@ -548,7 +548,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     *
 +     * @param title the title to send
 +     * @throws NullPointerException if the title is null
-+     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    void sendTitle(@NotNull Title title);
@@ -560,7 +560,7 @@ index bd652a0c20335be67aae67ea663a23ea215d237a..9c9c9e504cb4db80e760207f6a27fd82
 +     *
 +     * @param title the title to send
 +     * @throws NullPointerException if title is null
-+     * @deprecated use {@link #showTitle(net.kyori.adventure.title.Title)}
++     * @deprecated Use {@link #showTitle(net.kyori.adventure.title.Title)} or {@link #sendTitlePart(net.kyori.adventure.title.TitlePart, Object)}
 +     */
 +    @Deprecated
 +    void updateTitle(@NotNull Title title);

--- a/patches/api/0024-Complete-resource-pack-API.patch
+++ b/patches/api/0024-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 9d56c51b64dfd70dbc83b32729c38615141930d5..bbdcb00642d6d91787f0c4184434de15b0e31646 100644
+index adf57da082ef37c369ed327804148ff992841055..2c3e43ccf862c9de27811de0a49a2dee85e5d459 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1220,7 +1220,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
@@ -18,7 +18,7 @@ index 9d56c51b64dfd70dbc83b32729c38615141930d5..bbdcb00642d6d91787f0c4184434de15
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -1731,6 +1733,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1733,6 +1735,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0044-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0044-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index bbdcb00642d6d91787f0c4184434de15b0e31646..638e106375a4be5bd49ddbe8ce32b1c4eeb32800 100644
+index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df2c4387bd 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -68,7 +68,7 @@ index bbdcb00642d6d91787f0c4184434de15b0e31646..638e106375a4be5bd49ddbe8ce32b1c4
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1922,6 +1958,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1924,6 +1960,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index bbdcb00642d6d91787f0c4184434de15b0e31646..638e106375a4be5bd49ddbe8ce32b1c4
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -1934,6 +1971,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1936,6 +1973,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0090-Player.setPlayerProfile-API.patch
+++ b/patches/api/0090-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index befcda55ba8b12d5116f4afe9984c2871fefe8f2..8c29b5bc634e017c3abe5dd9c0fc55ffd2d54c11 100644
+index b98a0bfe2c58377e0b3b135ef4e6250c3a59cc7f..5379b34f82bc36604d53f527b949a93c42ff441f 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
@@ -17,7 +17,7 @@ index befcda55ba8b12d5116f4afe9984c2871fefe8f2..8c29b5bc634e017c3abe5dd9c0fc55ff
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1908,6 +1909,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1910,6 +1911,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6687f3020dc217c63a6bd6ec916855bd505261ea..fa9bcf16d74bd4001fe7cc5e4947b09808048996 100644
+index debe69ccb0da02815dfcb5288eb37b22ce55cb90..63691e910ef8cbd81a8c73bd8d799c4e76591f44 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2083,6 +2083,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2085,6 +2085,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0197-Add-Player-Client-Options-API.patch
+++ b/patches/api/0197-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index fa9bcf16d74bd4001fe7cc5e4947b09808048996..23588bf0642810e775f556e0e7f3945433f9f280 100644
+index 63691e910ef8cbd81a8c73bd8d799c4e76591f44..6fa1b87f08165b90fb49fc4f1343bdeb7c5e5abb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index fa9bcf16d74bd4001fe7cc5e4947b09808048996..23588bf0642810e775f556e0e7f39454
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2103,6 +2104,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2105,6 +2106,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0222-Brand-support.patch
+++ b/patches/api/0222-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 23588bf0642810e775f556e0e7f3945433f9f280..42988e8ea5c7c4caca3b046e74621b846b1ff0af 100644
+index 6fa1b87f08165b90fb49fc4f1343bdeb7c5e5abb..a4be2f8a53913ec315907694c31dcf9f8d5b3676 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2238,6 +2238,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2240,6 +2240,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0231-Player-elytra-boost-API.patch
+++ b/patches/api/0231-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 42988e8ea5c7c4caca3b046e74621b846b1ff0af..220838894bb24a5cab3f005c8a9f4ba7c438b576 100644
+index a4be2f8a53913ec315907694c31dcf9f8d5b3676..88182db3de76905d6553e8c1034ae52b2a2be930 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2110,6 +2110,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2112,6 +2112,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0260-Add-sendOpLevel-API.patch
+++ b/patches/api/0260-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 220838894bb24a5cab3f005c8a9f4ba7c438b576..6bac2d1828ed0397460753ecc5680730418b54dc 100644
+index 88182db3de76905d6553e8c1034ae52b2a2be930..7e3acf07b180622d5078051009492a90a2794beb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2123,6 +2123,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2125,6 +2125,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0275-Expose-Tracked-Players.patch
+++ b/patches/api/0275-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6bac2d1828ed0397460753ecc5680730418b54dc..782bd1657b487e38ee943857b3d3543ef294c8f3 100644
+index 7e3acf07b180622d5078051009492a90a2794beb..6503bb08731fb2dcfc4f771e802c41be7f3fd4cb 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1,6 +1,7 @@
@@ -16,7 +16,7 @@ index 6bac2d1828ed0397460753ecc5680730418b54dc..782bd1657b487e38ee943857b3d3543e
  import java.util.UUID;
  import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
-@@ -2136,6 +2137,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2138,6 +2139,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end
  

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -2176,7 +2176,7 @@ index 53d6950ad270ba901de5226b9daecb683248ad05..3e7d14564f11a3ed0b0766444e9d6818
      public boolean isPermissionSet(String name) {
          return this.getCaller().isPermissionSet(name);
 diff --git a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
-index 8107ed0d248ff2a1cf8e556b7610a68f6c197691..6d1db92e5eedce03817264a4cd6e9a43b8e7ad2a 100644
+index 8107ed0d248ff2a1cf8e556b7610a68f6c197691..eaff8df6c8c12c64e005a68a02e2e35ed88f757c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
 +++ b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
 @@ -14,6 +14,7 @@ import org.bukkit.plugin.Plugin;
@@ -2197,7 +2197,7 @@ index 8107ed0d248ff2a1cf8e556b7610a68f6c197691..6d1db92e5eedce03817264a4cd6e9a43
 +    public net.kyori.adventure.pointer.Pointers pointers() {
 +        if (this.adventure$pointers == null) {
 +            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
-+                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.DISPLAY_NAME, this::name)
 +                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::permissionValue)
 +                .build();
 +        }
@@ -2224,7 +2224,7 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f13410c3376c7c5b666c803666ba23a40fbea8a0..c8f7cb2faf2812d88b4cca30ed1f711e97efcc4a 100644
+index f13410c3376c7c5b666c803666ba23a40fbea8a0..a527e4e04babfaf6f324e4aa3b93a86009664166 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -189,6 +189,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
@@ -2255,7 +2255,7 @@ index f13410c3376c7c5b666c803666ba23a40fbea8a0..c8f7cb2faf2812d88b4cca30ed1f711e
 +    public net.kyori.adventure.pointer.Pointers pointers() {
 +        if (this.adventure$pointers == null) {
 +            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
-+                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.DISPLAY_NAME, this::name)
 +                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUniqueId)
 +                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::permissionValue)
 +                .build();

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -1854,6 +1854,37 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
 +    }
      // Paper end
  }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 62252343490fb1e96c2ec48113e2e3ce741930b6..8c47fbd10b634daf24eb14949b124ee87d87ff73 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -130,6 +130,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+     private int waterAnimalSpawn = -1;
+     private int waterAmbientSpawn = -1;
+     private int ambientSpawn = -1;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     private static final Random rand = new Random();
+ 
+@@ -1751,4 +1752,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         return this.spigot;
+     }
+     // Spigot end
++
++    // Paper start - implement pointers
++    @Override
++    public net.kyori.adventure.pointer.Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUID)
++                .build();
++        }
++
++        return this.adventure$pointers;
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/Main.java b/src/main/java/org/bukkit/craftbukkit/Main.java
 index 11d1bc56439ff867224ef1c2058aee67ba0ee332..52f78b8a3d4588f9aba10c8aea4d36cb02f1f54f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/Main.java
@@ -2144,6 +2175,37 @@ index 53d6950ad270ba901de5226b9daecb683248ad05..3e7d14564f11a3ed0b0766444e9d6818
      @Override
      public boolean isPermissionSet(String name) {
          return this.getCaller().isPermissionSet(name);
+diff --git a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
+index 8107ed0d248ff2a1cf8e556b7610a68f6c197691..6d1db92e5eedce03817264a4cd6e9a43b8e7ad2a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
++++ b/src/main/java/org/bukkit/craftbukkit/command/ServerCommandSender.java
+@@ -14,6 +14,7 @@ import org.bukkit.plugin.Plugin;
+ public abstract class ServerCommandSender implements CommandSender {
+     private static PermissibleBase blockPermInst;
+     private final PermissibleBase perm;
++    private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     public ServerCommandSender() {
+         if (this instanceof CraftBlockCommandSender) {
+@@ -134,4 +135,18 @@ public abstract class ServerCommandSender implements CommandSender {
+         return this.spigot;
+     }
+     // Spigot end
++
++    // Paper start - implement pointers
++    @Override
++    public net.kyori.adventure.pointer.Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::permissionValue)
++                .build();
++        }
++
++        return this.adventure$pointers;
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
 index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6e31d7465 100644
 --- a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
@@ -2162,10 +2224,18 @@ index cf69a45f038c2b8336010f5fe277313fd0513b5b..eb99e0c2462a2d1ab4508a5c3f1580b6
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
          return this.target;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f13410c3376c7c5b666c803666ba23a40fbea8a0..a120193418f0edff022752defb5b62663643f0f9 100644
+index f13410c3376c7c5b666c803666ba23a40fbea8a0..c8f7cb2faf2812d88b4cca30ed1f711e97efcc4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -815,6 +815,19 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -189,6 +189,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+     protected Entity entity;
+     private EntityDamageEvent lastDamageEvent;
+     private final CraftPersistentDataContainer persistentDataContainer = new CraftPersistentDataContainer(CraftEntity.DATA_TYPE_REGISTRY);
++    protected net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
+ 
+     public CraftEntity(final CraftServer server, final Entity entity) {
+         this.server = server;
+@@ -815,6 +816,32 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.getHandle().getVehicle().getBukkitEntity();
      }
  
@@ -2180,12 +2250,25 @@ index f13410c3376c7c5b666c803666ba23a40fbea8a0..a120193418f0edff022752defb5b6266
 +    public void customName(final net.kyori.adventure.text.Component customName) {
 +        this.getHandle().setCustomName(customName != null ? io.papermc.paper.adventure.PaperAdventure.asVanilla(customName) : null);
 +    }
++
++    @Override
++    public net.kyori.adventure.pointer.Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUniqueId)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::permissionValue)
++                .build();
++        }
++
++        return this.adventure$pointers;
++    }
 +    // Paper end
 +
      @Override
      public void setCustomName(String name) {
          // sane limit for name length
-@@ -870,6 +883,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -870,6 +897,17 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public String getName() {
          return CraftChatMessage.fromComponent(this.getHandle().getName());
      }
@@ -2256,7 +2339,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..2f604c883ee1341ad3896b74de01f4dc9537ecfa 100644
+index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4e2b7040a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2434,7 +2517,7 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..2f604c883ee1341ad3896b74de01f4dc
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1734,6 +1804,160 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1734,6 +1804,195 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2506,6 +2589,26 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..2f604c883ee1341ad3896b74de01f4dc
 +        final ClientboundSetTitleTextPacket tp = new ClientboundSetTitleTextPacket((net.minecraft.network.chat.Component) null);
 +        tp.adventure$text = title.title();
 +        connection.send(tp);
++    }
++
++    @Override
++    public <T> void sendTitlePart(final net.kyori.adventure.title.TitlePart<T> part, T value) {
++        java.util.Objects.requireNonNull(part, "part");
++        java.util.Objects.requireNonNull(value, "value");
++        if (part == net.kyori.adventure.title.TitlePart.TITLE) {
++            final ClientboundSetTitleTextPacket tp = new ClientboundSetTitleTextPacket((net.minecraft.network.chat.Component) null);
++            tp.adventure$text = (net.kyori.adventure.text.Component) value;
++            this.getHandle().connection.send(tp);
++        } else if (part == net.kyori.adventure.title.TitlePart.SUBTITLE) {
++            final ClientboundSetSubtitleTextPacket sp = new ClientboundSetSubtitleTextPacket((net.minecraft.network.chat.Component) null);
++            sp.adventure$text = (net.kyori.adventure.text.Component) value;
++            this.getHandle().connection.send(sp);
++        } else if (part == net.kyori.adventure.title.TitlePart.TIMES) {
++            final net.kyori.adventure.title.Title.Times times = (net.kyori.adventure.title.Title.Times) value;
++            this.getHandle().connection.send(new ClientboundSetTitlesAnimationPacket(ticks(times.fadeIn()), ticks(times.stay()), ticks(times.fadeOut())));
++        } else {
++            throw new IllegalArgumentException("Unknown TitlePart");
++        }
 +    }
 +
 +    private static int ticks(final java.time.Duration duration) {
@@ -2589,6 +2692,21 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..2f604c883ee1341ad3896b74de01f4dc
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, item));
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundOpenBookPacket(net.minecraft.world.InteractionHand.MAIN_HAND));
 +        connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, inventory.getSelected()));
++    }
++
++    @Override
++    public net.kyori.adventure.pointer.Pointers pointers() {
++        if (this.adventure$pointers == null) {
++            this.adventure$pointers = net.kyori.adventure.pointer.Pointers.builder()
++                .withDynamic(net.kyori.adventure.identity.Identity.DISPLAY_NAME, this::displayName)
++                .withDynamic(net.kyori.adventure.identity.Identity.NAME, this::getName)
++                .withDynamic(net.kyori.adventure.identity.Identity.UUID, this::getUniqueId)
++                .withStatic(net.kyori.adventure.permission.PermissionChecker.POINTER, this::permissionValue)
++                .withDynamic(net.kyori.adventure.identity.Identity.LOCALE, this::locale)
++                .build();
++        }
++
++        return this.adventure$pointers;
 +    }
 +    // Paper end
 +

--- a/patches/server/0026-Entity-Origin-API.patch
+++ b/patches/server/0026-Entity-Origin-API.patch
@@ -132,10 +132,10 @@ index 394164f50256ad9a167e15531a9202875abb6cb6..8ad1b3cb16533d62deda643ce0cdda30
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index a120193418f0edff022752defb5b62663643f0f9..8afa6d638d12ddbabb5db11ada314b4d111e5e11 100644
+index 6afc76de073301603f0aa84182fe507d34e93283..6749de33dba17c4ded7a4457bc2509495c328495 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1132,4 +1132,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1146,4 +1146,21 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0052-Add-velocity-warnings.patch
+++ b/patches/server/0052-Add-velocity-warnings.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add velocity warnings
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 45c6c2bc739c842d27cb9c4a87c2154f6e447d17..28a3fa002a77ecc7f5bd16aa4316f6d74e2503e1 100644
+index dd69c7962a90c4ff4b251599f95fa01525855abc..db13ac548b7c250f84df9d5dbfb85021010b2d86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -278,6 +278,7 @@ public final class CraftServer implements Server {
@@ -17,10 +17,10 @@ index 45c6c2bc739c842d27cb9c4a87c2154f6e447d17..28a3fa002a77ecc7f5bd16aa4316f6d7
      static {
          ConfigurationSerialization.registerClass(CraftOfflinePlayer.class);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 118ba56a539471bded0cb42334576d5394aee4ab..7e50d589724c15ce30424cf1d82eb56e84acd28b 100644
+index 6749de33dba17c4ded7a4457bc2509495c328495..8a50cce54f3271f20f8d01007fdd3a773fb699b1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -435,10 +435,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -436,10 +436,40 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public void setVelocity(Vector velocity) {
          Preconditions.checkArgument(velocity != null, "velocity");
          velocity.checkFinite();

--- a/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
+++ b/patches/server/0126-Provide-E-TE-Chunk-count-stat-methods.patch
@@ -20,12 +20,12 @@ index 98c205efbe7f31fb35eefedf083b366dd5dbb8f8..d6e6b5a29ddf980e179471059372dfda
      private boolean tickingBlockEntities;
      public final Thread thread;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b628a66c37d4de732876d9dd428b77e1c04c0da4..f5cc3134edfc56885b53fa2efbbff1ab24955f0f 100644
+index 8c47fbd10b634daf24eb14949b124ee87d87ff73..5575bf752c72a947e51f250d5edbadb1d77324c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -131,6 +131,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
-     private int waterAmbientSpawn = -1;
+@@ -132,6 +132,57 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      private int ambientSpawn = -1;
+     private net.kyori.adventure.pointer.Pointers adventure$pointers; // Paper - implement pointers
  
 +    // Paper start - Provide fast information methods
 +    @Override

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -49,10 +49,10 @@ index 037dafb59e54047d1d54474c44897d35b8f46c98..e310c1eb1108780bcff4d7ba9d49cefa
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index b5e44370c847d4a2e51e610a6b6aca5586b17cad..60d7bb2aa29032f278d9e4ba054bad6b1ea1bb36 100644
+index 8a50cce54f3271f20f8d01007fdd3a773fb699b1..26b914638162ce1bdd0f578f06257e51485e268a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1178,5 +1178,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1192,5 +1192,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          //noinspection ConstantConditions
          return originVector.toLocation(world);
      }

--- a/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
+++ b/patches/server/0198-Expand-World.spawnParticle-API-and-add-Builder.patch
@@ -34,10 +34,10 @@ index 26c25b103f08a2e66179d1ed8f450778aa2e539a..86a5a4456be65b94b0c27a0355c3844c
  
              if (this.sendParticles(entityplayer, force, d0, d1, d2, packetplayoutworldparticles)) { // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3a3d128e2c9abbb699f151af5bf28af58653bf1a..f34cfd72b5323ca0a14ef4a20e67cc44c0453ced 100644
+index 5575bf752c72a947e51f250d5edbadb1d77324c9..a6679e40c161ca34b059cd2fe1f27cd23a888a88 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1722,11 +1722,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1723,11 +1723,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public <T> void spawnParticle(Particle particle, double x, double y, double z, int count, double offsetX, double offsetY, double offsetZ, double extra, T data, boolean force) {

--- a/patches/server/0208-Fix-CraftEntity-hashCode.patch
+++ b/patches/server/0208-Fix-CraftEntity-hashCode.patch
@@ -21,10 +21,10 @@ check is essentially the same as this.getHandle() == other.getHandle()
 However, replaced it too to make it clearer of intent.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index edf381a0fd8a568fb2095a0369c3eb062e9a566b..8b776445716e483e040be165c18118593a63d694 100644
+index 26b914638162ce1bdd0f578f06257e51485e268a..95bc2136eaa118f28c7ec2d8b557ed0773f5f9ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -791,14 +791,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -792,14 +792,15 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
              return false;
          }
          final CraftEntity other = (CraftEntity) obj;

--- a/patches/server/0215-Expand-Explosions-API.patch
+++ b/patches/server/0215-Expand-Explosions-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expand Explosions API
 Add Entity as a Source capability, and add more API choices, and on Location.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d6a9f43b72d8b135734a17946cb0482c9dffbaec..1200a6ddf67643250bb3386190bb2f6538abe52e 100644
+index a6679e40c161ca34b059cd2fe1f27cd23a888a88..387d1262212a2ee72286bcdb83ce3599ff0c1425 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -686,6 +686,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -687,6 +687,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean createExplosion(double x, double y, double z, float power, boolean setFire, boolean breakBlocks, Entity source) {
          return !this.world.explode(source == null ? null : ((CraftEntity) source).getHandle(), x, y, z, power, setFire, breakBlocks ? Explosion.BlockInteraction.BREAK : Explosion.BlockInteraction.NONE).wasCanceled;
      }

--- a/patches/server/0219-Implement-World.getEntity-UUID-API.patch
+++ b/patches/server/0219-Implement-World.getEntity-UUID-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement World.getEntity(UUID) API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 1200a6ddf67643250bb3386190bb2f6538abe52e..a049c5b10db3ebc3f5a27b3510d09075d2bccf2a 100644
+index 387d1262212a2ee72286bcdb83ce3599ff0c1425..687798fab7d38eccf679727f047ceb6f196ffb5c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1020,6 +1020,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1021,6 +1021,15 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return list;
      }
  

--- a/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
+++ b/patches/server/0259-Make-CraftWorld-loadChunk-int-int-false-load-unconve.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Make CraftWorld#loadChunk(int, int, false) load unconverted
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a049c5b10db3ebc3f5a27b3510d09075d2bccf2a..d99d019df02f8defb6c5c9082b8c650231c20775 100644
+index 687798fab7d38eccf679727f047ceb6f196ffb5c..74825cd20ae25bbaa1f69ecb208a1c01c1213083 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -367,7 +367,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -368,7 +368,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -2303,7 +2303,7 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..7ce854edba32ffcafaa5268d4bb2822a
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataFixers.getDataFixer(), minecraftsessionservice, gameprofilerepository, usercache, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cc4a94669c5f0dee99b6d8cb89650cf0c701e9ab..7210ad3c4d83b883590c7659925b8b3f56a057e5 100644
+index 7b760a65cad1f7dd5adb3a05b8b5ed7d0f49c0a9..00920e574ee1f104781d1f776d88ec9cd45eda93 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1000,7 +1000,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -2348,7 +2348,7 @@ index bbf2dee8cdd2d8239d9230b1a7fff4f07c2edaf8..ffa3dc07ec566464ce10abe793de61ef
          ChunkHolder.FullChunkStatus playerchunk_state1 = ChunkHolder.getFullChunkStatus(this.ticketLevel);
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ab3a6aaa7d9df119af219a0c7cd83a763b8c830c..f5800e2b7657de374daa54d68f1adab1873b5516 100644
+index 75719f5ba225db613f1669785da15b70159b7ab6..c70d12b6af98562faaddef8a6d77d1f2f45c8d44 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -447,6 +447,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -2627,7 +2627,7 @@ index ab3a6aaa7d9df119af219a0c7cd83a763b8c830c..f5800e2b7657de374daa54d68f1adab1
          return this.poiManager;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index dd61048b3898ef3ea5a2bd2f95e9bd3fc11dc298..e12a794ace00f2b440e4cb1c197df018e7e27063 100644
+index 1f3fe980e71c13b5e7852349cba1cb0e4aa42dcd..30b88f0e8ad40438af8a7d5bec1471a60ddd977b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -481,10 +481,128 @@ public class ServerChunkCache extends ChunkSource {
@@ -3622,10 +3622,10 @@ index e5e138fb23d03eb63e547e74d3e14ec9d96d8107..90f7b06bd2c558be35c4577044fa033e
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index e7722b8805bbd07473aadee9ea60d18de68ddfad..9b671c90f30d8211469771a29d3c3b78c4627c9c 100644
+index 74825cd20ae25bbaa1f69ecb208a1c01c1213083..e43135fc10cb2d024295cbe89daf7127fec4898c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1785,6 +1785,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1786,6 +1786,34 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public DragonBattle getEnderDragonBattle() {
          return (this.getHandle().dragonFight() == null) ? null : new CraftDragonBattle(this.getHandle().dragonFight());
      }
@@ -3661,7 +3661,7 @@ index e7722b8805bbd07473aadee9ea60d18de68ddfad..9b671c90f30d8211469771a29d3c3b78
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 8b776445716e483e040be165c18118593a63d694..f1fdf5fdaf3a590e8a011db0c5c741be4bfefc9c 100644
+index 95bc2136eaa118f28c7ec2d8b557ed0773f5f9ad..2ef8ffdf8c957aa91caa3b628cfeb0276989bc75 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;
@@ -3672,7 +3672,7 @@ index 8b776445716e483e040be165c18118593a63d694..f1fdf5fdaf3a590e8a011db0c5c741be
  import net.minecraft.world.damagesource.DamageSource;
  import net.minecraft.world.entity.AreaEffectCloud;
  import net.minecraft.world.entity.Entity;
-@@ -518,6 +519,37 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -519,6 +520,37 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          this.entity.setYHeadRot(yaw);
      }
  

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 592829e14b6965a2ce83c53af4fc0ab9826e3406..d9808ee4fdf19c78d3253782875d1b794eb4b490 100644
+index 6b6c3fbccbf9b4fe2e362c3b2e23920b429a1295..f88921668305085d79edee265a1457cd3d22a338 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2254,6 +2254,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
-         connection.send(new net.minecraft.network.protocol.game.ClientboundOpenBookPacket(net.minecraft.world.InteractionHand.MAIN_HAND));
-         connection.send(new net.minecraft.network.protocol.game.ClientboundContainerSetSlotPacket(0, stateId, slot, inventory.getSelected()));
+@@ -2289,6 +2289,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+ 
+         return this.adventure$pointers;
      }
 +
 +    @Override

--- a/patches/server/0275-Add-sun-related-API.patch
+++ b/patches/server/0275-Add-sun-related-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sun related API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5d0e56a2c8fb6f801643928f8b75e06cdff83a52..4edfe886ae753f1c9e90be2bff69483c330287ae 100644
+index e43135fc10cb2d024295cbe89daf7127fec4898c..eea482e6acdda3b3f84eb49697957f78edac6f20 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -662,6 +662,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -663,6 +663,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          }
      }
  

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 6afe4428761073d11c86a1e853598bd10ac55b5f..aa0d348df457fb2b340955fdb9a98029f8557fec 100644
+index 465e0299a4e6819e530750c670c88d9a4bdc2722..d28c7f3257e20104e7d8dc57a5752a3773457712 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2301,6 +2301,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2336,6 +2336,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -105,10 +105,10 @@ index 494174608c0c6d0e0d9820ad4f263bef90c3dfdf..fe5e691ebbe930662f8a4f00811fdd8e
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f635962e99e1a078171037e3e41c9c413dff66fd..4b9e73536b75ae805bf306ed262011a2d9dc7456 100644
+index 2ef8ffdf8c957aa91caa3b628cfeb0276989bc75..15d29a56d1597310aa73b9faa07216eac1a1f533 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1216,5 +1216,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1230,5 +1230,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean fromMobSpawner() {
          return getHandle().spawnedViaMobSpawner;
      }

--- a/patches/server/0324-Add-Heightmap-API.patch
+++ b/patches/server/0324-Add-Heightmap-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Heightmap API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 4edfe886ae753f1c9e90be2bff69483c330287ae..ef9779a35d6102b5977dda0c68d4ca311d7298ad 100644
+index eea482e6acdda3b3f84eb49697957f78edac6f20..b94bca3f04a0dd004c5885afbab848325fe6bd97 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -202,6 +202,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -203,6 +203,29 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return this.getHighestBlockYAt(x, z, org.bukkit.HeightMap.MOTION_BLOCKING);
      }
  

--- a/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
+++ b/patches/server/0329-improve-CraftWorld-isChunkLoaded.patch
@@ -9,10 +9,10 @@ waiting for the execution queue to get to our request; We can just query
 the chunk status and get a response now, vs having to wait
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ef9779a35d6102b5977dda0c68d4ca311d7298ad..642c0d98f3fc8a4a4caf75f4e67dfaadbde7dd70 100644
+index b94bca3f04a0dd004c5885afbab848325fe6bd97..7db56c1b150ba58777cd5d017bbe5522837c4cb7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -273,13 +273,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -274,13 +274,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkLoaded(int x, int z) {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -23,7 +23,7 @@ index 2a7d31f533240e0b683c00d65f5632d7a8ff236d..3816623fa85db14a89bd165221695de1
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bdfa5c65e41edb7cdcb5a0fff54d9384a9598028..e029064acc58332914eef0524ad991a45d368c93 100644
+index 3ca73d8c4709d6a95bc8f6b81b977a069f9cba17..d284ed9d1cc6ea3ee2e7878faf43184507f91186 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -787,35 +787,36 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -221,10 +221,10 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 823da324da549b33b3db36e2063391b6c56b42cd..5a44c904bd952a5d6b64b0f1331bd4e3496e0b4f 100644
+index 7db56c1b150ba58777cd5d017bbe5522837c4cb7..50ad307aa6d9f19092c59f0ee7d6321d5ec08c92 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1335,15 +1335,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1336,15 +1336,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setKeepSpawnInMemory(boolean keepLoaded) {

--- a/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
+++ b/patches/server/0336-Fix-World-isChunkGenerated-calls.patch
@@ -32,7 +32,7 @@ index d226247b93a2f1f7e039b0963d2e27b5dd11c15e..1ea32090783ac5b885b95ae2009dd61d
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getFutureIfPresentUnchecked(ChunkStatus leastStatus) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index f5800e2b7657de374daa54d68f1adab1873b5516..6d0092c8a71d775ffbe03374199a4be28f418058 100644
+index c70d12b6af98562faaddef8a6d77d1f2f45c8d44..0bb5071f78644607eaed2a4d4a74262e99f3ed72 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -84,6 +84,7 @@ import net.minecraft.world.level.chunk.ProtoChunk;
@@ -108,7 +108,7 @@ index f5800e2b7657de374daa54d68f1adab1873b5516..6d0092c8a71d775ffbe03374199a4be2
          // Spigot start
          return this.isOutsideOfRange(chunkPos, false);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index e12a794ace00f2b440e4cb1c197df018e7e27063..ddd535ad7d2b051e0d05320e4491bad46df8ffbe 100644
+index 30b88f0e8ad40438af8a7d5bec1471a60ddd977b..5d920d7df52c12f5f1d1d8111340800cbddaac78 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -482,6 +482,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -235,7 +235,7 @@ index 24092d3d3d234b6f1f2b90e22d90f297532358cc..43510774d489bfdd30f10d521e424fa1
              } catch (Throwable throwable) {
                  if (dataoutputstream != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b53c4296afca4755b39ec2e08d258a84984fb394..2a5d4e4efe9ea9fcac4c6079c28a020b4c2df118 100644
+index 50ad307aa6d9f19092c59f0ee7d6321d5ec08c92..86fb57b2d014e88bc25eae9c30ebb7b40ca60e80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -19,6 +19,7 @@ import java.util.Objects;
@@ -246,7 +246,7 @@ index b53c4296afca4755b39ec2e08d258a84984fb394..2a5d4e4efe9ea9fcac4c6079c28a020b
  import java.util.function.Predicate;
  import java.util.stream.Collectors;
  import net.minecraft.core.BlockPos;
-@@ -278,8 +279,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -279,8 +280,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public boolean isChunkGenerated(int x, int z) {
@@ -270,7 +270,7 @@ index b53c4296afca4755b39ec2e08d258a84984fb394..2a5d4e4efe9ea9fcac4c6079c28a020b
          } catch (IOException ex) {
              throw new RuntimeException(ex);
          }
-@@ -390,20 +405,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -391,20 +406,48 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public boolean loadChunk(int x, int z, boolean generate) {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -145,7 +145,7 @@ index 1ea32090783ac5b885b95ae2009dd61de3063ae0..8d3cdd288eacc91f7c9a624f601284e5
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getOrScheduleFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 292fb6d71ca8bd63ad04d87d04f13b7f4f6f98fc..831394e82fd04daf00971019a7d479629e83baaf 100644
+index 2bbba8239cdce5952817b992879f00f35abdee67..1caa33f1bdae0df640ac28036679bef28e15867f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -127,7 +127,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -658,10 +658,10 @@ index 515e28eea8cbab261320352ee0db9b877807f3ed..83ed84f89a036d3768b22a36bc8a0bfc
  
                  this.postProcessing[i].clear();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 25361c7f0493de56575f6422a86dd0a9406c289f..05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53 100644
+index 86fb57b2d014e88bc25eae9c30ebb7b40ca60e80..fcf7076c1df858d35d6b69995b7c4768233b8370 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1896,10 +1896,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1897,10 +1897,39 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0454-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0454-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,10 +44,10 @@ index 7cc882333b28fe79d3445c0b9d1bb5e71e2418eb..ecc65fe9783f0f369695edc1183f3d49
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8fe656cf28 100644
+index fcf7076c1df858d35d6b69995b7c4768233b8370..ea6cb4873e72cf6be81c1a6bf48e5932cc5684f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -262,8 +262,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -263,8 +263,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk getChunkAt(int x, int z) {
@@ -70,7 +70,7 @@ index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8f
  
      @Override
      public Chunk getChunkAt(Block block) {
-@@ -330,7 +343,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -331,7 +344,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean unloadChunkRequest(int x, int z) {
          org.spigotmc.AsyncCatcher.catchOp("chunk unload"); // Spigot
          if (this.isChunkLoaded(x, z)) {
@@ -79,7 +79,7 @@ index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8f
          }
  
          return true;
-@@ -407,9 +420,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -408,9 +421,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8f
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -417,7 +433,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -418,7 +434,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8f
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -443,7 +459,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -444,7 +460,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 05eb3dd86a8d24d7e8746cd18efe5e1415ad1a53..9d7b33c71525b11afa0c2f2371d2ff8f
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1888,6 +1904,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1889,6 +1905,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0481-Add-entity-liquid-API.patch
+++ b/patches/server/0481-Add-entity-liquid-API.patch
@@ -17,10 +17,10 @@ index 19a6b2c686e6421624282d0536dfdd3320da4ec6..3e1f34ed8c3b4bd4f6c3624332a5f2be
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 4b9e73536b75ae805bf306ed262011a2d9dc7456..e43552590253e6662cd72bdb114185217539ffa4 100644
+index 15d29a56d1597310aa73b9faa07216eac1a1f533..17bed708187e1fd58c0c245bfcabddbf52a79548 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1221,5 +1221,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1235,5 +1235,29 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason getEntitySpawnReason() {
          return getHandle().spawnReason;
      }

--- a/patches/server/0487-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0487-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -361,7 +361,7 @@ index fe8e6d66665dc8c38e74c0b264cf507f99f83091..e317c73b430105052cbf28502916adc3
                  }
              }).exceptionally((throwable) -> {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index daa13434cf4ba47f77b4f47c4d2ecb3d9d672031..ac848504fd7105506d6d733709ad05dc8b37c9d9 100644
+index 48b704bfb25e6f96235ca8743bd007654c58e948..0303a48729e087afbb51817de64d7f99fc487ec8 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -122,6 +122,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1509,10 +1509,10 @@ index a84b75a53a0324fab9aeb9b80bf74eb0a84ecd2e..d580f0375cce5e995c024f1b0cd4843b
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 9d7b33c71525b11afa0c2f2371d2ff8fe656cf28..ddaeee92af57247e0cdf674a80c1ddaf9556d02a 100644
+index ea6cb4873e72cf6be81c1a6bf48e5932cc5684f1..24198751b911b3a7d7ca4be4a76734ed448b4bf1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1902,6 +1902,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1903,6 +1903,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  
@@ -1526,7 +1526,7 @@ index 9d7b33c71525b11afa0c2f2371d2ff8fe656cf28..ddaeee92af57247e0cdf674a80c1ddaf
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a3ab8ab4bbcca4783a2546bbeb180e04e07e9a5d..ac57fe602e4ee8908fba36410f39a8d27a4db50a 100644
+index 656c69f261a042542e57ca4f92927594138affa1..80b1ef3c886fe592586ba61db58da0c2e2800d8e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -896,6 +896,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0498-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0498-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index ddaeee92af57247e0cdf674a80c1ddaf9556d02a..c8e11309fecb4b07fa971c13fee8012fd221f7d9 100644
+index 24198751b911b3a7d7ca4be4a76734ed448b4bf1..3ceff62c394a456932e93e5a21ec7697ab6881f4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1973,6 +1973,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1974,6 +1974,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0504-Brand-support.patch
+++ b/patches/server/0504-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 121b612a80f7a6f6a52d916d61c9f46f91ffb1f1..b6a7a129b0357ab7d25037e646960aee152a9261 100644
+index 7bf9f2b85c51424b53c08166b6ba3943f1abe0fe..b2ca9f3297806e9ac709e790d37d1a455797da38 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
@@ -72,10 +72,10 @@ index 121b612a80f7a6f6a52d916d61c9f46f91ffb1f1..b6a7a129b0357ab7d25037e646960aee
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ac57fe602e4ee8908fba36410f39a8d27a4db50a..0aff206c6c7d2b81f683c814a3876e3b9226f382 100644
+index 80b1ef3c886fe592586ba61db58da0c2e2800d8e..9e8c44ebb1fa833ff2334af2ac242ffce470edf7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2442,6 +2442,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2477,6 +2477,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0508-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
+++ b/patches/server/0508-Fix-SpawnChangeEvent-not-firing-for-all-use-cases.patch
@@ -17,10 +17,10 @@ index 86d060691405401fe8ae8ae8ef59322ee841b196..1b13c67441c46208a9b2adde5ca109f9
              // if this keepSpawnInMemory is false a plugin has already removed our tickets, do not re-add
              this.removeTicketsForSpawn(this.paperConfig.keepLoadedRange, prevSpawn);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c8e11309fecb4b07fa971c13fee8012fd221f7d9..885c5179a3fba962d91c55e7971d04c696911c64 100644
+index 3ceff62c394a456932e93e5a21ec7697ab6881f4..1365ecf96870661902be5ea73de793c1fda87570 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -243,11 +243,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -244,11 +244,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public boolean setSpawnLocation(int x, int y, int z, float angle) {
          try {
              Location previousLocation = this.getSpawnLocation();

--- a/patches/server/0509-Add-moon-phase-API.patch
+++ b/patches/server/0509-Add-moon-phase-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add moon phase API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 885c5179a3fba962d91c55e7971d04c696911c64..48cb3bd3016d33d1b168de2a1ecf33ae52b38181 100644
+index 1365ecf96870661902be5ea73de793c1fda87570..b7ae4b4bb1a8b74e96a61ab428d8bca132db4016 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -181,6 +181,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -182,6 +182,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getPlayerCount() {
          return world.players().size();
      }

--- a/patches/server/0522-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0522-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index c05ced79e5bf6d2900f0479db3150e76e3874ba0..c791013aac43061453d13ce50f4864b3be1251e3 100644
+index b2ca9f3297806e9ac709e790d37d1a455797da38..98fed8b9b7f67dffd666b3a2fce544defbd69a85 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -681,7 +681,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -69,10 +69,10 @@ index b9e738542692aba7b78fc514ae8e3248df9998ea..c601b8b12756682a4cb300be8ebed431
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 2ae9392961383cbce07835234b95f415094c11fc..1f41d39fe3378bccc6c005d20e41d98f903762cc 100644
+index 17bed708187e1fd58c0c245bfcabddbf52a79548..ee6daf914efc18ce2e3b4bcf2c3a1a5e37154ddf 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -576,7 +576,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -577,7 +577,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
          }
  
          // entity.setLocation() throws no event, and so cannot be cancelled

--- a/patches/server/0529-Entity-isTicking.patch
+++ b/patches/server/0529-Entity-isTicking.patch
@@ -27,10 +27,10 @@ index 9e6a2c5fc55674ab144ebd46da6152e51d3c1dba..9524771be6268b28f14618523d59cff0
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 5400bbbe231bf7ac3227acd8060a520cebfdeb0a..b4e08dcdf2d94935b58eb90c7ff84511ef525f52 100644
+index ee6daf914efc18ce2e3b4bcf2c3a1a5e37154ddf..81e8c1320fc8f1b8d803a5b5de826c3d6c7db865 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-@@ -1245,5 +1245,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
+@@ -1259,5 +1259,9 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {
      public boolean isInLava() {
          return getHandle().isInLava();
      }

--- a/patches/server/0554-Expose-world-spawn-angle.patch
+++ b/patches/server/0554-Expose-world-spawn-angle.patch
@@ -18,10 +18,10 @@ index 76e21498b6cfd1c9a601a55e1483eb8dfd892c2e..3e7c9716b6d05859e7d63d9c7b9616f8
  
              Player respawnPlayer = entityplayer1.getBukkitEntity();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 48cb3bd3016d33d1b168de2a1ecf33ae52b38181..2979eb18175d3093c7ce0d353d74ef03c05b5529 100644
+index b7ae4b4bb1a8b74e96a61ab428d8bca132db4016..9e10a3c47dfa9a65d716425a91615300433d512f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -234,7 +234,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -235,7 +235,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public Location getSpawnLocation() {
          BlockPos spawn = this.world.getSharedSpawnPos();

--- a/patches/server/0587-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0587-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 888d812118c15c212284687ae5842a94f5715d52..e7ca5d6fb8922e7e8065864f736b0605
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 2979eb18175d3093c7ce0d353d74ef03c05b5529..b0b6695c8b0e4e40410e9b28ba93c5769e049aba 100644
+index 9e10a3c47dfa9a65d716425a91615300433d512f..250f26782994ab56389030db20a95b479cc929cd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1707,8 +1707,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1708,8 +1708,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 2979eb18175d3093c7ce0d353d74ef03c05b5529..b0b6695c8b0e4e40410e9b28ba93c576
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1743,8 +1748,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1744,8 +1749,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0624-Expose-Tracked-Players.patch
+++ b/patches/server/0624-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 2ec9cfbd665bc2dd7c731ab5603073d21b1a2977..b3305deb28c99e2f1cc08e04da7be18bfe891f02 100644
+index 98c10141f4bf79722f3b225426738a93c1273e9b..20293f62e6b44eaa742fe1eecf2f17a05dff9a37 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2361,6 +2361,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2396,6 +2396,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0637-Implement-Keyed-on-World.patch
+++ b/patches/server/0637-Implement-Keyed-on-World.patch
@@ -34,10 +34,10 @@ index bca12654736aa4134e634607753b0268cc69eccb..847dc9ef6d490386c419d536247e322b
          // Check if a World already exists with the UID.
          if (this.getWorld(world.getUID()) != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b0b6695c8b0e4e40410e9b28ba93c5769e049aba..fe085df2fecadf6cd28a16beda0ec032edaa2570 100644
+index 250f26782994ab56389030db20a95b479cc929cd..1a7f81268cec6f574eb15979664aef12a186be65 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1930,6 +1930,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1931,6 +1931,11 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return java.util.concurrent.CompletableFuture.completedFuture(chunk == null ? null : chunk.getBukkitChunk());
          }, net.minecraft.server.MinecraftServer.getServer());
      }

--- a/patches/server/0661-More-World-API.patch
+++ b/patches/server/0661-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index fe085df2fecadf6cd28a16beda0ec032edaa2570..d79aec050701b43e029606ee181c9ac5236a08c6 100644
+index 1a7f81268cec6f574eb15979664aef12a186be65..25810416f04d3a6fd41e4e21feb4c81402eb3e8b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1876,6 +1876,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1877,6 +1877,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0688-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0688-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -104,10 +104,10 @@ index cd840dc4a8ca432868fb3e9c912ea928e5303e0d..4d0af984490b556a9911c3b8fdca1e16
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d79aec050701b43e029606ee181c9ac5236a08c6..b91a4968540d2dca4702582eb231b925bd6709e1 100644
+index 25810416f04d3a6fd41e4e21feb4c81402eb3e8b..2fccbe6e58a2e5a29c0cfe78b135854fbf402238 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1168,7 +1168,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1169,7 +1169,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -116,7 +116,7 @@ index d79aec050701b43e029606ee181c9ac5236a08c6..b91a4968540d2dca4702582eb231b925
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1190,7 +1190,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1191,7 +1191,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0702-Line-Of-Sight-Changes.patch
+++ b/patches/server/0702-Line-Of-Sight-Changes.patch
@@ -19,10 +19,10 @@ index 702b166e032f1aedc8e1faa1e04738e768b40aa9..928fe7bb4ef959b7c8ab1f7d421612b9
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b91a4968540d2dca4702582eb231b925bd6709e1..7d6c2889a07c99412a47700f001ec1a3f72a3b45 100644
+index 2fccbe6e58a2e5a29c0cfe78b135854fbf402238..a2a8080314966fe2e5d2692d6ee2f6ca65207161 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -186,6 +186,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -187,6 +187,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public io.papermc.paper.world.MoonPhase getMoonPhase() {
          return io.papermc.paper.world.MoonPhase.getPhase(getFullTime() / 24000L);
      }

--- a/patches/server/0703-add-per-world-spawn-limits.patch
+++ b/patches/server/0703-add-per-world-spawn-limits.patch
@@ -30,10 +30,10 @@ index ba8ae4d1c86293ca5c95d830d145023b4fe21d71..fc9b69d87364b578327dffb657746c08
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7d6c2889a07c99412a47700f001ec1a3f72a3b45..527a1b5c523718af96009b4c52c40ed32906d49a 100644
+index a2a8080314966fe2e5d2692d6ee2f6ca65207161..00522af9b6c4938e9b0b169178243be53aab98d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -208,6 +208,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -209,6 +209,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;

--- a/patches/server/0768-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0768-Do-not-copy-visible-chunks.patch
@@ -156,10 +156,10 @@ index 82dbeb5a10104ed3599a007186f61b0c92bea2b1..58cf34b714ba98f35bdbe3895078ae4f
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 527a1b5c523718af96009b4c52c40ed32906d49a..c9eb449afef26a14a5859b3f248ec560a983c0a4 100644
+index 00522af9b6c4938e9b0b169178243be53aab98d8..5af560b0466ec5ba80489e8f3d65aa2ee298786c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -147,7 +147,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -148,7 +148,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      @Override
      public int getTileEntityCount() {
          // We don't use the full world tile entity list, so we must iterate chunks
@@ -168,7 +168,7 @@ index 527a1b5c523718af96009b4c52c40ed32906d49a..c9eb449afef26a14a5859b3f248ec560
          int size = 0;
          for (ChunkHolder playerchunk : chunks.values()) {
              net.minecraft.world.level.chunk.LevelChunk chunk = playerchunk.getTickingChunk();
-@@ -168,7 +168,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -169,7 +169,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      public int getChunkCount() {
          int ret = 0;
  
@@ -177,7 +177,7 @@ index 527a1b5c523718af96009b4c52c40ed32906d49a..c9eb449afef26a14a5859b3f248ec560
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -341,7 +341,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -342,7 +342,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {

--- a/patches/server/0769-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0769-Replace-player-chunk-loader-system.patch
@@ -1692,10 +1692,10 @@ index f0c43f9f636a5dd1f0dfbae604dfa1f4ff9ebd4e..9e75ee7f43722f05dd5df4ef00f7d3e2
              /*
               * If it's a new world, the first few chunks are generated inside
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index c9eb449afef26a14a5859b3f248ec560a983c0a4..f9df6e9d3d74e25a72abee8b43df21bbc0372409 100644
+index 5af560b0466ec5ba80489e8f3d65aa2ee298786c..883b2070fcf99cf10d44aef6dece0f7f84bfeeed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2040,14 +2040,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2041,14 +2041,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          net.minecraft.server.level.ChunkMap chunkMap = getHandle().getChunkSource().chunkMap;
@@ -1712,7 +1712,7 @@ index c9eb449afef26a14a5859b3f248ec560a983c0a4..f9df6e9d3d74e25a72abee8b43df21bb
      }
  
      @Override
-@@ -2056,11 +2056,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2057,11 +2057,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          net.minecraft.server.level.ChunkMap chunkMap = getHandle().getChunkSource().chunkMap;
@@ -1737,7 +1737,7 @@ index c9eb449afef26a14a5859b3f248ec560a983c0a4..f9df6e9d3d74e25a72abee8b43df21bb
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d6e82abc76cd72fa31c1b3f961f3f5d27ee7b043..1ccbdd2554073a41ca2f37deca3f1ec3e6a0665f 100644
+index aa9775083aa804d72965a7af4988b14551293571..2f943a5f5135d4bb7c516e09277ddf15b8732fca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -517,15 +517,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
This PR updates Paper to Adventure 4.9.1.

Included changes:
- Update to Adventure 4.9.1 (new `sendTitlePart` method implementation).
- Add `TriState` permission check to `Permissable`.
- Implement Adventure's Pointers system.
- Add Checker annotations back (removed in Adventure 4.9.0).
- Deprecates the string-based title API methods.