### PR TITLE
Init PaperConfig before PaperConsole is created

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -298,10 +298,10 @@ index 0000000000000000000000000000000000000000..bee2fa2bfbb61209381f24ed6508d3d1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a6839fc73
+index 0000000000000000000000000000000000000000..56f6e4aa2b261506cb44bd172015dbfc397e9406
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,186 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Throwables;
@@ -315,10 +315,10 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +import java.util.List;
 +import java.util.Map;
 +import java.util.concurrent.TimeUnit;
-+import java.util.logging.Level;
 +import java.util.regex.Pattern;
 +
 +import net.minecraft.server.MinecraftServer;
++import org.apache.logging.log4j.Logger;
 +import org.bukkit.Bukkit;
 +import org.bukkit.command.Command;
 +import org.bukkit.configuration.ConfigurationSection;
@@ -327,6 +327,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +
 +public class PaperConfig {
 +
++    private static final Logger LOGGER = MinecraftServer.LOGGER;
 +    private static File CONFIG_FILE;
 +    private static final String HEADER = "This is the main configuration file for Paper.\n"
 +            + "As you can see, there's tons to configure. Some options may impact gameplay, so use\n"
@@ -354,7 +355,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +            config.load(CONFIG_FILE);
 +        } catch (IOException ex) {
 +        } catch (InvalidConfigurationException ex) {
-+            Bukkit.getLogger().log(Level.SEVERE, "Could not load paper.yml, please correct your syntax errors", ex);
++            LOGGER.fatal("Could not load paper.yml, please correct your syntax errors", ex);
 +            throw Throwables.propagate(ex);
 +        }
 +        config.options().header(HEADER);
@@ -370,7 +371,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +    }
 +
 +    protected static void logError(String s) {
-+        Bukkit.getLogger().severe(s);
++        LOGGER.error(s);
 +    }
 +
 +    protected static void fatal(String s) {
@@ -380,7 +381,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +
 +    protected static void log(String s) {
 +        if (verbose) {
-+            Bukkit.getLogger().info(s);
++            LOGGER.info(s);
 +        }
 +    }
 +
@@ -400,7 +401,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +                    } catch (InvocationTargetException ex) {
 +                        throw Throwables.propagate(ex.getCause());
 +                    } catch (Exception ex) {
-+                        Bukkit.getLogger().log(Level.SEVERE, "Error invoking " + method, ex);
++                        LOGGER.error("Error invoking " + method, ex);
 +                    }
 +                }
 +            }
@@ -409,7 +410,7 @@ index 0000000000000000000000000000000000000000..a632a796a3e5f2b361a521d70581b83a
 +        try {
 +            config.save(CONFIG_FILE);
 +        } catch (IOException ex) {
-+            Bukkit.getLogger().log(Level.SEVERE, "Could not save " + CONFIG_FILE, ex);
++            LOGGER.error("Could not save " + CONFIG_FILE, ex);
 +        }
 +    }
 +
