### PR TITLE
Update jline and TCA

### DIFF
--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..9b70376813531718c02082633e9f8105f4879a63 100644
+index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..e2ec23e597a3519550251b9f150bad8795b29a48 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -16,7 +16,17 @@ repositories {
@@ -28,8 +28,8 @@ index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..9b70376813531718c02082633e9f8105
      implementation(project(":Paper-API"))
 -    implementation("jline:jline:2.12.1")
 +    // Paper start
-+    implementation("org.jline:jline-terminal-jansi:3.12.1")
-+    implementation("net.minecrell:terminalconsoleappender:1.2.0")
++    implementation("org.jline:jline-terminal-jansi:3.20.0")
++    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 +    /*
 +          Required to add the missing Log4j2Plugins.dat file from log4j-core
 +          which has been removed by Mojang. Without it, log4j has to classload
@@ -230,7 +230,7 @@ index 7d834c1b1588851188372eebd9efad9313c610f7..967552df9d5ae7e58bb39127e1adb51b
          System.setOut(IoBuilder.forLogger(logger).setLevel(Level.INFO).buildPrintStream());
          System.setErr(IoBuilder.forLogger(logger).setLevel(Level.WARN).buildPrintStream());
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 24add1cd1f865012c5382548e415218d481ecefe..31dccb0b4ab60d6cedf236fc7d51a363c8367d71 100644
+index 71991aee0d60299f744c896075502d1b436b3e44..0eea43c994e76b466fdda8ecd145d0b1c9273cea 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -154,8 +154,7 @@ public abstract class PlayerList {

--- a/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
+++ b/patches/server/0137-Use-TerminalConsoleAppender-for-console-improvements.patch
@@ -19,7 +19,7 @@ Other changes:
     configuration
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..e2ec23e597a3519550251b9f150bad8795b29a48 100644
+index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..ba7f0c199c60c062d399586e5c9a0d3da8ddb013 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -16,7 +16,17 @@ repositories {
@@ -28,7 +28,7 @@ index 1f4c0f2156c588fcbb3b0329a416dc20a4b355a8..e2ec23e597a3519550251b9f150bad87
      implementation(project(":Paper-API"))
 -    implementation("jline:jline:2.12.1")
 +    // Paper start
-+    implementation("org.jline:jline-terminal-jansi:3.20.0")
++    implementation("org.jline:jline-terminal-jansi:3.21.0")
 +    implementation("net.minecrell:terminalconsoleappender:1.3.0")
 +    /*
 +          Required to add the missing Log4j2Plugins.dat file from log4j-core

--- a/patches/server/0422-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0422-Implement-Brigadier-Mojang-API.patch
@@ -10,7 +10,7 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index a195b90d310f72a8846717944fbd86de9e4198b8..967219dffd1d659e7209bf55ec040c7dc98bc159 100644
+index 24465fa59dd9eeff82ad620731fadcb19910aa4e..053e65679dd44f3d1c669ef560f07554af09086b 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -16,6 +16,7 @@ repositories {
@@ -19,7 +19,7 @@ index a195b90d310f72a8846717944fbd86de9e4198b8..967219dffd1d659e7209bf55ec040c7d
      implementation(project(":Paper-API"))
 +    implementation(project(":Paper-MojangAPI"))
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.20.0")
+     implementation("org.jline:jline-terminal-jansi:3.21.0")
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 index 880fc9fea286384d002518137972935fdf1d2d72..a59d14e61fcbca7861a5593d0717b81262ccbdc5 100644

--- a/patches/server/0422-Implement-Brigadier-Mojang-API.patch
+++ b/patches/server/0422-Implement-Brigadier-Mojang-API.patch
@@ -10,7 +10,7 @@ Adds CommandRegisteredEvent
   - Allows manipulating the CommandNode to add more children/metadata for the client
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index c981944f4a5d40ec14ade9aaa22041887a317e1f..2c39461ce531cfa8fc0aa6928e0de819640b0553 100644
+index a195b90d310f72a8846717944fbd86de9e4198b8..967219dffd1d659e7209bf55ec040c7dc98bc159 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -16,6 +16,7 @@ repositories {
@@ -19,8 +19,8 @@ index c981944f4a5d40ec14ade9aaa22041887a317e1f..2c39461ce531cfa8fc0aa6928e0de819
      implementation(project(":Paper-API"))
 +    implementation(project(":Paper-MojangAPI"))
      // Paper start
-     implementation("org.jline:jline-terminal-jansi:3.12.1")
-     implementation("net.minecrell:terminalconsoleappender:1.2.0")
+     implementation("org.jline:jline-terminal-jansi:3.20.0")
+     implementation("net.minecrell:terminalconsoleappender:1.3.0")
 diff --git a/src/main/java/net/minecraft/commands/CommandSourceStack.java b/src/main/java/net/minecraft/commands/CommandSourceStack.java
 index 880fc9fea286384d002518137972935fdf1d2d72..a59d14e61fcbca7861a5593d0717b81262ccbdc5 100644
 --- a/src/main/java/net/minecraft/commands/CommandSourceStack.java
@@ -81,7 +81,7 @@ index 07c4d909324c8aad3a8c5d27811e2c28fe7a91f3..96a33f63024c1f72ab018e1590450583
          event.getPlayer().getServer().getPluginManager().callEvent(event);
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f585cd4f4682a9d2a6ebc2367a32995d8660d591..11d9e22c9ef64db62528da73066de8c118565054 100644
+index 9fc196ada8dc3b9b9a8f3f35ac6b07c949ce2339..3071053aa9c6a9abc2af50b3c370a408cddbac85 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -759,8 +759,12 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser

--- a/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Enhance console tab completions for brigadier commands
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 5af9d91e15b0c10da79fa935cc884cd2766edfae..6c4bb838792c779da7b2d84831f6e67779695993 100644
+index 4e824a87b463a417c204a9ee188450bdd9f4fbc2..ef1e6e898b3cb9d012b2cf24aedffea4afce8a38 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -500,4 +500,11 @@ public class PaperConfig {
@@ -145,10 +145,10 @@ index 0000000000000000000000000000000000000000..d3f80b5dcd366c5b8a48cb885d825d24
 +}
 diff --git a/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java b/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f33e9376bd166ebdb3d9f8c7467cd923ea0aadeb
+index 0000000000000000000000000000000000000000..9cb535a14b490ee8553561481ac62fe3ef729d6c
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java
-@@ -0,0 +1,57 @@
+@@ -0,0 +1,69 @@
 +package io.papermc.paper.console;
 +
 +import com.mojang.brigadier.ParseResults;
@@ -162,6 +162,8 @@ index 0000000000000000000000000000000000000000..f33e9376bd166ebdb3d9f8c7467cd923
 +import org.jline.utils.AttributedString;
 +import org.jline.utils.AttributedStringBuilder;
 +import org.jline.utils.AttributedStyle;
++
++import java.util.regex.Pattern;
 +
 +public final class BrigadierCommandHighlighter implements Highlighter {
 +    private static final int[] COLORS = {AttributedStyle.CYAN, AttributedStyle.YELLOW, AttributedStyle.GREEN, AttributedStyle.MAGENTA, /* Client uses GOLD here, not BLUE, however there is no GOLD AttributedStyle. */ AttributedStyle.BLUE};
