### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0157-Add-Material-Tags.patch
+++ b/patches/api/0157-Add-Material-Tags.patch
@@ -958,10 +958,10 @@ index 0000000000000000000000000000000000000000..683688edff2c86d92f6b3e15271c3289
 +        .ensureSize("WATER_BASED", 11);
 +}
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 53b66c28f0fed97664d0886683731e94ca59bdd2..88ea8b6c5c2c4d2116f646341de62590718bc28c 100644
+index c86ac9f44c81ed86a157f0666b52e8a4d8e9304c..cbe233c67f97452f662bb49ec5778f7187bf3441 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -10,6 +10,10 @@ import org.jetbrains.annotations.NotNull;
+@@ -11,6 +11,10 @@ import org.jetbrains.annotations.NotNull;
   * Note that whilst all tags defined within this interface must be present in
   * implementations, their existence is not guaranteed across future versions.
   *

--- a/patches/api/0165-Support-cancellation-supression-of-EntityDismount-Ve.patch
+++ b/patches/api/0165-Support-cancellation-supression-of-EntityDismount-Ve.patch
@@ -21,7 +21,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
-index 963b9ead4ca0426b2e95c5641b0e89317c48853d..a976c32de6ad5e90b0a96a0f387136ab0f5eb52e 100644
+index 963b9ead4ca0426b2e95c5641b0e89317c48853d..39f6afd2f9cbcff6a74a91a21dcc3e29d2497dd8 100644
 --- a/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 +++ b/src/main/java/org/bukkit/event/vehicle/VehicleExitEvent.java
 @@ -13,10 +13,18 @@ public class VehicleExitEvent extends VehicleEvent implements Cancellable {
@@ -57,7 +57,7 @@ index 963b9ead4ca0426b2e95c5641b0e89317c48853d..a976c32de6ad5e90b0a96a0f387136ab
  
 +    public boolean isCancellable() {
 +        return isCancellable;
-+        // paper end
++        // Paper end
 +    }
 +
      @NotNull

--- a/patches/api/0264-Added-Vanilla-Entity-Tags.patch
+++ b/patches/api/0264-Added-Vanilla-Entity-Tags.patch
@@ -5,37 +5,49 @@ Subject: [PATCH] Added Vanilla Entity Tags
 
 
 diff --git a/src/main/java/org/bukkit/Tag.java b/src/main/java/org/bukkit/Tag.java
-index 88ea8b6c5c2c4d2116f646341de62590718bc28c..a2da2cbef6c09b9defbdf97e79cfb3efd742d439 100644
+index cbe233c67f97452f662bb49ec5778f7187bf3441..7893402e43aeaa2846f728b2d6f06fcc93fda23f 100644
 --- a/src/main/java/org/bukkit/Tag.java
 +++ b/src/main/java/org/bukkit/Tag.java
-@@ -589,6 +589,32 @@ public interface Tag<T extends Keyed> extends Keyed {
-      * Vanilla fluid tag representing water and flowing water.
+@@ -634,6 +634,44 @@ public interface Tag<T extends Keyed> extends Keyed {
+      * Vanilla tag representing entities extra susceptible to freezing.
       */
-     Tag<Fluid> FLUIDS_WATER = Bukkit.getTag(REGISTRY_FLUIDS, NamespacedKey.minecraft("water"), Fluid.class);
+     Tag<EntityType> ENTITY_TYPES_FREEZE_HURTS_EXTRA_TYPES = Bukkit.getTag(REGISTRY_ENTITY_TYPES, NamespacedKey.minecraft("freeze_hurts_extra_types"), EntityType.class);
 +    // Paper start
 +    /**
-+     * Key for the build in entity registry
++     * Key for the built-in entity registry
++     * @deprecated use {@link #REGISTRY_ENTITY_TYPES}
 +     */
++    @Deprecated(forRemoval = true)
 +    String REGISTRY_ENTITIES = "entities";
 +    /**
 +     * Vanilla entity tag representing arrow entities.
++     * @deprecated use {@link #ENTITY_TYPES_ARROWS}
 +     */
++    @Deprecated(forRemoval = true)
 +    Tag<org.bukkit.entity.EntityType> ARROWS = Bukkit.getTag(REGISTRY_ENTITIES, NamespacedKey.minecraft("arrows"), org.bukkit.entity.EntityType.class);
 +    /**
 +     * Vanilla entity tag representing entities that live in beehives
++     * @deprecated use {@link #ENTITY_TYPES_BEEHIVE_INHABITORS}
 +     */
++    @Deprecated(forRemoval = true)
 +    Tag<org.bukkit.entity.EntityType> BEEHIVE_INHABITORS = Bukkit.getTag(REGISTRY_ENTITIES, NamespacedKey.minecraft("beehive_inhabitors"), org.bukkit.entity.EntityType.class);
 +    /**
 +     * Vanilla entity tag representing projectiles that impact
++     * @deprecated use {@link #ENTITY_TYPES_IMPACT_PROJECTILES}
 +     */
++    @Deprecated(forRemoval = true)
 +    Tag<org.bukkit.entity.EntityType> IMPACT_PROJECTILES = Bukkit.getTag(REGISTRY_ENTITIES, NamespacedKey.minecraft("impact_projectiles"), org.bukkit.entity.EntityType.class);
 +    /**
 +     * Vanilla entity tag for village raiders
++     * @deprecated use {@link #ENTITY_TYPES_RAIDERS}
 +     */
++    @Deprecated(forRemoval = true)
 +    Tag<org.bukkit.entity.EntityType> RAIDERS = Bukkit.getTag(REGISTRY_ENTITIES, NamespacedKey.minecraft("raiders"), org.bukkit.entity.EntityType.class);
 +    /**
 +     * Vanilla entity tag for skeleton types
++     * @deprecated use {@link #ENTITY_TYPES_SKELETONS}
 +     */
++    @Deprecated(forRemoval = true)
 +    Tag<org.bukkit.entity.EntityType> SKELETONS = Bukkit.getTag(REGISTRY_ENTITIES, NamespacedKey.minecraft("skeletons"), org.bukkit.entity.EntityType.class);
 +    // Paper end
  

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -686,10 +686,10 @@ index ae26cf65169fd25520263a3edb93424383fa7bb0..5de52a4c33fd136b43b150b7ed0df770
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6d38950a957be4eced2bda68d68dd13f3ec4eb1e..1a7269c3a1d4bcc960c508304a2d92c7551c50a7 100644
+index 14989d371a04e4b86e1ad3c2f7905c602cf73834..2a4c75cd96626c8a6df844b72056644520008729 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -820,6 +820,7 @@ public final class CraftServer implements Server {
+@@ -823,6 +823,7 @@ public final class CraftServer implements Server {
          }
  
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
@@ -697,7 +697,7 @@ index 6d38950a957be4eced2bda68d68dd13f3ec4eb1e..1a7269c3a1d4bcc960c508304a2d92c7
          for (ServerLevel world : this.console.getAllLevels()) {
              world.serverLevelData.setDifficulty(config.difficulty);
              world.setSpawnSettings(config.spawnMonsters, config.spawnAnimals);
-@@ -853,12 +854,14 @@ public final class CraftServer implements Server {
+@@ -856,12 +857,14 @@ public final class CraftServer implements Server {
                  world.ticksPerAmbientSpawns = this.getTicksPerAmbientSpawns();
              }
              world.spigotConfig.init(); // Spigot
@@ -712,7 +712,7 @@ index 6d38950a957be4eced2bda68d68dd13f3ec4eb1e..1a7269c3a1d4bcc960c508304a2d92c7
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2244,4 +2247,35 @@ public final class CraftServer implements Server {
+@@ -2256,4 +2259,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1049,7 +1049,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 12a9a6fa04867d5695d46bf7973f1542798485be..e0794c0eac5c2d323b10e1f69d9c1875731da125 100644
+index f6ed7482fd9c3d536fc8956a80a6ad6f315431e2..ce767bab0c85cbfb8476a899f05305d915815288 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,7 +1,9 @@
@@ -1795,10 +1795,10 @@ index b645a2fc839dbf922ce73b23b7d53e9a5fe1a2ee..03190535999d30aea0428631ae576b18
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 1a7269c3a1d4bcc960c508304a2d92c7551c50a7..9e8b8512a23578b73ec3599a13932fc34e47e16b 100644
+index 2a4c75cd96626c8a6df844b72056644520008729..323b44d2c8f2e993c96e61d3ecec1ca6754b137e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2216,12 +2216,31 @@ public final class CraftServer implements Server {
+@@ -2228,12 +2228,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -1713,10 +1713,10 @@ index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328ba9ee476e 100644
+index 323b44d2c8f2e993c96e61d3ecec1ca6754b137e..5bc1aa82b825bb41c2dd55836a0cfd78b4beacd3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -579,8 +579,10 @@ public final class CraftServer implements Server {
+@@ -582,8 +582,10 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1727,7 +1727,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
      }
  
      @Override
-@@ -1402,7 +1404,15 @@ public final class CraftServer implements Server {
+@@ -1405,7 +1407,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1743,7 +1743,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1555,7 +1565,20 @@ public final class CraftServer implements Server {
+@@ -1558,7 +1568,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1764,7 +1764,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1563,14 +1586,14 @@ public final class CraftServer implements Server {
+@@ -1566,14 +1589,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1781,7 +1781,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1806,6 +1829,14 @@ public final class CraftServer implements Server {
+@@ -1809,6 +1832,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1796,7 +1796,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1818,13 +1849,28 @@ public final class CraftServer implements Server {
+@@ -1821,13 +1852,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1825,7 +1825,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1868,6 +1914,12 @@ public final class CraftServer implements Server {
+@@ -1871,6 +1917,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1838,7 +1838,7 @@ index 9e8b8512a23578b73ec3599a13932fc34e47e16b..6fe94bfe110fe105acb05d4c5f2a328b
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2296,5 +2348,15 @@ public final class CraftServer implements Server {
+@@ -2308,5 +2360,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }
@@ -1903,10 +1903,10 @@ index 11d1bc56439ff867224ef1c2058aee67ba0ee332..52f78b8a3d4588f9aba10c8aea4d36cb
          OptionParser parser = new OptionParser() {
              {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
-index 449f42b324e31e1a28562b1fe99416f8925f5204..c35e1964a295032623cf9cb6ade84e69ed92194f 100644
+index ff7740d5fb54c7a27638c69a1c0e45191aa71a11..22e9245b0a0d30972980c6c13a22cb4501c3d3ca 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
-@@ -73,6 +73,19 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
+@@ -68,6 +68,19 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
          this.getSnapshot().secondaryPower = (effect != null) ? MobEffect.byId(effect.getId()) : null;
      }
  
@@ -1927,10 +1927,10 @@ index 449f42b324e31e1a28562b1fe99416f8925f5204..c35e1964a295032623cf9cb6ade84e69
      public String getCustomName() {
          BeaconBlockEntity beacon = this.getSnapshot();
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
-index 94ebc38a7f7bf9b08f4469f0c239fe8774249faf..c7af598a039f0d41aa4d1943714ed06986828c2a 100644
+index 02fc6b189541fdedd0acef6700722eb7e53346c4..5df1e8c7277759bda57253db449907eb1185cce3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
-@@ -35,4 +35,16 @@ public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity>
+@@ -30,4 +30,16 @@ public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity>
      public void setName(String name) {
          getSnapshot().getCommandBlock().setName(CraftChatMessage.fromStringOrNull(name != null ? name : "@"));
      }
@@ -1948,10 +1948,10 @@ index 94ebc38a7f7bf9b08f4469f0c239fe8774249faf..c7af598a039f0d41aa4d1943714ed069
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftContainer.java b/src/main/java/org/bukkit/craftbukkit/block/CraftContainer.java
-index 16a0f6e390a7415635e3573c1f79f7d78e5ef859..b1edc96d7e0444e72b79f190982de1d1bb5987f3 100644
+index 05f37f306d623280823c7cf9516027189659f902..65104a0506131373b6b33433a118c7e1cd3696dc 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftContainer.java
-@@ -32,6 +32,19 @@ public abstract class CraftContainer<T extends BaseContainerBlockEntity> extends
+@@ -27,6 +27,19 @@ public abstract class CraftContainer<T extends BaseContainerBlockEntity> extends
          this.getSnapshot().lockKey = (key == null) ? LockCode.NO_LOCK : new LockCode(key);
      }
  
@@ -1972,11 +1972,11 @@ index 16a0f6e390a7415635e3573c1f79f7d78e5ef859..b1edc96d7e0444e72b79f190982de1d1
      public String getCustomName() {
          T container = this.getSnapshot();
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftEnchantingTable.java b/src/main/java/org/bukkit/craftbukkit/block/CraftEnchantingTable.java
-index add5b68d5fbd887e3fc2d226eff9ab00ed01ce73..2c3d6ba06d876df168aae4cc09b7b4400e2fa33d 100644
+index 0beb96dc896f63003e1b1ae458b73902bdbe648a..102eb86bad3000f258775ac06ecd1a6dad174b0a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftEnchantingTable.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftEnchantingTable.java
-@@ -16,6 +16,19 @@ public class CraftEnchantingTable extends CraftBlockEntityState<EnchantmentTable
-         super(material, te);
+@@ -11,6 +11,19 @@ public class CraftEnchantingTable extends CraftBlockEntityState<EnchantmentTable
+         super(world, tileEntity);
      }
  
 +    // Paper start
@@ -1996,10 +1996,10 @@ index add5b68d5fbd887e3fc2d226eff9ab00ed01ce73..2c3d6ba06d876df168aae4cc09b7b440
      public String getCustomName() {
          EnchantmentTableBlockEntity enchant = this.getSnapshot();
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 2509a39bec5edd38b54709fec241c7c18e0d1c26..6e89b039479a034d98d1ec183b06d5418ab51733 100644
+index 5422bec518f96ed559898cd746663f3492466f93..b0a7f558cfe0f2ff859ab7b2db38ac303e9ae842 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -12,8 +12,10 @@ import org.bukkit.craftbukkit.util.CraftChatMessage;
+@@ -11,34 +11,60 @@ import org.bukkit.craftbukkit.util.CraftChatMessage;
  public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements Sign {
  
      // Lazily initialized only if requested:
@@ -2010,10 +2010,8 @@ index 2509a39bec5edd38b54709fec241c7c18e0d1c26..6e89b039479a034d98d1ec183b06d541
 +    private java.util.ArrayList<net.kyori.adventure.text.Component> lines = null; // ArrayList for RandomAccess
 +    // Paper end
  
-     public CraftSign(final Block block) {
-         super(block, SignBlockEntity.class);
-@@ -23,27 +25,51 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
-         super(material, te);
+     public CraftSign(World world, SignBlockEntity tileEntity) {
+         super(world, tileEntity);
      }
  
 +    // Paper start
@@ -2075,7 +2073,7 @@ index 2509a39bec5edd38b54709fec241c7c18e0d1c26..6e89b039479a034d98d1ec183b06d541
      }
  
      @Override
-@@ -81,16 +107,32 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
+@@ -76,16 +102,32 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
          super.applyTo(sign);
  
          if (this.lines != null) {
@@ -2735,10 +2733,10 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4
      private final Player.Spigot spigot = new Player.Spigot()
      {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index a4c436ca7b05726df9a8e18f79022b76de5d4a1d..30b00d4c3824749c991084e69cd2bf33ff674ad6 100644
+index 02f7a3081e9366f62a957dde4ec6487e1f66fb51..e172f574d5a5ab848197a113167872ec82355471 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -806,9 +806,9 @@ public class CraftEventFactory {
+@@ -807,9 +807,9 @@ public class CraftEventFactory {
          return event;
      }
  
@@ -2750,7 +2748,7 @@ index a4c436ca7b05726df9a8e18f79022b76de5d4a1d..30b00d4c3824749c991084e69cd2bf33
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
          org.bukkit.World world = entity.getWorld();
-@@ -833,7 +833,7 @@ public class CraftEventFactory {
+@@ -834,7 +834,7 @@ public class CraftEventFactory {
       * Server methods
       */
      public static ServerListPingEvent callServerListPingEvent(Server craftServer, InetAddress address, String motd, int numPlayers, int maxPlayers) {

--- a/patches/server/0014-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0014-Configurable-fishing-time-ranges.patch
@@ -22,7 +22,7 @@ index d473f8bb1a6000320b3e774561220f10c0469e81..f2f17a649b472f3a3271e9d799a7d34c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index dde25bf5e4e6e6514a8141e4dee473d96eee83f5..c30b53d07bcd2575d65c323d8170573bbe85f212 100644
+index dde25bf5e4e6e6514a8141e4dee473d96eee83f5..b007efe91c0abef3e90179b67dfdaf999ced11d2 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -83,6 +83,10 @@ public class FishingHook extends Projectile {
@@ -32,7 +32,7 @@ index dde25bf5e4e6e6514a8141e4dee473d96eee83f5..c30b53d07bcd2575d65c323d8170573b
 +        // Paper start
 +        minWaitTime = world.paperConfig.fishingMinTicks;
 +        maxWaitTime = world.paperConfig.fishingMaxTicks;
-+        // paper end
++        // Paper end
      }
  
      public FishingHook(EntityType<? extends FishingHook> type, Level world) {

--- a/patches/server/0019-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0019-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -32,10 +32,10 @@ index 5de0b15ee206ad01b1b4522b2d375fae08d2486f..daad04711adcaac9dc3868f20f7dc3c4
  
      public SystemReport fillSystemReport(SystemReport details) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ca36773a4a01d050a79bfabeb5aba854a86be168..7d197e075874c70207e1068e300eaf5f076745a8 100644
+index 5bc1aa82b825bb41c2dd55836a0cfd78b4beacd3..6d46d4e7061b79cd566d0b3bcac5a59d6ed9584b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -242,7 +242,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -245,7 +245,7 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
  public final class CraftServer implements Server {

--- a/patches/server/0024-Further-improve-server-tick-loop.patch
+++ b/patches/server/0024-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c24c5c39103fd2ae37711b745fef74c44ac18565..d9a305f39a4004f28ad5f8c35db1016c1bedea16 100644
+index daad04711adcaac9dc3868f20f7dc3c4a09fbac8..b02306027b5aab96fd5036ec41296c8d3d9d99fd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -283,7 +283,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -144,10 +144,10 @@ index c24c5c39103fd2ae37711b745fef74c44ac18565..d9a305f39a4004f28ad5f8c35db1016c
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fca1032a38684191655282fb0815f3988b48da4b..a1735f595930b382b4339f26b5fff34114a1ed98 100644
+index 6d46d4e7061b79cd566d0b3bcac5a59d6ed9584b..adcb4244c70ec9acfa0815ec88a148ade095b378 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2264,6 +2264,17 @@ public final class CraftServer implements Server {
+@@ -2276,6 +2276,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0045-Ensure-commands-are-not-ran-async.patch
+++ b/patches/server/0045-Ensure-commands-are-not-ran-async.patch
@@ -48,10 +48,10 @@ index da9f4b3337b49597c17b50964656457cd629a0b7..22c2c121bbcc7b0e15d73d20c9cc83d5
          } else if (this.player.getChatVisibility() == ChatVisiblity.SYSTEM) {
              // Do nothing, this is coming from a plugin
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 66420a9b1e917856b94343b90859323a1d84341f..022326790d61d163a47b2fe888627f0625405755 100644
+index adcb4244c70ec9acfa0815ec88a148ade095b378..0ea239d2ba64b062af89d0462eb4be5c9e60a421 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -773,6 +773,28 @@ public final class CraftServer implements Server {
+@@ -776,6 +776,28 @@ public final class CraftServer implements Server {
          Validate.notNull(commandLine, "CommandLine cannot be null");
          org.spigotmc.AsyncCatcher.catchOp("command dispatch"); // Spigot
  

--- a/patches/server/0047-Expose-server-CommandMap.patch
+++ b/patches/server/0047-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 171efcdaa81351df1028f8efdc1b181fabe7feb2..dd69c7962a90c4ff4b251599f95fa01525855abc 100644
+index 0ea239d2ba64b062af89d0462eb4be5c9e60a421..57fb066bc95ef31ec9dd8918adf3ab78cb28a70b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1902,6 +1902,7 @@ public final class CraftServer implements Server {
+@@ -1905,6 +1905,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0052-Add-velocity-warnings.patch
+++ b/patches/server/0052-Add-velocity-warnings.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index dd69c7962a90c4ff4b251599f95fa01525855abc..db13ac548b7c250f84df9d5dbfb85021010b2d86 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -278,6 +278,7 @@ public final class CraftServer implements Server {
+@@ -281,6 +281,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;

--- a/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
@@ -30,10 +30,10 @@ index f5155d4b48f17c82b7a637418c40ffcdc6cc6271..acdbd21947093ed076c4668d3480a50f
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 28a3fa002a77ecc7f5bd16aa4316f6d74e2503e1..451d911334dc1477c99f94705632c9fd5184ddb0 100644
+index 65bc692d45e2436f68f569ceecb49d824f4a1af1..62d1a2d2f9bed3f08484b3bf41d8300490dc0d2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -415,6 +415,7 @@ public final class CraftServer implements Server {
+@@ -418,6 +418,7 @@ public final class CraftServer implements Server {
          if (type == PluginLoadOrder.STARTUP) {
              this.helpMap.clear();
              this.helpMap.initializeGeneralTopics();
@@ -41,7 +41,7 @@ index 28a3fa002a77ecc7f5bd16aa4316f6d74e2503e1..451d911334dc1477c99f94705632c9fd
          }
  
          Plugin[] plugins = this.pluginManager.getPlugins();
-@@ -434,7 +435,7 @@ public final class CraftServer implements Server {
+@@ -437,7 +438,7 @@ public final class CraftServer implements Server {
              this.commandMap.registerServerAliases();
              DefaultPermissions.registerCorePermissions();
              CraftDefaultPermissions.registerCorePermissions();

--- a/patches/server/0061-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0061-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index abf985bb0b485dde6a843ef18b24caff329f5843..19d9af4e41ff6f14d894ab05ddcb4614fc56f2d8 100644
+index 62d1a2d2f9bed3f08484b3bf41d8300490dc0d2d..341006df6e2c22c00a2b3ec67fc6038dadef836f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2394,5 +2394,23 @@ public final class CraftServer implements Server {
+@@ -2406,5 +2406,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0062-Remove-Metadata-on-reload.patch
+++ b/patches/server/0062-Remove-Metadata-on-reload.patch
@@ -7,10 +7,10 @@ Metadata is not meant to persist reload as things break badly with non primitive
 This will remove metadata on reload so it does not crash everything if a plugin uses it.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c2b16834ccddda703973dc7ad85f584e2625a57f..8020aa53077e3eb09a866257c5648bf10ecc9227 100644
+index 341006df6e2c22c00a2b3ec67fc6038dadef836f..91ee302c5b3299fe7c1aa90b10f8ea06c5d23589 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -883,8 +883,16 @@ public final class CraftServer implements Server {
+@@ -886,8 +886,16 @@ public final class CraftServer implements Server {
              world.paperConfig.init(); // Paper
          }
  

--- a/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -642,7 +642,7 @@ index b79d9d26a8e60f9c0ecd69e9c2f9cfd087e21d23..f23fff80d07ac7d06715efe67cb49ebb
              if (player != null) {
                  builder.withLuck(player.getLuck()).withParameter(LootContextParams.THIS_ENTITY, player);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index bbe1ddca74a174a3da38475f586b5b61ae3abad3..4d84bcdfb17a3d1bc79e5ec2b201739fa0db1bd3 100644
+index d929ad6bd8af7b6676c08f8747ac0f93b85482fb..189674ce35f2da75a70e4a05c77dd022cef469db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 @@ -14,8 +14,9 @@ import org.bukkit.craftbukkit.CraftWorld;
@@ -654,21 +654,21 @@ index bbe1ddca74a174a3da38475f586b5b61ae3abad3..4d84bcdfb17a3d1bc79e5ec2b201739f
 -public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest {
 +public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest, PaperLootableBlockInventory { // Paper
  
-     public CraftChest(final Block block) {
-         super(block, ChestBlockEntity.class);
+     public CraftChest(World world, ChestBlockEntity tileEntity) {
+         super(world, tileEntity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
-index a688845f6b8fc3de2864dd896cd132b5c7b3be59..322a8292876b3b4eb73cff2ef768f4b9325b2bdb 100644
+index 982adacb361b0590799dc68f9b7c13c7195627fd..e49eece9bff3a53469673d03a7bbf8f9cf8776b8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftLootable.java
-@@ -10,7 +10,7 @@ import org.bukkit.craftbukkit.util.CraftNamespacedKey;
+@@ -9,7 +9,7 @@ import org.bukkit.craftbukkit.util.CraftNamespacedKey;
  import org.bukkit.loot.LootTable;
  import org.bukkit.loot.Lootable;
  
 -public abstract class CraftLootable<T extends RandomizableContainerBlockEntity> extends CraftContainer<T> implements Nameable, Lootable {
 +public abstract class CraftLootable<T extends RandomizableContainerBlockEntity> extends CraftContainer<T> implements Nameable, Lootable, com.destroystokyo.paper.loottable.PaperLootableBlockInventory { // Paper
  
-     public CraftLootable(Block block, Class<T> tileEntityClass) {
-         super(block, tileEntityClass);
+     public CraftLootable(World world, T tileEntity) {
+         super(world, tileEntity);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java
 index eb21b8457774d5ac765fa9008157cb29d9b72509..abf58bef2042a9efba5a78fd7f97339deceaa780 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftMinecartChest.java

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index f6cb864c45f960811acc02829d1f7883b916de29..8703f97dc2f392b136c6851aa09b607c
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80d0234cb72f16a4ce37ed9a4a458012a0f05e36..120c649365ee2567a5bab75c8d389b2455b0377e 100644
+index 91ee302c5b3299fe7c1aa90b10f8ea06c5d23589..be3eade64dd60fbd9fc28fd1713ab0a96eac863c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1645,7 +1645,7 @@ public final class CraftServer implements Server {
+@@ -1648,7 +1648,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -44,10 +44,10 @@ index c5a8edf426e79b8746c7a5a5a5de3e3df1708740..f030c8d7c28039fde273e6b30c63ea79
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 30b00d4c3824749c991084e69cd2bf33ff674ad6..f7dfc549dce8cd96656c80b0a2fe5a79796128a9 100644
+index e172f574d5a5ab848197a113167872ec82355471..918ea9531e5cb37cc60ad00f78a1b4d31037704f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1120,6 +1120,14 @@ public class CraftEventFactory {
+@@ -1121,6 +1121,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 120c649365ee2567a5bab75c8d389b2455b0377e..54d8cbbb610fa198db8dfcca691fb0435d4134a2 100644
+index be3eade64dd60fbd9fc28fd1713ab0a96eac863c..3e8a1f53cacdb513a8cd8f1d9314618eb75de4eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2420,5 +2420,24 @@ public final class CraftServer implements Server {
+@@ -2432,5 +2432,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index b902bca6135c3a7be4804a441bbf8f73b4596432..41556294841b2c280ba4eff861405ccb
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f7dfc549dce8cd96656c80b0a2fe5a79796128a9..aaac6afc2e80149b128321b1ae62295b0dc323eb 100644
+index 918ea9531e5cb37cc60ad00f78a1b4d31037704f..db16f9d4b65e64ead6728056e2528ea184c672db 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1079,6 +1079,17 @@ public class CraftEventFactory {
+@@ -1080,6 +1080,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index f81be1c6a5efc5090fbb8832f44dbb2ae6aa2f4a..8e81b19706a14c21b5ffdc4f12818fe7
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aaac6afc2e80149b128321b1ae62295b0dc323eb..4c135327c7d9acd0dc210bcef33241a2e6201044 100644
+index db16f9d4b65e64ead6728056e2528ea184c672db..b370bbad550d6efda1fe391fb5d093a99f2a5532 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1223,6 +1223,16 @@ public class CraftEventFactory {
+@@ -1224,6 +1224,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0125-PlayerTeleportEndGatewayEvent.patch
+++ b/patches/server/0125-PlayerTeleportEndGatewayEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] PlayerTeleportEndGatewayEvent
 Allows you to access the Gateway being used in a teleport event
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index fe33ed6fde98de61a9db594e8752b978b16db3e4..07c786b3988a2cc3a7bd3910dd909b887395a194 100644
+index fe33ed6fde98de61a9db594e8752b978b16db3e4..d6f67a87c46c95bd4c2dfad4c1c13cbfd263ef30 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -11,6 +11,7 @@ import net.minecraft.data.worldgen.Features;
@@ -22,7 +22,7 @@ index fe33ed6fde98de61a9db594e8752b978b16db3e4..07c786b3988a2cc3a7bd3910dd909b88
                      location.setYaw(player.getLocation().getYaw());
  
 -                    PlayerTeleportEvent teleEvent = new PlayerTeleportEvent(player, player.getLocation(), location, PlayerTeleportEvent.TeleportCause.END_GATEWAY);
-+                    PlayerTeleportEvent teleEvent = new com.destroystokyo.paper.event.player.PlayerTeleportEndGatewayEvent(player, player.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(net.minecraft.server.MCUtil.toLocation(worldserver, blockEntity.getBlockPos()).getBlock())); // Paper
++                    PlayerTeleportEvent teleEvent = new com.destroystokyo.paper.event.player.PlayerTeleportEndGatewayEvent(player, player.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(worldserver.getWorld(), blockEntity)); // Paper
                      Bukkit.getPluginManager().callEvent(teleEvent);
                      if (teleEvent.isCancelled()) {
                          return;

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index ac2c7977e2110feb7c45856d6f0a0ccdeedfcdb3..fa6beae844354849e73a45cf38eb1f06
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 54d8cbbb610fa198db8dfcca691fb0435d4134a2..17024e3dee35750884caaa1ca5254f21cfdb6806 100644
+index 3e8a1f53cacdb513a8cd8f1d9314618eb75de4eb..c30c8b786dfd1ba38aafaf3f138dfbdbc876db87 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2439,5 +2439,10 @@ public final class CraftServer implements Server {
+@@ -2451,5 +2451,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e36986a2f6e8548cba011fc2e8e84bb9f3f6e10d..ce5fab6878a65b7ad4fd6aead5b77a9724d3dd63 100644
+index 2e0bd32ebe06e39b3dc889be9b06e2d0047c1068..9a8779bed2a2fa7dc869d3283c59dbc132df8968 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -9,6 +9,7 @@ import com.mojang.authlib.GameProfile;
@@ -244,7 +244,7 @@ index 24add1cd1f865012c5382548e415218d481ecefe..31dccb0b4ab60d6cedf236fc7d51a363
  
          this.bans = new UserBanList(PlayerList.USERBANLIST_FILE);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 17024e3dee35750884caaa1ca5254f21cfdb6806..c9104042fae30d8d33eb278803d80c2696668058 100644
+index c30c8b786dfd1ba38aafaf3f138dfbdbc876db87..fc08897b4021c5a65fbd083ffd75fc9d9c2cfc82 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -47,7 +47,6 @@ import java.util.function.Consumer;
@@ -263,7 +263,7 @@ index 17024e3dee35750884caaa1ca5254f21cfdb6806..c9104042fae30d8d33eb278803d80c26
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.bossevents.CustomBossEvent;
  import net.minecraft.server.commands.ReloadCommand;
-@@ -1229,9 +1229,13 @@ public final class CraftServer implements Server {
+@@ -1232,9 +1232,13 @@ public final class CraftServer implements Server {
          return this.logger;
      }
  

--- a/patches/server/0142-Add-UnknownCommandEvent.patch
+++ b/patches/server/0142-Add-UnknownCommandEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add UnknownCommandEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a573643b089e02b9d7be3b2aaa2afbbf352af705..d76f2b4ff336819687f233a50b69ca1cafe5c0a5 100644
+index fc08897b4021c5a65fbd083ffd75fc9d9c2cfc82..fafd9f8d46c9bb5cce81f58376482dd0f9196b5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -803,7 +803,13 @@ public final class CraftServer implements Server {
+@@ -806,7 +806,13 @@ public final class CraftServer implements Server {
  
          // Spigot start
          if (!org.spigotmc.SpigotConfig.unknownCommandMessage.isEmpty()) {

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -491,10 +491,10 @@ index 6e1b7d5b20e9f6ed1b650eb9d6ac9f8c4867b4b7..61405c2b53e03a4b83e2c70c6e4d3739
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e224186a0b4eb2dc22d2727c9afedf028b6bf784..3ee6e3b81eb91fb9f74b5ff55ec10e64db6d8fd5 100644
+index fafd9f8d46c9bb5cce81f58376482dd0f9196b5a..a761dbe6fd7e2ed1805d080832acda768d0b3c03 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -241,6 +241,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
+@@ -244,6 +244,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
  
  import net.md_5.bungee.api.chat.BaseComponent; // Spigot
  
@@ -504,7 +504,7 @@ index e224186a0b4eb2dc22d2727c9afedf028b6bf784..3ee6e3b81eb91fb9f74b5ff55ec10e64
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2454,5 +2457,24 @@ public final class CraftServer implements Server {
+@@ -2466,5 +2469,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
+++ b/patches/server/0168-API-to-get-a-BlockState-without-a-snapshot.patch
@@ -13,14 +13,14 @@ also Avoid NPE during CraftBlockEntityState load if could not get TE
 If Tile Entity was null, correct Sign to return empty lines instead of null
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 77645019c88d61dde28b7598d8a29b7d0c23c209..8a079ee3ed243fd19b1dd7eed2de1dd33785faa1 100644
+index 77645019c88d61dde28b7598d8a29b7d0c23c209..560ee4eaa286197a0f8fc0a119ff5e06baca792a 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -42,6 +42,7 @@ public abstract class BlockEntity implements net.minecraft.server.KeyedObject {
          this.type = type;
          this.worldPosition = pos.immutable();
          this.blockState = state;
-+        persistentDataContainer = new CraftPersistentDataContainer(DATA_TYPE_REGISTRY); // Paper - always init
++        this.persistentDataContainer = new CraftPersistentDataContainer(DATA_TYPE_REGISTRY); // Paper - always init
      }
  
      // Paper start
@@ -29,25 +29,22 @@ index 77645019c88d61dde28b7598d8a29b7d0c23c209..8a079ee3ed243fd19b1dd7eed2de1dd3
      // CraftBukkit start - read container
      public void load(CompoundTag nbt) {
 -        this.persistentDataContainer = new CraftPersistentDataContainer(BlockEntity.DATA_TYPE_REGISTRY);
-+        this.persistentDataContainer.clear();
++        this.persistentDataContainer.clear(); // Paper - clear instead of init
  
          net.minecraft.nbt.Tag persistentDataTag = nbt.get("PublicBukkitValues");
          if (persistentDataTag instanceof CompoundTag) {
-@@ -221,8 +222,13 @@ public abstract class BlockEntity implements net.minecraft.server.KeyedObject {
-     }
+@@ -222,6 +223,11 @@ public abstract class BlockEntity implements net.minecraft.server.KeyedObject {
  
      // CraftBukkit start - add method
-+    // Paper start
      public InventoryHolder getOwner() {
--        if (this.level == null) return null;
++        // Paper start
 +        return getOwner(true);
 +    }
 +    public InventoryHolder getOwner(boolean useSnapshot) {
 +        // Paper end
-+        if (level == null) return null;
+         if (this.level == null) return null;
          // Spigot start
          org.bukkit.block.Block block = this.level.getWorld().getBlockAt(this.worldPosition.getX(), this.worldPosition.getY(), this.worldPosition.getZ());
-         if (block == null) {
 @@ -230,7 +236,7 @@ public abstract class BlockEntity implements net.minecraft.server.KeyedObject {
              return null;
          }
@@ -58,76 +55,57 @@ index 77645019c88d61dde28b7598d8a29b7d0c23c209..8a079ee3ed243fd19b1dd7eed2de1dd3
          return null;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 4175eb5f71522c23eadcbaac6e4b0fbd31f572bc..650e119a4683ad5cb0175dd558f9299f0ebcca0d 100644
+index e6b8dd52cd503f45ca9bb868891ae4c8b29b3fcb..f1c4c3a3392c2d4d836fa10d7a38558d08084d9d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -315,7 +315,21 @@ public class CraftBlock implements Block {
+@@ -314,7 +314,20 @@ public class CraftBlock implements Block {
  
      @Override
      public BlockState getState() {
--        Material material = this.getType();
-+        // Paper start - allow disabling the use of snapshots
-+        return getState(true);
++        // Paper start
++        return this.getState(true);
 +    }
++
++    @Override
 +    public BlockState getState(boolean useSnapshot) {
 +        boolean prev = CraftBlockEntityState.DISABLE_SNAPSHOT;
 +        CraftBlockEntityState.DISABLE_SNAPSHOT = !useSnapshot;
 +        try {
-+            return getState0();
+         return CraftBlockStates.getBlockState(this);
 +        } finally {
 +            CraftBlockEntityState.DISABLE_SNAPSHOT = prev;
-+        }
-+    }
-+    public BlockState getState0() {
-+        // Paper end
-+        Material material = getType();
- 
-         switch (material) {
-             case ACACIA_SIGN:
-diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 5203741fc3ba3b856f15d27e563b641c1e48e022..204a61767d5cacc962094b9ecc37f457987cbde7 100644
---- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-+++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -25,20 +25,40 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
-         this.tileEntity = tileEntityClass.cast(getWorldHandle().getBlockEntity(this.getPosition()));
-         Preconditions.checkState(this.tileEntity != null, "Tile is null, asynchronous access? %s", block);
- 
-+        // Paper start
-+        this.snapshotDisabled = DISABLE_SNAPSHOT;
-+        if (DISABLE_SNAPSHOT) {
-+            this.snapshot = this.tileEntity;
-+        } else {
-+            this.snapshot = this.createSnapshot(this.tileEntity);
-+        }
-         // copy tile entity data:
--        this.snapshot = this.createSnapshot(tileEntity);
--        this.load(snapshot);
-+        if(this.snapshot != null) {
-+            this.load(this.snapshot);
 +        }
 +        // Paper end
      }
  
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+index fbd52387299c90b85afd79897139cdb879fce74a..aaddbaecc25af87c863fe51098eb322fd5702104 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
+@@ -10,15 +10,26 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
+ 
+     private final T tileEntity;
+     private final T snapshot;
 +    public final boolean snapshotDisabled; // Paper
 +    public static boolean DISABLE_SNAPSHOT = false; // Paper
-+
-     public CraftBlockEntityState(Material material, T tileEntity) {
-         super(material);
  
-         this.tileEntityClass = (Class<T>) tileEntity.getClass();
+     public CraftBlockEntityState(World world, T tileEntity) {
+         super(world, tileEntity.getBlockPos(), tileEntity.getBlockState());
+ 
          this.tileEntity = tileEntity;
--
+ 
 +        // Paper start
 +        this.snapshotDisabled = DISABLE_SNAPSHOT;
 +        if (DISABLE_SNAPSHOT) {
 +            this.snapshot = this.tileEntity;
 +        } else {
-+            this.snapshot = this.createSnapshot(this.tileEntity);
++            this.snapshot = this.createSnapshot(tileEntity);
 +        }
          // copy tile entity data:
 -        this.snapshot = this.createSnapshot(tileEntity);
 -        this.load(snapshot);
-+        if(this.snapshot != null) {
++        if (this.snapshot != null) {
 +            this.load(this.snapshot);
 +        }
 +        // Paper end

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index cf42d59254f2786bfe8785249ad270d35996417a..8c2242d7e443bee26741608c65d314d8
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3ee6e3b81eb91fb9f74b5ff55ec10e64db6d8fd5..226caf084494619436c20bb15a777bb31d9af4ab 100644
+index a761dbe6fd7e2ed1805d080832acda768d0b3c03..54aad60880bd60d303c8b0395e93d74abaaffc2f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1989,7 +1989,7 @@ public final class CraftServer implements Server {
+@@ -1992,7 +1992,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0175-Add-setPlayerProfile-API-for-Skulls.patch
+++ b/patches/server/0175-Add-setPlayerProfile-API-for-Skulls.patch
@@ -7,7 +7,7 @@ This allows you to create already filled textures on Skulls to avoid texture loo
 which commonly cause rate limit issues with Mojang API
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
-index b08975f337c41fb8211563703b46328baf858566..6f776b44c1bafc299b15fd17140f9619f86ddba9 100644
+index d6a4638271644e31fbc38f5ae9150ded63a6d62f..e89eb5d631b4226d79caf49c89ebb44155e72a0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSkull.java
 @@ -1,5 +1,7 @@
@@ -18,7 +18,7 @@ index b08975f337c41fb8211563703b46328baf858566..6f776b44c1bafc299b15fd17140f9619
  import com.google.common.base.Preconditions;
  import com.mojang.authlib.GameProfile;
  import net.minecraft.server.MinecraftServer;
-@@ -105,6 +107,20 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
+@@ -100,6 +102,20 @@ public class CraftSkull extends CraftBlockEntityState<SkullBlockEntity> implemen
          }
      }
  

--- a/patches/server/0187-getPlayerUniqueId-API.patch
+++ b/patches/server/0187-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 226caf084494619436c20bb15a777bb31d9af4ab..f831f196e332604146e95289bf42139241f2bc0e 100644
+index 54aad60880bd60d303c8b0395e93d74abaaffc2f..c6c8f40521e4039406120dbde5c01e5ad28f58d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1647,6 +1647,25 @@ public final class CraftServer implements Server {
+@@ -1650,6 +1650,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0206-Implement-EntityTeleportEndGatewayEvent.patch
+++ b/patches/server/0206-Implement-EntityTeleportEndGatewayEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement EntityTeleportEndGatewayEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
-index 07c786b3988a2cc3a7bd3910dd909b887395a194..370ec4cd08a50ad0b8154db9afcaa76ec741dcb2 100644
+index d6f67a87c46c95bd4c2dfad4c1c13cbfd263ef30..f41dfe8bff59d17000f3eb17670c524102adb276 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/TheEndGatewayBlockEntity.java
 @@ -225,9 +225,20 @@ public class TheEndGatewayBlockEntity extends TheEndPortalBlockEntity {
@@ -18,7 +18,7 @@ index 07c786b3988a2cc3a7bd3910dd909b887395a194..370ec4cd08a50ad0b8154db9afcaa76e
 +                location.setPitch(bukkitEntity.getLocation().getPitch());
 +                location.setYaw(bukkitEntity.getLocation().getYaw());
 +
-+                com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent event = new com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent(bukkitEntity, bukkitEntity.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(MCUtil.toLocation(world, blockEntity.getBlockPos()).getBlock()));
++                com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent event = new com.destroystokyo.paper.event.entity.EntityTeleportEndGatewayEvent(bukkitEntity, bukkitEntity.getLocation(), location, new org.bukkit.craftbukkit.block.CraftEndGateway(world.getWorld(), blockEntity));
 +                if (!event.callEvent()) {
 +                    return;
 +                }

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -174,7 +174,7 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..460828d29583ee21a7c5b716f9687a82
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d14f4f8a457d62c4fdeaaab4062bc53bdd62d4aa..592829e14b6965a2ce83c53af4fc0ab9826e3406 100644
+index fdb4e636f1cfad6cb99753aee02d5734c7607fbf..b77d9477a425691ddad244d2912b9574d640f32a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -928,7 +928,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -187,10 +187,10 @@ index d14f4f8a457d62c4fdeaaab4062bc53bdd62d4aa..592829e14b6965a2ce83c53af4fc0ab9
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4c135327c7d9acd0dc210bcef33241a2e6201044..6bb94a7c712996555d290d0c556ff490db30b489 100644
+index b370bbad550d6efda1fe391fb5d093a99f2a5532..8e0b6910c97789b4d03ae62723dceb962487fc5a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1192,7 +1192,7 @@ public class CraftEventFactory {
+@@ -1193,7 +1193,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index 4c135327c7d9acd0dc210bcef33241a2e6201044..6bb94a7c712996555d290d0c556ff490
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1358,8 +1358,18 @@ public class CraftEventFactory {
+@@ -1359,8 +1359,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0233-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0233-Vanished-players-don-t-have-rights.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Vanished players don't have rights
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
-index b09f52330b50879d5594b21302e70ca676b60951..d7d4aa7ed2f321df8099adb97a3c699ed38ae6fc 100644
+index 8af1571c614a39c9673e0dc90e3aa9a89a367e34..daa55eed9cf385c7e2cdd0a5dceaf0a719652213 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/Projectile.java
 @@ -209,7 +209,14 @@ public abstract class Projectile extends Entity {
@@ -24,7 +24,7 @@ index b09f52330b50879d5594b21302e70ca676b60951..d7d4aa7ed2f321df8099adb97a3c699e
              return false;
          }
 diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
-index b65736c8395c04b29f97d460a8559c2e44ed3a4f..8e6df16568c0dab482e10ad1b38920d77f6e684f 100644
+index 8cf2dc21bcc2547b5af5501e60be39ca18a0e9f2..d36e73cfab79960bf4d778ea01a684b9b6af39d7 100644
 --- a/src/main/java/net/minecraft/world/item/BlockItem.java
 +++ b/src/main/java/net/minecraft/world/item/BlockItem.java
 @@ -195,7 +195,8 @@ public class BlockItem extends Item {
@@ -99,10 +99,10 @@ index d49ce298219dd2144ca1357ab9f158455187c985..17f596e6059334114ce3ee17fbde1ce3
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 6bb94a7c712996555d290d0c556ff490db30b489..e6f2dff4e581535047136b398aca023cd46cf4b4 100644
+index 8e0b6910c97789b4d03ae62723dceb962487fc5a..4faf98079a6a6af662e11050a0088578ba65a5eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1228,6 +1228,14 @@ public class CraftEventFactory {
+@@ -1229,6 +1229,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0239-Add-hand-to-bucket-events.patch
+++ b/patches/server/0239-Add-hand-to-bucket-events.patch
@@ -139,10 +139,10 @@ index 17f596e6059334114ce3ee17fbde1ce3d14c5ca1..96c685ffbf6058b69f0c573a1255a9e8
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index e6f2dff4e581535047136b398aca023cd46cf4b4..fb17ab47d45b1cb2aa48ba28c452a683ce8a1568 100644
+index 4faf98079a6a6af662e11050a0088578ba65a5eb..e094b1b00d5fb73da73abcadb02ffd98b91fb869 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -226,7 +226,7 @@ public class CraftEventFactory {
+@@ -227,7 +227,7 @@ public class CraftEventFactory {
      public static Entity entityDamage; // For use in EntityDamageByEntityEvent
  
      // helper methods
@@ -151,7 +151,7 @@ index e6f2dff4e581535047136b398aca023cd46cf4b4..fb17ab47d45b1cb2aa48ba28c452a683
          int spawnSize = Bukkit.getServer().getSpawnRadius();
  
          if (world.dimension() != Level.OVERWORLD) return true;
-@@ -420,6 +420,20 @@ public class CraftEventFactory {
+@@ -421,6 +421,20 @@ public class CraftEventFactory {
      }
  
      private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item) {
@@ -172,7 +172,7 @@ index e6f2dff4e581535047136b398aca023cd46cf4b4..fb17ab47d45b1cb2aa48ba28c452a683
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);
          Material bucket = CraftMagicNumbers.getMaterial(itemstack.getItem());
-@@ -432,10 +446,10 @@ public class CraftEventFactory {
+@@ -433,10 +447,10 @@ public class CraftEventFactory {
  
          PlayerEvent event;
          if (isFilling) {

--- a/patches/server/0240-Add-TNTPrimeEvent.patch
+++ b/patches/server/0240-Add-TNTPrimeEvent.patch
@@ -21,10 +21,10 @@ index 3a01ffffcc37a93866b8b6774874959dfcabba26..29aa428e019681af8d6b0020c12b1866
  
                  this.level.removeBlock(blockposition, false);
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index dd19c31360891245dbe465cf94a9f456cf71e23d..becf80cdbbeb6327958758779cc42ea894127988 100644
+index 2703afdd101092c92da2eb619757271c2a5f9305..8ce3dea66a1f45bb3f416bca1765c563394ad8ed 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-@@ -290,7 +290,7 @@ public class FireBlock extends BaseFireBlock {
+@@ -291,7 +291,7 @@ public class FireBlock extends BaseFireBlock {
  
                  world.setBlock(blockposition, this.getStateWithAge(world, blockposition, l), 3);
              } else {
@@ -33,7 +33,7 @@ index dd19c31360891245dbe465cf94a9f456cf71e23d..becf80cdbbeb6327958758779cc42ea8
              }
  
              Block block = iblockdata.getBlock();
-@@ -298,6 +298,13 @@ public class FireBlock extends BaseFireBlock {
+@@ -299,6 +299,13 @@ public class FireBlock extends BaseFireBlock {
              if (block instanceof TntBlock) {
                  TntBlock blocktnt = (TntBlock) block;
  

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -36,7 +36,7 @@ index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d702
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 74e780212773e0d3cce19cb9c33cdcaa4a708f14..cc4a94669c5f0dee99b6d8cb89650cf0c701e9ab 100644
+index 1bffdc632a19318325b60ef737f9e8555ae40230..7b760a65cad1f7dd5adb3a05b8b5ed7d0f49c0a9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1100,6 +1100,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -48,10 +48,10 @@ index 74e780212773e0d3cce19cb9c33cdcaa4a708f14..cc4a94669c5f0dee99b6d8cb89650cf0
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f831f196e332604146e95289bf42139241f2bc0e..0c73ed409f96fb8fef721fbfb0592157c2d06b80 100644
+index c6c8f40521e4039406120dbde5c01e5ad28f58d8..c611cd9677e988290c8d2f27fe7ff88d0d826779 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -821,6 +821,7 @@ public final class CraftServer implements Server {
+@@ -824,6 +824,7 @@ public final class CraftServer implements Server {
  
      @Override
      public void reload() {
@@ -59,7 +59,7 @@ index f831f196e332604146e95289bf42139241f2bc0e..0c73ed409f96fb8fef721fbfb0592157
          this.reloadCount++;
          this.configuration = YamlConfiguration.loadConfiguration(this.getConfigFile());
          this.commandsConfiguration = YamlConfiguration.loadConfiguration(this.getCommandsConfigFile());
-@@ -932,6 +933,7 @@ public final class CraftServer implements Server {
+@@ -935,6 +936,7 @@ public final class CraftServer implements Server {
          this.enablePlugins(PluginLoadOrder.STARTUP);
          this.enablePlugins(PluginLoadOrder.POSTWORLD);
          this.getPluginManager().callEvent(new ServerLoadEvent(ServerLoadEvent.LoadType.RELOAD));

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -277,7 +277,7 @@ index d545349f659b2a164a28d06e9ff0f9fff8fa8ecf..bbde9b758643c087733064a126d90689
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d9808ee4fdf19c78d3253782875d1b794eb4b490..c3d0a76f24653b610056024ab5368053316eb04e 100644
+index aac0938fab644218fa642faa4f26ca65a0d24941..1ca818e242221d426aa1736c5d24d96651dfd579 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1869,7 +1869,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -297,10 +297,10 @@ index d9808ee4fdf19c78d3253782875d1b794eb4b490..c3d0a76f24653b610056024ab5368053
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index fb17ab47d45b1cb2aa48ba28c452a683ce8a1568..aa652bfcd0e60784afc36a800a0278c3baa32221 100644
+index e094b1b00d5fb73da73abcadb02ffd98b91fb869..ce67bbe8d29abe61d6e7db7b0a5c8f695ed2a1a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -806,9 +806,16 @@ public class CraftEventFactory {
+@@ -807,9 +807,16 @@ public class CraftEventFactory {
      public static EntityDeathEvent callEntityDeathEvent(net.minecraft.world.entity.LivingEntity victim, List<org.bukkit.inventory.ItemStack> drops) {
          CraftLivingEntity entity = (CraftLivingEntity) victim.getBukkitEntity();
          EntityDeathEvent event = new EntityDeathEvent(entity, drops, victim.getExpReward());
@@ -317,7 +317,7 @@ index fb17ab47d45b1cb2aa48ba28c452a683ce8a1568..aa652bfcd0e60784afc36a800a0278c3
          victim.expToDrop = event.getDroppedExp();
  
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
-@@ -825,8 +832,15 @@ public class CraftEventFactory {
+@@ -826,8 +833,15 @@ public class CraftEventFactory {
          PlayerDeathEvent event = new PlayerDeathEvent(entity, drops, victim.getExpReward(), 0, deathMessage, stringDeathMessage); // Paper - Adventure
          event.setKeepInventory(keepInventory);
          event.setKeepLevel(victim.keepLevel); // SPIGOT-2222: pre-set keepLevel
@@ -333,7 +333,7 @@ index fb17ab47d45b1cb2aa48ba28c452a683ce8a1568..aa652bfcd0e60784afc36a800a0278c3
  
          victim.keepLevel = event.getKeepLevel();
          victim.newLevel = event.getNewLevel();
-@@ -843,6 +857,31 @@ public class CraftEventFactory {
+@@ -844,6 +858,31 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
+++ b/patches/server/0270-Implement-furnace-cook-speed-multiplier-API.patch
@@ -89,10 +89,10 @@ index 265fa3cb96b7d39194a7e83b8b77b811bc3e8b40..02ded982bc36ce6530c92e18a079dc0b
              this.setChanged();
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-index 5028a6388f95a14df8d1590cddd7414d8de5bf78..92c156b09cc46e5d70ed7d803683787248495a62 100644
+index a5022dc1e2376e655bfa00f7c3ffb63788fa54d6..501e064d6b9b1970699e2724d1911125aa5ac143 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftFurnace.java
-@@ -63,4 +63,20 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
+@@ -58,4 +58,20 @@ public abstract class CraftFurnace<T extends AbstractFurnaceBlockEntity> extends
      public void setCookTimeTotal(int cookTimeTotal) {
          this.getSnapshot().cookingTotalTime = cookTimeTotal;
      }

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -225,10 +225,10 @@ index 39bdda56aaa5503efc15207261634127b462c3e7..3fd913f3e963cf2da849a52364356e3b
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d62f1650a0879e46e6c619c0f7387e0c438430ec..d64bcc0aafb918e82e881f6503ce8311e78a3f6f 100644
+index c611cd9677e988290c8d2f27fe7ff88d0d826779..e4db68be9fa9d275c13360309d3d3ac5dfab07da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -694,7 +694,7 @@ public final class CraftServer implements Server {
+@@ -697,7 +697,7 @@ public final class CraftServer implements Server {
      @Override
      public long getConnectionThrottle() {
          // Spigot Start - Automatically set connection throttle for bungee configurations

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -42,10 +42,10 @@ index 4b4fbd8747740111cc2e25f0c4d29a29926a3a1b..26ac165135ef53cec9e065ae1c15220a
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0b6ea1fde85313a44b7d390c6c92be053af7305d..cdbdeef88b0b54ae3d51aec5641aac3b216a1cf3 100644
+index e4db68be9fa9d275c13360309d3d3ac5dfab07da..977b4f3a624d0087171441fed19c2c7745f3b1f9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2479,6 +2479,11 @@ public final class CraftServer implements Server {
+@@ -2491,6 +2491,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0297-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0297-force-entity-dismount-during-teleportation.patch
@@ -20,7 +20,7 @@ this is going to be the best soultion all around.
 Improvements/suggestions welcome!
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d32e6feca6c39a28f80574e4b080ddd4cbb60fdc..a0530081a1d4bf2b46d82f15013dd3d8d289ee47 100644
+index d32e6feca6c39a28f80574e4b080ddd4cbb60fdc..42035548577b7c60806a557dd9f9931ca9584e8c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1296,11 +1296,13 @@ public class ServerPlayer extends Player {
@@ -32,7 +32,7 @@ index d32e6feca6c39a28f80574e4b080ddd4cbb60fdc..a0530081a1d4bf2b46d82f15013dd3d8
 +    // Paper start
 +    @Override public void stopRiding() { stopRiding(false); }
 +    @Override public void stopRiding(boolean suppressCancellation) {
-+        // paper end
++        // Paper end
          Entity entity = this.getVehicle();
  
 -        super.stopRiding();

--- a/patches/server/0325-Mob-Spawner-API-Enhancements.patch
+++ b/patches/server/0325-Mob-Spawner-API-Enhancements.patch
@@ -93,10 +93,10 @@ index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248
              nbt.putShort("MaxNearbyEntities", (short) this.maxNearbyEntities);
              nbt.putShort("RequiredPlayerRange", (short) this.requiredPlayerRange);
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java b/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
-index ff8eba31e6169b5a1debe47f17a40e6d0be67897..75575b24aa0291c26d65de9787bc9d2f88c867e4 100644
+index 38dc811970b8f90b11a2b0013da3b6b3b775cbec..6bc17063c7ed9da9a16e2f8ab6117d49729c9b28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftCreatureSpawner.java
-@@ -121,4 +121,30 @@ public class CraftCreatureSpawner extends CraftBlockEntityState<SpawnerBlockEnti
+@@ -116,4 +116,30 @@ public class CraftCreatureSpawner extends CraftBlockEntityState<SpawnerBlockEnti
      public void setSpawnRange(int spawnRange) {
          this.getSnapshot().getSpawner().spawnRange = spawnRange;
      }

--- a/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,7 +16,7 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 16a5fb9ef97170f337ede5da0646dcdd233f7b4e..bdfa5c65e41edb7cdcb5a0fff54d9384a9598028 100644
+index 3a7bf5483380624e50ab3cbcd48aa5e34f807f51..3ca73d8c4709d6a95bc8f6b81b977a069f9cba17 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2287,7 +2287,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -29,10 +29,10 @@ index 16a5fb9ef97170f337ede5da0646dcdd233f7b4e..bdfa5c65e41edb7cdcb5a0fff54d9384
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cdbdeef88b0b54ae3d51aec5641aac3b216a1cf3..4581483c0a4834501040add9f1314fe9cb29d133 100644
+index 977b4f3a624d0087171441fed19c2c7745f3b1f9..25fb7bafcc42e75fc47a7fbe28d2e2ba2bf580b4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1978,7 +1978,7 @@ public final class CraftServer implements Server {
+@@ -1981,7 +1981,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -221,7 +221,7 @@ index 4185e6bcf9b2bb65b2a0fa5fcbeb5684615169a7..dbc29442f2b2ad3ea451910f4944e901
          this.maxCount = i * i;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7db56c1b150ba58777cd5d017bbe5522837c4cb7..50ad307aa6d9f19092c59f0ee7d6321d5ec08c92 100644
+index 7db56c1b150ba58777cd5d017bbe5522837c4cb7..d99238423aa3a699dcf302283cf5bf8dd57785d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -1336,15 +1336,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -243,7 +243,7 @@ index 7db56c1b150ba58777cd5d017bbe5522837c4cb7..50ad307aa6d9f19092c59f0ee7d6321d
          } else {
 -            // TODO: doesn't work well if spawn changed....
 -            this.world.getChunkSource().removeRegionTicket(TicketType.START, new ChunkPos(chunkcoordinates), 11, Unit.INSTANCE);
-+            // TODO: doesn't work well if spawn changed.... // paper - resolved
++            // TODO: doesn't work well if spawn changed.... // Paper - resolved
 +            this.world.removeTicketsForSpawn(this.world.paperConfig.keepLoadedRange, chunkcoordinates);
          }
 +        // Paper end

--- a/patches/server/0332-Implement-CraftBlockSoundGroup.patch
+++ b/patches/server/0332-Implement-CraftBlockSoundGroup.patch
@@ -49,10 +49,10 @@ index 0000000000000000000000000000000000000000..9a516520d975f52169e346adc4ec6d9d
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 650e119a4683ad5cb0175dd558f9299f0ebcca0d..bfacffcb39d0c4e6992df282b5b28bd7ca8d5398 100644
+index f1c4c3a3392c2d4d836fa10d7a38558d08084d9d..71b5ef18e6b0ef48834c125d9503f70359a2dfd0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -763,4 +763,10 @@ public class CraftBlock implements Block {
+@@ -594,4 +594,10 @@ public class CraftBlock implements Block {
          VoxelShape shape = this.getNMS().getCollisionShape(world, position);
          return new CraftVoxelShape(shape);
      }

--- a/patches/server/0335-Expose-the-internal-current-tick.patch
+++ b/patches/server/0335-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4581483c0a4834501040add9f1314fe9cb29d133..2e4433d1c1474a8b686ed85ba3b09d3640f9e1d2 100644
+index 25fb7bafcc42e75fc47a7fbe28d2e2ba2bf580b4..7289ebb6ae2c38964acc362d911b3f6c9f08f5b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2502,5 +2502,10 @@ public final class CraftServer implements Server {
+@@ -2514,5 +2514,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0337-Show-blockstate-location-if-we-failed-to-read-it.patch
+++ b/patches/server/0337-Show-blockstate-location-if-we-failed-to-read-it.patch
@@ -5,19 +5,18 @@ Subject: [PATCH] Show blockstate location if we failed to read it
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-index 204a61767d5cacc962094b9ecc37f457987cbde7..890881fad11549fe35d16f25e3f1f2b2ee527d02 100644
+index 5ddf15cf79def8b769624b9f1ab0440dbf0ab395..5a7046de1d60ebb6080609341f93c4b00e7137e5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockEntityState.java
-@@ -19,6 +19,8 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
-     public CraftBlockEntityState(Block block, Class<T> tileEntityClass) {
-         super(block);
+@@ -18,6 +18,7 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
  
-+        try {// Paper - show location on failure
-+
-         this.tileEntityClass = tileEntityClass;
+         this.tileEntity = tileEntity;
  
-         // get tile entity from block:
-@@ -37,6 +39,14 @@ public class CraftBlockEntityState<T extends BlockEntity> extends CraftBlockStat
++        try { // Paper - show location on failure
+         // Paper start
+         this.snapshotDisabled = DISABLE_SNAPSHOT;
+         if (DISABLE_SNAPSHOT) {
+@@ -30,6 +31,14 @@ public abstract class CraftBlockEntityState<T extends BlockEntity> extends Craft
              this.load(this.snapshot);
          }
          // Paper end
@@ -26,9 +25,9 @@ index 204a61767d5cacc962094b9ecc37f457987cbde7..890881fad11549fe35d16f25e3f1f2b2
 +            if (thr instanceof ThreadDeath) {
 +                throw (ThreadDeath)thr;
 +            }
-+            throw new RuntimeException("Failed to read BlockState at: world: " + block.getWorld().getName() + " location: (" + block.getX() + ", " + block.getY() + ", " + block.getZ() + ")", thr);
++            throw new RuntimeException("Failed to read BlockState at: world: " + this.getWorld().getName() + " location: (" + this.getX() + ", " + this.getY() + ", " + this.getZ() + ")", thr);
 +        }
 +        // Paper end
      }
  
-     public final boolean snapshotDisabled; // Paper
+     public void refreshSnapshot() {

--- a/patches/server/0362-Fix-last-firework-in-stack-not-having-effects-when-d.patch
+++ b/patches/server/0362-Fix-last-firework-in-stack-not-having-effects-when-d.patch
@@ -9,10 +9,10 @@ dispensed. The resulting item would have size == 0 and therefore
 be convertered to air, hence why the effects disappeared.
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index b665d4293b746b221d469a7b029c1c7f17df6188..92623ae25249d63efb92be8bd6c95228f9155ad2 100644
+index 442845d1aa26cf888c88536c6a7db510807b2855..c5c8a889b745f36c2dce9dbb5d0b6edaefafdd22 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-@@ -431,7 +431,7 @@ public interface DispenseItemBehavior {
+@@ -513,7 +513,7 @@ public interface DispenseItemBehavior {
                  }
  
                  itemstack1 = CraftItemStack.asNMSCopy(event.getItem());

--- a/patches/server/0363-Add-effect-to-block-break-naturally.patch
+++ b/patches/server/0363-Add-effect-to-block-break-naturally.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index bfacffcb39d0c4e6992df282b5b28bd7ca8d5398..d15dda75952269addf0aa2a028c6552217bef312 100644
+index 71b5ef18e6b0ef48834c125d9503f70359a2dfd0..5f9f35c25a6247b6cd1ba31888a0afb8cea31da2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -634,6 +634,18 @@ public class CraftBlock implements Block {
+@@ -465,6 +465,18 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean breakNaturally(ItemStack item) {
@@ -27,7 +27,7 @@ index bfacffcb39d0c4e6992df282b5b28bd7ca8d5398..d15dda75952269addf0aa2a028c65522
          // Order matters here, need to drop before setting to air so skulls can get their data
          net.minecraft.world.level.block.state.BlockState iblockdata = this.getNMS();
          net.minecraft.world.level.block.Block block = iblockdata.getBlock();
-@@ -643,6 +655,7 @@ public class CraftBlock implements Block {
+@@ -474,6 +486,7 @@ public class CraftBlock implements Block {
          // Modelled off EntityHuman#hasBlock
          if (block != Blocks.AIR && (item == null || !iblockdata.requiresCorrectToolForDrops() || nmsItem.isCorrectToolForDrops(iblockdata))) {
              net.minecraft.world.level.block.Block.dropResources(iblockdata, this.world.getMinecraftWorld(), position, this.world.getBlockEntity(position), null, nmsItem);

--- a/patches/server/0382-add-hand-to-BlockMultiPlaceEvent.patch
+++ b/patches/server/0382-add-hand-to-BlockMultiPlaceEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add hand to BlockMultiPlaceEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aa652bfcd0e60784afc36a800a0278c3baa32221..8063583b8b59534d277d14c28faa607efc1e26ed 100644
+index ce67bbe8d29abe61d6e7db7b0a5c8f695ed2a1a1..1ae46f54e88b5e0eb218689d39ddadafd4f98d57 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -343,13 +343,18 @@ public class CraftEventFactory {
+@@ -344,13 +344,18 @@ public class CraftEventFactory {
          }
  
          org.bukkit.inventory.ItemStack item;

--- a/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
@@ -87,7 +87,7 @@ index 86e16e39a9a996669989d990b76f69116bcee300..f1034cfb63ea37c22e67b5d4a1821477
          version = getInt("config-version", 22);
          set("config-version", 22);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 273774ad46b993212a0cd4cfa81f0e02807c442e..c4f52d4511476f8fd904e4eb790b07d36cfdb145 100644
+index 026397cbedd2d1cd08ec8a82a3468f35cd8e4765..74051c9b620516dc2f302b1595e74faf91519962 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -248,6 +248,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -146,10 +146,10 @@ index 273774ad46b993212a0cd4cfa81f0e02807c442e..c4f52d4511476f8fd904e4eb790b07d3
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2e4433d1c1474a8b686ed85ba3b09d3640f9e1d2..c706fbe6ce3110b377c2c36c5c6ab0761f0667dc 100644
+index 7289ebb6ae2c38964acc362d911b3f6c9f08f5b9..d141e1edc81c1f3af8104541e571a1d34c392e76 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2340,6 +2340,16 @@ public final class CraftServer implements Server {
+@@ -2352,6 +2352,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0398-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0398-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index c706fbe6ce3110b377c2c36c5c6ab0761f0667dc..685f96a7beef1bfddbe1750b1b5bb32fdc12a983 100644
+index d141e1edc81c1f3af8104541e571a1d34c392e76..8831a73ee723bd510d48b577f3d765beb09d45d6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2517,5 +2517,10 @@ public final class CraftServer implements Server {
+@@ -2529,5 +2529,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0402-Improved-Watchdog-Support.patch
+++ b/patches/server/0402-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index e3b605695e3b837246f72ccb364af06ea48bda45..62c3c597732e6fb30ed5367d902ea876
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c4f52d4511476f8fd904e4eb790b07d36cfdb145..2e8892211dd3eb4cac27bcb3b302a25d833e2626 100644
+index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d7579d912 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -299,7 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -262,7 +262,7 @@ index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 147ee80242758417464a7cdf02e746758b54f6d7..a586623ed0f7003905e053c238d9b62632b87bc6 100644
+index 0f87595cb58d1ea0162b5eda81490c584a82aaf7..ced402efc036ae6111867c4c1872390b720659f3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -581,6 +581,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -323,10 +323,10 @@ index 016c2302d8bcf121eafd1be7eb4f3b206dbdbeec..1de1566b76c73ddfaf7e022296068db0
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 685f96a7beef1bfddbe1750b1b5bb32fdc12a983..a9f58486cb9656542f7e870ee4e4c8b5c4fc384a 100644
+index 8831a73ee723bd510d48b577f3d765beb09d45d6..92dc9b6829b591b20664306af1a8147cc8171734 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1978,7 +1978,7 @@ public final class CraftServer implements Server {
+@@ -1981,7 +1981,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0419-Don-t-fire-BlockFade-on-worldgen-threads.patch
+++ b/patches/server/0419-Don-t-fire-BlockFade-on-worldgen-threads.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Don't fire BlockFade on worldgen threads
 Caused a deadlock
 
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index becf80cdbbeb6327958758779cc42ea894127988..3249b4a7e2267d8c321ae4cf592e9fc26dfdcb98 100644
+index 8ce3dea66a1f45bb3f416bca1765c563394ad8ed..4156f212461201e8f8001f3fbcd7fb683e86ed6b 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-@@ -100,6 +100,7 @@ public class FireBlock extends BaseFireBlock {
+@@ -101,6 +101,7 @@ public class FireBlock extends BaseFireBlock {
      @Override
      public BlockState updateShape(BlockState state, Direction direction, BlockState neighborState, LevelAccessor world, BlockPos pos, BlockPos neighborPos) {
          // CraftBukkit start
@@ -17,7 +17,7 @@ index becf80cdbbeb6327958758779cc42ea894127988..3249b4a7e2267d8c321ae4cf592e9fc2
          if (!this.canSurvive(state, world, pos)) {
              // Suppress during worldgen
              if (!(world instanceof Level)) {
-@@ -115,7 +116,7 @@ public class FireBlock extends BaseFireBlock {
+@@ -116,7 +117,7 @@ public class FireBlock extends BaseFireBlock {
                  return blockState.getHandle();
              }
          }

--- a/patches/server/0421-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0421-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -102,10 +102,10 @@ index bbde9b758643c087733064a126d90689d71830cf..069cdfce085909991a69ebec3004d407
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 794f8cbcf7072b10fa06c26a122739b37fe0430c..09e0b2fface050699872341215c257d4b8f403c2 100644
+index 1ae46f54e88b5e0eb218689d39ddadafd4f98d57..00dc51a50e34240380411f7ebee23ece32f48d00 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -826,7 +826,8 @@ public class CraftEventFactory {
+@@ -827,7 +827,8 @@ public class CraftEventFactory {
          for (org.bukkit.inventory.ItemStack stack : event.getDrops()) {
              if (stack == null || stack.getType() == Material.AIR || stack.getAmount() == 0) continue;
  

--- a/patches/server/0425-Expose-game-version.patch
+++ b/patches/server/0425-Expose-game-version.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose game version
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index a9f58486cb9656542f7e870ee4e4c8b5c4fc384a..89124225b6cf10a4e370fbb88dca956c6551d4e5 100644
+index 92dc9b6829b591b20664306af1a8147cc8171734..4a326f928f81442c02e2cec94a8e84abff497c96 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -532,6 +532,13 @@ public final class CraftServer implements Server {
+@@ -535,6 +535,13 @@ public final class CraftServer implements Server {
          return this.bukkitVersion;
      }
  

--- a/patches/server/0428-misc-debugging-dumps.patch
+++ b/patches/server/0428-misc-debugging-dumps.patch
@@ -29,7 +29,7 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2e8892211dd3eb4cac27bcb3b302a25d833e2626..99555bb8b6f5b8c2bb9a15ee469fe2dd3b980f67 100644
+index 67858a375fba9b1d5f55d97bd9abfe5d7579d912..02158eee02ca4735015e768f7bd03c36fc9942f0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -936,6 +936,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -74,10 +74,10 @@ index bd1203a5b58bac7cccf1f81337fa2967a0e9eb40..6468a675862ee2956308b760012fe25c
                  this.connection.send(new ClientboundDisconnectPacket(chatmessage));
                  this.connection.disconnect(chatmessage);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 89124225b6cf10a4e370fbb88dca956c6551d4e5..5c5bc6f7184ce604f27183dfe70919c8175e7708 100644
+index 4a326f928f81442c02e2cec94a8e84abff497c96..bc152fea503bfb43eb39b2c18c15a7c557bb08b7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -935,6 +935,7 @@ public final class CraftServer implements Server {
+@@ -938,6 +938,7 @@ public final class CraftServer implements Server {
                  plugin.getDescription().getFullName(),
                  "This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
              ));

--- a/patches/server/0430-Implement-Mob-Goal-API.patch
+++ b/patches/server/0430-Implement-Mob-Goal-API.patch
@@ -798,10 +798,10 @@ index fabd20265863751ad980ee4a697f3f0d47df101f..3a4da2bb86a742985d309eb325dc843a
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5c5bc6f7184ce604f27183dfe70919c8175e7708..fec172291cc2f5544943b3c0f2fe64221ba7d54c 100644
+index bc152fea503bfb43eb39b2c18c15a7c557bb08b7..a6068abb1fa7b2f2d6aba1df0cd8b2799c9d6226 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2530,5 +2530,11 @@ public final class CraftServer implements Server {
+@@ -2542,5 +2542,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -22,10 +22,10 @@ index e146dad0d90fee216630eb3df6a34e2a0f6441a6..eb30ec087b90835aba281580b0563d02
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 09e0b2fface050699872341215c257d4b8f403c2..bb80d9840fd9448bf18df00c205a93a623b45ba9 100644
+index 00dc51a50e34240380411f7ebee23ece32f48d00..d2039090446834ad57d09d441ee412715d6cecc3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -629,16 +629,30 @@ public class CraftEventFactory {
+@@ -630,16 +630,30 @@ public class CraftEventFactory {
              net.minecraft.world.entity.ExperienceOrb xp = (net.minecraft.world.entity.ExperienceOrb) entity;
              double radius = world.spigotConfig.expMerge;
              if (radius > 0) {

--- a/patches/server/0435-ExperienceOrbMergeEvent.patch
+++ b/patches/server/0435-ExperienceOrbMergeEvent.patch
@@ -9,10 +9,10 @@ Plugins can cancel this if they want to ensure experience orbs do not lose impor
 metadata such as spawn reason, or conditionally move data from source to target.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bb80d9840fd9448bf18df00c205a93a623b45ba9..0cb910df23ed963b70b28be26a30460b7882c112 100644
+index d2039090446834ad57d09d441ee412715d6cecc3..bbc7f21bfdf5c8f413866fc24ebb2fefb2166096 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -639,7 +639,7 @@ public class CraftEventFactory {
+@@ -640,7 +640,7 @@ public class CraftEventFactory {
                      if (e instanceof net.minecraft.world.entity.ExperienceOrb) {
                          net.minecraft.world.entity.ExperienceOrb loopItem = (net.minecraft.world.entity.ExperienceOrb) e;
                          // Paper start

--- a/patches/server/0439-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0439-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,7 +10,7 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 99555bb8b6f5b8c2bb9a15ee469fe2dd3b980f67..f5ef6219b20d5b7af81537dab8d9815d74d1560a 100644
+index 02158eee02ca4735015e768f7bd03c36fc9942f0..324ebb1bec9c25fe11b39b637c089836b303d766 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -971,6 +971,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -22,10 +22,10 @@ index 99555bb8b6f5b8c2bb9a15ee469fe2dd3b980f67..f5ef6219b20d5b7af81537dab8d9815d
          // CraftBukkit end
          if (this.getConnection() != null) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fec172291cc2f5544943b3c0f2fe64221ba7d54c..7cc882333b28fe79d3445c0b9d1bb5e71e2418eb 100644
+index a6068abb1fa7b2f2d6aba1df0cd8b2799c9d6226..746234b93587ab3aa45e53ae4684314606453dc7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -944,6 +944,35 @@ public final class CraftServer implements Server {
+@@ -947,6 +947,35 @@ public final class CraftServer implements Server {
          org.spigotmc.WatchdogThread.hasStarted = true; // Paper - Disable watchdog early timeout on reload
      }
  

--- a/patches/server/0454-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0454-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,10 +22,10 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 7cc882333b28fe79d3445c0b9d1bb5e71e2418eb..ecc65fe9783f0f369695edc1183f3d49686d66f9 100644
+index 746234b93587ab3aa45e53ae4684314606453dc7..fa11223ea8a1ecb1bafcca63855dc9930ec18a34 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -360,7 +360,7 @@ public final class CraftServer implements Server {
+@@ -363,7 +363,7 @@ public final class CraftServer implements Server {
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));
@@ -34,7 +34,7 @@ index 7cc882333b28fe79d3445c0b9d1bb5e71e2418eb..ecc65fe9783f0f369695edc1183f3d49
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
      }
-@@ -845,7 +845,7 @@ public final class CraftServer implements Server {
+@@ -848,7 +848,7 @@ public final class CraftServer implements Server {
          this.waterAmbientSpawn = this.configuration.getInt("spawn-limits.water-ambient");
          this.ambientSpawn = this.configuration.getInt("spawn-limits.ambient");
          this.warningState = WarningState.value(this.configuration.getString("settings.deprecated-verbose"));

--- a/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -94,10 +94,10 @@ index 7bd2a88de8eaf9d72d9424a39d5df2600bed7e58..c0ae236619bbdf9293fbf1c4a1764a78
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ecc65fe9783f0f369695edc1183f3d49686d66f9..d1038dc34735e666ea35d5b0fcec67120a15ff85 100644
+index fa11223ea8a1ecb1bafcca63855dc9930ec18a34..eda4a886caf1070090e862029f61775b4cd0fd84 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -865,8 +865,8 @@ public final class CraftServer implements Server {
+@@ -868,8 +868,8 @@ public final class CraftServer implements Server {
          org.spigotmc.SpigotConfig.init((File) console.options.valueOf("spigot-settings")); // Spigot
          com.destroystokyo.paper.PaperConfig.init((File) console.options.valueOf("paper-settings")); // Paper
          for (ServerLevel world : this.console.getAllLevels()) {

--- a/patches/server/0484-Add-PrepareResultEvent.patch
+++ b/patches/server/0484-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index 3df5031ec2c50dc6eb2533318cf8a98f21b03d2a..c971a534ded962e3be92c71059c75cc1
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0cb910df23ed963b70b28be26a30460b7882c112..c1ae63dfd9ad7519ba538b60f6c254f791d53600 100644
+index bbc7f21bfdf5c8f413866fc24ebb2fefb2166096..0fcfa522d16386edca72450975ce9f90140240ed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1555,19 +1555,44 @@ public class CraftEventFactory {
+@@ -1556,19 +1556,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0485-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0485-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ecc65fe9783f0f369695edc1183f3d49686d66f9..f150b3558783c70b63114e3c9e23767b16ba4564 100644
+index fa11223ea8a1ecb1bafcca63855dc9930ec18a34..a145fbfcd0905660b37e44489ee0ecf2ae27d87f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2172,6 +2172,32 @@ public final class CraftServer implements Server {
+@@ -2175,6 +2175,32 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world);
      }
  

--- a/patches/server/0505-Add-setMaxPlayers-API.patch
+++ b/patches/server/0505-Add-setMaxPlayers-API.patch
@@ -18,10 +18,10 @@ index 9a73364f4d56f3a7cecb27bc8034166b8f5731b9..4d1d5dacb175e7059a6af036432ef891
      private boolean allowCheatsForAllPlayers;
      private static final boolean ALLOW_LOGOUTIVATOR = false;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f150b3558783c70b63114e3c9e23767b16ba4564..b3d31570fdd9954cee8d600da3ab57eb520a4171 100644
+index a145fbfcd0905660b37e44489ee0ecf2ae27d87f..f8e4c529ac0ec0d22a81c7548ec5626edb79cb79 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -627,6 +627,13 @@ public final class CraftServer implements Server {
+@@ -630,6 +630,13 @@ public final class CraftServer implements Server {
          return this.playerList.getMaxPlayers();
      }
  

--- a/patches/server/0516-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/patches/server/0516-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -60,7 +60,7 @@ index a36d31caa5bfc82a5fd9b16dc42334955fe7511d..177d1da44c83da5f99ae91891dec41dc
  
          }
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index 3249b4a7e2267d8c321ae4cf592e9fc26dfdcb98..6754d071fe91f9e89cca0be4a06431007289ab10 100644
+index 4156f212461201e8f8001f3fbcd7fb683e86ed6b..c8a58cd67bb7f7491de04bda703e2a1f166fb845 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 @@ -13,6 +13,7 @@ import net.minecraft.core.Direction;
@@ -71,7 +71,7 @@ index 3249b4a7e2267d8c321ae4cf592e9fc26dfdcb98..6754d071fe91f9e89cca0be4a0643100
  import net.minecraft.world.level.BlockGetter;
  import net.minecraft.world.level.GameRules;
  import net.minecraft.world.level.Level;
-@@ -358,9 +359,11 @@ public class FireBlock extends BaseFireBlock {
+@@ -359,9 +360,11 @@ public class FireBlock extends BaseFireBlock {
      }
  
      @Override

--- a/patches/server/0519-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0519-Add-methods-to-get-translation-keys.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add methods to get translation keys
 Co-authored-by: MeFisto94 <MeFisto94@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index d15dda75952269addf0aa2a028c6552217bef312..4cebd01eb5cb83395439f92bffdeb8563c300818 100644
+index 5f9f35c25a6247b6cd1ba31888a0afb8cea31da2..4febad176d8dc7c56e9cb09c8e5ce55f4c9f3288 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -781,5 +781,15 @@ public class CraftBlock implements Block {
+@@ -612,5 +612,15 @@ public class CraftBlock implements Block {
      public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
          return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
      }

--- a/patches/server/0534-Optimise-getType-calls.patch
+++ b/patches/server/0534-Optimise-getType-calls.patch
@@ -41,10 +41,10 @@ index e2e6652fc227173b69580dba74855c3ed8884a3b..2c23712aadfe32439ae014c62aa16f1b
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index ab47da233bd06cff0c5c9109e615e1cb9a39ebf0..564aaa0c01a120ed9035e664702a32822dc3076e 100644
+index 4febad176d8dc7c56e9cb09c8e5ce55f4c9f3288..fd4a0bbd1438bfc94580f29382d0c5f50531292b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -213,7 +213,7 @@ public class CraftBlock implements Block {
+@@ -212,7 +212,7 @@ public class CraftBlock implements Block {
  
      @Override
      public Material getType() {
@@ -54,10 +54,10 @@ index ab47da233bd06cff0c5c9109e615e1cb9a39ebf0..564aaa0c01a120ed9035e664702a3282
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
-index ba3e56185f2fba36143cb2ba5178399088a385a8..77ec9742e375ba4a534c148e9871071ce882de99 100644
+index 3d8d8e797a08067725924de1d1f07ada75cdb683..b2b41b5c3a6cab44d49a43b6b0db2fea3271c225 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
-@@ -161,7 +161,7 @@ public class CraftBlockState implements BlockState {
+@@ -153,7 +153,7 @@ public class CraftBlockState implements BlockState {
  
      @Override
      public Material getType() {

--- a/patches/server/0543-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0543-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b3d31570fdd9954cee8d600da3ab57eb520a4171..f5a57059b4a605bafcd203fbfeaf81cbdc2f58e5 100644
+index f8e4c529ac0ec0d22a81c7548ec5626edb79cb79..aea50864299a761894921109f2a2ad788cca92e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1742,6 +1742,28 @@ public final class CraftServer implements Server {
+@@ -1745,6 +1745,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0549-Beacon-API-custom-effect-ranges.patch
+++ b/patches/server/0549-Beacon-API-custom-effect-ranges.patch
@@ -95,10 +95,10 @@ index 0fa01b98f4a2ce2a7d34437a71d8c1cc7e718fb1..11740e6a312cf8ab10b52461f455feba
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
-index c35e1964a295032623cf9cb6ade84e69ed92194f..d1195dbe84eecb209b8863d177a5eb568d567f87 100644
+index 22e9245b0a0d30972980c6c13a22cb4501c3d3ca..046981c5611d2064811fa34a02218db4a7c1c0c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBeacon.java
-@@ -34,7 +34,7 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
+@@ -29,7 +29,7 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
          if (tileEntity instanceof BeaconBlockEntity) {
              BeaconBlockEntity beacon = (BeaconBlockEntity) tileEntity;
  
@@ -107,7 +107,7 @@ index c35e1964a295032623cf9cb6ade84e69ed92194f..d1195dbe84eecb209b8863d177a5eb56
              Collection<LivingEntity> bukkit = new ArrayList<LivingEntity>(nms.size());
  
              for (Player human : nms) {
-@@ -111,4 +111,21 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
+@@ -106,4 +106,21 @@ public class CraftBeacon extends CraftBlockEntityState<BeaconBlockEntity> implem
      public void setLock(String key) {
          this.getSnapshot().lockKey = (key == null) ? LockCode.NO_LOCK : new LockCode(key);
      }

--- a/patches/server/0555-Add-Destroy-Speed-API.patch
+++ b/patches/server/0555-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 0a3c4453cab41e003a386c1e13dffb4ebb893cdd..367334575ef6dbfd0d17f4a40ce97f8f4715e19b 100644
+index fd4a0bbd1438bfc94580f29382d0c5f50531292b..6d79409f58715038de1e9e397e73f8739fb9dca2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -791,5 +791,23 @@ public class CraftBlock implements Block {
+@@ -622,5 +622,23 @@ public class CraftBlock implements Block {
      public String translationKey() {
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/server/0571-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
+++ b/patches/server/0571-Add-OBSTRUCTED-reason-to-BedEnterResult.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add OBSTRUCTED reason to BedEnterResult
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c1ae63dfd9ad7519ba538b60f6c254f791d53600..caf747d2a9079b5161c1b3a5be1e66e29146e56f 100644
+index 0fcfa522d16386edca72450975ce9f90140240ed..3dac0ddcbc5d620e4db3b24c80505bf4aedd4608 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -261,6 +261,10 @@ public class CraftEventFactory {
+@@ -262,6 +262,10 @@ public class CraftEventFactory {
                          return BedEnterResult.TOO_FAR_AWAY;
                      case NOT_SAFE:
                          return BedEnterResult.NOT_SAFE;

--- a/patches/server/0575-Additional-Block-Material-API-s.patch
+++ b/patches/server/0575-Additional-Block-Material-API-s.patch
@@ -9,10 +9,10 @@ process to do this in the Bukkit API
 Adds API for buildable, replaceable, burnable too.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index ffbe3d5af03b5e6b6cf1fe6212f5a0f7396babb3..b78c6bc81474024658857679f943e0bc5553edea 100644
+index 6d79409f58715038de1e9e397e73f8739fb9dca2..4d6a5f6db4803aa04d2eb25ef849b7d76de00e6b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -622,6 +622,25 @@ public class CraftBlock implements Block {
+@@ -453,6 +453,25 @@ public class CraftBlock implements Block {
          return this.getNMS().getMaterial().isLiquid();
      }
  

--- a/patches/server/0590-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0590-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 51723c8f740c7b0bbd15acc0f1c848790c2ff299..5a95b550c767284563c124df1ff45322
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index caf747d2a9079b5161c1b3a5be1e66e29146e56f..133a4a00d74a719881bca47d9d5efc850c7fa4bf 100644
+index 3dac0ddcbc5d620e4db3b24c80505bf4aedd4608..efb0ea920f3e8729745a2bb5b5c27f2656b1e509 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1829,4 +1829,12 @@ public class CraftEventFactory {
+@@ -1830,4 +1830,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0595-Implement-API-to-expose-exact-interaction-point.patch
+++ b/patches/server/0595-Implement-API-to-expose-exact-interaction-point.patch
@@ -18,7 +18,7 @@ index 0b274a5b9e0bf68769637f10e43dbff6d909512b..da2ae74b6f5875200e22c42ed0743101
          this.interactResult = event.useItemInHand() == Event.Result.DENY;
          this.interactPosition = blockposition.immutable();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 08edd5d673e3dab3aec7d6e775e0c24942bba3ee..64a3d7a44a208e966411a006c7a2d1c5d349df95 100644
+index efb0ea920f3e8729745a2bb5b5c27f2656b1e509..239b43267e292b57467a98814308b6ce9820a690 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -56,7 +56,9 @@ import net.minecraft.world.level.storage.loot.parameters.LootContextParams;
@@ -31,7 +31,7 @@ index 08edd5d673e3dab3aec7d6e775e0c24942bba3ee..64a3d7a44a208e966411a006c7a2d1c5
  import org.bukkit.Material;
  import org.bukkit.NamespacedKey;
  import org.bukkit.Server;
-@@ -481,7 +483,13 @@ public class CraftEventFactory {
+@@ -482,7 +484,13 @@ public class CraftEventFactory {
          return CraftEventFactory.callPlayerInteractEvent(who, action, position, direction, itemstack, false, hand);
      }
  
@@ -45,7 +45,7 @@ index 08edd5d673e3dab3aec7d6e775e0c24942bba3ee..64a3d7a44a208e966411a006c7a2d1c5
          Player player = (who == null) ? null : (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asCraftMirror(itemstack);
  
-@@ -507,7 +515,10 @@ public class CraftEventFactory {
+@@ -508,7 +516,10 @@ public class CraftEventFactory {
              itemInHand = null;
          }
  

--- a/patches/server/0605-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0605-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 501a5483160dba050261bb3448317a097cdb7ef2..2dcac4b638073aa1748f26f61219dbf9
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 64a3d7a44a208e966411a006c7a2d1c5d349df95..5722f246843cd9094524462346889b04c8ad6d89 100644
+index 239b43267e292b57467a98814308b6ce9820a690..e78064303898e00d6438c4262676cbdc1afdd3ac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1847,5 +1847,11 @@ public class CraftEventFactory {
+@@ -1848,5 +1848,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0606-Added-Vanilla-Entity-Tags.patch
+++ b/patches/server/0606-Added-Vanilla-Entity-Tags.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Added Vanilla Entity Tags
 
 diff --git a/src/main/java/io/papermc/paper/CraftEntityTag.java b/src/main/java/io/papermc/paper/CraftEntityTag.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf95fdb2d8
+index 0000000000000000000000000000000000000000..dd6faad4f2591de0cf4a48744a7bd0280594605b
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/CraftEntityTag.java
-@@ -0,0 +1,28 @@
+@@ -0,0 +1,29 @@
 +package io.papermc.paper;
 +
 +import org.bukkit.craftbukkit.tag.CraftTag;
@@ -22,6 +22,7 @@ index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf
 +import net.minecraft.resources.ResourceLocation;
 +import net.minecraft.tags.TagCollection;
 +
++@Deprecated(forRemoval = true)
 +public class CraftEntityTag extends CraftTag<net.minecraft.world.entity.EntityType<?>, EntityType> {
 +
 +    public CraftEntityTag(TagCollection<net.minecraft.world.entity.EntityType<?>> registry, ResourceLocation tag) {
@@ -39,13 +40,13 @@ index 0000000000000000000000000000000000000000..6271586368c65250c887739d04c5fccf
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index f5a57059b4a605bafcd203fbfeaf81cbdc2f58e5..bca12654736aa4134e634607753b0268cc69eccb 100644
+index 1b6db3c2e2db1d5187edb43b60449c23338f7a0e..00b9a201325311ad92f8a195e05e1ea759c6fc06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2361,6 +2361,11 @@ public final class CraftServer implements Server {
-                 Preconditions.checkArgument(clazz == org.bukkit.Fluid.class, "Fluid namespace must have fluid type");
+@@ -2368,6 +2368,11 @@ public final class CraftServer implements Server {
+                 Preconditions.checkArgument(clazz == org.bukkit.entity.EntityType.class, "Entity type namespace must have entity type");
  
-                 return (org.bukkit.Tag<T>) new CraftFluidTag(FluidTags.getAllTags(), key);
+                 return (org.bukkit.Tag<T>) new CraftEntityTag(EntityTypeTags.getAllTags(), key);
 +            // Paper start
 +            case org.bukkit.Tag.REGISTRY_ENTITIES:
 +                Preconditions.checkArgument(clazz == org.bukkit.entity.EntityType.class, "Entity namespace must have entitytype type");

--- a/patches/server/0611-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0611-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -122,10 +122,10 @@ index b9b67134f02fd7484ed19905c9ae1f9b8a26ce26..c05f173b7642380900fdd77ce5d2c020
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b3d218a1a1bd52dfe00062ef82779cf81157e74b..0deb6fd786ffdb2f3a2b51f487288d6917b1229f 100644
+index e78064303898e00d6438c4262676cbdc1afdd3ac..28b3206df48335b27360bf4e2343cfcb550ae9e8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1488,8 +1488,10 @@ public class CraftEventFactory {
+@@ -1489,8 +1489,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0614-add-DragonEggFormEvent.patch
+++ b/patches/server/0614-add-DragonEggFormEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] add DragonEggFormEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
-index f88719dede80c064f6210e078c435ffda32ecc1a..93dd5a2d0b550b0373cbf59376a04e9fd6146e92 100644
+index f88719dede80c064f6210e078c435ffda32ecc1a..dec99c9d40705a89c395437d0d050f3ab36bc17b 100644
 --- a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 @@ -363,9 +363,24 @@ public class EndDragonFight {
@@ -15,7 +15,7 @@ index f88719dede80c064f6210e078c435ffda32ecc1a..93dd5a2d0b550b0373cbf59376a04e9f
 +            // Paper start - DragonEggFormEvent
 +            BlockPos eggPosition = this.level.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, EndPodiumFeature.END_PODIUM_LOCATION);
 +            org.bukkit.craftbukkit.block.CraftBlock eggBlock = org.bukkit.craftbukkit.block.CraftBlock.at(this.level, eggPosition);
-+            org.bukkit.craftbukkit.block.CraftBlockState eggState = new org.bukkit.craftbukkit.block.CraftBlockState(eggBlock);
++            org.bukkit.craftbukkit.block.CraftBlockState eggState = org.bukkit.craftbukkit.block.CraftBlockStates.getBlockState(this.level, eggPosition);
 +            eggState.setData(Blocks.DRAGON_EGG.defaultBlockState());
 +            io.papermc.paper.event.block.DragonEggFormEvent eggEvent = new io.papermc.paper.event.block.DragonEggFormEvent(eggBlock, eggState,
 +                    new org.bukkit.craftbukkit.boss.CraftDragonBattle(this));

--- a/patches/server/0618-Allow-adding-items-to-BlockDropItemEvent.patch
+++ b/patches/server/0618-Allow-adding-items-to-BlockDropItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow adding items to BlockDropItemEvent
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0deb6fd786ffdb2f3a2b51f487288d6917b1229f..31bbf018e3b7cafb1e186c7d00b421fb133331a3 100644
+index 28b3206df48335b27360bf4e2343cfcb550ae9e8..bae223104530f39facdf15d45c9a27ea8414b3f8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -394,13 +394,30 @@ public class CraftEventFactory {
+@@ -395,13 +395,30 @@ public class CraftEventFactory {
      }
  
      public static void handleBlockDropItemEvent(Block block, BlockState state, ServerPlayer player, List<ItemEntity> items) {

--- a/patches/server/0635-Add-Block-isValidTool.patch
+++ b/patches/server/0635-Add-Block-isValidTool.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 703698c40cecea2c412d14e9fb82dfe4c6f7e9cf..39fbe639eddc7728c87fbafb924b9b9439e7e409 100644
+index 4d6a5f6db4803aa04d2eb25ef849b7d76de00e6b..ea1fa9758fcaa87de11b84d5a2e1d36b0e8930ee 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -828,5 +828,9 @@ public class CraftBlock implements Block {
+@@ -659,5 +659,9 @@ public class CraftBlock implements Block {
          }
          return speed;
      }

--- a/patches/server/0637-Implement-Keyed-on-World.patch
+++ b/patches/server/0637-Implement-Keyed-on-World.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement Keyed on World
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index bca12654736aa4134e634607753b0268cc69eccb..847dc9ef6d490386c419d536247e322b49e41e96 100644
+index 8a2a702db26cb1ae3db8680488977c28ad8b94e4..a65a9597fbb838b7bc939768220166e4242918c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1178,7 +1178,7 @@ public final class CraftServer implements Server {
+@@ -1181,7 +1181,7 @@ public final class CraftServer implements Server {
          } else if (name.equals(levelName + "_the_end")) {
              worldKey = net.minecraft.world.level.Level.END;
          } else {
@@ -17,7 +17,7 @@ index bca12654736aa4134e634607753b0268cc69eccb..847dc9ef6d490386c419d536247e322b
          }
  
          ServerLevel internal = (ServerLevel) new ServerLevel(this.console, console.executor, worldSession, worlddata, worldKey, dimensionmanager, this.getServer().progressListenerFactory.create(11),
-@@ -1270,6 +1270,15 @@ public final class CraftServer implements Server {
+@@ -1273,6 +1273,15 @@ public final class CraftServer implements Server {
          return null;
      }
  

--- a/patches/server/0641-copy-TESign-isEditable-from-snapshots.patch
+++ b/patches/server/0641-copy-TESign-isEditable-from-snapshots.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] copy TESign#isEditable from snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-index 6e89b039479a034d98d1ec183b06d5418ab51733..924a8278ffc27f0db5f50c16ff06ddfc3042f333 100644
+index b0a7f558cfe0f2ff859ab7b2db38ac303e9ae842..32e92c3ce1b50ec9eba53908070ea94763880479 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftSign.java
-@@ -118,6 +118,7 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
+@@ -113,6 +113,7 @@ public class CraftSign extends CraftBlockEntityState<SignBlockEntity> implements
              }
              // Paper end
          }

--- a/patches/server/0670-Add-EntityBlockStorage-clearEntities.patch
+++ b/patches/server/0670-Add-EntityBlockStorage-clearEntities.patch
@@ -21,10 +21,10 @@ index 61125c1c1a6efbb3ba13a29d5e4e6bbe67df8a4e..8484e80a70129fb0358d56efab6fd547
          return (Integer) state.getValue(BeehiveBlock.HONEY_LEVEL);
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
-index bf51c9e4fd5a5c19eef8572794ecc17157eb7767..5a0b6640de0e95bfe48ababeed4115240d205ddd 100644
+index 5db69fd9e822d80abb82b4a2145fc479d22f4f17..489d259d105476092d401f788c88c17c3bed86ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
-@@ -85,4 +85,10 @@ public class CraftBeehive extends CraftBlockEntityState<BeehiveBlockEntity> impl
+@@ -80,4 +80,10 @@ public class CraftBeehive extends CraftBlockEntityState<BeehiveBlockEntity> impl
  
          getSnapshot().addOccupant(((CraftBee) entity).getHandle(), false);
      }

--- a/patches/server/0677-Add-basic-Datapack-API.patch
+++ b/patches/server/0677-Add-basic-Datapack-API.patch
@@ -92,10 +92,10 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 847dc9ef6d490386c419d536247e322b49e41e96..b833a9eb958eeccc642869d669b3a63583d0fffa 100644
+index a65a9597fbb838b7bc939768220166e4242918c7..18f2a7bd9e7c3aa2f72a63280e9285d6d5cad305 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -281,6 +281,7 @@ public final class CraftServer implements Server {
+@@ -284,6 +284,7 @@ public final class CraftServer implements Server {
      public boolean ignoreVanillaPermissions = false;
      private final List<CraftPlayer> playerView;
      public int reloadCount;
@@ -103,7 +103,7 @@ index 847dc9ef6d490386c419d536247e322b49e41e96..b833a9eb958eeccc642869d669b3a635
      public static Exception excessiveVelEx; // Paper - Velocity warnings
  
      static {
-@@ -363,6 +364,7 @@ public final class CraftServer implements Server {
+@@ -366,6 +367,7 @@ public final class CraftServer implements Server {
          TicketType.PLUGIN.timeout = Math.min(20, this.configuration.getInt("chunk-gc.period-in-ticks")); // Paper - cap plugin loads to 1 second
          this.minimumAPI = this.configuration.getString("settings.minimum-api");
          this.loadIcon();
@@ -111,7 +111,7 @@ index 847dc9ef6d490386c419d536247e322b49e41e96..b833a9eb958eeccc642869d669b3a635
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2634,5 +2636,11 @@ public final class CraftServer implements Server {
+@@ -2646,5 +2648,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0682-Add-command-line-option-to-load-extra-plugin-jars-no.patch
+++ b/patches/server/0682-Add-command-line-option-to-load-extra-plugin-jars-no.patch
@@ -7,10 +7,10 @@ Subject: [PATCH] Add command line option to load extra plugin jars not in the
 ex: java -jar paperclip.jar nogui -add-plugin=/path/to/plugin.jar -add-plugin=/path/to/another/plugin_jar.jar
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b833a9eb958eeccc642869d669b3a63583d0fffa..4d330d1f71448cb9cbeb14cff04b48fdf18d3298 100644
+index 18f2a7bd9e7c3aa2f72a63280e9285d6d5cad305..e74259d55ca89f504f947380726321ca9e0680e9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -400,8 +400,13 @@ public final class CraftServer implements Server {
+@@ -403,8 +403,13 @@ public final class CraftServer implements Server {
  
          File pluginFolder = (File) console.options.valueOf("plugins");
  
@@ -26,7 +26,7 @@ index b833a9eb958eeccc642869d669b3a63583d0fffa..4d330d1f71448cb9cbeb14cff04b48fd
              for (Plugin plugin : plugins) {
                  try {
                      String message = String.format("Loading %s", plugin.getDescription().getFullName());
-@@ -416,6 +421,18 @@ public final class CraftServer implements Server {
+@@ -419,6 +424,18 @@ public final class CraftServer implements Server {
          }
      }
  

--- a/patches/server/0683-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0683-Fix-and-optimise-world-force-upgrading.patch
@@ -265,7 +265,7 @@ index cf0a74b8a1c31d4bc493eb09a69ee2bd94cb6485..cfd43069ee2b6f79afb12e10d223f6bf
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, worlds, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e35ca22d83e799c4682b54430c65291aa04aab18..2855749701f9fe6d3284e6f072e0971b46816e2a 100644
+index 3e90aa894b026278c61580791cb9fcd72d1e158f..22edac5278efc495885a5fc34677f26ea67ae9ca 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -563,13 +563,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -352,10 +352,10 @@ index 43510774d489bfdd30f10d521e424fa1363b8919..6496108953effae82391b5c1ea6fdec8
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 4d330d1f71448cb9cbeb14cff04b48fdf18d3298..15f38a0d0cd8de4f80b4360a22537ec478ebb77e 100644
+index e74259d55ca89f504f947380726321ca9e0680e9..28300c6cd9cd2a55a5c1b179d9b44aa754cf346d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1154,14 +1154,7 @@ public final class CraftServer implements Server {
+@@ -1157,14 +1157,7 @@ public final class CraftServer implements Server {
          }
          worlddata.checkName(name);
          worlddata.setModdedInfo(this.console.getServerModName(), this.console.getModdedStatus().isPresent());
@@ -371,7 +371,7 @@ index 4d330d1f71448cb9cbeb14cff04b48fdf18d3298..15f38a0d0cd8de4f80b4360a22537ec4
  
          long j = BiomeManager.obfuscateSeed(creator.seed());
          List<CustomSpawner> list = ImmutableList.of(new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(worlddata));
-@@ -1190,6 +1183,14 @@ public final class CraftServer implements Server {
+@@ -1193,6 +1186,14 @@ public final class CraftServer implements Server {
              }
          }
  

--- a/patches/server/0686-Add-EntityInsideBlockEvent.patch
+++ b/patches/server/0686-Add-EntityInsideBlockEvent.patch
@@ -149,10 +149,10 @@ index f0a3ef0529951e7732602d358ddea1782001db7e..6588b207d93d96934e72176874ba60c8
              entity.lavaHurt();
          }
 diff --git a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
-index a22676495796784e59a0dd11343c966ec7ea6bc6..d06a20f12a4c0d7d561141ca004a965751a68f9e 100644
+index 7f42886ce6dfff6807d3b38e26a1b122941d9f8c..3de9fc8873327ed14f231dde08ddfb24621a05da 100644
 --- a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
-@@ -59,6 +59,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
+@@ -60,6 +60,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
  
      @Override
      public void entityInside(BlockState state, Level world, BlockPos pos, Entity entity) {

--- a/patches/server/0689-More-Lidded-Block-API.patch
+++ b/patches/server/0689-More-Lidded-Block-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More Lidded Block API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
-index 2f3849135e5f335a6eef6e35cf40c8f93ac80124..ae7478b6de1b6e1812d081ec726130388e915337 100644
+index 9d0c272b1d89a96b0b63603fa8e4649f11fb6c51..d5fdf4504a0ca76fb0483f4ae5861c93fb622b2d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBarrel.java
-@@ -63,4 +63,11 @@ public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Bar
+@@ -58,4 +58,11 @@ public class CraftBarrel extends CraftLootable<BarrelBlockEntity> implements Bar
          }
          getTileEntity().openersCounter.opened = false;
      }
@@ -21,10 +21,10 @@ index 2f3849135e5f335a6eef6e35cf40c8f93ac80124..ae7478b6de1b6e1812d081ec72613038
 +    // Paper end - More Lidded Block API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-index 4d84bcdfb17a3d1bc79e5ec2b201739fa0db1bd3..bac6385f99d7475c627d69cde972f5a92ab57f4b 100644
+index 189674ce35f2da75a70e4a05c77dd022cef469db..2a723bd0850ee1201bb87760647bd4b3a93279fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
-@@ -82,4 +82,11 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+@@ -78,4 +78,11 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
          }
          getTileEntity().openersCounter.opened = false;
      }
@@ -37,12 +37,12 @@ index 4d84bcdfb17a3d1bc79e5ec2b201739fa0db1bd3..bac6385f99d7475c627d69cde972f5a9
 +    // Paper end - More Lidded Block API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
-index 25add8bee6ea35beeb205dd828759304346e4f48..599f6747dfa140e40fef26ed4d8244bfe87b7cdf 100644
+index 950066001b23e7b9aec48b2369163d6196979640..c48d7ec19603962855962c6ae6e1275c1552c906 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftEnderChest.java
-@@ -14,4 +14,33 @@ public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity
-     public CraftEnderChest(final Material material, final EnderChestBlockEntity te) {
-         super(material, te);
+@@ -9,4 +9,33 @@ public class CraftEnderChest extends CraftBlockEntityState<EnderChestBlockEntity
+     public CraftEnderChest(World world, EnderChestBlockEntity tileEntity) {
+         super(world, tileEntity);
      }
 +
 +    // Paper start - More Lidded Block API
@@ -75,12 +75,12 @@ index 25add8bee6ea35beeb205dd828759304346e4f48..599f6747dfa140e40fef26ed4d8244bf
 +    // Paper end - More Lidded Block API
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
-index 87395e1000dda3063dcdbc01c9e874ede2ccf5d9..35b05ff905de0f102a60ed3fcf9996fab1f047a6 100644
+index 2d5205a9adfa66545f40a13bf0e37dc62ac0fdb9..72074b4c0feea8136e80589345538552ce28a2ea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftShulkerBox.java
-@@ -61,8 +61,15 @@ public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implem
+@@ -55,8 +55,15 @@ public class CraftShulkerBox extends CraftLootable<ShulkerBoxBlockEntity> implem
          if (getTileEntity().opened && getWorldHandle() instanceof net.minecraft.world.level.Level) {
-             Level world = getTileEntity().getLevel();
+             net.minecraft.world.level.Level world = getTileEntity().getLevel();
              world.blockEvent(getPosition(), getTileEntity().getBlockState().getBlock(), 1, 0);
 -            world.playSound(null, getPosition(), SoundEvents.SHULKER_BOX_OPEN, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F);
 +            world.playSound(null, getPosition(), SoundEvents.SHULKER_BOX_CLOSE, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.1F + 0.9F); // Paper - More Lidded Block API (Wrong sound)

--- a/patches/server/0706-Add-more-LimitedRegion-API.patch
+++ b/patches/server/0706-Add-more-LimitedRegion-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add more LimitedRegion API
 
 diff --git a/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java b/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ccb6b20b5f56c3bacdc6bd384931986cf804f06a
+index 0000000000000000000000000000000000000000..1c6668c2b5e1816db7e0ebabc99af3586849e606
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/world/generation/CraftProtoWorld.java
 @@ -0,0 +1,116 @@
@@ -108,8 +108,8 @@ index 0000000000000000000000000000000000000000..ccb6b20b5f56c3bacdc6bd384931986c
 +    public <T extends Entity> @NotNull T spawn(@NotNull Vector location, @NotNull Class<T> clazz, @Nullable Consumer<T> function, CreatureSpawnEvent.@NotNull SpawnReason reason) throws IllegalArgumentException {
 +        net.minecraft.world.entity.Entity entity = getDelegate().getMinecraftWorld().getWorld().createEntity(location.toLocation(getWorld()), clazz);
 +        Objects.requireNonNull(entity, "Cannot spawn null entity");
-+        if (entity instanceof Mob) {
-+            ((Mob) entity).finalizeSpawn(getDelegate(), getDelegate().getCurrentDifficultyAt(entity.blockPosition()), MobSpawnType.COMMAND, (SpawnGroupData) null, null);
++        if (entity instanceof Mob mob) {
++            mob.finalizeSpawn(getDelegate(), getDelegate().getCurrentDifficultyAt(entity.blockPosition()), MobSpawnType.COMMAND, (SpawnGroupData) null, null);
 +        }
 +
 +        if (function != null) {
@@ -198,10 +198,10 @@ index d91c88d7bdfd954fa81fbf1c9ad92161d70993a6..f5ef7e026061351590f1ce77694e2d8f
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
-index 98461949badc8a708c1e7e2f225a93e8d1ca5822..4fa8cce0818a8e461330fc29021e6ff65cb67125 100644
+index eb82aaf9dcbc912d780a90842601da85497fa443..1b05bb78eaee548806df8ebfff1a1401e30d52e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
 +++ b/src/main/java/org/bukkit/craftbukkit/generator/CustomChunkGenerator.java
-@@ -187,6 +187,12 @@ public class CustomChunkGenerator extends InternalChunkGenerator {
+@@ -196,6 +196,12 @@ public class CustomChunkGenerator extends InternalChunkGenerator {
          for (BlockPos lightPosition : craftData.getLights()) {
              ((ProtoChunk) chunk).addLight(new BlockPos((x << 4) + lightPosition.getX(), lightPosition.getY(), (z << 4) + lightPosition.getZ())); // PAIL rename addLightBlock
          }
@@ -215,256 +215,41 @@ index 98461949badc8a708c1e7e2f225a93e8d1ca5822..4fa8cce0818a8e461330fc29021e6ff6
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-index bfdeb4f2971e65c38334f2f90c66ef62564e83e6..5ec7a3903838ce2f60926782965107e84b44643c 100644
+index 55dd618d8421271063843c6e65dbcaceba9a33de..56f65b49e0ce55ee5aa9d929a98ea055ce27a8a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaBlockState.java
-@@ -271,13 +271,18 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-         return this.blockEntityTag != null;
-     }
+@@ -214,11 +214,16 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
  
-+    // Paper start - Delegate to utility method
      @Override
      public BlockState getBlockState() {
 -        Material stateMaterial = (this.material != Material.SHIELD) ? this.material : CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag); // Only actually used for jigsaws
 -        if (this.blockEntityTag != null) {
 -            switch (this.material) {
++        // Paper start
 +        return createBlockState(this.material, this.blockEntityTag);
 +    }
-+
 +    public static BlockState createBlockState(Material material, CompoundTag blockEntityTag) {
 +        Material stateMaterial = (material != Material.SHIELD) ? material : CraftMetaBlockState.shieldToBannerHack(blockEntityTag); // Only actually used for jigsaws
 +        if (blockEntityTag != null) {
 +            switch (material) {
++                // Paper end
                  case SHIELD:
 -                    this.blockEntityTag.putString("id", "banner");
-+                    blockEntityTag.putString("id", "banner");
++                    blockEntityTag.putString("id", "banner"); // Paper
                      break;
                  case SHULKER_BOX:
                  case WHITE_SHULKER_BOX:
-@@ -296,19 +301,19 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
+@@ -237,11 +242,11 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
                  case GREEN_SHULKER_BOX:
                  case RED_SHULKER_BOX:
                  case BLACK_SHULKER_BOX:
 -                    this.blockEntityTag.putString("id", "shulker_box");
-+                    blockEntityTag.putString("id", "shulker_box");
++                    blockEntityTag.putString("id", "shulker_box"); // Paper
                      break;
                  case BEE_NEST:
                  case BEEHIVE:
 -                    this.blockEntityTag.putString("id", "beehive");
-+                    blockEntityTag.putString("id", "beehive");
++                    blockEntityTag.putString("id", "beehive"); // Paper
                      break;
              }
          }
-         BlockPos blockposition = BlockPos.ZERO;
-         net.minecraft.world.level.block.state.BlockState iblockdata = CraftMagicNumbers.getBlock(stateMaterial).defaultBlockState();
--        BlockEntity te = (this.blockEntityTag == null) ? null : BlockEntity.loadStatic(blockposition, iblockdata, blockEntityTag);
-+        BlockEntity te = (blockEntityTag == null) ? null : BlockEntity.loadStatic(blockposition, iblockdata, blockEntityTag);
- 
--        switch (this.material) {
-+        switch (material) {
-         case ACACIA_SIGN:
-         case ACACIA_WALL_SIGN:
-         case BIRCH_SIGN:
-@@ -328,53 +333,53 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-             if (te == null) {
-                 te = new SignBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftSign(this.material, (SignBlockEntity) te);
-+            return new CraftSign(material, (SignBlockEntity) te);
-         case CHEST:
-         case TRAPPED_CHEST:
-             if (te == null) {
-                 te = new ChestBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftChest(this.material, (ChestBlockEntity) te);
-+            return new CraftChest(material, (ChestBlockEntity) te);
-         case FURNACE:
-             if (te == null) {
-                 te = new FurnaceBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftFurnaceFurnace(this.material, (FurnaceBlockEntity) te);
-+            return new CraftFurnaceFurnace(material, (FurnaceBlockEntity) te);
-         case DISPENSER:
-             if (te == null) {
-                 te = new DispenserBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftDispenser(this.material, (DispenserBlockEntity) te);
-+            return new CraftDispenser(material, (DispenserBlockEntity) te);
-         case DROPPER:
-             if (te == null) {
-                 te = new DropperBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftDropper(this.material, (DropperBlockEntity) te);
-+            return new CraftDropper(material, (DropperBlockEntity) te);
-         case END_GATEWAY:
-             if (te == null) {
-                 te = new TheEndGatewayBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftEndGateway(this.material, (TheEndGatewayBlockEntity) te);
-+            return new CraftEndGateway(material, (TheEndGatewayBlockEntity) te);
-         case HOPPER:
-             if (te == null) {
-                 te = new HopperBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftHopper(this.material, (HopperBlockEntity) te);
-+            return new CraftHopper(material, (HopperBlockEntity) te);
-         case SPAWNER:
-             if (te == null) {
-                 te = new SpawnerBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftCreatureSpawner(this.material, (SpawnerBlockEntity) te);
-+            return new CraftCreatureSpawner(material, (SpawnerBlockEntity) te);
-         case JUKEBOX:
-             if (te == null) {
-                 te = new JukeboxBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftJukebox(this.material, (JukeboxBlockEntity) te);
-+            return new CraftJukebox(material, (JukeboxBlockEntity) te);
-         case BREWING_STAND:
-             if (te == null) {
-                 te = new BrewingStandBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBrewingStand(this.material, (BrewingStandBlockEntity) te);
-+            return new CraftBrewingStand(material, (BrewingStandBlockEntity) te);
-         case CREEPER_HEAD:
-         case CREEPER_WALL_HEAD:
-         case DRAGON_HEAD:
-@@ -390,24 +395,24 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-             if (te == null) {
-                 te = new SkullBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftSkull(this.material, (SkullBlockEntity) te);
-+            return new CraftSkull(material, (SkullBlockEntity) te);
-         case COMMAND_BLOCK:
-         case REPEATING_COMMAND_BLOCK:
-         case CHAIN_COMMAND_BLOCK:
-             if (te == null) {
-                 te = new CommandBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftCommandBlock(this.material, (CommandBlockEntity) te);
-+            return new CraftCommandBlock(material, (CommandBlockEntity) te);
-         case BEACON:
-             if (te == null) {
-                 te = new BeaconBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBeacon(this.material, (BeaconBlockEntity) te);
-+            return new CraftBeacon(material, (BeaconBlockEntity) te);
-         case SHIELD:
-             if (te == null) {
-                 te = new BannerBlockEntity(blockposition, iblockdata);
-             }
--            ((BannerBlockEntity) te).baseColor = (this.blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(this.blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
-+            ((BannerBlockEntity) te).baseColor = (blockEntityTag == null) ? DyeColor.WHITE : DyeColor.byId(blockEntityTag.getInt(CraftMetaBanner.BASE.NBT));
-         case BLACK_BANNER:
-         case BLACK_WALL_BANNER:
-         case BLUE_BANNER:
-@@ -443,12 +448,12 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-             if (te == null) {
-                 te = new BannerBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBanner(this.material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(this.blockEntityTag) : this.material, (BannerBlockEntity) te);
-+            return new CraftBanner(material == Material.SHIELD ? CraftMetaBlockState.shieldToBannerHack(blockEntityTag) : material, (BannerBlockEntity) te);
-         case STRUCTURE_BLOCK:
-             if (te == null) {
-                 te = new StructureBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftStructureBlock(this.material, (StructureBlockEntity) te);
-+            return new CraftStructureBlock(material, (StructureBlockEntity) te);
-         case SHULKER_BOX:
-         case WHITE_SHULKER_BOX:
-         case ORANGE_SHULKER_BOX:
-@@ -469,78 +474,79 @@ public class CraftMetaBlockState extends CraftMetaItem implements BlockStateMeta
-             if (te == null) {
-                 te = new ShulkerBoxBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftShulkerBox(this.material, (ShulkerBoxBlockEntity) te);
-+            return new CraftShulkerBox(material, (ShulkerBoxBlockEntity) te);
-         case ENCHANTING_TABLE:
-             if (te == null) {
-                 te = new EnchantmentTableBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftEnchantingTable(this.material, (EnchantmentTableBlockEntity) te);
-+            return new CraftEnchantingTable(material, (EnchantmentTableBlockEntity) te);
-         case ENDER_CHEST:
-             if (te == null) {
-                 te = new EnderChestBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftEnderChest(this.material, (EnderChestBlockEntity) te);
-+            return new CraftEnderChest(material, (EnderChestBlockEntity) te);
-         case DAYLIGHT_DETECTOR:
-             if (te == null) {
-                 te = new DaylightDetectorBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftDaylightDetector(this.material, (DaylightDetectorBlockEntity) te);
-+            return new CraftDaylightDetector(material, (DaylightDetectorBlockEntity) te);
-         case COMPARATOR:
-             if (te == null) {
-                 te = new ComparatorBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftComparator(this.material, (ComparatorBlockEntity) te);
-+            return new CraftComparator(material, (ComparatorBlockEntity) te);
-         case BARREL:
-             if (te == null) {
-                 te = new BarrelBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBarrel(this.material, (BarrelBlockEntity) te);
-+            return new CraftBarrel(material, (BarrelBlockEntity) te);
-         case BELL:
-             if (te == null) {
-                 te = new BellBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBell(this.material, (BellBlockEntity) te);
-+            return new CraftBell(material, (BellBlockEntity) te);
-         case BLAST_FURNACE:
-             if (te == null) {
-                 te = new BlastFurnaceBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBlastFurnace(this.material, (BlastFurnaceBlockEntity) te);
-+            return new CraftBlastFurnace(material, (BlastFurnaceBlockEntity) te);
-         case CAMPFIRE:
-         case SOUL_CAMPFIRE:
-             if (te == null) {
-                 te = new CampfireBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftCampfire(this.material, (CampfireBlockEntity) te);
-+            return new CraftCampfire(material, (CampfireBlockEntity) te);
-         case JIGSAW:
-             if (te == null) {
-                 te = new JigsawBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftJigsaw(this.material, (JigsawBlockEntity) te);
-+            return new CraftJigsaw(material, (JigsawBlockEntity) te);
-         case LECTERN:
-             if (te == null) {
-                 te = new LecternBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftLectern(this.material, (LecternBlockEntity) te);
-+            return new CraftLectern(material, (LecternBlockEntity) te);
-         case SMOKER:
-             if (te == null) {
-                 te = new SmokerBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftSmoker(this.material, (SmokerBlockEntity) te);
-+            return new CraftSmoker(material, (SmokerBlockEntity) te);
-         case BEE_NEST:
-         case BEEHIVE:
-             if (te == null) {
-                 te = new BeehiveBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftBeehive(this.material, (BeehiveBlockEntity) te);
-+            return new CraftBeehive(material, (BeehiveBlockEntity) te);
-         case SCULK_SENSOR:
-             if (te == null) {
-                 te = new SculkSensorBlockEntity(blockposition, iblockdata);
-             }
--            return new CraftSculkSensor(this.material, (SculkSensorBlockEntity) te);
-+            return new CraftSculkSensor(material, (SculkSensorBlockEntity) te);
-         default:
--            throw new IllegalStateException("Missing blockState for " + this.material);
-+            throw new IllegalStateException("Missing blockState for " + material);
-         }
-     }
-+    // Paper end
- 
-     @Override
-     public void setBlockState(BlockState blockState) {

--- a/patches/server/0711-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
+++ b/patches/server/0711-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix return value of Block#applyBoneMeal always being false
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 39fbe639eddc7728c87fbafb924b9b9439e7e409..38b823e0c036ae0274dd13da7a350fd478c39c1e 100644
+index ea1fa9758fcaa87de11b84d5a2e1d36b0e8930ee..e3944d0f4fd18ef6c545dc4a131c0b120dff753a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -686,7 +686,7 @@ public class CraftBlock implements Block {
+@@ -517,7 +517,7 @@ public class CraftBlock implements Block {
          Direction direction = CraftBlock.blockFaceToNotch(face);
          UseOnContext context = new UseOnContext(this.getCraftWorld().getHandle(), null, InteractionHand.MAIN_HAND, Items.BONE_MEAL.getDefaultInstance(), new BlockHitResult(Vec3.ZERO, direction, this.getPosition(), false));
  

--- a/patches/server/0724-Add-System.out-err-catcher.patch
+++ b/patches/server/0724-Add-System.out-err-catcher.patch
@@ -105,7 +105,7 @@ index 0000000000000000000000000000000000000000..76d0d00cd6742991e3f3ec827a75ee87
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 15f38a0d0cd8de4f80b4360a22537ec478ebb77e..c1fc309411c277f7b7450686543a6a7a7fe2fdb1 100644
+index 28300c6cd9cd2a55a5c1b179d9b44aa754cf346d..1d2378e3b338bf759e3d5d7e6496bc3968fded6c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -18,6 +18,7 @@ import com.mojang.serialization.Lifecycle;
@@ -116,7 +116,7 @@ index 15f38a0d0cd8de4f80b4360a22537ec478ebb77e..c1fc309411c277f7b7450686543a6a7a
  import it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap;
  import java.awt.image.BufferedImage;
  import java.io.File;
-@@ -283,6 +284,7 @@ public final class CraftServer implements Server {
+@@ -286,6 +287,7 @@ public final class CraftServer implements Server {
      public int reloadCount;
      private final io.papermc.paper.datapack.PaperDatapackManager datapackManager; // Paper
      public static Exception excessiveVelEx; // Paper - Velocity warnings

--- a/patches/server/0739-Clear-bucket-NBT-after-dispense.patch
+++ b/patches/server/0739-Clear-bucket-NBT-after-dispense.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Clear bucket NBT after dispense
 
 
 diff --git a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-index 92623ae25249d63efb92be8bd6c95228f9155ad2..0d34026a70c72661a9ba6b319690370e589714cc 100644
+index c5c8a889b745f36c2dce9dbb5d0b6edaefafdd22..e966238696944afea47ae6d869cd25f0d480c248 100644
 --- a/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
 +++ b/src/main/java/net/minecraft/core/dispenser/DispenseItemBehavior.java
-@@ -555,8 +555,7 @@ public interface DispenseItemBehavior {
+@@ -637,8 +637,7 @@ public interface DispenseItemBehavior {
                      Item item = Items.BUCKET;
                      stack.shrink(1);
                      if (stack.isEmpty()) {

--- a/patches/server/0810-More-CommmandBlock-API.patch
+++ b/patches/server/0810-More-CommmandBlock-API.patch
@@ -44,19 +44,19 @@ index 0000000000000000000000000000000000000000..0b42306f17bf8850a13a51067c2d19e7
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
-index c7af598a039f0d41aa4d1943714ed06986828c2a..ed10b13b29880459d68b6a7a60a5a9e1e1107d71 100644
+index 5df1e8c7277759bda57253db449907eb1185cce3..f36aa9d37facc5f1e2c6ae95f27c7020b5d0002b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftCommandBlock.java
-@@ -6,7 +6,7 @@ import org.bukkit.block.Block;
+@@ -5,7 +5,7 @@ import org.bukkit.World;
  import org.bukkit.block.CommandBlock;
  import org.bukkit.craftbukkit.util.CraftChatMessage;
  
 -public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity> implements CommandBlock {
 +public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity> implements CommandBlock, io.papermc.paper.commands.PaperCommandBlockHolder {
  
-     public CraftCommandBlock(Block block) {
-         super(block, CommandBlockEntity.class);
-@@ -46,5 +46,10 @@ public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity>
+     public CraftCommandBlock(World world, CommandBlockEntity tileEntity) {
+         super(world, tileEntity);
+@@ -41,5 +41,10 @@ public class CraftCommandBlock extends CraftBlockEntityState<CommandBlockEntity>
      public void name(net.kyori.adventure.text.Component name) {
          getSnapshot().getCommandBlock().setName(name == null ? new net.minecraft.network.chat.TextComponent("@") : io.papermc.paper.adventure.PaperAdventure.asVanilla(name));
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
19e985ec SPIGOT-6746: Clarify PlayerPortalEvent documentation
2a0a2e2e SPIGOT-6738: Add entity type tags

CraftBukkit Changes:
dc764e7a PR-877: Improve and simplify CraftBlockState
2d933bae SPIGOT-6741: shouldGenerateStructures isn't implemented
9aeb46ae SPIGOT-6023, SPIGOT-6745: Fix missing BlockDispenseArmorEvents
d3cc4120 SPIGOT-6738: Add entity type tags