### PR TITLE
Fix nullability on Block#breakNaturally

### DIFF
--- a/patches/api/0188-Add-effect-to-block-break-naturally.patch
+++ b/patches/api/0188-Add-effect-to-block-break-naturally.patch
@@ -5,17 +5,25 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 5ac36e0f90d0889853736390877aa92ec0ca181b..786b8011e98b2fe93cc2418d624f6350ede62d90 100644
+index 5ac36e0f90d0889853736390877aa92ec0ca181b..25294bd8c4faa05af1429d934c5666742e3ee23c 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -470,6 +470,18 @@ public interface Block extends Metadatable {
+@@ -470,6 +470,26 @@ public interface Block extends Metadatable {
       */
      boolean breakNaturally(@Nullable ItemStack tool);
  
 +    // Paper start
 +    /**
-+     * Breaks the block and spawns items as if a player had digged it with a
-+     * specific tool
++     * Breaks the block and spawns item drops as if a player had broken it
++     *
++     * @param triggerEffect Play the block break particle effect and sound
++     * @return true if the block was destroyed
++     */
++    boolean breakNaturally(boolean triggerEffect);
++
++    /**
++     * Breaks the block and spawns item drops as if a player had broken it
++     * with a specific tool
 +     *
 +     * @param tool The tool or item in hand used for digging
 +     * @param triggerEffect Play the block break particle effect and sound

--- a/patches/api/0224-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0224-Add-methods-to-get-translation-keys.patch
@@ -212,7 +212,7 @@ index 13eac9ad2c1672051635d1c35cc49239252e7a61..107e36ef02a9481954bd770ce9a55a0b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 786b8011e98b2fe93cc2418d624f6350ede62d90..e7957ec1727f7483d6d75b9e94333f06dc6d1da2 100644
+index 25294bd8c4faa05af1429d934c5666742e3ee23c..271ebba09fd9248717750e998668ae6fe013bacc 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
@@ -224,7 +224,7 @@ index 786b8011e98b2fe93cc2418d624f6350ede62d90..e7957ec1727f7483d6d75b9e94333f06
  
      /**
       * Gets the metadata for this block
-@@ -610,5 +610,15 @@ public interface Block extends Metadatable {
+@@ -618,5 +618,15 @@ public interface Block extends Metadatable {
       */
      @NotNull
      com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();

--- a/patches/api/0237-Add-Destroy-Speed-API.patch
+++ b/patches/api/0237-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index e7957ec1727f7483d6d75b9e94333f06dc6d1da2..cc570b31e817433d6e90990277cce283ee5d449e 100644
+index 271ebba09fd9248717750e998668ae6fe013bacc..33fa378176d2a46e60de539246e5e13a34cb4bac 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -620,5 +620,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -628,5 +628,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
      @NotNull
      @Deprecated
      String getTranslationKey();

--- a/patches/server/0363-Add-effect-to-block-break-naturally.patch
+++ b/patches/server/0363-Add-effect-to-block-break-naturally.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index bfacffcb39d0c4e6992df282b5b28bd7ca8d5398..f92e8a53e327779d4e30a5f6806825a2a21b547a 100644
+index bfacffcb39d0c4e6992df282b5b28bd7ca8d5398..d15dda75952269addf0aa2a028c6552217bef312 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -634,6 +634,13 @@ public class CraftBlock implements Block {
+@@ -634,6 +634,18 @@ public class CraftBlock implements Block {
  
      @Override
      public boolean breakNaturally(ItemStack item) {
@@ -17,12 +17,17 @@ index bfacffcb39d0c4e6992df282b5b28bd7ca8d5398..f92e8a53e327779d4e30a5f6806825a2
 +    }
 +
 +    @Override
++    public boolean breakNaturally(boolean triggerEffect) {
++        return breakNaturally(null, triggerEffect);
++    }
++
++    @Override
 +    public boolean breakNaturally(ItemStack item, boolean triggerEffect) {
 +        // Paper end
          // Order matters here, need to drop before setting to air so skulls can get their data
          net.minecraft.world.level.block.state.BlockState iblockdata = this.getNMS();
          net.minecraft.world.level.block.Block block = iblockdata.getBlock();
-@@ -643,6 +650,7 @@ public class CraftBlock implements Block {
+@@ -643,6 +655,7 @@ public class CraftBlock implements Block {
          // Modelled off EntityHuman#hasBlock
          if (block != Blocks.AIR && (item == null || !iblockdata.requiresCorrectToolForDrops() || nmsItem.isCorrectToolForDrops(iblockdata))) {
              net.minecraft.world.level.block.Block.dropResources(iblockdata, this.world.getMinecraftWorld(), position, this.world.getBlockEntity(position), null, nmsItem);

--- a/patches/server/0519-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0519-Add-methods-to-get-translation-keys.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add methods to get translation keys
 Co-authored-by: MeFisto94 <MeFisto94@users.noreply.github.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index f92e8a53e327779d4e30a5f6806825a2a21b547a..ab47da233bd06cff0c5c9109e615e1cb9a39ebf0 100644
+index d15dda75952269addf0aa2a028c6552217bef312..4cebd01eb5cb83395439f92bffdeb8563c300818 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -776,5 +776,15 @@ public class CraftBlock implements Block {
+@@ -781,5 +781,15 @@ public class CraftBlock implements Block {
      public com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup() {
          return new com.destroystokyo.paper.block.CraftBlockSoundGroup(getNMS().getBlock().defaultBlockState().getSoundType());
      }

--- a/patches/server/0555-Add-Destroy-Speed-API.patch
+++ b/patches/server/0555-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 564aaa0c01a120ed9035e664702a32822dc3076e..ffbe3d5af03b5e6b6cf1fe6212f5a0f7396babb3 100644
+index 0a3c4453cab41e003a386c1e13dffb4ebb893cdd..367334575ef6dbfd0d17f4a40ce97f8f4715e19b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -786,5 +786,23 @@ public class CraftBlock implements Block {
+@@ -791,5 +791,23 @@ public class CraftBlock implements Block {
      public String translationKey() {
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }

--- a/patches/server/0635-Add-Block-isValidTool.patch
+++ b/patches/server/0635-Add-Block-isValidTool.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index b78c6bc81474024658857679f943e0bc5553edea..207e6ad42a32396b2b43e1782297e1837ce94d7d 100644
+index 703698c40cecea2c412d14e9fb82dfe4c6f7e9cf..39fbe639eddc7728c87fbafb924b9b9439e7e409 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -823,5 +823,9 @@ public class CraftBlock implements Block {
+@@ -828,5 +828,9 @@ public class CraftBlock implements Block {
          }
          return speed;
      }

--- a/patches/server/0711-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
+++ b/patches/server/0711-Fix-return-value-of-Block-applyBoneMeal-always-being.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix return value of Block#applyBoneMeal always being false
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index 207e6ad42a32396b2b43e1782297e1837ce94d7d..a53a9974a2358fa4b6a7216e4b849bd3ad5023ea 100644
+index 39fbe639eddc7728c87fbafb924b9b9439e7e409..38b823e0c036ae0274dd13da7a350fd478c39c1e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -681,7 +681,7 @@ public class CraftBlock implements Block {
+@@ -686,7 +686,7 @@ public class CraftBlock implements Block {
          Direction direction = CraftBlock.blockFaceToNotch(face);
          UseOnContext context = new UseOnContext(this.getCraftWorld().getHandle(), null, InteractionHand.MAIN_HAND, Items.BONE_MEAL.getDefaultInstance(), new BlockHitResult(Vec3.ZERO, direction, this.getPosition(), false));
  


### PR DESCRIPTION
The implementation of this method allows for null tools. The use of a null tool would be useful if the block should be dropped always. E.g. bedrock can't be broken with any tool, but it will be dropped if you specify a null tool.

Additionally, the original breakNaturally method also allows for null tools and just calls the added method from paper.