### PR TITLE
Don't fire EntityZapEvent twice

### DIFF
--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -4,22 +4,6 @@ Date: Sun, 16 Oct 2016 23:19:30 -0700
 Subject: [PATCH] Add EntityZapEvent
 
 
-diff --git a/src/main/java/net/minecraft/world/entity/animal/Pig.java b/src/main/java/net/minecraft/world/entity/animal/Pig.java
-index e4d811025a000f6d12ab8587de293e929c8fd970..53eaafad559cd6413bb1e10d07374da0ab907ec6 100644
---- a/src/main/java/net/minecraft/world/entity/animal/Pig.java
-+++ b/src/main/java/net/minecraft/world/entity/animal/Pig.java
-@@ -254,6 +254,11 @@ public class Pig extends Animal implements ItemSteerable, Saddleable {
-             }
- 
-             entitypigzombie.setPersistenceRequired();
-+            // Paper start
-+            if (CraftEventFactory.callEntityZapEvent(this, lightning, entitypigzombie).isCancelled()) {
-+                return;
-+            }
-+            // Paper end
-             // CraftBukkit start
-             if (CraftEventFactory.callPigZapEvent(this, lightning, entitypigzombie).isCancelled()) {
-                 return;
 diff --git a/src/main/java/net/minecraft/world/entity/npc/Villager.java b/src/main/java/net/minecraft/world/entity/npc/Villager.java
 index e6f1f9794ddd86a1ea0a6adceb9c9dc81997183f..7ddcdafdd9b60e9cab2d6b0a3c5b40694ea59506 100644
 --- a/src/main/java/net/minecraft/world/entity/npc/Villager.java


### PR DESCRIPTION
PigZapEvent extends EntityZapEvent, and the HandlerList was moved from PigZapEvent to EntityZapEvent so any EntityZapHandler was called twice on pigs getting struck by lightning