### PR TITLE
Add missing team sidebar display slots

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -241,3 +241,8 @@ public-f com.mojang.brigadier.tree.CommandNode requirement
 # Block Enderpearl Travel Exploit
 public net.minecraft.world.entity.projectile.Projectile cachedOwner
 public net.minecraft.world.entity.projectile.Projectile ownerUUID
+
+# Add missing display slots
+public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations
+public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations toBukkitSlot(I)Lorg/bukkit/scoreboard/DisplaySlot;
+public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations fromBukkitSlot(Lorg/bukkit/scoreboard/DisplaySlot;)I

--- a/patches/api/0335-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/api/0335-Add-missing-team-sidebar-display-slots.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 1 Oct 2021 08:04:43 -0700
+Subject: [PATCH] Add missing team sidebar display slots
+
+
+diff --git a/src/main/java/org/bukkit/scoreboard/DisplaySlot.java b/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
+index 5d58a18b3625fd01ea34969200edc3bc80cbb587..fe7d0a19f970ac5b4e0c4bef4ff7c4ceae60bb86 100644
+--- a/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
++++ b/src/main/java/org/bukkit/scoreboard/DisplaySlot.java
+@@ -1,10 +1,55 @@
+ package org.bukkit.scoreboard;
+ 
++import net.kyori.adventure.text.format.NamedTextColor; // Paper
+ /**
+  * Locations for displaying objectives to the player
+  */
+ public enum DisplaySlot {
+-    BELOW_NAME,
+-    PLAYER_LIST,
+-    SIDEBAR;
++    // Paper start
++    BELOW_NAME("belowName"),
++    PLAYER_LIST("list"),
++    SIDEBAR("sidebar"),
++    SIDEBAR_TEAM_BLACK(NamedTextColor.BLACK),
++    SIDEBAR_TEAM_DARK_BLUE(NamedTextColor.DARK_BLUE),
++    SIDEBAR_TEAM_DARK_GREEN(NamedTextColor.DARK_GREEN),
++    SIDEBAR_TEAM_DARK_AQUA(NamedTextColor.DARK_AQUA),
++    SIDEBAR_TEAM_DARK_RED(NamedTextColor.DARK_RED),
++    SIDEBAR_TEAM_DARK_PURPLE(NamedTextColor.DARK_PURPLE),
++    SIDEBAR_TEAM_GOLD(NamedTextColor.GOLD),
++    SIDEBAR_TEAM_GRAY(NamedTextColor.GRAY),
++    SIDEBAR_TEAM_DARK_GRAY(NamedTextColor.DARK_GRAY),
++    SIDEBAR_TEAM_BLUE(NamedTextColor.BLUE),
++    SIDEBAR_TEAM_GREEN(NamedTextColor.GREEN),
++    SIDEBAR_TEAM_AQUA(NamedTextColor.AQUA),
++    SIDEBAR_TEAM_RED(NamedTextColor.RED),
++    SIDEBAR_TEAM_LIGHT_PURPLE(NamedTextColor.LIGHT_PURPLE),
++    SIDEBAR_TEAM_YELLOW(NamedTextColor.YELLOW),
++    SIDEBAR_TEAM_WHITE(NamedTextColor.WHITE);
++
++    public static final net.kyori.adventure.util.Index<String, DisplaySlot> NAMES = net.kyori.adventure.util.Index.create(DisplaySlot.class, DisplaySlot::getId);
++
++    private final String id;
++
++    DisplaySlot(@org.jetbrains.annotations.NotNull String id) {
++        this.id = id;
++    }
++
++    DisplaySlot(@org.jetbrains.annotations.NotNull NamedTextColor color) {
++        this.id = "sidebar.team." + color;
++    }
++
++    /**
++     * Get the string id of this display slot.
++     *
++     * @return the string id
++     */
++    public @org.jetbrains.annotations.NotNull String getId() {
++        return id;
++    }
++
++    @Override
++    public String toString() {
++        return this.id;
++    }
++    // Paper end
+ }

--- a/patches/server/0814-Add-missing-team-sidebar-display-slots.patch
+++ b/patches/server/0814-Add-missing-team-sidebar-display-slots.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 1 Oct 2021 08:04:39 -0700
+Subject: [PATCH] Add missing team sidebar display slots
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
+index f1be7a4f96a556569e4a607959bfd085fa0cb64c..ca58cde37f4e5abeb33e2f583b3d53e80697eba9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardTranslations.java
+@@ -7,7 +7,8 @@ import org.bukkit.scoreboard.DisplaySlot;
+ import org.bukkit.scoreboard.RenderType;
+ 
+ public final class CraftScoreboardTranslations {
+-    static final int MAX_DISPLAY_SLOT = 3;
++    static final int MAX_DISPLAY_SLOT = Scoreboard.getDisplaySlotNames().length; // Paper
++    @Deprecated // Paper
+     static ImmutableBiMap<DisplaySlot, String> SLOTS = ImmutableBiMap.of(
+             DisplaySlot.BELOW_NAME, "belowName",
+             DisplaySlot.PLAYER_LIST, "list",
+@@ -16,10 +17,12 @@ public final class CraftScoreboardTranslations {
+     private CraftScoreboardTranslations() {}
+ 
+     public static DisplaySlot toBukkitSlot(int i) {
++        if (true) return org.bukkit.scoreboard.DisplaySlot.NAMES.value(Scoreboard.getDisplaySlotName(i)); // Paper
+         return CraftScoreboardTranslations.SLOTS.inverse().get(Scoreboard.getDisplaySlotName(i));
+     }
+ 
+     public static int fromBukkitSlot(DisplaySlot slot) {
++        if (true) return Scoreboard.getDisplaySlotByName(slot.getId()); // Paper
+         return Scoreboard.getDisplaySlotByName(CraftScoreboardTranslations.SLOTS.get(slot));
+     }
+ 
+diff --git a/src/test/java/io/papermc/paper/scoreboard/DisplaySlotTest.java b/src/test/java/io/papermc/paper/scoreboard/DisplaySlotTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bb41a2f2c0a5e3b4cb3fe1b584e0ceb7a7116afb
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/scoreboard/DisplaySlotTest.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.scoreboard;
++
++import net.minecraft.world.scores.Scoreboard;
++import org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations;
++import org.bukkit.scoreboard.DisplaySlot;
++import org.junit.Test;
++
++import static org.junit.Assert.assertNotEquals;
++import static org.junit.Assert.assertNotNull;
++
++public class DisplaySlotTest {
++
++    @Test
++    public void testBukkitToMinecraftDisplaySlots() {
++        for (DisplaySlot value : DisplaySlot.values()) {
++            assertNotEquals(-1, CraftScoreboardTranslations.fromBukkitSlot(value));
++        }
++    }
++
++    @Test
++    public void testMinecraftToBukkitDisplaySlots() {
++        for (String name : Scoreboard.getDisplaySlotNames()) {
++            assertNotNull(CraftScoreboardTranslations.toBukkitSlot(Scoreboard.getDisplaySlotByName(name)));
++        }
++    }
++}


### PR DESCRIPTION
There are 19 display slots, not just the 3 in the original enum