### PR TITLE
Fix CraftCriteria defaults map

### DIFF
--- a/patches/server/0817-Fix-CraftCriteria-defaults-map.patch
+++ b/patches/server/0817-Fix-CraftCriteria-defaults-map.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 4 Oct 2021 22:31:51 -0700
+Subject: [PATCH] Fix CraftCriteria defaults map
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
+index 22801e33fa15322c37cd11d73a40a43fa721a8e4..7241e0900df6e5dedf08db2fc88211b1256ed648 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
+@@ -37,7 +37,13 @@ final class CraftCriteria {
+     }
+ 
+     static CraftCriteria getFromNMS(Objective objective) {
++        if (CraftCriteria.DEFAULTS.containsKey(objective.getCriteria().getName())) { // Paper - fix criteria defaults
+         return CraftCriteria.DEFAULTS.get(objective.getCriteria().getName());
++        // Paper start
++        } else {
++            return new CraftCriteria(objective.getCriteria());
++        }
++        // Paper end
+     }
+ 
+     static CraftCriteria getFromBukkit(String name) {
+@@ -45,6 +51,12 @@ final class CraftCriteria {
+         if (criteria != null) {
+             return criteria;
+         }
++        // Paper start - fix criteria defaults
++        var nmsCriteria = ObjectiveCriteria.byName(name);
++        if (nmsCriteria.isPresent()) {
++            return new CraftCriteria(nmsCriteria.get());
++        }
++        // Paper end
+         return new CraftCriteria(name);
+     }
+ 

--- a/patches/server/0817-Fix-CraftCriteria-defaults-map.patch
+++ b/patches/server/0817-Fix-CraftCriteria-defaults-map.patch
@@ -5,24 +5,19 @@ Subject: [PATCH] Fix CraftCriteria defaults map
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
-index 22801e33fa15322c37cd11d73a40a43fa721a8e4..7241e0900df6e5dedf08db2fc88211b1256ed648 100644
+index 22801e33fa15322c37cd11d73a40a43fa721a8e4..0cd63772871311fc0cb7111657cc9a9dac106167 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftCriteria.java
-@@ -37,7 +37,13 @@ final class CraftCriteria {
+@@ -37,7 +37,7 @@ final class CraftCriteria {
      }
  
      static CraftCriteria getFromNMS(Objective objective) {
-+        if (CraftCriteria.DEFAULTS.containsKey(objective.getCriteria().getName())) { // Paper - fix criteria defaults
-         return CraftCriteria.DEFAULTS.get(objective.getCriteria().getName());
-+        // Paper start
-+        } else {
-+            return new CraftCriteria(objective.getCriteria());
-+        }
-+        // Paper end
+-        return CraftCriteria.DEFAULTS.get(objective.getCriteria().getName());
++        return java.util.Objects.requireNonNullElseGet(CraftCriteria.DEFAULTS.get(objective.getCriteria().getName()), () -> new CraftCriteria(objective.getCriteria())); // Paper
      }
  
      static CraftCriteria getFromBukkit(String name) {
-@@ -45,6 +51,12 @@ final class CraftCriteria {
+@@ -45,6 +45,12 @@ final class CraftCriteria {
          if (criteria != null) {
              return criteria;
          }


### PR DESCRIPTION
In a static block in CraftCriteria it loads a immutable map called `DEFAULTS` by iterating through the `CRITERIA_CACHE` in ObjectiveCriteria. Problem is, that cache isn't loaded with all possible valid criteria upon load. It's loaded with the base scoreboard criterias, and all custom statistics, BUT, all non-custom statistics are loaded as-needed. So they aren't present when that `DEFAULTS` map is built.