### PR TITLE
Expose the potential player cause of a lightning

### DIFF
--- a/patches/api/0240-More-lightning-API.patch
+++ b/patches/api/0240-More-lightning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More lightning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/LightningStrike.java b/src/main/java/org/bukkit/entity/LightningStrike.java
-index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..2c81a3f685588431a3c7675c84b35a28975232af 100644
+index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..6f5b6901032eb03606c4566b24459a03baac0c73 100644
 --- a/src/main/java/org/bukkit/entity/LightningStrike.java
 +++ b/src/main/java/org/bukkit/entity/LightningStrike.java
-@@ -31,4 +31,38 @@ public interface LightningStrike extends Entity {
+@@ -31,4 +31,72 @@ public interface LightningStrike extends Entity {
      @Override
      Spigot spigot();
      // Spigot end
@@ -45,5 +45,39 @@ index be347c3d0291f44036bae29a4e7e4645d6a4cdf6..2c81a3f685588431a3c7675c84b35a28
 +     * @param lifeTicks ticks the current flash will do damage for
 +     */
 +    void setLifeTicks(int lifeTicks);
++
++    /**
++     * Returns the potential entity that caused this lightning strike to spawn in the world.
++     * <p>
++     * As of implementing this method, only {@link Player}s are capable of causing a lightning strike, however as this
++     * might change in future minecraft releases, this method does not guarantee a player as the cause of a lightning.
++     * Consumers of this method should hence validate whether or not the entity is a player if they want to use player
++     * specific methods through an {@code instanceOf} check.
++     * </p>
++     * <p>
++     * A player is, as of implementing this method, responsible for a lightning, and will hence be returned here as
++     * a cause, if they channeled a {@link Trident} to summon it or were explicitly defined as the cause of this
++     * lightning through {@link #setCausingPlayer(Player)}.
++     * </p>
++     *
++     * @return the entity that caused this lightning or null if the lightning was not caused by a entity (e.g. normal
++     * weather)
++     */
++    @org.jetbrains.annotations.Nullable
++    Entity getCausingEntity();
++
++    /**
++     * Updates the player that caused this lightning to be summoned into the world.
++     * By default, players that channel their {@link Trident} will be the cause of the respective lightning.
++     * <p>
++     * While the respective getter method {@link #getCausingEntity()} does not guarantee a player as the cause of a
++     * lightning to stay as future proof as possible, as of implementing this method, players are the only entities
++     * that can cause a lightning strike and hence this setter is restricted to players.
++     * </p>
++     *
++     * @param causingPlayer the player that should be the new cause of this lightning. {@code null} may be passed to
++     *                      indicate that no player is responsible for this lightning.
++     */
++    void setCausingPlayer(@org.jetbrains.annotations.Nullable Player causingPlayer);
 +    // Paper end
  }

--- a/patches/server/0559-More-lightning-API.patch
+++ b/patches/server/0559-More-lightning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More lightning API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
-index f7991ff14ef9cda0327b8621bf615b49cffd7ac5..db6b158f18ad7b9171a8c041802e3495d733bc16 100644
+index f7991ff14ef9cda0327b8621bf615b49cffd7ac5..e515e819774bfb31ec03f05a5502921e66f2b0e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLightningStrike.java
-@@ -45,4 +45,27 @@ public class CraftLightningStrike extends CraftEntity implements LightningStrike
+@@ -45,4 +45,38 @@ public class CraftLightningStrike extends CraftEntity implements LightningStrike
          return this.spigot;
      }
      // Spigot end
@@ -33,6 +33,17 @@ index f7991ff14ef9cda0327b8621bf615b49cffd7ac5..db6b158f18ad7b9171a8c041802e3495
 +    @Override
 +    public void setLifeTicks(int lifeTicks) {
 +        getHandle().life = lifeTicks;
++    }
++
++    @Override
++    public @org.jetbrains.annotations.Nullable org.bukkit.entity.Entity getCausingEntity() {
++        final var cause = this.getHandle().getCause();
++        return cause == null ? null : cause.getBukkitEntity();
++    }
++
++    @Override
++    public void setCausingPlayer(@org.jetbrains.annotations.Nullable org.bukkit.entity.Player causingPlayer) {
++        this.getHandle().setCause(causingPlayer == null ? null : ((CraftPlayer) causingPlayer).getHandle());
 +    }
 +    // Paper end
  }


### PR DESCRIPTION
As the internal lightning bolt representation already stores the player
instance that may have caused the lightning in the first place, through
tridents, this commit expands the existing additions to the lightning
api to expose the previously mentioned player instance that caused the
lightning.

Resolves: #6781 