### PR TITLE
Allow spawners to be disabled

### DIFF
--- a/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0037-Configurable-mob-spawner-tick-rate.patch
@@ -19,7 +19,7 @@ index a8e2bbe12255a071c6f9f68bd61cf6a8e2d6b159..e25050d2842503876da6694e72f54e1e
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index a003e1c0d99a4d4c88269ea5bad250ba73bbc9c9..037dafb59e54047d1d54474c44897d35b8f46c98 100644
+index a003e1c0d99a4d4c88269ea5bad250ba73bbc9c9..65744b55f06c225745e3e145e5f5e60ebefd304c 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -46,6 +46,7 @@ public abstract class BaseSpawner {
@@ -30,13 +30,14 @@ index a003e1c0d99a4d4c88269ea5bad250ba73bbc9c9..037dafb59e54047d1d54474c44897d35
  
      public BaseSpawner() {
          this.spawnPotentials = BaseSpawner.EMPTY_POTENTIALS;
-@@ -101,13 +102,17 @@ public abstract class BaseSpawner {
+@@ -101,13 +102,18 @@ public abstract class BaseSpawner {
      }
  
      public void serverTick(ServerLevel world, BlockPos pos) {
 +        // Paper start - Configurable mob spawner tick rate
 +        if (spawnDelay > 0 && --tickDelay > 0) return;
 +        tickDelay = world.paperConfig.mobSpawnerTickRate;
++        if (tickDelay == -1) { return; } // If disabled
 +        // Paper end
          if (this.isNearPlayer(world, pos)) {
 -            if (this.spawnDelay == -1) {
@@ -50,7 +51,7 @@ index a003e1c0d99a4d4c88269ea5bad250ba73bbc9c9..037dafb59e54047d1d54474c44897d35
              } else {
                  boolean flag = false;
  
-@@ -156,8 +161,7 @@ public abstract class BaseSpawner {
+@@ -156,8 +162,7 @@ public abstract class BaseSpawner {
                                  ((Mob) entity).finalizeSpawn(world, world.getCurrentDifficultyAt(entity.blockPosition()), MobSpawnType.SPAWNER, (SpawnGroupData) null, (CompoundTag) null);
                              }
                              // Spigot Start

--- a/patches/server/0147-Entity-fromMobSpawner.patch
+++ b/patches/server/0147-Entity-fromMobSpawner.patch
@@ -37,10 +37,10 @@ index bf52f5f9b13e8b4eb3c7ee19b0e57bb872d2af1d..3b2334e9ba44205a4e0ec12045eab4fa
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 037dafb59e54047d1d54474c44897d35b8f46c98..e310c1eb1108780bcff4d7ba9d49cefa2926287c 100644
+index 65744b55f06c225745e3e145e5f5e60ebefd304c..e720c751518af3f38fba0c1b22e4c01a46561b00 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -166,6 +166,7 @@ public abstract class BaseSpawner {
+@@ -167,6 +167,7 @@ public abstract class BaseSpawner {
                              }
                              // Spigot End
                          }
@@ -49,7 +49,7 @@ index 037dafb59e54047d1d54474c44897d35b8f46c98..e310c1eb1108780bcff4d7ba9d49cefa
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 2c638d95b396044841ab0dea8d8ce829077992fe..21edae1b8d91341621155897d4da36bc06d2b2e5 100644
+index 78b3be2ea6351cb6375b77340218615aa75b87f5..a83d15178f71b1c4c6d8d49f7621eddd66577251 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1192,5 +1192,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0155-Reset-spawner-timer-when-spawner-event-is-cancelled.patch
+++ b/patches/server/0155-Reset-spawner-timer-when-spawner-event-is-cancelled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Reset spawner timer when spawner event is cancelled
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index e310c1eb1108780bcff4d7ba9d49cefa2926287c..12a78685848b7fd945a472902d8200ea1d50b9ec 100644
+index e720c751518af3f38fba0c1b22e4c01a46561b00..14188ac6f158b36755abe23c0a967763cf7367d8 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -167,6 +167,7 @@ public abstract class BaseSpawner {
+@@ -168,6 +168,7 @@ public abstract class BaseSpawner {
                              // Spigot End
                          }
                          entity.spawnedViaMobSpawner = true; // Paper
@@ -16,7 +16,7 @@ index e310c1eb1108780bcff4d7ba9d49cefa2926287c..12a78685848b7fd945a472902d8200ea
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
                              Entity vehicle = entity.getVehicle();
-@@ -190,7 +191,7 @@ public abstract class BaseSpawner {
+@@ -191,7 +192,7 @@ public abstract class BaseSpawner {
                              ((Mob) entity).spawnAnim();
                          }
  

--- a/patches/server/0174-PreCreatureSpawnEvent.patch
+++ b/patches/server/0174-PreCreatureSpawnEvent.patch
@@ -66,10 +66,10 @@ index 3839bacbd5f4d06eb13d0e604651232d9fbd7b6a..206aee8bf14ffc4ddbb8a7001bc3baae
  
                  if (entityirongolem != null) {
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 12a78685848b7fd945a472902d8200ea1d50b9ec..900cba8c2b04fc1b82a13af76d7079b6a6a2994d 100644
+index 14188ac6f158b36755abe23c0a967763cf7367d8..572328fafb2347886900352983fd5b6490b0dd68 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -132,6 +132,27 @@ public abstract class BaseSpawner {
+@@ -133,6 +133,27 @@ public abstract class BaseSpawner {
                      double d2 = j >= 3 ? nbttaglist.getDouble(2) : (double) pos.getZ() + (world.random.nextDouble() - world.random.nextDouble()) * (double) this.spawnRange + 0.5D;
  
                      if (world.noCollision(((EntityType) optional.get()).getAABB(d0, d1, d2)) && SpawnPlacements.checkSpawnRules((EntityType) optional.get(), world, MobSpawnType.SPAWNER, new BlockPos(d0, d1, d2), world.getRandom())) {

--- a/patches/server/0292-PreSpawnerSpawnEvent.patch
+++ b/patches/server/0292-PreSpawnerSpawnEvent.patch
@@ -9,10 +9,10 @@ SpawnerSpawnEvent gets called instead of the CreatureSpawnEvent for
 spawners.
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 900cba8c2b04fc1b82a13af76d7079b6a6a2994d..494174608c0c6d0e0d9820ad4f263bef90c3dfdf 100644
+index 572328fafb2347886900352983fd5b6490b0dd68..8c266bd81b9350b056067d83415bf2b581e19c94 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -138,11 +138,11 @@ public abstract class BaseSpawner {
+@@ -139,11 +139,11 @@ public abstract class BaseSpawner {
  
                          org.bukkit.entity.EntityType type = org.bukkit.entity.EntityType.fromName(key);
                          if (type != null) {

--- a/patches/server/0316-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0316-Entity-getEntitySpawnReason.patch
@@ -10,7 +10,7 @@ persistenting Living Entity, SPAWNER for spawners,
 or DEFAULT since data was not stored.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 769753441eea00296d818b7a741551fd3034cb6a..174f94b8bc5b3830ff5bcfb9777f3d57c1f781ff 100644
+index 5be5f95fe01e0132f9d4477149ba022351d8b2be..891633981124a5b864af0f9bd50f11e48da2835d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1162,6 +1162,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -22,7 +22,7 @@ index 769753441eea00296d818b7a741551fd3034cb6a..174f94b8bc5b3830ff5bcfb9777f3d57
              // Paper start
              if (DEBUG_ENTITIES) {
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 2c17e723a1b1613c06b53c1e426c4ce1c072e8ad..abba62b7252c6d6ee92a4b1a9b23df7758ab6a77 100644
+index bc73d5052611dba90c2d9c86854447be6a31fdac..d63977984ebec1b4c32bcd2626bdddc15f9e078a 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -343,7 +343,7 @@ public abstract class PlayerList {
@@ -93,10 +93,10 @@ index 3c7e75b8fc1bfbe08e232fcba412c83f4aba274c..8e30a0d42d422fea6bda77d16d5eae8b
  
          } catch (Throwable throwable) {
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 494174608c0c6d0e0d9820ad4f263bef90c3dfdf..fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52 100644
+index 8c266bd81b9350b056067d83415bf2b581e19c94..f2c69ce7a33ef69c71e218cdb2f6a429c5e7b531 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -188,6 +188,7 @@ public abstract class BaseSpawner {
+@@ -189,6 +189,7 @@ public abstract class BaseSpawner {
                              // Spigot End
                          }
                          entity.spawnedViaMobSpawner = true; // Paper
@@ -105,7 +105,7 @@ index 494174608c0c6d0e0d9820ad4f263bef90c3dfdf..fe5e691ebbe930662f8a4f00811fdd8e
                          // Spigot Start
                          if (org.bukkit.craftbukkit.event.CraftEventFactory.callSpawnerSpawnEvent(entity, pos).isCancelled()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index 0a0ece8361a0368629696e06c00165741b14e308..c9e716900d88d025be1f09b6fe0156cf0dac2d33 100644
+index 989824be9c26d138ceed62ac533fcf2bbf37755f..fd811e2ba455d7e4eb618d48ca2c4983797a265c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -1230,5 +1230,10 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {

--- a/patches/server/0325-Mob-Spawner-API-Enhancements.patch
+++ b/patches/server/0325-Mob-Spawner-API-Enhancements.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Mob Spawner API Enhancements
 
 
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248df9998ea 100644
+index f2c69ce7a33ef69c71e218cdb2f6a429c5e7b531..409467ca9a8a21d1e22e3a08f462e54d6124f6a1 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -31,7 +31,7 @@ public abstract class BaseSpawner {
@@ -26,7 +26,7 @@ index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248
          return world.isAffectsSpawningPlayerNearby((double) pos.getX() + 0.5D, (double) pos.getY() + 0.5D, (double) pos.getZ() + 0.5D, (double) this.requiredPlayerRange); // Paper
      }
  
-@@ -225,7 +225,7 @@ public abstract class BaseSpawner {
+@@ -226,7 +226,7 @@ public abstract class BaseSpawner {
          }
      }
  
@@ -35,7 +35,7 @@ index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248
          if (this.maxSpawnDelay <= this.minSpawnDelay) {
              this.spawnDelay = this.minSpawnDelay;
          } else {
-@@ -239,7 +239,13 @@ public abstract class BaseSpawner {
+@@ -240,7 +240,13 @@ public abstract class BaseSpawner {
      }
  
      public void load(@Nullable Level world, BlockPos pos, CompoundTag nbt) {
@@ -49,7 +49,7 @@ index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248
          List<SpawnData> list = Lists.newArrayList();
  
          if (nbt.contains("SpawnPotentials", 9)) {
-@@ -258,10 +264,15 @@ public abstract class BaseSpawner {
+@@ -259,10 +265,15 @@ public abstract class BaseSpawner {
                  this.setSpawnData(world, pos, mobspawnerdata);
              });
          }
@@ -68,7 +68,7 @@ index fe5e691ebbe930662f8a4f00811fdd8ed8ce1c52..b9e738542692aba7b78fc514ae8e3248
              this.spawnCount = nbt.getShort("SpawnCount");
          }
  
-@@ -283,9 +294,20 @@ public abstract class BaseSpawner {
+@@ -284,9 +295,20 @@ public abstract class BaseSpawner {
          if (minecraftkey == null) {
              return nbt;
          } else {

--- a/patches/server/0522-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0522-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -9,7 +9,7 @@ as this is how Vanilla teleports entities.
 Cancel any pending motion when teleported.
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index a80781a0525ef5b46a7c9af3011dab6662f06016..be682e8459bb7293256c3552d90f5cdb8d97a29d 100644
+index f20578abf959bf4005b2de0726de99ab7daaba47..17289eeb53dc4463897819a1c732fab3ec6a9cdd 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -681,7 +681,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -57,10 +57,10 @@ index 8df955a0aa6cd0c7d10619fb63abd16af4754be8..a652bbc4b3c768fecfb6f067d21a9031
          this.setYRot(yaw);
          this.setXRot(pitch);
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index b9e738542692aba7b78fc514ae8e3248df9998ea..c601b8b12756682a4cb300be8ebed4319902c5b5 100644
+index 409467ca9a8a21d1e22e3a08f462e54d6124f6a1..56d3867f748d92a55976820215d9b8316989677b 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-@@ -170,6 +170,7 @@ public abstract class BaseSpawner {
+@@ -171,6 +171,7 @@ public abstract class BaseSpawner {
                              return;
                          }
  
@@ -69,7 +69,7 @@ index b9e738542692aba7b78fc514ae8e3248df9998ea..c601b8b12756682a4cb300be8ebed431
                          if (entity instanceof Mob) {
                              Mob entityinsentient = (Mob) entity;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
-index f28f857d6218db1634348e8a57e7b275b9115bfc..a0a24a46624b3d174d08c806c8ad45d8a9028a09 100644
+index 38e38abd5302a9f8c5eb2d3d81d825cdae99d7c4..0547727afbd1b37c1a75fd8b4da585d80d54245a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftEntity.java
 @@ -577,7 +577,7 @@ public abstract class CraftEntity implements org.bukkit.entity.Entity {


### PR DESCRIPTION
Allows mob spawners to be disabled without adding a really high tick rate.
Useful for:
- Hubs/Lobby servers and creative servers that use/allow mob spawners to be used for decoration.
- Plugins that take complete control over mob spawners and just cancel any and all mob spawner events, adding their own spawn system on top.

I found that with plugins that disable all related events, spawners were taking upwards of 4-6% on a spawner heavy server even with a very high configured tick rate on timings reports and further inspection with Spark showed the cost was from the spawner server tick doing AABB checks and EntityTypes#create costing performance.

I'll make a PaperDocs PR to mention this change if this gets approved/merged.