### PR TITLE
Add missing block data mins and maxes

### DIFF
--- a/patches/api/0370-Add-missing-block-data-mins-and-maxes.patch
+++ b/patches/api/0370-Add-missing-block-data-mins-and-maxes.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 16 Oct 2021 22:57:10 -0700
+Subject: [PATCH] Add missing block data mins and maxes
+
+
+diff --git a/src/main/java/org/bukkit/block/data/Levelled.java b/src/main/java/org/bukkit/block/data/Levelled.java
+index 5255538fecae6da413546be3adacd2a99f6c74e9..860f072dee391b300cb1629058a3f9c23dfd95e2 100644
+--- a/src/main/java/org/bukkit/block/data/Levelled.java
++++ b/src/main/java/org/bukkit/block/data/Levelled.java
+@@ -36,4 +36,13 @@ public interface Levelled extends BlockData {
+      * @return the maximum 'level' value
+      */
+     int getMaximumLevel();
++
++    // Paper start
++    /**
++     * Gets the minimum allowed value of the 'level' property.
++     *
++     * @return the minimum 'level' value
++     */
++    int getMinimumLevel();
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/block/data/type/Candle.java b/src/main/java/org/bukkit/block/data/type/Candle.java
+index d4d08bd424f84523200d1a2012f4d37c07cc3497..7baccce27f2db2242f628ea92a9d040267caef75 100644
+--- a/src/main/java/org/bukkit/block/data/type/Candle.java
++++ b/src/main/java/org/bukkit/block/data/type/Candle.java
+@@ -28,4 +28,13 @@ public interface Candle extends Lightable, Waterlogged {
+      * @return the maximum 'candles' value
+      */
+     int getMaximumCandles();
++
++    // Paper start
++    /**
++     * Gets the minimum allowed value of the 'candles' property.
++     *
++     * @return the minimum 'candles' value
++     */
++    int getMinimumCandles();
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/block/data/type/Leaves.java b/src/main/java/org/bukkit/block/data/type/Leaves.java
+index 3874d5d9647107c409651d20470a57197b4f3a3d..1050f5d9d2e75d221ce26eca0ef14add07221f19 100644
+--- a/src/main/java/org/bukkit/block/data/type/Leaves.java
++++ b/src/main/java/org/bukkit/block/data/type/Leaves.java
+@@ -39,4 +39,20 @@ public interface Leaves extends BlockData {
+      * @param distance the new 'distance' value
+      */
+     void setDistance(int distance);
++
++    // Paper start
++    /**
++     * Gets the maximum allowed value of the 'distance' property.
++     *
++     * @return the maximum 'distance' value
++     */
++    int getMaximumDistance();
++
++    /**
++     * Gets the minimum allowed value of the 'distance' property.
++     *
++     * @return the minimum 'distance' value
++     */
++    int getMinimumDistance();
++    // Paper end
+ }

--- a/patches/server/0873-Add-missing-block-data-mins-and-maxes.patch
+++ b/patches/server/0873-Add-missing-block-data-mins-and-maxes.patch
@@ -1,0 +1,155 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 16 Oct 2021 22:57:31 -0700
+Subject: [PATCH] Add missing block data mins and maxes
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftLeaves.java b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftLeaves.java
+index 5b0da54982fc0879005fd1db104284eb3318bee8..3c5a2de56724bc784f619f3087140c72a42dc57b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftLeaves.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/data/type/CraftLeaves.java
+@@ -3,7 +3,7 @@ package org.bukkit.craftbukkit.block.data.type;
+ import org.bukkit.block.data.type.Leaves;
+ import org.bukkit.craftbukkit.block.data.CraftBlockData;
+ 
+-public class CraftLeaves extends CraftBlockData implements Leaves {
++public abstract class CraftLeaves extends CraftBlockData implements Leaves { // Paper - make abstract (not used anyways)
+ 
+     private static final net.minecraft.world.level.block.state.properties.IntegerProperty DISTANCE = getInteger("distance");
+     private static final net.minecraft.world.level.block.state.properties.BooleanProperty PERSISTENT = getBoolean("persistent");
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCandle.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCandle.java
+index 83f86725c00f0e175cb46c7e27705ca777f413ba..24d16825c10edfed6d22e8e37ddb9fd804b716c4 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCandle.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCandle.java
+@@ -31,6 +31,12 @@ public final class CraftCandle extends org.bukkit.craftbukkit.block.data.CraftBl
+     public int getMaximumCandles() {
+         return getMax(CraftCandle.CANDLES);
+     }
++    // Paper start
++    @Override
++    public int getMinimumCandles() {
++        return getMin(CraftCandle.CANDLES);
++    }
++    // Paper end
+ 
+     // org.bukkit.craftbukkit.block.data.CraftLightable
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCauldron.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCauldron.java
+index e17a85182555b7b50b4b1e42af871462699dba06..ef90de836888caa0a56c9c34c15bcd0d6c2d16a8 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCauldron.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftCauldron.java
+@@ -31,4 +31,11 @@ public final class CraftCauldron extends org.bukkit.craftbukkit.block.data.Craft
+     public int getMaximumLevel() {
+         return getMax(CraftCauldron.LEVEL);
+     }
++
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftCauldron.LEVEL);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftComposter.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftComposter.java
+index 780b6a29592571f4a730a858734256f69519cca7..ef97e77b25562a8aed35d68d42ced4825d43a29d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftComposter.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftComposter.java
+@@ -31,4 +31,11 @@ public final class CraftComposter extends org.bukkit.craftbukkit.block.data.Craf
+     public int getMaximumLevel() {
+         return getMax(CraftComposter.LEVEL);
+     }
++
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftComposter.LEVEL);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftFluids.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftFluids.java
+index f083cf727e7fd55f0749e85e3d034b5606121110..e40cda2f23d63e9d2029a8c8818103b6eeb6a925 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftFluids.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftFluids.java
+@@ -31,4 +31,11 @@ public final class CraftFluids extends org.bukkit.craftbukkit.block.data.CraftBl
+     public int getMaximumLevel() {
+         return getMax(CraftFluids.LEVEL);
+     }
++
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftFluids.LEVEL);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLayeredCauldron.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLayeredCauldron.java
+index 0d08c81dd8582ef4f259f0e0db88e1b85d79f2a1..5b96ec73bf7bd4d90ce77cfe8ffec82580b20d2b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLayeredCauldron.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLayeredCauldron.java
+@@ -31,4 +31,11 @@ public final class CraftLayeredCauldron extends org.bukkit.craftbukkit.block.dat
+     public int getMaximumLevel() {
+         return getMax(CraftLayeredCauldron.LEVEL);
+     }
++
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftLayeredCauldron.LEVEL);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLeaves.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLeaves.java
+index c4ac30e38bf786c491e0e1d47a9003f2b8e1d985..709812fd312f9eddfada21d3836eca6a696183fd 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLeaves.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLeaves.java
+@@ -37,4 +37,16 @@ public final class CraftLeaves extends org.bukkit.craftbukkit.block.data.CraftBl
+     public void setDistance(int distance) {
+         set(CraftLeaves.DISTANCE, distance);
+     }
++
++    // Paper start
++    @Override
++    public int getMaximumDistance() {
++        return getMax(CraftLeaves.DISTANCE);
++    }
++
++    @Override
++    public int getMinimumDistance() {
++        return getMin(CraftLeaves.DISTANCE);
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLight.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLight.java
+index de882af105fae1166aced908cfe45b826a07f418..0d430382a05dfc0802a2569816c5ec876a053f16 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLight.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftLight.java
+@@ -32,6 +32,13 @@ public final class CraftLight extends org.bukkit.craftbukkit.block.data.CraftBlo
+         return getMax(CraftLight.LEVEL);
+     }
+ 
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftLight.LEVEL);
++    }
++    // Paper end
++
+     // org.bukkit.craftbukkit.block.data.CraftWaterlogged
+ 
+     private static final net.minecraft.world.level.block.state.properties.BooleanProperty WATERLOGGED = getBoolean(net.minecraft.world.level.block.LightBlock.class, "waterlogged");
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPowderSnowCauldron.java b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPowderSnowCauldron.java
+index c6bd91bdf6bf64701ffc69619174cc3b43b72d88..c6289306f0f933b67ff1f6db63ef976df7aa5438 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPowderSnowCauldron.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/impl/CraftPowderSnowCauldron.java
+@@ -31,4 +31,11 @@ public final class CraftPowderSnowCauldron extends org.bukkit.craftbukkit.block.
+     public int getMaximumLevel() {
+         return getMax(CraftPowderSnowCauldron.LEVEL);
+     }
++
++    // Paper start
++    @Override
++    public int getMinimumLevel() {
++        return getMin(CraftPowderSnowCauldron.LEVEL);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
I noticed some inconsistency in methods for BlockDatas. For any integer property, there should be a getMinimum*Value* method so long as the minimum value isn't 0, and always a getMaximum*Value* method. This was missing in a couple places.