### PR TITLE
[ci skip] Fix incorrect javadoc for Mob pathfinding API

### DIFF
--- a/patches/api/0150-Mob-Pathfinding-API.patch
+++ b/patches/api/0150-Mob-Pathfinding-API.patch
@@ -13,7 +13,7 @@ You can use EntityPathfindEvent to cancel new pathfinds from overriding your cur
 
 diff --git a/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2a6f9c3881ff9d7373ac30e60009200432555aa
+index 0000000000000000000000000000000000000000..43f062257472a06e9e64c2feef6c3b1012aee00e
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/entity/Pathfinder.java
 @@ -0,0 +1,212 @@
@@ -214,7 +214,7 @@ index 0000000000000000000000000000000000000000..e2a6f9c3881ff9d7373ac30e60009200
 +
 +        /**
 +         * @return Returns the index of the current point along the points returned in {@link #getPoints()} the entity
-+         * is trying to reach, or null if we are done with this pathfinding.
++         * is trying to reach. This value will be higher than the maximum index of {@link #getPoints()} if this path finding is done.
 +         */
 +        int getNextPointIndex();
 +


### PR DESCRIPTION
The javadoc mentions the method returning null if the pathfinding is done, but `int`'s can obviously never be null. A different solution would be to update the method to return an `Integer`, and null if the pathfinding is done, although that would break backwards compatibility.

Thanks to @andrew121410 for spotting this [on Discord](https://canary.discord.com/channels/289587909051416579/555462289851940864/903357214415290419).