### PR TITLE
Added getHostname to AsyncPlayerPreLoginEvent

### DIFF
--- a/patches/api/0356-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/api/0356-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -1,0 +1,61 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MCMDEV <john-m.1@gmx.de>
+Date: Fri, 24 Sep 2021 17:59:23 +0200
+Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
+
+
+diff --git a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+index 694a81769076ea58aae9f14f076ab80c9952c957..356d1154b0732e2daf242d60fa715dba9f2dc9db 100644
+--- a/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
++++ b/src/main/java/org/bukkit/event/player/AsyncPlayerPreLoginEvent.java
+@@ -22,6 +22,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+     private final InetAddress ipAddress;
+     private final InetAddress rawAddress; // Paper
+     //private UUID uniqueId; // Paper - Not used anymore
++    private final String hostname; // Paper
+ 
+     @Deprecated
+     public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress) {
+@@ -66,7 +67,14 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         this(name, ipAddress, ipAddress, uniqueId, profile);
+     }
+ 
++    @Deprecated // Paper - Add hostname
+     public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final InetAddress rawAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile) {
++        // Paper start - Add hostname
++        this(name, ipAddress, rawAddress, uniqueId, profile, "");
++    }
++
++    public AsyncPlayerPreLoginEvent(@NotNull final String name, @NotNull final InetAddress ipAddress, @NotNull final InetAddress rawAddress, @NotNull final UUID uniqueId, @NotNull PlayerProfile profile, @NotNull String hostname) {
++        // Paper end - Add hostname
+         super(true);
+         this.profile = profile;
+         // Paper end
+@@ -76,6 +84,7 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         this.ipAddress = ipAddress;
+         this.rawAddress = rawAddress; // Paper
+         //this.uniqueId = uniqueId; // Paper - Not used anymore
++        this.hostname = hostname; // Paper - Add hostname
+     }
+ 
+     /**
+@@ -261,6 +270,19 @@ public class AsyncPlayerPreLoginEvent extends Event {
+         return profile.getId(); // Paper
+     }
+ 
++    // Paper start
++    /**
++     * Gets the hostname that the player used to connect to the server, or
++     * blank if unknown
++     *
++     * @return The hostname
++     */
++    @NotNull
++    public String getHostname() {
++        return hostname;
++    }
++    // Paper end
++
+     @NotNull
+     @Override
+     public HandlerList getHandlers() {

--- a/patches/server/0851-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
+++ b/patches/server/0851-Added-getHostname-to-AsyncPlayerPreLoginEvent.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MCMDEV <john-m.1@gmx.de>
+Date: Fri, 24 Sep 2021 17:59:21 +0200
+Subject: [PATCH] Added getHostname to AsyncPlayerPreLoginEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+index 462d8c36166c63a4dc8fa74ac7f82859e6f4b83a..60ba196e17df34c3ae2a9883e5d28830a2243517 100644
+--- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
+@@ -391,7 +391,7 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
+ 
+                             // Paper start
+                             PlayerProfile profile = CraftPlayerProfile.asBukkitMirror(ServerLoginPacketListenerImpl.this.gameProfile);
+-                            AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile);
++                            AsyncPlayerPreLoginEvent asyncEvent = new AsyncPlayerPreLoginEvent(playerName, address, rawAddress, uniqueId, profile, ServerLoginPacketListenerImpl.this.hostname);
+                         server.getPluginManager().callEvent(asyncEvent);
+                             profile = asyncEvent.getPlayerProfile();
+                             profile.complete(true);


### PR DESCRIPTION
Adds the getHostname method which is available in the PlayerLoginEvent to the AsyncPlayerPreLoginEvent.
I personally needed this when setting a PlayerProfile if the player connects with a specific hostname.