### PR TITLE
Fix interaction pos in range check

### DIFF
--- a/patches/server/0493-Move-range-check-for-block-placing-up.patch
+++ b/patches/server/0493-Move-range-check-for-block-placing-up.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Move range check for block placing up
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 36a69fb0a9cd81ceb0f9cbe6549fc89bd643c77c..7bf9f2b85c51424b53c08166b6ba3943f1abe0fe 100644
+index 36a69fb0a9cd81ceb0f9cbe6549fc89bd643c77c..51303e89ec160f3715e538903ae98be993d59150 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1661,6 +1661,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -29,7 +29,7 @@ index 36a69fb0a9cd81ceb0f9cbe6549fc89bd643c77c..7bf9f2b85c51424b53c08166b6ba3943
  
 +        // Paper start - move check up and check actual location as well
 +        final Vec3 clickedLocation = movingobjectpositionblock.getLocation();
-+        if (isOutsideOfReach(blockposition.getX(), blockposition.getY(), blockposition.getZ())
++        if (isOutsideOfReach(blockposition.getX() + 0.5D, blockposition.getY() + 0.5D, blockposition.getZ() + 0.5D)
 +            || !Double.isFinite(clickedLocation.x) || !Double.isFinite(clickedLocation.y) || !Double.isFinite(clickedLocation.z)
 +            || isOutsideOfReach(clickedLocation.x, clickedLocation.y, clickedLocation.z)) {
 +            return;


### PR DESCRIPTION
Currently the interaction range check uses the negative corner of the block you clicked. This causes a problem as with the client survival interaction range of 4.5 it is posible to make this check fail with a vanilla client if you click on the positive corner of the block while standing as far away from it as you can. In this way your eye pos can be up to 4.5+sqrt(3)=6,23 blocks away from the negative corner, which will make the check fail as limits range to 6.
This commit makes it use the center of the block instead of the negative corner, making the maximum distance a vanilla client can be from it 4.5+sqrt(0,75)=5,36 blocks, which is less than 6 so the check wouldn't fail.