### PR TITLE
Update paperweight to 1.1.13

### DIFF
--- a/build-data/reobf-mappings-patch.tiny
+++ b/build-data/reobf-mappings-patch.tiny
@@ -19,28 +19,6 @@ c	net/minecraft/server/level/ServerLevel	net/minecraft/server/level/WorldServer
 c	net/minecraft/world/level/chunk/LevelChunk	net/minecraft/world/level/chunk/Chunk
 	f	Lnet/minecraft/server/level/ServerLevel;	level	i
 
-# unknown issue
-c	net/minecraft/core/RegistryAccess	net/minecraft/core/IRegistryCustom
-	m	(Lnet/minecraft/resources/ResourceKey;)Lnet/minecraft/core/Registry;	registryOrThrow	d
-
-c	net/minecraft/server/ServerResources	net/minecraft/server/DataPackResources
-	m	()Lnet/minecraft/server/packs/resources/ResourceManager;	getResourceManager	i
-
-c	net/minecraft/server/MinecraftServer	net/minecraft/server/MinecraftServer
-	m	()Lnet/minecraft/world/level/storage/WorldData;	getWorldData	getSaveData
-
-c	net/minecraft/server/MinecraftServer	net/minecraft/server/MinecraftServer
-	m	()Lnet/minecraft/world/level/storage/loot/LootTables;	getLootTables	getLootTableRegistry
-
-c	net/minecraft/world/effect/MobEffect	net/minecraft/world/effect/MobEffectList
-	m	(I)Lnet/minecraft/world/effect/MobEffect;	byId	fromId
-
-c	net/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess	net/minecraft/world/level/storage/Convertable$ConversionSession
-	m	(Lcom/mojang/serialization/DynamicOps;Lnet/minecraft/world/level/DataPackConfig;)Lnet/minecraft/world/level/storage/WorldData;	getDataTag	a
-
-c	net/minecraft/commands/arguments/MobEffectArgument	net/minecraft/commands/arguments/ArgumentMobEffect
-	m	(Lcom/mojang/brigadier/context/CommandContext;Ljava/lang/String;)Lnet.minecraft.world.effect/MobEffect;	getEffect	a
-
 # Paper moves method up from ServerLevel to Level
 c	net/minecraft/world/level/Level	net/minecraft/world/level/World
 	m	()Lnet/minecraft/core/BlockPos;	getSharedSpawnPos	getSpawn

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.0" apply false
-    id("io.papermc.paperweight.core") version "1.1.12"
+    id("io.papermc.paperweight.core") version "1.1.13"
 }
 
 allprojects {

--- a/patches/server/0074-EntityPathfindEvent.patch
+++ b/patches/server/0074-EntityPathfindEvent.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] EntityPathfindEvent
 Fires when an Entity decides to start moving to a location.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/FlyingPathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/FlyingPathNavigation.java
