### PR TITLE
Fix issues with mob conversion

### DIFF
--- a/patches/api/0343-Fix-issues-with-mob-conversion.patch
+++ b/patches/api/0343-Fix-issues-with-mob-conversion.patch
@@ -1,0 +1,34 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 24 Oct 2021 20:29:27 -0700
+Subject: [PATCH] Fix issues with mob conversion
+
+
+diff --git a/src/main/java/org/bukkit/entity/PiglinAbstract.java b/src/main/java/org/bukkit/entity/PiglinAbstract.java
+index 87f4b7ad7c0a95a7123d142fa023c5da5c760341..70a45e657c6cab6058d1a56fc51c5df79fdce60f 100644
+--- a/src/main/java/org/bukkit/entity/PiglinAbstract.java
++++ b/src/main/java/org/bukkit/entity/PiglinAbstract.java
+@@ -31,14 +31,17 @@ public interface PiglinAbstract extends Monster, Ageable {
+     public int getConversionTime();
+ 
+     /**
+-     * Sets the amount of ticks until this entity will be converted to a
+-     * Zombified Piglin.
++     * Sets the conversion counter value. The counter is incremented
++     * every tick the {@link #isConverting()} returns true. Setting this
++     * value will not start the conversion if the {@link PiglinAbstract} is
++     * not in a valid environment ({@link org.bukkit.World#isPiglinSafe})
++     * to convert or {@link #isImmuneToZombification()} is true or
++     * has no AI.
+      *
+-     * When this reaches 0, the entity will be converted. A value of less than 0
+-     * will stop the current conversion process without converting the current
+-     * entity.
++     * When this reaches 300, the entity will be converted. To stop the
++     * conversion use {@link #setImmuneToZombification(boolean)}.
+      *
+-     * @param time new conversion time
++     * @param time new conversion counter
+      */
+     public void setConversionTime(int time);
+ 

--- a/patches/server/0838-Fix-issues-with-mob-conversion.patch
+++ b/patches/server/0838-Fix-issues-with-mob-conversion.patch
@@ -1,0 +1,57 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 24 Oct 2021 20:29:45 -0700
+Subject: [PATCH] Fix issues with mob conversion
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Skeleton.java b/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
+index 116709ba2b298268ac806e6e45f2e910ca600706..1eeaf0cc9b00afd54f38f9cb50404ec9f9ba51f8 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Skeleton.java
+@@ -86,10 +86,15 @@ public class Skeleton extends AbstractSkeleton {
+     }
+ 
+     protected void doFreezeConversion() {
+-        this.convertTo(EntityType.STRAY, true, org.bukkit.event.entity.EntityTransformEvent.TransformReason.FROZEN, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.FROZEN); // CraftBukkit - add spawn and transform reasons
+-        if (!this.isSilent()) {
++        Stray stray = this.convertTo(EntityType.STRAY, true, org.bukkit.event.entity.EntityTransformEvent.TransformReason.FROZEN, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.FROZEN); // CraftBukkit - add spawn and transform reasons // Paper - track result of conversion
++        if (stray != null && !this.isSilent()) { // Paper - only send event if conversion succeeded
+             this.level.levelEvent((Player) null, 1048, this.blockPosition(), 0);
+         }
++        // Paper start - reset conversion time to prevent event spam
++        if (stray == null) {
++            this.conversionTime = 300;
++        }
++        // Paper end
+ 
+     }
+ 
+diff --git a/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java b/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java
+index cbf181b30bae134150933c721f22161e3e9ffca3..12a1cb536d5cb109cac75636369ed1b2bfa3a0a4 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/piglin/AbstractPiglin.java
+@@ -105,6 +105,11 @@ public abstract class AbstractPiglin extends Monster {
+         if (entitypigzombie != null) {
+             entitypigzombie.addEffect(new MobEffectInstance(MobEffects.CONFUSION, 200, 0));
+         }
++        // Paper start - reset to prevent event spam
++        else {
++            this.timeInOverworld = 0;
++        }
++        // Paper end
+ 
+     }
+ 
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
+index 61e2841fea6603e3e5fbd004de7ffdfb79fc9981..4a873a278a4dc76d868d789574a7890bf53832d7 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftSkeleton.java
+@@ -28,7 +28,7 @@ public class CraftSkeleton extends CraftAbstractSkeleton implements Skeleton {
+             this.getHandle().conversionTime = -1;
+             this.getHandle().getEntityData().set(net.minecraft.world.entity.monster.Skeleton.DATA_STRAY_CONVERSION_ID, false);
+         } else {
+-            this.getHandle().getSwimAmount(time); // PAIL rename startStrayConversion
++            this.getHandle().startFreezeConversion(time); // PAIL rename startStrayConversion // Paper - nope, that's not the right method
+         }
+     }
+ 


### PR DESCRIPTION
* PiglinAbstract docs were incorrect for setConversionTime
* converting skeletons to strays would spam EntityTransformEvent if the event was cancelled
* converting piglins in the overworld had the same spam-event result
* upstream used the wrong method when setting a skeletons conversion time