### PR TITLE
update issue template to remove checkboxes and add datapacks

### DIFF
--- a/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
+++ b/.github/ISSUE_TEMPLATE/behavior-bug-or-plugin-incompatibility.yml
@@ -1,36 +1,37 @@
 name: Behavior Bug or Plugin Incompatibility
 description: Report issues with plugin incompatbility or other behavior related issues.
+labels: [ "status: needs triage", "type: bug" ]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Before reporting a crash here, please make sure you are on the latest version of Paper.
-        Forks of Paper receive no support here. If you are using a fork, please make sure that this issue also happens when using Paper.
-
   - type: textarea
     attributes:
       label: Expected behavior
       description: What you expected to see.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Observed/Actual behavior
       description: What you actually saw.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Steps/models to reproduce
       description: This may include a build schematic, a video, or detailed instructions to help reconstruct the issue.
     validations:
       required: true
+
   - type: textarea
     attributes:
-      label: Plugin list
-      description: All plugins running on the server.
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Paper version
@@ -53,18 +54,6 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
-    attributes:
-      label: Agreements
-      description: Please agree to the following.
-      options:
-        - label: I am running the latest version of Paper available from https://papermc.io/downloads.
-          required: true
-        - label: I have searched for and ensured there isn't already an open issue regarding this.
-          required: true
-        - label: My version of Minecraft is supported by Paper.
-          required: true
-
   - type: textarea
     attributes:
       label: Other
