### PR TITLE
Couple fixes/improvements to PlayerSetSpawnEvent

### DIFF
--- a/patches/api/0319-Add-PlayerSetSpawnEvent.patch
+++ b/patches/api/0319-Add-PlayerSetSpawnEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add PlayerSetSpawnEvent
 
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..b5f38a3b0efad52df07c74cfcef30f8e389b11be
+index 0000000000000000000000000000000000000000..c615dbe6ca1289bb090b8e28e98b9ad7b0af8b2a
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerSetSpawnEvent.java
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import net.kyori.adventure.text.Component;
@@ -58,7 +58,9 @@ index 0000000000000000000000000000000000000000..b5f38a3b0efad52df07c74cfcef30f8e
 +
 +    /**
 +     * Gets the location that the spawn is set to. The yaw
-+     * of this location is the spawn angle.
++     * of this location is the spawn angle. Mutating this location
++     * will change the resulting spawn point of the player. Use
++     * {@link Location#clone()} to get a copy of this location.
 +     *
 +     * @return the spawn location, or null if removing the location
 +     */

--- a/patches/server/0695-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0695-Add-PlayerSetSpawnEvent.patch
@@ -5,20 +5,34 @@ Subject: [PATCH] Add PlayerSetSpawnEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/commands/SetSpawnCommand.java b/src/main/java/net/minecraft/server/commands/SetSpawnCommand.java
-index e95f2222814e104bf9194a96385737dffe2cb2b5..249ab7357aa19d87179fa4c3ae89d9d37f32fbfb 100644
+index e95f2222814e104bf9194a96385737dffe2cb2b5..dd6b78d94dcd16c0a708dbc1764e24e9dbe4d3b1 100644
 --- a/src/main/java/net/minecraft/server/commands/SetSpawnCommand.java
 +++ b/src/main/java/net/minecraft/server/commands/SetSpawnCommand.java
