### PR TITLE
Call onRemove logic for breakNaturally

### DIFF
--- a/patches/server/0843-Call-onRemove-logic-for-breakNaturally.patch
+++ b/patches/server/0843-Call-onRemove-logic-for-breakNaturally.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 31 Oct 2021 14:49:43 -0700
+Subject: [PATCH] Call onRemove logic for breakNaturally
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 5154cfffc414e1f6039e55f1a256bbaacb56bc55..6f01af8cc3f9ed4d2eaa3304990ca33f8692a453 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -513,8 +513,14 @@ public class CraftBlock implements Block {
+             if (triggerEffect) world.levelEvent(org.bukkit.Effect.STEP_SOUND.getId(), position, net.minecraft.world.level.block.Block.getId(block.defaultBlockState())); // Paper
+             result = true;
+         }
++        // Paper start
++        net.minecraft.world.level.block.state.BlockState newBlockState = Blocks.AIR.defaultBlockState();
++        if (this.world instanceof net.minecraft.world.level.Level level) {
++            iblockdata.onRemove(level, position, newBlockState, false);
++        }
++        // Paper end
+ 
+-        return this.setTypeAndData(Blocks.AIR.defaultBlockState(), true) && result;
++        return this.setTypeAndData(newBlockState, true) && result; // Paper
+     }
+ 
+     @Override


### PR DESCRIPTION
Addresses https://github.com/EngineHub/WorldEdit/issues/1924

breakNaturally previously wasn't calling the block's onRemove behavior, which includes dropping items in containers and more. I didn't put the logic inside CraftBlock#setTypeAndData because all the other calls to setTypeAndData shouldn't be calling this anyways, so I think having it as part of breakNaturally is fine.