### PR TITLE
Allow components in conversation prompts

### DIFF
--- a/patches/api/0336-Allow-components-in-conversation-prompts.patch
+++ b/patches/api/0336-Allow-components-in-conversation-prompts.patch
@@ -1,0 +1,107 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Tim Hagemann <tim@eternalwings.de>
+Date: Tue, 5 Oct 2021 20:49:08 +0200
+Subject: [PATCH] Allow components in conversation prompts
+
+
+diff --git a/src/main/java/org/bukkit/command/ConsoleCommandSender.java b/src/main/java/org/bukkit/command/ConsoleCommandSender.java
+index f309c2ed39bcc700e5b491ff549bf0608a07aab8..704ecebef291a9e8477eab5e0d2b30aeff463f63 100644
+--- a/src/main/java/org/bukkit/command/ConsoleCommandSender.java
++++ b/src/main/java/org/bukkit/command/ConsoleCommandSender.java
+@@ -3,4 +3,10 @@ package org.bukkit.command;
+ import org.bukkit.conversations.Conversable;
+ 
+ public interface ConsoleCommandSender extends CommandSender, Conversable {
++    // Paper start - Allow components in conversation prompts
++    @Override
++    default void sendMessage(@org.jetbrains.annotations.NotNull net.kyori.adventure.text.Component message) {
++        CommandSender.super.sendMessage(message);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/conversations/Conversable.java b/src/main/java/org/bukkit/conversations/Conversable.java
+index b7d8dd30360a38dbdc7bbce40c8e6ced7261f833..14e9e75b622de0e3ee8ca92a75a923714789b09f 100644
+--- a/src/main/java/org/bukkit/conversations/Conversable.java
++++ b/src/main/java/org/bukkit/conversations/Conversable.java
+@@ -57,6 +57,8 @@ public interface Conversable {
+      */
+     public void sendRawMessage(@NotNull String message);
+ 
++    public void sendMessage(@NotNull net.kyori.adventure.text.Component component); // Paper - Allow components in conversation prompts
++
+     /**
+      * Sends this sender a message raw
+      *
+diff --git a/src/main/java/org/bukkit/conversations/Conversation.java b/src/main/java/org/bukkit/conversations/Conversation.java
+index bf2407c838bc20197802687c150d513f4e86ed2b..d909b14fd2ccf6704e0611e13f619c1331424a2d 100644
+--- a/src/main/java/org/bukkit/conversations/Conversation.java
++++ b/src/main/java/org/bukkit/conversations/Conversation.java
+@@ -287,7 +287,11 @@ public class Conversation {
+         if (currentPrompt == null) {
+             abandon(new ConversationAbandonedEvent(this));
+         } else {
+-            context.getForWhom().sendRawMessage(prefix.getPrefix(context) + currentPrompt.getPromptText(context));
++            // Paper start - Allow components in conversation prompts
++            final net.kyori.adventure.text.Component prefixComp = net.kyori.adventure.text.Component.text(prefix.getPrefix(context));
++            final net.kyori.adventure.text.Component message = currentPrompt.getPromptMessage(context);
++            context.getForWhom().sendMessage(prefixComp.append(message));
++            // Paper end
+             if (!currentPrompt.blocksForInput(context)) {
+                 currentPrompt = currentPrompt.acceptInput(context, null);
+                 outputNextPrompt();
+diff --git a/src/main/java/org/bukkit/conversations/Prompt.java b/src/main/java/org/bukkit/conversations/Prompt.java
+index fcca208c0f31b41ab67323d0e77a8e3ecf9e78dd..f0f2762e52e8f65161c6edf1b378a9a39d636a95 100644
+--- a/src/main/java/org/bukkit/conversations/Prompt.java
++++ b/src/main/java/org/bukkit/conversations/Prompt.java
+@@ -25,7 +25,16 @@ public interface Prompt extends Cloneable {
+      * @return The text to display.
+      */
+     @NotNull
+-    String getPromptText(@NotNull ConversationContext context);
++    // Paper start - Allow components in conversation prompts
++    default String getPromptText(@NotNull ConversationContext context) {
++        throw new UnsupportedOperationException("Please override either getPromptText or getPromptMessage");
++    }
++
++    @NotNull
++    default net.kyori.adventure.text.Component getPromptMessage(@NotNull ConversationContext context) {
++        return io.papermc.paper.text.PaperComponents.legacySectionSerializer().deserialize(getPromptText(context));
++    }
++    // Paper end
+ 
+     /**
+      * Checks to see if this prompt implementation should wait for user input
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 3e8cd3971ac8256a40d9b85cd7514998c965512c..d44859f7d4bcf4cac31528826de3d967fa07d9cb 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -2295,4 +2295,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+     @Override
+     Spigot spigot();
+     // Spigot end
++
++    // Paper start - Allow components in conversation prompts
++    @Override
++    default void sendMessage(final @NotNull Component message) {
++        this.sendMessage(net.kyori.adventure.identity.Identity.nil(), message);
++    }
++    // Paper end
+ }
+diff --git a/src/test/java/org/bukkit/conversations/FakeConversable.java b/src/test/java/org/bukkit/conversations/FakeConversable.java
+index 567bfd7d3e45d83b5520af6ddd0140c2b84139b2..c5036858671b6d346bcb9db465f7ef3ea13dfe46 100644
+--- a/src/test/java/org/bukkit/conversations/FakeConversable.java
++++ b/src/test/java/org/bukkit/conversations/FakeConversable.java
+@@ -51,6 +51,13 @@ public class FakeConversable implements Conversable {
+         lastSentMessage = message;
+     }
+ 
++    // Paper end - Allow components in conversation prompts
++    @Override
++    public void sendMessage(@NotNull net.kyori.adventure.text.Component component) {
++        lastSentMessage = ((net.kyori.adventure.text.TextComponent)component).content();
++    }
++    // Paper end
++
+     @Override
+     public void sendRawMessage(@Nullable UUID sender, @NotNull String message) {
+         this.sendRawMessage(message);


### PR DESCRIPTION
This allows prompts to alternatively return a text component, implementing #6644.

I'm not entirely happy with how it is right now, but the alternative I've explored also didn't sit well with me. Specifically, the `Prompt` now doesn't force a user to implement a method of getting something to display. Both methods are default, so there's no hard requirement and it will just compile fine without overwriting either of them and eventually crash at runtime. Unfortunately, making either of them non-default would be unsatisfactory in my eyes.
- Making `getPromptMessage` (the new API) non-default: Breaks every prompt in existence, so not an option.
- Making `getPromptText` (the existing API) non-default: Any prompts that want to return a component directly now have to deal with a dead method.

The alternative that I explored was creating a new prompt interface, say `ComponentPrompt` that would include the new method and provide a default for the `getPromptText` method.
<details>
  <summary>ComponentPrompt</summary>

  ```java
public interface ComponentPrompt extends Prompt {

    @Override
    @NotNull
    default String getPromptText(@NotNull ConversationContext context) {
        throw new UnsupportedOperationException("Use getPromptMessage() for component prompts.");
    }

    /**
     * Gets the message component to display to the user when this prompt is first
     * presented.
     *
     * @param context Context information about the conversation.
     * @return The chat component to display.
     */
    @NotNull Component getPromptMessage(ConversationContext context);
}
  ```
</details>

This would ensure old prompts won't break as they wouldn't be forced to implement this new interface. It would also force users of both prompt types (the old and new) to implement the correct method for getting the prompt text. I think this was more satisfactory from a user perspective, but this would now require instance checking internally when using the prompts. As a result I found this solution also a little unsatisfactory. But maybe the upside of having a clear guide on what to implement is more important?

Unfortunately, adding `sendMessage(Component)` to the `Conversible` causes a clash with the equivalent method in `Audience` - to some degree on purpose. Since it was defined as default there, it had to be overwritten in both `Player` and `ConsoleCommandSender`. Not particularly happy about this either, but creating yet another new method for this kind of thing felt awful. Overriding with the default implementation felt like a lesser evil.

I was also debating allowing the prefix to be a component too while I was at it. It would effectively have the same implementation challenge as the prompt so decided to leave that aside for now and see where we're going with the prompt implementation.

I acknowledge that this is a small and low priority change but I'd still be appreciative of feedback.