### PR TITLE
Handle missing Spawn Egg item meta for 1.17 mobs

### DIFF
--- a/patches/server/0815-Register-spawn-egg-meta-for-1.17-mobs.patch
+++ b/patches/server/0815-Register-spawn-egg-meta-for-1.17-mobs.patch
@@ -1,0 +1,69 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
+Date: Sat, 2 Oct 2021 10:14:04 -0500
+Subject: [PATCH] Register spawn egg meta for 1.17 mobs
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+index 1a8ff7339c58a4fffb051a090a7b8c34cb346a61..aa7fd5c80712fecca1110341a234f60e8607b809 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemFactory.java
+@@ -122,6 +122,7 @@ public final class CraftItemFactory implements ItemFactory {
+         case YELLOW_BANNER:
+         case YELLOW_WALL_BANNER:
+             return meta instanceof CraftMetaBanner ? meta : new CraftMetaBanner(meta);
++        case AXOLOTL_SPAWN_EGG: // Paper
+         case BAT_SPAWN_EGG:
+         case BEE_SPAWN_EGG:
+         case BLAZE_SPAWN_EGG:
+@@ -140,6 +141,8 @@ public final class CraftItemFactory implements ItemFactory {
+         case EVOKER_SPAWN_EGG:
+         case FOX_SPAWN_EGG:
+         case GHAST_SPAWN_EGG:
++        case GLOW_SQUID_SPAWN_EGG: // Paper
++        case GOAT_SPAWN_EGG: // Paper
+         case GUARDIAN_SPAWN_EGG:
+         case HOGLIN_SPAWN_EGG:
+         case HORSE_SPAWN_EGG:
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+index e9fa60755da0bc358020266ff4e450e1b31da595..f6a820e2456c66b8db4140984e0306bea3ee4e9b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftItemStack.java
+@@ -349,6 +349,7 @@ public final class CraftItemStack extends ItemStack {
+             case YELLOW_BANNER:
+             case YELLOW_WALL_BANNER:
+                 return new CraftMetaBanner(item.getTag());
++            case AXOLOTL_SPAWN_EGG: // Paper
+             case BAT_SPAWN_EGG:
+             case BEE_SPAWN_EGG:
+             case BLAZE_SPAWN_EGG:
+@@ -367,6 +368,8 @@ public final class CraftItemStack extends ItemStack {
+             case EVOKER_SPAWN_EGG:
+             case FOX_SPAWN_EGG:
+             case GHAST_SPAWN_EGG:
++            case GLOW_SQUID_SPAWN_EGG: // Paper
++            case GOAT_SPAWN_EGG: // Paper
+             case GUARDIAN_SPAWN_EGG:
+             case HOGLIN_SPAWN_EGG:
+             case HORSE_SPAWN_EGG:
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+index 31d649ad03fb80374155a3a276066a4c668d02f4..c485f2cb13cdaae2afdd047c55ae0c7d3fab3d49 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaSpawnEgg.java
+@@ -112,6 +112,7 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+     @Override
+     boolean applicableTo(Material type) {
+         switch (type) {
++            case AXOLOTL_SPAWN_EGG: // Paper
+             case BAT_SPAWN_EGG:
+             case BEE_SPAWN_EGG:
+             case BLAZE_SPAWN_EGG:
+@@ -130,6 +131,8 @@ public class CraftMetaSpawnEgg extends CraftMetaItem implements SpawnEggMeta {
+             case EVOKER_SPAWN_EGG:
+             case FOX_SPAWN_EGG:
+             case GHAST_SPAWN_EGG:
++            case GLOW_SQUID_SPAWN_EGG: // Paper
++            case GOAT_SPAWN_EGG: // Paper
+             case GUARDIAN_SPAWN_EGG:
+             case HOGLIN_SPAWN_EGG:
+             case HORSE_SPAWN_EGG:


### PR DESCRIPTION
When upstream completed the 1.17 update, they failed to register the new spawn egg items for the SpawnEgg item meta.
This PR resolves that issue for Paper. 

This patch has been successfully in use since mid-September, just now getting around to PRing it up.
https://github.com/starlis/empirecraft/blob/07d80af3ae154657694fa8c55d9d73eff93ed52f/patches/server/0107-Add-1.17-mobs-to-CraftMetaSpawnEgg.patch