### PR TITLE
Add API for checking if a zombie has the option to break doors

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -246,3 +246,6 @@ public net.minecraft.world.entity.ai.attributes.AttributeSupplier instances
 
 # Add ItemFactory#getSpawnEgg API
 public net.minecraft.world.item.SpawnEggItem BY_ID
+
+# Zombie API - breaking doors
+public net.minecraft.world.entity.monster.Zombie supportsBreakDoorGoal()Z

--- a/patches/api/0251-Zombie-API-breaking-doors.patch
+++ b/patches/api/0251-Zombie-API-breaking-doors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Zombie API - breaking doors
 
 
 diff --git a/src/main/java/org/bukkit/entity/Zombie.java b/src/main/java/org/bukkit/entity/Zombie.java
-index 1217576e6f08abf0175ab800cfca058d5deda116..a39fbc9fa0903be8ed8e89f3ef39f93c02dfc90b 100644
+index 1217576e6f08abf0175ab800cfca058d5deda116..6eeab75e985ece3fb606551bc42b05f958da4d60 100644
 --- a/src/main/java/org/bukkit/entity/Zombie.java
 +++ b/src/main/java/org/bukkit/entity/Zombie.java
-@@ -140,5 +140,19 @@ public interface Zombie extends Monster, Ageable {
+@@ -140,5 +140,32 @@ public interface Zombie extends Monster, Ageable {
       * @param shouldBurnInDay True to burn in sunlight
       */
      void setShouldBurnInDay(boolean shouldBurnInDay);
@@ -21,10 +21,23 @@ index 1217576e6f08abf0175ab800cfca058d5deda116..a39fbc9fa0903be8ed8e89f3ef39f93c
 +    boolean canBreakDoors();
 +
 +    /**
-+     * Sets if this zombie can break doors
++     * Sets if this zombie can break doors.
++     * Check {@link #supportsBreakingDoors()} to see
++     * if this zombie type will even be affected by using
++     * this method.
 +     *
 +     * @param canBreakDoors True if zombie can break doors
 +     */
 +    void setCanBreakDoors(boolean canBreakDoors);
++
++    /**
++     * Checks if this zombie type supports breaking doors.
++     * {@link Drowned} do not have support for breaking doors
++     * so using {@link #setCanBreakDoors(boolean)} on them has
++     * no effect.
++     *
++     * @return
++     */
++    boolean supportsBreakingDoors();
      // Paper end
  }

--- a/patches/server/0583-Zombie-API-breaking-doors.patch
+++ b/patches/server/0583-Zombie-API-breaking-doors.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Zombie API - breaking doors
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
-index 77e4875484bdaedfba576a6b008245c488b2a112..6caf2496395385a449b093aede3f061d6af8218a 100644
+index 77e4875484bdaedfba576a6b008245c488b2a112..bcd765abe0317fe5c1fa2efcbc43d7b8503f80a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftZombie.java
-@@ -128,6 +128,16 @@ public class CraftZombie extends CraftMonster implements Zombie {
+@@ -128,6 +128,21 @@ public class CraftZombie extends CraftMonster implements Zombie {
      public void setShouldBurnInDay(boolean shouldBurnInDay) {
          getHandle().setShouldBurnInDay(shouldBurnInDay);
      }
@@ -21,6 +21,11 @@ index 77e4875484bdaedfba576a6b008245c488b2a112..6caf2496395385a449b093aede3f061d
 +    @Override
 +    public void setCanBreakDoors(boolean canBreakDoors) {
 +        getHandle().setCanBreakDoors(canBreakDoors);
++    }
++
++    @Override
++    public boolean supportsBreakingDoors() {
++        return getHandle().supportsBreakDoorGoal();
 +    }
      // Paper end
  


### PR DESCRIPTION
Drowned do not have support for door breaking so setCanBreakDoors on a drowned wouldn't have any effect.