### PR TITLE
Make despawn distance configs per-category, improve per category spawn limit config

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -252,3 +252,6 @@ public net.minecraft.world.entity.monster.Zombie supportsBreakDoorGoal()Z
 
 # Add Material#hasCollision
 public net.minecraft.world.level.block.state.BlockBehaviour hasCollision
+
+# add per world spawn limits
+public net.minecraft.world.level.NaturalSpawner SPAWNING_CATEGORIES

--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -298,10 +298,10 @@ index 0000000000000000000000000000000000000000..bee2fa2bfbb61209381f24ed6508d3d1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..24c6f957aaf1f4064718b05d4e5f5759853c6f00
+index 0000000000000000000000000000000000000000..e4368db074da7b5e48b47d41875c1e63b9745c2a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -0,0 +1,185 @@
+@@ -0,0 +1,188 @@
 +package com.destroystokyo.paper;
 +
 +import com.google.common.base.Throwables;
@@ -364,8 +364,8 @@ index 0000000000000000000000000000000000000000..24c6f957aaf1f4064718b05d4e5f5759
 +        commands = new HashMap<String, Command>();
 +        commands.put("paper", new PaperCommand("paper"));
 +
-+        version = getInt("config-version", 23);
-+        set("config-version", 23);
++        version = getInt("config-version", 24);
++        set("config-version", 24);
 +        readConfig(PaperConfig.class, null);
 +    }
 +
@@ -405,7 +405,10 @@ index 0000000000000000000000000000000000000000..24c6f957aaf1f4064718b05d4e5f5759
 +                }
 +            }
 +        }
++        saveConfig();
++    }
 +
