### PR TITLE
Saveable Scoreboards

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -311,3 +311,8 @@ public-f net.minecraft.world.level.chunk.ChunkGenerator strongholdSeed
 
 # More Sculk Sensor API
 public-f net.minecraft.world.level.gameevent.vibrations.VibrationListener listenerRange
+
+# Saveable Scoreboards
+public-f org.bukkit.craftbukkit.scoreboard.CraftScoreboard
+public org.bukkit.craftbukkit.scoreboard.CraftScoreboard <init>(Lnet/minecraft/world/scores/Scoreboard;)V
+public net.minecraft.server.ServerScoreboard server

--- a/patches/api/0371-Saveable-Scoreboards.patch
+++ b/patches/api/0371-Saveable-Scoreboards.patch
@@ -1,0 +1,59 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 4 Oct 2021 22:20:44 -0700
+Subject: [PATCH] Saveable Scoreboards
+
+
+diff --git a/src/main/java/io/papermc/paper/scoreboard/SaveableScoreboard.java b/src/main/java/io/papermc/paper/scoreboard/SaveableScoreboard.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..019222bb25a4adf8fe2ec34c28ecf861509d8c0f
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/SaveableScoreboard.java
+@@ -0,0 +1,26 @@
++package io.papermc.paper.scoreboard;
++
++import org.bukkit.scoreboard.Scoreboard;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Path;
++
++/**
++ * Represents a scoreboard backed by a file.
++ */
++public interface SaveableScoreboard extends Scoreboard {
++
++    /**
++     * If the scoreboard is dirty, saves to the file. Plugins
++     * are in charge of handling the saving of the scoreboard,
++     * there is no automatic saving (just like configuration files).
++     */
++    void save();
++
++    /**
++     * Gets the file this scoreboard will be saved to.
++     *
++     * @return the file
++     */
++    @NotNull Path getFile();
++}
+diff --git a/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java b/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java
+index e4f05975685c04b7826b25f3e84c1d41f2d119bf..776188f5ec329d717e6c9475ce51b91113607b0c 100644
+--- a/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java
++++ b/src/main/java/org/bukkit/scoreboard/ScoreboardManager.java
+@@ -29,4 +29,16 @@ public interface ScoreboardManager {
+      */
+     @NotNull
+     Scoreboard getNewScoreboard();
++
++    // Paper start
++    /**
++     * Gets a new Scoreboard to be tracked by the server. This scoreboard
++     * with be loaded from the provided file if it exists and provide
++     * a method to save it to the file.
++     *
++     * @param path the file for the scoreboard
++     * @return an saveable scoreboard
++     */
++    @NotNull java.util.concurrent.CompletableFuture<io.papermc.paper.scoreboard.SaveableScoreboard> getNewScoreboard(@NotNull java.nio.file.Path path);
++    // Paper end
+ }

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -7,7 +7,7 @@ Co-authored-by: zml <zml@stellardrift.ca>
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 756a2ab6ad416f55fa3864cff9818473840b04fc..701a2ffd04df48d437b2cb963dd150af99725b6e 100644
+index cc4c008a99bf5a16614d445d2a5e75ce2d5dedb5..043fd38598e36bb96e6d3ab1ab0966435c9aa61b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -225,4 +225,13 @@ public class PaperConfig {
@@ -3399,10 +3399,10 @@ index e9bb0728ae5c16aad4acc106d332db5095db4033..6752cd9b3bc246fc2a7764df0d2b40d3
      public String getDisplayName() throws IllegalStateException {
          CraftScoreboard scoreboard = this.checkState();
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index afc059755ae3e7b1c0a4cf3c6b8f32ce13cc458d..59f60fcadd8767cf8698482547e8c771d970732a 100644
+index 58abf0fbc22ee787dad8b9c13f69d98fd0d88c60..5b760554d5e912d7eac6a137fac6766800c3aba7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-@@ -27,6 +27,27 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -27,6 +27,27 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      public CraftObjective registerNewObjective(String name, String criteria) throws IllegalArgumentException {
          return this.registerNewObjective(name, criteria, name);
      }
@@ -3430,7 +3430,7 @@ index afc059755ae3e7b1c0a4cf3c6b8f32ce13cc458d..59f60fcadd8767cf8698482547e8c771
  
      @Override
      public CraftObjective registerNewObjective(String name, String criteria, String displayName) throws IllegalArgumentException {
-@@ -35,7 +56,7 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -35,7 +56,7 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
  
      @Override
      public CraftObjective registerNewObjective(String name, String criteria, String displayName, RenderType renderType) throws IllegalArgumentException {
@@ -3439,7 +3439,7 @@ index afc059755ae3e7b1c0a4cf3c6b8f32ce13cc458d..59f60fcadd8767cf8698482547e8c771
          Validate.notNull(criteria, "Criteria cannot be null");
          Validate.notNull(displayName, "Display name cannot be null");
          Validate.notNull(renderType, "RenderType cannot be null");
-@@ -45,7 +66,11 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -45,7 +66,11 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
  
          CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
          net.minecraft.world.scores.Objective objective = this.board.addObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));

--- a/patches/server/0509-Lazily-track-plugin-scoreboards-by-default.patch
+++ b/patches/server/0509-Lazily-track-plugin-scoreboards-by-default.patch
@@ -14,7 +14,7 @@ this breaks your workflow you can always force all scoreboards to be tracked wit
 settings.track-plugin-scoreboards in paper.yml.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 8111e5e1752d93f94b773e35f7ff3857144def63..ec42fb00b6f4a691fa710c68131f80b242e3e6e8 100644
+index b3f872e4920babfe521effb233b13f8e9c85bef1..7a99db37a91edd12ef4a5d8cad690f6e62d31ba0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -96,6 +96,11 @@ public class PaperConfig {
@@ -30,18 +30,18 @@ index 8111e5e1752d93f94b773e35f7ff3857144def63..ec42fb00b6f4a691fa710c68131f80b2
          for (Map.Entry<String, Command> entry : commands.entrySet()) {
              MinecraftServer.getServer().server.getCommandMap().register(entry.getKey(), "Paper", entry.getValue());
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index 59f60fcadd8767cf8698482547e8c771d970732a..7b61a2be2be0bdf06592b65be9acd4cbbae5bf7f 100644
+index 5b760554d5e912d7eac6a137fac6766800c3aba7..9586afaed88fb35e3c61d303b58761fff6ec683c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 @@ -18,6 +18,7 @@ import org.bukkit.scoreboard.Team;
  
- public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      final Scoreboard board;
-+    boolean registeredGlobally = false; // Paper
++    public boolean registeredGlobally = false; // Paper
  
-     CraftScoreboard(Scoreboard board) {
+     public CraftScoreboard(Scoreboard board) {
          this.board = board;
-@@ -44,6 +45,12 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -44,6 +45,12 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
          Validate.isTrue(name.length() <= 16, "The name '" + name + "' is longer than the limit of 16 characters");
          Validate.isTrue(board.getObjective(name) == null, "An objective of name '" + name + "' already exists");
          CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);
@@ -54,7 +54,7 @@ index 59f60fcadd8767cf8698482547e8c771d970732a..7b61a2be2be0bdf06592b65be9acd4cb
          net.minecraft.world.scores.Objective objective = board.addObjective(name, craftCriteria.criteria, io.papermc.paper.adventure.PaperAdventure.asVanilla(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
          return new CraftObjective(this, objective);
      }
-@@ -68,6 +75,12 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -68,6 +75,12 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
          net.minecraft.world.scores.Objective objective = this.board.addObjective(name, craftCriteria.criteria, CraftChatMessage.fromStringOrNull(displayName), CraftScoreboardTranslations.fromBukkitRender(renderType));
  
          CraftCriteria craftCriteria = CraftCriteria.getFromBukkit(criteria);

--- a/patches/server/0829-Improve-scoreboard-entries.patch
+++ b/patches/server/0829-Improve-scoreboard-entries.patch
@@ -24,10 +24,10 @@ index 6752cd9b3bc246fc2a7764df0d2b40d3e638fa62..c5cf800ab8cbb5ebcf1b06ad591f08be
      public void unregister() throws IllegalStateException {
          CraftScoreboard scoreboard = this.checkState();
 diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-index 7b61a2be2be0bdf06592b65be9acd4cbbae5bf7f..152bd54ebd0b0eeee4f3f7faf0c3043d83c01cc1 100644
+index 9586afaed88fb35e3c61d303b58761fff6ec683c..575dd4932ab5c4f7a70eee5ddae622b306701ca4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
 +++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
-@@ -234,4 +234,23 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+@@ -234,4 +234,23 @@ public class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
      public Scoreboard getHandle() {
          return this.board;
      }

--- a/patches/server/0874-Saveable-Scoreboards.patch
+++ b/patches/server/0874-Saveable-Scoreboards.patch
@@ -1,0 +1,143 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 4 Oct 2021 22:20:34 -0700
+Subject: [PATCH] Saveable Scoreboards
+
+
+diff --git a/src/main/java/io/papermc/paper/scoreboard/PaperSaveableScoreboard.java b/src/main/java/io/papermc/paper/scoreboard/PaperSaveableScoreboard.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..3e4091d33edd1afcdc5ed56e01f28f6bcf9d4fcf
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/scoreboard/PaperSaveableScoreboard.java
+@@ -0,0 +1,48 @@
++package io.papermc.paper.scoreboard;
++
++import net.minecraft.SharedConstants;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.server.ServerScoreboard;
++import net.minecraft.world.scores.ScoreboardSaveData;
++import org.bukkit.craftbukkit.scoreboard.CraftScoreboard;
++import org.jetbrains.annotations.NotNull;
++
++import java.nio.file.Files;
++import java.nio.file.Path;
++
++public class PaperSaveableScoreboard extends CraftScoreboard implements SaveableScoreboard {
++
++    private final Path file;
++    private final ScoreboardSaveData saveData;
++
++    public PaperSaveableScoreboard(ServerScoreboard serverScoreboard, Path file) {
++        super(serverScoreboard);
++        this.saveData = this.getHandle().createData();
++        if (Files.exists(file)) {
++            CompoundTag tag = null;
++            try {
++                tag = serverScoreboard.server.overworld().getDataStorage().readTagFromDisk(file.toFile(), SharedConstants.getCurrentVersion().getWorldVersion());
++            } catch (Exception e) {
++                throw new IllegalArgumentException("Could not load scoreboard from " + file, e);
++            }
++            this.saveData.load(tag.getCompound("data"));
++        }
++        this.file = file;
++    }
++
++    @Override
++    public synchronized void save() {
++        this.saveData.save(this.file.toFile());
++    }
++
++    @Override
++    public @NotNull Path getFile() {
++        return this.file;
++    }
++
++    @Override
++    public ServerScoreboard getHandle() {
++        return (ServerScoreboard) super.getHandle();
++    }
++
++}
+diff --git a/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java b/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
+index e84b99ca10621cb1021d7ec17ba21df24e8c7474..46caeb6be996b481d8896444b7f698b212bd680b 100644
+--- a/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
++++ b/src/main/java/net/minecraft/world/level/storage/DimensionDataStorage.java
+@@ -78,6 +78,11 @@ public class DimensionDataStorage {
+ 
+     public CompoundTag readTagFromDisk(String id, int dataVersion) throws IOException {
+         File file = this.getDataFile(id);
++        // Paper start
++        return readTagFromDisk(file, dataVersion);
++    }
++    public CompoundTag readTagFromDisk(File file, int dataVersion) throws IOException {
++        // Paper end
+         FileInputStream fileInputStream = new FileInputStream(file);
+ 
+         CompoundTag var8;
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
+index 1a3b1eb7b70b9a668aa33ea943c13890eaa23a05..d823f333c657fd8e7cfd6900e566db6c04b0e4fc 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboardManager.java
+@@ -25,7 +25,7 @@ import org.bukkit.scoreboard.ScoreboardManager;
+ public final class CraftScoreboardManager implements ScoreboardManager {
+     private final CraftScoreboard mainScoreboard;
+     private final MinecraftServer server;
+-    private final Collection<CraftScoreboard> scoreboards = new WeakCollection<CraftScoreboard>();
++    private final Collection<CraftScoreboard> scoreboards = java.util.Collections.synchronizedCollection(new WeakCollection<CraftScoreboard>()); // Paper
+     private final Map<CraftPlayer, CraftScoreboard> playerBoards = new HashMap<CraftPlayer, CraftScoreboard>();
+ 
+     public CraftScoreboardManager(MinecraftServer minecraftserver, net.minecraft.world.scores.Scoreboard scoreboardServer) {
+@@ -42,7 +42,7 @@ public final class CraftScoreboardManager implements ScoreboardManager {
+ 
+     @Override
+     public CraftScoreboard getNewScoreboard() {
+-        org.spigotmc.AsyncCatcher.catchOp("scoreboard creation"); // Spigot
++        // org.spigotmc.AsyncCatcher.catchOp("scoreboard creation"); // Spigot // Paper
+         CraftScoreboard scoreboard = new CraftScoreboard(new ServerScoreboard(this.server));
+         // Paper start
+         if (com.destroystokyo.paper.PaperConfig.trackPluginScoreboards) {
+@@ -54,8 +54,30 @@ public final class CraftScoreboardManager implements ScoreboardManager {
+     }
+ 
+     // Paper start
++    @Override
++    public java.util.concurrent.CompletableFuture<io.papermc.paper.scoreboard.SaveableScoreboard> getNewScoreboard(java.nio.file.Path path) {
++        var serverScoreboard = new ServerScoreboard(this.server);
++        return java.util.concurrent.CompletableFuture.supplyAsync(() -> {
++            return new io.papermc.paper.scoreboard.PaperSaveableScoreboard(serverScoreboard, path);
++        }, net.minecraft.Util.ioPool()).thenApply(board -> {
++            if (com.destroystokyo.paper.PaperConfig.trackPluginScoreboards) {
++                board.registeredGlobally = true;
++                registerScoreboardForVanilla(board);
++            } else {
++                for (Objective objective : board.getHandle().getObjectives()) {
++                    if (objective.getCriteria() != ObjectiveCriteria.DUMMY) {
++                        board.registeredGlobally = true;
++                        registerScoreboardForVanilla(board);
++                        break;
++                    }
++                }
++            }
++            return board;
++        });
++    }
++
+     public void registerScoreboardForVanilla(CraftScoreboard scoreboard) {
+-        org.spigotmc.AsyncCatcher.catchOp("scoreboard registration");
++        // org.spigotmc.AsyncCatcher.catchOp("scoreboard registration"); // Paper
+         scoreboards.add(scoreboard);
+     }
+     // Paper end
+@@ -118,10 +140,12 @@ public final class CraftScoreboardManager implements ScoreboardManager {
+         co.aikar.timings.MinecraftTimings.scoreboardScoreSearch.startTimingIfSync();
+         try {
+         // Paper end - add timings for scoreboard search
++        synchronized (this.scoreboards) { // Paper
+         for (CraftScoreboard scoreboard : this.scoreboards) {
+             Scoreboard board = scoreboard.board;
+             board.forAllObjectives(criteria, name, (score) -> consumer.accept(score));
+         }
++        } // Paper
+         } finally { // Paper start - add timings for scoreboard search
+             co.aikar.timings.MinecraftTimings.scoreboardScoreSearch.stopTimingIfSync();
+         }


### PR DESCRIPTION
~~Couple problems with this that I don't know the best way to solve. If plugins get/join the returned completable future at the wrong time (like during plugin onEnable) it locks up cause the server is waiting for the plugin to load so the main thread (which at the moment is required for scoreboard creating/registration) can't register the scoreboard.~~

I'm not 100% sure that scoreboard registration needs to be done on the main thread. Would wrapping the WeakCollection of scoreboards in CraftScoreboardManager as a syncronized collection really solve that issue of scoreboard creation requiring the main thread.

EDIT: So I did go ahead and make the scoreboard collection a synchronous collection and removed the async catchers for scoreboard creation.