### PR TITLE
Prevent CraftNamespacedKey induced server crash

### DIFF
--- a/patches/server/0837-Fix-Bukkit-NamespacedKey-shenanigans.patch
+++ b/patches/server/0837-Fix-Bukkit-NamespacedKey-shenanigans.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
+Date: Sun, 24 Oct 2021 15:49:35 +0200
+Subject: [PATCH] Fix Bukkit NamespacedKey shenanigans
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java b/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
+index 5f40d240b879e3989897b6e45725a8e5a6a7f194..5014192edb9616ce725fc1592832034789527b6f 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftNamespacedKey.java
+@@ -13,7 +13,7 @@ public final class CraftNamespacedKey {
+             return null;
+         }
+         ResourceLocation minecraft = ResourceLocation.tryParse(string);
+-        return (minecraft == null) ? null : CraftNamespacedKey.fromMinecraft(minecraft);
++        return (minecraft == null || minecraft.getPath().isEmpty()) ? null : CraftNamespacedKey.fromMinecraft(minecraft); // Paper - Bukkit's parser does not match Vanilla for empty paths
+     }
+ 
+     public static NamespacedKey fromString(String string) {


### PR DESCRIPTION
Bukkit is Bukkit and does not accept empty paths, while Vanilla does. This doesn't actually fix the underlying parsing problem, but properly returns null for (what Bukkit thinks) are invalid locations, instead of throwing an error
Fixes #6558
Closes #6559