### PR TITLE
Fix cancelled snow bucket placement

### DIFF
--- a/patches/server/0865-Fix-cancelled-powdered-snow-bucket-placement.patch
+++ b/patches/server/0865-Fix-cancelled-powdered-snow-bucket-placement.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 8 Oct 2021 13:12:58 -0700
+Subject: [PATCH] Fix cancelled powdered snow bucket placement
+
+Cancelling the placement of powdered snow from the powdered
+snow bucket didn't revert grass that became snowy because of the
+placement.
+
+diff --git a/src/main/java/net/minecraft/world/item/BlockItem.java b/src/main/java/net/minecraft/world/item/BlockItem.java
+index 893d5bf448ddbccb30db0ee751c7f4a4e83634b9..8f3b9b8784f0d7b137a1ad87655ee8bad801b59d 100644
+--- a/src/main/java/net/minecraft/world/item/BlockItem.java
++++ b/src/main/java/net/minecraft/world/item/BlockItem.java
+@@ -115,6 +115,7 @@ public class BlockItem extends Item {
+                                 blockstate.update(true, false);
+ 
+                                 if (this instanceof SolidBucketItem) {
++                                    ((ServerPlayer) entityhuman).connection.send(new net.minecraft.network.protocol.game.ClientboundBlockUpdatePacket(world, blockposition.below())); // Paper - update block below
+                                     ((ServerPlayer) entityhuman).getBukkitEntity().updateInventory(); // SPIGOT-4541
+                                 }
+                                 return InteractionResult.FAIL;
+diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
+index 66f808cabcf6a9a6584849b285f1c60133adc7b4..8bd12326e591213f0a093b96a5af3f04e19dc980 100644
+--- a/src/main/java/net/minecraft/world/item/ItemStack.java
++++ b/src/main/java/net/minecraft/world/item/ItemStack.java
+@@ -315,7 +315,7 @@ public final class ItemStack {
+             int oldCount = this.getCount();
+             ServerLevel world = (ServerLevel) itemactioncontext.getLevel();
+ 
+-            if (!(this.getItem() instanceof BucketItem || this.getItem() instanceof SolidBucketItem)) { // if not bucket
++            if (!(this.getItem() instanceof BucketItem/* || this.getItem() instanceof SolidBucketItem*/)) { // if not bucket // Paper - capture block states for snow buckets
+                 world.captureBlockStates = true;
+                 // special case bonemeal
+                 if (this.getItem() == Items.BONE_MEAL) {
+@@ -369,7 +369,7 @@ public final class ItemStack {
+                 world.capturedBlockStates.clear();
+                 if (blocks.size() > 1) {
+                     placeEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callBlockMultiPlaceEvent(world, entityhuman, enumhand, blocks, blockposition.getX(), blockposition.getY(), blockposition.getZ());
+-                } else if (blocks.size() == 1) {
++                } else if (blocks.size() == 1 && item != Items.POWDER_SNOW_BUCKET) { // Paper - don't call event twice for snow buckets
+                     placeEvent = org.bukkit.craftbukkit.event.CraftEventFactory.callBlockPlaceEvent(world, entityhuman, enumhand, blocks.get(0), blockposition.getX(), blockposition.getY(), blockposition.getZ());
+                 }
+ 


### PR DESCRIPTION
SolidBucketItems need to use the existing capturedBlockStates, but have their block place event handled elsewhere, so the event called in ItemStack needs to be skipped.

Fixes #6630