### PR TITLE
ci: Update gh actions with caching [Supersedes 6474]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,22 +16,13 @@ jobs:
                 java: [16]
             fail-fast: true
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v2.3.5
             - name: JDK ${{ matrix.java }}
-              uses: actions/setup-java@v2
+              uses: actions/setup-java@v2.3.1
               with:
                   java-version: ${{ matrix.java }}
-                  distribution: 'adopt'
-            - name: Cache gradle
-              uses: actions/cache@v2
-              with:
-                  path: |
-                    ~/.gradle/caches
-                    ~/.gradle/jdks
-                    ~/.gradle/native
-                    ~/.gradle/wrapper
-                  key: ${{ runner.os }}-paper-2-${{ hashFiles('**/*.gradle*', 'gradle/**', 'gradle.properties') }}
-                  restore-keys: ${{ runner.os }}-paper-2
+                  cache: 'gradle'
+                  distribution: 'temurin'
             - name: Patch and build
               run: |
                   git config --global user.email "no-reply@github.com"


### PR DESCRIPTION
cc @MiniDigger https://github.com/PaperMC/Paper/pull/6474#issuecomment-904419334

Built in caching reduces the build duration by ~87%, see https://github.com/NotMyFault/Paper/actions/runs/1375290878
