### PR TITLE
Separate the despawn ranges from the squared range

### DIFF
--- a/patches/server/0016-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0016-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,16 +5,18 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 419f3bca4c1dd18790ad9e602bdec009c2933606..4634da27cde654e682ac4525df9850ea40afbb87 100644
+index 419f3bca4c1dd18790ad9e602bdec009c2933606..e24f889a54118380bdb1f92a76456717b45e5ed7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -107,4 +107,20 @@ public class PaperWorldConfig {
+@@ -107,4 +107,22 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }
 +
 +    public int softDespawnDistance;
 +    public int hardDespawnDistance;
++    public int softDespawnDistanceSq;
++    public int hardDespawnDistanceSq;
 +    private void despawnDistances() {
 +        softDespawnDistance = getInt("despawn-ranges.soft", 32); // 32^2 = 1024, Minecraft Default
 +        hardDespawnDistance = getInt("despawn-ranges.hard", 128); // 128^2 = 16384, Minecraft Default
@@ -25,12 +27,12 @@ index 419f3bca4c1dd18790ad9e602bdec009c2933606..4634da27cde654e682ac4525df9850ea
 +
 +        log("Living Entity Despawn Ranges:  Soft: " + softDespawnDistance + " Hard: " + hardDespawnDistance);
 +
-+        softDespawnDistance = softDespawnDistance*softDespawnDistance;
-+        hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
++        softDespawnDistanceSq = softDespawnDistance*softDespawnDistance;
++        hardDespawnDistanceSq = hardDespawnDistance*hardDespawnDistance;
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index abaa57d9a4d222753d28801c6ab86b11c71aca6b..c9a9a4c6ba930dedb227c1f1d4ca4bb520983854 100644
+index abaa57d9a4d222753d28801c6ab86b11c71aca6b..8c432bd591735bad3f48bb9073bd1d0287dc3c29 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -778,16 +778,16 @@ public abstract class Mob extends LivingEntity {
@@ -38,7 +40,7 @@ index abaa57d9a4d222753d28801c6ab86b11c71aca6b..c9a9a4c6ba930dedb227c1f1d4ca4bb5
                  int j = i * i;
  
 -                if (d0 > (double) j) { // CraftBukkit - remove isTypeNotPersistent() check
-+                if (d0 > (double) level.paperConfig.hardDespawnDistance) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
++                if (d0 > (double) level.paperConfig.hardDespawnDistanceSq) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
                      this.discard();
                  }
  
@@ -46,10 +48,10 @@ index abaa57d9a4d222753d28801c6ab86b11c71aca6b..c9a9a4c6ba930dedb227c1f1d4ca4bb5
                  int l = k * k;
  
 -                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l) { // CraftBukkit - remove isTypeNotPersistent() check
-+                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > level.paperConfig.softDespawnDistance) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
++                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > level.paperConfig.softDespawnDistanceSq) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
                      this.discard();
 -                } else if (d0 < (double) l) {
-+                } else if (d0 < level.paperConfig.softDespawnDistance) { // Paper - custom despawn distances
++                } else if (d0 < level.paperConfig.softDespawnDistanceSq) { // Paper - custom despawn distances
                      this.noActionTime = 0;
                  }
              }