-index 3afe97f4e330016164e741934c888f5b85824e67..48a42a8374641f4737d5eb6a460bf80a12c2cae5 100644
+index 3afe97f4e330016164e741934c888f5b85824e67..6cdb0f0f881ea57c95821914262208c4b636587e 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/FlyingPathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/FlyingPathNavigation.java
 @@ -35,7 +35,7 @@ public class FlyingPathNavigation extends PathNavigation {
@@ -14,12 +14,12 @@ index 3afe97f4e330016164e741934c888f5b85824e67..48a42a8374641f4737d5eb6a460bf80a
      @Override
      public Path createPath(Entity entity, int distance) {
 -        return this.createPath(entity.blockPosition(), distance);
-+        return this.a(entity.blockPosition(), entity, distance); // Paper - Forward target entity
++        return this.createPath(entity.blockPosition(), entity, distance); // Paper - Forward target entity
      }
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
-index d2e71f1e70a8b3360110f7e5e6c5ec278218ae27..0ac90b5fefa9720a9d0130f5438e5ef55fccf29a 100644
+index d2e71f1e70a8b3360110f7e5e6c5ec278218ae27..f351b1eb923cc72bc5bb7f891d27246af14f4e1d 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/GroundPathNavigation.java
 @@ -70,7 +70,7 @@ public class GroundPathNavigation extends PathNavigation {
@@ -27,12 +27,12 @@ index d2e71f1e70a8b3360110f7e5e6c5ec278218ae27..0ac90b5fefa9720a9d0130f5438e5ef5
      @Override
      public Path createPath(Entity entity, int distance) {
 -        return this.createPath(entity.blockPosition(), distance);
-+        return this.a(entity.blockPosition(), entity, distance); // Paper - Forward target entity
++        return this.createPath(entity.blockPosition(), entity, distance); // Paper - Forward target entity
      }
  
      private int getSurfaceY() {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index f4f2b7a1de7eb37c3d6331bd16f916cf4bbf1a03..989a0c44d6685b5824a055d077fb0f28c1ba4b17 100644
+index f4f2b7a1de7eb37c3d6331bd16f916cf4bbf1a03..5ddc033594c26a69f8c610cf1610a06a9be8dd4d 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -10,6 +10,7 @@ import net.minecraft.core.BlockPos;
@@ -43,21 +43,22 @@ index f4f2b7a1de7eb37c3d6331bd16f916cf4bbf1a03..989a0c44d6685b5824a055d077fb0f28
  import net.minecraft.util.Mth;
  import net.minecraft.world.entity.Entity;
  import net.minecraft.world.entity.Mob;
-@@ -108,7 +109,12 @@ public abstract class PathNavigation {
+@@ -108,7 +109,13 @@ public abstract class PathNavigation {
  
      @Nullable
      public Path createPath(BlockPos target, int distance) {
 -        return this.createPath(ImmutableSet.of(target), 8, false, distance);
-+        // Paper start - add target parameter
-+        return this.a(target, null, distance);
++        // Paper start - add target entity parameter
++        return this.createPath(target, null, distance);
 +    }
-+    @Nullable public Path a(BlockPos blockposition, Entity target, int distance) {
-+        return this.createPath(ImmutableSet.of(blockposition), target, 8, false, distance);
++    @Nullable
++    public Path createPath(BlockPos target, Entity entity, int distance) {
++        return this.createPath(ImmutableSet.of(target), entity, 8, false, distance);
 +        // Paper end
      }
  
      @Nullable
-@@ -118,7 +124,7 @@ public abstract class PathNavigation {
+@@ -118,7 +125,7 @@ public abstract class PathNavigation {
  
      @Nullable
      public Path createPath(Entity entity, int distance) {
@@ -66,7 +67,7 @@ index f4f2b7a1de7eb37c3d6331bd16f916cf4bbf1a03..989a0c44d6685b5824a055d077fb0f28
      }
  
      @Nullable
-@@ -128,6 +134,16 @@ public abstract class PathNavigation {
+@@ -128,6 +135,16 @@ public abstract class PathNavigation {
  
      @Nullable
      protected Path createPath(Set<BlockPos> positions, int range, boolean useHeadPos, int distance, float followRange) {
@@ -83,7 +84,7 @@ index f4f2b7a1de7eb37c3d6331bd16f916cf4bbf1a03..989a0c44d6685b5824a055d077fb0f28
          if (positions.isEmpty()) {
              return null;
          } else if (this.mob.getY() < (double)this.level.getMinBuildHeight()) {
-@@ -137,6 +153,23 @@ public abstract class PathNavigation {
+@@ -137,6 +154,23 @@ public abstract class PathNavigation {
          } else if (this.path != null && !this.path.isDone() && positions.contains(this.targetPos)) {
              return this.path;
          } else {

--- a/patches/server/0116-Prevent-Pathfinding-out-of-World-Border.patch
+++ b/patches/server/0116-Prevent-Pathfinding-out-of-World-Border.patch
@@ -13,10 +13,10 @@ by adding code to all overrides in:
 to return BLOCKED if it is outside the world border.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 989a0c44d6685b5824a055d077fb0f28c1ba4b17..98953769a4418385971651e43e2ff6f4ea1ec638 100644
+index 5ddc033594c26a69f8c610cf1610a06a9be8dd4d..c7147605f0f2c57274e48ecee20a78efda84ddf9 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-@@ -156,7 +156,7 @@ public abstract class PathNavigation {
+@@ -157,7 +157,7 @@ public abstract class PathNavigation {
              // Paper start - Pathfind event
              boolean copiedSet = false;
              for (BlockPos possibleTarget : positions) {

--- a/patches/server/0403-Optimize-Pathfinding.patch
+++ b/patches/server/0403-Optimize-Pathfinding.patch
@@ -7,10 +7,10 @@ Prevents pathfinding from spamming failures for things such as
 arrow attacks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index 98953769a4418385971651e43e2ff6f4ea1ec638..e605daac0c90f5d0b9315d1499938feb0e478d0e 100644
+index c7147605f0f2c57274e48ecee20a78efda84ddf9..61080352ef305a1f276dbc297aa680b3175a5da2 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-@@ -190,9 +190,29 @@ public abstract class PathNavigation {
+@@ -191,9 +191,29 @@ public abstract class PathNavigation {
          return this.moveTo(this.createPath(x, y, z, 1), speed);
      }
  

--- a/patches/server/0794-Optimise-WorldServer-notify.patch
+++ b/patches/server/0794-Optimise-WorldServer-notify.patch
@@ -8,7 +8,7 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 955c42be5c5ed5c3a1a76e868da2087ced436e49..b3c99c1678c3ee159861c8aac38e765d664c4d1d 100644
+index 10d1e1f728519ad49379895c7fd3668badcbfd5a..4b1797659f6bb5913b105641ecaac38954ce8bc0 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -290,15 +290,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -110,7 +110,7 @@ index 955c42be5c5ed5c3a1a76e868da2087ced436e49..b3c99c1678c3ee159861c8aac38e765d
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 796ae447fcc305335fe943fc6d97e21422f406b1..9e4ad810dd6348ad95c9a7e6d1bd63f6ec37c986 100644
+index fba157221a54335dfd7b1a5911cebd5547a81712..08c6ea9f19fa9218af089ed3bd2dcda1e83591ed 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1079,6 +1079,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -169,7 +169,7 @@ index 796ae447fcc305335fe943fc6d97e21422f406b1..9e4ad810dd6348ad95c9a7e6d1bd63f6
  
          public void onTrackingStart(Entity entity) {
 diff --git a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
-index e605daac0c90f5d0b9315d1499938feb0e478d0e..b5c385aeb86ac267cae9726354c896ee38a50634 100644
+index 61080352ef305a1f276dbc297aa680b3175a5da2..10505f32b71b723ed8dbfd9e1348a1691c9f7f18 100644
 --- a/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 +++ b/src/main/java/net/minecraft/world/entity/ai/navigation/PathNavigation.java
 @@ -27,7 +27,7 @@ import net.minecraft.world.phys.Vec3;
@@ -204,7 +204,7 @@ index e605daac0c90f5d0b9315d1499938feb0e478d0e..b5c385aeb86ac267cae9726354c896ee
      public PathNavigation(Mob mob, Level world) {
          this.mob = mob;
          this.level = world;
-@@ -404,7 +411,7 @@ public abstract class PathNavigation {
+@@ -405,7 +412,7 @@ public abstract class PathNavigation {
      }
  
      public void recomputePath(BlockPos pos) {
@@ -214,7 +214,7 @@ index e605daac0c90f5d0b9315d1499938feb0e478d0e..b5c385aeb86ac267cae9726354c896ee
              Vec3 vec3 = new Vec3(((double)node.x + this.mob.getX()) / 2.0D, ((double)node.y + this.mob.getY()) / 2.0D, ((double)node.z + this.mob.getZ()) / 2.0D);
              if (pos.closerThan(vec3, (double)(this.path.getNodeCount() - this.path.getNextNodeIndex()))) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 2276536a0c3e7c6e242400436e8e841cc3fff3b4..7492498917d38eaeb2b2028c1779ce27622aabaa 100644
+index 62a5007bce6c2337db9ddfd41d3df6b201f91800..ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -67,6 +67,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A

--- a/patches/server/0835-Async-catch-modifications-to-critical-entity-state.patch
+++ b/patches/server/0835-Async-catch-modifications-to-critical-entity-state.patch
@@ -8,14 +8,14 @@ Now in 1.17, this state is _even more_ critical than it was before,
 so these must exist to catch stupid plugins.
 
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d..6c6a3a15654e18b53d45c5c96f39dbc944106f8d 100644
+index ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d..8634cf852d7ecb70c7bac6ad7f606aed1347f61d 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -134,6 +134,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private boolean addEntityUuid(T entity) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity add by UUID"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity add by UUID"); // Paper
          if (!this.knownUuids.add(entity.getUUID())) {
              // Paper start
              T conflict = this.visibleEntityStorage.getEntity(entity.getUUID());
@@ -23,7 +23,7 @@ index ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d..6c6a3a15654e18b53d45c5c96f39dbc9
      }
  
      private boolean addEntity(T entity, boolean existing) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity add"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity add"); // Paper
          if (!this.addEntityUuid(entity)) {
              return false;
          } else {
@@ -31,23 +31,23 @@ index ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d..6c6a3a15654e18b53d45c5c96f39dbc9
      }
  
      void startTicking(T entity) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity start ticking"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity start ticking"); // Paper
          this.callbacks.onTickingStart(entity);
      }
  
      void stopTicking(T entity) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity stop ticking"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity stop ticking"); // Paper
          this.callbacks.onTickingEnd(entity);
      }
  
      void startTracking(T entity) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity start tracking"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity start tracking"); // Paper
          this.visibleEntityStorage.add(entity);
          this.callbacks.onTrackingStart(entity);
      }
  
      void stopTracking(T entity) {
-+        org.spigotmc.AsyncCatcher.catchOp("Enity stop tracking"); // Paper
++        org.spigotmc.AsyncCatcher.catchOp("Entity stop tracking"); // Paper
          this.callbacks.onTrackingEnd(entity);
          this.visibleEntityStorage.remove(entity);
      }


### PR DESCRIPTION
Fixes #6802 and various other reobf mappings issues, as well as fixes source remapping for some anonymous classes.
All of the "unknown issue" reobf mappings patches are now no longer needed as paperweight generates the correct mapping.