### PR TITLE
Fix unplaced block states after new chunk gen API

### DIFF
--- a/patches/server/0822-Fix-unplaced-block-states-after-new-chunk-gen-API.patch
+++ b/patches/server/0822-Fix-unplaced-block-states-after-new-chunk-gen-API.patch
@@ -1,0 +1,60 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 7 Oct 2021 20:49:13 -0700
+Subject: [PATCH] Fix unplaced block states after new chunk gen API
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
+index 489d259d105476092d401f788c88c17c3bed86ff..250afe0acb37e6ea2288a6079160566965b3b2bf 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBeehive.java
+@@ -60,11 +60,11 @@ public class CraftBeehive extends CraftBlockEntityState<BeehiveBlockEntity> impl
+ 
+     @Override
+     public List<Bee> releaseEntities() {
+-        Preconditions.checkState(getWorldHandle() instanceof net.minecraft.world.level.Level, "Can't release entities during world generation");
+ 
+         List<Bee> bees = new ArrayList<>();
+ 
+         if (isPlaced()) {
++            Preconditions.checkState(getWorldHandle() instanceof net.minecraft.world.level.Level, "Can't release entities during world generation"); // Paper - don't fail if block isnt placed, this method did not use to fail
+             BeehiveBlockEntity beehive = ((BeehiveBlockEntity) this.getTileEntityFromWorld());
+             for (Entity bee : beehive.releaseBees(this.getHandle(), BeeReleaseStatus.BEE_RELEASED, true)) {
+                 bees.add((Bee) bee.getBukkitEntity());
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
+index b2b41b5c3a6cab44d49a43b6b0db2fea3271c225..b17a448a4bb78b0527031815de5adee82d7d7f01 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
+@@ -58,12 +58,14 @@ public class CraftBlockState implements BlockState {
+ 
+     public LevelAccessor getWorldHandle() {
+         if (this.weakWorld == null) {
++            requirePlaced(); // Paper
+             return this.world.getHandle();
+         }
+ 
+         LevelAccessor access = this.weakWorld.get();
+         if (access == null) {
+             this.weakWorld = null;
++            requirePlaced(); // Paper
+             return this.world.getHandle();
+         }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
+index 2a723bd0850ee1201bb87760647bd4b3a93279fe..6bcd71928fee7c4f4e1fd11e52293f641d11b12b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftChest.java
+@@ -38,12 +38,12 @@ public class CraftChest extends CraftLootable<ChestBlockEntity> implements Chest
+ 
+     @Override
+     public Inventory getInventory() {
+-        Preconditions.checkState(getWorldHandle() instanceof net.minecraft.world.level.Level, "Can't get inventory during world generation, use getBlockInventory() instead");
+ 
+         CraftInventory inventory = (CraftInventory) this.getBlockInventory();
+         if (!isPlaced()) {
+             return inventory;
+         }
++        Preconditions.checkState(getWorldHandle() instanceof net.minecraft.world.level.Level, "Can't get inventory during world generation, use getBlockInventory() instead"); // Paper - move after placed check
+ 
+         // The logic here is basically identical to the logic in BlockChest.interact
+         CraftWorld world = (CraftWorld) this.getWorld();


### PR DESCRIPTION
Fixes #6745 

Several of upstream's checks to ensure the BlockState was one from an actual world instead of a world gen world broke existing legitimate behavior. 