### PR TITLE
Convert section chars in components to components in more places

### DIFF
--- a/patches/server/0434-Update-itemstack-legacy-name-and-lore.patch
+++ b/patches/server/0434-Update-itemstack-legacy-name-and-lore.patch
@@ -3,57 +3,149 @@ From: William Blake Galbreath <Blake.Galbreath@GMail.com>
 Date: Wed, 1 Jul 2020 11:57:40 -0500
 Subject: [PATCH] Update itemstack legacy name and lore
 
+== AT ==
+public net.minecraft.network.chat.Component$Serializer GSON
 
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
+
+diff --git a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+index db54a9c32578defa02fa58dc694c96684a4885ac..606e55d7e2a7d372d1565f8a09474cfb8ebd9c0b 100644
+--- a/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
++++ b/src/main/java/io/papermc/paper/adventure/PaperAdventure.java
+@@ -1,5 +1,6 @@
+ package io.papermc.paper.adventure;
+ 
++import com.google.gson.JsonParseException;
+ import com.mojang.brigadier.exceptions.CommandSyntaxException;
+ import io.netty.util.AttributeKey;
+ import java.io.IOException;
+@@ -18,10 +19,12 @@ import net.kyori.adventure.sound.Sound;
+ import net.kyori.adventure.text.Component;
+ import net.kyori.adventure.text.TranslatableComponent;
+ import net.kyori.adventure.text.flattener.ComponentFlattener;
++import net.kyori.adventure.text.format.Style;
+ import net.kyori.adventure.text.format.TextColor;
+ import net.kyori.adventure.text.serializer.ComponentSerializer;
+ import net.kyori.adventure.text.serializer.ansi.ANSIComponentSerializer;
+ import net.kyori.adventure.text.serializer.gson.GsonComponentSerializer;
++import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+ import net.kyori.adventure.text.serializer.plain.PlainComponentSerializer;
+ import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+ import net.kyori.adventure.translation.GlobalTranslator;
+@@ -38,6 +41,8 @@ import net.minecraft.nbt.ListTag;
+ import net.minecraft.nbt.StringTag;
+ import net.minecraft.nbt.TagParser;
+ import net.minecraft.network.chat.ComponentUtils;
++import net.minecraft.network.chat.MutableComponent;
++import net.minecraft.network.chat.contents.LiteralContents;
+ import net.minecraft.network.protocol.Packet;
+ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;
+ import net.minecraft.network.protocol.game.ClientboundSoundPacket;
+@@ -51,6 +56,7 @@ import net.minecraft.world.item.WrittenBookItem;
+ import org.bukkit.command.CommandSender;
+ import org.bukkit.craftbukkit.command.VanillaCommandWrapper;
+ import org.bukkit.craftbukkit.entity.CraftEntity;
++import org.jetbrains.annotations.Contract;
+ import org.jetbrains.annotations.NotNull;
+ import org.jetbrains.annotations.Nullable;
+ 
+@@ -146,6 +152,10 @@ public final class PaperAdventure {
+ 
+     // Component
+ 
++    public static Style asAdventure(final net.minecraft.network.chat.Style style) {
++        return GsonComponentSerializer.gson().serializer().fromJson(net.minecraft.network.chat.Component.Serializer.GSON.toJsonTree(style), Style.class);
++    }
++
+     public static Component asAdventure(final net.minecraft.network.chat.Component component) {
+         return component == null ? Component.empty() : GsonComponentSerializer.gson().serializer().fromJson(net.minecraft.network.chat.Component.Serializer.toJsonTree(component), Component.class);
+     }
+@@ -167,9 +177,16 @@ public final class PaperAdventure {
+     }
+ 
+     public static List<String> asJson(final List<? extends Component> adventures) {
++        return asJson(adventures, false);
++    }
++    public static List<String> asJson(final List<? extends Component> adventures, boolean convertLegacy) {
+         final List<String> jsons = new ArrayList<>(adventures.size());
+         for (final Component component : adventures) {
++            if (convertLegacy) {
++                jsons.add(convertTopLevelLegacyChars(GsonComponentSerializer.gson().serialize(component)));
++            } else {
+             jsons.add(GsonComponentSerializer.gson().serialize(component));
++            }
+         }
+         return jsons;
+     }
+@@ -391,4 +408,31 @@ public final class PaperAdventure {
+     public static @Nullable ChatFormatting asVanilla(final TextColor color) {
+         return ChatFormatting.getByHexValue(color.value());
+     }
++
++    // Legacy
++
++    @Contract("!null -> !null")
++    public static @Nullable String convertTopLevelLegacyChars(final @Nullable String json) {
++        return convertTopLevelLegacyChars(json, true);
++    }
++    @Contract("!null,_ -> !null")
++    public static @Nullable String convertTopLevelLegacyChars(final @Nullable String json, final boolean catchJsonParseException) {
++        if (json == null) return null;
++        if (json.indexOf(ChatFormatting.PREFIX_CODE) < 0) return json;
++        try {
++            MutableComponent component = net.minecraft.network.chat.Component.Serializer.fromJson(json);
++            if (component != null && component.getContents() instanceof LiteralContents literal && literal.text().indexOf(ChatFormatting.PREFIX_CODE) > -1 && component.getSiblings().isEmpty()) {
++                // Only convert if the root component is a single comp with legacy in it, don't convert already normal components
++                final Component converted = LegacyComponentSerializer.legacySection().deserialize(literal.text())
++                    .applyFallbackStyle(asAdventure(component.getStyle()));
++                return GsonComponentSerializer.gson().serialize(converted);
++            }
++            return json;
++        } catch (JsonParseException parseException) {
++            if (catchJsonParseException) {
++                return net.minecraft.network.chat.Component.Serializer.toJson(net.minecraft.network.chat.Component.empty());
++            }
++            throw parseException;
++        }
++    }
+ }
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 7d80eded30109982fd3a1b815ba5dff4b699689a..dcb01c399d2b30d907bfc51584215d9300b6d23e 100644
+index 0caf3eeb7984e842f7a0bdfed3021d0b231a0dd0..aec306d9dead142e4c3f0f8e81e950a6718e3241 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -171,6 +171,44 @@ public final class ItemStack {
+@@ -171,6 +171,31 @@ public final class ItemStack {
              list.sort((java.util.Comparator<? super net.minecraft.nbt.Tag>) enchantSorter); // Paper
          } catch (Exception ignored) {}
      }
 +
 +    private void processText() {
-+        CompoundTag display = getTagElement("display");
++        CompoundTag display = getTagElement(TAG_DISPLAY);
 +        if (display != null) {
-+            if (display.contains("Name", 8)) {
-+                String json = display.getString("Name");
-+                if (json != null && json.contains("\u00A7")) {
++            if (display.contains(TAG_DISPLAY_NAME, Tag.TAG_STRING)) {
++                String json = display.getString(TAG_DISPLAY_NAME);
++                if (json.contains("\u00A7")) {
 +                    try {
-+                        display.put("Name", convert(json));
++                        display.put(TAG_DISPLAY_NAME, net.minecraft.nbt.StringTag.valueOf(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(json, false)));
 +                    } catch (com.google.gson.JsonParseException jsonparseexception) {
-+                        display.remove("Name");
++                        display.remove(TAG_DISPLAY_NAME);
 +                    }
 +                }
 +            }
-+            if (display.contains("Lore", 9)) {
-+                ListTag list = display.getList("Lore", 8);
++            if (display.contains(TAG_LORE, Tag.TAG_LIST)) {
++                ListTag list = display.getList(TAG_LORE, Tag.TAG_STRING);
 +                for (int index = 0; index < list.size(); index++) {
 +                    String json = list.getString(index);
-+                    if (json != null && json.contains("\u00A7")) { // Only try if it has legacy in the unparsed json
-+                        try {
-+                            list.set(index, convert(json));
-+                        } catch (com.google.gson.JsonParseException e) {
-+                            list.set(index, net.minecraft.nbt.StringTag.valueOf(org.bukkit.craftbukkit.util.CraftChatMessage.toJSON(net.minecraft.network.chat.Component.literal(""))));
-+                        }
++                    if (json.contains("\u00A7")) { // Only try if it has legacy in the unparsed json
++                        list.set(index, net.minecraft.nbt.StringTag.valueOf(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(json)));
 +                    }
 +                }
 +            }
 +        }
-+    }
-+
-+    private net.minecraft.nbt.StringTag convert(String json) {
-+        Component component = Component.Serializer.fromJson(json);
-+        if (component.getContents() instanceof net.minecraft.network.chat.contents.LiteralContents literalContents && literalContents.text().contains("\u00A7") && component.getSiblings().isEmpty()) {
-+            // Only convert if the root component is a single comp with legacy in it, don't convert already normal components
-+            component = org.bukkit.craftbukkit.util.CraftChatMessage.fromString(literalContents.text())[0];
-+        }
-+        return net.minecraft.nbt.StringTag.valueOf(org.bukkit.craftbukkit.util.CraftChatMessage.toJSON(component));
 +    }
      // Paper end
  
      public ItemStack(ItemLike item) {
-@@ -222,6 +260,7 @@ public final class ItemStack {
+@@ -222,6 +247,7 @@ public final class ItemStack {
              this.tag = nbttagcompound.getCompound("tag").copy();
              // CraftBukkit end
              this.processEnchantOrder(this.tag); // Paper
@@ -61,3 +153,112 @@ index 7d80eded30109982fd3a1b815ba5dff4b699689a..dcb01c399d2b30d907bfc51584215d93
              this.getItem().verifyTagAfterLoad(this.tag);
          }
  
+@@ -834,6 +860,7 @@ public final class ItemStack {
+     public void setTag(@Nullable CompoundTag nbt) {
+         this.tag = nbt;
+         this.processEnchantOrder(this.tag); // Paper
++        this.processText(); // Paper
+         if (this.getItem().canBeDepleted()) {
+             this.setDamageValue(this.getDamageValue());
+         }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/SignText.java b/src/main/java/net/minecraft/world/level/block/entity/SignText.java
+index eb64cc844c3e68f00e4ea314a5b204ace2832d30..382927c93436c594f5438eab25acd6ec0467ad39 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/SignText.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/SignText.java
+@@ -18,7 +18,25 @@ import net.minecraft.world.entity.player.Player;
+ import net.minecraft.world.item.DyeColor;
+ 
+ public class SignText {
+-    private static final Codec<Component[]> LINES_CODEC = ExtraCodecs.FLAT_COMPONENT.listOf().comapFlatMap((messages) -> {
++    // Paper start - convert legacy sign chars
++    // taken from ExtraCodecs#FLAT_COMPONENT
++    public static final com.mojang.serialization.Decoder<Component> FLAT_COMPONENT_CONVERTED = Codec.STRING.flatMap((json) -> {
++        try {
++            Component component = Component.Serializer.fromJson(json);
++
++            if (json.indexOf(net.minecraft.ChatFormatting.PREFIX_CODE) > -1) {
++                if (component != null && component.getContents() instanceof net.minecraft.network.chat.contents.LiteralContents literal && literal.text().indexOf(net.minecraft.ChatFormatting.PREFIX_CODE) > -1 && component.getSiblings().isEmpty()) {
++                    net.minecraft.network.chat.MutableComponent converted = ((net.minecraft.network.chat.MutableComponent) ((io.papermc.paper.adventure.AdventureComponent) io.papermc.paper.adventure.PaperAdventure.asVanilla(net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(literal.text()))).deepConverted());
++                    component = converted.setStyle(converted.getStyle().applyTo(component.getStyle()));
++                }
++            }
++            return com.mojang.serialization.DataResult.success(component);
++        } catch (com.google.gson.JsonParseException var2) {
++            return com.mojang.serialization.DataResult.error(var2::getMessage);
++        }
++    });
++    private static final Codec<Component[]> LINES_CODEC = Codec.of(ExtraCodecs.FLAT_COMPONENT, FLAT_COMPONENT_CONVERTED).listOf().comapFlatMap((messages) -> {
++    // Paper end
+         return Util.fixedSize(messages, 4).map((list) -> {
+             return new Component[]{list.get(0), list.get(1), list.get(2), list.get(3)};
+         });
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+index b34f364f8580ae900e25ef3f31f58f4e8fee88e0..86f28370fc413cf31cdc645129fafeaa55fab983 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaItem.java
+@@ -520,7 +520,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     }
+ 
+     CraftMetaItem(Map<String, Object> map) {
+-        this.displayName = CraftChatMessage.fromJSONOrStringOrNullToJSON(SerializableMeta.getString(map, NAME.BUKKIT, true));
++        this.displayName = io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(CraftChatMessage.fromJSONOrStringOrNullToJSON(SerializableMeta.getString(map, NAME.BUKKIT, true))); // Paper
+ 
+         this.locName = CraftChatMessage.fromJSONOrStringOrNullToJSON(SerializableMeta.getString(map, LOCNAME.BUKKIT, true));
+ 
+@@ -690,7 +690,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     @Overridden
+     void applyToItem(CompoundTag itemTag) {
+         if (this.hasDisplayName()) {
+-            this.setDisplayTag(itemTag, NAME.NBT, StringTag.valueOf(displayName));
++            this.setDisplayTag(itemTag, NAME.NBT, StringTag.valueOf(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(displayName))); // Paper
+         }
+         if (this.hasLocalizedName()) {
+             this.setDisplayTag(itemTag, LOCNAME.NBT, StringTag.valueOf(locName));
+@@ -868,7 +868,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public void displayName(final net.kyori.adventure.text.Component displayName) {
+-        this.displayName = displayName == null ? null : net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson().serialize(displayName);
++        this.displayName = displayName == null ? null : io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(net.kyori.adventure.text.serializer.gson.GsonComponentSerializer.gson().serialize(displayName)); // Paper
+     }
+     // Paper end
+ 
+@@ -891,7 +891,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+     // Paper start
+     @Override
+     public void setDisplayNameComponent(net.md_5.bungee.api.chat.BaseComponent[] component) {
+-        this.displayName = net.md_5.bungee.chat.ComponentSerializer.toString(component);
++        this.displayName = io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(net.md_5.bungee.chat.ComponentSerializer.toString(component)); // Paper
+     }
+     // Paper end
+     @Override
+@@ -927,7 +927,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+ 
+     @Override
+     public void lore(final List<? extends net.kyori.adventure.text.Component> lore) {
+-        this.lore = lore != null ? io.papermc.paper.adventure.PaperAdventure.asJson(lore) : null;
++        this.lore = lore != null ? io.papermc.paper.adventure.PaperAdventure.asJson(lore, true) : null; // Paper
+     }
+     // Paper end
+ 
+@@ -1543,7 +1543,7 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+         for (Object object : addFrom) {
+             // Paper start - support components
+             if(object instanceof net.md_5.bungee.api.chat.BaseComponent[]) {
+-                addTo.add(net.md_5.bungee.chat.ComponentSerializer.toString((net.md_5.bungee.api.chat.BaseComponent[]) object));
++                addTo.add(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(net.md_5.bungee.chat.ComponentSerializer.toString((net.md_5.bungee.api.chat.BaseComponent[]) object))); // Paper
+             } else
+             // Paper end
+             if (!(object instanceof String)) {
+@@ -1559,9 +1559,9 @@ class CraftMetaItem implements ItemMeta, Damageable, Repairable, BlockDataMeta {
+                 String entry = object.toString();
+ 
+                 if (possiblyJsonInput) {
+-                    addTo.add(CraftChatMessage.fromJSONOrStringToJSON(entry));
++                    addTo.add(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(CraftChatMessage.fromJSONOrStringToJSON(entry))); // Paper
+                 } else {
+-                    addTo.add(CraftChatMessage.fromStringToJSON(entry));
++                    addTo.add(io.papermc.paper.adventure.PaperAdventure.convertTopLevelLegacyChars(CraftChatMessage.fromStringToJSON(entry))); // Paper
+                 }
+             }
+         }

--- a/patches/server/0459-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/patches/server/0459-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PortalCreateEvent needs to know its entity
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index ee274fb9c8292a807e438902cc5d7f49c30d6627..34e54233d54f21cf4304c39e53aa6a7fb06a67cf 100644
+index aec306d9dead142e4c3f0f8e81e950a6718e3241..049989efe1868b85a88f7f02e91691da629d8b36 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -452,7 +452,7 @@ public final class ItemStack {
+@@ -439,7 +439,7 @@ public final class ItemStack {
                          net.minecraft.world.level.block.state.BlockState block = world.getBlockState(newblockposition);
  
                          if (!(block.getBlock() instanceof BaseEntityBlock)) { // Containers get placed automatically

--- a/patches/server/0655-Added-EntityDamageItemEvent.patch
+++ b/patches/server/0655-Added-EntityDamageItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added EntityDamageItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 34e54233d54f21cf4304c39e53aa6a7fb06a67cf..afbf619feb35751046131e7b22791e789d16427f 100644
+index 049989efe1868b85a88f7f02e91691da629d8b36..3b5ae39f0cc356c1d89159b17fa2a8c6e178a771 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -596,7 +596,7 @@ public final class ItemStack {
+@@ -583,7 +583,7 @@ public final class ItemStack {
          return this.getItem().getMaxDamage();
      }
  
@@ -17,7 +17,7 @@ index 34e54233d54f21cf4304c39e53aa6a7fb06a67cf..afbf619feb35751046131e7b22791e78
          if (!this.isDamageableItem()) {
              return false;
          } else {
-@@ -614,8 +614,8 @@ public final class ItemStack {
+@@ -601,8 +601,8 @@ public final class ItemStack {
  
                  amount -= k;
                  // CraftBukkit start
@@ -28,7 +28,7 @@ index 34e54233d54f21cf4304c39e53aa6a7fb06a67cf..afbf619feb35751046131e7b22791e78
                      event.getPlayer().getServer().getPluginManager().callEvent(event);
  
                      if (amount != event.getDamage() || event.isCancelled()) {
-@@ -626,6 +626,14 @@ public final class ItemStack {
+@@ -613,6 +613,14 @@ public final class ItemStack {
                      }
  
                      amount = event.getDamage();
@@ -43,7 +43,7 @@ index 34e54233d54f21cf4304c39e53aa6a7fb06a67cf..afbf619feb35751046131e7b22791e78
                  }
                  // CraftBukkit end
                  if (amount <= 0) {
-@@ -633,8 +641,8 @@ public final class ItemStack {
+@@ -620,8 +628,8 @@ public final class ItemStack {
                  }
              }
  
@@ -54,7 +54,7 @@ index 34e54233d54f21cf4304c39e53aa6a7fb06a67cf..afbf619feb35751046131e7b22791e78
              }
  
              j = this.getDamageValue() + amount;
-@@ -646,7 +654,7 @@ public final class ItemStack {
+@@ -633,7 +641,7 @@ public final class ItemStack {
      public <T extends LivingEntity> void hurtAndBreak(int amount, T entity, Consumer<T> breakCallback) {
          if (!entity.level().isClientSide && (!(entity instanceof net.minecraft.world.entity.player.Player) || !((net.minecraft.world.entity.player.Player) entity).getAbilities().instabuild)) {
              if (this.isDamageableItem()) {

--- a/patches/server/0777-Fix-cancelled-powdered-snow-bucket-placement.patch
+++ b/patches/server/0777-Fix-cancelled-powdered-snow-bucket-placement.patch
@@ -20,10 +20,10 @@ index e581dc10f3c805f7f8b6e4c842092609e7e1a0f8..b0204af850ee182773ad458208cccd94
                                  }
                                  return InteractionResult.FAIL;
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index afbf619feb35751046131e7b22791e789d16427f..f62585f3112886c927f1f65f982b9db9194457e9 100644
+index 3b5ae39f0cc356c1d89159b17fa2a8c6e178a771..e90ec40dde0bbda5ecf4f922fa0f73ee0109a2eb 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -353,7 +353,7 @@ public final class ItemStack {
+@@ -340,7 +340,7 @@ public final class ItemStack {
              int oldCount = this.getCount();
              ServerLevel world = (ServerLevel) context.getLevel();
  
@@ -32,7 +32,7 @@ index afbf619feb35751046131e7b22791e789d16427f..f62585f3112886c927f1f65f982b9db9
                  world.captureBlockStates = true;
                  // special case bonemeal
                  if (item == Items.BONE_MEAL) {
-@@ -412,7 +412,7 @@ public final class ItemStack {
+@@ -399,7 +399,7 @@ public final class ItemStack {
                  world.capturedBlockStates.clear();
                  if (blocks.size() > 1) {
                      placeEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callBlockMultiPlaceEvent(world, entityhuman, enumhand, blocks, blockposition.getX(), blockposition.getY(), blockposition.getZ());

--- a/patches/server/0813-Add-pre-unbreaking-amount-to-PlayerItemDamageEvent.patch
+++ b/patches/server/0813-Add-pre-unbreaking-amount-to-PlayerItemDamageEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add pre-unbreaking amount to PlayerItemDamageEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index f62585f3112886c927f1f65f982b9db9194457e9..cc58df88fc3788dcfb7e429ef899b3d558a931cc 100644
+index e90ec40dde0bbda5ecf4f922fa0f73ee0109a2eb..edc53f693cd35295921d19396d68fe27a3b1621f 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -612,10 +612,11 @@ public final class ItemStack {
+@@ -599,10 +599,11 @@ public final class ItemStack {
                      }
                  }
  

--- a/patches/server/0941-Optimize-Hoppers.patch
+++ b/patches/server/0941-Optimize-Hoppers.patch
@@ -13,7 +13,7 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c5f3dc74888919e82e2ffbb8d648b7640aa6b690..80cf4852e4010eeeadaf920ab927a40df0179b40 100644
+index 365bcfcf667ffa76253b1db5cd06a96e0f3679d5..ae9b78c4e321eb811ee87e1827d3684371977609 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -1522,6 +1522,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -25,10 +25,10 @@ index c5f3dc74888919e82e2ffbb8d648b7640aa6b690..80cf4852e4010eeeadaf920ab927a40d
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index cc58df88fc3788dcfb7e429ef899b3d558a931cc..b3c99bb1da54209a21b090d31713167fd9729654 100644
+index edc53f693cd35295921d19396d68fe27a3b1621f..47ca103140718a638a610e9d84b3791c3f2c9b8c 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -723,10 +723,16 @@ public final class ItemStack {
+@@ -710,10 +710,16 @@ public final class ItemStack {
      }
  
      public ItemStack copy() {

--- a/patches/server/0942-Fix-beehives-generating-from-using-bonemeal.patch
+++ b/patches/server/0942-Fix-beehives-generating-from-using-bonemeal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix beehives generating from using bonemeal
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index b3c99bb1da54209a21b090d31713167fd9729654..c9363f01b3c2369d5c63e50977c28a3fa760bae1 100644
+index 47ca103140718a638a610e9d84b3791c3f2c9b8c..4ada694edbba9f5b8b0c322075d513894cc0e215 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -396,6 +396,7 @@ public final class ItemStack {
+@@ -383,6 +383,7 @@ public final class ItemStack {
                      }
                      for (CraftBlockState blockstate : blocks) {
                          world.setBlock(blockstate.getPosition(),blockstate.getHandle(), blockstate.getFlag()); // SPIGOT-7248 - manual update to avoid physics where appropriate

--- a/patches/server/0962-Fix-block-place-logic.patch
+++ b/patches/server/0962-Fix-block-place-logic.patch
@@ -22,10 +22,10 @@ index b0204af850ee182773ad458208cccd946ad148d5..ebee8de2ed831755b6fd154f6cc77ac9
                      if ((entityhuman == null || !entityhuman.getAbilities().instabuild) && itemstack != ItemStack.EMPTY) { // CraftBukkit
                          itemstack.shrink(1);
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index c9363f01b3c2369d5c63e50977c28a3fa760bae1..6f00794aec16db3e7a466f4b446d38bdb2623e8b 100644
+index 4ada694edbba9f5b8b0c322075d513894cc0e215..8c34e7b1a560c41a8267621526a0e004cdefa269 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -467,13 +467,7 @@ public final class ItemStack {
+@@ -454,13 +454,7 @@ public final class ItemStack {
                          if (tileentity instanceof JukeboxBlockEntity) {
                              JukeboxBlockEntity tileentityjukebox = (JukeboxBlockEntity) tileentity;
  

--- a/patches/server/0963-Fix-spigot-sound-playing-for-BlockItem-ItemStacks.patch
+++ b/patches/server/0963-Fix-spigot-sound-playing-for-BlockItem-ItemStacks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix spigot sound playing for BlockItem ItemStacks
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 6f00794aec16db3e7a466f4b446d38bdb2623e8b..2223aba0841280c5205ab0963c406449f85fa433 100644
+index 8c34e7b1a560c41a8267621526a0e004cdefa269..32535c0d6d3e52d81180c8624f796bc7eab08a29 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -518,7 +518,11 @@ public final class ItemStack {
+@@ -505,7 +505,11 @@ public final class ItemStack {
  
                      // SPIGOT-1288 - play sound stripped from ItemBlock
                      if (this.item instanceof BlockItem) {

--- a/patches/server/0974-Add-event-for-player-editing-sign.patch
+++ b/patches/server/0974-Add-event-for-player-editing-sign.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add event for player editing sign
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 2223aba0841280c5205ab0963c406449f85fa433..879cc823d56625867eb73bb621db6a13f40ad81c 100644
+index 32535c0d6d3e52d81180c8624f796bc7eab08a29..b5a8dfe3433e3ff93f06e32edc462587f04cd7e2 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -497,7 +497,7 @@ public final class ItemStack {
+@@ -484,7 +484,7 @@ public final class ItemStack {
                          try {
                              if (world.getBlockEntity(SignItem.openSign) instanceof SignBlockEntity tileentitysign) {
                                  if (world.getBlockState(SignItem.openSign).getBlock() instanceof SignBlock blocksign) {


### PR DESCRIPTION
Fixes #4888
Fixes #7599
Fixes https://github.com/PaperMC/Paper/issues/9399

Does the same conversion in more places to ensure comparisons are correct. Section chars in top-level components are now converted to json structure. This doesnt touch section chars in children components, but it didnt originally do that either.