### PR TITLE
Suggest PlayerPostRespawnEvent if changing player state

### DIFF
--- a/patches/api/0176-Add-PlayerPostRespawnEvent.patch
+++ b/patches/api/0176-Add-PlayerPostRespawnEvent.patch
@@ -62,3 +62,17 @@ index 0000000000000000000000000000000000000000..31f34b54801f6699ce43355fa2a0a51f
 +        return handlers;
 +    }
 +}
+diff --git a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
+index d2be2ad2e3665728e614a89dd62ef9237f1d3ce6..e2c87a23e4743a34cfe911a71fd82b5a5ba1f9b7 100644
+--- a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
+@@ -8,6 +8,9 @@ import org.jetbrains.annotations.NotNull;
+ 
+ /**
+  * Called when a player respawns.
++ * <p>
++ * If changing player state, see {@link com.destroystokyo.paper.event.player.PlayerPostRespawnEvent}
++ * because the player is "reset" between this event and that event and some changes won't persist.
+  */
+ public class PlayerRespawnEvent extends PlayerEvent {
+     private static final HandlerList handlers = new HandlerList();

--- a/patches/api/0294-add-RespawnFlags-to-PlayerRespawnEvent.patch
+++ b/patches/api/0294-add-RespawnFlags-to-PlayerRespawnEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] add RespawnFlags to PlayerRespawnEvent
 
 
 diff --git a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
-index d2be2ad2e3665728e614a89dd62ef9237f1d3ce6..359e385bd6854a4b146cd0a54badb9c3d31ca12d 100644
+index e2c87a23e4743a34cfe911a71fd82b5a5ba1f9b7..a951568def24f809a6a019eefe623974c1867e22 100644
 --- a/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
 +++ b/src/main/java/org/bukkit/event/player/PlayerRespawnEvent.java
-@@ -14,17 +14,30 @@ public class PlayerRespawnEvent extends PlayerEvent {
+@@ -17,17 +17,30 @@ public class PlayerRespawnEvent extends PlayerEvent {
      private Location respawnLocation;
      private final boolean isBedSpawn;
      private final boolean isAnchorSpawn;
@@ -39,7 +39,7 @@ index d2be2ad2e3665728e614a89dd62ef9237f1d3ce6..359e385bd6854a4b146cd0a54badb9c3
      }
  
      /**
-@@ -77,4 +90,31 @@ public class PlayerRespawnEvent extends PlayerEvent {
+@@ -80,4 +93,31 @@ public class PlayerRespawnEvent extends PlayerEvent {
      public static HandlerList getHandlerList() {
          return handlers;
      }


### PR DESCRIPTION
Since the player is reset between PlayerRespawnEvent and PlayerPostRespawnEvent some changes to Player are not kept.