### PR TITLE
Fix plugin provides load order

### DIFF
--- a/patches/api/0334-Fix-plugin-provides-load-order.patch
+++ b/patches/api/0334-Fix-plugin-provides-load-order.patch
@@ -1,0 +1,27 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
+Date: Fri, 1 Oct 2021 09:47:00 +0200
+Subject: [PATCH] Fix plugin provides load order
+
+Fixes https://hub.spigotmc.org/jira/browse/SPIGOT-6740
+
+diff --git a/src/main/java/org/bukkit/plugin/SimplePluginManager.java b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+index 0e25119564dfa9cb12f3c5dc5f653d7f2c147a9d..98fb7241d9902cd2ffc703e6c5eb2771307779f8 100644
+--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
++++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+@@ -283,6 +283,7 @@ public final class SimplePluginManager implements PluginManager {
+                             // Paper end
+                             missingDependency = false;
+                             pluginIterator.remove();
++                            pluginsProvided.values().removeIf(s -> s.equals(plugin)); // Paper - remove provided plugins
+                             softDependencies.remove(plugin);
+                             dependencies.remove(plugin);
+ 
+@@ -316,6 +317,7 @@ public final class SimplePluginManager implements PluginManager {
+                     // We're clear to load, no more soft or hard dependencies left
+                     File file = plugins.get(plugin);
+                     pluginIterator.remove();
++                    pluginsProvided.values().removeIf(s -> s.equals(plugin)); // Paper - remove provided plugins
+                     missingDependency = false;
+ 
+                     try {


### PR DESCRIPTION
Fixes dumb plugin load order when a plugin "provides" another plugin via the plugin.yml https://hub.spigotmc.org/jira/browse/SPIGOT-6740