-@@ -33,7 +33,7 @@ public class SetSpawnCommand {
+@@ -32,9 +32,21 @@ public class SetSpawnCommand {
+     private static int setSpawn(CommandSourceStack source, Collection<ServerPlayer> targets, BlockPos pos, float angle) {
          ResourceKey<Level> resourceKey = source.getLevel().dimension();
  
++        final Collection<ServerPlayer> actualTargets = new java.util.ArrayList<>(); // Paper
          for(ServerPlayer serverPlayer : targets) {
 -            serverPlayer.setRespawnPosition(resourceKey, pos, angle, true, false);
-+            serverPlayer.setRespawnPosition(resourceKey, pos, angle, true, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.COMMAND); // Paper - PlayerSetSpawnEvent
++            // Paper start - PlayerSetSpawnEvent
++            if (serverPlayer.setRespawnPosition(resourceKey, pos, angle, true, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.COMMAND)) {
++                actualTargets.add(serverPlayer);
++            }
++            // Paper end
          }
++        // Paper start
++        if (actualTargets.isEmpty()) {
++            return 0;
++        } else {
++            targets = actualTargets;
++        }
++        // Paper end
  
          String string = resourceKey.location().toString();
+         if (targets.size() == 1) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 3b1a7cfadd669afafe7e34a3c7c31fd913e3bbd6..cb67d57bf4e7f02bf9416e4286612924e9989afc 100644
+index 3b1a7cfadd669afafe7e34a3c7c31fd913e3bbd6..58ece1e30d316a81e347f196d288292154d71bfe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1279,7 +1279,7 @@ public class ServerPlayer extends Player {
@@ -39,7 +53,7 @@ index 3b1a7cfadd669afafe7e34a3c7c31fd913e3bbd6..cb67d57bf4e7f02bf9416e4286612924
 +        // Paper start
 +        this.setRespawnPosition(dimension, pos, angle, forced, sendMessage, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.UNKNOWN);
 +    }
-+    public void setRespawnPosition(ResourceKey<Level> dimension, @Nullable BlockPos pos, float angle, boolean forced, boolean sendMessage, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause cause) {
++    public boolean setRespawnPosition(ResourceKey<Level> dimension, @Nullable BlockPos pos, float angle, boolean forced, boolean sendMessage, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause cause) {
 +        Location spawnLoc = null;
 +        boolean willNotify = false;
          if (pos != null) {
@@ -50,7 +64,7 @@ index 3b1a7cfadd669afafe7e34a3c7c31fd913e3bbd6..cb67d57bf4e7f02bf9416e4286612924
 +        }
 +        com.destroystokyo.paper.event.player.PlayerSetSpawnEvent event = new com.destroystokyo.paper.event.player.PlayerSetSpawnEvent(this.getBukkitEntity(), cause, spawnLoc, forced, willNotify, willNotify ? net.kyori.adventure.text.Component.translatable("block.minecraft.set_spawn") : null);
 +        if (!event.callEvent()) {
-+            return;
++            return false;
 +        }
 +        if (event.getLocation() != null) {
 +            dimension = event.getLocation().getWorld() != null ? ((CraftWorld) event.getLocation().getWorld()).getHandle().dimension() : dimension;
@@ -66,11 +80,19 @@ index 3b1a7cfadd669afafe7e34a3c7c31fd913e3bbd6..cb67d57bf4e7f02bf9416e4286612924
              }
  
              this.respawnPosition = pos;
+@@ -2126,6 +2147,7 @@ public class ServerPlayer extends Player {
+             this.respawnForced = false;
+         }
+ 
++        return true; // Paper
+     }
+ 
+     public void trackChunk(ChunkPos chunkPos, Packet<?> chunkDataPacket) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 88820ba073e89638304b26e52a39a426f76fb2e9..81957d99205fcee40752914180f9f4a1158a613f 100644
+index 88820ba073e89638304b26e52a39a426f76fb2e9..1fad95b709bbc755e5906a93c8d2ed09b52154ce 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
-@@ -895,7 +895,7 @@ public abstract class PlayerList {
+@@ -895,13 +895,13 @@ public abstract class PlayerList {
                          f1 = (float) Mth.wrapDegrees(Mth.atan2(vec3d1.z, vec3d1.x) * 57.2957763671875D - 90.0D);
                      }
  
@@ -79,21 +101,35 @@ index 88820ba073e89638304b26e52a39a426f76fb2e9..81957d99205fcee40752914180f9f4a1
                      flag2 = !flag && flag3;
                      isBedSpawn = true;
                      location = new Location(worldserver1.getWorld(), vec3d.x, vec3d.y, vec3d.z, f1, 0.0F);
+                 } else if (blockposition != null) {
+                     entityplayer1.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.NO_RESPAWN_BLOCK_AVAILABLE, 0.0F));
+-                    entityplayer1.setRespawnPosition(null, null, 0f, false, false); // CraftBukkit - SPIGOT-5988: Clear respawn location when obstructed
++                    entityplayer1.setRespawnPosition(null, null, 0f, false, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.PLAYER_RESPAWN); // CraftBukkit - SPIGOT-5988: Clear respawn location when obstructed // Paper - PlayerSetSpawnEvent
+                 }
+             }
+ 
 diff --git a/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java b/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
-index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d60346ca82 100644
+index d620f559cdd1bd0e161a99123ef6c6f64e3302df..3770313892b6e9b9ab6f9fcc200dfc0b4972e516 100644
 --- a/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/RespawnAnchorBlock.java
-@@ -73,7 +73,7 @@ public class RespawnAnchorBlock extends Block {
+@@ -73,9 +73,14 @@ public class RespawnAnchorBlock extends Block {
              if (!world.isClientSide) {
                  ServerPlayer serverPlayer = (ServerPlayer)player;
                  if (serverPlayer.getRespawnDimension() != world.dimension() || !pos.equals(serverPlayer.getRespawnPosition())) {
 -                    serverPlayer.setRespawnPosition(world.dimension(), pos, 0.0F, false, true);
-+                    serverPlayer.setRespawnPosition(world.dimension(), pos, 0.0F, false, true, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.RESPAWN_ANCHOR); // Paper - PlayerSetSpawnEvent
++                    if (serverPlayer.setRespawnPosition(world.dimension(), pos, 0.0F, false, true, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.RESPAWN_ANCHOR)) { // Paper - PlayerSetSpawnEvent
                      world.playSound((Player)null, (double)pos.getX() + 0.5D, (double)pos.getY() + 0.5D, (double)pos.getZ() + 0.5D, SoundEvents.RESPAWN_ANCHOR_SET_SPAWN, SoundSource.BLOCKS, 1.0F, 1.0F);
                      return InteractionResult.SUCCESS;
++                    // Paper start - handle failed set spawn
++                    } else {
++                        return InteractionResult.FAIL;
++                    }
++                    // Paper end
                  }
+             }
+ 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 56884ab0053051fca28c5ff58af55c027e296f39..415bcb2b53e943fefeaa58c49d901b029bfd2049 100644
+index 56884ab0053051fca28c5ff58af55c027e296f39..f110643dd7147f0e95dd5fba8e8506407089ed19 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1194,9 +1194,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -104,7 +140,7 @@ index 56884ab0053051fca28c5ff58af55c027e296f39..415bcb2b53e943fefeaa58c49d901b02
 +            this.getHandle().setRespawnPosition(null, null, 0.0F, override, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.PLUGIN); // Paper - PlayerSetSpawnEvent
          } else {
 -            this.getHandle().setRespawnPosition(((CraftWorld) location.getWorld()).getHandle().dimension(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), location.getYaw(), override, false);
-+            this.getHandle().setRespawnPosition(((CraftWorld) location.getWorld()).getHandle().dimension(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), location.getYaw(), override, false); // Paper - PlayerSetSpawnEvent
++            this.getHandle().setRespawnPosition(((CraftWorld) location.getWorld()).getHandle().dimension(), new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ()), location.getYaw(), override, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.PLUGIN); // Paper - PlayerSetSpawnEvent
          }
      }
  

