### PR TITLE
Add isCollidable methods to various places

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -249,3 +249,6 @@ public net.minecraft.world.item.SpawnEggItem BY_ID
 
 # Zombie API - breaking doors
 public net.minecraft.world.entity.monster.Zombie supportsBreakDoorGoal()Z
+
+# Add Material#hasCollision
+public net.minecraft.world.level.block.state.BlockBehaviour hasCollision

--- a/patches/api/0344-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0344-Add-isCollidable-methods-to-various-places.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 4 Nov 2021 11:50:35 -0700
+Subject: [PATCH] Add isCollidable methods to various places
+
+
+diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
+index ed6dfb28f8f434680fc8eacbe49a9d0b6cf9be83..f1ff88a5db58eed6087c3e9e6c211a95e00f35b4 100644
+--- a/src/main/java/org/bukkit/Material.java
++++ b/src/main/java/org/bukkit/Material.java
+@@ -4031,6 +4031,16 @@ public enum Material implements Keyed, net.kyori.adventure.translation.Translata
+     public com.google.common.collect.Multimap<org.bukkit.attribute.Attribute, org.bukkit.attribute.AttributeModifier> getItemAttributes(@NotNull EquipmentSlot equipmentSlot) {
+         return Bukkit.getUnsafe().getItemAttributes(this, equipmentSlot);
+     }
++
++    /**
++     * Checks if this material is collidable.
++     *
++     * @return true if collidable
++     * @throws IllegalArgumentException if {@link #isBlock()} is false
++     */
++    public boolean isCollidable() {
++        return Bukkit.getUnsafe().isCollidable(this);
++    }
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index 0b15fe8b5da29bf691c394098f0203a49504242e..c8c2e5bc2ec1d8d7ea445a1203c9d5a904dfc666 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -200,5 +200,14 @@ public interface UnsafeValues {
+      * @throws IllegalArgumentException if the entity does not exist of have default attributes (use {@link #hasDefaultEntityAttributes(NamespacedKey)} first)
+      */
+     @org.jetbrains.annotations.NotNull org.bukkit.attribute.Attributable getDefaultEntityAttributes(@org.jetbrains.annotations.NotNull NamespacedKey entityKey);
++
++    /**
++     * Checks if this material is collidable.
++     *
++     * @param material the material to check
++     * @return true if collidable
++     * @throws IllegalArgumentException if {@link Material#isBlock()} is false
++     */
++    boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
+index 0006a5a53dfa9fc81c608423e8740a9c820659a3..70caaf05be813ba390412714ba0a39981edc2475 100644
+--- a/src/main/java/org/bukkit/block/Block.java
++++ b/src/main/java/org/bukkit/block/Block.java
+@@ -471,6 +471,13 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+      * @return true if block is solid
+      */
+     boolean isSolid();
++
++    /**
++     * Checks if this block is collidable.
++     *
++     * @return true if collidable
++     */
++    boolean isCollidable();
+     // Paper end
+ 
+     /**
+diff --git a/src/main/java/org/bukkit/block/BlockState.java b/src/main/java/org/bukkit/block/BlockState.java
+index 631cbf2be51040eee00aa39a39c5ec4003f91843..96cde879922c796f3ac8d14ee99d7b190ff67bd9 100644
+--- a/src/main/java/org/bukkit/block/BlockState.java
++++ b/src/main/java/org/bukkit/block/BlockState.java
+@@ -221,4 +221,13 @@ public interface BlockState extends Metadatable {
+      *         or 'virtual' (e.g. on an itemstack)
+      */
+     boolean isPlaced();
++
++    // Paper start
++    /**
++     * Checks if this block state is collidable.
++     *
++     * @return true if collidable
++     */
++    boolean isCollidable();
++    // Paper end
+ }

--- a/patches/server/0839-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/server/0839-Add-isCollidable-methods-to-various-places.patch
@@ -1,0 +1,55 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 4 Nov 2021 11:50:40 -0700
+Subject: [PATCH] Add isCollidable methods to various places
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index e3944d0f4fd18ef6c545dc4a131c0b120dff753a..5154cfffc414e1f6039e55f1a256bbaacb56bc55 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -470,6 +470,11 @@ public class CraftBlock implements Block {
+     public boolean isSolid() {
+         return getNMS().getMaterial().blocksMotion();
+     }
++
++    @Override
++    public boolean isCollidable() {
++        return getNMS().getBlock().hasCollision;
++    }
+     // Paper end
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
+index 7b9e943b391c061782fccd2b8d705ceec8db50fe..966ac60daebb7bb211ab8096fc0c5f33db67320a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlockState.java
+@@ -324,4 +324,11 @@ public class CraftBlockState implements BlockState {
+             throw new IllegalStateException("The blockState must be placed to call this method");
+         }
+     }
++
++    // Paper start
++    @Override
++    public boolean isCollidable() {
++        return this.data.getBlock().hasCollision;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index dcaa189c17dd928d7a19e820ec2ff521e7243b7a..c6bd1c1f973157c1d8a56e8297729cb896785dd6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -521,6 +521,12 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         var supplier = net.minecraft.world.entity.ai.attributes.DefaultAttributes.getSupplier((net.minecraft.world.entity.EntityType<? extends net.minecraft.world.entity.LivingEntity>) net.minecraft.core.Registry.ENTITY_TYPE.get(CraftNamespacedKey.toMinecraft(bukkitEntityKey)));
+         return new io.papermc.paper.attribute.UnmodifiableAttributeMap(supplier);
+     }
++
++    @Override
++    public boolean isCollidable(Material material) {
++        Preconditions.checkArgument(material.isBlock(), material + " is not a block");
++        return getBlock(material).hasCollision;
++    }
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
isSolid isn't a good representation of what a entity can stand on, this should be better. For example, an Oak Sign block returns true for isSolid, which it doesnt collide with an entity at all. 