### PR TITLE
Update paperweight to 1.1.14

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     java
     `maven-publish`
     id("com.github.johnrengelman.shadow") version "7.1.0" apply false
-    id("io.papermc.paperweight.core") version "1.1.13"
+    id("io.papermc.paperweight.core") version "1.1.14"
 }
 
 allprojects {


### PR DESCRIPTION
1.1.14 was a bugfix for userdev, regardless it's best to keep Paper on the latest version