--- a/patches/server/0856-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0856-Replace-player-chunk-loader-system.patch
@@ -1930,10 +1930,10 @@ index 4c9832ccede082a468e97870b5f6b07bbed652f3..344c5bafe291a2542c4940e4d8023264
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e89f18625fd5655087f1ec2992005142c1a5423b..f35cd0e7446e7929087b735b3e9351d57dac296d 100644
+index 6f3dcd6bd19cbd9e4c1d65c17531863b451769de..09a64a9b002f0da20cbe19731068837be27d3480 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-@@ -2441,5 +2441,5 @@ public class ServerPlayer extends Player {
+@@ -2442,5 +2442,5 @@ public class ServerPlayer extends Player {
      }
      // CraftBukkit end
  
@@ -1941,7 +1941,7 @@ index e89f18625fd5655087f1ec2992005142c1a5423b..f35cd0e7446e7929087b735b3e9351d5
 +    public final int getViewDistance() { throw new UnsupportedOperationException("Use PlayerChunkLoader"); } // Paper - placeholder
  }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index fae67931849eb0c19598def9f538c7971c36c575..f5852341161b0d632e22af9b3e625ca1e786bd63 100644
+index c88f57256e6f784e39fe74c3b7fc7e3d8b3a618a..1f221b5451004093af6e46b65b9e60499a12b5ad 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -271,7 +271,7 @@ public abstract class PlayerList {
@@ -2189,7 +2189,7 @@ index eac1891c8eb073522ea9fb5608a7ef0b809d6a80..e663ebbfd687fc94bca6c489506ce85c
      // Paper end - view distance api
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4a372ab984a02b1f54232e45b5a0d483216d37e5..7e7b3692b5b7168f6122ae10fbb1772369f922fd 100644
+index 68c3d6bde1e1e25a9032c22a2d5dddb4baf10059..f12efe51b14ed3637a8ba45def9c94634a6f5e8f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -538,45 +538,80 @@ public class CraftPlayer extends CraftHumanEntity implements Player {


### PR DESCRIPTION
Makes the setspawn command handle cancellation of the event.
Adds missing reasons for setting (clearing) spawn on player respawn if obstructed.
Adds missing plugin reason on api use.
Handles interaction result failure if event is cancelled for respawn anchors.