@@ -605,13 +606,13 @@ index 1707449cbbfa5eab585657cdde811b34a92e1d17..c8385460701395cb5c65fba41335469f
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, worlds, eraseCache);
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index cd65a5bb6da734a39b0bb6e9a0571455d19ceac4..fac993d58bd6e3bb19fd69881092a863c8952c65 100644
+index cd65a5bb6da734a39b0bb6e9a0571455d19ceac4..64be9c102290158844adb6dfcd2b93555106769a 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -194,6 +194,15 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
-         org.spigotmc.SpigotConfig.init((java.io.File) options.valueOf("spigot-settings"));
-         org.spigotmc.SpigotConfig.registerCommands();
-         // Spigot end
+@@ -102,6 +102,14 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+ 
+     @Override
+     public boolean initServer() throws IOException {
 +        // Paper start
 +        try {
 +            com.destroystokyo.paper.PaperConfig.init((java.io.File) options.valueOf("paper-settings"));
@@ -619,6 +620,15 @@ index cd65a5bb6da734a39b0bb6e9a0571455d19ceac4..fac993d58bd6e3bb19fd69881092a863
 +            DedicatedServer.LOGGER.error("Unable to load server configuration", e);
 +            return false;
 +        }
++        // Paper end
+         Thread thread = new Thread("Server console handler") {
+             public void run() {
+                 // CraftBukkit start
+@@ -194,6 +202,9 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         org.spigotmc.SpigotConfig.init((java.io.File) options.valueOf("spigot-settings"));
+         org.spigotmc.SpigotConfig.registerCommands();
+         // Spigot end
++        // Paper start
 +        com.destroystokyo.paper.PaperConfig.registerCommands();
 +        // Paper end
  

--- a/patches/server/0008-Paper-Metrics.patch
+++ b/patches/server/0008-Paper-Metrics.patch
@@ -690,10 +690,10 @@ index 0000000000000000000000000000000000000000..e3b74dbdf8e14219a56fab939f3174e0
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a632a796a3e5f2b361a521d70581b83a6839fc73..644a26bd5ac49e67a04ced0ac07097e22fe064f5 100644
+index 56f6e4aa2b261506cb44bd172015dbfc397e9406..e4d1ac70f04ac12db6d32bb3157677a8f820c1b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -42,6 +42,7 @@ public class PaperConfig {
+@@ -43,6 +43,7 @@ public class PaperConfig {
      private static boolean verbose;
      private static boolean fatalError;
      /*========================================================================*/
@@ -701,7 +701,7 @@ index a632a796a3e5f2b361a521d70581b83a6839fc73..644a26bd5ac49e67a04ced0ac07097e2
  
      public static void init(File configFile) {
          CONFIG_FILE = configFile;
-@@ -84,6 +85,11 @@ public class PaperConfig {
+@@ -85,6 +86,11 @@ public class PaperConfig {
          for (Map.Entry<String, Command> entry : commands.entrySet()) {
              MinecraftServer.getServer().server.getCommandMap().register(entry.getKey(), "Paper", entry.getValue());
          }

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -669,17 +669,18 @@ index 0000000000000000000000000000000000000000..0fda52841b5e1643efeda92106124998
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 644a26bd5ac49e67a04ced0ac07097e22fe064f5..666d956d0417d02a3c9e78a688edbe66e42cce18 100644
+index e4d1ac70f04ac12db6d32bb3157677a8f820c1b7..19607f8a354220ad618c9329483cba7bc449ff48 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -14,12 +14,15 @@ import java.util.concurrent.TimeUnit;
- import java.util.logging.Level;
+@@ -13,6 +13,7 @@ import java.util.Map;
+ import java.util.concurrent.TimeUnit;
  import java.util.regex.Pattern;
  
 +import com.google.common.collect.Lists;
  import net.minecraft.server.MinecraftServer;
+ import org.apache.logging.log4j.Logger;
  import org.bukkit.Bukkit;
- import org.bukkit.command.Command;
+@@ -20,6 +21,8 @@ import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
  import org.bukkit.configuration.file.YamlConfiguration;
@@ -688,7 +689,7 @@ index 644a26bd5ac49e67a04ced0ac07097e22fe064f5..666d956d0417d02a3c9e78a688edbe66
  
  public class PaperConfig {
  
-@@ -188,4 +191,35 @@ public class PaperConfig {
+@@ -189,4 +192,35 @@ public class PaperConfig {
          config.addDefault(path, def);
          return config.getString(path, config.getString(path));
      }
@@ -968,7 +969,7 @@ index b0ff982603e61805e3a0426aa8376330c73d9cf4..cf711f7fecdab70ff2ee48c87a3a1f08
                  i = this.context.runTopCommand(function, source);
              } finally {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b253f1348a 100644
+index 64be9c102290158844adb6dfcd2b93555106769a..f677edf190a44c57cbc8535f9ece3f2c3dbecc1d 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -67,8 +67,9 @@ import org.apache.logging.log4j.Logger;
@@ -982,7 +983,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
  import org.bukkit.event.server.RemoteServerCommandEvent;
  // CraftBukkit end
  
-@@ -467,7 +468,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -469,7 +470,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
      }
  
      public void handleConsoleInputs() {
@@ -991,7 +992,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
          while (!this.consoleInput.isEmpty()) {
              ConsoleInput servercommand = (ConsoleInput) this.consoleInput.remove(0);
  
-@@ -482,7 +483,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -484,7 +485,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              // CraftBukkit end
          }
  
@@ -1000,7 +1001,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
      }
  
      @Override
-@@ -713,6 +714,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -715,6 +716,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
  
      @Override
      public String runCommand(String command) {
@@ -1008,7 +1009,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
          this.rconConsoleSource.prepareForCommand();
          this.executeBlocking(() -> {
              // CraftBukkit start - fire RemoteServerCommandEvent
-@@ -721,10 +723,39 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -723,10 +725,39 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              if (event.isCancelled()) {
                  return;
              }
@@ -1049,7 +1050,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 12a9a6fa04867d5695d46bf7973f1542798485be..e0794c0eac5c2d323b10e1f69d9c1875731da125 100644
+index f6ed7482fd9c3d536fc8956a80a6ad6f315431e2..ce767bab0c85cbfb8476a899f05305d915815288 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,7 +1,9 @@

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -7,10 +7,10 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 666d956d0417d02a3c9e78a688edbe66e42cce18..f5155d4b48f17c82b7a637418c40ffcdc6cc6271 100644
+index 19607f8a354220ad618c9329483cba7bc449ff48..da88668b4a8d358145c6bcf0a51eaa2e78dc1037 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -222,4 +222,13 @@ public class PaperConfig {
+@@ -223,4 +223,13 @@ public class PaperConfig {
                  " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
                  " - Server Name: " + timingsServerName);
      }

--- a/patches/server/0021-Add-version-history-to-version-command.patch
+++ b/patches/server/0021-Add-version-history-to-version-command.patch
@@ -202,12 +202,12 @@ index 0000000000000000000000000000000000000000..aac3f66cb23d260729c2a48d8710a9de
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 2b062beaad39f2e86801fdd5b0cc84b253f1348a..bd94277862e0f5546b4df81fbd535d2e4c7ef5b1 100644
+index f677edf190a44c57cbc8535f9ece3f2c3dbecc1d..6c874bd9790f3b4ea9f68eaee6a647b7a609162f 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -203,6 +203,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
-             return false;
-         }
+@@ -205,6 +205,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         // Spigot end
+         // Paper start
          com.destroystokyo.paper.PaperConfig.registerCommands();
 +        com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
          // Paper end

--- a/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f5155d4b48f17c82b7a637418c40ffcdc6cc6271..acdbd21947093ed076c4668d3480a50f4e289b8d 100644
+index da88668b4a8d358145c6bcf0a51eaa2e78dc1037..9d75ebda9cbb2fa8c63b631347aa838f07358aa4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -231,4 +231,9 @@ public class PaperConfig {
+@@ -232,4 +232,9 @@ public class PaperConfig {
          }
          useDisplayNameInQuit = getBoolean("settings.use-display-name-in-quit-message", useDisplayNameInQuit);
      }
@@ -30,7 +30,7 @@ index f5155d4b48f17c82b7a637418c40ffcdc6cc6271..acdbd21947093ed076c4668d3480a50f
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 28a3fa002a77ecc7f5bd16aa4316f6d74e2503e1..451d911334dc1477c99f94705632c9fd5184ddb0 100644
+index db13ac548b7c250f84df9d5dbfb85021010b2d86..abf985bb0b485dde6a843ef18b24caff329f5843 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -415,6 +415,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0075-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/patches/server/0075-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index acdbd21947093ed076c4668d3480a50f4e289b8d..a3a4ecabed1ec7511005affe610fc2ec8a87d67a 100644
+index 9d75ebda9cbb2fa8c63b631347aa838f07358aa4..f7fba23d6cce25ea01e655c90645c1272d790729 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -236,4 +236,9 @@ public class PaperConfig {
+@@ -237,4 +237,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }

--- a/patches/server/0084-Configurable-Player-Collision.patch
+++ b/patches/server/0084-Configurable-Player-Collision.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Player Collision
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a3a4ecabed1ec7511005affe610fc2ec8a87d67a..1d2680ad57c2a44838157fbf8601b14fda03ce17 100644
+index f7fba23d6cce25ea01e655c90645c1272d790729..25767e17b929c79948f93aef6ab7e704d28a40e6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -241,4 +241,9 @@ public class PaperConfig {
+@@ -242,4 +242,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = Math.max(getInt("settings.region-file-cache-size", 256), 4);
      }
@@ -32,7 +32,7 @@ index 8885220e4813b34627b42523834bbec995d8950d..4c9660176e783999301565790b8cf6f4
              buf.writeComponent(this.playerPrefix);
              buf.writeComponent(this.playerSuffix);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1faf63b6de560b23e3ca3b8358a4fd1ff9204bd4..7b947c0d5bd63957df6348ea2ade79f9dc3e59fa 100644
+index 46eaa77f33a375da80f8290883f6ed1f321be87e..ec73f52f7a82a9c1428979c562a9df5002261cd4 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -161,6 +161,7 @@ import net.minecraft.world.level.storage.loot.LootTables;

--- a/patches/server/0093-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/patches/server/0093-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1d2680ad57c2a44838157fbf8601b14fda03ce17..f94db56dfcae9843ef341912c43b092d62fe0627 100644
+index 25767e17b929c79948f93aef6ab7e704d28a40e6..b6f36811eba414d36130b6aae40b1db9bf101dcd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -246,4 +246,9 @@ public class PaperConfig {
+@@ -247,4 +247,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }

--- a/patches/server/0095-Optimize-UserCache-Thread-Safe.patch
+++ b/patches/server/0095-Optimize-UserCache-Thread-Safe.patch
@@ -12,7 +12,7 @@ the user never changed the default setting for Spigot's save on stop only.
 1.17: TODO does this need the synchronized blocks anymore?
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2c605296eb674b96813aa0c8f2711cf0662af3d2..69f4f8e5fdb7958076671dec0614c401beed9854 100644
+index 623a2cf6b6e05598124014c7340590d26c7880b8..79270b3969c6c05a5a90756a88f3547b64cf5f3b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -988,7 +988,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -25,10 +25,10 @@ index 2c605296eb674b96813aa0c8f2711cf0662af3d2..69f4f8e5fdb7958076671dec0614c401
          // Spigot end
  
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index bd94277862e0f5546b4df81fbd535d2e4c7ef5b1..7d834c1b1588851188372eebd9efad9313c610f7 100644
+index 6c874bd9790f3b4ea9f68eaee6a647b7a609162f..676a71de134ce5eb884b4784b23058739766ea61 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -257,7 +257,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -259,7 +259,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          }
  
          if (this.convertOldUsers()) {

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add setting for proxy online mode status
 TODO: Add isProxyOnlineMode check to Metrics
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f94db56dfcae9843ef341912c43b092d62fe0627..e7606adc0e7e81e1878f87d2538d8b75c58d5555 100644
+index b6f36811eba414d36130b6aae40b1db9bf101dcd..2ea8cbe6f2967f8bd7f849e1ec3c729d0460f9ec 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
@@ -17,7 +17,7 @@ index f94db56dfcae9843ef341912c43b092d62fe0627..e7606adc0e7e81e1878f87d2538d8b75
  
  public class PaperConfig {
  
-@@ -251,4 +252,13 @@ public class PaperConfig {
+@@ -252,4 +253,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }

--- a/patches/server/0105-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0105-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e7606adc0e7e81e1878f87d2538d8b75c58d5555..e2e96dd87c08e749fd513db2156d49f18dee8eb8 100644
+index 2ea8cbe6f2967f8bd7f849e1ec3c729d0460f9ec..c96a5530165d825a8165d288fce97c9d3d0599a3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -261,4 +261,13 @@ public class PaperConfig {
+@@ -262,4 +262,13 @@ public class PaperConfig {
      public static boolean isProxyOnlineMode() {
          return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }

--- a/patches/server/0106-Configurable-flying-kick-messages.patch
+++ b/patches/server/0106-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e2e96dd87c08e749fd513db2156d49f18dee8eb8..ac2c7977e2110feb7c45856d6f0a0ccdeedfcdb3 100644
+index c96a5530165d825a8165d288fce97c9d3d0599a3..ea60d6ed81e1e4d2b5a18103c71f0a66441a96ed 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -270,4 +270,11 @@ public class PaperConfig {
+@@ -271,4 +271,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ac2c7977e2110feb7c45856d6f0a0ccdeedfcdb3..fa6beae844354849e73a45cf38eb1f0669c01e93 100644
+index ea60d6ed81e1e4d2b5a18103c71f0a66441a96ed..d8bf09993c70a29708faa2bd2ad8c28d473c65ac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -277,4 +277,9 @@ public class PaperConfig {
+@@ -278,4 +278,9 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d97e9ba4432fc87c84f9f128820ff741464e1e25..ee6257e1106794614b9d3ec4e9ee354f14f86e69 100644
+index 9248d3701a2ac282d85ab92a515397b5150ffa86..43f4037dad7394d6ee94b5f91fbdb783428a6f62 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -17,7 +17,17 @@ repositories {
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index e36986a2f6e8548cba011fc2e8e84bb9f3f6e10d..ce5fab6878a65b7ad4fd6aead5b77a9724d3dd63 100644
+index 2e0bd32ebe06e39b3dc889be9b06e2d0047c1068..9a8779bed2a2fa7dc869d3283c59dbc132df8968 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -9,6 +9,7 @@ import com.mojang.authlib.GameProfile;
@@ -179,10 +179,10 @@ index e36986a2f6e8548cba011fc2e8e84bb9f3f6e10d..ce5fab6878a65b7ad4fd6aead5b77a97
  
      public KeyPair getKeyPair() {
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51bbf49dc28 100644
+index 676a71de134ce5eb884b4784b23058739766ea61..c66c3a761da4e2d965d96e2baf131f2973f2b7ca 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -109,6 +109,9 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -117,6 +117,9 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
                  if (!org.bukkit.craftbukkit.Main.useConsole) {
                      return;
                  }
@@ -192,7 +192,7 @@ index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51b
                  jline.console.ConsoleReader bufferedreader = reader;
  
                  // MC-33041, SPIGOT-5538: if System.in is not valid due to javaw, then return
-@@ -140,7 +143,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -148,7 +151,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
                              continue;
                          }
                          if (s.trim().length() > 0) { // Trim to filter lines which are just spaces
@@ -201,7 +201,7 @@ index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51b
                          }
                          // CraftBukkit end
                      }
-@@ -148,6 +151,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -156,6 +159,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
                      DedicatedServer.LOGGER.error("Exception handling console input", ioexception);
                  }
  
@@ -210,7 +210,7 @@ index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51b
              }
          };
  
-@@ -159,6 +164,9 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -167,6 +172,9 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          }
          global.addHandler(new org.bukkit.craftbukkit.util.ForwardLogHandler());
  
@@ -220,7 +220,7 @@ index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51b
          final org.apache.logging.log4j.core.Logger logger = ((org.apache.logging.log4j.core.Logger) LogManager.getRootLogger());
          for (org.apache.logging.log4j.core.Appender appender : logger.getAppenders().values()) {
              if (appender instanceof org.apache.logging.log4j.core.appender.ConsoleAppender) {
-@@ -167,6 +175,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -175,6 +183,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          }
  
          new org.bukkit.craftbukkit.util.TerminalConsoleWriterThread(System.out, this.reader).start();

--- a/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index fa6beae844354849e73a45cf38eb1f0669c01e93..5bb6f09d138f981329378edab707f8275cdfc5a0 100644
+index d8bf09993c70a29708faa2bd2ad8c28d473c65ac..ec04805136b40e2de758792e80106d4b033cce3b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index fa6beae844354849e73a45cf38eb1f0669c01e93..5bb6f09d138f981329378edab707f827
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -282,4 +283,9 @@ public class PaperConfig {
+@@ -283,4 +284,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }

--- a/patches/server/0188-Upstream-config-migrations.patch
+++ b/patches/server/0188-Upstream-config-migrations.patch
@@ -7,10 +7,10 @@ This patch contains config migrations for when upstream adds options
 which Paper already had.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5bb6f09d138f981329378edab707f8275cdfc5a0..3d5fd6be97bef7ec47893a85cae771f4a4451092 100644
+index ec04805136b40e2de758792e80106d4b033cce3b..cf50fbfd5e4a61e144d1f694596cde394b0d16bd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -288,4 +288,22 @@ public class PaperConfig {
+@@ -289,4 +289,22 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }

--- a/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3d5fd6be97bef7ec47893a85cae771f4a4451092..ce4ab03a40fac6a840f4c4b78da0a96bb6fb6823 100644
+index cf50fbfd5e4a61e144d1f694596cde394b0d16bd..a829214bdb54c0d058128da9d2019a12eccefb75 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -306,4 +306,12 @@ public class PaperConfig {
+@@ -307,4 +307,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }
@@ -48,7 +48,7 @@ index 3d5fd6be97bef7ec47893a85cae771f4a4451092..ce4ab03a40fac6a840f4c4b78da0a96b
 +    private static void useAlternativeLuckFormula() {
 +        useAlternativeLuckFormula = getBoolean("settings.use-alternative-luck-formula", false);
 +        if (useAlternativeLuckFormula) {
-+            Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
++            LOGGER.info("Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
 +        }
 +    }
  }

--- a/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,11 +22,11 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ce4ab03a40fac6a840f4c4b78da0a96bb6fb6823..a6d27dcdf954bc2682aba1d9efab42d2d626f8da 100644
+index a829214bdb54c0d058128da9d2019a12eccefb75..02950b5b2ee63d6d4fa9d2bd1ef196df042d8685 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -314,4 +314,18 @@ public class PaperConfig {
-             Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
+@@ -315,4 +315,18 @@ public class PaperConfig {
+             LOGGER.info("Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }
 +

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,18 +9,10 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d70232b824f3 100644
+index 02950b5b2ee63d6d4fa9d2bd1ef196df042d8685..b25c4d143ed8e7c4e835fdc7df0068f38e7e8128 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
- import co.aikar.timings.Timings;
- import co.aikar.timings.TimingsManager;
- import org.spigotmc.SpigotConfig;
-+import org.spigotmc.WatchdogThread;
- 
- public class PaperConfig {
- 
-@@ -315,6 +316,14 @@ public class PaperConfig {
+@@ -316,6 +316,13 @@ public class PaperConfig {
          }
      }
  
@@ -29,14 +21,13 @@ index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d702
 +    private static void watchdogEarlyWarning() {
 +        watchdogPrintEarlyWarningEvery = getInt("settings.watchdog.early-warning-every", 5000);
 +        watchdogPrintEarlyWarningDelay = getInt("settings.watchdog.early-warning-delay", 10000);
-+        WatchdogThread.doStart(SpigotConfig.timeoutTime, SpigotConfig.restartOnCrash );
 +    }
 +
      public static int tabSpamIncrement = 1;
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 74e780212773e0d3cce19cb9c33cdcaa4a708f14..cc4a94669c5f0dee99b6d8cb89650cf0c701e9ab 100644
+index 1bffdc632a19318325b60ef737f9e8555ae40230..7b760a65cad1f7dd5adb3a05b8b5ed7d0f49c0a9 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1100,6 +1100,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -47,6 +38,18 @@ index 74e780212773e0d3cce19cb9c33cdcaa4a708f14..cc4a94669c5f0dee99b6d8cb89650cf0
                  Arrays.fill( recentTps, 20 );
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
                  lastTick = start - TICK_TIME; // Paper
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index c66c3a761da4e2d965d96e2baf131f2973f2b7ca..6677b178a61bd4744a8786673b2ad526dc37285a 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -214,6 +214,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         org.spigotmc.SpigotConfig.registerCommands();
+         // Spigot end
+         // Paper start
++        org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash); // After Paper & Spigot configs have been initialized
+         com.destroystokyo.paper.PaperConfig.registerCommands();
+         com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
+         // Paper end
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 index f831f196e332604146e95289bf42139241f2bc0e..0c73ed409f96fb8fef721fbfb0592157c2d06b80 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java

--- a/patches/server/0248-Use-a-Queue-for-Queueing-Commands.patch
+++ b/patches/server/0248-Use-a-Queue-for-Queueing-Commands.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Use a Queue for Queueing Commands
 Lists are bad as Queues mmmkay.
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 967552df9d5ae7e58bb39127e1adb51bbf49dc28..047ec5fe63789fb0ac003ecee641542f5e9cba2f 100644
+index bcc640fb4d9d6fd75fe21397075157f7461604d6..c51d5653886c6209d97dc2f191bd263e9e0c78ec 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -79,7 +79,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
@@ -18,7 +18,7 @@ index 967552df9d5ae7e58bb39127e1adb51bbf49dc28..047ec5fe63789fb0ac003ecee641542f
      private QueryThreadGs4 queryThreadGs4;
      public final RconConsoleSource rconConsoleSource;
      private RconThread rconThread;
-@@ -475,13 +475,15 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -478,13 +478,15 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
      }
  
      public void handleConsoleInput(String command, CommandSourceStack commandSource) {

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -159,7 +159,7 @@ index 0fda52841b5e1643efeda92106124998abc4e0aa..fe79c0add4f7cb18d487c5bb9415c40c
  
      public static Timing getTickList(ServerLevel worldserver, String timingsType) {
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index dd81701230133442186524e9cd65d70232b824f3..8a1f581bd7ef8a20329813dedb5bb952e32d41ae 100644
+index b25c4d143ed8e7c4e835fdc7df0068f38e7e8128..bff44b15a972c793091148828bd4d73796a779fa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -169,7 +169,7 @@ index dd81701230133442186524e9cd65d70232b824f3..8a1f581bd7ef8a20329813dedb5bb952
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -337,4 +338,58 @@ public class PaperConfig {
+@@ -336,4 +337,58 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
@@ -3661,7 +3661,7 @@ index 74825cd20ae25bbaa1f69ecb208a1c01c1213083..e43135fc10cb2d024295cbe89daf7127
      // Spigot start
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 95bc2136eaa118f28c7ec2d8b557ed0773f5f9ad..2ef8ffdf8c957aa91caa3b628cfeb0276989bc75 100644
+index 473dc5e5ee3458e605ecf5e2b2dadb3573fd685b..0a0ece8361a0368629696e06c00165741b14e308 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -15,6 +15,7 @@ import net.minecraft.network.chat.Component;

--- a/patches/server/0273-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0273-Configurable-connection-throttle-kick-message.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8a1f581bd7ef8a20329813dedb5bb952e32d41ae..69ad59f0faf1e9a1134d0a460b49569f670055f0 100644
+index bff44b15a972c793091148828bd4d73796a779fa..f11a7a78eed0c664c26f661a0d5447173dcdd73e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -291,6 +291,11 @@ public class PaperConfig {

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 69ad59f0faf1e9a1134d0a460b49569f670055f0..4b4fbd8747740111cc2e25f0c4d29a29926a3a1b 100644
+index f11a7a78eed0c664c26f661a0d5447173dcdd73e..6011f34fb2a338b5066a2bedb2a1dbdd8a0f3f1e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -9,6 +9,7 @@ import java.io.IOException;
@@ -34,7 +34,7 @@ index 69ad59f0faf1e9a1134d0a460b49569f670055f0..4b4fbd8747740111cc2e25f0c4d29a29
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -344,6 +345,20 @@ public class PaperConfig {
+@@ -343,6 +344,20 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  
@@ -225,7 +225,7 @@ index 39bdda56aaa5503efc15207261634127b462c3e7..3fd913f3e963cf2da849a52364356e3b
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d62f1650a0879e46e6c619c0f7387e0c438430ec..d64bcc0aafb918e82e881f6503ce8311e78a3f6f 100644
+index 0c73ed409f96fb8fef721fbfb0592157c2d06b80..0b6ea1fde85313a44b7d390c6c92be053af7305d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -694,7 +694,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -18,12 +18,12 @@ index 1fa190e098079522e0fe3593fa261c1b7ad4e24b..1eb45df9dca5d0c31ac46709e706136a
      }
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4b4fbd8747740111cc2e25f0c4d29a29926a3a1b..26ac165135ef53cec9e065ae1c15220a8fba5869 100644
+index 6011f34fb2a338b5066a2bedb2a1dbdd8a0f3f1e..9d71598fb404f22c4c42ead7165f0da2e9bf6555 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -20,6 +20,7 @@ import java.util.regex.Pattern;
- import com.google.common.collect.Lists;
+@@ -20,6 +20,7 @@ import com.google.common.collect.Lists;
  import net.minecraft.server.MinecraftServer;
+ import org.apache.logging.log4j.Logger;
  import org.bukkit.Bukkit;
 +import org.bukkit.ChatColor;
  import org.bukkit.command.Command;

--- a/patches/server/0299-Book-Size-Limits.patch
+++ b/patches/server/0299-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 26ac165135ef53cec9e065ae1c15220a8fba5869..34e82edf683a33f140f3b4580b3245f29a775fcd 100644
+index 9d71598fb404f22c4c42ead7165f0da2e9bf6555..b732a2e96832be767b27f53b3bc77268a63f7934 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -365,6 +365,13 @@ public class PaperConfig {
+@@ -364,6 +364,13 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,10 +42,10 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 34e82edf683a33f140f3b4580b3245f29a775fcd..86e16e39a9a996669989d990b76f69116bcee300 100644
+index b732a2e96832be767b27f53b3bc77268a63f7934..094d94d329ff19bfd86735fb60d70b5fa64967f3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -372,6 +372,13 @@ public class PaperConfig {
+@@ -371,6 +371,13 @@ public class PaperConfig {
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
  
@@ -925,7 +925,7 @@ index 8d3cdd288eacc91f7c9a624f601284e5cd2a36cc..a3ba56f437fe9e4dac59370463052341
              });
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 472146bea17f323397df1d3ed1aa31fc91a8741c..c7ecb8fb1cbc1433986fbd03c68b4dbe5a2835c7 100644
+index c6213a7dfcf9aeccdb546eaf74fa8eb119a6a32c..ec0d8e58a518a20634b902769251d6d04750433e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -218,6 +218,18 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0390-Remote-Connections-shouldn-t-hold-up-shutdown.patch
+++ b/patches/server/0390-Remote-Connections-shouldn-t-hold-up-shutdown.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Remote Connections shouldn't hold up shutdown
 Bugs in the connection logic appears to leave stale connections even, preventing shutdown
 
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 047ec5fe63789fb0ac003ecee641542f5e9cba2f..b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee 100644
+index c51d5653886c6209d97dc2f191bd263e9e0c78ec..d68283963cb89af89027813025811fb96376d484 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -441,11 +441,11 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -444,11 +444,11 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          }
  
          if (this.rconThread != null) {

--- a/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 86e16e39a9a996669989d990b76f69116bcee300..f1034cfb63ea37c22e67b5d4a18214774f208de2 100644
+index 094d94d329ff19bfd86735fb60d70b5fa64967f3..900f496041a99111709318e6c6800d31fc372bdf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -87,7 +87,7 @@ index 86e16e39a9a996669989d990b76f69116bcee300..f1034cfb63ea37c22e67b5d4a1821477
          version = getInt("config-version", 22);
          set("config-version", 22);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 273774ad46b993212a0cd4cfa81f0e02807c442e..c4f52d4511476f8fd904e4eb790b07d36cfdb145 100644
+index 026397cbedd2d1cd08ec8a82a3468f35cd8e4765..74051c9b620516dc2f302b1595e74faf91519962 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -248,6 +248,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/patches/server/0402-Improved-Watchdog-Support.patch
+++ b/patches/server/0402-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index e3b605695e3b837246f72ccb364af06ea48bda45..62c3c597732e6fb30ed5367d902ea876
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c4f52d4511476f8fd904e4eb790b07d36cfdb145..2e8892211dd3eb4cac27bcb3b302a25d833e2626 100644
+index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d7579d912 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -299,7 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -230,10 +230,10 @@ index c4f52d4511476f8fd904e4eb790b07d36cfdb145..2e8892211dd3eb4cac27bcb3b302a25d
              this.functionManager.replaceLibrary(this.resources.getFunctionLibrary());
              this.structureManager.onResourceManagerReload(this.resources.getResourceManager());
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e115f23ed0 100644
+index d68283963cb89af89027813025811fb96376d484..7bdbd55a42df5007e4c8ee42d4ada60e7ba458a3 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -285,7 +285,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -288,7 +288,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              long j = Util.getNanos() - i;
              String s = String.format(Locale.ROOT, "%.3fs", (double) j / 1.0E9D);
  
@@ -242,7 +242,7 @@ index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e1
              if (dedicatedserverproperties.announcePlayerAchievements != null) {
                  ((GameRules.BooleanValue) this.getGameRules().getRule(GameRules.RULE_ANNOUNCE_ADVANCEMENTS)).set(dedicatedserverproperties.announcePlayerAchievements, (MinecraftServer) this);
              }
-@@ -448,7 +448,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -451,7 +451,8 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              //this.remoteStatusListener.b(); // Paper - don't wait for remote connections
          }
  
@@ -252,7 +252,7 @@ index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e1
      }
  
      @Override
-@@ -781,7 +782,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -784,7 +785,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
      @Override
      public void stopServer() {
          super.stopServer();
@@ -262,7 +262,7 @@ index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 147ee80242758417464a7cdf02e746758b54f6d7..a586623ed0f7003905e053c238d9b62632b87bc6 100644
+index 0f87595cb58d1ea0162b5eda81490c584a82aaf7..ced402efc036ae6111867c4c1872390b720659f3 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -581,6 +581,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0429-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0429-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -92,10 +92,10 @@ index fd037da8b655b329ef016356519a69ca2621fd4f..03c9f894a2eaa065c456843eef4d3ab1
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f1034cfb63ea37c22e67b5d4a18214774f208de2..a8740f03a7feef40490e9f5be610c2c835114f08 100644
+index 900f496041a99111709318e6c6800d31fc372bdf..80566ae26100eb039f876fa8371af2c68bb4cf4d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -433,4 +433,9 @@ public class PaperConfig {
+@@ -432,4 +432,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }
@@ -518,11 +518,11 @@ index 3941e14d1c3e6e688e28904948039c8b2200de5f..a4fda4a3bae9ce600e778b44cd3ef432
          }
      }
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index a335d48467d1730bfed25eb5fd9046e115f23ed0..8098875a5c4146dec81f5daed0e34ddfe17a26c6 100644
+index 772bbdb63c08a7683dc7534dbfc76807d2e98eb1..8f2db2e55199fa51781186ceeafa631553026d2e 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -214,6 +214,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
-         }
+@@ -217,6 +217,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash); // After Paper & Spigot configs have been initialized
          com.destroystokyo.paper.PaperConfig.registerCommands();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
 +        io.papermc.paper.util.ObfHelper.INSTANCE.getClass(); // load mappings for stacktrace deobf and etc.

--- a/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a8740f03a7feef40490e9f5be610c2c835114f08..155fa55eb859da90d59d01b21ae422bf99ccfa87 100644
+index 80566ae26100eb039f876fa8371af2c68bb4cf4d..e88a56a828c9fbeff26aff6746ceb425f490d7d9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -438,4 +438,15 @@ public class PaperConfig {
+@@ -437,4 +437,15 @@ public class PaperConfig {
      private static void loggerSettings() {
          deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
      }

--- a/patches/server/0445-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0445-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 155fa55eb859da90d59d01b21ae422bf99ccfa87..ddf9b5592e2203315d239ab28a338633600c69fc 100644
+index e88a56a828c9fbeff26aff6746ceb425f490d7d9..87f7499123a55952fbf0f38e068f6ddb204f6887 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -449,4 +449,9 @@ public class PaperConfig {
+@@ -448,4 +448,9 @@ public class PaperConfig {
          config.set("settings.unsupported-settings.allow-permanent-block-break-exploits-readme", "This setting controls if players should be able to break bedrock, end portals and other intended to be permanent blocks.");
          allowBlockPermanentBreakingExploits = getBoolean("settings.unsupported-settings.allow-permanent-block-break-exploits", allowBlockPermanentBreakingExploits);
      }

--- a/patches/server/0458-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0458-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ddf9b5592e2203315d239ab28a338633600c69fc..0ff0a71fe5dc53fa5fb81edffabc69790e3bcd1e 100644
+index 87f7499123a55952fbf0f38e068f6ddb204f6887..776c5636d5ed4a8df1490e8d2b15b10fd5b307ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -454,4 +454,12 @@ public class PaperConfig {
+@@ -453,4 +453,12 @@ public class PaperConfig {
      private static void consoleHasAllPermissions() {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }

--- a/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -68,10 +68,10 @@ index 33c859df0b669d0c3e97ccba29f17c1ba2166a27..9f03b738aea623fe409ca176397f48be
              return 0;
          }
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 8098875a5c4146dec81f5daed0e34ddfe17a26c6..286863b7eb9ee0389154304e61942dd68f978ff1 100644
+index 0659183375e5b3066934295ad1aa42c137c19312..36583df8265ec3fbcb05d28cde3981e2eb559136 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -370,7 +370,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -373,7 +373,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
  
      @Override
      public void forceDifficulty() {

--- a/patches/server/0499-Incremental-player-saving.patch
+++ b/patches/server/0499-Incremental-player-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Incremental player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 0ff0a71fe5dc53fa5fb81edffabc69790e3bcd1e..d74f0bdabd64976bf8608f2a5d8f2dc6118a35f2 100644
+index 776c5636d5ed4a8df1490e8d2b15b10fd5b307ae..f2023af1ec27f55e2ecfc2f5317e582c65a3babb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -462,4 +462,14 @@ public class PaperConfig {
+@@ -461,4 +461,14 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  
@@ -24,7 +24,7 @@ index 0ff0a71fe5dc53fa5fb81edffabc69790e3bcd1e..d74f0bdabd64976bf8608f2a5d8f2dc6
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 186193d1d652876e9ad7cdf5223ec2c6f5c65779..5595fc75df984b3d21f78759cb76f5b4018ff550 100644
+index 58652325de8c3978359a9864bb68da9347990774..4af56ca699d456eb23794673861323ab06cf6de8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -981,7 +981,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -54,7 +54,7 @@ index 186193d1d652876e9ad7cdf5223ec2c6f5c65779..5595fc75df984b3d21f78759cb76f5b4
          } // Paper start
          for (ServerLevel level : this.getAllLevels()) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f1cd338942d709e3d2d8de40241fe6e14bcba062..d4ab5061026eaff96b917427fd278ae06e103c6d 100644
+index e5ea07605913ea1488b7b73290c821034c935103..3e2900e346f9bb1bdce5bec747812dd9bf1cf4d5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -175,6 +175,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0510-Prevent-headless-pistons-from-being-created.patch
+++ b/patches/server/0510-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d74f0bdabd64976bf8608f2a5d8f2dc6118a35f2..c59a881632810da1408e74493bafcd4e6b01d975 100644
+index f2023af1ec27f55e2ecfc2f5317e582c65a3babb..2508c59a37892d300e7a30022ce04633da7bcd5f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -462,6 +462,12 @@ public class PaperConfig {
+@@ -461,6 +461,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/patches/server/0513-Buffer-joins-to-world.patch
+++ b/patches/server/0513-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c59a881632810da1408e74493bafcd4e6b01d975..07eeb01c95a04299fab2daddfdaf5d1a96495ef0 100644
+index 2508c59a37892d300e7a30022ce04633da7bcd5f..e6733c6a2237218f27744633b8aa5ccebda4891c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -478,4 +478,9 @@ public class PaperConfig {
+@@ -477,4 +477,9 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/patches/server/0528-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0528-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 07eeb01c95a04299fab2daddfdaf5d1a96495ef0..4747eb55decd797c7872028997f4e22d15c5a661 100644
+index e6733c6a2237218f27744633b8aa5ccebda4891c..39668f85f95f888c4a24f147ac0346603f224542 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -483,4 +483,9 @@ public class PaperConfig {
+@@ -482,4 +482,9 @@ public class PaperConfig {
      private static void maxJoinsPerTick() {
          maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
      }

--- a/patches/server/0565-Limit-recipe-packets.patch
+++ b/patches/server/0565-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4747eb55decd797c7872028997f4e22d15c5a661..ff337f7f5317f30b65e1b40c11c1783421f1a89d 100644
+index 39668f85f95f888c4a24f147ac0346603f224542..9faa1c4ba6cb97fe2e59e6faf3c2f1df80e20230 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -352,6 +352,13 @@ public class PaperConfig {
+@@ -351,6 +351,13 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  
@@ -23,7 +23,7 @@ index 4747eb55decd797c7872028997f4e22d15c5a661..ff337f7f5317f30b65e1b40c11c17834
      public static boolean velocityOnlineMode;
      public static byte[] velocitySecretKey;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4224cf13528c2c2deeb1c1ffeadc954e166d3f61..ecb62a1fd7d0458bd2e7dbbf54c3a415a6889832 100644
+index 7cfdd686773b8ef67c99f3211c3ed2bf84fb54ea..7a4766d4fd86b6f0ab725955e364c631d37752b6 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -231,6 +231,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0567-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0567-MC-4-Fix-item-position-desync.patch
@@ -9,10 +9,10 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ff337f7f5317f30b65e1b40c11c1783421f1a89d..5af9d91e15b0c10da79fa935cc884cd2766edfae 100644
+index 9faa1c4ba6cb97fe2e59e6faf3c2f1df80e20230..3f519a3166ddd1cedab52b586091d1e8eea55db7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -495,4 +495,9 @@ public class PaperConfig {
+@@ -494,4 +494,9 @@ public class PaperConfig {
      private static void trackPluginScoreboards() {
          trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
      }

--- a/patches/server/0630-fix-converting-txt-to-json-file.patch
+++ b/patches/server/0630-fix-converting-txt-to-json-file.patch
@@ -21,10 +21,10 @@ index aeb91eefa0949b2a53d77f1e4a48a29b9d1bc3fe..918f5221e94cbc867349c69c83563e22
          this.saveUserBanList();
          this.loadIpBanList();
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 286863b7eb9ee0389154304e61942dd68f978ff1..67afb97e6cb545d319202f3eca771015065089f6 100644
+index 85165f4a226f154e9b2c571d4d1d74a2f48d98a6..5458d60eac3899b92b41332bb5df299298fbee58 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -205,6 +205,12 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -213,6 +213,12 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          org.spigotmc.SpigotConfig.init((java.io.File) options.valueOf("spigot-settings"));
          org.spigotmc.SpigotConfig.registerCommands();
          // Spigot end
@@ -35,9 +35,9 @@ index 286863b7eb9ee0389154304e61942dd68f978ff1..67afb97e6cb545d319202f3eca771015
 +        this.getPlayerList().loadAndSaveFiles(); // Must be after convertNames
 +        // Paper end
          // Paper start
-         try {
-             com.destroystokyo.paper.PaperConfig.init((java.io.File) options.valueOf("paper-settings"));
-@@ -267,9 +273,6 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+         org.spigotmc.WatchdogThread.doStart(org.spigotmc.SpigotConfig.timeoutTime, org.spigotmc.SpigotConfig.restartOnCrash); // After Paper & Spigot configs have been initialized
+         com.destroystokyo.paper.PaperConfig.registerCommands();
+@@ -270,9 +276,6 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
              DedicatedServer.LOGGER.warn("To change this, set \"online-mode\" to \"true\" in the server.properties file.");
          }
  

--- a/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Enhance console tab completions for brigadier commands
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5af9d91e15b0c10da79fa935cc884cd2766edfae..6c4bb838792c779da7b2d84831f6e67779695993 100644
+index 3f519a3166ddd1cedab52b586091d1e8eea55db7..279bd2687a97b3e52d792480f534506296a8e78d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -500,4 +500,11 @@ public class PaperConfig {
+@@ -499,4 +499,11 @@ public class PaperConfig {
      private static void fixEntityPositionDesync() {
          fixEntityPositionDesync = getBoolean("settings.fix-entity-position-desync", fixEntityPositionDesync);
      }

--- a/patches/server/0663-Implement-methods-to-convert-between-Component-and-B.patch
+++ b/patches/server/0663-Implement-methods-to-convert-between-Component-and-B.patch
@@ -42,10 +42,10 @@ index 0000000000000000000000000000000000000000..dd6012b6a097575b2d1471be5069ecce
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 67afb97e6cb545d319202f3eca771015065089f6..472d0635719c0a8f495ce474bd4a268d4e9071c8 100644
+index 6bf41a085df5a73dbc87e91714436ce6f7ffb48b..295b418707d516385f1dbd56c496764442a7c94d 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -221,6 +221,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -224,6 +224,7 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          com.destroystokyo.paper.PaperConfig.registerCommands();
          com.destroystokyo.paper.VersionHistoryManager.INSTANCE.getClass(); // load version history now
          io.papermc.paper.util.ObfHelper.INSTANCE.getClass(); // load mappings for stacktrace deobf and etc.

--- a/patches/server/0685-Add-Unix-domain-socket-support.patch
+++ b/patches/server/0685-Add-Unix-domain-socket-support.patch
@@ -27,10 +27,10 @@ index bdd4f4db9849d9107b5c62d5e83b1277621f49f1..9d09ec3b127e3440bef6b248578dec10
      }
      // Spigot End
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 472d0635719c0a8f495ce474bd4a268d4e9071c8..1bf19965d12514dee34545235bfbadc0b74ddc8b 100644
+index 295b418707d516385f1dbd56c496764442a7c94d..96e81b6cb03fdc7467f7537701fb9c70bbe22a88 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-@@ -232,6 +232,20 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -235,6 +235,20 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          this.setEnforceWhitelist(dedicatedserverproperties.enforceWhitelist);
          // this.worldData.setGameType(dedicatedserverproperties.gamemode); // CraftBukkit - moved to world loading
          DedicatedServer.LOGGER.info("Default game type: {}", dedicatedserverproperties.gamemode);
@@ -51,7 +51,7 @@ index 472d0635719c0a8f495ce474bd4a268d4e9071c8..1bf19965d12514dee34545235bfbadc0
          InetAddress inetaddress = null;
  
          if (!this.getLocalIp().isEmpty()) {
-@@ -241,12 +255,15 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+@@ -244,12 +258,15 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
          if (this.getPort() < 0) {
              this.setPort(dedicatedserverproperties.serverPort);
          }

--- a/patches/server/0701-Make-item-validations-configurable.patch
+++ b/patches/server/0701-Make-item-validations-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6c4bb838792c779da7b2d84831f6e67779695993..bc4081483a228aa275511d28231d615fe0f36d4e 100644
+index 279bd2687a97b3e52d792480f534506296a8e78d..2ba50877f9081b7e5ebb0b76a2b8740e243a801b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -507,4 +507,19 @@ public class PaperConfig {
+@@ -506,4 +506,19 @@ public class PaperConfig {
          enableBrigadierConsoleHighlighting = getBoolean("settings.console.enable-brigadier-highlighting", enableBrigadierConsoleHighlighting);
          enableBrigadierConsoleCompletions = getBoolean("settings.console.enable-brigadier-completions", enableBrigadierConsoleCompletions);
      }

--- a/patches/server/0769-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0769-Replace-player-chunk-loader-system.patch
@@ -80,10 +80,10 @@ index cfe293881f68c8db337c3a48948362bb7b3e3522..7d44abcb4fff9717a1af55879deb7eb9
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index bc4081483a228aa275511d28231d615fe0f36d4e..be132f9d683767002a3e7f5641cb3cc3db74464c 100644
+index 2ba50877f9081b7e5ebb0b76a2b8740e243a801b..adcfd02956b7666c37ceebb48d3aaa87ac1acecb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -522,4 +522,26 @@ public class PaperConfig {
+@@ -521,4 +521,26 @@ public class PaperConfig {
          itemValidationBookAuthorLength = getInt("settings.item-validation.book.author", itemValidationBookAuthorLength);
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }
@@ -1548,7 +1548,7 @@ index 108f2212f8bd00247bf73ff4f3ba42830abad459..0d8a47770435c27519af4ebd78835ec7
                  return true;
              } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index f563e52c94735648670acd80169c0f7c4d6ad36a..6d2d2ba4a83d887f4d52188305a4a28c2ee2f014 100644
+index d0e5af6ed4ef49934de0bc3aab1d74987d5ec9b8..9e6342ac61bdccfde371674249a5d43c692358eb 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -261,7 +261,7 @@ public class ServerPlayer extends Player {
@@ -1737,7 +1737,7 @@ index 5af560b0466ec5ba80489e8f3d65aa2ee298786c..883b2070fcf99cf10d44aef6dece0f7f
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index aa9775083aa804d72965a7af4988b14551293571..2f943a5f5135d4bb7c516e09277ddf15b8732fca 100644
+index 9da0bf8cf59fd37837ba4febf93c022fb4f08278..c64911651f3d736c83cc83996de04920b091cc57 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -517,15 +517,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0779-Add-packet-limiter-config.patch
+++ b/patches/server/0779-Add-packet-limiter-config.patch
@@ -24,10 +24,10 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index be132f9d683767002a3e7f5641cb3cc3db74464c..4d6d07627bd3cbb7041f5c1e19fa03cb0a301268 100644
+index adcfd02956b7666c37ceebb48d3aaa87ac1acecb..716c997804fab66fc9df233be2ad27669d29f407 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -544,4 +544,102 @@ public class PaperConfig {
+@@ -543,4 +543,102 @@ public class PaperConfig {
          playerMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.player-max-concurrent-loads", 4.0);
          globalMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.global-max-concurrent-loads", 500.0);
      }

--- a/patches/server/0780-Lag-compensate-block-breaking.patch
+++ b/patches/server/0780-Lag-compensate-block-breaking.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Lag compensate block breaking
 Use time instead of ticks if ticks fall behind
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4d6d07627bd3cbb7041f5c1e19fa03cb0a301268..b0ea9aefb6e652388becb79d4b19433fe3717c87 100644
+index 716c997804fab66fc9df233be2ad27669d29f407..139f26154cf55ec5437e55180caf7a1b99dea68e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -642,4 +642,10 @@ public class PaperConfig {
+@@ -641,4 +641,10 @@ public class PaperConfig {
              }
          }
      }

--- a/patches/server/0785-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0785-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index b0ea9aefb6e652388becb79d4b19433fe3717c87..f421e6a2e43e0a673dbb8a9a2b4331387e523e02 100644
+index 139f26154cf55ec5437e55180caf7a1b99dea68e..5f3c8cc555944275e8bbbcfe042dd3223c083048 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -648,4 +648,10 @@ public class PaperConfig {
+@@ -647,4 +647,10 @@ public class PaperConfig {
      private static void lagCompensateBlockBreaking() {
          lagCompensateBlockBreaking = getBoolean("settings.lag-compensate-block-breaking", true);
      }


### PR DESCRIPTION
fixes #6309

had to replace usages of Bukkit.getLogger() as Bukkit.server is not yet initialized

edit: this causes config migrations involving SpigotConfig to fail as the migration code assumes SpigotConfig was already initialized - need to either fix that or solve another way

superseded by https://github.com/PaperMC/Paper/pull/6716