@@ -73,4 +62,16 @@ body:
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of Paper from [our downloads page](https://papermc.io/downloads).
+        2. You searched for and ensured there isn't already an open issue regarding this.
+        3. Your version of Minecraft is supported by Paper.
+
+        If you think you have a bug but are not sure, feel free to ask the `#paper-help` channel of our
+        [Discord](https://discord.gg/papermc).
 

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,5 +6,5 @@ contact_links:
   - name: Exploit Report
     url: https://discord.gg/papermc
     about: |
-      Due to github not currently allowing private issues, exploit reports are currently handled via our discord.
+      Due to GitHub not currently allowing private issues, exploit reports are currently handled via our Discord.
       To report an exploit, see the `#paper-exploit-report` channel.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,3 +3,8 @@ contact_links:
   - name: PaperMC Discord
     url: https://discord.gg/papermc
     about: If you are having issues with timings or have other minor issues, come ask us on our Discord server!
+  - name: Exploit Report
+    url: https://discord.gg/papermc
+    about: |
+      Due to github not currently allowing private issues, exploit reports are currently handled via our discord.
+      To report an exploit, see the `#paper-exploit-report` channel.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,6 @@
 name: Feature Request
 description: Suggest an idea for Paper
+labels: [ "status: needs triage", "type: feature" ]
 body:
   - type: markdown
     attributes:
@@ -14,12 +15,14 @@ body:
       description: Please give some context for this request. Why do you want it added?
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Describe the solution you'd like.
       description: A clear and concise description of what you want.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Describe alternatives you've considered.
@@ -27,19 +30,15 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
-    attributes:
-      label: Agreements
-      description: Please agree to the following.
-      options:
-        - label: I have searched for and ensured there isn't already an open issue regarding this.
-          required: true
-        - label: I have ensured the feature I'm requesting isn't already in the latest supported Paper build.
-          required: true
-
   - type: textarea
     attributes:
       label: Other
       description: Add any other context or screenshots about the feature request below.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this feature request, please search our issue tracker to ensure your feature has not
+        alerady been requested.

--- a/.github/ISSUE_TEMPLATE/performance-problem.yml
+++ b/.github/ISSUE_TEMPLATE/performance-problem.yml
@@ -1,11 +1,13 @@
 name: Performance Problem
 description: Report performance related problems or other areas of concern
+labels: [ "status: needs triage", "type: performance" ]
 body:
   - type: markdown
     attributes:
       value: |
-        Before reporting performance problems here, please make sure you are on the latest version of Paper.
-        Forks of Paper receive no support here. If you are using a fork, please make sure that this problem also affects Paper.
+        Before creating an issue regarding server performance, please consider reaching out for support in the
+        `#paper-help` channel of [our Discord](https://discord.gg/papermc)!
+
   - type: input
     attributes:
       label: Timings or Profile link
@@ -13,18 +15,23 @@ body:
       placeholder: "Example: https://timings.aikar.co/?id=6b48586fbbdd48e585ca0ebb07c59dd0"
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Description of issue
       description: If applicable, please describe your issue.
     validations:
       required: false
+
   - type: textarea
     attributes:
-      label: Plugin list
-      description: All plugins running on the server.
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Server config files
@@ -36,6 +43,7 @@ body:
       placeholder: Please don't remove the backticks; it makes your issue a lot harder to read!
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Paper version
@@ -58,18 +66,6 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
-    attributes:
-      label: Agreements
-      description: Please agree to the following.
-      options:
-        - label: I am running the latest version of Paper available from https://papermc.io/downloads.
-          required: true
-        - label: I have searched for and ensured there isn't already an open issue regarding this.
-          required: true
-        - label: My version of Minecraft is supported by Paper.
-          required: true
-
   - type: textarea
     attributes:
       label: Other
@@ -78,3 +74,11 @@ body:
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
     validations:
       required: false
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of Paper from [our downloads page](https://papermc.io/downloads).
+        2. You searched for and ensured there isn't already an open issue regarding this.
+        3. Your version of Minecraft is supported by Paper.

--- a/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
+++ b/.github/ISSUE_TEMPLATE/server-crash-or-stacktrace.yml
@@ -1,13 +1,7 @@
 name: Server crash or Stacktrace
 description: Report server crashes or scary stacktraces
+labels: [ "status: needs triage" ]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Before reporting a crash here, please make sure you are on the latest version of Paper.
-        Forks of Paper receive no support here. If you are using a fork, please make sure that this crash also happens when using Paper.
-        Please do not make reports when the report says "DO NOT REPORT THIS TO PAPER". These are simply messages informing you of lag, to find what is causing it. Ask for tips on Discord or IRC instead.
-
   - type: textarea
     attributes:
       label: Stack trace
@@ -21,18 +15,23 @@ body:
       placeholder: Please don't remove the backticks; it makes your issue a lot harder to read!
     validations:
       required: true
+
   - type: textarea
     attributes:
-      label: Plugin list
-      description: All plugins running on the server.
+      label: Plugin and Datapack List
+      description: |
+        All plugins and datapacks running on your server.
+        To list plugins, run `/plugins`. For datapacks, run `/datapack list`.
     validations:
       required: true
+
   - type: textarea
     attributes:
       label: Actions to reproduce (if known)
       description: This may include a build schematic, a video, or detailed instructions to help reconstruct the issue. Anything helps!
     validations:
       required: false
+
   - type: textarea
     attributes:
       label: Paper version
@@ -55,18 +54,6 @@ body:
     validations:
       required: true
 
-  - type: checkboxes
-    attributes:
-      label: Agreements
-      description: Please agree to the following.
-      options:
-        - label: I am running the latest version of Paper available from https://papermc.io/downloads.
-          required: true
-        - label: I have searched for and ensured there isn't already an open issue regarding this.
-          required: true
-        - label: My version of Minecraft is supported by Paper.
-          required: true
-
   - type: textarea
     attributes:
       label: Other
@@ -75,3 +62,15 @@ body:
         The more information we receive, the quicker and more effective we can be at finding the solution to the issue.
     validations:
       required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        Before submitting this issue, please ensure the following:
+
+        1. You are running the latest version of Paper from [our downloads page](https://papermc.io/downloads).
+        2. Your version of Minecraft is supported by Paper.
+
+        If your server crash log contains `DO NOT REPORT THIS TO PAPER`, please ask in our
+        [Discord](https://discord.gg/papermc) before opening this issue. These messages are informing you of server
+        lag and providing debug information.


### PR DESCRIPTION
While checkboxes used to work well, they now add a `x/3 tasks done` card to each issue. They also feel very TOC-like in that you just check them and don't read them. A markdown field works better. Additionally, datapacks are becoming more and more prevalent, and thus more important to include in issues.

Issue templates can also apply labels, so that is used here both for the needs triage label as well as a type. Must be merged with https://github.com/SpongePowered/limbo-config/pull/7