### PR TITLE
Add methods to find targets for lightning strikes

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -241,3 +241,6 @@ public net.minecraft.world.entity.projectile.Projectile ownerUUID
 public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations
 public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations toBukkitSlot(I)Lorg/bukkit/scoreboard/DisplaySlot;
 public org.bukkit.craftbukkit.scoreboard.CraftScoreboardTranslations fromBukkitSlot(Lorg/bukkit/scoreboard/DisplaySlot;)I
+
+# Add methods to find targets for lightning strikes
+public net.minecraft.server.level.ServerLevel findLightningRod(Lnet/minecraft/core/BlockPos;)Ljava/util/Optional;

--- a/patches/api/0337-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/api/0337-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Mon, 4 Oct 2021 08:29:36 +0200
+Subject: [PATCH] Add methods to find targets for lightning strikes
+
+
+diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
+index 77577de113b1413ed1474850b4ef8e7fd0c07dd6..4f673e9123145dc78564dc3eef0edf75795dafc2 100644
+--- a/src/main/java/org/bukkit/World.java
++++ b/src/main/java/org/bukkit/World.java
+@@ -757,6 +757,37 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
+     @NotNull
+     public LightningStrike strikeLightningEffect(@NotNull Location loc);
+ 
++    // Paper start
++    /**
++     * Finds the location of the nearest unobstructed Lightning Rod in a 128-block
++     * radius around the given location. Returns {@code null} if no Lightning Rod is found.
++     *
++     * <p>Note: To activate a Lightning Rod, the position one block above it must be struck by lightning.</p>
++     *
++     * @param location {@link Location} to search for Lightning Rod around
++     * @return {@link Location} of Lightning Rod or {@code null}
++     */
++    @Nullable
++    public Location findLightningRod(@NotNull Location location);
++
++    /**
++     * Finds a target {@link Location} for lightning to strike.
++     * <p>It selects from (in the following order):</p>
++     * <ol>
++     *  <li>the block above the nearest Lightning Rod, found using {@link World#findLightningRod(Location)}</li>
++     *  <li>a random {@link LivingEntity} that can see the sky in a 6x6 cuboid
++     *      around input X/Z coordinates. Y ranges from <i>the highest motion-blocking
++     *      block at the input X/Z - 3</i> to <i>the height limit + 3</i></li>
++     * </ol>
++     * <p>Returns {@code null} if no target is found.</p>
++     *
++     * @param location {@link Location} to search for target around
++     * @return lightning target or {@code null}
++     */
++    @Nullable
++    public Location findLightningTarget(@NotNull Location location);
++    // Paper end
++
+     /**
+      * Get a list of all entities in this World
+      *

--- a/patches/server/0821-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0821-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -1,0 +1,58 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Mon, 4 Oct 2021 10:16:44 +0200
+Subject: [PATCH] Add methods to find targets for lightning strikes
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 6911fbbd3a0b2aed7257e31433fc01fe8fade5ec..96ccf894519fc892e35fbd13ab97fe289236caca 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -956,6 +956,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+     }
+ 
+     protected BlockPos findLightningTargetAround(BlockPos pos) {
++        // Paper start
++        return this.findLightningTargetAround(pos, false);
++    }
++    public BlockPos findLightningTargetAround(BlockPos pos, boolean returnNullWhenNoTarget) {
++        // Paper end
+         BlockPos blockposition1 = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, pos);
+         Optional<BlockPos> optional = this.findLightningRod(blockposition1);
+ 
+@@ -970,6 +975,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+             if (!list.isEmpty()) {
+                 return ((LivingEntity) list.get(this.random.nextInt(list.size()))).blockPosition();
+             } else {
++                if (returnNullWhenNoTarget) return null; // Paper
+                 if (blockposition1.getY() == this.getMinBuildHeight() - 1) {
+                     blockposition1 = blockposition1.above(2);
+                 }
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 8c238a445b327e24d8152b36ebc2b1b57e73d0e1..00d8b61c04ac91770b0ff3b846d3ff70bef2e8e7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -700,6 +700,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+         return (LightningStrike) lightning.getBukkitEntity();
+     }
+ 
++    // Paper start
++    @Override
++    public Location findLightningRod(Location location) {
++        return this.world.findLightningRod(net.minecraft.server.MCUtil.toBlockPosition(location))
++            .map(blockPos -> net.minecraft.server.MCUtil.toLocation(this.world, blockPos)
++                // get the actual rod pos
++                .subtract(0, 1, 0))
++            .orElse(null);
++    }
++
++    @Override
++    public Location findLightningTarget(Location location) {
++        final BlockPos pos = this.world.findLightningTargetAround(net.minecraft.server.MCUtil.toBlockPosition(location), true);
++        return pos == null ? null : net.minecraft.server.MCUtil.toLocation(this.world, pos);
++    }
++    // Paper end
++
+     @Override
+     public boolean generateTree(Location loc, TreeType type) {
+         return generateTree(loc, CraftWorld.rand, type);


### PR DESCRIPTION
There was no way to find lightning rods around a location except for reimplementing methods already present in NMS...

Thanks to @lynxplay for investigating a problem with ATs :)