@@ -204,6 +206,16 @@ index 0000000000000000000000000000000000000000..f33e9376bd166ebdb3d9f8c7467cd923
 +            builder.append((buffer.substring(pos)), AttributedStyle.DEFAULT.foreground(AttributedStyle.RED));
 +        }
 +        return builder.toAttributedString();
++    }
++
++    @Override
++    public void setErrorPattern(Pattern errorPattern) {
++
++    }
++
++    @Override
++    public void setErrorIndex(int errorIndex) {
++
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java

--- a/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
+++ b/patches/server/0649-Enhance-console-tab-completions-for-brigadier-comman.patch
@@ -145,15 +145,16 @@ index 0000000000000000000000000000000000000000..d3f80b5dcd366c5b8a48cb885d825d24
 +}
 diff --git a/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java b/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..9cb535a14b490ee8553561481ac62fe3ef729d6c
+index 0000000000000000000000000000000000000000..5ab8365b806dd035800ba9b449c9bc9233772d13
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/console/BrigadierCommandHighlighter.java
-@@ -0,0 +1,69 @@
+@@ -0,0 +1,64 @@
 +package io.papermc.paper.console;
 +
 +import com.mojang.brigadier.ParseResults;
 +import com.mojang.brigadier.context.ParsedCommandNode;
 +import com.mojang.brigadier.tree.LiteralCommandNode;
++import java.util.regex.Pattern;
 +import net.minecraft.commands.CommandSourceStack;
 +import net.minecraft.server.dedicated.DedicatedServer;
 +import org.checkerframework.checker.nullness.qual.NonNull;
@@ -162,8 +163,6 @@ index 0000000000000000000000000000000000000000..9cb535a14b490ee8553561481ac62fe3
 +import org.jline.utils.AttributedString;
 +import org.jline.utils.AttributedStringBuilder;
 +import org.jline.utils.AttributedStyle;
-+
-+import java.util.regex.Pattern;
 +
 +public final class BrigadierCommandHighlighter implements Highlighter {
 +    private static final int[] COLORS = {AttributedStyle.CYAN, AttributedStyle.YELLOW, AttributedStyle.GREEN, AttributedStyle.MAGENTA, /* Client uses GOLD here, not BLUE, however there is no GOLD AttributedStyle. */ AttributedStyle.BLUE};
@@ -209,14 +208,10 @@ index 0000000000000000000000000000000000000000..9cb535a14b490ee8553561481ac62fe3
 +    }
 +
 +    @Override
-+    public void setErrorPattern(Pattern errorPattern) {
-+
-+    }
++    public void setErrorPattern(final Pattern errorPattern) {}
 +
 +    @Override
-+    public void setErrorIndex(int errorIndex) {
-+
-+    }
++    public void setErrorIndex(final int errorIndex) {}
 +}
 diff --git a/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java b/src/main/java/net/minecraft/server/dedicated/DedicatedServer.java
 index 67afb97e6cb545d319202f3eca771015065089f6..0300390025c3f5461ef5f379c1710a58de164117 100644


### PR DESCRIPTION
updates jline to 3.21.0, and TCA to 1.3.0

There is some considerations here given that now the ASM library is bundled with the mojang server, we could maybe go back to using the JNA version of jline, which, IIRC, worked better in some areas vs jline, I forget if there was another reason for switching to jline, given the years of terminals being terminals it's hard to remember what were the implications of all solutions available, windows being a common breaking ground here...

maybe want to perform the typical "has it broken an environment we care about" tests...

jar available here in the next few minutes: https://keybase.pub/electronicboy/builds/paper/versions/1.17.1/Paper-1.17.1-R0.1-SNAPSHOT-update-jline.jar