++    static void saveConfig() {
 +        try {
 +            config.save(CONFIG_FILE);
 +        } catch (IOException ex) {
@@ -489,10 +492,10 @@ index 0000000000000000000000000000000000000000..24c6f957aaf1f4064718b05d4e5f5759
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0f80a0d930bff8c19440ee33a4c8d56d17495b5f
+index 0000000000000000000000000000000000000000..6cb3a37612240d4150d7c62628f4b7440c822d48
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,73 @@
+@@ -0,0 +1,88 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
@@ -503,6 +506,7 @@ index 0000000000000000000000000000000000000000..0f80a0d930bff8c19440ee33a4c8d56d
 +
 +import static com.destroystokyo.paper.PaperConfig.log;
 +import static com.destroystokyo.paper.PaperConfig.logError;
++import static com.destroystokyo.paper.PaperConfig.saveConfig;
 +
 +public class PaperWorldConfig {
 +
@@ -531,6 +535,14 @@ index 0000000000000000000000000000000000000000..0f80a0d930bff8c19440ee33a4c8d56d
 +        }
 +    }
 +
++    public void removeOldValues() {
++        boolean needsSave = false;
++
++        if (needsSave) {
++            saveConfig();
++        }
++    }
++
 +    private boolean getBoolean(String path, boolean def) {
 +        config.addDefault("world-settings.default." + path, def);
 +        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
@@ -542,8 +554,14 @@ index 0000000000000000000000000000000000000000..0f80a0d930bff8c19440ee33a4c8d56d
 +    }
 +
 +    private int getInt(String path, int def) {
-+        config.addDefault("world-settings.default." + path, def);
-+        return config.getInt("world-settings." + worldName + "." + path, config.getInt("world-settings.default." + path));
++        return getInt(path, def, true);
++    }
++
++    private int getInt(String path, int def, boolean setDefault) {
++        if (setDefault) {
++            config.addDefault("world-settings.default." + path, def);
++        }
++        return config.getInt("world-settings." + worldName + "." + path, config.getInt("world-settings.default." + path, def));
 +    }
 +
 +    private long getLong(String path, long def) {
@@ -567,7 +585,7 @@ index 0000000000000000000000000000000000000000..0f80a0d930bff8c19440ee33a4c8d56d
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index 1707449cbbfa5eab585657cdde811b34a92e1d17..c8385460701395cb5c65fba41335469ffb2d9b9a 100644
+index 21c0fe42af0239cf8d857fa9fddae8a5974930e2..39ca32e006a36991b9d948c709c1b9ce03bca018 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -101,6 +101,12 @@ public class Main {
@@ -604,6 +622,18 @@ index 1707449cbbfa5eab585657cdde811b34a92e1d17..c8385460701395cb5c65fba41335469f
      public static void forceUpgrade(LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, boolean eraseCache, BooleanSupplier booleansupplier, ImmutableSet<ResourceKey<DimensionType>> worlds) { // CraftBukkit
          Main.LOGGER.info("Forcing world upgrade! {}", session.getLevelId()); // CraftBukkit
          WorldUpgrader worldupgrader = new WorldUpgrader(session, dataFixer, worlds, eraseCache);
+diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
+index 2f393503204cf219c60dbae868172a29a0d23d5f..9f3d7089d066bda13af8b4b714a0ebd0c3403e4f 100644
+--- a/src/main/java/net/minecraft/server/MinecraftServer.java
++++ b/src/main/java/net/minecraft/server/MinecraftServer.java
+@@ -609,6 +609,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         }
+         this.forceDifficulty();
+         for (ServerLevel worldserver : this.getAllLevels()) {
++            worldserver.paperConfig.removeOldValues(); // Paper - callback for clearing old config options, after any migrations have taken place
+             this.loadSpawn(worldserver.getChunkSource().chunkMap.progressListener, worldserver);
+             worldserver.entityManager.tick(); // SPIGOT-6526: Load pending entities so they are available to the API
+             this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index cd65a5bb6da734a39b0bb6e9a0571455d19ceac4..fac993d58bd6e3bb19fd69881092a863c8952c65 100644
 --- a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
@@ -686,7 +716,7 @@ index 5e0f455d2efe5f5be6ef3f82b06f024c54b22829..8516eef6ba56bd81710a8ad706f0fac8
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e49e3643fa01cafdc96260aa01c710c37c6f1ffe..dc52fa7a78e79e0fbe087f89d7250225bb30228f 100644
+index cfbf2190b2b61683b574b9048cb4bb40cecfbf1f..fea5e7abcb5e429a3de5dd8968773fe5043a4448 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -835,6 +835,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0005-MC-Dev-fixes.patch
+++ b/patches/server/0005-MC-Dev-fixes.patch
@@ -157,10 +157,10 @@ index 3db1f50262df75dc99fd5a1224985cd9f5f14c9f..6611aebafb14b83bce3eeb87701e2edc
      private static final int MIN_PROTOCOL_ID = -1;
      private static final int MAX_PROTOCOL_ID = 2;
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4e8e28b0224aab1d40cae17d330488c09d5497a8..6f56df5b0550735e3da122729080125c3dff5d06 100644
+index 53db2468b3bde473fd90a218047db8149c4e7755..8be15a63be90720ce34a7c0cb696a59d864396f8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1783,7 +1783,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1784,7 +1784,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              PackRepository resourcepackrepository = this.packRepository;
  
              Objects.requireNonNull(this.packRepository);

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -4987,7 +4987,7 @@ index 0000000000000000000000000000000000000000..850caa39d4875620b05c9a3cc27c65ef
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 6f56df5b0550735e3da122729080125c3dff5d06..dab59e1a523ab14f28764b179931a7a54e1bf52e 100644
+index 8be15a63be90720ce34a7c0cb696a59d864396f8..2c2c70e784e9c7bebc6bca1ef48e6992b12b82d5 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -296,6 +296,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -4998,7 +4998,7 @@ index 6f56df5b0550735e3da122729080125c3dff5d06..dab59e1a523ab14f28764b179931a7a5
  
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
-@@ -964,6 +965,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -965,6 +966,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              MinecraftServer.LOGGER.error("Failed to unlock level {}", this.storageSource.getLevelId(), ioexception1);
          }
          // Spigot start
@@ -5008,7 +5008,7 @@ index 6f56df5b0550735e3da122729080125c3dff5d06..dab59e1a523ab14f28764b179931a7a5
          if (org.spigotmc.SpigotConfig.saveUserCacheOnStopOnly) {
              MinecraftServer.LOGGER.info("Saving usercache.json");
              this.getProfileCache().save();
-@@ -1026,6 +1030,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1027,6 +1031,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                          this.lastOverloadWarning = this.nextTickTime;
                      }
  
@@ -5016,7 +5016,7 @@ index 6f56df5b0550735e3da122729080125c3dff5d06..dab59e1a523ab14f28764b179931a7a5
                      if ( tickCount++ % MinecraftServer.SAMPLE_INTERVAL == 0 )
                      {
                          double currentTps = 1E3 / ( curTime - tickSection ) * MinecraftServer.SAMPLE_INTERVAL;
-@@ -1247,6 +1252,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1248,6 +1253,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.snooper.prepare();
          }
  
@@ -5024,7 +5024,7 @@ index 6f56df5b0550735e3da122729080125c3dff5d06..dab59e1a523ab14f28764b179931a7a5
          this.profiler.pop();
          this.profiler.push("tallying");
          long l = this.tickTimes[this.tickCount % 100] = Util.getNanos() - i;
-@@ -1310,6 +1316,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1311,6 +1317,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              try {
                  worldserver.timings.doTick.startTiming(); // Spigot
                  worldserver.tick(shouldKeepTicking);

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -688,7 +688,7 @@ index 97cfdb625401f44e6e0c0582116cb847ac2355bc..c6a38fefbb1c0e0483a1d0468dd4e7c2
  
  public class PaperConfig {
  
-@@ -188,4 +191,35 @@ public class PaperConfig {
+@@ -191,4 +194,35 @@ public class PaperConfig {
          config.addDefault(path, def);
          return config.getString(path, config.getString(path));
      }
@@ -784,7 +784,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
  import org.spigotmc.SlackActivityAccountant; // Spigot
  
  public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTask> implements SnooperPopulator, CommandSource, AutoCloseable {
-@@ -911,6 +911,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -912,6 +912,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
          // CraftBukkit end
          MinecraftServer.LOGGER.info("Stopping server");
@@ -792,7 +792,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();
-@@ -1114,9 +1115,21 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1115,9 +1116,21 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean haveTime() {
          // CraftBukkit start
@@ -814,7 +814,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
      private void executeModerately() {
          this.runAllTasks();
          java.util.concurrent.locks.LockSupport.parkNanos("executing tasks", 1000L);
-@@ -1124,9 +1137,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1125,9 +1138,9 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit end
  
      protected void waitUntilNextTick() {
@@ -826,7 +826,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          });
      }
  
-@@ -1212,10 +1225,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1213,10 +1226,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      public void onServerExit() {}
  
      public void tickServer(BooleanSupplier shouldKeepTicking) {
@@ -846,7 +846,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          ++this.tickCount;
          this.tickChildren(shouldKeepTicking);
          if (i - this.lastServerStatus >= 5000000000L) {
-@@ -1233,14 +1254,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1234,14 +1255,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          if (this.autosavePeriod > 0 && this.tickCount % this.autosavePeriod == 0) { // CraftBukkit
@@ -861,7 +861,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          }
  
          this.profiler.push("snooper");
-@@ -1254,6 +1273,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1255,6 +1274,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          io.papermc.paper.util.CachedLists.reset(); // Paper
          this.profiler.pop();
@@ -875,7 +875,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          this.profiler.push("tallying");
          long l = this.tickTimes[this.tickCount % 100] = Util.getNanos() - i;
  
-@@ -1264,30 +1290,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1265,30 +1291,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.profiler.pop();
          org.spigotmc.WatchdogThread.tick(); // Spigot
          this.slackActivityAccountant.tickEnded(l); // Spigot
@@ -914,7 +914,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
          // Send time updates to everyone, it will get the right time from the world the player is in.
          if (this.tickCount % 20 == 0) {
              for (int i = 0; i < this.getPlayerList().players.size(); ++i) {
-@@ -1295,7 +1320,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1296,7 +1321,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  entityplayer.connection.send(new ClientboundSetTimePacket(entityplayer.level.getGameTime(), entityplayer.getPlayerTime(), entityplayer.level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT))); // Add support for per player time
              }
          }
@@ -923,7 +923,7 @@ index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a6
  
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
-@@ -1341,24 +1366,24 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1342,24 +1367,24 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
  
          this.profiler.popPush("connection");

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -10,7 +10,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index c6a38fefbb1c0e0483a1d0468dd4e7c2b3881097..4a2edc70432a45931fcc0e98be3ca900df02814b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -222,4 +222,13 @@ public class PaperConfig {
+@@ -225,4 +225,13 @@ public class PaperConfig {
                  " - Length: " + timeSummary(Timings.getHistoryLength() / 20) +
                  " - Server Name: " + timingsServerName);
      }

--- a/patches/server/0012-Configurable-cactus-bamboo-and-reed-growth-heights.patch
+++ b/patches/server/0012-Configurable-cactus-bamboo-and-reed-growth-heights.patch
@@ -7,10 +7,10 @@ Bamboo - Both the minimum fully-grown heights and the maximum are configurable
 - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0f80a0d930bff8c19440ee33a4c8d56d17495b5f..a0db9b7ec0a6eb80e44e62eb460d9a8d25d2a8cc 100644
+index 6cb3a37612240d4150d7c62628f4b7440c822d48..3d9a805d01cea0b414446c0540ac9a4f86f1e1e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -70,4 +70,17 @@ public class PaperWorldConfig {
+@@ -85,4 +85,17 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def);
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }

--- a/patches/server/0013-Configurable-baby-zombie-movement-speed.patch
+++ b/patches/server/0013-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a0db9b7ec0a6eb80e44e62eb460d9a8d25d2a8cc..d473f8bb1a6000320b3e774561220f10c0469e81 100644
+index 3d9a805d01cea0b414446c0540ac9a4f86f1e1e3..d5a93adafc9e897b78f83102ea101d96c5bf2744 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -83,4 +83,15 @@ public class PaperWorldConfig {
+@@ -98,4 +98,15 @@ public class PaperWorldConfig {
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight + ". Max height for bamboo growth " + bambooMaxHeight + ". Min height for fully-grown bamboo " + bambooMinHeight + ".");
  
      }
@@ -25,7 +25,7 @@ index a0db9b7ec0a6eb80e44e62eb460d9a8d25d2a8cc..d473f8bb1a6000320b3e774561220f10
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index d42ce43f3ca2e720cb46fffb52e08945727883be..f17a91a654d11aaace39f04b3f4c3e061a374dc9 100644
+index 998d11263b96f72a29787e5d58f4850e8cd5cdf7..6f990e39e696890d39c3ae94fd6a0ecf9513d710 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -79,7 +79,7 @@ import org.bukkit.event.entity.EntityTransformEvent;

--- a/patches/server/0014-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0014-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d473f8bb1a6000320b3e774561220f10c0469e81..f2f17a649b472f3a3271e9d799a7d34c36ba2cb6 100644
+index d5a93adafc9e897b78f83102ea101d96c5bf2744..3b35d45881a041aaa7adea0ffc92379208a138b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -94,4 +94,12 @@ public class PaperWorldConfig {
+@@ -109,4 +109,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/patches/server/0015-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0015-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f2f17a649b472f3a3271e9d799a7d34c36ba2cb6..419f3bca4c1dd18790ad9e602bdec009c2933606 100644
+index 3b35d45881a041aaa7adea0ffc92379208a138b7..a6f0e2193f930cf4f1e38ac30e92a7f7cafb8413 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -102,4 +102,9 @@ public class PaperWorldConfig {
+@@ -117,4 +117,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }
@@ -19,7 +19,7 @@ index f2f17a649b472f3a3271e9d799a7d34c36ba2cb6..419f3bca4c1dd18790ad9e602bdec009
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1b8563be119498b8a9199ebd6fd4ad405577e0ee..f903453fd129f6fb5023615088bd84d33052f0dc 100644
+index 70154157221dcdd0d228a934aee2213d4ea2545a..40f644f25bb0489631765f5768317e20a7997eb4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1270,6 +1270,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0016-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0016-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,51 +5,83 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 419f3bca4c1dd18790ad9e602bdec009c2933606..4634da27cde654e682ac4525df9850ea40afbb87 100644
+index a6f0e2193f930cf4f1e38ac30e92a7f7cafb8413..6d1a880737c90da743fd772426b4050036bdb926 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -107,4 +107,20 @@ public class PaperWorldConfig {
+@@ -2,6 +2,9 @@ package com.destroystokyo.paper;
+ 
+ import java.util.List;
+ 
++import it.unimi.dsi.fastutil.objects.Reference2IntMap;
++import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
++import net.minecraft.world.entity.MobCategory;
+ import org.bukkit.Bukkit;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.spigotmc.SpigotWorldConfig;
+@@ -40,6 +43,13 @@ public class PaperWorldConfig {
+     public void removeOldValues() {
+         boolean needsSave = false;
+ 
++        if (PaperConfig.version < 24) {
++            needsSave = true;
++
++            set("despawn-ranges.soft", null);
++            set("despawn-ranges.hard", null);
++        }
++
+         if (needsSave) {
+             saveConfig();
+         }
+@@ -122,4 +132,31 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }
 +
-+    public int softDespawnDistance;
-+    public int hardDespawnDistance;
++    public final Reference2IntMap<MobCategory> softDespawnDistances = new Reference2IntOpenHashMap<>(MobCategory.values().length);
++    public final Reference2IntMap<MobCategory> hardDespawnDistances = new Reference2IntOpenHashMap<>(MobCategory.values().length);
 +    private void despawnDistances() {
-+        softDespawnDistance = getInt("despawn-ranges.soft", 32); // 32^2 = 1024, Minecraft Default
-+        hardDespawnDistance = getInt("despawn-ranges.hard", 128); // 128^2 = 16384, Minecraft Default
-+
-+        if (softDespawnDistance > hardDespawnDistance) {
-+            softDespawnDistance = hardDespawnDistance;
++        if (PaperConfig.version < 24) {
++            int softDistance = getInt("despawn-ranges.soft", 32, false); // 32^2 = 1024, Minecraft Default
++            int hardDistance = getInt("despawn-ranges.hard", 128, false); // 128^2 = 16384, Minecraft Default
++            for (MobCategory value : MobCategory.values()) {
++                if (softDistance != 32) {
++                    softDespawnDistances.put(value, softDistance);
++                }
++                if (hardDistance != 128) {
++                    hardDespawnDistances.put(value, hardDistance);
++                }
++            }
 +        }
-+
-+        log("Living Entity Despawn Ranges:  Soft: " + softDespawnDistance + " Hard: " + hardDespawnDistance);
-+
-+        softDespawnDistance = softDespawnDistance*softDespawnDistance;
-+        hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
++        for (MobCategory category : MobCategory.values()) {
++            int softDistance = getInt("despawn-ranges." + category.getName() + ".soft", softDespawnDistances.getOrDefault(category, category.getNoDespawnDistance()));
++            int hardDistance = getInt("despawn-ranges." + category.getName() + ".hard", hardDespawnDistances.getOrDefault(category, category.getDespawnDistance()));
++            if (softDistance > hardDistance) {
++                softDistance = hardDistance;
++            }
++            log("Mobs in " + category.getName() + " Despawn Ranges: Soft" + softDistance + " Hard: " + hardDistance);
++            softDespawnDistances.put(category, softDistance);
++            hardDespawnDistances.put(category, hardDistance);
++        }
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index abaa57d9a4d222753d28801c6ab86b11c71aca6b..c9a9a4c6ba930dedb227c1f1d4ca4bb520983854 100644
+index abaa57d9a4d222753d28801c6ab86b11c71aca6b..867ada6ba562d9d3db6bf97cb3fd2c5a281f915f 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
-@@ -778,16 +778,16 @@ public abstract class Mob extends LivingEntity {
-                 int i = this.getType().getCategory().getDespawnDistance();
+@@ -775,14 +775,14 @@ public abstract class Mob extends LivingEntity {
+ 
+             if (entityhuman != null) {
+                 double d0 = entityhuman.distanceToSqr((Entity) this); // CraftBukkit - decompile error
+-                int i = this.getType().getCategory().getDespawnDistance();
++                int i = this.level.paperConfig.hardDespawnDistances.getInt(this.getType().getCategory()); // Paper - custom despawn distances
                  int j = i * i;
  
--                if (d0 > (double) j) { // CraftBukkit - remove isTypeNotPersistent() check
-+                if (d0 > (double) level.paperConfig.hardDespawnDistance) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
+                 if (d0 > (double) j) { // CraftBukkit - remove isTypeNotPersistent() check
                      this.discard();
                  }
  
-                 int k = this.getType().getCategory().getNoDespawnDistance();
+-                int k = this.getType().getCategory().getNoDespawnDistance();
++                int k = this.level.paperConfig.softDespawnDistances.getInt(this.getType().getCategory()); // Paper - custom despawn distances
                  int l = k * k;
  
--                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l) { // CraftBukkit - remove isTypeNotPersistent() check
-+                if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > level.paperConfig.softDespawnDistance) { // CraftBukkit - remove isTypeNotPersistent() check // Paper - custom despawn distances
-                     this.discard();
--                } else if (d0 < (double) l) {
-+                } else if (d0 < level.paperConfig.softDespawnDistance) { // Paper - custom despawn distances
-                     this.noActionTime = 0;
-                 }
-             }
+                 if (this.noActionTime > 600 && this.random.nextInt(800) == 0 && d0 > (double) l) { // CraftBukkit - remove isTypeNotPersistent() check

--- a/patches/server/0017-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0017-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4634da27cde654e682ac4525df9850ea40afbb87..9eb44bd14a5fd351d1514f4de8bc7ba328b0253d 100644
+index 6d1a880737c90da743fd772426b4050036bdb926..8521772cf6cf9716093495cb8c41dfb7a649e741 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -123,4 +123,10 @@ public class PaperWorldConfig {
-         softDespawnDistance = softDespawnDistance*softDespawnDistance;
-         hardDespawnDistance = hardDespawnDistance*hardDespawnDistance;
+@@ -159,4 +159,10 @@ public class PaperWorldConfig {
+             hardDespawnDistances.put(category, hardDistance);
+         }
      }
 +
 +    public boolean keepSpawnInMemory;

--- a/patches/server/0018-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0018-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 * Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9eb44bd14a5fd351d1514f4de8bc7ba328b0253d..128b7cb5ed01f31555b169a6132a39fe4bfb90c7 100644
+index 8521772cf6cf9716093495cb8c41dfb7a649e741..1cfa6ae0a2fc42cd83c1323d49151ec2bbbacf83 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -129,4 +129,14 @@ public class PaperWorldConfig {
+@@ -165,4 +165,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }

--- a/patches/server/0019-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
+++ b/patches/server/0019-Show-Paper-in-client-crashes-server-lists-and-Mojang.patch
@@ -19,10 +19,10 @@ index 2c53a400611c78236c5a1c1270d27c02e94251bf..a1d5c0f8fe2adb2ee56f3217e089211e
                      if (outputStream != null) {
                          try {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5de0b15ee206ad01b1b4522b2d375fae08d2486f..daad04711adcaac9dc3868f20f7dc3c4a09fbac8 100644
+index e6afb76adc428dc1e919a1255a43b8d96aefd79b..e6be4991f07a9cd59946d501c002fd9113b46af0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1443,7 +1443,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1444,7 +1444,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @DontObfuscate
      public String getServerModName() {

--- a/patches/server/0024-Further-improve-server-tick-loop.patch
+++ b/patches/server/0024-Further-improve-server-tick-loop.patch
@@ -12,7 +12,7 @@ Previous implementation did not calculate TPS correctly.
 Switch to a realistic rolling average and factor in std deviation as an extra reporting variable
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index daad04711adcaac9dc3868f20f7dc3c4a09fbac8..b02306027b5aab96fd5036ec41296c8d3d9d99fd 100644
+index e6be4991f07a9cd59946d501c002fd9113b46af0..25a0038179ae71511638ecb5cd3f47bd9b81e4b1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -283,7 +283,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -33,7 +33,7 @@ index daad04711adcaac9dc3868f20f7dc3c4a09fbac8..b02306027b5aab96fd5036ec41296c8d
      public final double[] recentTps = new double[ 3 ];
      public final SlackActivityAccountant slackActivityAccountant = new SlackActivityAccountant();
      // Spigot end
-@@ -1006,6 +1006,57 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1007,6 +1007,57 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      {
          return ( avg * exp ) + ( tps * ( 1 - exp ) );
      }
@@ -91,7 +91,7 @@ index daad04711adcaac9dc3868f20f7dc3c4a09fbac8..b02306027b5aab96fd5036ec41296c8d
      // Spigot End
  
      protected void runServer() {
-@@ -1018,26 +1069,33 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1019,26 +1070,33 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
                  // Spigot start
                  Arrays.fill( recentTps, 20 );
@@ -133,7 +133,7 @@ index daad04711adcaac9dc3868f20f7dc3c4a09fbac8..b02306027b5aab96fd5036ec41296c8d
                          tickSection = curTime;
                      }
                      // Spigot end
-@@ -1047,7 +1105,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1048,7 +1106,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                          this.debugCommandProfiler = new MinecraftServer.TimeProfiler(Util.getNanos(), this.tickCount);
                      }
  

--- a/patches/server/0028-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0028-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 128b7cb5ed01f31555b169a6132a39fe4bfb90c7..3978f58b320465e72b0f416282f79dace44766cc 100644
+index 1cfa6ae0a2fc42cd83c1323d49151ec2bbbacf83..08281351cc99e904a3a388607425dde4c83f13e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -139,4 +139,19 @@ public class PaperWorldConfig {
+@@ -175,4 +175,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }
@@ -29,7 +29,7 @@ index 128b7cb5ed01f31555b169a6132a39fe4bfb90c7..3978f58b320465e72b0f416282f79dac
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3d6b2a74182485af701838be075edd999520ddf2..8c8ef6d7df8589d37cb722949fc3ffe9a9432c48 100644
+index 30502371b8d49738787b7cddab713472b6f2ce41..3acb00b025d5e45c7244cb62b59c5466d16a88dc 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -628,7 +628,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0031-Configurable-end-credits.patch
+++ b/patches/server/0031-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3978f58b320465e72b0f416282f79dace44766cc..7dee0219c69c5cf3025f63a9397f15f390ebe1ba 100644
+index 08281351cc99e904a3a388607425dde4c83f13e2..58c8c6db87492cf70de3a26d23209a931c6726b2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -154,4 +154,10 @@ public class PaperWorldConfig {
+@@ -190,4 +190,10 @@ public class PaperWorldConfig {
              }
          }
      }
@@ -20,7 +20,7 @@ index 3978f58b320465e72b0f416282f79dace44766cc..7dee0219c69c5cf3025f63a9397f15f3
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d1efa7b3fb2b22bd77fd01ffd137ddc975e5fe60..6bee392787a517d5ab8966b94c035db00eeb7d99 100644
+index 0e7c09c80509c83a52f32f735a1b19960bb369ee..a29058a772bcb908de631c34cd9743f4721cf1ae 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -936,6 +936,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0033-Optimize-explosions.patch
+++ b/patches/server/0033-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7dee0219c69c5cf3025f63a9397f15f390ebe1ba..83f869eca8bd1aa65add0a9f286aa09472cff1f3 100644
+index 58c8c6db87492cf70de3a26d23209a931c6726b2..ef0ec6b45cee27547e06ead7ef5acd6e51380a52 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -160,4 +160,10 @@ public class PaperWorldConfig {
+@@ -196,4 +196,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }
@@ -25,10 +25,10 @@ index 7dee0219c69c5cf3025f63a9397f15f390ebe1ba..83f869eca8bd1aa65add0a9f286aa094
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b02306027b5aab96fd5036ec41296c8d3d9d99fd..0d58b58537de49ddb7c8c841e9077af4e727ba82 100644
+index bfb835174390f6265d78c980cd56cd48ab1f4994..564517db80c3e7346f01746600d497becf0f0cff 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1422,6 +1422,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1423,6 +1423,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
              this.profiler.pop();
              this.profiler.pop();

--- a/patches/server/0034-Disable-explosion-knockback.patch
+++ b/patches/server/0034-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83f869eca8bd1aa65add0a9f286aa09472cff1f3..cac8606f65e587d34e2ae12f5962f236c316751e 100644
+index ef0ec6b45cee27547e06ead7ef5acd6e51380a52..dc8a1e4c5375fdd733146f671df91f59817f8377 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -166,4 +166,9 @@ public class PaperWorldConfig {
+@@ -202,4 +202,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }
@@ -19,7 +19,7 @@ index 83f869eca8bd1aa65add0a9f286aa09472cff1f3..cac8606f65e587d34e2ae12f5962f236
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index c57aa9226cee48d5ca0928c159a55e1c1fd42c3f..2e8ad50e7bf351ca6df1239303625a899a3a7f63 100644
+index 2e1857e80797c9012e203f69f44d5a6126d48ea7..c5fb30aec04bd46ab4ad376382889f99015f63b9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1380,6 +1380,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0035-Disable-thunder.patch
+++ b/patches/server/0035-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cac8606f65e587d34e2ae12f5962f236c316751e..b18622c199f57e0d7c201582fe83bb75dca143f9 100644
+index dc8a1e4c5375fdd733146f671df91f59817f8377..3ca83e07060e184cbd19a5585d44f5e7a5354462 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -171,4 +171,9 @@ public class PaperWorldConfig {
+@@ -207,4 +207,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/patches/server/0036-Disable-ice-and-snow.patch
+++ b/patches/server/0036-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b18622c199f57e0d7c201582fe83bb75dca143f9..a8e2bbe12255a071c6f9f68bd61cf6a8e2d6b159 100644
+index 3ca83e07060e184cbd19a5585d44f5e7a5354462..bf0c767af0ca5129b69b3c8dcfe54cdee989854b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -176,4 +176,9 @@ public class PaperWorldConfig {
+@@ -212,4 +212,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }
@@ -19,7 +19,7 @@ index b18622c199f57e0d7c201582fe83bb75dca143f9..a8e2bbe12255a071c6f9f68bd61cf6a8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index bf42ee77cb877a83031ce19f1b54f5659cd93ea0..c9ee1a12b6fe92db6896cd4abd7e7833b094c9da 100644
+index 2649c180cbfcc210458ca795d3f14fa0b6017546..6899be05202c114a6e6086bc3fdf739d3ab97fd7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -668,7 +668,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a8e2bbe12255a071c6f9f68bd61cf6a8e2d6b159..e25050d2842503876da6694e72f54e1e47b0c439 100644
+index bf0c767af0ca5129b69b3c8dcfe54cdee989854b..cff814a123e02aea96197c1be092c210c2fcf781 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -181,4 +181,9 @@ public class PaperWorldConfig {
+@@ -217,4 +217,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }

--- a/patches/server/0040-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0040-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e25050d2842503876da6694e72f54e1e47b0c439..daf4c0bfc75476b34f8399c9b6685e83bbed5f9e 100644
+index cff814a123e02aea96197c1be092c210c2fcf781..0f93c6ba2bc1b6207f8a5c3f9a39cb086797e800 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -186,4 +186,9 @@ public class PaperWorldConfig {
+@@ -222,4 +222,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }
@@ -19,7 +19,7 @@ index e25050d2842503876da6694e72f54e1e47b0c439..daf4c0bfc75476b34f8399c9b6685e83
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index ae63083b1283a5628fa900827c0af6e9254592c2..2b7dd46fe090db01aa4d1f0e4211bed769ad76dc 100644
+index d263d9ce353312fe6954cdd2ef1a2c4c0260f168..3f3404d7d890864fcdcde7d65f726d288ddec688 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -217,6 +217,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0044-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/patches/server/0044-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index daf4c0bfc75476b34f8399c9b6685e83bbed5f9e..7d9414e42991f9e82d7892f71e0c0612a53617eb 100644
+index 0f93c6ba2bc1b6207f8a5c3f9a39cb086797e800..0ccb86aed122ecd54a460db426163d0d2639c609 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -191,4 +191,9 @@ public class PaperWorldConfig {
+@@ -227,4 +227,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/patches/server/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0046-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d9414e42991f9e82d7892f71e0c0612a53617eb..0f37c427ac66dd4a9f112255a021079c2e247d79 100644
+index 0ccb86aed122ecd54a460db426163d0d2639c609..84df54523eada327033bb8821a7009df62dc7bca 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -196,4 +196,9 @@ public class PaperWorldConfig {
+@@ -232,4 +232,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }

--- a/patches/server/0051-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0051-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0f37c427ac66dd4a9f112255a021079c2e247d79..d80de8777ae4d21256578c039e3fbe65ca9ade7c 100644
+index 84df54523eada327033bb8821a7009df62dc7bca..304883dc18bab3bf4740006a5e6d7c58bab12348 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -201,4 +201,13 @@ public class PaperWorldConfig {
+@@ -237,4 +237,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }
@@ -23,7 +23,7 @@ index 0f37c427ac66dd4a9f112255a021079c2e247d79..d80de8777ae4d21256578c039e3fbe65
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8c8ef6d7df8589d37cb722949fc3ffe9a9432c48..e26973d77ba380c91b2f0561f2c6c5886d7b82b8 100644
+index 3acb00b025d5e45c7244cb62b59c5466d16a88dc..3456dcbac4984d4485c85b432f33ab33e76d1361 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2906,7 +2906,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d80de8777ae4d21256578c039e3fbe65ca9ade7c..1fc5b40f59a7edb25b0bd95f205a8fdf5c77fe64 100644
+index 304883dc18bab3bf4740006a5e6d7c58bab12348..6d1473a5267ecd3617d76fee23527bde58283bb1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -210,4 +210,9 @@ public class PaperWorldConfig {
+@@ -246,4 +246,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
          portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }

--- a/patches/server/0056-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0056-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1fc5b40f59a7edb25b0bd95f205a8fdf5c77fe64..664ef3fd4053172b16e00ab091a726e77bc31c74 100644
+index 6d1473a5267ecd3617d76fee23527bde58283bb1..1ab2ede5e9d8939f69fb430084437fda63879fb7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -215,4 +215,9 @@ public class PaperWorldConfig {
+@@ -251,4 +251,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }
@@ -25,7 +25,7 @@ index 1fc5b40f59a7edb25b0bd95f205a8fdf5c77fe64..664ef3fd4053172b16e00ab091a726e7
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e26973d77ba380c91b2f0561f2c6c5886d7b82b8..9fbe3ed59416d773dc5c19d5ea73f95ddd9b5143 100644
+index 3456dcbac4984d4485c85b432f33ab33e76d1361..bd64589488506c018dde86ff3a47836168dd7025 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2555,6 +2555,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -37,7 +37,7 @@ index e26973d77ba380c91b2f0561f2c6c5886d7b82b8..9fbe3ed59416d773dc5c19d5ea73f95d
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2e8ad50e7bf351ca6df1239303625a899a3a7f63..5335312b9a8c8166590df69a78311652b4b36d7e 100644
+index c5fb30aec04bd46ab4ad376382889f99015f63b9..0f27ee2ed35f54e30e2169941706eb0fc11275d5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -803,6 +803,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
+++ b/patches/server/0060-Default-loading-permissions.yml-before-plugins.patch
@@ -16,10 +16,10 @@ modify that. Under the previous logic, plugins were unable (cleanly) override pe
 A config option has been added for those who depend on the previous behavior, but I don't expect that.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f5155d4b48f17c82b7a637418c40ffcdc6cc6271..acdbd21947093ed076c4668d3480a50f4e289b8d 100644
+index 701a2ffd04df48d437b2cb963dd150af99725b6e..817d4572c9991992b720b3ba163188ac0e5b59b7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -231,4 +231,9 @@ public class PaperConfig {
+@@ -234,4 +234,9 @@ public class PaperConfig {
          }
          useDisplayNameInQuit = getBoolean("settings.use-display-name-in-quit-message", useDisplayNameInQuit);
      }

--- a/patches/server/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0064-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 664ef3fd4053172b16e00ab091a726e77bc31c74..9da18e568116a5279a7aa00023751e625bd5e9c0 100644
+index 1ab2ede5e9d8939f69fb430084437fda63879fb7..e5d5f4c692e80c616ccde58ab13604777eb71101 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -220,4 +220,19 @@ public class PaperWorldConfig {
+@@ -256,4 +256,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/patches/server/0069-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0069-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9da18e568116a5279a7aa00023751e625bd5e9c0..eae8a876b05c17d87b3971f8f2568ae5379feddb 100644
+index e5d5f4c692e80c616ccde58ab13604777eb71101..7addb5c66c88da73a4d80da1e898d629d76074f0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -235,4 +235,12 @@ public class PaperWorldConfig {
+@@ -271,4 +271,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }
@@ -22,7 +22,7 @@ index 9da18e568116a5279a7aa00023751e625bd5e9c0..eae8a876b05c17d87b3971f8f2568ae5
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 41dab560595a6d052c82b4474d824a584756371a..5df7fe061fdfd7f1455cf283973be471d878ffb2 100644
+index e47fffb3a8e2ce12dedce764fbd7ff52a0616426..53713875d95af656abbb30bc7b8c4ba251677615 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -648,7 +648,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0071-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0071-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Only process BlockPhysicsEvent if a plugin has a listener
 Saves on some object allocation and processing when no plugin listens to this
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 0d58b58537de49ddb7c8c841e9077af4e727ba82..46eaa77f33a375da80f8290883f6ed1f321be87e 100644
+index 2450bb69e08190804212172a298c1f12cd5345d7..d6195f7b0bac1bd1ababe8c4eec07654c323c014 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1383,6 +1383,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1384,6 +1384,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
@@ -18,7 +18,7 @@ index 0d58b58537de49ddb7c8c841e9077af4e727ba82..46eaa77f33a375da80f8290883f6ed1f
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 5df7fe061fdfd7f1455cf283973be471d878ffb2..c2dc2ec29949074e71d0b4e5244ec71587f01178 100644
+index 75fa3f2392936d86d29fee73079507c642660b30..525cf19c9ecc5886720d0505f0554b667ef3267f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -198,6 +198,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0073-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0073-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eae8a876b05c17d87b3971f8f2568ae5379feddb..8ccdae60f97c38f7a56b68e94a801c7ee3fa9079 100644
+index 7addb5c66c88da73a4d80da1e898d629d76074f0..a0688ef7eb38e7c156193db3d94c44a3c290d8f2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -243,4 +243,14 @@ public class PaperWorldConfig {
+@@ -279,4 +279,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }

--- a/patches/server/0075-Sanitise-RegionFileCache-and-make-configurable.patch
+++ b/patches/server/0075-Sanitise-RegionFileCache-and-make-configurable.patch
@@ -11,10 +11,10 @@ The implementation uses a LinkedHashMap as an LRU cache (modified from HashMap).
 The maximum size of the RegionFileCache is also made configurable.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index acdbd21947093ed076c4668d3480a50f4e289b8d..a3a4ecabed1ec7511005affe610fc2ec8a87d67a 100644
+index 817d4572c9991992b720b3ba163188ac0e5b59b7..01da2246c70237676597b3e70e3e169ab1132071 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -236,4 +236,9 @@ public class PaperConfig {
+@@ -239,4 +239,9 @@ public class PaperConfig {
      private static void loadPermsBeforePlugins() {
          loadPermsBeforePlugins = getBoolean("settings.load-permissions-yml-before-plugins", true);
      }

--- a/patches/server/0079-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/patches/server/0079-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8ccdae60f97c38f7a56b68e94a801c7ee3fa9079..2c3754c0bcebc33f88168136b519baef6927553b 100644
+index a0688ef7eb38e7c156193db3d94c44a3c290d8f2..53692c9a72a75cb5280165a99c95667928eec753 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -253,4 +253,10 @@ public class PaperWorldConfig {
+@@ -289,4 +289,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0082-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2c3754c0bcebc33f88168136b519baef6927553b..d9590dbc3db4ec4d32d86906bb290fbe2ca81ccd 100644
+index 53692c9a72a75cb5280165a99c95667928eec753..91d9717c88d7a413a71cc0897402dac0013fea4d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -259,4 +259,9 @@ public class PaperWorldConfig {
+@@ -295,4 +295,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/patches/server/0084-Configurable-Player-Collision.patch
+++ b/patches/server/0084-Configurable-Player-Collision.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index ad73dbb8e7112e2843c4104d367c98bf8b2b3370..f54096daee8c51a887b943ddd257ac2eae63952e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -241,4 +241,9 @@ public class PaperConfig {
+@@ -244,4 +244,9 @@ public class PaperConfig {
      private static void regionFileCacheSize() {
          regionFileCacheSize = Math.max(getInt("settings.region-file-cache-size", 256), 4);
      }
@@ -32,7 +32,7 @@ index 8885220e4813b34627b42523834bbec995d8950d..4c9660176e783999301565790b8cf6f4
              buf.writeComponent(this.playerPrefix);
              buf.writeComponent(this.playerSuffix);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 46eaa77f33a375da80f8290883f6ed1f321be87e..ec73f52f7a82a9c1428979c562a9df5002261cd4 100644
+index d6195f7b0bac1bd1ababe8c4eec07654c323c014..4e7016c20a72271ff62fb676280d3880864919f1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -161,6 +161,7 @@ import net.minecraft.world.level.storage.loot.LootTables;
@@ -43,7 +43,7 @@ index 46eaa77f33a375da80f8290883f6ed1f321be87e..ec73f52f7a82a9c1428979c562a9df50
  import org.apache.commons.lang3.Validate;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -615,6 +616,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -616,6 +617,20 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.server.getPluginManager().callEvent(new org.bukkit.event.world.WorldLoadEvent(worldserver.getWorld()));
          }
  

--- a/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d9590dbc3db4ec4d32d86906bb290fbe2ca81ccd..e480f1cd7830cd170f3744edec96221cbdfabe27 100644
+index 91d9717c88d7a413a71cc0897402dac0013fea4d..ee771addea0af09749d6cbed8ff332ddc6895dd5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -264,4 +264,14 @@ public class PaperWorldConfig {
+@@ -300,4 +300,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/patches/server/0090-remove-null-possibility-for-getServer-singleton.patch
+++ b/patches/server/0090-remove-null-possibility-for-getServer-singleton.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] remove null possibility for getServer singleton
 to stop IDE complaining about potential NPE
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ec73f52f7a82a9c1428979c562a9df5002261cd4..623a2cf6b6e05598124014c7340590d26c7880b8 100644
+index 4e7016c20a72271ff62fb676280d3880864919f1..d58516922198ffeb51263243e7b7b666de2d9ea2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -188,6 +188,7 @@ import org.spigotmc.SlackActivityAccountant; // Spigot
@@ -25,7 +25,7 @@ index ec73f52f7a82a9c1428979c562a9df5002261cd4..623a2cf6b6e05598124014c7340590d2
          this.metricsRecorder = InactiveMetricsRecorder.INSTANCE;
          this.profiler = this.metricsRecorder.getProfiler();
          this.onMetricsRecordingStopped = (methodprofilerresults) -> {
-@@ -2258,7 +2260,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2259,7 +2261,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Deprecated
      public static MinecraftServer getServer() {

--- a/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e480f1cd7830cd170f3744edec96221cbdfabe27..7346ff09a8c2a04ce6f2b898fb7e23ed264ce951 100644
+index ee771addea0af09749d6cbed8ff332ddc6895dd5..1c8ca94e981b216c338f8b0a34303d558901c5d8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -274,4 +274,26 @@ public class PaperWorldConfig {
+@@ -310,4 +310,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }
@@ -515,7 +515,7 @@ index 0000000000000000000000000000000000000000..3377b86c337d0234bbb9b0349e4034a7
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 287ee89418e28366866e70bd104cd11b5ae0aad6..8473dcb54b26ea6b264125423fc2d52b87176b83 100644
+index cff2867eb92fb3b69ed4645d3b5294eaca62e998..78d547660cc3996606e671466d33170faa8a2c29 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -168,6 +168,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0093-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
+++ b/patches/server/0093-Don-t-save-empty-scoreboard-teams-to-scoreboard.dat.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't save empty scoreboard teams to scoreboard.dat
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 1d2680ad57c2a44838157fbf8601b14fda03ce17..f94db56dfcae9843ef341912c43b092d62fe0627 100644
+index c8242aa5b4a896111b23de60fa120ec6be06d0ca..c6ca15a5cc53995ca0ada9c9ac9dc1d084963eb5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -246,4 +246,9 @@ public class PaperConfig {
+@@ -249,4 +249,9 @@ public class PaperConfig {
      private static void enablePlayerCollisions() {
          enablePlayerCollisions = getBoolean("settings.enable-player-collisions", true);
      }

--- a/patches/server/0095-Optimize-UserCache-Thread-Safe.patch
+++ b/patches/server/0095-Optimize-UserCache-Thread-Safe.patch
@@ -12,10 +12,10 @@ the user never changed the default setting for Spigot's save on stop only.
 1.17: TODO does this need the synchronized blocks anymore?
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 623a2cf6b6e05598124014c7340590d26c7880b8..79270b3969c6c05a5a90756a88f3547b64cf5f3b 100644
+index d58516922198ffeb51263243e7b7b666de2d9ea2..9c73d69658de96b8216c7d945521af84d41c69ab 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -988,7 +988,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -989,7 +989,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          } catch (java.lang.InterruptedException ignored) {} // Paper
          if (org.spigotmc.SpigotConfig.saveUserCacheOnStopOnly) {
              MinecraftServer.LOGGER.info("Saving usercache.json");

--- a/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7346ff09a8c2a04ce6f2b898fb7e23ed264ce951..057397e4a4e86122928c9a016d4b573b5860e9db 100644
+index 1c8ca94e981b216c338f8b0a34303d558901c5d8..6324c3465cf34cea2e7fd7d8c26a0cbeeb20eefd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -296,4 +296,14 @@ public class PaperWorldConfig {
+@@ -332,4 +332,14 @@ public class PaperWorldConfig {
              );
          }
      }
@@ -24,7 +24,7 @@ index 7346ff09a8c2a04ce6f2b898fb7e23ed264ce951..057397e4a4e86122928c9a016d4b573b
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index a70bf50c3a17295bb9ffe30ea86f3b84e134cdbc..f835ef1c7109f56f32da394c9afc9fd35b05b51a 100644
+index c062b9e2b58485ad54afe06ec09d9ed2d22adefb..3a94e2fca036ba7853de2e79a585e66116612845 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -68,7 +68,7 @@ public class ServerEntity {

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Add setting for proxy online mode status
 TODO: Add isProxyOnlineMode check to Metrics
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f94db56dfcae9843ef341912c43b092d62fe0627..e7606adc0e7e81e1878f87d2538d8b75c58d5555 100644
+index c6ca15a5cc53995ca0ada9c9ac9dc1d084963eb5..728835cddd413d778e9628360989724f65335b46 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -23,6 +23,7 @@ import org.bukkit.configuration.InvalidConfigurationException;
@@ -17,7 +17,7 @@ index f94db56dfcae9843ef341912c43b092d62fe0627..e7606adc0e7e81e1878f87d2538d8b75
  
  public class PaperConfig {
  
-@@ -251,4 +252,13 @@ public class PaperConfig {
+@@ -254,4 +255,13 @@ public class PaperConfig {
      private static void saveEmptyScoreboardTeams() {
          saveEmptyScoreboardTeams = getBoolean("settings.save-empty-scoreboard-teams", false);
      }

--- a/patches/server/0105-Configurable-packet-in-spam-threshold.patch
+++ b/patches/server/0105-Configurable-packet-in-spam-threshold.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable packet in spam threshold
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e7606adc0e7e81e1878f87d2538d8b75c58d5555..e2e96dd87c08e749fd513db2156d49f18dee8eb8 100644
+index 728835cddd413d778e9628360989724f65335b46..6c13fe725ca2b2a6f0f375b80f6c2cb643b9913d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -261,4 +261,13 @@ public class PaperConfig {
+@@ -264,4 +264,13 @@ public class PaperConfig {
      public static boolean isProxyOnlineMode() {
          return Bukkit.getOnlineMode() || (SpigotConfig.bungee && bungeeOnlineMode);
      }

--- a/patches/server/0106-Configurable-flying-kick-messages.patch
+++ b/patches/server/0106-Configurable-flying-kick-messages.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable flying kick messages
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e2e96dd87c08e749fd513db2156d49f18dee8eb8..ac2c7977e2110feb7c45856d6f0a0ccdeedfcdb3 100644
+index 6c13fe725ca2b2a6f0f375b80f6c2cb643b9913d..5e23ff0c5e44427a996281ae42fc12c28649e158 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -270,4 +270,11 @@ public class PaperConfig {
+@@ -273,4 +273,11 @@ public class PaperConfig {
          }
          packetInSpamThreshold = getInt("settings.incoming-packet-spam-threshold", 300);
      }

--- a/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
+++ b/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 057397e4a4e86122928c9a016d4b573b5860e9db..e70c930d8ce1a385840b4fcf26fdeb8d8ee853b9 100644
+index 6324c3465cf34cea2e7fd7d8c26a0cbeeb20eefd..097991f2dd8d35fd5bc62e23e7361d47e70da493 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -306,4 +306,9 @@ public class PaperWorldConfig {
+@@ -342,4 +342,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e70c930d8ce1a385840b4fcf26fdeb8d8ee853b9..efdec6529abd5c0e09ee48f9cb4df3cd12bea31b 100644
+index 097991f2dd8d35fd5bc62e23e7361d47e70da493..4bda78d36a64e89bc68885a2a10b40a759720d1a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -311,4 +311,12 @@ public class PaperWorldConfig {
+@@ -347,4 +347,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index efdec6529abd5c0e09ee48f9cb4df3cd12bea31b..b2b3f336ac4e5d9c2598ecc7b3202d1efdd55feb 100644
+index 4bda78d36a64e89bc68885a2a10b40a759720d1a..bfb83d85601f6e3298395c8424cf4476797a2e79 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -319,4 +319,14 @@ public class PaperWorldConfig {
+@@ -355,4 +355,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b2b3f336ac4e5d9c2598ecc7b3202d1efdd55feb..91e9672d01b6042d6f9a0f96c351ad97dfee0b73 100644
+index bfb83d85601f6e3298395c8424cf4476797a2e79..299f4b5967a740429b2074161449a27941f5c387 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -329,4 +329,10 @@ public class PaperWorldConfig {
+@@ -365,4 +365,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }
@@ -27,7 +27,7 @@ index b2b3f336ac4e5d9c2598ecc7b3202d1efdd55feb..91e9672d01b6042d6f9a0f96c351ad97
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 6211a425e81f9ba9718af6c30e534d35b10bad02..bf52f5f9b13e8b4eb3c7ee19b0e57bb872d2af1d 100644
+index 700cf06b588f4a6d25fc5050cc94ba56e2e2c4f9..56c05c91fc0306437c97339589268e8a4c2c5d76 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -322,6 +322,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -39,7 +39,7 @@ index 6211a425e81f9ba9718af6c30e534d35b10bad02..bf52f5f9b13e8b4eb3c7ee19b0e57bb8
      // Spigot end
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4f915072f9847327ec4fa5b33541f7105bc7fff6..5f24963bd2681cab15d20221154a9a758be53b03 100644
+index 84c7955cb6eacf7d552a2310b7820453cfb3e999..2940738eb6ac4aba76bd67fc10392b525f07f3f0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3228,8 +3228,11 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0134-Properly-handle-async-calls-to-restart-the-server.patch
+++ b/patches/server/0134-Properly-handle-async-calls-to-restart-the-server.patch
@@ -30,7 +30,7 @@ will have plugins and worlds saving to the disk has a high potential to result
 in corruption/dataloss.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 79270b3969c6c05a5a90756a88f3547b64cf5f3b..2e0bd32ebe06e39b3dc889be9b06e2d0047c1068 100644
+index 9c73d69658de96b8216c7d945521af84d41c69ab..0b70123deec6470c8bcf46df7418086f31e893fe 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -232,6 +232,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -41,7 +41,7 @@ index 79270b3969c6c05a5a90756a88f3547b64cf5f3b..2e0bd32ebe06e39b3dc889be9b06e2d0
      private boolean stopped;
      private int tickCount;
      protected final Proxy proxy;
-@@ -941,7 +942,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -942,7 +943,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          if (this.playerList != null) {
              MinecraftServer.LOGGER.info("Saving players");
              this.playerList.saveAll();
@@ -50,7 +50,7 @@ index 79270b3969c6c05a5a90756a88f3547b64cf5f3b..2e0bd32ebe06e39b3dc889be9b06e2d0
              try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
  
-@@ -1007,6 +1008,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1008,6 +1009,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
  
      public void halt(boolean flag) {

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 91e9672d01b6042d6f9a0f96c351ad97dfee0b73..f4c80bc26f4f7cf02d368df4d9717cf1ca3e0730 100644
+index 299f4b5967a740429b2074161449a27941f5c387..c93346af613c50c7797c991c0b3bb6565729129f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -335,4 +335,10 @@ public class PaperWorldConfig {
+@@ -371,4 +371,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }
@@ -26,7 +26,7 @@ index 91e9672d01b6042d6f9a0f96c351ad97dfee0b73..f4c80bc26f4f7cf02d368df4d9717cf1
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 6eb01dcf59fda2656b6d93b0c39380302665f930..41f1b355a8a90216964e89432244a7d6929c9152 100644
+index b10cc589871f2d35704f5f58b4902101904a1d8f..ab33f49318132a78402726a88e49bb58bc9a9de8 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2044,6 +2044,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add configuration option to prevent player names from being
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ac2c7977e2110feb7c45856d6f0a0ccdeedfcdb3..fa6beae844354849e73a45cf38eb1f0669c01e93 100644
+index 5e23ff0c5e44427a996281ae42fc12c28649e158..7a69f9d9bb9c05474d8fbab22d626529a41a66a1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -277,4 +277,9 @@ public class PaperConfig {
+@@ -280,4 +280,9 @@ public class PaperConfig {
          flyingKickPlayerMessage = getString("messages.kick.flying-player", flyingKickPlayerMessage);
          flyingKickVehicleMessage = getString("messages.kick.flying-vehicle", flyingKickVehicleMessage);
      }

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -112,7 +112,7 @@ index 0000000000000000000000000000000000000000..685deaa0e5d1ddc13e3a7c0471b1cfcf
 +
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 2e0bd32ebe06e39b3dc889be9b06e2d0047c1068..9a8779bed2a2fa7dc869d3283c59dbc132df8968 100644
+index 0b70123deec6470c8bcf46df7418086f31e893fe..031bd2ed5c6fd2a859e8a69c48db3938cf71d61b 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -9,6 +9,7 @@ import com.mojang.authlib.GameProfile;
@@ -160,7 +160,7 @@ index 2e0bd32ebe06e39b3dc889be9b06e2d0047c1068..9a8779bed2a2fa7dc869d3283c59dbc1
          Runtime.getRuntime().addShutdownHook(new org.bukkit.craftbukkit.util.ServerShutdownThread(this));
      }
      // CraftBukkit end
-@@ -1185,7 +1190,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1186,7 +1191,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  org.spigotmc.WatchdogThread.doStop(); // Spigot
                  // CraftBukkit start - Restore terminal to original settings
                  try {
@@ -169,7 +169,7 @@ index 2e0bd32ebe06e39b3dc889be9b06e2d0047c1068..9a8779bed2a2fa7dc869d3283c59dbc1
                  } catch (Exception ignored) {
                  }
                  // CraftBukkit end
-@@ -1574,7 +1579,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1575,7 +1580,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public void sendMessage(Component message, UUID sender) {

--- a/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f4c80bc26f4f7cf02d368df4d9717cf1ca3e0730..e6c29e08b20734c3f64e1d596d103a5c1fbb6920 100644
+index c93346af613c50c7797c991c0b3bb6565729129f..e2894138d3efb32161087ad2a1093b8c15c56a65 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -341,4 +341,10 @@ public class PaperWorldConfig {
+@@ -377,4 +377,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
+++ b/patches/server/0156-Allow-specifying-a-custom-authentication-servers-dow.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Allow specifying a custom "authentication servers down" kick
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index fa6beae844354849e73a45cf38eb1f0669c01e93..5bb6f09d138f981329378edab707f8275cdfc5a0 100644
+index 7a69f9d9bb9c05474d8fbab22d626529a41a66a1..f4735cc330822183e098a67f2c0f00f21db9e137 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -1,5 +1,6 @@
@@ -16,7 +16,7 @@ index fa6beae844354849e73a45cf38eb1f0669c01e93..5bb6f09d138f981329378edab707f827
  import com.google.common.base.Throwables;
  
  import java.io.File;
-@@ -282,4 +283,9 @@ public class PaperConfig {
+@@ -285,4 +286,9 @@ public class PaperConfig {
      private static void suggestPlayersWhenNull() {
          suggestPlayersWhenNullTabCompletions = getBoolean("settings.suggest-player-names-when-null-tab-completions", suggestPlayersWhenNullTabCompletions);
      }

--- a/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
+++ b/patches/server/0172-Make-max-squid-spawn-height-configurable.patch
@@ -7,10 +7,10 @@ I don't know why upstream made only the minimum height configurable but
 whatever
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e6c29e08b20734c3f64e1d596d103a5c1fbb6920..b6e762fbb79d19affb93e10ed0cbe29c2d0b6c22 100644
+index e2894138d3efb32161087ad2a1093b8c15c56a65..5892823425055efb92bf635b035d62981942b966 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -347,4 +347,9 @@ public class PaperWorldConfig {
+@@ -383,4 +383,9 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }

--- a/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0181-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b6e762fbb79d19affb93e10ed0cbe29c2d0b6c22..0f1252ae47df5568b6844e76dceb3e8e4c8394c8 100644
+index 5892823425055efb92bf635b035d62981942b966..0e08f6e566d1c93cc89a179583d0b0939127de8b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -197,6 +197,11 @@ public class PaperWorldConfig {
+@@ -233,6 +233,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  

--- a/patches/server/0183-Implement-extended-PaperServerListPingEvent.patch
+++ b/patches/server/0183-Implement-extended-PaperServerListPingEvent.patch
@@ -190,7 +190,7 @@ index 67455a5ba75c9b816213e44d6872c5ddf8e27e98..23efad80934930beadf15e65781551d4
  
      public ClientboundStatusResponsePacket(ServerStatus metadata) {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 9a8779bed2a2fa7dc869d3283c59dbc132df8968..1bffdc632a19318325b60ef737f9e8555ae40230 100644
+index 031bd2ed5c6fd2a859e8a69c48db3938cf71d61b..d9fab29a066367a5cf4a3486989fa7f35451801e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -2,6 +2,9 @@ package net.minecraft.server;
@@ -203,7 +203,7 @@ index 9a8779bed2a2fa7dc869d3283c59dbc132df8968..1bffdc632a19318325b60ef737f9e855
  import com.google.common.collect.Lists;
  import com.google.common.collect.Maps;
  import com.google.common.collect.Sets;
-@@ -1330,7 +1333,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1331,7 +1334,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          if (i - this.lastServerStatus >= 5000000000L) {
              this.lastServerStatus = i;
              this.status.setPlayers(new ServerStatus.Players(this.getMaxPlayers(), this.getPlayerCount()));

--- a/patches/server/0188-Upstream-config-migrations.patch
+++ b/patches/server/0188-Upstream-config-migrations.patch
@@ -7,10 +7,10 @@ This patch contains config migrations for when upstream adds options
 which Paper already had.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5bb6f09d138f981329378edab707f8275cdfc5a0..3d5fd6be97bef7ec47893a85cae771f4a4451092 100644
+index f4735cc330822183e098a67f2c0f00f21db9e137..c5c82496524705a0ce85df5508ec730c19246ec7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -288,4 +288,22 @@ public class PaperConfig {
+@@ -291,4 +291,22 @@ public class PaperConfig {
      private static void authenticationServersDownKickMessage() {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }

--- a/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0193-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0f1252ae47df5568b6844e76dceb3e8e4c8394c8..f3ce248c576643ec172ba42c4bea41a59cfe9ec6 100644
+index 0e08f6e566d1c93cc89a179583d0b0939127de8b..4e0f61179e3b2ae91811746d32b24998173a922c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -357,4 +357,9 @@ public class PaperWorldConfig {
+@@ -393,4 +393,9 @@ public class PaperWorldConfig {
      private void squidMaxSpawnHeight() {
          squidMaxSpawnHeight = getDouble("squid-spawn-height.maximum", 0.0D);
      }

--- a/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0197-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f3ce248c576643ec172ba42c4bea41a59cfe9ec6..10f7437d62bfa774309d6334ca791505254bcaf7 100644
+index 4e0f61179e3b2ae91811746d32b24998173a922c..a0937dd52e4a2aa1bfadcbd1ac0dc2cb26d59cf0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -362,4 +362,10 @@ public class PaperWorldConfig {
+@@ -398,4 +398,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
+++ b/patches/server/0209-Configurable-Alternative-LootPool-Luck-Formula.patch
@@ -36,10 +36,10 @@ This change will result in some major changes to fishing formulas.
 I would love to see this change in Vanilla, so Mojang please pull :)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 3d5fd6be97bef7ec47893a85cae771f4a4451092..ce4ab03a40fac6a840f4c4b78da0a96bb6fb6823 100644
+index c5c82496524705a0ce85df5508ec730c19246ec7..8ecd1e851cc2168c538947623e1c328e463b52d9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -306,4 +306,12 @@ public class PaperConfig {
+@@ -309,4 +309,12 @@ public class PaperConfig {
              SpigotConfig.save();
          }
      }

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 10f7437d62bfa774309d6334ca791505254bcaf7..6d2d82c24c9f43fab2cddee03960325c15708a58 100644
+index a0937dd52e4a2aa1bfadcbd1ac0dc2cb26d59cf0..4dce401da0e0fdf985ecb90f37b92e16cf210d25 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -368,4 +368,9 @@ public class PaperWorldConfig {
+@@ -404,4 +404,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/patches/server/0218-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6d2d82c24c9f43fab2cddee03960325c15708a58..cd2bf3596e2d1cb5bbffa727976a9bee9319dcf5 100644
+index 4dce401da0e0fdf985ecb90f37b92e16cf210d25..35c6978eaf25ed505f99e42a58d388c62fde8319 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -373,4 +373,9 @@ public class PaperWorldConfig {
+@@ -409,4 +409,9 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }

--- a/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0232-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index cd2bf3596e2d1cb5bbffa727976a9bee9319dcf5..0edbd0bf3d7d71b73bcf5cb9da233e8dcfca346f 100644
+index 35c6978eaf25ed505f99e42a58d388c62fde8319..0fd29d5854d9d6155ea590f86d4492d86afab433 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -378,4 +378,9 @@ public class PaperWorldConfig {
+@@ -414,4 +414,9 @@ public class PaperWorldConfig {
      private void scanForLegacyEnderDragon() {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }

--- a/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/server/0234-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0edbd0bf3d7d71b73bcf5cb9da233e8dcfca346f..3c7af3c4dc864c1143451350861e64093a2f5a06 100644
+index 0fd29d5854d9d6155ea590f86d4492d86afab433..ff6cf94dec708c6d3cac837ca03be2fe12d5e05f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -383,4 +383,10 @@ public class PaperWorldConfig {
+@@ -419,4 +419,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
+++ b/patches/server/0241-Break-up-and-make-tab-spam-limits-configurable.patch
@@ -22,10 +22,10 @@ to take the burden of this into their own hand without having to rely on
 plugins doing unsafe things.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ce4ab03a40fac6a840f4c4b78da0a96bb6fb6823..a6d27dcdf954bc2682aba1d9efab42d2d626f8da 100644
+index 8ecd1e851cc2168c538947623e1c328e463b52d9..1508afe593a1b62e3a33455707e2552468786614 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -314,4 +314,18 @@ public class PaperConfig {
+@@ -317,4 +317,18 @@ public class PaperConfig {
              Bukkit.getLogger().log(Level.INFO, "Using Aikar's Alternative Luck Formula to apply Luck attribute to all loot pool calculations. See https://luckformula.emc.gs");
          }
      }

--- a/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
+++ b/patches/server/0245-Add-Early-Warning-Feature-to-WatchDog.patch
@@ -9,7 +9,7 @@ thread dumps at an interval until the point of crash.
 This will help diagnose what was going on in that time before the crash.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d70232b824f3 100644
+index 1508afe593a1b62e3a33455707e2552468786614..73b49d24cd428e2328d56f5f42333a25a1d6ebae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -25,6 +25,7 @@ import org.bukkit.configuration.file.YamlConfiguration;
@@ -20,7 +20,7 @@ index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d702
  
  public class PaperConfig {
  
-@@ -315,6 +316,14 @@ public class PaperConfig {
+@@ -318,6 +319,14 @@ public class PaperConfig {
          }
      }
  
@@ -36,10 +36,10 @@ index a6d27dcdf954bc2682aba1d9efab42d2d626f8da..dd81701230133442186524e9cd65d702
      public static int tabSpamLimit = 500;
      private static void tabSpamLimiters() {
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1bffdc632a19318325b60ef737f9e8555ae40230..7b760a65cad1f7dd5adb3a05b8b5ed7d0f49c0a9 100644
+index d9fab29a066367a5cf4a3486989fa7f35451801e..13f94e196ffd9f37e8049a4a76bc83389ff58d84 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1100,6 +1100,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1101,6 +1101,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.updateStatusIcon(this.status);
  
                  // Spigot start

--- a/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/patches/server/0253-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3c7af3c4dc864c1143451350861e64093a2f5a06..316978a376f57b420c946e87c16f2bc3b09425e1 100644
+index ff6cf94dec708c6d3cac837ca03be2fe12d5e05f..29703f57969b80e25ff9a4971e640f34fb212edf 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -389,4 +389,10 @@ public class PaperWorldConfig {
+@@ -425,4 +425,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
+++ b/patches/server/0260-Asynchronous-chunk-IO-and-loading.patch
@@ -169,7 +169,7 @@ index 15e71c00f98721e609dfab341395313db95cdfc7..c29da813f5fcba07860314914180c9d9
  import com.google.common.base.Strings;
  import com.google.common.base.Throwables;
  
-@@ -337,4 +338,58 @@ public class PaperConfig {
+@@ -340,4 +341,58 @@ public class PaperConfig {
          }
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
@@ -2303,10 +2303,10 @@ index fb0b3c5770f66cc3590f5ac4e690a33cb6179be3..7ce854edba32ffcafaa5268d4bb2822a
                  DedicatedServer dedicatedserver1 = new DedicatedServer(optionset, datapackconfiguration1, thread, iregistrycustom_dimension, convertable_conversionsession, resourcepackrepository, datapackresources, null, dedicatedserversettings, DataFixers.getDataFixer(), minecraftsessionservice, gameprofilerepository, usercache, LoggerChunkProgressListener::new);
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 7b760a65cad1f7dd5adb3a05b8b5ed7d0f49c0a9..00920e574ee1f104781d1f776d88ec9cd45eda93 100644
+index 13f94e196ffd9f37e8049a4a76bc83389ff58d84..50d4948034036b0ec6cdf447f03743baa33ab2ac 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1000,7 +1000,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1001,7 +1001,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getProfileCache().save(false); // Paper
          }
          // Spigot end

--- a/patches/server/0273-Configurable-connection-throttle-kick-message.patch
+++ b/patches/server/0273-Configurable-connection-throttle-kick-message.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable connection throttle kick message
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8a1f581bd7ef8a20329813dedb5bb952e32d41ae..69ad59f0faf1e9a1134d0a460b49569f670055f0 100644
+index a89ccdf2ea517d2ec38c9433bdc26802884ed988..da21f1623a90ade429723d4eb12d646aaf28071e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -291,6 +291,11 @@ public class PaperConfig {
+@@ -294,6 +294,11 @@ public class PaperConfig {
          authenticationServersDownKickMessage = Strings.emptyToNull(getString("messages.kick.authentication-servers-down", authenticationServersDownKickMessage));
      }
  

--- a/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
+++ b/patches/server/0280-Add-Velocity-IP-Forwarding-Support.patch
@@ -14,7 +14,7 @@ forwarding, and is integrated into the Minecraft login process by using the 1.13
 login plugin message packet.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 69ad59f0faf1e9a1134d0a460b49569f670055f0..4b4fbd8747740111cc2e25f0c4d29a29926a3a1b 100644
+index da21f1623a90ade429723d4eb12d646aaf28071e..1015fcc6c77bd64c3f3cbf234e85a6602dbfa0d7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -9,6 +9,7 @@ import java.io.IOException;
@@ -25,7 +25,7 @@ index 69ad59f0faf1e9a1134d0a460b49569f670055f0..4b4fbd8747740111cc2e25f0c4d29a29
  import java.util.HashMap;
  import java.util.List;
  import java.util.Map;
-@@ -262,7 +263,7 @@ public class PaperConfig {
+@@ -265,7 +266,7 @@ public class PaperConfig {
      }
  
      public static boolean isProxyOnlineMode() {
@@ -34,7 +34,7 @@ index 69ad59f0faf1e9a1134d0a460b49569f670055f0..4b4fbd8747740111cc2e25f0c4d29a29
      }
  
      public static int packetInSpamThreshold = 300;
-@@ -344,6 +345,20 @@ public class PaperConfig {
+@@ -347,6 +348,20 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0284-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 316978a376f57b420c946e87c16f2bc3b09425e1..2a7d31f533240e0b683c00d65f5632d7a8ff236d 100644
+index 29703f57969b80e25ff9a4971e640f34fb212edf..84b0304c538766949990f26f1e4a792a633f67f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -395,4 +395,9 @@ public class PaperWorldConfig {
+@@ -431,4 +431,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }
@@ -20,7 +20,7 @@ index 316978a376f57b420c946e87c16f2bc3b09425e1..2a7d31f533240e0b683c00d65f5632d7
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 912171f8b3280a6c45311104216e04d661daff8a..38a48add445e8dd6888bc5bb22e7bf5482682536 100644
+index cec99a9e7ab4efef9e7eda723821e9d7bf854946..00a12243a2981903653825edb507b96eb646fd47 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -531,6 +531,13 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0288-Optimize-World-Time-Updates.patch
+++ b/patches/server/0288-Optimize-World-Time-Updates.patch
@@ -8,10 +8,10 @@ the updates per world, so that we can re-use the same packet
 object for every player unless they have per-player time enabled.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index a9f40f74cbd35533c6a334020c4f3ecd7ced3a43..62f42de43835a4cca56ab092bd407f2aa9a5e314 100644
+index 7cc7918628937dcc14538fe4784bfd6fa068e393..e7fefa95597d4c7388052731a79b8c7c55d2a766 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1407,12 +1407,24 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1408,12 +1408,24 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          MinecraftTimings.timeUpdateTimer.startTiming(); // Spigot // Paper
          // Send time updates to everyone, it will get the right time from the world the player is in.

--- a/patches/server/0294-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0294-Make-the-default-permission-message-configurable.patch
@@ -18,7 +18,7 @@ index 1fa190e098079522e0fe3593fa261c1b7ad4e24b..1eb45df9dca5d0c31ac46709e706136a
      }
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4b4fbd8747740111cc2e25f0c4d29a29926a3a1b..26ac165135ef53cec9e065ae1c15220a8fba5869 100644
+index 1015fcc6c77bd64c3f3cbf234e85a6602dbfa0d7..769353df1fcdaacecd80085165a1d72f99b577ee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -20,6 +20,7 @@ import java.util.regex.Pattern;
@@ -29,7 +29,7 @@ index 4b4fbd8747740111cc2e25f0c4d29a29926a3a1b..26ac165135ef53cec9e065ae1c15220a
  import org.bukkit.command.Command;
  import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.InvalidConfigurationException;
-@@ -297,6 +298,11 @@ public class PaperConfig {
+@@ -300,6 +301,11 @@ public class PaperConfig {
          connectionThrottleKickMessage = getString("messages.kick.connection-throttle", connectionThrottleKickMessage);
      }
  

--- a/patches/server/0299-Book-Size-Limits.patch
+++ b/patches/server/0299-Book-Size-Limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Book Size Limits
 Puts some limits on the size of books.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 26ac165135ef53cec9e065ae1c15220a8fba5869..34e82edf683a33f140f3b4580b3245f29a775fcd 100644
+index 769353df1fcdaacecd80085165a1d72f99b577ee..4875e323e8ba52cf91259262b8418310061718ad 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -365,6 +365,13 @@ public class PaperConfig {
+@@ -368,6 +368,13 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0321-Server-Tick-Events.patch
+++ b/patches/server/0321-Server-Tick-Events.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Server Tick Events
 Fires event at start and end of a server tick
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 62f42de43835a4cca56ab092bd407f2aa9a5e314..3a7bf5483380624e50ab3cbcd48aa5e34f807f51 100644
+index e7fefa95597d4c7388052731a79b8c7c55d2a766..1a7a9315893887227da8bc39230b656b79f96f49 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1329,6 +1329,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1330,6 +1330,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          });
          isOversleep = false;MinecraftTimings.serverOversleep.stopTiming();
          // Paper end
@@ -17,7 +17,7 @@ index 62f42de43835a4cca56ab092bd407f2aa9a5e314..3a7bf5483380624e50ab3cbcd48aa5e3
  
          ++this.tickCount;
          this.tickChildren(shouldKeepTicking);
-@@ -1373,6 +1374,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1374,6 +1375,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
          // Paper end
  

--- a/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0328-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -16,10 +16,10 @@ handling that should have been handled synchronously will be handled
 synchronously when the server gets shut down.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3a7bf5483380624e50ab3cbcd48aa5e34f807f51..3ca73d8c4709d6a95bc8f6b81b977a069f9cba17 100644
+index 1a7a9315893887227da8bc39230b656b79f96f49..8fc9c88a3e4733505dcb53bad1bfdffcb7a2bfc2 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2287,7 +2287,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2288,7 +2288,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit start
      @Override
      public boolean isSameThread() {

--- a/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0330-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2a7d31f533240e0b683c00d65f5632d7a8ff236d..3816623fa85db14a89bd165221695de1a39e70c0 100644
+index 84b0304c538766949990f26f1e4a792a633f67f4..70fc301b25fb1e2271255b3d3b6facaf0cb87bad 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -36,6 +36,12 @@ public class PaperWorldConfig {
+@@ -55,6 +55,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -23,10 +23,10 @@ index 2a7d31f533240e0b683c00d65f5632d7a8ff236d..3816623fa85db14a89bd165221695de1
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 3ca73d8c4709d6a95bc8f6b81b977a069f9cba17..d284ed9d1cc6ea3ee2e7878faf43184507f91186 100644
+index 6c86d1d8c43448f4c83084a731bedd92d85b01fc..ad4ff2f7ee8d01ff3a49b9b2a8feb59131ae5afb 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -787,35 +787,36 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -788,35 +788,36 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      // CraftBukkit start
      public void loadSpawn(ChunkProgressListener worldloadlistener, ServerLevel worldserver) {
@@ -75,7 +75,7 @@ index 3ca73d8c4709d6a95bc8f6b81b977a069f9cba17..d284ed9d1cc6ea3ee2e7878faf431845
  
          if (true) {
              ServerLevel worldserver1 = worldserver;
-@@ -838,7 +839,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -839,7 +840,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // this.nextTick = SystemUtils.getMonotonicMillis() + 10L;
          this.executeModerately();
          // CraftBukkit end
@@ -85,7 +85,7 @@ index 3ca73d8c4709d6a95bc8f6b81b977a069f9cba17..d284ed9d1cc6ea3ee2e7878faf431845
          // CraftBukkit start
          // this.updateSpawnFlags();
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 174f94b8bc5b3830ff5bcfb9777f3d57c1f781ff..b3d54c90e87347cb7c709059c090371a40c7b047 100644
+index 891633981124a5b864af0f9bd50f11e48da2835d..1befd73091687cdda980d74a22b1909a4dc0038b 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -61,6 +61,7 @@ import net.minecraft.network.protocol.game.ClientboundSoundEntityPacket;

--- a/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0338-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3816623fa85db14a89bd165221695de1a39e70c0..9d52060319e6a0403c9979766c761e2f5324f6aa 100644
+index 70fc301b25fb1e2271255b3d3b6facaf0cb87bad..6295242e1926ae3f03c304f3372dcca16a84bf3f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -406,4 +406,15 @@ public class PaperWorldConfig {
+@@ -442,4 +442,15 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
@@ -37,7 +37,7 @@ index 3816623fa85db14a89bd165221695de1a39e70c0..9d52060319e6a0403c9979766c761e2f
  }
 +
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index c8b9877135aebf1f500ab9b00d94dde0e846d247..eeefd5b5d1cd4c1b38e706210fd0e56b17969b18 100644
+index 7891ee828b030814034e6e1def7938a31fbe4fdd..461b64232c0f04e17e168f1e7f7857ee555200fc 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -85,6 +85,13 @@ public final class NaturalSpawner {

--- a/patches/server/0339-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0339-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9d52060319e6a0403c9979766c761e2f5324f6aa..de1820a6b0e568bbc13eea7a31e5cd40234c0f66 100644
+index 6295242e1926ae3f03c304f3372dcca16a84bf3f..d9437b3ef3919bff5d2eebd8b5e016ddb7a0e793 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -416,5 +416,10 @@ public class PaperWorldConfig {
+@@ -452,5 +452,10 @@ public class PaperWorldConfig {
              log("Using improved mob spawn limits (Only Natural Spawns impact spawn limits for more natural spawns)");
          }
      }

--- a/patches/server/0341-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
+++ b/patches/server/0341-Do-less-work-if-we-have-a-custom-Bukkit-generator.patch
@@ -7,10 +7,10 @@ If the Bukkit generator already has a spawn, use it immediately instead
 of spending time generating one that we won't use
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index d284ed9d1cc6ea3ee2e7878faf43184507f91186..728719e488444ada53698a4aa7ac66ded324bf67 100644
+index cae3c20eba546dcf42d035e9a5998302df350d4b..7ef0c9c8edf1202d0e20a505b18f9d36bdc20139 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -690,12 +690,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -691,12 +691,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              worldProperties.setSpawn(BlockPos.ZERO.above(80), 0.0F);
          } else {
              ChunkGenerator chunkgenerator = world.getChunkSource().getGenerator();
@@ -24,7 +24,7 @@ index d284ed9d1cc6ea3ee2e7878faf43184507f91186..728719e488444ada53698a4aa7ac66de
              // CraftBukkit start
              if (world.generator != null) {
                  Random rand = new Random(world.getSeed());
-@@ -711,6 +706,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -712,6 +707,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  }
              }
              // CraftBukkit end

--- a/patches/server/0344-Generator-Settings.patch
+++ b/patches/server/0344-Generator-Settings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Generator Settings
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index de1820a6b0e568bbc13eea7a31e5cd40234c0f66..d3cd79cf51bc7bead548549c25d5ae7b67d704c3 100644
+index d9437b3ef3919bff5d2eebd8b5e016ddb7a0e793..d3da5175ce1075511229ea52f1237898bcae9a11 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -421,5 +421,10 @@ public class PaperWorldConfig {
+@@ -457,5 +457,10 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }
@@ -20,7 +20,7 @@ index de1820a6b0e568bbc13eea7a31e5cd40234c0f66..d3cd79cf51bc7bead548549c25d5ae7b
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 6a676995b157702b4bd423ff8590b6c682102b61..0f88ab98f8f33265dc223d55f4afae60230d9afe 100644
+index fcd25c4476e2afcf4e676dca7a8abad9cc112bef..41253d8adf85cf318fcb1cee36ac1763f440fca6 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -726,7 +726,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider

--- a/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
+++ b/patches/server/0348-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d3cd79cf51bc7bead548549c25d5ae7b67d704c3..216eda49d1540c857e2c108c3d3e2e135ef90013 100644
+index d3da5175ce1075511229ea52f1237898bcae9a11..a9ab8cbb739a72222dc7775f52ef2cfdc49fd29f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -426,5 +426,10 @@ public class PaperWorldConfig {
+@@ -462,5 +462,10 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", false);
      }

--- a/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/patches/server/0351-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 216eda49d1540c857e2c108c3d3e2e135ef90013..2bfab88523bd5825db29b6a00b5bc1aa40324de8 100644
+index a9ab8cbb739a72222dc7775f52ef2cfdc49fd29f..72fc65fde0be760ef6a98d26ee7adf45c8a0242e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -431,5 +431,10 @@ public class PaperWorldConfig {
+@@ -467,5 +467,10 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2bfab88523bd5825db29b6a00b5bc1aa40324de8..031829d1ba1e859368878245fe0edb6fbe726821 100644
+index 72fc65fde0be760ef6a98d26ee7adf45c8a0242e..8108cbc492dc14e5dd5a183105e89eb0cfb378fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -407,6 +407,45 @@ public class PaperWorldConfig {
+@@ -443,6 +443,45 @@ public class PaperWorldConfig {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
  

--- a/patches/server/0353-Optimize-Hoppers.patch
+++ b/patches/server/0353-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 031829d1ba1e859368878245fe0edb6fbe726821..d01f5df4ec18a35fbf6222d76a2617a07f20a87b 100644
+index 8108cbc492dc14e5dd5a183105e89eb0cfb378fe..0705e04b395938fc7ef7b759813d979de3a899f4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -475,5 +475,14 @@ public class PaperWorldConfig {
+@@ -511,5 +511,14 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }
@@ -32,10 +32,10 @@ index 031829d1ba1e859368878245fe0edb6fbe726821..d01f5df4ec18a35fbf6222d76a2617a0
  }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 728719e488444ada53698a4aa7ac66ded324bf67..8284c8690295cf9e57c47f198058c3e4ad39191b 100644
+index fa9d70300ab1ecb83b8a21e5a707dd7ffd7ad74b..bf08c45525cd898ad12d70bec5de3762063af2e0 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1442,6 +1442,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1443,6 +1443,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper

--- a/patches/server/0365-Increase-Light-Queue-Size.patch
+++ b/patches/server/0365-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d01f5df4ec18a35fbf6222d76a2617a07f20a87b..27de7cdc4f3bb5604162f2cc114fcd27a6ed4a14 100644
+index 0705e04b395938fc7ef7b759813d979de3a899f4..5707befe1c64df3e01fe810459d716d550b7daa8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -484,5 +484,10 @@ public class PaperWorldConfig {
+@@ -520,5 +520,10 @@ public class PaperWorldConfig {
          disableHopperMoveEvents = getBoolean("hopper.disable-move-event", disableHopperMoveEvents);
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
@@ -29,10 +29,10 @@ index d01f5df4ec18a35fbf6222d76a2617a07f20a87b..27de7cdc4f3bb5604162f2cc114fcd27
  }
  
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 8284c8690295cf9e57c47f198058c3e4ad39191b..026397cbedd2d1cd08ec8a82a3468f35cd8e4765 100644
+index bf08c45525cd898ad12d70bec5de3762063af2e0..28066e92531d2d8834686f075169007e25caa73d 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -844,7 +844,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -845,7 +845,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.executeModerately();
          // CraftBukkit end
          if (worldserver.getWorld().getKeepSpawnInMemory()) worldloadlistener.stop(); // Paper

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -5,20 +5,23 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 27de7cdc4f3bb5604162f2cc114fcd27a6ed4a14..4dde7eec6afad0b4340631482dc23a9796736d43 100644
+index 5707befe1c64df3e01fe810459d716d550b7daa8..5dd6d78742212ae4756f7bc7d7699521cb280ee0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,7 +1,9 @@
+@@ -1,10 +1,12 @@
  package com.destroystokyo.paper;
  
 +import java.util.Arrays;
  import java.util.List;
  
+ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+ import net.minecraft.world.entity.MobCategory;
 +import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -489,5 +491,40 @@ public class PaperWorldConfig {
+@@ -525,5 +527,40 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -23,10 +23,10 @@ index ee53453440177537fc653ea156785d7591498614..cfe293881f68c8db337c3a48948362bb
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4dde7eec6afad0b4340631482dc23a9796736d43..f3ba9d869179fb4dc86acf1f4d097fb0da701a09 100644
+index 5dd6d78742212ae4756f7bc7d7699521cb280ee0..9d1f14274af2f9af4de9e914f7c4ed10b11d3782 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -492,6 +492,11 @@ public class PaperWorldConfig {
+@@ -528,6 +528,11 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  
@@ -39,7 +39,7 @@ index 4dde7eec6afad0b4340631482dc23a9796736d43..f3ba9d869179fb4dc86acf1f4d097fb0
      public EngineMode engineMode;
      public int maxBlockHeight;
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 892524ffb54a3e4f43e1a6f259a736334bad9b58..6ace1cac8aad9baef045f332d387bbd9a25f360a 100644
+index 2fe519d4059fac06781c30e140895b604e13104f..1d469a9ea0049687d7686f88382ac14514ad3bee 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -641,7 +641,8 @@ public final class MCUtil {
@@ -53,7 +53,7 @@ index 892524ffb54a3e4f43e1a6f259a736334bad9b58..6ace1cac8aad9baef045f332d387bbd9
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
              worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 1ea32090783ac5b885b95ae2009dd61de3063ae0..8d3cdd288eacc91f7c9a624f601284e5cd2a36cc 100644
+index 47b3f4d84a9c7c730d07442ec69c064243d71ee1..84f370e887a3e7ff49296bdf8d6d8de9cc194cfb 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -75,6 +75,17 @@ public class ChunkHolder {
@@ -145,7 +145,7 @@ index 1ea32090783ac5b885b95ae2009dd61de3063ae0..8d3cdd288eacc91f7c9a624f601284e5
  
      public CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> getOrScheduleFuture(ChunkStatus targetStatus, ChunkMap chunkStorage) {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 85a3ccce473604561b5550b2b2b1f4aa02a04415..72471db48a9c67ced8b1ef1ebb3381be4f773e06 100644
+index 5bbdf56179d2e5fd0b42c37c84c9d4bc5faaee24..f6ff29613d09b82185c2b2132d1ed34b0f71c222 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -169,21 +169,68 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -502,7 +502,7 @@ index 45c7ebe67019cdbe88b6617a95d5c40d3a68286c..38eebda226e007c8910e04f502ce218c
                  if (withinViewDistance) {
                      DistanceManager.this.ticketThrottlerInput.tell(ChunkTaskPriorityQueueSorter.message(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 363d86e4a35b87c3fabf7a0e4b6d9e6c2caaf3de..188b549fc56e1394c7119da99e4732065b256388 100644
+index e8cfc0856c33dab2d94bfebd0cc70823a2a4b69c..97d6963b6c7f0fb71324ac760df940fbf03e321f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -242,6 +242,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0369-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0369-Implement-alternative-item-despawn-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f3ba9d869179fb4dc86acf1f4d097fb0da701a09..c2601c8d0635e4150be622fc681c2f4adb55bc59 100644
+index 9d1f14274af2f9af4de9e914f7c4ed10b11d3782..bfcfe431548bf36d50b9bf12957fed59ed9c6984 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -497,6 +497,54 @@ public class PaperWorldConfig {
+@@ -533,6 +533,54 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0372-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0372-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index fe79c0add4f7cb18d487c5bb9415c40c5b551ea2..8d9ddad1879e7616d980ca70de8aecac
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c2601c8d0635e4150be622fc681c2f4adb55bc59..9dfb35654df01cf8fea6cf1842786f8466419729 100644
+index bfcfe431548bf36d50b9bf12957fed59ed9c6984..705dcec93ab60f88bb407b7d75fbc0aca65fb7f8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -579,5 +579,13 @@ public class PaperWorldConfig {
+@@ -615,5 +615,13 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }
@@ -548,7 +548,7 @@ index 0000000000000000000000000000000000000000..11de56afaf059b00fa5bec293516bcdc
 +    }
 +} 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index e6ae3405995c4e472a731311695de7ef9b2d704b..f604fd1a4eb9ac5b7f43962a583183441a680319 100644
+index 15b514aa20370a010ff3ab891d875dc70e41d75a..be9ae4f0f19da069ae44e45a772096bb09918219 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -145,6 +145,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -617,7 +617,7 @@ index 5d920d7df52c12f5f1d1d8111340800cbddaac78..9f71dc37b0cef2284d6abc051b379cfa
  
              this.lastSpawnState = spawnercreature_d;
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 188b549fc56e1394c7119da99e4732065b256388..7adb5ba76810d39c61e25beeb781f384ce96396a 100644
+index 97d6963b6c7f0fb71324ac760df940fbf03e321f..4ca8f2f63e04da730a85a36d57058a481d1f9104 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -224,6 +224,11 @@ public class ServerPlayer extends Player {
@@ -641,7 +641,7 @@ index 188b549fc56e1394c7119da99e4732065b256388..7adb5ba76810d39c61e25beeb781f384
  
      // Yes, this doesn't match Vanilla, but it's the best we can do for now.
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index eeefd5b5d1cd4c1b38e706210fd0e56b17969b18..d69abf154f056883dcd6dc4d9d97d2b772b62368 100644
+index 461b64232c0f04e17e168f1e7f7857ee555200fc..4d8251a961a9c52456db997506dd9691beaec022 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -17,6 +17,7 @@ import net.minecraft.core.Registry;

--- a/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0380-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9dfb35654df01cf8fea6cf1842786f8466419729..6316597c52cb23f3cea81c95c0f7a7a289028537 100644
+index 705dcec93ab60f88bb407b7d75fbc0aca65fb7f8..1eea1d2b0747b904ff30f0c6debb8f04fcbb6923 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -487,6 +487,11 @@ public class PaperWorldConfig {
+@@ -523,6 +523,11 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  
@@ -21,7 +21,7 @@ index 9dfb35654df01cf8fea6cf1842786f8466419729..6316597c52cb23f3cea81c95c0f7a7a2
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index eec286fd4607c1d9a68c9063535bb630f92b6f4a..f8c611a6a55dd56e5231834c9481c61727b628e9 100644
+index bcdf26151eef02f3e37692a71d579ddfe9d3ed59..e198a4b7f8b0db72855461c2741041e67a195f55 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -330,6 +330,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/patches/server/0385-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6316597c52cb23f3cea81c95c0f7a7a289028537..7dbd6fad3824bfe62c6c2a59804fb8723f8745d1 100644
+index 1eea1d2b0747b904ff30f0c6debb8f04fcbb6923..9ce95f6b6b53f6f30d3c9aeaee8938354fc0d3b5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -387,6 +387,11 @@ public class PaperWorldConfig {
+@@ -423,6 +423,11 @@ public class PaperWorldConfig {
          scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
      }
  

--- a/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0386-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7dbd6fad3824bfe62c6c2a59804fb8723f8745d1..1218411afe1e2e3c2ee54aec6287ff33b59afd01 100644
+index 9ce95f6b6b53f6f30d3c9aeaee8938354fc0d3b5..c6e721b19ddc9e01ffbed765aaf52bef50e80b1d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -497,6 +497,11 @@ public class PaperWorldConfig {
+@@ -533,6 +533,11 @@ public class PaperWorldConfig {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
  
@@ -24,7 +24,7 @@ index 7dbd6fad3824bfe62c6c2a59804fb8723f8745d1..1218411afe1e2e3c2ee54aec6287ff33
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 4f328c3281663a55eef879604d713ff38d797298..26200a9680d5fc95b04ba0c70ea20e145c4c220b 100644
+index c3fd3b354812dd690d68b45bc5a179778e4511e0..20d8e705ea432df64917b59f8290aa5400795f4b 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -452,10 +452,13 @@ public class Zombie extends Monster {

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -45,7 +45,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index 26c5ae72f63d930bf6de2ec18a964ddfeca16379..e9954fa75412a7077950e3813af4b201c084f68f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -372,6 +372,13 @@ public class PaperConfig {
+@@ -375,6 +375,13 @@ public class PaperConfig {
          maxBookTotalSizeMultiplier = getDouble("settings.book-size.total-multiplier", maxBookTotalSizeMultiplier);
      }
  

--- a/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0389-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1218411afe1e2e3c2ee54aec6287ff33b59afd01..03c45d4fa891e9f00d4b6b24cfc144086294618b 100644
+index c6e721b19ddc9e01ffbed765aaf52bef50e80b1d..00d1ea2440aecd81fc0e23a06f53890c55424ab3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -474,10 +474,21 @@ public class PaperWorldConfig {
+@@ -510,10 +510,21 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;
@@ -36,7 +36,7 @@ index 1218411afe1e2e3c2ee54aec6287ff33b59afd01..03c45d4fa891e9f00d4b6b24cfc14408
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 7adb5ba76810d39c61e25beeb781f384ce96396a..bbc8f7909b6ae8452a8f3c697bfba92d0170dbe1 100644
+index 4ca8f2f63e04da730a85a36d57058a481d1f9104..f515ef16ef0c92c6cf59301d2818ad714554030a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -220,6 +220,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0397-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index e9954fa75412a7077950e3813af4b201c084f68f..f4b1eb512defda8523ddaba054bde744a4aaeb32 100644
+index 217779a280b70ba5b3bbe1f5412dd149c12b40fa..4bdc154ce5b91c3d5c4b5dc63ff32a7fe094bd37 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -84,10 +84,10 @@ index e9954fa75412a7077950e3813af4b201c084f68f..f4b1eb512defda8523ddaba054bde744
          commands.put("paper", new PaperCommand("paper"));
 +        commands.put("mspt", new MSPTCommand("mspt"));
  
-         version = getInt("config-version", 23);
-         set("config-version", 23);
+         version = getInt("config-version", 24);
+         set("config-version", 24);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 026397cbedd2d1cd08ec8a82a3468f35cd8e4765..74051c9b620516dc2f302b1595e74faf91519962 100644
+index 9683c29c583e8b7e4f41d088160455714033a135..5edbb9132d2895da2b693fe35d4a25000982b636 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -248,6 +248,11 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -102,7 +102,7 @@ index 026397cbedd2d1cd08ec8a82a3468f35cd8e4765..74051c9b620516dc2f302b1595e74faf
      @Nullable
      private KeyPair keyPair;
      @Nullable
-@@ -1391,6 +1396,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1392,6 +1397,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          this.averageTickTime = this.averageTickTime * 0.8F + (float) l / 1000000.0F * 0.19999999F;
          long i1 = Util.getNanos();
  
@@ -115,7 +115,7 @@ index 026397cbedd2d1cd08ec8a82a3468f35cd8e4765..74051c9b620516dc2f302b1595e74faf
          this.frameTimer.logFrameDuration(i1 - i);
          this.profiler.pop();
          org.spigotmc.WatchdogThread.tick(); // Spigot
-@@ -2462,4 +2473,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2463,4 +2474,29 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              };
          }
      }

--- a/patches/server/0402-Improved-Watchdog-Support.patch
+++ b/patches/server/0402-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index e3b605695e3b837246f72ccb364af06ea48bda45..62c3c597732e6fb30ed5367d902ea876
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d7579d912 100644
+index 5edbb9132d2895da2b693fe35d4a25000982b636..42642e923b68e1074ee322d290983370cdf8881f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -299,7 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -93,7 +93,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
      public static <S extends MinecraftServer> S spin(Function<Thread, S> serverFactory) {
          AtomicReference<S> atomicreference = new AtomicReference();
          Thread thread = new Thread(() -> {
-@@ -932,6 +935,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -933,6 +936,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      // CraftBukkit start
      private boolean hasStopped = false;
@@ -101,7 +101,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (this.stopLock) {
-@@ -946,6 +950,19 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -947,6 +951,19 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              if (this.hasStopped) return;
              this.hasStopped = true;
          }
@@ -121,7 +121,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
          // CraftBukkit end
          MinecraftServer.LOGGER.info("Stopping server");
          MinecraftTimings.stopServer(); // Paper
-@@ -1011,7 +1028,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1012,7 +1029,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getProfileCache().save(false); // Paper
          }
          // Spigot end
@@ -140,7 +140,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
      }
  
      public String getLocalIp() {
-@@ -1104,6 +1132,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1105,6 +1133,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      protected void runServer() {
          try {
@@ -148,7 +148,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
              if (this.initServer()) {
                  this.nextTickTime = Util.getMillis();
                  this.status.setDescription(new TextComponent(this.motd));
-@@ -1111,6 +1140,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1112,6 +1141,18 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.updateStatusIcon(this.status);
  
                  // Spigot start
@@ -167,7 +167,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
                  org.spigotmc.WatchdogThread.hasStarted = true; // Paper
                  Arrays.fill( recentTps, 20 );
                  long start = System.nanoTime(), curTime, tickSection = start; // Paper - Further improve server tick loop
-@@ -1167,6 +1208,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1168,6 +1209,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  this.onServerCrash((CrashReport) null);
              }
          } catch (Throwable throwable) {
@@ -180,7 +180,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
              MinecraftServer.LOGGER.error("Encountered an unexpected exception", throwable);
              // Spigot Start
              if ( throwable.getCause() != null )
-@@ -1202,14 +1249,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1203,14 +1250,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              } catch (Throwable throwable1) {
                  MinecraftServer.LOGGER.error("Exception stopping the server", throwable1);
              } finally {
@@ -198,7 +198,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
              }
  
          }
-@@ -1248,6 +1295,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1249,6 +1296,12 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      @Override
      public TickTask wrapRunnable(Runnable runnable) {
@@ -211,7 +211,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
          return new TickTask(this.tickCount, runnable);
      }
  
-@@ -1483,6 +1536,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1484,6 +1537,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  try {
                      crashreport = CrashReport.forThrowable(throwable, "Exception ticking world");
                  } catch (Throwable t) {
@@ -219,7 +219,7 @@ index 74051c9b620516dc2f302b1595e74faf91519962..67858a375fba9b1d5f55d97bd9abfe5d
                      throw new RuntimeException("Error generating crash report", t);
                  }
                  // Spigot End
-@@ -1960,7 +2014,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1961,7 +2015,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(datapacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              datapackresources.updateGlobals();

--- a/patches/server/0420-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0420-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 03c45d4fa891e9f00d4b6b24cfc144086294618b..e146dad0d90fee216630eb3df6a34e2a0f6441a6 100644
+index 00d1ea2440aecd81fc0e23a06f53890c55424ab3..f036c3179f4e7633eac4e1889c029383c291da92 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -518,6 +518,13 @@ public class PaperWorldConfig {
+@@ -554,6 +554,13 @@ public class PaperWorldConfig {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
  

--- a/patches/server/0428-misc-debugging-dumps.patch
+++ b/patches/server/0428-misc-debugging-dumps.patch
@@ -29,10 +29,10 @@ index 0000000000000000000000000000000000000000..2d5494d2813b773e60ddba6790b750a9
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 67858a375fba9b1d5f55d97bd9abfe5d7579d912..02158eee02ca4735015e768f7bd03c36fc9942f0 100644
+index 42642e923b68e1074ee322d290983370cdf8881f..d986d03ee40866880ff7a4f39e83b06e1bcc7b6e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -936,6 +936,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -937,6 +937,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      // CraftBukkit start
      private boolean hasStopped = false;
      public volatile boolean hasFullyShutdown = false; // Paper
@@ -40,7 +40,7 @@ index 67858a375fba9b1d5f55d97bd9abfe5d7579d912..02158eee02ca4735015e768f7bd03c36
      private final Object stopLock = new Object();
      public final boolean hasStopped() {
          synchronized (this.stopLock) {
-@@ -950,6 +951,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -951,6 +952,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              if (this.hasStopped) return;
              this.hasStopped = true;
          }
@@ -48,7 +48,7 @@ index 67858a375fba9b1d5f55d97bd9abfe5d7579d912..02158eee02ca4735015e768f7bd03c36
          // Paper start - kill main thread, and kill it hard
          shutdownThread = Thread.currentThread();
          org.spigotmc.WatchdogThread.doStop(); // Paper
-@@ -1060,6 +1062,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1061,6 +1063,8 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
      }
      public void safeShutdown(boolean flag, boolean isRestarting) {
          this.isRestarting = isRestarting;

--- a/patches/server/0429-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0429-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -95,10 +95,10 @@ index a482ad74b9a5d06a982ac2a6d9b6c5dc9f664f46..974f0bbbd3d271d28ce884490dc68b68
      exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index f4b1eb512defda8523ddaba054bde744a4aaeb32..14416856fde78bccbf53fa60f17c82588a2d11f6 100644
+index 4bdc154ce5b91c3d5c4b5dc63ff32a7fe094bd37..e1d91a95c306e71ac77b3658de77ec9d18c4f8e6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -433,4 +433,9 @@ public class PaperConfig {
+@@ -436,4 +436,9 @@ public class PaperConfig {
              log("Async Chunks: Enabled - Chunks will be loaded much faster, without lag.");
          }
      }

--- a/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0434-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e146dad0d90fee216630eb3df6a34e2a0f6441a6..eb30ec087b90835aba281580b0563d020440be0e 100644
+index f036c3179f4e7633eac4e1889c029383c291da92..16b4711496ce4cc7b8e53de4614836d2590a5704 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -361,6 +361,12 @@ public class PaperWorldConfig {
+@@ -397,6 +397,12 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  

--- a/patches/server/0439-Wait-for-Async-Tasks-during-shutdown.patch
+++ b/patches/server/0439-Wait-for-Async-Tasks-during-shutdown.patch
@@ -10,10 +10,10 @@ Adds a 5 second grace period for any async tasks to finish and warns
 if any are still running after that delay just as reload does.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 02158eee02ca4735015e768f7bd03c36fc9942f0..324ebb1bec9c25fe11b39b637c089836b303d766 100644
+index d986d03ee40866880ff7a4f39e83b06e1bcc7b6e..62b17026df08cc4d8c1dd98f451fc606c92c57f1 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -971,6 +971,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -972,6 +972,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // CraftBukkit start
          if (this.server != null) {
              this.server.disablePlugins();

--- a/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -13,10 +13,10 @@ A config is provided if you rather let players use these exploits, and let
 them destroy the worlds End Portals and get on top of the nether easy.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a8740f03a7feef40490e9f5be610c2c835114f08..155fa55eb859da90d59d01b21ae422bf99ccfa87 100644
+index e1d91a95c306e71ac77b3658de77ec9d18c4f8e6..c9bf57298c7023b2d609d5271609a4070bb1c773 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -438,4 +438,15 @@ public class PaperConfig {
+@@ -441,4 +441,15 @@ public class PaperConfig {
      private static void loggerSettings() {
          deobfuscateStacktraces = getBoolean("settings.loggers.deobfuscate-stacktraces", deobfuscateStacktraces);
      }

--- a/patches/server/0445-Add-option-for-console-having-all-permissions.patch
+++ b/patches/server/0445-Add-option-for-console-having-all-permissions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option for console having all permissions
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 155fa55eb859da90d59d01b21ae422bf99ccfa87..ddf9b5592e2203315d239ab28a338633600c69fc 100644
+index c9bf57298c7023b2d609d5271609a4070bb1c773..31e127151d2a046bf1652a909bc3ea64f95f2d1f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -449,4 +449,9 @@ public class PaperConfig {
+@@ -452,4 +452,9 @@ public class PaperConfig {
          config.set("settings.unsupported-settings.allow-permanent-block-break-exploits-readme", "This setting controls if players should be able to break bedrock, end portals and other intended to be permanent blocks.");
          allowBlockPermanentBreakingExploits = getBoolean("settings.unsupported-settings.allow-permanent-block-break-exploits", allowBlockPermanentBreakingExploits);
      }

--- a/patches/server/0452-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0452-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eb30ec087b90835aba281580b0563d020440be0e..3984d85f1e1833ec199fde1ba64d9c83376b1819 100644
+index 16b4711496ce4cc7b8e53de4614836d2590a5704..22a04bfddccd5a118d6297ca88a5e396b6a884f9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -536,6 +536,15 @@ public class PaperWorldConfig {
+@@ -572,6 +572,15 @@ public class PaperWorldConfig {
          this.noTickViewDistance = this.getInt("viewdistances.no-tick-view-distance", -1);
      }
  

--- a/patches/server/0455-incremental-chunk-saving.patch
+++ b/patches/server/0455-incremental-chunk-saving.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] incremental chunk saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3984d85f1e1833ec199fde1ba64d9c83376b1819..144a8d424cd4f953b1471f20d1521ed1b7639f1a 100644
+index 22a04bfddccd5a118d6297ca88a5e396b6a884f9..f9caed53ffc10300511b576cf822864b101df83d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -44,6 +44,21 @@ public class PaperWorldConfig {
+@@ -63,6 +63,21 @@ public class PaperWorldConfig {
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }
  
@@ -31,7 +31,7 @@ index 3984d85f1e1833ec199fde1ba64d9c83376b1819..144a8d424cd4f953b1471f20d1521ed1
          config.addDefault("world-settings.default." + path, def);
          return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 324ebb1bec9c25fe11b39b637c089836b303d766..b4ca88f9285fb5a55ed5b03355a77fd564ebaa80 100644
+index 4d9326099bdff037e5fe9a6ee14f8610c482ac7a..f07dd72d2ba1b3e1d30dab5973ca3785ea517471 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -298,6 +298,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -42,7 +42,7 @@ index 324ebb1bec9c25fe11b39b637c089836b303d766..b4ca88f9285fb5a55ed5b03355a77fd5
      public Commands vanillaCommandDispatcher;
      public boolean forceTicks; // Paper
      // CraftBukkit end
-@@ -1415,14 +1416,23 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1416,14 +1417,23 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.status.getPlayers().setSample(agameprofile);
          }
  
@@ -72,7 +72,7 @@ index 324ebb1bec9c25fe11b39b637c089836b303d766..b4ca88f9285fb5a55ed5b03355a77fd5
          this.profiler.push("snooper");
          if (((DedicatedServer) this).getProperties().snooperEnabled && !this.snooper.isStarted() && this.tickCount > 100) { // Spigot
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index c6c4d2fd3205dfcaff9e0f1a6b92b74903275991..fe8e6d66665dc8c38e74c0b264cf507f99f83091 100644
+index b9e9bfb6c73cfb309c5d9399817546399b333a12..467449049359c721c27b7cd249b03acc5fb8f3cc 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -111,6 +111,8 @@ public class ChunkHolder {
@@ -139,7 +139,7 @@ index c6c4d2fd3205dfcaff9e0f1a6b92b74903275991..fe8e6d66665dc8c38e74c0b264cf507f
          for (int i = 0; i < this.futures.length(); ++i) {
              CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = (CompletableFuture) this.futures.get(i);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index cec1906adc4d2953b50d262abb1c2cb61cb3ba41..c3b927e612806b3de4ec57bd6f926af35ad1146a 100644
+index d372fb640e34cd451cf79f5b4e03b47c5cb034ab..d70d977290b07fca61fea965a907c9f60a393ba7 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -97,6 +97,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureMana
@@ -260,7 +260,7 @@ index 0ce86c72cb829b816ec7bfb8f0d19396e1b12eb6..e5317a994cb9b30293ad54b8fc537f70
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 35ba86f0104b39903804de86dc5dff81050003bc..86d060691405401fe8ae8ae8ef59322ee841b196 100644
+index 320cd209ab725a9ad4d5dff70987d7efabae5798..012ac1089205411a56576b26c90ff9122146725e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1050,6 +1050,37 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0458-Fix-piston-physics-inconsistency-MC-188840.patch
+++ b/patches/server/0458-Fix-piston-physics-inconsistency-MC-188840.patch
@@ -32,10 +32,10 @@ This patch fixes https://bugs.mojang.com/browse/MC-188840
 This patch also fixes rail duping and carpet duping.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ddf9b5592e2203315d239ab28a338633600c69fc..0ff0a71fe5dc53fa5fb81edffabc69790e3bcd1e 100644
+index 31e127151d2a046bf1652a909bc3ea64f95f2d1f..db2aa6998ab7d2786bb455401f653eec724d53ba 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -454,4 +454,12 @@ public class PaperConfig {
+@@ -457,4 +457,12 @@ public class PaperConfig {
      private static void consoleHasAllPermissions() {
          consoleHasAllPermissions = getBoolean("settings.console-has-all-permissions", consoleHasAllPermissions);
      }

--- a/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
+++ b/patches/server/0468-Fix-Per-World-Difficulty-Remembering-Difficulty.patch
@@ -8,10 +8,10 @@ makes it so that the server keeps the last difficulty used instead
 of restoring the server.properties every single load.
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index b4ca88f9285fb5a55ed5b03355a77fd564ebaa80..58652325de8c3978359a9864bb68da9347990774 100644
+index 4f630156a597f2b8ebe16856d0db2c1723e958cd..335d42592d99d91ae1d99fe1b99122a3bac97a49 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -856,7 +856,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -857,7 +857,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          chunkproviderserver.getLightEngine().setTaskPerBatch(worldserver.paperConfig.lightQueueSize); // Paper - increase light queue size
          // CraftBukkit start
          // this.updateSpawnFlags();
@@ -20,7 +20,7 @@ index b4ca88f9285fb5a55ed5b03355a77fd564ebaa80..58652325de8c3978359a9864bb68da93
  
          this.forceTicks = false;
          // CraftBukkit end
-@@ -1726,11 +1726,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1727,11 +1727,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          }
      }
  
@@ -40,7 +40,7 @@ index b4ca88f9285fb5a55ed5b03355a77fd564ebaa80..58652325de8c3978359a9864bb68da93
          }
      }
  
-@@ -1744,7 +1747,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1745,7 +1748,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
  

--- a/patches/server/0499-Incremental-player-saving.patch
+++ b/patches/server/0499-Incremental-player-saving.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index 4b02a035cec0aa260e67f77c7025d2fb0e85f2eb..0b23250cbbfd947568afcb8c4510b7dea4468380 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -462,4 +462,14 @@ public class PaperConfig {
+@@ -465,4 +465,14 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  
@@ -24,10 +24,10 @@ index 4b02a035cec0aa260e67f77c7025d2fb0e85f2eb..0b23250cbbfd947568afcb8c4510b7de
 +    }
  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 58652325de8c3978359a9864bb68da9347990774..4af56ca699d456eb23794673861323ab06cf6de8 100644
+index 335d42592d99d91ae1d99fe1b99122a3bac97a49..968476493bcea8b4d961e838b142912d3eac91cd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -981,7 +981,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -982,7 +982,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
          if (this.playerList != null) {
              MinecraftServer.LOGGER.info("Saving players");
@@ -35,7 +35,7 @@ index 58652325de8c3978359a9864bb68da9347990774..4af56ca699d456eb23794673861323ab
              this.playerList.removeAll(this.isRestarting); // Paper
              try { Thread.sleep(100); } catch (InterruptedException ex) {} // CraftBukkit - SPIGOT-625 - give server at least a chance to send packets
          }
-@@ -1419,9 +1418,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1420,9 +1419,15 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          // if (this.autosavePeriod > 0 && this.tickCount % this.autosavePeriod == 0) { // CraftBukkit // Paper - move down
          //     MinecraftServer.LOGGER.debug("Autosave started"); // Paper
          serverAutoSave = (autosavePeriod > 0 && this.tickCount % autosavePeriod == 0); // Paper

--- a/patches/server/0510-Prevent-headless-pistons-from-being-created.patch
+++ b/patches/server/0510-Prevent-headless-pistons-from-being-created.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Prevent headless pistons from being created
 Prevent headless pistons from being created by explosions or tree/mushroom growth.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index d74f0bdabd64976bf8608f2a5d8f2dc6118a35f2..c59a881632810da1408e74493bafcd4e6b01d975 100644
+index 64ccc906fef2c0988c30d289c392b13221b9b4c1..6b725dc2217e68255286caad6a0820bcccffb6da 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -462,6 +462,12 @@ public class PaperConfig {
+@@ -465,6 +465,12 @@ public class PaperConfig {
          set("settings.unsupported-settings.allow-tnt-duplication", null);
      }
  

--- a/patches/server/0512-Add-zombie-targets-turtle-egg-config.patch
+++ b/patches/server/0512-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 144a8d424cd4f953b1471f20d1521ed1b7639f1a..ee8a1be2fa90f4503f90a2690713de234479de9d 100644
+index f9caed53ffc10300511b576cf822864b101df83d..483f7f790173f1fc30f2b2b98e543098114c4cab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -38,6 +38,11 @@ public class PaperWorldConfig {
+@@ -57,6 +57,11 @@ public class PaperWorldConfig {
          }
      }
  
@@ -21,7 +21,7 @@ index 144a8d424cd4f953b1471f20d1521ed1b7639f1a..ee8a1be2fa90f4503f90a2690713de23
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 26200a9680d5fc95b04ba0c70ea20e145c4c220b..c4bbec1573d304a4d1bf20a8d16681ad828b5a51 100644
+index 20d8e705ea432df64917b59f8290aa5400795f4b..c210f83044ec2cddbfb776094da3d7f5f21df23b 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -109,7 +109,7 @@ public class Zombie extends Monster {

--- a/patches/server/0513-Buffer-joins-to-world.patch
+++ b/patches/server/0513-Buffer-joins-to-world.patch
@@ -8,10 +8,10 @@ the world per tick, this attempts to reduce the impact that join floods
 has on the server
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index c59a881632810da1408e74493bafcd4e6b01d975..07eeb01c95a04299fab2daddfdaf5d1a96495ef0 100644
+index 6b725dc2217e68255286caad6a0820bcccffb6da..6733e78ba6bf2993bb2adde4cf9f1f6ca366679c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -478,4 +478,9 @@ public class PaperConfig {
+@@ -481,4 +481,9 @@ public class PaperConfig {
              maxPlayerAutoSavePerTick = (playerAutoSaveRate == -1 || playerAutoSaveRate > 100) ? 10 : 20;
          }
      }

--- a/patches/server/0514-Optimize-redstone-algorithm.patch
+++ b/patches/server/0514-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ee8a1be2fa90f4503f90a2690713de234479de9d..b114b60266f4f29f243d09fe9ea3df2082fd0d6c 100644
+index 483f7f790173f1fc30f2b2b98e543098114c4cab..b70be9eea934aa88a9597581dbd1fd5662876c2d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -43,6 +43,16 @@ public class PaperWorldConfig {
+@@ -62,6 +62,16 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0521-Cache-block-data-strings.patch
+++ b/patches/server/0521-Cache-block-data-strings.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Cache block data strings
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 4af56ca699d456eb23794673861323ab06cf6de8..bb18848f2b91b80ab5099c00b423738bbb2560e8 100644
+index 968476493bcea8b4d961e838b142912d3eac91cd..b9c628b2786df4b85329b4d1da55452f61d80dfd 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2042,6 +2042,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2043,6 +2043,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.getPlayerList().reloadResources();
              this.functionManager.replaceLibrary(this.resources.getFunctionLibrary());
              this.structureManager.onResourceManagerReload(this.resources.getResourceManager());

--- a/patches/server/0528-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0528-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,10 +14,10 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 07eeb01c95a04299fab2daddfdaf5d1a96495ef0..4747eb55decd797c7872028997f4e22d15c5a661 100644
+index 6733e78ba6bf2993bb2adde4cf9f1f6ca366679c..380c4f46b98e6296cf28568abb1e74a80278ffa0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -483,4 +483,9 @@ public class PaperConfig {
+@@ -486,4 +486,9 @@ public class PaperConfig {
      private static void maxJoinsPerTick() {
          maxJoinsPerTick = getInt("settings.max-joins-per-tick", 3);
      }

--- a/patches/server/0530-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
+++ b/patches/server/0530-Fix-deop-kicking-non-whitelisted-player-when-white-l.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix deop kicking non-whitelisted player when white list is
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index bb18848f2b91b80ab5099c00b423738bbb2560e8..0747007ea6d779d1fd957efcb414e28faaa3da3b 100644
+index b9c628b2786df4b85329b4d1da55452f61d80dfd..1e163dd6f1f1038cb7945347982407969962e277 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2108,13 +2108,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2109,13 +2109,14 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          if (this.isEnforceWhitelist()) {
              PlayerList playerlist = source.getServer().getPlayerList();
              UserWhiteList whitelist = playerlist.getWhiteList();

--- a/patches/server/0545-Toggle-for-removing-existing-dragon.patch
+++ b/patches/server/0545-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b114b60266f4f29f243d09fe9ea3df2082fd0d6c..b5ede8b54261753b09f770428e9bf23f356bb8ea 100644
+index b70be9eea934aa88a9597581dbd1fd5662876c2d..568da8f2ef3c5e1412cf13c10b425100af75e902 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -53,6 +53,14 @@ public class PaperWorldConfig {
+@@ -72,6 +72,14 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0551-Seed-based-feature-search.patch
+++ b/patches/server/0551-Seed-based-feature-search.patch
@@ -21,10 +21,10 @@ changes but this should usually not happen. A config option to disable
 this completely is added though in case that should ever be necessary.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index b5ede8b54261753b09f770428e9bf23f356bb8ea..a2dfbb2380b468b0ae41c01039a949a58bb49550 100644
+index 568da8f2ef3c5e1412cf13c10b425100af75e902..7ef45c941dacaa1f5cc4f0544af9ec76424cc783 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -381,6 +381,14 @@ public class PaperWorldConfig {
+@@ -417,6 +417,14 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0552-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/patches/server/0552-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a2dfbb2380b468b0ae41c01039a949a58bb49550..ccdc2be5957e74fbfdcbd56efe3ec85a2fa0b0d7 100644
+index 7ef45c941dacaa1f5cc4f0544af9ec76424cc783..e1aa521a3947b38643866e038c7d0536658c58f2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -61,6 +61,19 @@ public class PaperWorldConfig {
+@@ -80,6 +80,19 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0560-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0560-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ccdc2be5957e74fbfdcbd56efe3ec85a2fa0b0d7..5267c958ce8e70dcdbf30c7db42e9af7c4a89e0f 100644
+index e1aa521a3947b38643866e038c7d0536658c58f2..a6cfc237fe5e06d43732dcd76b3a52a886ae8fe3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -74,6 +74,11 @@ public class PaperWorldConfig {
+@@ -93,6 +93,11 @@ public class PaperWorldConfig {
          wanderingTraderSpawnChanceMax = getInt("wandering-trader.spawn-chance-max", wanderingTraderSpawnChanceMax);
      }
  
@@ -21,7 +21,7 @@ index ccdc2be5957e74fbfdcbd56efe3ec85a2fa0b0d7..5267c958ce8e70dcdbf30c7db42e9af7
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9524771be6268b28f14618523d59cff00a127d9b..34b3e3a522dd8fd226cb32d1218f75092065c431 100644
+index 368c80ac596b66396985521e6e8c6aee6af26697..7e0f711ded0ecf0b94a79f69a3d75c2afa57c5a9 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1749,6 +1749,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -61,7 +61,7 @@ index 8fb89326395a7e70982c0d757b506565e98b12a4..a060cca08631fb42041e3a79a9abc422
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2e7d7bd60ac340568b1bc0f3052affcf445090f7..e3d8557733e20a51bb71d9c968f4f12cc3192624 100644
+index 40964014376aa911f412f6a5b717c6cf523530ab..327199d0e002bb7e7c2194fb54c213e837dd8dd8 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3277,7 +3277,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0564-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0564-Fix-curing-zombie-villager-discount-exploit.patch
@@ -8,10 +8,10 @@ and curing a villager on repeat by simply resetting the relevant part of
 the reputation when it is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5267c958ce8e70dcdbf30c7db42e9af7c4a89e0f..d1cd007032abf3073ea4ee0e61ce0995addf40dd 100644
+index a6cfc237fe5e06d43732dcd76b3a52a886ae8fe3..87e3f45057bde15e10b5bb55a9be6e9b6131e254 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -79,6 +79,11 @@ public class PaperWorldConfig {
+@@ -98,6 +98,11 @@ public class PaperWorldConfig {
          fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
      }
  

--- a/patches/server/0565-Limit-recipe-packets.patch
+++ b/patches/server/0565-Limit-recipe-packets.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit recipe packets
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4747eb55decd797c7872028997f4e22d15c5a661..ff337f7f5317f30b65e1b40c11c1783421f1a89d 100644
+index 380c4f46b98e6296cf28568abb1e74a80278ffa0..288310df8ca9eff6901d906b48ba7cd1b6bc8ae3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -352,6 +352,13 @@ public class PaperConfig {
+@@ -355,6 +355,13 @@ public class PaperConfig {
          tabSpamLimit = getInt("settings.spam-limiter.tab-spam-limit", tabSpamLimit);
      }
  

--- a/patches/server/0567-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0567-MC-4-Fix-item-position-desync.patch
@@ -9,10 +9,10 @@ loss, which forces the server to lose the same precision as the client
 keeping them in sync.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index ff337f7f5317f30b65e1b40c11c1783421f1a89d..5af9d91e15b0c10da79fa935cc884cd2766edfae 100644
+index 288310df8ca9eff6901d906b48ba7cd1b6bc8ae3..3a39180042a7753feba2262ad1a8fd6b92132846 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -495,4 +495,9 @@ public class PaperConfig {
+@@ -498,4 +498,9 @@ public class PaperConfig {
      private static void trackPluginScoreboards() {
          trackPluginScoreboards = getBoolean("settings.track-plugin-scoreboards", false);
      }

--- a/patches/server/0579-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/patches/server/0579-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d1cd007032abf3073ea4ee0e61ce0995addf40dd..e81325c323d2e07fab4f3db2c812a08549453760 100644
+index 87e3f45057bde15e10b5bb55a9be6e9b6131e254..802f3e00c745300a9811d0ab3f563e9fbf5b1ec2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -84,6 +84,11 @@ public class PaperWorldConfig {
+@@ -103,6 +103,11 @@ public class PaperWorldConfig {
          fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
      }
  
@@ -21,7 +21,7 @@ index d1cd007032abf3073ea4ee0e61ce0995addf40dd..e81325c323d2e07fab4f3db2c812a085
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/item/SpawnEggItem.java b/src/main/java/net/minecraft/world/item/SpawnEggItem.java
-index 88d33491e858a25a53872b49311e7a5a97c1f67c..b16f338a001254c700fe4e10a5cec0d6dc7bd127 100644
+index 82505b87de6ad73d59dd45306e504d20db3f3311..6cb0be998757d3ec89cc1064480c3a3ddc3cc381 100644
 --- a/src/main/java/net/minecraft/world/item/SpawnEggItem.java
 +++ b/src/main/java/net/minecraft/world/item/SpawnEggItem.java
 @@ -61,7 +61,7 @@ public class SpawnEggItem extends Item {

--- a/patches/server/0588-Added-ServerResourcesReloadedEvent.patch
+++ b/patches/server/0588-Added-ServerResourcesReloadedEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added ServerResourcesReloadedEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index c2c84eb3d43968424ed995fde312a6ac2ba74b2e..1a3158738bf4c506f3868a43cadc30c854532238 100644
+index 1e163dd6f1f1038cb7945347982407969962e277..d37b14523dd2a0e6412449001c7876bd27bf760e 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2021,7 +2021,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2022,7 +2022,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          return this.functionManager;
      }
  
@@ -22,7 +22,7 @@ index c2c84eb3d43968424ed995fde312a6ac2ba74b2e..1a3158738bf4c506f3868a43cadc30c8
          CompletableFuture<Void> completablefuture = CompletableFuture.supplyAsync(() -> {
              Stream<String> stream = datapacks.stream(); // CraftBukkit - decompile error
              PackRepository resourcepackrepository = this.packRepository;
-@@ -2037,6 +2043,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2038,6 +2044,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              this.packRepository.setSelected(datapacks);
              this.worldData.setDataPackConfig(MinecraftServer.getSelectedPacks(this.packRepository));
              datapackresources.updateGlobals();

--- a/patches/server/0589-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0589-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e81325c323d2e07fab4f3db2c812a08549453760..9c0ab3605375c7255204d3a27bc542f1e6b1761d 100644
+index 802f3e00c745300a9811d0ab3f563e9fbf5b1ec2..4b28347ac5850a878b55d2a815c2c9346dab0568 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -435,6 +435,14 @@ public class PaperWorldConfig {
+@@ -471,6 +471,14 @@ public class PaperWorldConfig {
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
  
@@ -37,7 +37,7 @@ index 3d8f3e22223e4effeaf52cb18c14c60276d4689c..6b4163f5601a0961055c8451ec7ef220
              LocalDate localdate = LocalDate.now();
              int i = localdate.get(ChronoField.DAY_OF_MONTH);
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index c4bbec1573d304a4d1bf20a8d16681ad828b5a51..49368bcb5a872c8f4ef60b936650c8ce6d81fe3e 100644
+index c210f83044ec2cddbfb776094da3d7f5f21df23b..3a6c9c06e8cc6ec5937059c8a5953af6ee0bb0e9 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -501,7 +501,7 @@ public class Zombie extends Monster {

--- a/patches/server/0593-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0593-Configurable-door-breaking-difficulty.patch
@@ -5,14 +5,13 @@ Subject: [PATCH] Configurable door breaking difficulty
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9c0ab3605375c7255204d3a27bc542f1e6b1761d..59302ef7db7dbda7889981ca87fa310d8dc74e8f 100644
+index 4b28347ac5850a878b55d2a815c2c9346dab0568..2c67111621937d9649ac79d133c955d25bc50485 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -2,7 +2,10 @@ package com.destroystokyo.paper;
- 
- import java.util.Arrays;
- import java.util.List;
--
+@@ -6,6 +6,10 @@ import java.util.List;
+ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+ import net.minecraft.world.entity.MobCategory;
 +import java.util.stream.Collectors;
 +import net.minecraft.world.Difficulty;
 +import net.minecraft.world.entity.monster.Vindicator;
@@ -20,7 +19,7 @@ index 9c0ab3605375c7255204d3a27bc542f1e6b1761d..59302ef7db7dbda7889981ca87fa310d
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
-@@ -89,6 +92,25 @@ public class PaperWorldConfig {
+@@ -108,6 +112,25 @@ public class PaperWorldConfig {
          disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
      }
  
@@ -46,7 +45,7 @@ index 9c0ab3605375c7255204d3a27bc542f1e6b1761d..59302ef7db7dbda7889981ca87fa310d
      public short keepLoadedRange;
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
-@@ -145,6 +167,11 @@ public class PaperWorldConfig {
+@@ -170,6 +193,11 @@ public class PaperWorldConfig {
          return config.getString("world-settings." + worldName + "." + path, config.getString("world-settings.default." + path));
      }
  
@@ -72,7 +71,7 @@ index 48593ad8dd80054f89a672a648cb1608a6c5eb8d..f7bcd6b8e1fb2e97db7da9bf218be0e9
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/monster/Zombie.java b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
-index 49368bcb5a872c8f4ef60b936650c8ce6d81fe3e..0235cf791a3a5b0e5dc515b405c0263438ffaf7e 100644
+index 3a6c9c06e8cc6ec5937059c8a5953af6ee0bb0e9..8da494792786fd80be50efc4cbb56caeae18d004 100644
 --- a/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 +++ b/src/main/java/net/minecraft/world/entity/monster/Zombie.java
 @@ -100,7 +100,7 @@ public class Zombie extends Monster {

--- a/patches/server/0600-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0600-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 59302ef7db7dbda7889981ca87fa310d8dc74e8f..1c6cca5452a2635509003b6daba30605d3433d88 100644
+index 2c67111621937d9649ac79d133c955d25bc50485..94c6d7013547d3a2a86aaf72aa485761d601acee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -64,6 +64,18 @@ public class PaperWorldConfig {
+@@ -84,6 +84,18 @@ public class PaperWorldConfig {
          }
      }
  
@@ -28,7 +28,7 @@ index 59302ef7db7dbda7889981ca87fa310d8dc74e8f..1c6cca5452a2635509003b6daba30605
      public int wanderingTraderSpawnDayTicks = 24000;
      public int wanderingTraderSpawnChanceFailureIncrement = 25;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 7b8e747a44d9a60f345154a9aee817b8d923b424..5703949d5ffa56602418d40a85f2fa1827690254 100644
+index 1db86fbfdc705c33948fb4c26be622616bcbdb12..392fa93b37cc79988c60b3215f69f5fff0ea97e5 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1632,6 +1632,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n

--- a/patches/server/0604-Configurable-max-leash-distance.patch
+++ b/patches/server/0604-Configurable-max-leash-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max leash distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1c6cca5452a2635509003b6daba30605d3433d88..4cdc6766b82345ec01d1a4f5cfddb76be5511460 100644
+index 94c6d7013547d3a2a86aaf72aa485761d601acee..cdaf146c11239858391cd899758c3d8f91b8806c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -268,6 +268,12 @@ public class PaperWorldConfig {
+@@ -305,6 +305,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0609-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0609-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add toggle for always placing the dragon egg
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4cdc6766b82345ec01d1a4f5cfddb76be5511460..c17747e226dd5c4ec1c4142d4fa60b7def21e90e 100644
+index cdaf146c11239858391cd899758c3d8f91b8806c..e996b5a8559d731accb6f09eb46437c33b088d3e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -762,5 +762,10 @@ public class PaperWorldConfig {
+@@ -799,5 +799,10 @@ public class PaperWorldConfig {
          }
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }

--- a/patches/server/0615-EntityMoveEvent.patch
+++ b/patches/server/0615-EntityMoveEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] EntityMoveEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 1a3158738bf4c506f3868a43cadc30c854532238..c8b68b5a996491dcd668f929badf294386832388 100644
+index d37b14523dd2a0e6412449001c7876bd27bf760e..f3976a53514249e64d91075ec2e620e4c7cef37f 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -1526,6 +1526,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1527,6 +1527,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          while (iterator.hasNext()) {
              ServerLevel worldserver = (ServerLevel) iterator.next();
              worldserver.hasPhysicsEvent =  org.bukkit.event.block.BlockPhysicsEvent.getHandlerList().getRegisteredListeners().length > 0; // Paper
@@ -17,7 +17,7 @@ index 1a3158738bf4c506f3868a43cadc30c854532238..c8b68b5a996491dcd668f929badf2943
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index aedb1d7a0b60fba72a952fa140569b72795660e4..d5c7180376562cd576d832d44ab11c9cc323ba12 100644
+index 073dbf69b5b58c4351110d28491e7feb2e47081c..c58b0de1cf1c51ceb0a0ecc145f4a98929521934 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -197,6 +197,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0616-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0616-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c17747e226dd5c4ec1c4142d4fa60b7def21e90e..5e45ad4638d94b4602c660aab72ee8bb7ead9de6 100644
+index e996b5a8559d731accb6f09eb46437c33b088d3e..9cea705b59e198ca5bcf89be74e310d686901173 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -767,5 +767,10 @@ public class PaperWorldConfig {
+@@ -804,5 +804,10 @@ public class PaperWorldConfig {
      private void enderDragonsDeathAlwaysPlacesDragonEgg() {
          enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
      }
@@ -20,7 +20,7 @@ index c17747e226dd5c4ec1c4142d4fa60b7def21e90e..5e45ad4638d94b4602c660aab72ee8bb
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d5c7180376562cd576d832d44ab11c9cc323ba12..044aa3df0c26b7a64eefcacf0b6b5c2d9224938c 100644
+index b8495c2240795a14eaf4c230355c23c7090f39a1..614d9b5865e9cf5e939db8b3840e9dc4b72fe7e0 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1386,6 +1386,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0626-MC-29274-Fix-Wither-hostility-towards-players.patch
+++ b/patches/server/0626-MC-29274-Fix-Wither-hostility-towards-players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-29274: Fix Wither hostility towards players
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5e45ad4638d94b4602c660aab72ee8bb7ead9de6..e53b6515ca427b90f21441cf142ecde6e986058d 100644
+index 9cea705b59e198ca5bcf89be74e310d686901173..81c78a33e76451879eb9b6f946bc04a28cca72bc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -772,5 +772,11 @@ public class PaperWorldConfig {
+@@ -809,5 +809,11 @@ public class PaperWorldConfig {
      private void setUpdatePathfindingOnBlockUpdate() {
          updatePathfindingOnBlockUpdate = getBoolean("update-pathfinding-on-block-update", this.updatePathfindingOnBlockUpdate);
      }

--- a/patches/server/0636-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0636-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e53b6515ca427b90f21441cf142ecde6e986058d..1da69d56f0b58708d4c85e76307b725221f9caed 100644
+index 81c78a33e76451879eb9b6f946bc04a28cca72bc..723bf8c37494a11b5e6cccc22a2c125c5cba3c01 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -778,5 +778,10 @@ public class PaperWorldConfig {
+@@ -815,5 +815,10 @@ public class PaperWorldConfig {
          fixWitherTargetingBug = getBoolean("fix-wither-targeting-bug", false);
          log("Withers properly target players: " + fixWitherTargetingBug);
      }
@@ -20,7 +20,7 @@ index e53b6515ca427b90f21441cf142ecde6e986058d..1da69d56f0b58708d4c85e76307b7252
  }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 2ee8097e2a3e6bf4fb02ded2d2499487eaf7c142..8424884bcd36e3daff47725ef343d9b99030bdc6 100644
+index 6de62cbd8475d04c765d532731336638225525bc..2d459cf7899461fbacaa22b0b2d68a73578bc95f 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1723,7 +1723,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0643-forced-whitelist-use-configurable-kick-message.patch
+++ b/patches/server/0643-forced-whitelist-use-configurable-kick-message.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] forced whitelist: use configurable kick message
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index cfcc29ed3b1396b1429af14195f420c550653aa5..84afe36963178aa0319e219244ddbe6f0b91260b 100644
+index f3976a53514249e64d91075ec2e620e4c7cef37f..fca8d2100b48be9698afa7f3e8cf20212ca37974 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -74,7 +74,6 @@ import net.minecraft.nbt.NbtOps;
@@ -16,7 +16,7 @@ index cfcc29ed3b1396b1429af14195f420c550653aa5..84afe36963178aa0319e219244ddbe6f
  import net.minecraft.network.protocol.Packet;
  import net.minecraft.network.protocol.game.ClientboundChangeDifficultyPacket;
  import net.minecraft.network.protocol.game.ClientboundSetTimePacket;
-@@ -2124,7 +2123,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2125,7 +2124,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)

--- a/patches/server/0645-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0645-Entity-load-save-limit-per-chunk.patch
@@ -9,15 +9,14 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1da69d56f0b58708d4c85e76307b725221f9caed..5eeb09c7cbc743c4273a6d02d9f0c357c2724ba2 100644
+index 723bf8c37494a11b5e6cccc22a2c125c5cba3c01..0938b38aaca2bfaf3a70c392849222fc0128c60c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1,9 +1,12 @@
- package com.destroystokyo.paper;
- 
- import java.util.Arrays;
+@@ -6,8 +6,11 @@ import java.util.List;
+ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+ import net.minecraft.world.entity.MobCategory;
 +import java.util.HashMap;
- import java.util.List;
 +import java.util.Map;
  import java.util.stream.Collectors;
  import net.minecraft.world.Difficulty;
@@ -25,7 +24,7 @@ index 1da69d56f0b58708d4c85e76307b725221f9caed..5eeb09c7cbc743c4273a6d02d9f0c357
  import net.minecraft.world.entity.monster.Vindicator;
  import net.minecraft.world.entity.monster.Zombie;
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
-@@ -123,6 +126,38 @@ public class PaperWorldConfig {
+@@ -143,6 +146,38 @@ public class PaperWorldConfig {
          );
      }
  
@@ -90,7 +89,7 @@ index 8c829066939a4069953097fd268f7c214a555779..1c446dba5de89698397041ee38a2e1a0
                          return entity;
                      });
 diff --git a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
-index 50afe31798664b2e0ac7546d775ecea534e351e2..0e13a1f898a793799416056bd468851013f9c5cb 100644
+index 04aecfbafa2840755b8b025d5605205cc7f821cf..bab6e0ac7b57a86ff36e8caf1014f1625ca976b6 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/storage/EntityStorage.java
 @@ -107,7 +107,18 @@ public class EntityStorage implements EntityPersistentStorage<Entity> {

--- a/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index 4e824a87b463a417c204a9ee188450bdd9f4fbc2..ef1e6e898b3cb9d012b2cf24aedffea4afce8a38 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -500,4 +500,11 @@ public class PaperConfig {
+@@ -503,4 +503,11 @@ public class PaperConfig {
      private static void fixEntityPositionDesync() {
          fixEntityPositionDesync = getBoolean("settings.fix-entity-position-desync", fixEntityPositionDesync);
      }

--- a/patches/server/0690-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0690-Limit-item-frame-cursors-on-maps.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5eeb09c7cbc743c4273a6d02d9f0c357c2724ba2..436362e1325284278484c7fd10f533041cad89dd 100644
+index 0938b38aaca2bfaf3a70c392849222fc0128c60c..81c3a4a2c7e95e92566030ab48f534285d185cf5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -818,5 +818,10 @@ public class PaperWorldConfig {
+@@ -855,5 +855,10 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }
@@ -20,7 +20,7 @@ index 5eeb09c7cbc743c4273a6d02d9f0c357c2724ba2..436362e1325284278484c7fd10f53304
  }
  
 diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
-index 2e5155fe541ed7040a6be9fdec98b23e8c45bfb0..60d7496966b22e0553372a93e3c0e7ed9e166cba 100644
+index ad6c3459712d08de248b8ef299ddbedfda6c7ac2..6f64d1ce0f5b20e1579f8af64c08ef8fc4e4444b 100644
 --- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 +++ b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 @@ -296,8 +296,12 @@ public class MapItemSavedData extends SavedData {

--- a/patches/server/0692-Add-PlayerKickEvent-causes.patch
+++ b/patches/server/0692-Add-PlayerKickEvent-causes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerKickEvent causes
 
 
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index be6b19b587ae2bbc708d712fc4327e4c56b7197c..a2a012d69a7f5e2d623ad93c3b6e3aece2cbf1a3 100644
+index 18a9d84c9508318132bb9b1dcb01ea11ea018916..71181012314d20e3505543a6d2abe88cb8e17a27 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
-@@ -2125,7 +2125,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -2126,7 +2126,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
                  ServerPlayer entityplayer = (ServerPlayer) iterator.next();
  
                  if (!whitelist.isWhiteListed(entityplayer.getGameProfile()) && !this.getPlayerList().isOp(entityplayer.getGameProfile())) { // Paper - Fix kicking ops when whitelist is reloaded (MC-171420)

--- a/patches/server/0695-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0695-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 436362e1325284278484c7fd10f533041cad89dd..42ad87b87305f394777cdd97f00f2e8d40a6b5e8 100644
+index 81c3a4a2c7e95e92566030ab48f534285d185cf5..d02cf8e3726063b0b364bd7f54be80759d789c7a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -823,5 +823,10 @@ public class PaperWorldConfig {
+@@ -860,5 +860,10 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0697-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0697-Fix-invulnerable-end-crystals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 42ad87b87305f394777cdd97f00f2e8d40a6b5e8..ba8ae4d1c86293ca5c95d830d145023b4fe21d71 100644
+index d02cf8e3726063b0b364bd7f54be80759d789c7a..8b72fb402233358709836082f245bfc8fabebfa8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -828,5 +828,10 @@ public class PaperWorldConfig {
+@@ -865,5 +865,10 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0701-Make-item-validations-configurable.patch
+++ b/patches/server/0701-Make-item-validations-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make item validations configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 6c4bb838792c779da7b2d84831f6e67779695993..bc4081483a228aa275511d28231d615fe0f36d4e 100644
+index 247c172c3b722cb1b753fd92839ab427233d7a13..939744ef6850d4e59e5c94bc4781d045041b977d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -507,4 +507,19 @@ public class PaperConfig {
+@@ -510,4 +510,19 @@ public class PaperConfig {
          enableBrigadierConsoleHighlighting = getBoolean("settings.console.enable-brigadier-highlighting", enableBrigadierConsoleHighlighting);
          enableBrigadierConsoleCompletions = getBoolean("settings.console.enable-brigadier-completions", enableBrigadierConsoleCompletions);
      }

--- a/patches/server/0703-add-per-world-spawn-limits.patch
+++ b/patches/server/0703-add-per-world-spawn-limits.patch
@@ -6,43 +6,66 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ba8ae4d1c86293ca5c95d830d145023b4fe21d71..fc9b69d87364b578327dffb657746c08ab505be3 100644
+index 8b72fb402233358709836082f245bfc8fabebfa8..3de0e744415887a408b8c97e15caa85af5f1051f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -681,6 +681,19 @@ public class PaperWorldConfig {
+@@ -14,6 +14,7 @@ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.entity.monster.Vindicator;
+ import net.minecraft.world.entity.monster.Zombie;
+ import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
++import net.minecraft.world.level.NaturalSpawner;
+ import org.bukkit.Bukkit;
+ import org.bukkit.configuration.file.YamlConfiguration;
+ import org.spigotmc.SpigotWorldConfig;
+@@ -57,6 +58,11 @@ public class PaperWorldConfig {
+ 
+             set("despawn-ranges.soft", null);
+             set("despawn-ranges.hard", null);
++
++            set("spawn-limits.monsters", null);
++            set("spawn-limits.animals", null);
++            set("spawn-limits.water-animals", null);
++            set("spawn-limits.water-ambient", null);
+         }
+ 
+         if (needsSave) {
+@@ -718,6 +724,21 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  
-+    public int spawnLimitMonsters = -1;
-+    public int spawnLimitAnimals = -1;
-+    public int spawnLimitWaterAnimals = -1;
-+    public int spawnLimitWaterAmbient = -1;
-+    public int spawnLimitAmbient = -1;
++    public Reference2IntMap<MobCategory> perWorldSpawnLimits = new Reference2IntOpenHashMap<>(NaturalSpawner.SPAWNING_CATEGORIES.length);
 +    private void perWorldSpawnLimits() {
-+        spawnLimitMonsters = getInt("spawn-limits.monsters", spawnLimitMonsters);
-+        spawnLimitAnimals = getInt("spawn-limits.animals", spawnLimitAnimals);
-+        spawnLimitWaterAnimals = getInt("spawn-limits.water-animals", spawnLimitWaterAnimals);
-+        spawnLimitWaterAmbient = getInt("spawn-limits.water-ambient", spawnLimitWaterAmbient);
-+        spawnLimitAmbient = getInt("spawn-limits.ambient", spawnLimitAmbient);
++        perWorldSpawnLimits.defaultReturnValue(-1);
++        if (PaperConfig.version < 24) {
++            // ambient category already had correct name
++            perWorldSpawnLimits.put(MobCategory.MONSTER, getInt("spawn-limits.monsters", -1, false));
++            perWorldSpawnLimits.put(MobCategory.CREATURE, getInt("spawn-limits.animals", -1, false));
++            perWorldSpawnLimits.put(MobCategory.WATER_CREATURE, getInt("spawn-limits.water-animals", -1, false));
++            perWorldSpawnLimits.put(MobCategory.WATER_AMBIENT, getInt("spawn-limits.water-ambient", -1, false));
++        }
++        for (MobCategory value : NaturalSpawner.SPAWNING_CATEGORIES) {
++            perWorldSpawnLimits.put(value, getInt("spawn-limits." + value.getName(), perWorldSpawnLimits.getInt(value)));
++        }
 +    }
 +
      public int lightQueueSize = 20;
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6a4c379a2905455b14c3cbd4a46a0f95c5f78aac..a1f26413e30c80162738595427837c7177357a1b 100644
+index 6a4c379a2905455b14c3cbd4a46a0f95c5f78aac..4430385a758906239b8573c59b18d19470339ec5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -210,6 +210,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -210,6 +210,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          this.biomeProvider = biomeProvider;
  
          this.environment = env;
 +        // Paper start - per world spawn limits
-+        this.monsterSpawn = this.world.paperConfig.spawnLimitMonsters;
-+        this.animalSpawn = this.world.paperConfig.spawnLimitAnimals;
-+        this.waterAnimalSpawn = this.world.paperConfig.spawnLimitWaterAnimals;
-+        this.waterAmbientSpawn = this.world.paperConfig.spawnLimitWaterAmbient;
-+        this.ambientSpawn = this.world.paperConfig.spawnLimitAmbient;
++        this.monsterSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.MONSTER);
++        this.animalSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.CREATURE);
++        this.waterAnimalSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_CREATURE);
++        this.waterAmbientSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.WATER_AMBIENT);
++        this.ambientSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.AMBIENT);
++        this.waterUndergroundCreatureSpawn = this.world.paperConfig.perWorldSpawnLimits.getInt(net.minecraft.world.entity.MobCategory.UNDERGROUND_WATER_CREATURE);
 +        // Paper end
      }
  

--- a/patches/server/0713-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0713-Fix-commands-from-signs-not-firing-command-events.patch
@@ -10,10 +10,10 @@ This patch changes sign command logic so that `run_command` click events:
   - sends failure messages to the player who clicked the sign
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fc9b69d87364b578327dffb657746c08ab505be3..04b27d96d7a6396989c6a9d67b92af259dc0cc26 100644
+index 3de0e744415887a408b8c97e15caa85af5f1051f..ff7766553743172cb83049ed89532eba596f39b6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -846,5 +846,10 @@ public class PaperWorldConfig {
+@@ -891,5 +891,10 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }

--- a/patches/server/0716-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0716-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04b27d96d7a6396989c6a9d67b92af259dc0cc26..2bfadd245b5d08c1b77805ee049456cc786c093e 100644
+index ff7766553743172cb83049ed89532eba596f39b6..d16e3be9e64db9cba4bb90cccd170aa92534b76a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -671,6 +671,21 @@ public class PaperWorldConfig {
+@@ -714,6 +714,21 @@ public class PaperWorldConfig {
          log("Hopper Move Item Events: " + (disableHopperMoveEvents ? "disabled" : "enabled"));
      }
  
@@ -31,7 +31,7 @@ index 04b27d96d7a6396989c6a9d67b92af259dc0cc26..2bfadd245b5d08c1b77805ee049456cc
      private void nerfNetherPortalPigmen() {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a60d289f3cf3826ac5368f3de77584fb63bf5e64..38e8d8c7d37fc824323dac372c56550480360515 100644
+index bd2e2eece61fd7fa6ab63d8926308044ceaa4012..2a16984f417967cf11838b1a05d60b9d49af91c3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1133,7 +1133,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0719-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0719-Don-t-apply-cramming-damage-to-players.patch
@@ -11,10 +11,10 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2bfadd245b5d08c1b77805ee049456cc786c093e..88abb1dfd994e5bc51aa181121407f3d84f85f5b 100644
+index d16e3be9e64db9cba4bb90cccd170aa92534b76a..35e6a18dea889db8bd497ac029fda653ef3926ab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -866,5 +866,10 @@ public class PaperWorldConfig {
+@@ -911,5 +911,10 @@ public class PaperWorldConfig {
      private void showSignClickCommandFailureMessagesToPlayer() {
          showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }
@@ -26,7 +26,7 @@ index 2bfadd245b5d08c1b77805ee049456cc786c093e..88abb1dfd994e5bc51aa181121407f3d
  }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3833c0c863c49c2ff5552030e7a0799cf2ec0614..822c38033e9134d631b031e3571b05951a4625b1 100644
+index 9fcf6019423a84baa6ee91e3a10957f092f023b6..e809fd6616e2b7a602be10f0a62d0261b4b3b0da 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1419,7 +1419,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0720-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0720-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,13 +28,13 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..34d3ca57acd3aa37a37d44cd81bdd10967f12aaa 100644
+index 35e6a18dea889db8bd497ac029fda653ef3926ab..ef569d01165d7953c5802342e00da7d655811ff7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -3,14 +3,19 @@ package com.destroystokyo.paper;
- import java.util.Arrays;
+@@ -7,8 +7,12 @@ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
+ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
+ import net.minecraft.world.entity.MobCategory;
  import java.util.HashMap;
- import java.util.List;
 +import java.util.Locale;
  import java.util.Map;
  import java.util.stream.Collectors;
@@ -44,14 +44,15 @@ index 88abb1dfd994e5bc51aa181121407f3d84f85f5b..34d3ca57acd3aa37a37d44cd81bdd109
  import net.minecraft.world.Difficulty;
  import net.minecraft.world.entity.EntityType;
  import net.minecraft.world.entity.monster.Vindicator;
- import net.minecraft.world.entity.monster.Zombie;
+@@ -16,6 +20,7 @@ import net.minecraft.world.entity.monster.Zombie;
  import com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray.EngineMode;
+ import net.minecraft.world.level.NaturalSpawner;
  import org.bukkit.Bukkit;
 +import org.bukkit.configuration.ConfigurationSection;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -871,5 +876,58 @@ public class PaperWorldConfig {
+@@ -916,5 +921,58 @@ public class PaperWorldConfig {
      private void playerCrammingDamage() {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }

--- a/patches/server/0733-Config-option-for-Piglins-guarding-chests.patch
+++ b/patches/server/0733-Config-option-for-Piglins-guarding-chests.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Config option for Piglins guarding chests
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 34d3ca57acd3aa37a37d44cd81bdd10967f12aaa..eac8ebb2538144d584eb02152a8d1366526150fe 100644
+index ef569d01165d7953c5802342e00da7d655811ff7..7bc5ba3514d2f091f745b33f96fe86bd839b04c2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -54,6 +54,11 @@ public class PaperWorldConfig {
+@@ -80,6 +80,11 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0737-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0737-Configurable-item-frame-map-cursor-update-interval.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable item frame map cursor update interval
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eac8ebb2538144d584eb02152a8d1366526150fe..fd7ac4be153538dcee60fade6e7a00f57770e97f 100644
+index 7bc5ba3514d2f091f745b33f96fe86bd839b04c2..410e1e67ca625fc01553d61c2b0eaeec10317e5e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -862,6 +862,11 @@ public class PaperWorldConfig {
+@@ -907,6 +907,11 @@ public class PaperWorldConfig {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }
  
@@ -21,7 +21,7 @@ index eac8ebb2538144d584eb02152a8d1366526150fe..fd7ac4be153538dcee60fade6e7a00f5
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
 diff --git a/src/main/java/net/minecraft/server/level/ServerEntity.java b/src/main/java/net/minecraft/server/level/ServerEntity.java
-index e5cae2fb67541785072324e5434820ee4b169556..9950541e0432240207458274b76b1c5d402ac704 100644
+index 69a671a2cd068d7665fdcd455c2710ee2890f564..764d449aa63af88029f80918884a0c942d630113 100644
 --- a/src/main/java/net/minecraft/server/level/ServerEntity.java
 +++ b/src/main/java/net/minecraft/server/level/ServerEntity.java
 @@ -99,7 +99,7 @@ public class ServerEntity {

--- a/patches/server/0766-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0766-Execute-chunk-tasks-mid-tick.patch
@@ -31,7 +31,7 @@ index 5fdaefc128956581be4bb9b34199fd6410563991..b7edc1121797bc1c57e25f540ed0124f
                  // start copy from TickListServer // TODO check on update
                  CrashReport crashreport = CrashReport.forThrowable(thr, "Exception while ticking");
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index ecb167f6a114a7e3bfac05db2e87631ec88a0ba2..fe6d5051b139cd6079e288ffdf20e30fdd46fdda 100644
+index 71181012314d20e3505543a6d2abe88cb8e17a27..4778d45d14317d78ae1988de18f675d997d28c98 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -330,6 +330,76 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -111,7 +111,7 @@ index ecb167f6a114a7e3bfac05db2e87631ec88a0ba2..fe6d5051b139cd6079e288ffdf20e30f
      public MinecraftServer(OptionSet options, DataPackConfig datapackconfiguration, Thread thread, RegistryAccess.RegistryHolder iregistrycustom_dimension, LevelStorageSource.LevelStorageAccess convertable_conversionsession, WorldData savedata, PackRepository resourcepackrepository, Proxy proxy, DataFixer datafixer, ServerResources datapackresources, @Nullable MinecraftSessionService minecraftsessionservice, @Nullable GameProfileRepository gameprofilerepository, @Nullable GameProfileCache usercache, ChunkProgressListenerFactory worldloadlistenerfactory) {
          super("Server");
          SERVER = this; // Paper - better singleton
-@@ -1324,6 +1394,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1325,6 +1395,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
  
      private boolean pollTaskInternal() {
          if (super.pollTask()) {
@@ -140,7 +140,7 @@ index 7ea86cbeb72f08d751c14006f428fe5921916061..108f2212f8bd00247bf73ff4f3ba4283
              } // Paper start - optimise chunk tick iteration
              } finally {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3351c4d43b41db5a0718d7ff761b06d950b7ee87..9c69855874da2c18e9c80decf4244a0f50021a28 100644
+index 675fca76f5f7319d45e0d4f03b74d27bf2a5a647..9c4f8d59ece0222bb2b7c8aa3b0a0044b8205e77 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -190,7 +190,9 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0768-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0768-Do-not-copy-visible-chunks.patch
@@ -156,7 +156,7 @@ index aae8dca773686bec3f867b79aa11d668032b9244..2f5ab00d26dcf027ec0e152a8bf17686
          while (objectbidirectionaliterator.hasNext()) {
              Entry<ChunkHolder> entry = (Entry) objectbidirectionaliterator.next();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index a1f26413e30c80162738595427837c7177357a1b..072c2bbd8dd94bf3b687cee2eb7c09c79190231c 100644
+index 4430385a758906239b8573c59b18d19470339ec5..b4cf0d44bda13625cfa8264043a49c1a0daf1054 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -149,7 +149,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -177,7 +177,7 @@ index a1f26413e30c80162738595427837c7177357a1b..072c2bbd8dd94bf3b687cee2eb7c09c7
              if (chunkHolder.getTickingChunk() != null) {
                  ++ret;
              }
-@@ -343,7 +343,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -344,7 +344,18 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public Chunk[] getLoadedChunks() {

--- a/patches/server/0769-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0769-Replace-player-chunk-loader-system.patch
@@ -80,10 +80,10 @@ index cfe293881f68c8db337c3a48948362bb7b3e3522..7d44abcb4fff9717a1af55879deb7eb9
          }));
  
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index efe964caada458a34c58a0396cc7e3321c58e404..98288f83d1276a47ad3335153aee5c7ea9a5e451 100644
+index 939744ef6850d4e59e5c94bc4781d045041b977d..a72f15c10410508ff344caf3ca376fd3d7317518 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -522,4 +522,29 @@ public class PaperConfig {
+@@ -525,4 +525,29 @@ public class PaperConfig {
          itemValidationBookAuthorLength = getInt("settings.item-validation.book.author", itemValidationBookAuthorLength);
          itemValidationBookPageLength = getInt("settings.item-validation.book.page", itemValidationBookPageLength);
      }
@@ -1695,10 +1695,10 @@ index f0c43f9f636a5dd1f0dfbae604dfa1f4ff9ebd4e..9e75ee7f43722f05dd5df4ef00f7d3e2
              /*
               * If it's a new world, the first few chunks are generated inside
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 072c2bbd8dd94bf3b687cee2eb7c09c79190231c..8c238a445b327e24d8152b36ebc2b1b57e73d0e1 100644
+index b4cf0d44bda13625cfa8264043a49c1a0daf1054..e5e23c907d49ee64218f3302e2a2323d6937a8a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2066,14 +2066,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2067,14 +2067,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          net.minecraft.server.level.ChunkMap chunkMap = getHandle().getChunkSource().chunkMap;
@@ -1715,7 +1715,7 @@ index 072c2bbd8dd94bf3b687cee2eb7c09c79190231c..8c238a445b327e24d8152b36ebc2b1b5
      }
  
      @Override
-@@ -2082,11 +2082,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2083,11 +2083,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              throw new IllegalArgumentException("View distance " + viewDistance + " is out of range of [2, 32]");
          }
          net.minecraft.server.level.ChunkMap chunkMap = getHandle().getChunkSource().chunkMap;

--- a/patches/server/0779-Add-packet-limiter-config.patch
+++ b/patches/server/0779-Add-packet-limiter-config.patch
@@ -24,10 +24,10 @@ and an action can be defined: DROP or KICK
 If interval or rate are less-than 0, the limit is ignored
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 98288f83d1276a47ad3335153aee5c7ea9a5e451..448def89819e8263fda5902be508dcf9789dbf3c 100644
+index a72f15c10410508ff344caf3ca376fd3d7317518..5ccc86d714d5e6e40df853bb30be11662cd53809 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -547,4 +547,102 @@ public class PaperConfig {
+@@ -550,4 +550,102 @@ public class PaperConfig {
          playerMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.player-max-concurrent-loads", 4.0);
          globalMaxConcurrentChunkLoads = getDouble("settings.chunk-loading.global-max-concurrent-loads", 500.0);
      }

--- a/patches/server/0780-Lag-compensate-block-breaking.patch
+++ b/patches/server/0780-Lag-compensate-block-breaking.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Lag compensate block breaking
 Use time instead of ticks if ticks fall behind
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 448def89819e8263fda5902be508dcf9789dbf3c..31662010b1c3d3fb9f667afd13e33e0a35005867 100644
+index 5ccc86d714d5e6e40df853bb30be11662cd53809..cf9a72b7fe0b41e1ca68bbae2164162447405fc5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -645,4 +645,10 @@ public class PaperConfig {
+@@ -648,4 +648,10 @@ public class PaperConfig {
              }
          }
      }

--- a/patches/server/0785-Send-full-pos-packets-for-hard-colliding-entities.patch
+++ b/patches/server/0785-Send-full-pos-packets-for-hard-colliding-entities.patch
@@ -9,10 +9,10 @@ Configurable under
 `send-full-pos-for-hard-colliding-entities`
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 31662010b1c3d3fb9f667afd13e33e0a35005867..b3f4ac2ce6f515e406d2f31b1d2429729c9e2b60 100644
+index cf9a72b7fe0b41e1ca68bbae2164162447405fc5..0940655792402ed29a1ec80a2a6fb2f100de4659 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -651,4 +651,10 @@ public class PaperConfig {
+@@ -654,4 +654,10 @@ public class PaperConfig {
      private static void lagCompensateBlockBreaking() {
          lagCompensateBlockBreaking = getBoolean("settings.lag-compensate-block-breaking", true);
      }

--- a/patches/server/0792-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0792-Optimise-nearby-player-lookups.patch
@@ -26,7 +26,7 @@ index 4588ae8037407b81c99135863eb0c4e97c564c24..2a33071c4b69cb7b5a7e296e8fd903e3
      // Paper end - optimise isOutsideOfRange
      long lastAutoSaveTime; // Paper - incremental autosave
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 87172ee94f5796a23c22c58bbb591dede2b2dc3c..955c42be5c5ed5c3a1a76e868da2087ced436e49 100644
+index 6522eb4b72c50be3ff7d1b094066a1cbec88634d..10d1e1f728519ad49379895c7fd3668badcbfd5a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -217,6 +217,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -114,7 +114,7 @@ index 87172ee94f5796a23c22c58bbb591dede2b2dc3c..955c42be5c5ed5c3a1a76e868da2087c
                      holder = new ChunkHolder(new ChunkPos(pos), level, this.level, this.lightEngine, this.queueSorter, this);
                      // Paper start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f512d68cbeb243fbef8fad73472ea6587112f889..796ae447fcc305335fe943fc6d97e21422f406b1 100644
+index ed696ed93251e644c2b71e468e2556d24b273933..3afb8b91dceb86e88b848462a5b8dbd5c8365239 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -392,6 +392,83 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -217,7 +217,7 @@ index f512d68cbeb243fbef8fad73472ea6587112f889..796ae447fcc305335fe943fc6d97e214
  
          this.handlingTick = true;
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index bada11542390b7575466f0e7062470665b8266c4..8a864238e154e2131834d013652746b7e7a78c97 100644
+index 5f4556505d831ea45e576a4c4e10f99e1353684e..55d07e70a67e08bab3a7a66076c980986736e5b8 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -789,7 +789,12 @@ public abstract class Mob extends LivingEntity {
@@ -226,7 +226,7 @@ index bada11542390b7575466f0e7062470665b8266c4..8a864238e154e2131834d013652746b7
          } else if (!this.isPersistenceRequired() && !this.requiresCustomPersistence()) {
 -            Player entityhuman = this.level.findNearbyPlayer(this, -1.0D, EntitySelector.affectsSpawning); // Paper
 +            // Paper start - optimise checkDespawn
-+            Player entityhuman = this.level.findNearbyPlayer(this, level.paperConfig.hardDespawnDistance + 1, EntitySelector.affectsSpawning); // Paper
++            Player entityhuman = this.level.findNearbyPlayer(this, level.paperConfig.hardDespawnDistances.getInt(this.getType().getCategory()) + 1, EntitySelector.affectsSpawning); // Paper
 +            if (entityhuman == null) {
 +                entityhuman = ((ServerLevel)this.level).playersAffectingSpawning.isEmpty() ? null : ((ServerLevel)this.level).playersAffectingSpawning.get(0);
 +            }
@@ -309,7 +309,7 @@ index 64d5e71a8a26116385cee195d86fce1ef1574a8c..f936e9f9a9fa655fa997d6862b5ed54c
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Anti-Xray - Pass executor
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index d69abf154f056883dcd6dc4d9d97d2b772b62368..e588ac628ac855ec13004ae4a212e01637e524fa 100644
+index 4d8251a961a9c52456db997506dd9691beaec022..55dd04816886d27a62856ac952d2fc5d15bf40e6 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -267,7 +267,7 @@ public final class NaturalSpawner {

--- a/patches/server/0800-Configurable-feature-seeds.patch
+++ b/patches/server/0800-Configurable-feature-seeds.patch
@@ -19,10 +19,10 @@ index 7d44abcb4fff9717a1af55879deb7eb9c2d9e7e9..e29b0a90019b12bd6586ad0f7b5314f3
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fd7ac4be153538dcee60fade6e7a00f57770e97f..beab9b5701a32a34bcb739920ff3c0106ede7530 100644
+index 410e1e67ca625fc01553d61c2b0eaeec10317e5e..0a611df010c9c5e621f10ae55a0ce66fd0cae0e2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -927,6 +927,55 @@ public class PaperWorldConfig {
+@@ -972,6 +972,55 @@ public class PaperWorldConfig {
          return table;
      }
  

--- a/patches/server/0803-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0803-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -270,7 +270,7 @@ index 2ef4b4c2ff81d0fa33d4630593266066d8e6a6f3..34bc24403a83ae578d2fc3956b488389
          List<org.bukkit.World> worlds;
          if (args.length < 2 || args[1].equals("*")) {
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index e588ac628ac855ec13004ae4a212e01637e524fa..0c857fce997d918d1552f7d1e8695e7908df8b3c 100644
+index 55dd04816886d27a62856ac952d2fc5d15bf40e6..790999fea74e4d03a80a4c0c9665af87bd683577 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -145,32 +145,16 @@ public final class NaturalSpawner {

--- a/patches/server/0811-Preserve-overstacked-loot.patch
+++ b/patches/server/0811-Preserve-overstacked-loot.patch
@@ -10,10 +10,10 @@ chunk bans via the large amount of NBT created by unstacking the items.
 Fixes GH-5140 and GH-4748.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9a3f75288b1d743a7ec4bfd663c1c2988678d3e6..416ecbdf244716c2fb1277d7d1df697fe6f77756 100644
+index 0a611df010c9c5e621f10ae55a0ce66fd0cae0e2..0906a2d410e11cb352b13e5c0390560085b8f254 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -887,6 +887,11 @@ public class PaperWorldConfig {
+@@ -932,6 +932,11 @@ public class PaperWorldConfig {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }
  

--- a/patches/server/0815-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
+++ b/patches/server/0815-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Dont count named piglins and hoglins towards mob cap
 
 
 diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index 0c857fce997d918d1552f7d1e8695e7908df8b3c..bacd75f67f783f49208a74501cc7e6e7485010a4 100644
+index 0b228b8bcae5ed2840ab244b6de35732f737504d..f316585ccf6baf5e7e514ba3a68b4344e781a82d 100644
 --- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
 @@ -83,7 +83,7 @@ public final class NaturalSpawner {

--- a/patches/server/0819-Add-config-option-for-logging-player-ip-addresses.patch
+++ b/patches/server/0819-Add-config-option-for-logging-player-ip-addresses.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/j
 index b3f4ac2ce6f515e406d2f31b1d2429729c9e2b60..0277627e97b51e20470ccf578cee48470e06a34b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-@@ -486,6 +486,11 @@ public class PaperConfig {
+@@ -489,6 +489,11 @@ public class PaperConfig {
          }
      }
  

--- a/patches/server/0820-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0820-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index 08c6ea9f19fa9218af089ed3bd2dcda1e83591ed..710a1064cec9c7ec93e1258b0786e74a
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8c238a445b327e24d8152b36ebc2b1b57e73d0e1..00d8b61c04ac91770b0ff3b846d3ff70bef2e8e7 100644
+index e5e23c907d49ee64218f3302e2a2323d6937a8a1..858e29ad77aee8a1b7797c2d82902abbfd662da2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -700,6 +700,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -701,6 +701,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  


### PR DESCRIPTION
Fixes #6598 

In vanilla, there's one difference based on mob category to a despawn range value, and vanilla's mob category enum supports different despawn distances per category so I updated the config to reflect that.