### PR TITLE
Fix dupe uuid check on entity add

### DIFF
--- a/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
@@ -165,17 +165,18 @@ index 0f88ab98f8f33265dc223d55f4afae60230d9afe..20a9d213b977cf8d8ada3815931bb060
          ChunkPos chunkcoordintpair = holder.getPos();
          CompletableFuture<Either<List<ChunkAccess>, ChunkHolder.ChunkLoadingFailure>> completablefuture = this.getChunkRangeFuture(chunkcoordintpair, 1, (i) -> {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 02767e831301b9112a77e9c2eb786ddbd95edfbd..59c3f1263f6418736e207786bc50448ed5dde32a 100644
+index 02767e831301b9112a77e9c2eb786ddbd95edfbd..799a60df575b7c420b1583f0fea01407be9e30dd 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -74,7 +74,21 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -74,7 +74,22 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
  
      private boolean addEntityUuid(T entity) {
          if (!this.knownUuids.add(entity.getUUID())) {
 +            // Paper start
-+            if (((Entity) entity).isRemoved()) {
-+                stopTracking(entity); // remove the existing entity
-+                return false;
++            T conflict = this.visibleEntityStorage.getEntity(entity.getUUID());
++            if (conflict != null && ((Entity) conflict).isRemoved()) {
++                stopTracking(conflict); // remove the existing entity
++                return true;
 +            }
 +            // Paper end
              PersistentEntitySectionManager.LOGGER.warn("UUID of added entity already exists: {}", entity);

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -1109,10 +1109,10 @@ index 3b8c04f6ffd7e6c197465aa1caf633ba92529472..1007bfc9c19641f42afd5526cfe7bdb6
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 59c3f1263f6418736e207786bc50448ed5dde32a..e9d455736a2ff7a87f319615af4a090ddc943641 100644
+index 799a60df575b7c420b1583f0fea01407be9e30dd..32303ac7950effe468ef675d74d9ad436c5183f0 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -303,6 +303,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -304,6 +304,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              List<Entity> entities = this.getEntities(chunkentities.getPos()); // PAIL rename getChunkPos
              CraftEventFactory.callEntitiesLoadEvent(((EntityStorage) this.permanentStorage).level, chunkentities.getPos(), entities);
              // CraftBukkit end

--- a/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -47,10 +47,10 @@ index 439f82a48e6f6ce7b4773505ced32324cacb302d..2a99aa989ac5c19d99bb3cbc0934425e
  
      public static int getX(long pos) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index e9d455736a2ff7a87f319615af4a090ddc943641..cb6fc8bab2bf4d4b6293ce6e3e62aedadf04b771 100644
+index 32303ac7950effe468ef675d74d9ad436c5183f0..522e913e77cab591d8b31cb56b6821806ab7b69d 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -384,6 +384,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -385,6 +385,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      public LevelEntityGetter<T> getEntityGetter() {
          return this.entityGetter;
      }

--- a/patches/server/0761-Add-more-async-catchers.patch
+++ b/patches/server/0761-Add-more-async-catchers.patch
@@ -31,10 +31,10 @@ index f01182a0ac8a14bcd5b1deb778306e7bf1bf70ed..b27c8db914cca3ff0ea8a24acddb9cb9
              throw new UnsupportedOperationException("Only one concurrent iteration supported");
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index cb6fc8bab2bf4d4b6293ce6e3e62aedadf04b771..0c4ffc0049679b911cc1e1bea36eb21ff6324c46 100644
+index 522e913e77cab591d8b31cb56b6821806ab7b69d..6fe07e1c207efbf5dcec1bdfb1366764d99aa580 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -161,6 +161,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -162,6 +162,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void updateChunkStatus(ChunkPos chunkPos, ChunkHolder.FullChunkStatus levelType) {

--- a/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1210,7 +1210,7 @@ index 59703eb6610c21df22f25c22cc884c4450f0316c..bdd50c28a76576be7950e3ccf8e00b62
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729efd013009 100644
+index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841cc3fff3b4 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -49,8 +49,10 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
@@ -1225,7 +1225,7 @@ index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729e
          this.sectionStorage = new EntitySectionStorage<>(entityClass, this.chunkVisibility);
          this.chunkVisibility.defaultReturnValue(Visibility.HIDDEN);
          this.chunkLoadStatuses.defaultReturnValue(PersistentEntitySectionManager.ChunkLoadStatus.FRESH);
-@@ -107,6 +109,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -108,6 +110,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              EntitySection<T> entitysection = this.sectionStorage.getOrCreateSection(i);
  
              entitysection.add(entity); // CraftBukkit - decompile error
@@ -1233,7 +1233,7 @@ index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729e
              entity.setLevelCallback(new PersistentEntitySectionManager.Callback(entity, i, entitysection));
              if (!existing) {
                  this.callbacks.onCreated(entity);
-@@ -164,6 +167,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -165,6 +168,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          io.papermc.paper.util.TickThread.ensureTickThread("Asynchronous chunk ticking status update"); // Paper
          Visibility visibility = Visibility.fromFullChunkStatus(levelType);
  
@@ -1241,7 +1241,7 @@ index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729e
          this.updateChunkStatus(chunkPos, visibility);
      }
  
-@@ -456,6 +460,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -457,6 +461,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              long i = SectionPos.asLong(blockposition);
  
              if (i != this.currentSectionKey) {
@@ -1249,7 +1249,7 @@ index 0c4ffc0049679b911cc1e1bea36eb21ff6324c46..dbb78ee61a6a3a7336f0656414cd729e
                  Visibility visibility = this.currentSection.getStatus();
  
                  if (!this.currentSection.remove(this.entity)) {
-@@ -504,6 +509,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -505,6 +510,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              if (!this.currentSection.remove(this.entity)) {
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", this.entity, SectionPos.of(this.currentSectionKey), reason);
              }

--- a/patches/server/0794-Optimise-WorldServer-notify.patch
+++ b/patches/server/0794-Optimise-WorldServer-notify.patch
@@ -214,7 +214,7 @@ index e605daac0c90f5d0b9315d1499938feb0e478d0e..b5c385aeb86ac267cae9726354c896ee
              Vec3 vec3 = new Vec3(((double)node.x + this.mob.getX()) / 2.0D, ((double)node.y + this.mob.getY()) / 2.0D, ((double)node.z + this.mob.getZ()) / 2.0D);
              if (pos.closerThan(vec3, (double)(this.path.getNodeCount() - this.path.getNextNodeIndex()))) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index dbb78ee61a6a3a7336f0656414cd729efd013009..1ed6573e0ca6b353d1de3b4486e199a5db9aa447 100644
+index 2276536a0c3e7c6e242400436e8e841cc3fff3b4..7492498917d38eaeb2b2028c1779ce27622aabaa 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -67,6 +67,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
@@ -283,7 +283,7 @@ index dbb78ee61a6a3a7336f0656414cd729efd013009..1ed6573e0ca6b353d1de3b4486e199a5
      void removeSectionIfEmpty(long sectionPos, EntitySection<T> section) {
          if (section.isEmpty()) {
              this.sectionStorage.remove(sectionPos);
-@@ -457,11 +516,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -458,11 +517,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          @Override
          public void onMove() {
              BlockPos blockposition = this.entity.blockPosition();
@@ -311,7 +311,7 @@ index dbb78ee61a6a3a7336f0656414cd729efd013009..1ed6573e0ca6b353d1de3b4486e199a5
  
                  if (!this.currentSection.remove(this.entity)) {
                      PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (moving to {})", this.entity, SectionPos.of(this.currentSectionKey), i);
-@@ -473,6 +546,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -474,6 +547,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
                  entitysection.add(this.entity); // CraftBukkit - decompile error
                  this.currentSection = entitysection;
                  this.currentSectionKey = i;


### PR DESCRIPTION
I'm pretty sure, looking at how this was implemted in 1.16.5 paper, that it was ported incorrectly. I'm guessing this will fix increase in dupe uuid error reports we've gotten but I'm not sure.