### PR TITLE
Re-readd root/admin user detection

### DIFF
--- a/patches/server/0814-Add-root-admin-user-detection.patch
+++ b/patches/server/0814-Add-root-admin-user-detection.patch
@@ -12,10 +12,10 @@ Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9bc2cbf015998b98b6681a427596b151ed1806a0
+index 0000000000000000000000000000000000000000..18ea1dddf600920999d6b254bc55cf5d0d8a1cfb
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,39 @@
 +package io.papermc.paper.util;
 +
 +import com.sun.security.auth.module.NTSystem;
@@ -38,9 +38,12 @@ index 0000000000000000000000000000000000000000..9bc2cbf015998b98b6681a427596b151
 +            if (new UnixSystem().getUid() == 0) {
 +                // Due to an OpenJDK bug, UnixSystem#getUid incorrectly returns 0 when the user doesn't have a username.
 +                // Because of this, we'll have to double-check if the user ID is actually 0 by running the id command.
-+                try (final InputStream inputStream = Runtime.getRuntime().exec("id -u").getInputStream()) {
++                try {
++                    Process process = new ProcessBuilder("id", "-u").start();
++                    process.waitFor();
++                    InputStream inputStream = process.getInputStream();
 +                    isRunningAsRoot = new String(inputStream.readAllBytes()).trim().equals("0");
-+                } catch (IOException ignored) {
++                } catch (InterruptedException | IOException ignored) {
 +                    isRunningAsRoot = false;
 +                }
 +            }

--- a/patches/server/0814-Add-root-admin-user-detection.patch
+++ b/patches/server/0814-Add-root-admin-user-detection.patch
@@ -12,10 +12,10 @@ Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..18ea1dddf600920999d6b254bc55cf5d0d8a1cfb
+index 0000000000000000000000000000000000000000..6bd0afddbcc461149dfe9a5c7a86fff6ea13a5f1
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +package io.papermc.paper.util;
 +
 +import com.sun.security.auth.module.NTSystem;
@@ -36,8 +36,9 @@ index 0000000000000000000000000000000000000000..18ea1dddf600920999d6b254bc55cf5d
 +        } else {
 +            boolean isRunningAsRoot = false;
 +            if (new UnixSystem().getUid() == 0) {
-+                // Due to an OpenJDK bug, UnixSystem#getUid incorrectly returns 0 when the user doesn't have a username.
-+                // Because of this, we'll have to double-check if the user ID is actually 0 by running the id command.
++                // Due to an OpenJDK bug (https://bugs.openjdk.java.net/browse/JDK-8274721), UnixSystem#getUid incorrectly
++                // returns 0 when the user doesn't have a username. Because of this, we'll have to double-check if the user ID is
++                // actually 0 by running the id -u command.
 +                try {
 +                    Process process = new ProcessBuilder("id", "-u").start();
 +                    process.waitFor();

--- a/patches/server/0814-Add-root-admin-user-detection.patch
+++ b/patches/server/0814-Add-root-admin-user-detection.patch
@@ -12,13 +12,14 @@ Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..afec67a3c69dcc0cbdc4fb14d9444b4434cb82e9
+index 0000000000000000000000000000000000000000..9bc2cbf015998b98b6681a427596b151ed1806a0
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,36 @@
 +package io.papermc.paper.util;
 +
 +import com.sun.security.auth.module.NTSystem;
++import com.sun.security.auth.module.UnixSystem;
 +import org.apache.commons.lang.SystemUtils;
 +
 +import java.io.IOException;
@@ -33,11 +34,15 @@ index 0000000000000000000000000000000000000000..afec67a3c69dcc0cbdc4fb14d9444b44
 +        if (SystemUtils.IS_OS_WINDOWS) {
 +            RUNNING_AS_ROOT_OR_ADMIN = Set.of(new NTSystem().getGroupIDs()).contains(WINDOWS_HIGH_INTEGRITY_LEVEL);
 +        } else {
-+            boolean isRunningAsRoot;
-+            try (final InputStream inputStream = Runtime.getRuntime().exec("id -u").getInputStream()) {
-+                isRunningAsRoot = new String(inputStream.readAllBytes()).trim().equals("0");
-+            } catch (IOException ignored) {
-+                isRunningAsRoot = false;
++            boolean isRunningAsRoot = false;
++            if (new UnixSystem().getUid() == 0) {
++                // Due to an OpenJDK bug, UnixSystem#getUid incorrectly returns 0 when the user doesn't have a username.
++                // Because of this, we'll have to double-check if the user ID is actually 0 by running the id command.
++                try (final InputStream inputStream = Runtime.getRuntime().exec("id -u").getInputStream()) {
++                    isRunningAsRoot = new String(inputStream.readAllBytes()).trim().equals("0");
++                } catch (IOException ignored) {
++                    isRunningAsRoot = false;
++                }
 +            }
 +            RUNNING_AS_ROOT_OR_ADMIN = isRunningAsRoot;
 +        }

--- a/patches/server/0814-Add-root-admin-user-detection.patch
+++ b/patches/server/0814-Add-root-admin-user-detection.patch
@@ -1,0 +1,70 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: egg82 <eggys82@gmail.com>
+Date: Sat, 11 Sep 2021 22:55:14 +0200
+Subject: [PATCH] Add root/admin user detection
+
+This patch detects whether or not the server is currently executing as a privileged user and spits out a warning.
+The warning serves as a sort-of PSA for newer server admins who don't understand the risks of running as root.
+We've seen plenty of bad/malicious plugins hit markets, and there's been a few close-calls with exploits in the past.
+Hopefully this helps mitigate some potential damage to servers, even if it is just a warning.
+
+Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
+
+diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..ab9b0faaa60226cc05adf63ae4766f5287ff5632
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
+@@ -0,0 +1,31 @@
++package io.papermc.paper.util;
++
++import com.sun.security.auth.module.NTSystem;
++import org.apache.commons.lang.SystemUtils;
++
++import java.io.IOException;
++import java.io.InputStream;
++import java.util.Set;
++
++public class ServerEnvironment {
++    private static final boolean RUNNING_AS_ROOT_OR_ADMIN;
++    private static final String WINDOWS_HIGH_INTEGRITY_LEVEL = "S-1-16-12288";
++
++    static {
++        if (SystemUtils.IS_OS_WINDOWS) {
++            RUNNING_AS_ROOT_OR_ADMIN = Set.of(new NTSystem().getGroupIDs()).contains(WINDOWS_HIGH_INTEGRITY_LEVEL);
++        } else {
++            boolean isRunningAsRoot;
++            try (final InputStream inputStream = Runtime.getRuntime().exec("id -u " + System.getProperty("user.name")).getInputStream()) {
++                isRunningAsRoot = new String(inputStream.readAllBytes()).trim().equals("0");
++            } catch (IOException ignored) {
++                isRunningAsRoot = false;
++            }
++            RUNNING_AS_ROOT_OR_ADMIN = isRunningAsRoot;
++        }
++    }
++
++    public static boolean userIsRootOrAdmin() {
++        return RUNNING_AS_ROOT_OR_ADMIN;
++    }
++}
+diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+index 1bf19965d12514dee34545235bfbadc0b74ddc8b..49a85ad513993bfdc0759f26d38923c881af82e6 100644
+--- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
++++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
+@@ -190,6 +190,16 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface
+             DedicatedServer.LOGGER.warn("To start the server with more ram, launch it as \"java -Xmx1024M -Xms1024M -jar minecraft_server.jar\"");
+         }
+ 
++        // Paper start - detect running as root
++        if (io.papermc.paper.util.ServerEnvironment.userIsRootOrAdmin()) {
++            DedicatedServer.LOGGER.warn("****************************");
++            DedicatedServer.LOGGER.warn("YOU ARE RUNNING THIS SERVER AS AN ADMINISTRATIVE OR ROOT USER. THIS IS NOT ADVISED.");
++            DedicatedServer.LOGGER.warn("YOU ARE OPENING YOURSELF UP TO POTENTIAL RISKS WHEN DOING THIS.");
++            DedicatedServer.LOGGER.warn("FOR MORE INFORMATION, SEE https://madelinemiller.dev/blog/root-minecraft-server/");
++            DedicatedServer.LOGGER.warn("****************************");
++        }
++        // Paper end
++
+         DedicatedServer.LOGGER.info("Loading properties");
+         DedicatedServerProperties dedicatedserverproperties = this.settings.getProperties();
+ 

--- a/patches/server/0814-Add-root-admin-user-detection.patch
+++ b/patches/server/0814-Add-root-admin-user-detection.patch
@@ -12,7 +12,7 @@ Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/io/papermc/paper/util/ServerEnvironment.java b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..ab9b0faaa60226cc05adf63ae4766f5287ff5632
+index 0000000000000000000000000000000000000000..afec67a3c69dcc0cbdc4fb14d9444b4434cb82e9
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/util/ServerEnvironment.java
 @@ -0,0 +1,31 @@
@@ -34,7 +34,7 @@ index 0000000000000000000000000000000000000000..ab9b0faaa60226cc05adf63ae4766f52
 +            RUNNING_AS_ROOT_OR_ADMIN = Set.of(new NTSystem().getGroupIDs()).contains(WINDOWS_HIGH_INTEGRITY_LEVEL);
 +        } else {
 +            boolean isRunningAsRoot;
-+            try (final InputStream inputStream = Runtime.getRuntime().exec("id -u " + System.getProperty("user.name")).getInputStream()) {
++            try (final InputStream inputStream = Runtime.getRuntime().exec("id -u").getInputStream()) {
 +                isRunningAsRoot = new String(inputStream.readAllBytes()).trim().equals("0");
 +            } catch (IOException ignored) {
 +                isRunningAsRoot = false;

--- a/patches/server/0824-Add-root-admin-user-detection.patch
+++ b/patches/server/0824-Add-root-admin-user-detection.patch
@@ -57,7 +57,7 @@ index 0000000000000000000000000000000000000000..6bd0afddbcc461149dfe9a5c7a86fff6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
-index 1bf19965d12514dee34545235bfbadc0b74ddc8b..49a85ad513993bfdc0759f26d38923c881af82e6 100644
+index 7ce1ce59eeba8b57cd76b1c9c561733b476e7ebf..b6ee0e709b0f0529b99567bc9b8fb6bfd99bcd8e 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 +++ b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 @@ -190,6 +190,16 @@ public class DedicatedServer extends MinecraftServer implements ServerInterface


### PR DESCRIPTION
This PR re-adds the root reverted in e8830b27. The check was throwing false positives because of a OpenJDk bug (no issue # yet, will add here later). This PR uses a different method for getting the UID (executing the id command), which isn't affected by the openjdk issue.