### PR TITLE
Fix click event when vanilla scoreboard name coloring is enabled

### DIFF
--- a/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -26,7 +26,7 @@ index 2c3754c0bcebc33f88168136b519baef6927553b..d9590dbc3db4ec4d32d86906bb290fbe
 +    }
  }
 diff --git a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
-index 4e9e0a39b876c900fdee1343d04a7046f5b3f80e..eb0053850f53ceb60eb1ae3ac0e34034648fe1eb 100644
+index 4e9e0a39b876c900fdee1343d04a7046f5b3f80e..3adcd991b88bc83e1dc59439d3cf91a6751c9274 100644
 --- a/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 +++ b/src/main/java/io/papermc/paper/adventure/ChatProcessor.java
 @@ -17,7 +17,11 @@ import net.kyori.adventure.text.TextReplacementConfig;
@@ -41,25 +41,19 @@ index 4e9e0a39b876c900fdee1343d04a7046f5b3f80e..eb0053850f53ceb60eb1ae3ac0e34034
  import org.bukkit.craftbukkit.entity.CraftPlayer;
  import org.bukkit.craftbukkit.util.LazyPlayerSet;
  import org.bukkit.craftbukkit.util.Waitable;
-@@ -188,10 +192,22 @@ public final class ChatProcessor {
+@@ -188,10 +192,16 @@ public final class ChatProcessor {
      }
  
      private static String legacyDisplayName(final CraftPlayer player) {
 +        if (((CraftWorld) player.getWorld()).getHandle().paperConfig.useVanillaScoreboardColoring) {
-+            final ServerPlayer ep = player.getHandle();
-+            net.minecraft.network.chat.Component name = ep.getName();
-+            final Team team = ep.getTeam();
-+            if (team != null) {
-+                name = team.getFormattedName(name);
-+            }
-+            return PaperAdventure.LEGACY_SECTION_UXRC.serialize(PaperAdventure.asAdventure(name)) + ChatColor.RESET;
++            return PaperAdventure.LEGACY_SECTION_UXRC.serialize(player.teamDisplayName()) + ChatColor.RESET;
 +        }
          return player.getDisplayName();
      }
  
      private static Component displayName(final CraftPlayer player) {
 +        if (((CraftWorld) player.getWorld()).getHandle().paperConfig.useVanillaScoreboardColoring) {
-+            return PaperAdventure.asAdventure(PlayerTeam.formatNameForTeam(player.getHandle().getTeam(), player.getHandle().getName()));
++            return player.teamDisplayName();
 +        }
          return player.displayName();
      }


### PR DESCRIPTION
The click event is added in Player#getDisplayName, which calls PlayerTeam.formatNameForTeam for us. getDisplayName is also what vanilla uses for chat, and is exposed to API by teamDisplayName

