### PR TITLE
Fix CME in CraftPersistentDataTypeRegistry

### DIFF
--- a/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
+++ b/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
@@ -5,16 +5,15 @@ Subject: [PATCH] Fix CME in CraftPersistentDataTypeRegistry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
-index 355c9f79fd3132848a00eacde951d1e1bfa92737..1078a4ad4d81ab0c967ac0c658c1eb04676a3262 100644
+index 355c9f79fd3132848a00eacde951d1e1bfa92737..6070f7d954e201e06efb6ef27ad0e7d9ff1ab9ff 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
-@@ -92,7 +92,8 @@ public final class CraftPersistentDataTypeRegistry {
+@@ -92,7 +92,7 @@ public final class CraftPersistentDataTypeRegistry {
          }
      }
  
 -    private final Map<Class, TagAdapter> adapters = new HashMap<>();
-+    // Paper - Replace HashMap with ConcurrentHashMap to avoid CME
-+    private final Map<Class, TagAdapter> adapters = new java.util.concurrent.ConcurrentHashMap<>();
++    private final Map<Class, TagAdapter> adapters = new java.util.concurrent.ConcurrentHashMap<>(); // Paper - Replace HashMap with ConcurrentHashMap to avoid CME
  
      /**
       * Creates a suitable adapter instance for the primitive class type

--- a/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
+++ b/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix CME in CraftPersistentDataTypeRegistry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
-index 355c9f79fd3132848a00eacde951d1e1bfa92737..63e471ca7c975ba070b25a403284fac184c381ba 100644
+index 355c9f79fd3132848a00eacde951d1e1bfa92737..1078a4ad4d81ab0c967ac0c658c1eb04676a3262 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
 @@ -92,7 +92,8 @@ public final class CraftPersistentDataTypeRegistry {
@@ -13,7 +13,7 @@ index 355c9f79fd3132848a00eacde951d1e1bfa92737..63e471ca7c975ba070b25a403284fac1
      }
  
 -    private final Map<Class, TagAdapter> adapters = new HashMap<>();
-+    // Paper - Replay HashMap with ConcurrentHashMap to avoid CME
++    // Paper - Replace HashMap with ConcurrentHashMap to avoid CME
 +    private final Map<Class, TagAdapter> adapters = new java.util.concurrent.ConcurrentHashMap<>();
  
      /**

--- a/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
+++ b/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix CME in CraftPersistentDataTypeRegistry
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
-index 355c9f79fd3132848a00eacde951d1e1bfa92737..b59a7c2cea451bb34fdd17687344f727b3707b6d 100644
+index 355c9f79fd3132848a00eacde951d1e1bfa92737..63e471ca7c975ba070b25a403284fac184c381ba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
 +++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
 @@ -92,7 +92,8 @@ public final class CraftPersistentDataTypeRegistry {
@@ -13,8 +13,8 @@ index 355c9f79fd3132848a00eacde951d1e1bfa92737..b59a7c2cea451bb34fdd17687344f727
      }
  
 -    private final Map<Class, TagAdapter> adapters = new HashMap<>();
-+    // Paper - Synchronize Map to avoid CME
-+    private final Map<Class, TagAdapter> adapters = java.util.Collections.synchronizedMap(new HashMap<>());
++    // Paper - Replay HashMap with ConcurrentHashMap to avoid CME
++    private final Map<Class, TagAdapter> adapters = new java.util.concurrent.ConcurrentHashMap<>();
  
      /**
       * Creates a suitable adapter instance for the primitive class type

--- a/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
+++ b/patches/server/0814-Fix-CME-in-CraftPersistentDataTypeRegistry.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Gero <gecam59@gmail.com>
+Date: Sat, 2 Oct 2021 20:08:30 +0200
+Subject: [PATCH] Fix CME in CraftPersistentDataTypeRegistry
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
+index 355c9f79fd3132848a00eacde951d1e1bfa92737..b59a7c2cea451bb34fdd17687344f727b3707b6d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
++++ b/src/main/java/org/bukkit/craftbukkit/persistence/CraftPersistentDataTypeRegistry.java
+@@ -92,7 +92,8 @@ public final class CraftPersistentDataTypeRegistry {
+         }
+     }
+ 
+-    private final Map<Class, TagAdapter> adapters = new HashMap<>();
++    // Paper - Synchronize Map to avoid CME
++    private final Map<Class, TagAdapter> adapters = java.util.Collections.synchronizedMap(new HashMap<>());
+ 
+     /**
+      * Creates a suitable adapter instance for the primitive class type


### PR DESCRIPTION
When using PersistentDataContainers in an asynchronous task a CME can occur. Afaik creating/modifing ItemStacks asynchronously should be allowed. This PR fixes the CME.
http://paste.cytooxien.de/icetuzifeq.bash