### PR TITLE
Fix player death kept items not being in same slot

### DIFF
--- a/patches/server/0322-PlayerDeathEvent-getItemsToKeep.patch
+++ b/patches/server/0322-PlayerDeathEvent-getItemsToKeep.patch
@@ -8,7 +8,7 @@ Exposes a mutable array on items a player should keep on death
 Example Usage: https://gist.github.com/aikar/5bb202de6057a051a950ce1f29feb0b4
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6d723445f80fc6db5880f658098046de5f13f563..dac01b65319ee246ddbb974ad379e2bd59033830 100644
+index 6d723445f80fc6db5880f658098046de5f13f563..dc0b6b9a22b31940cc997431af644ea9c772f8cb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -724,6 +724,46 @@ public class ServerPlayer extends Player {
@@ -58,10 +58,11 @@ index 6d723445f80fc6db5880f658098046de5f13f563..dac01b65319ee246ddbb974ad379e2bd
      @Override
      public void die(DamageSource source) {
          boolean flag = this.level.getGameRules().getBoolean(GameRules.RULE_SHOWDEATHMESSAGES);
-@@ -810,6 +850,12 @@ public class ServerPlayer extends Player {
+@@ -809,7 +849,12 @@ public class ServerPlayer extends Player {
+         this.dropExperience();
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {
-             this.getInventory().clearContent();
+-            this.getInventory().clearContent();
 +            // Paper start - replace logic
 +            for (NonNullList<ItemStack> inv : this.getInventory().compartments) {
 +                processKeep(event, inv);

--- a/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
+++ b/patches/server/0347-Fix-stuck-in-sneak-when-changing-worlds-MC-10657.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix stuck in sneak when changing worlds (MC-10657)
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index dac01b65319ee246ddbb974ad379e2bd59033830..289b2881c0f16d1cb54a70b25b9bfd808988cb9a 100644
+index dc0b6b9a22b31940cc997431af644ea9c772f8cb..259536a667d64ff4a81aa7f7b8c8ffb7ff593c5c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1098,6 +1098,8 @@ public class ServerPlayer extends Player {
+@@ -1097,6 +1097,8 @@ public class ServerPlayer extends Player {
                  this.lastSentHealth = -1.0F;
                  this.lastSentFood = -1;
  

--- a/patches/server/0354-PlayerDeathEvent-shouldDropExperience.patch
+++ b/patches/server/0354-PlayerDeathEvent-shouldDropExperience.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerDeathEvent#shouldDropExperience
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 289b2881c0f16d1cb54a70b25b9bfd808988cb9a..10c56aa51a6dcfec8ef00faeeea4191188f24d36 100644
+index 259536a667d64ff4a81aa7f7b8c8ffb7ff593c5c..ccbcfa2e0b4b8e7f302333b891a0f9b4de94ac93 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -846,7 +846,7 @@ public class ServerPlayer extends Player {
@@ -16,4 +16,4 @@ index 289b2881c0f16d1cb54a70b25b9bfd808988cb9a..10c56aa51a6dcfec8ef00faeeea41911
 +        if (event.shouldDropExperience()) this.dropExperience(); // Paper - tie to event
          // we clean the player's inventory after the EntityDeathEvent is called so plugins can get the exact state of the inventory.
          if (!event.getKeepInventory()) {
-             this.getInventory().clearContent();
+             // Paper start - replace logic

--- a/patches/server/0407-Prevent-opening-inventories-when-frozen.patch
+++ b/patches/server/0407-Prevent-opening-inventories-when-frozen.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Prevent opening inventories when frozen
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3f57c10472c8add423f1d237ad03e525113e444c..3d17c7c5c35133c3aefce9c2706b669011c6edac 100644
+index 8b0e58618a78ea5dfe57ee67ed63b0b408e97d8c..1f62b23c69053e30c8a0d2989eb4a1d5976f0f13 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -609,7 +609,7 @@ public class ServerPlayer extends Player {
@@ -17,7 +17,7 @@ index 3f57c10472c8add423f1d237ad03e525113e444c..3d17c7c5c35133c3aefce9c2706b6690
              this.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.CANT_USE); // Paper
              this.containerMenu = this.inventoryMenu;
          }
-@@ -1456,7 +1456,7 @@ public class ServerPlayer extends Player {
+@@ -1455,7 +1455,7 @@ public class ServerPlayer extends Player {
              } else {
                  // CraftBukkit start
                  this.containerMenu = container;

--- a/patches/server/0411-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0411-Implement-Player-Client-Options-API.patch
@@ -85,10 +85,10 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3d17c7c5c35133c3aefce9c2706b669011c6edac..18945fe987f7464f9bc1a55145b3456c76859603 100644
+index 1f62b23c69053e30c8a0d2989eb4a1d5976f0f13..4ab83e544dbe2b4fdd351ac30359089df847dc81 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1808,6 +1808,7 @@ public class ServerPlayer extends Player {
+@@ -1807,6 +1807,7 @@ public class ServerPlayer extends Player {
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
@@ -97,7 +97,7 @@ index 3d17c7c5c35133c3aefce9c2706b669011c6edac..18945fe987f7464f9bc1a55145b3456c
          if (getMainArm() != packet.getMainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aa0d348df457fb2b340955fdb9a98029f8557fec..a3ab8ab4bbcca4783a2546bbeb180e04e07e9a5d 100644
+index a30010595f98de56c59d54a97e5a5d0f0ab28d2d..80914eed36523b120e4d056497cb2ccb1cb5110d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -521,6 +521,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0568-Player-Chunk-Load-Unload-Events.patch
+++ b/patches/server/0568-Player-Chunk-Load-Unload-Events.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player Chunk Load/Unload Events
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ed1076e7d9ea9fd0e2e7504726b21bf2cbe7e151..92f16e89d19543725f64cbcbd2db5fcf507ea51a 100644
+index 1c70003c27952332c3dfc2e73923ca67b792d004..9bbdcd6115d926e3957bad127c70c65bc6c23e63 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2095,11 +2095,21 @@ public class ServerPlayer extends Player {
+@@ -2094,11 +2094,21 @@ public class ServerPlayer extends Player {
      public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket, Packet<?> lightUpdatePacket) {
          this.connection.send(lightUpdatePacket);
          this.connection.send(chunkDataPacket);

--- a/patches/server/0613-Reset-shield-blocking-on-dimension-change.patch
+++ b/patches/server/0613-Reset-shield-blocking-on-dimension-change.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset shield blocking on dimension change
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 92f16e89d19543725f64cbcbd2db5fcf507ea51a..d044ceb467621f3ddc2fd1471648d03fe4e1ec85 100644
+index 9bbdcd6115d926e3957bad127c70c65bc6c23e63..02874e0a596e17a3b7098de40f7b77c6686b2614 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1143,6 +1143,11 @@ public class ServerPlayer extends Player {
+@@ -1142,6 +1142,11 @@ public class ServerPlayer extends Player {
                  this.level.getCraftServer().getPluginManager().callEvent(changeEvent);
                  // CraftBukkit end
              }

--- a/patches/server/0674-call-PortalCreateEvent-players-and-end-platform.patch
+++ b/patches/server/0674-call-PortalCreateEvent-players-and-end-platform.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] call PortalCreateEvent players and end platform
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d044ceb467621f3ddc2fd1471648d03fe4e1ec85..f388b75e6d7fc726349435f86308ae729144343a 100644
+index 02874e0a596e17a3b7098de40f7b77c6686b2614..75f545f735928fdd9d41b06a4fc68eb4ecca1d48 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1170,15 +1170,21 @@ public class ServerPlayer extends Player {
+@@ -1169,15 +1169,21 @@ public class ServerPlayer extends Player {
      private void createEndPlatform(ServerLevel world, BlockPos centerPos) {
          BlockPos.MutableBlockPos blockposition_mutableblockposition = centerPos.mutable();
  

--- a/patches/server/0679-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0679-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,10 +45,10 @@ index d75f78d2e3fb1376e8f6a8668c98a04a693c99e1..79f6089b934124c3309c6bee2e48b36b
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f388b75e6d7fc726349435f86308ae729144343a..742ebd3c3abec18a274ab85d1a9e8ad5fa442ccb 100644
+index 75f545f735928fdd9d41b06a4fc68eb4ecca1d48..25f2d8306acaf4df36e6f0d2b3a3bfc1f838bb0b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1791,8 +1791,15 @@ public class ServerPlayer extends Player {
+@@ -1790,8 +1790,15 @@ public class ServerPlayer extends Player {
      }
  
      public boolean setGameMode(GameType gameMode) {
@@ -66,7 +66,7 @@ index f388b75e6d7fc726349435f86308ae729144343a..742ebd3c3abec18a274ab85d1a9e8ad5
          } else {
              this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.CHANGE_GAME_MODE, (float) gameMode.getId()));
              if (gameMode == GameType.SPECTATOR) {
-@@ -1804,7 +1811,7 @@ public class ServerPlayer extends Player {
+@@ -1803,7 +1810,7 @@ public class ServerPlayer extends Player {
  
              this.onUpdateAbilities();
              this.updateEffectVisibility();
@@ -75,7 +75,7 @@ index f388b75e6d7fc726349435f86308ae729144343a..742ebd3c3abec18a274ab85d1a9e8ad5
          }
      }
  
-@@ -2186,6 +2193,16 @@ public class ServerPlayer extends Player {
+@@ -2185,6 +2192,16 @@ public class ServerPlayer extends Player {
      }
  
      public void loadGameTypes(@Nullable CompoundTag nbt) {
@@ -126,7 +126,7 @@ index da2ae74b6f5875200e22c42ed07431016a90845e..35d05cc4bddea5b168a6498add1de9bc
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 18c36a21d3ef1f439fa7ef625609a5eb59e63ae9..5f7abfba4154a3191d56eddb6dc75f26d3da3ca9 100644
+index b2925d150a98ffb25cbf3c72f6df2abd862dae44..b4e11d39cf1d9791a8fe4ccd297f6afde7a38c7b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2470,7 +2470,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -139,7 +139,7 @@ index 18c36a21d3ef1f439fa7ef625609a5eb59e63ae9..5f7abfba4154a3191d56eddb6dc75f26
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b3305deb28c99e2f1cc08e04da7be18bfe891f02..dd238588bfab67ee0f3a9eec6cbf35f1bfdadddb 100644
+index 719358b5b8dea1cdcbb79f2d21873f5a0fef2242..56ba161666f895a7fd366f8186b0c55597b16d42 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1256,7 +1256,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0707-Fix-PlayerDropItemEvent-using-wrong-item.patch
+++ b/patches/server/0707-Fix-PlayerDropItemEvent-using-wrong-item.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix PlayerDropItemEvent using wrong item
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 742ebd3c3abec18a274ab85d1a9e8ad5fa442ccb..a8c25bdaa230db9298ec2cb2fb7e09924b84be4d 100644
+index 25f2d8306acaf4df36e6f0d2b3a3bfc1f838bb0b..04021879aafb1da727358b08cc5a0bf6ee9820d5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2162,7 +2162,7 @@ public class ServerPlayer extends Player {
+@@ -2161,7 +2161,7 @@ public class ServerPlayer extends Player {
  
              if (retainOwnership) {
                  if (!itemstack1.isEmpty()) {

--- a/patches/server/0719-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0719-Don-t-apply-cramming-damage-to-players.patch
@@ -26,10 +26,10 @@ index 2bfadd245b5d08c1b77805ee049456cc786c093e..88abb1dfd994e5bc51aa181121407f3d
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index a8c25bdaa230db9298ec2cb2fb7e09924b84be4d..0061f57c6dbd6df5bc62e4982203415db69de5aa 100644
+index 04021879aafb1da727358b08cc5a0bf6ee9820d5..85bbafdc19b6fc17eb4815c05ed0e78e256e9aad 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1420,7 +1420,7 @@ public class ServerPlayer extends Player {
+@@ -1419,7 +1419,7 @@ public class ServerPlayer extends Player {
  
      @Override
      public boolean isInvulnerableTo(DamageSource damageSource) {

--- a/patches/server/0730-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0730-Add-PlayerSetSpawnEvent.patch
@@ -18,10 +18,10 @@ index e95f2222814e104bf9194a96385737dffe2cb2b5..249ab7357aa19d87179fa4c3ae89d9d3
  
          String string = resourceKey.location().toString();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0061f57c6dbd6df5bc62e4982203415db69de5aa..6e44ab13755bec97b6e29335cc1e2a9d0ee685aa 100644
+index 85bbafdc19b6fc17eb4815c05ed0e78e256e9aad..f508695f622f5ac76c0a3c037ebde393234fab54 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1261,7 +1261,7 @@ public class ServerPlayer extends Player {
+@@ -1260,7 +1260,7 @@ public class ServerPlayer extends Player {
              } else if (this.bedBlocked(blockposition, enumdirection)) {
                  return Either.left(Player.BedSleepingProblem.OBSTRUCTED);
              } else {
@@ -30,7 +30,7 @@ index 0061f57c6dbd6df5bc62e4982203415db69de5aa..6e44ab13755bec97b6e29335cc1e2a9d
                  if (this.level.isDay()) {
                      return Either.left(Player.BedSleepingProblem.NOT_POSSIBLE_NOW);
                  } else {
-@@ -2089,12 +2089,33 @@ public class ServerPlayer extends Player {
+@@ -2088,12 +2088,33 @@ public class ServerPlayer extends Player {
          return this.respawnForced;
      }
  
@@ -93,7 +93,7 @@ index af4eb4a8814491afef449a2874521636957d7557..0a5d563700c9f806139001181f01fa9d
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 31769476ce54e83927e93d339bd3ea8663a2db87..d6e82abc76cd72fa31c1b3f961f3f5d27ee7b043 100644
+index d3dfa6c27fe1e069866ebd6709057ddb267e238c..194d095eccbad692bcee1d365fa3fae093204b38 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1076,9 +1076,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0750-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
+++ b/patches/server/0750-Do-not-run-close-logic-for-inventories-on-chunk-unlo.patch
@@ -28,10 +28,10 @@ index f8c0574137cab33d0b5efe5d532efb132dcb914a..80f59abeb0081fe4784f3c0d027e8dfc
          }
          // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 6e44ab13755bec97b6e29335cc1e2a9d0ee685aa..afad4f6069fc546f98f688715d0ae914bdd3e317 100644
+index f508695f622f5ac76c0a3c037ebde393234fab54..c5ce1bd8317801d0cfe0ef4f7ed40573f61e4a16 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -1563,6 +1563,18 @@ public class ServerPlayer extends Player {
+@@ -1562,6 +1562,18 @@ public class ServerPlayer extends Player {
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
          this.doCloseContainer();
      }


### PR DESCRIPTION
Fixes #6661 

(See [this](https://github.com/PaperMC/Paper/commit/19da14ee00f93cc6b3e234162062a818df1f97d2#diff-572f8c768008a01463e81b5d066d23591a1bceb30ab001411448a58d695f9ea6L65))

![image](https://user-images.githubusercontent.com/15055071/134782388-bbb5de57-4a72-47c0-bd26-721b4b8c3fed.png)
