### PR TITLE
Correctly inflate villager activation bounding box

### DIFF
--- a/patches/server/0364-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0364-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fa5aa491c3ed6bf50b7f34c9f32a0b146e6c0aef..8a1df5b26a6ba0e2fa13a9974cf41384a8e6d4fe 100644
+index 6fb49058cd958a394870dc527342be4cd94135c9..4c45110320004eb1c6f8c73d5c67880110e6ef08 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -351,7 +351,7 @@ index 9b631698d1c736f61e07a5a1253127f4081dc90d..54020a3f2b18c4f42008f5d5f4541ef1
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2574ccd92c43f56e8be71f1bf6857c761a72a510 100644
+index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..e0302f82356e8cba848aa8cec1e821e02abbd6f6 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -1,39 +1,51 @@
@@ -521,7 +521,7 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..2574ccd92c43f56e8be71f1bf6857c76
 +            // Paper start
 +            ActivationType.WATER.boundingBox = player.getBoundingBox().inflate( waterActivationRange, 256, waterActivationRange );
 +            ActivationType.FLYING_MONSTER.boundingBox = player.getBoundingBox().inflate( flyingActivationRange, 256, flyingActivationRange );
-+            ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate( villagerActivationRange, 256, waterActivationRange );
++            ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate( villagerActivationRange, 256, villagerActivationRange );
 +            // Paper end
  
              world.getEntities().get(maxBB, ActivationRange::activateEntity);

--- a/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -914,7 +914,7 @@ index 0000000000000000000000000000000000000000..3ba094e640d7fe7803e2bbdab8ff3beb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 80f59abeb0081fe4784f3c0d027e8dfce752814b..3351c4d43b41db5a0718d7ff761b06d950b7ee87 100644
+index 7e0b656c5df0e778d3f07befc853a5de6516f951..675fca76f5f7319d45e0d4f03b74d27bf2a5a647 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -437,7 +437,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1309,11 +1309,11 @@ index c5d132dcf70a55de041c0187ff8fb889248bdfee..950d4381459d31d02acf55c4aef4f5e3
 +    // Paper end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 951e8ba1e05436aa0afcd0a72358550422afa791..b5da2f39ff6e2e7cb519c5d22be6ae4d77dc60ab 100644
+index 85449fc6d19974622588e7f13e1dc78c8dffbeee..9c456cce42ef9d1654df9047d6fc1e0da13dc1c9 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
 @@ -205,7 +205,13 @@ public class ActivationRange
-             ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate( villagerActivationRange, 256, waterActivationRange );
+             ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate( villagerActivationRange, 256, villagerActivationRange );
              // Paper end
  
 -            world.getEntities().get(maxBB, ActivationRange::activateEntity);


### PR DESCRIPTION
Prior to this commit, the activation bounding box used for villagers was
inflated using the 'entity-activation-range.villagers' for the x axis
and 'entity-activation-range.water' for the z axis, causing villagers to
use the water mobs activation range on the z axis.

This commit now properly uses the 'entity-activation-range.villagers'
value for both the x and z axis inflation for the villagers activation
range.

Resolves: #6797