--- a/patches/server/0017-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0017-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4634da27cde654e682ac4525df9850ea40afbb87..9eb44bd14a5fd351d1514f4de8bc7ba328b0253d 100644
+index e24f889a54118380bdb1f92a76456717b45e5ed7..0d6f312d57ecd72d349287e498948c596b6e76be 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -123,4 +123,10 @@ public class PaperWorldConfig {
-         softDespawnDistance = softDespawnDistance*softDespawnDistance;
-         hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
+@@ -125,4 +125,10 @@ public class PaperWorldConfig {
+         softDespawnDistanceSq = softDespawnDistance*softDespawnDistance;
+         hardDespawnDistanceSq = hardDespawnDistance*hardDespawnDistance;
      }
 +
 +    public boolean keepSpawnInMemory;

--- a/patches/server/0018-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0018-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 * Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9eb44bd14a5fd351d1514f4de8bc7ba328b0253d..128b7cb5ed01f31555b169a6132a39fe4bfb90c7 100644
+index 0d6f312d57ecd72d349287e498948c596b6e76be..2b2b106c34ebd2986c0295debf3ca285e5ce29ca 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -129,4 +129,14 @@ public class PaperWorldConfig {
+@@ -131,4 +131,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }

--- a/patches/server/0028-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0028-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 128b7cb5ed01f31555b169a6132a39fe4bfb90c7..3978f58b320465e72b0f416282f79dace44766cc 100644
+index 2b2b106c34ebd2986c0295debf3ca285e5ce29ca..ab6efcbd83256f54268b828a7bcadb4011bf7623 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -139,4 +139,19 @@ public class PaperWorldConfig {
+@@ -141,4 +141,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }

--- a/patches/server/0031-Configurable-end-credits.patch
+++ b/patches/server/0031-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3978f58b320465e72b0f416282f79dace44766cc..7dee0219c69c5cf3025f63a9397f15f390ebe1ba 100644
+index ab6efcbd83256f54268b828a7bcadb4011bf7623..da6f0e85fb0210fbe1559d854396d49959c7fa12 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -154,4 +154,10 @@ public class PaperWorldConfig {
+@@ -156,4 +156,10 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/patches/server/0033-Optimize-explosions.patch
+++ b/patches/server/0033-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7dee0219c69c5cf3025f63a9397f15f390ebe1ba..83f869eca8bd1aa65add0a9f286aa09472cff1f3 100644
+index da6f0e85fb0210fbe1559d854396d49959c7fa12..6b4521d1dec8f4a50c1a01a9eb0f4a7381b27364 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -160,4 +160,10 @@ public class PaperWorldConfig {
+@@ -162,4 +162,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }
@@ -25,7 +25,7 @@ index 7dee0219c69c5cf3025f63a9397f15f390ebe1ba..83f869eca8bd1aa65add0a9f286aa094
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d9a305f39a4004f28ad5f8c35db1016c1bedea16..770134bd7a74616bf8d22439ff1ad1379fa27f0a 100644
+index b02306027b5aab96fd5036ec41296c8d3d9d99fd..0d58b58537de49ddb7c8c841e9077af4e727ba82 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1422,6 +1422,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0034-Disable-explosion-knockback.patch
+++ b/patches/server/0034-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83f869eca8bd1aa65add0a9f286aa09472cff1f3..cac8606f65e587d34e2ae12f5962f236c316751e 100644
+index 6b4521d1dec8f4a50c1a01a9eb0f4a7381b27364..bf1024b1909b407f4aa87bdaf58c0f84411df385 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -166,4 +166,9 @@ public class PaperWorldConfig {
+@@ -168,4 +168,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }
@@ -19,7 +19,7 @@ index 83f869eca8bd1aa65add0a9f286aa09472cff1f3..cac8606f65e587d34e2ae12f5962f236
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 914f69157ac5e5e9e77de968c4e328d8f44b9465..0f1a9e7561f6df4844545ff4565e996bb21eb9dc 100644
+index 9255134d9cdbeeb9529b4f962ea32c230c6c4403..eb9dac78db1a75a61b6bfdd6f3b6c829769355d2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1380,6 +1380,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0035-Disable-thunder.patch
+++ b/patches/server/0035-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cac8606f65e587d34e2ae12f5962f236c316751e..b18622c199f57e0d7c201582fe83bb75dca143f9 100644
+index bf1024b1909b407f4aa87bdaf58c0f84411df385..76a218cddca29a5a7800187b00325bd220d4ca7a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -171,4 +171,9 @@ public class PaperWorldConfig {
+@@ -173,4 +173,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/patches/server/0036-Disable-ice-and-snow.patch
+++ b/patches/server/0036-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b18622c199f57e0d7c201582fe83bb75dca143f9..a8e2bbe12255a071c6f9f68bd61cf6a8e2d6b159 100644
+index 76a218cddca29a5a7800187b00325bd220d4ca7a..1f18a4ed8392cc8f40d719404069b54965b4623e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -176,4 +176,9 @@ public class PaperWorldConfig {
+@@ -178,4 +178,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }

--- a/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a8e2bbe12255a071c6f9f68bd61cf6a8e2d6b159..e25050d2842503876da6694e72f54e1e47b0c439 100644
+index 1f18a4ed8392cc8f40d719404069b54965b4623e..1fbdc0b142868f56b5f3b557afc4f10b2a01ad8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -181,4 +181,9 @@ public class PaperWorldConfig {
+@@ -183,4 +183,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/patches/server/0040-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0040-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e25050d2842503876da6694e72f54e1e47b0c439..daf4c0bfc75476b34f8399c9b6685e83bbed5f9e 100644
+index 1fbdc0b142868f56b5f3b557afc4f10b2a01ad8a..482ddf96db3f09ff291e233afc108392a00c08a2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -186,4 +186,9 @@ public class PaperWorldConfig {
+@@ -188,4 +188,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }

--- a/patches/server/0044-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/patches/server/0044-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index daf4c0bfc75476b34f8399c9b6685e83bbed5f9e..7d9414e42991f9e82d7892f71e0c0612a53617eb 100644
+index 482ddf96db3f09ff291e233afc108392a00c08a2..b6131068acee9957c11d041d1c41f0a8149dc8f1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -191,4 +191,9 @@ public class PaperWorldConfig {
+@@ -193,4 +193,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/patches/server/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d9414e42991f9e82d7892f71e0c0612a53617eb..0f37c427ac66dd4a9f112255a021079c2e247d79 100644
+index b6131068acee9957c11d041d1c41f0a8149dc8f1..fafdd444d7f501fddaf4400917224ff57b8aab03 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -196,4 +196,9 @@ public class PaperWorldConfig {
+@@ -198,4 +198,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }

--- a/patches/server/0051-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0051-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0f37c427ac66dd4a9f112255a021079c2e247d79..d80de8777ae4d21256578c039e3fbe65ca9ade7c 100644
+index fafdd444d7f501fddaf4400917224ff57b8aab03..4122f1ba5cf93a8c7f7ab1ffceeb1192565c6b77 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -201,4 +201,13 @@ public class PaperWorldConfig {
+@@ -203,4 +203,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }

--- a/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d80de8777ae4d21256578c039e3fbe65ca9ade7c..1fc5b40f59a7edb25b0bd95f205a8fdf5c77fe64 100644
+index 4122f1ba5cf93a8c7f7ab1ffceeb1192565c6b77..7ab24721b75ad8f69adbc096f1236f9e774c5dd3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -210,4 +210,9 @@ public class PaperWorldConfig {
+@@ -212,4 +212,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
          portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }

--- a/patches/server/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1fc5b40f59a7edb25b0bd95f205a8fdf5c77fe64..664ef3fd4053172b16e00ab091a726e77bc31c74 100644
+index 7ab24721b75ad8f69adbc096f1236f9e774c5dd3..afbc8a8b8fdf61ce0bb7a885a29f0a3349ab398d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -215,4 +215,9 @@ public class PaperWorldConfig {
+@@ -217,4 +217,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }
@@ -37,7 +37,7 @@ index e26973d77ba380c91b2f0561f2c6c5886d7b82b8..9fbe3ed59416d773dc5c19d5ea73f95d
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0f1a9e7561f6df4844545ff4565e996bb21eb9dc..200aca8237dd7fbb0e4959831bda877c58ec37fb 100644
+index eb9dac78db1a75a61b6bfdd6f3b6c829769355d2..1ebfd0c77a5337a5ff8665f24655b8f2bc16a229 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -803,6 +803,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 664ef3fd4053172b16e00ab091a726e77bc31c74..9da18e568116a5279a7aa00023751e625bd5e9c0 100644
+index afbc8a8b8fdf61ce0bb7a885a29f0a3349ab398d..6ee8919442b4ba9a5a3f4de2fe1289e7ff9c32de 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -220,4 +220,19 @@ public class PaperWorldConfig {
+@@ -222,4 +222,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/patches/server/0069-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0069-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9da18e568116a5279a7aa00023751e625bd5e9c0..eae8a876b05c17d87b3971f8f2568ae5379feddb 100644
+index 6ee8919442b4ba9a5a3f4de2fe1289e7ff9c32de..04fcd1a6e7a16f95ebfc24d62dab297198d507d1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -235,4 +235,12 @@ public class PaperWorldConfig {
+@@ -237,4 +237,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/patches/server/0073-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0073-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eae8a876b05c17d87b3971f8f2568ae5379feddb..8ccdae60f97c38f7a56b68e94a801c7ee3fa9079 100644
+index 04fcd1a6e7a16f95ebfc24d62dab297198d507d1..8c56f7897f099642b8aaea14db1afb1f6bd2d0e0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -243,4 +243,14 @@ public class PaperWorldConfig {
+@@ -245,4 +245,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/patches/server/0079-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/patches/server/0079-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8ccdae60f97c38f7a56b68e94a801c7ee3fa9079..2c3754c0bcebc33f88168136b519baef6927553b 100644
+index 8c56f7897f099642b8aaea14db1afb1f6bd2d0e0..eafae7b8a1c1687fa98defbac526634558b4bb3a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -253,4 +253,10 @@ public class PaperWorldConfig {
+@@ -255,4 +255,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2c3754c0bcebc33f88168136b519baef6927553b..d9590dbc3db4ec4d32d86906bb290fbe2ca81ccd 100644
+index eafae7b8a1c1687fa98defbac526634558b4bb3a..89a8960ce277795889bda45175fb61bb5d08de4d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -259,4 +259,9 @@ public class PaperWorldConfig {
+@@ -261,4 +261,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d9590dbc3db4ec4d32d86906bb290fbe2ca81ccd..e480f1cd7830cd170f3744edec96221cbdfabe27 100644
+index 89a8960ce277795889bda45175fb61bb5d08de4d..77829587cc68b3303570ae5e0741685783ce281c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -264,4 +264,14 @@ public class PaperWorldConfig {
+@@ -266,4 +266,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e480f1cd7830cd170f3744edec96221cbdfabe27..7346ff09a8c2a04ce6f2b898fb7e23ed264ce951 100644
+index 77829587cc68b3303570ae5e0741685783ce281c..b3a256cc68992664aa5dc508d8b9e980ff1e0ee2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -274,4 +274,26 @@ public class PaperWorldConfig {
+@@ -276,4 +276,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7346ff09a8c2a04ce6f2b898fb7e23ed264ce951..057397e4a4e86122928c9a016d4b573b5860e9db 100644
+index b3a256cc68992664aa5dc508d8b9e980ff1e0ee2..18792b86e42fa0633202ef80496762a34bdbd407 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -296,4 +296,14 @@ public class PaperWorldConfig {
+@@ -298,4 +298,14 @@ public class PaperWorldConfig {
              );
          }
      }

--- a/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
+++ b/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 057397e4a4e86122928c9a016d4b573b5860e9db..e70c930d8ce1a385840b4fcf26fdeb8d8ee853b9 100644
+index 18792b86e42fa0633202ef80496762a34bdbd407..02fca10528874a2b627fc980b61f093d4ccf9047 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -306,4 +306,9 @@ public class PaperWorldConfig {
+@@ -308,4 +308,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e70c930d8ce1a385840b4fcf26fdeb8d8ee853b9..efdec6529abd5c0e09ee48f9cb4df3cd12bea31b 100644
+index 02fca10528874a2b627fc980b61f093d4ccf9047..5467dd1e030a4d2d32794302cd190b7732578ac5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -311,4 +311,12 @@ public class PaperWorldConfig {
+@@ -313,4 +313,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index efdec6529abd5c0e09ee48f9cb4df3cd12bea31b..b2b3f336ac4e5d9c2598ecc7b3202d1efdd55feb 100644
+index 5467dd1e030a4d2d32794302cd190b7732578ac5..186961beab5ab8070a43bedab96b0156b0c54cce 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -319,4 +319,14 @@ public class PaperWorldConfig {
+@@ -321,4 +321,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b2b3f336ac4e5d9c2598ecc7b3202d1efdd55feb..91e9672d01b6042d6f9a0f96c351ad97dfee0b73 100644
+index 186961beab5ab8070a43bedab96b0156b0c54cce..a32dcbdba15cfedb2c0d08ce6638e1c2f85f49cf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -329,4 +329,10 @@ public class PaperWorldConfig {
+@@ -331,4 +331,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 91e9672d01b6042d6f9a0f96c351ad97dfee0b73..f4c80bc26f4f7cf02d368df4d9717cf1ca3e0730 100644
+index a32dcbdba15cfedb2c0d08ce6638e1c2f85f49cf..c756b8a7826bda27a2b1b42e0663215ae30c58e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -335,4 +335,10 @@ public class PaperWorldConfig {
+@@ -337,4 +337,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }

--- a/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f4c80bc26f4f7cf02d368df4d9717cf1ca3e0730..e6c29e08b20734c3f64e1d596d103a5c1fbb6920 100644
+index c756b8a7826bda27a2b1b42e0663215ae30c58e2..6a1b93f18690e92afeee643fe298a684740b0e50 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -341,4 +341,10 @@ public class PaperWorldConfig {
+@@ -343,4 +343,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
+++ b/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e6c29e08b20734c3f64e1d596d103a5c1fbb6920..b6e762fbb79d19affb93e10ed0cbe29c2d0b6c22 100644
+index 6a1b93f18690e92afeee643fe298a684740b0e50..a9824ce8dfd5afba63ca42aff071847ef4867ccc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -347,4 +347,9 @@ public class PaperWorldConfig {
+@@ -349,4 +349,9 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b6e762fbb79d19affb93e10ed0cbe29c2d0b6c22..0f1252ae47df5568b6844e76dceb3e8e4c8394c8 100644
+index a9824ce8dfd5afba63ca42aff071847ef4867ccc..0286878f0649134ca7cf7f15a8a6d1ed0238f881 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -197,6 +197,11 @@ public class PaperWorldConfig {
+@@ -199,6 +199,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  

--- a/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0f1252ae47df5568b6844e76dceb3e8e4c8394c8..f3ce248c576643ec172ba42c4bea41a59cfe9ec6 100644
+index 0286878f0649134ca7cf7f15a8a6d1ed0238f881..8d913235ab37fe22082c9e0d19c4b8c7dcb7531f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -357,4 +357,9 @@ public class PaperWorldConfig {
+@@ -359,4 +359,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }

--- a/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f3ce248c576643ec172ba42c4bea41a59cfe9ec6..10f7437d62bfa774309d6334ca791505254bcaf7 100644
+index 8d913235ab37fe22082c9e0d19c4b8c7dcb7531f..2ab2dd8be896a61f14d59b9ca427af4188c780fc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -362,4 +362,10 @@ public class PaperWorldConfig {
+@@ -364,4 +364,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }
@@ -27,7 +27,7 @@ index f3ce248c576643ec172ba42c4bea41a59cfe9ec6..10f7437d62bfa774309d6334ca791505
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index e4294219be68c6f99cd0e5ea8330fae6dc03ddde..b09f52330b50879d5594b21302e70ca676b60951 100644
+index 4306db7db2c5b4eb1529dc3e9f0659ead2688fa5..8af1571c614a39c9673e0dc90e3aa9a89a367e34 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -88,6 +88,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 10f7437d62bfa774309d6334ca791505254bcaf7..6d2d82c24c9f43fab2cddee03960325c15708a58 100644
+index 2ab2dd8be896a61f14d59b9ca427af4188c780fc..98e97996867dcfe1b470673a86749b15c3197184 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -368,4 +368,9 @@ public class PaperWorldConfig {
+@@ -370,4 +370,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6d2d82c24c9f43fab2cddee03960325c15708a58..cd2bf3596e2d1cb5bbffa727976a9bee9319dcf5 100644
+index 98e97996867dcfe1b470673a86749b15c3197184..10e9fba86017a5b41664c1000d0d4aa45fa9b7b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -373,4 +373,9 @@ public class PaperWorldConfig {
+@@ -375,4 +375,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cd2bf3596e2d1cb5bbffa727976a9bee9319dcf5..0edbd0bf3d7d71b73bcf5cb9da233e8dcfca346f 100644
+index 10e9fba86017a5b41664c1000d0d4aa45fa9b7b4..6ce95411639153c367b3b0f33250909079dab7f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -378,4 +378,9 @@ public class PaperWorldConfig {
+@@ -380,4 +380,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0edbd0bf3d7d71b73bcf5cb9da233e8dcfca346f..3c7af3c4dc864c1143451350861e64093a2f5a06 100644
+index 6ce95411639153c367b3b0f33250909079dab7f4..ffa0f3e0def9db402c9bc747f64432da2c7087f1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -383,4 +383,10 @@ public class PaperWorldConfig {
+@@ -385,4 +385,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3c7af3c4dc864c1143451350861e64093a2f5a06..316978a376f57b420c946e87c16f2bc3b09425e1 100644
+index ffa0f3e0def9db402c9bc747f64432da2c7087f1..8db42424e8a8ee35bd202ec401c980d443725647 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -389,4 +389,10 @@ public class PaperWorldConfig {
+@@ -391,4 +391,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 316978a376f57b420c946e87c16f2bc3b09425e1..2a7d31f533240e0b683c00d65f5632d7a8ff236d 100644
+index 8db42424e8a8ee35bd202ec401c980d443725647..4a85edb5669c08b55fd72b834b58d8e7efa1647d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -395,4 +395,9 @@ public class PaperWorldConfig {
+@@ -397,4 +397,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3816623fa85db14a89bd165221695de1a39e70c0..9d52060319e6a0403c9979766c761e2f5324f6aa 100644
+index 80b14ca59ff1a5e7c6a5e093b893bd509e56a2e2..39210a9e25bf1a72d3ef13d41e2a708bdeb2a7d3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -406,4 +406,15 @@ public class PaperWorldConfig {
+@@ -408,4 +408,15 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/patches/server/0339-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0339-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9d52060319e6a0403c9979766c761e2f5324f6aa..de1820a6b0e568bbc13eea7a31e5cd40234c0f66 100644
+index 39210a9e25bf1a72d3ef13d41e2a708bdeb2a7d3..b9f596a20e8035fa2fa164e822b87fd5390c0f34 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -416,5 +416,10 @@ public class PaperWorldConfig {
+@@ -418,5 +418,10 @@ public class PaperWorldConfig {
              log("Using improved mob spawn limits (Only Natural Spawns impact spawn limits for more natural spawns)");
          }
      }
@@ -40,7 +40,7 @@ index 9d52060319e6a0403c9979766c761e2f5324f6aa..de1820a6b0e568bbc13eea7a31e5cd40
  }
  
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index 21ce4be0d8d0147a92f87e17bb5078a211419984..37356b36f0ae12d55150f399318581fa77c30cee 100644
+index 458a70f6e76eba707b890c78cbfd4f967eaf8a1b..6339203bda5e569d5df241dd589eb36e7233704b 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -161,7 +161,7 @@ public abstract class Projectile extends Entity {

--- a/patches/server/0344-Generator-Settings.patch
+++ b/patches/server/0344-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de1820a6b0e568bbc13eea7a31e5cd40234c0f66..d3cd79cf51bc7bead548549c25d5ae7b67d704c3 100644
+index b9f596a20e8035fa2fa164e822b87fd5390c0f34..52e6b01aac646e847bf77974f51ff116f1811436 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -421,5 +421,10 @@ public class PaperWorldConfig {
+@@ -423,5 +423,10 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
@@ -20,7 +20,7 @@ index de1820a6b0e568bbc13eea7a31e5cd40234c0f66..d3cd79cf51bc7bead548549c25d5ae7b
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6d0092c8a71d775ffbe03374199a4be28f418058..4ab3f694dda4d766d0421977d270f7b71b2db217 100644
+index 0bb5071f78644607eaed2a4d4a74262e99f3ed72..a61d1e0291f336365872f0051c6ca29708e4b903 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -726,7 +726,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
+++ b/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d3cd79cf51bc7bead548549c25d5ae7b67d704c3..216eda49d1540c857e2c108c3d3e2e135ef90013 100644
+index 52e6b01aac646e847bf77974f51ff116f1811436..4c819ab586069ee36b26195320c56f4c345223f9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -426,5 +426,10 @@ public class PaperWorldConfig {
+@@ -428,5 +428,10 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 216eda49d1540c857e2c108c3d3e2e135ef90013..2bfab88523bd5825db29b6a00b5bc1aa40324de8 100644
+index 4c819ab586069ee36b26195320c56f4c345223f9..4b3b74bf01167e2726c2a4e9005298893012256d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -431,5 +431,10 @@ public class PaperWorldConfig {
+@@ -433,5 +433,10 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2bfab88523bd5825db29b6a00b5bc1aa40324de8..031829d1ba1e859368878245fe0edb6fbe726821 100644
+index 4b3b74bf01167e2726c2a4e9005298893012256d..0d811469667d7d2847c8845330fa7832edb46d9f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -407,6 +407,45 @@ public class PaperWorldConfig {
+@@ -409,6 +409,45 @@ public class PaperWorldConfig {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
  
@@ -83,7 +83,7 @@ index 2bfab88523bd5825db29b6a00b5bc1aa40324de8..031829d1ba1e859368878245fe0edb6f
      private void countAllMobsForSpawning() {
          countAllMobsForSpawning = getBoolean("count-all-mobs-for-spawning", false);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 4ab3f694dda4d766d0421977d270f7b71b2db217..68997cc0b534c46c33c0f137738fbaca5569445b 100644
+index a61d1e0291f336365872f0051c6ca29708e4b903..c7d09502ff0c035300ecd0eb05ed876e27d29995 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,6 +1,7 @@

--- a/patches/server/0353-Optimize-Hoppers.patch
+++ b/patches/server/0353-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 031829d1ba1e859368878245fe0edb6fbe726821..d01f5df4ec18a35fbf6222d76a2617a07f20a87b 100644
+index 0d811469667d7d2847c8845330fa7832edb46d9f..c922aac62938455207966d99f2a579e2983a5421 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -475,5 +475,14 @@ public class PaperWorldConfig {
+@@ -477,5 +477,14 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
@@ -32,7 +32,7 @@ index 031829d1ba1e859368878245fe0edb6fbe726821..d01f5df4ec18a35fbf6222d76a2617a0
  }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1fa7e8890987f8f98af51e7e4cc03596f2207678..02766d82e48ea4e3adaa7a5b3957fe6b4c94d38a 100644
+index 728719e488444ada53698a4aa7ac66ded324bf67..8284c8690295cf9e57c47f198058c3e4ad39191b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1442,6 +1442,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0365-Increase-Light-Queue-Size.patch
+++ b/patches/server/0365-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d01f5df4ec18a35fbf6222d76a2617a07f20a87b..27de7cdc4f3bb5604162f2cc114fcd27a6ed4a14 100644
+index c922aac62938455207966d99f2a579e2983a5421..4afd697097d9705dc26840090078952850dd576d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -484,5 +484,10 @@ public class PaperWorldConfig {
+@@ -486,5 +486,10 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
@@ -29,7 +29,7 @@ index d01f5df4ec18a35fbf6222d76a2617a07f20a87b..27de7cdc4f3bb5604162f2cc114fcd27
  }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 02766d82e48ea4e3adaa7a5b3957fe6b4c94d38a..273774ad46b993212a0cd4cfa81f0e02807c442e 100644
+index 8284c8690295cf9e57c47f198058c3e4ad39191b..026397cbedd2d1cd08ec8a82a3468f35cd8e4765 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -844,7 +844,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 27de7cdc4f3bb5604162f2cc114fcd27a6ed4a14..4dde7eec6afad0b4340631482dc23a9796736d43 100644
+index 4afd697097d9705dc26840090078952850dd576d..9c90dc35a980f47c1674f9931c2250408c7d7439 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,7 +1,9 @@
@@ -18,7 +18,7 @@ index 27de7cdc4f3bb5604162f2cc114fcd27a6ed4a14..4dde7eec6afad0b4340631482dc23a97
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -489,5 +491,40 @@ public class PaperWorldConfig {
+@@ -491,5 +493,40 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
@@ -1091,7 +1091,7 @@ index c28879f32b004f36ff746ea2274f91ddd9501e71..60d72e488bc77cd913328be400ca374a
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 63d52f6f0c0097654ddab05fea4bd809dc612a9b..292fb6d71ca8bd63ad04d87d04f13b7f4f6f98fc 100644
+index 15d398ad9c9ee021880888317144b150144d8a38..2bbba8239cdce5952817b992879f00f35abdee67 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1534,7 +1534,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index ee53453440177537fc653ea156785d7591498614..cfe293881f68c8db337c3a48948362bb
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4dde7eec6afad0b4340631482dc23a9796736d43..f3ba9d869179fb4dc86acf1f4d097fb0da701a09 100644
+index 9c90dc35a980f47c1674f9931c2250408c7d7439..55b0768ed0971630c14bd4a5d533ef5c6c5bca20 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -492,6 +492,11 @@ public class PaperWorldConfig {
+@@ -494,6 +494,11 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  
@@ -145,7 +145,7 @@ index 1ea32090783ac5b885b95ae2009dd61de3063ae0..8d3cdd288eacc91f7c9a624f601284e5
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getOrScheduleFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 292fb6d71ca8bd63ad04d87d04f13b7f4f6f98fc..831394e82fd04daf00971019a7d479629e83baaf 100644
+index 2bbba8239cdce5952817b992879f00f35abdee67..1caa33f1bdae0df640ac28036679bef28e15867f 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -127,7 +127,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0369-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0369-Implement-alternative-item-despawn-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f3ba9d869179fb4dc86acf1f4d097fb0da701a09..c2601c8d0635e4150be622fc681c2f4adb55bc59 100644
+index 55b0768ed0971630c14bd4a5d533ef5c6c5bca20..24c901b2e00f080d41a2459907d2ee5771d3714f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -497,6 +497,54 @@ public class PaperWorldConfig {
+@@ -499,6 +499,54 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index fe79c0add4f7cb18d487c5bb9415c40c5b551ea2..8d9ddad1879e7616d980ca70de8aecac
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c2601c8d0635e4150be622fc681c2f4adb55bc59..9dfb35654df01cf8fea6cf1842786f8466419729 100644
+index 24c901b2e00f080d41a2459907d2ee5771d3714f..a914d20f390104c9793561bdc4a7eba76bd5f8ee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -579,5 +579,13 @@ public class PaperWorldConfig {
+@@ -581,5 +581,13 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }
@@ -548,7 +548,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 48ca60925b15d7e320cf07467bd0cf9ddee2a036..46b23a1e543c55b71a7837af41df8cf89d72c22b 100644
+index ccd5cbb9505fc76df030c4d41bf4ecdd05646215..afe44d5e8a82ddde71395290626c17dadf078fe5 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -145,6 +145,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -589,7 +589,7 @@ index 48ca60925b15d7e320cf07467bd0cf9ddee2a036..46b23a1e543c55b71a7837af41df8cf8
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index ddd535ad7d2b051e0d05320e4491bad46df8ffbe..cb273030b70f1d41110b90effe3d542ab930fe39 100644
+index 5d920d7df52c12f5f1d1d8111340800cbddaac78..9f71dc37b0cef2284d6abc051b379cfa1b7e1eb5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -912,7 +912,22 @@ public class ServerChunkCache extends ChunkSource {
@@ -641,7 +641,7 @@ index 0b11b136834f57a633f9461c7ad956b3c531f3ea..61202cc8610b9becb5e44e1897ff372b
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 95e5660e6cb1afb5ebdb3dbbe59a07c879bddb4b..88145f04989c71a686aae1b486087ecdf55e268c 100644
+index 95e5660e6cb1afb5ebdb3dbbe59a07c879bddb4b..75fc88e7def31a133e7d2a493507eacff2e7342d 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -17,6 +17,7 @@ import net.minecraft.core.Registry;

--- a/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9dfb35654df01cf8fea6cf1842786f8466419729..6316597c52cb23f3cea81c95c0f7a7a289028537 100644
+index a914d20f390104c9793561bdc4a7eba76bd5f8ee..177acd5d34531c7aeac2d32d73d8674ae3dd5ad2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -487,6 +487,11 @@ public class PaperWorldConfig {
+@@ -489,6 +489,11 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  

--- a/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6316597c52cb23f3cea81c95c0f7a7a289028537..7dbd6fad3824bfe62c6c2a59804fb8723f8745d1 100644
+index 177acd5d34531c7aeac2d32d73d8674ae3dd5ad2..ae884447c8004bee71e6979812fe5db98acda44a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -387,6 +387,11 @@ public class PaperWorldConfig {
+@@ -389,6 +389,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7dbd6fad3824bfe62c6c2a59804fb8723f8745d1..1218411afe1e2e3c2ee54aec6287ff33b59afd01 100644
+index ae884447c8004bee71e6979812fe5db98acda44a..e6cddbb609b0eb2832e1d0dfff4045e9760b040b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -497,6 +497,11 @@ public class PaperWorldConfig {
+@@ -499,6 +499,11 @@ public class PaperWorldConfig {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
  

--- a/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1218411afe1e2e3c2ee54aec6287ff33b59afd01..03c45d4fa891e9f00d4b6b24cfc144086294618b 100644
+index e6cddbb609b0eb2832e1d0dfff4045e9760b040b..8a86d00895dc75513e8f64825fccf1f6b7d9e96f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -474,10 +474,21 @@ public class PaperWorldConfig {
+@@ -476,10 +476,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/patches/server/0420-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0420-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 03c45d4fa891e9f00d4b6b24cfc144086294618b..e146dad0d90fee216630eb3df6a34e2a0f6441a6 100644
+index 8a86d00895dc75513e8f64825fccf1f6b7d9e96f..d566e5662bf04f638d3d012aa1273b8b0fbb5e8a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -518,6 +518,13 @@ public class PaperWorldConfig {
+@@ -520,6 +520,13 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  

--- a/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e146dad0d90fee216630eb3df6a34e2a0f6441a6..eb30ec087b90835aba281580b0563d020440be0e 100644
+index d566e5662bf04f638d3d012aa1273b8b0fbb5e8a..31898cdc4c30046d5291839bd2dc4a44c75a1f1d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -361,6 +361,12 @@ public class PaperWorldConfig {
+@@ -363,6 +363,12 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  
@@ -22,7 +22,7 @@ index e146dad0d90fee216630eb3df6a34e2a0f6441a6..eb30ec087b90835aba281580b0563d02
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 09e0b2fface050699872341215c257d4b8f403c2..bb80d9840fd9448bf18df00c205a93a623b45ba9 100644
+index c5cce149d5b0c8371be6c38a97c37decf9919099..9fadec1e4a1be8f769f54bd0329c37bd672bc640 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -629,16 +629,30 @@ public class CraftEventFactory {

--- a/patches/server/0452-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0452-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eb30ec087b90835aba281580b0563d020440be0e..3984d85f1e1833ec199fde1ba64d9c83376b1819 100644
+index 31898cdc4c30046d5291839bd2dc4a44c75a1f1d..c4f6f59299aabfe1c231d19e2aa87f84314c256a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -536,6 +536,15 @@ public class PaperWorldConfig {
+@@ -538,6 +538,15 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0551-Seed-based-feature-search.patch
+++ b/patches/server/0551-Seed-based-feature-search.patch
@@ -21,10 +21,10 @@ changes but this should usually not happen. A config option to disable
 this completely is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b5ede8b54261753b09f770428e9bf23f356bb8ea..a2dfbb2380b468b0ae41c01039a949a58bb49550 100644
+index d7cbc246fee1c8d1714afbae3dde28bc7034fab1..9b71694c6838b9127c031992affa0377c51824ba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -381,6 +381,14 @@ public class PaperWorldConfig {
+@@ -383,6 +383,14 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0589-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0589-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e81325c323d2e07fab4f3db2c812a08549453760..9c0ab3605375c7255204d3a27bc542f1e6b1761d 100644
+index 1d6908e898284acf3749eebc65922b81a646a1f8..baf42d44631010b8d1d7acb05ce3f9118f52c45a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -435,6 +435,14 @@ public class PaperWorldConfig {
+@@ -437,6 +437,14 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  

--- a/patches/server/0604-Configurable-max-leash-distance.patch
+++ b/patches/server/0604-Configurable-max-leash-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max leash distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1c6cca5452a2635509003b6daba30605d3433d88..4cdc6766b82345ec01d1a4f5cfddb76be5511460 100644
+index 5af8b2918aa59514ae2af4804635611047c79dc6..ba115f69bfbba4f8b333a1422605d5b7f717b552 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -268,6 +268,12 @@ public class PaperWorldConfig {
+@@ -270,6 +270,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0609-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0609-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add toggle for always placing the dragon egg
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4cdc6766b82345ec01d1a4f5cfddb76be5511460..c17747e226dd5c4ec1c4142d4fa60b7def21e90e 100644
+index ba115f69bfbba4f8b333a1422605d5b7f717b552..7a2545de428ffd082fffc860cc24f3b48c23933e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -762,5 +762,10 @@ public class PaperWorldConfig {
+@@ -764,5 +764,10 @@ public class PaperWorldConfig {
          }
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }

--- a/patches/server/0616-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0616-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c17747e226dd5c4ec1c4142d4fa60b7def21e90e..5e45ad4638d94b4602c660aab72ee8bb7ead9de6 100644
+index 7a2545de428ffd082fffc860cc24f3b48c23933e..84341a99aa536817ea92c414432f6d4c2e36c666 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -767,5 +767,10 @@ public class PaperWorldConfig {
+@@ -769,5 +769,10 @@ public class PaperWorldConfig {
      private void enderDragonsDeathAlwaysPlacesDragonEgg() {
          enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
      }

--- a/patches/server/0626-MC-29274-Fix-Wither-hostility-towards-players.patch
+++ b/patches/server/0626-MC-29274-Fix-Wither-hostility-towards-players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-29274: Fix Wither hostility towards players
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e45ad4638d94b4602c660aab72ee8bb7ead9de6..e53b6515ca427b90f21441cf142ecde6e986058d 100644
+index 84341a99aa536817ea92c414432f6d4c2e36c666..4b115066257b876e08f298f717862c2eaabb7c22 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -772,5 +772,11 @@ public class PaperWorldConfig {
+@@ -774,5 +774,11 @@ public class PaperWorldConfig {
      private void setUpdatePathfindingOnBlockUpdate() {
          updatePathfindingOnBlockUpdate = getBoolean("update-pathfinding-on-block-update", this.updatePathfindingOnBlockUpdate);
      }

--- a/patches/server/0636-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0636-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e53b6515ca427b90f21441cf142ecde6e986058d..1da69d56f0b58708d4c85e76307b725221f9caed 100644
+index 4b115066257b876e08f298f717862c2eaabb7c22..04495592ebb71cea9a09daa25c24abc39cae0c15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -778,5 +778,10 @@ public class PaperWorldConfig {
+@@ -780,5 +780,10 @@ public class PaperWorldConfig {
          fixWitherTargetingBug = getBoolean("fix-wither-targeting-bug", false);
          log("Withers properly target players: " + fixWitherTargetingBug);
      }
@@ -20,7 +20,7 @@ index e53b6515ca427b90f21441cf142ecde6e986058d..1da69d56f0b58708d4c85e76307b7252
  }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index cd2494a8396ef7f4372207ab89271386efdffa4f..35ccf3b784c114df269151ec9beed3de6b294319 100644
+index 7041a4503285f7df7aed286229a2ffb7f22668a4..fc4df23af7986d3580f265d640d074c567a77c02 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1723,7 +1723,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0691-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0691-Limit-item-frame-cursors-on-maps.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5eeb09c7cbc743c4273a6d02d9f0c357c2724ba2..436362e1325284278484c7fd10f533041cad89dd 100644
+index 1dcc1dea9ad25bea8a29c40f5d6183219f4c1b3e..ee67309d583025fa30df3a3d0389bbd7679d88e1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -818,5 +818,10 @@ public class PaperWorldConfig {
+@@ -820,5 +820,10 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }

--- a/patches/server/0696-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0696-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 436362e1325284278484c7fd10f533041cad89dd..42ad87b87305f394777cdd97f00f2e8d40a6b5e8 100644
+index ee67309d583025fa30df3a3d0389bbd7679d88e1..f95421969d32abdb5deb08f4246924f63be20279 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -823,5 +823,10 @@ public class PaperWorldConfig {
+@@ -825,5 +825,10 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0698-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0698-Fix-invulnerable-end-crystals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 42ad87b87305f394777cdd97f00f2e8d40a6b5e8..ba8ae4d1c86293ca5c95d830d145023b4fe21d71 100644
+index f95421969d32abdb5deb08f4246924f63be20279..f4c0ae4a7a6ab9bfe07dfcc7b358ecf04204b26f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -828,5 +828,10 @@ public class PaperWorldConfig {
+@@ -830,5 +830,10 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0704-add-per-world-spawn-limits.patch
+++ b/patches/server/0704-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ba8ae4d1c86293ca5c95d830d145023b4fe21d71..fc9b69d87364b578327dffb657746c08ab505be3 100644
+index f4c0ae4a7a6ab9bfe07dfcc7b358ecf04204b26f..1eb712d2e440df967cb08513b94ad3a6d7b5a724 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -681,6 +681,19 @@ public class PaperWorldConfig {
+@@ -683,6 +683,19 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  

--- a/patches/server/0714-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0714-Fix-commands-from-signs-not-firing-command-events.patch
@@ -10,10 +10,10 @@ This patch changes sign command logic so that `run_command` click events:
   - sends failure messages to the player who clicked the sign
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fc9b69d87364b578327dffb657746c08ab505be3..04b27d96d7a6396989c6a9d67b92af259dc0cc26 100644
+index 1eb712d2e440df967cb08513b94ad3a6d7b5a724..90481fa1e418368e172c7529e75fdd2a91d19604 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -846,5 +846,10 @@ public class PaperWorldConfig {
+@@ -848,5 +848,10 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }

--- a/patches/server/0717-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0717-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04b27d96d7a6396989c6a9d67b92af259dc0cc26..2bfadd245b5d08c1b77805ee049456cc786c093e 100644
+index 90481fa1e418368e172c7529e75fdd2a91d19604..82a0234255959c9d93a698824f7c867aaa9d0990 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -671,6 +671,21 @@ public class PaperWorldConfig {
+@@ -673,6 +673,21 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  

--- a/patches/server/0720-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0720-Don-t-apply-cramming-damage-to-players.patch
@@ -11,10 +11,10 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2bfadd245b5d08c1b77805ee049456cc786c093e..88abb1dfd994e5bc51aa181121407f3d84f85f5b 100644
+index 82a0234255959c9d93a698824f7c867aaa9d0990..8ce9cfa2948684904aab6784ab185477164323ef 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -866,5 +866,10 @@ public class PaperWorldConfig {
+@@ -868,5 +868,10 @@ public class PaperWorldConfig {
      private void showSignClickCommandFailureMessagesToPlayer() {
          showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }

--- a/patches/server/0721-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0721-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..34d3ca57acd3aa37a37d44cd81bdd10967f12aaa 100644
+index 8ce9cfa2948684904aab6784ab185477164323ef..f99e4b82ed7db06035bdb95289c01b99d876435c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,14 +3,19 @@ package com.destroystokyo.paper;
@@ -51,7 +51,7 @@ index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..34d3ca57acd3aa37a37d44cd81bdd109
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -871,5 +876,58 @@ public class PaperWorldConfig {
+@@ -873,5 +878,58 @@ public class PaperWorldConfig {
      private void playerCrammingDamage() {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }

--- a/patches/server/0738-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0738-Configurable-item-frame-map-cursor-update-interval.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable item frame map cursor update interval
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a14602b6ef00e9ac544582c0d8f4f43a5fcbf908..e1f386cccdf0d2f6831c86667230e0bc8ee39cc9 100644
+index 7909ee5994594441a81b66c425f14374521bc0f5..eadb185a5e7f881e06b5b5949ceea55ced755a5c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -862,6 +862,11 @@ public class PaperWorldConfig {
+@@ -864,6 +864,11 @@ public class PaperWorldConfig {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }
  

--- a/patches/server/0801-Configurable-feature-seeds.patch
+++ b/patches/server/0801-Configurable-feature-seeds.patch
@@ -19,10 +19,10 @@ index 7d44abcb4fff9717a1af55879deb7eb9c2d9e7e9..e29b0a90019b12bd6586ad0f7b5314f3
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e1f386cccdf0d2f6831c86667230e0bc8ee39cc9..78024e0b05fd24a0c3340f052fe8eb40191afdd6 100644
+index eadb185a5e7f881e06b5b5949ceea55ced755a5c..043550771fe2ef7f6496f3f0ede12776afa166d3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -927,6 +927,55 @@ public class PaperWorldConfig {
+@@ -929,6 +929,55 @@ public class PaperWorldConfig {
          return table;
      }
  


### PR DESCRIPTION
The patch "Optimise player lookups" uses the hard despawn distance when looking
for players. However, the method expects a normal range instead of the squared
range given. This change (goofy as it looks, since it doesn't modify the
problematic patch) ensures that the squared range is used for squared checks,
and the normal ranges are still available for non-squared checks.

I forgot to mention this is an optimization. It should be looking up to 128 blocks away for players, but instead looks 128*128=16384 blocks for players.