### PR TITLE
Remove markdown from areas of the issue template that do not render markdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -7,4 +7,4 @@ contact_links:
     url: https://discord.gg/papermc
     about: |
       Due to GitHub not currently allowing private issues, exploit reports are currently handled via our Discord.
-      To report an exploit, see the `#paper-exploit-report` channel.
+      To report an exploit, see the #paper-exploit-report channel.


### PR DESCRIPTION
I've made a mistake in #6702 and put markdown where it will not be rendered. Unfortunately, GitHub did not allow you to preview that file. This removes it.