### PR TITLE
Improve scoreboard entries

### DIFF
--- a/patches/api/0348-Improve-scoreboard-entries.patch
+++ b/patches/api/0348-Improve-scoreboard-entries.patch
@@ -1,0 +1,191 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 4 Nov 2021 12:31:45 -0700
+Subject: [PATCH] Improve scoreboard entries
+
+
+diff --git a/src/main/java/org/bukkit/scoreboard/Objective.java b/src/main/java/org/bukkit/scoreboard/Objective.java
+index 75acd6f8f3d774bb79e8e513125e801c5569a244..b93b1b0428d11589605c8edf5c053369e1031076 100644
+--- a/src/main/java/org/bukkit/scoreboard/Objective.java
++++ b/src/main/java/org/bukkit/scoreboard/Objective.java
+@@ -140,9 +140,8 @@ public interface Objective {
+      * @throws IllegalArgumentException if player is null
+      * @throws IllegalStateException if this objective has been unregistered
+      * @see #getScore(String)
+-     * @deprecated Scoreboards can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     @NotNull
+     Score getScore(@NotNull OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
+ 
+@@ -157,4 +156,16 @@ public interface Objective {
+      */
+     @NotNull
+     Score getScore(@NotNull String entry) throws IllegalArgumentException, IllegalStateException;
++
++    // Paper start
++    /**
++     * Gets an entity's Score for an Objective on this Scoreboard.
++     *
++     * @param entity Entity for the Score
++     * @return Score tracking the Objective and entity specified
++     * @throws IllegalArgumentException if entity is null
++     * @throws IllegalStateException if this objective has been unregistered
++     */
++    @NotNull Score getScoreFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException, IllegalStateException;
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/scoreboard/Scoreboard.java b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
+index f7754ab421c7b452a53c28d1e2fafdccfbba24bf..9a395b138be3f6fa9a52639f0ac4070c23f7d77c 100644
+--- a/src/main/java/org/bukkit/scoreboard/Scoreboard.java
++++ b/src/main/java/org/bukkit/scoreboard/Scoreboard.java
+@@ -163,9 +163,8 @@ public interface Scoreboard {
+      * @return immutable set of all scores tracked for the player
+      * @throws IllegalArgumentException if player is null
+      * @see #getScores(String)
+-     * @deprecated Scoreboards can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     @NotNull
+     Set<Score> getScores(@NotNull OfflinePlayer player) throws IllegalArgumentException;
+ 
+@@ -185,9 +184,8 @@ public interface Scoreboard {
+      * @param player the player to drop all current scores for
+      * @throws IllegalArgumentException if player is null
+      * @see #resetScores(String)
+-     * @deprecated Scoreboards can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     void resetScores(@NotNull OfflinePlayer player) throws IllegalArgumentException;
+ 
+     /**
+@@ -205,9 +203,8 @@ public interface Scoreboard {
+      * @return the player's Team or null if the player is not on a team
+      * @throws IllegalArgumentException if player is null
+      * @see #getEntryTeam(String)
+-     * @deprecated Scoreboards can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     @Nullable
+     Team getPlayerTeam(@NotNull OfflinePlayer player) throws IllegalArgumentException;
+ 
+@@ -276,4 +273,35 @@ public interface Scoreboard {
+      * @throws IllegalArgumentException if slot is null
+      */
+     void clearSlot(@NotNull DisplaySlot slot) throws IllegalArgumentException;
++
++    // Paper start
++    /**
++     * Gets all scores for a entity on this Scoreboard
++     *
++     * @param entity the entity whose scores are being retrieved
++     * @return immutable set of all scores tracked for the entity
++     * @throws IllegalArgumentException if entity is null
++     * @see #getScores(String)
++     */
++    @NotNull Set<Score> getScoresFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException;
++
++    /**
++     * Removes all scores for a entity on this Scoreboard
++     *
++     * @param entity the entity to drop all current scores for
++     * @throws IllegalArgumentException if entity is null
++     * @see #resetScores(String)
++     */
++    void resetScoresFor(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException;
++
++    /**
++     * Gets a entity's Team on this Scoreboard
++     *
++     * @param entity the entity to search for
++     * @return the entity's Team or null if the entity is not on a team
++     * @throws IllegalArgumentException if entity is null
++     * @see #getEntryTeam(String)
++     */
++    @Nullable Team getEntityTeam(@NotNull org.bukkit.entity.Entity entity) throws IllegalArgumentException;
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/scoreboard/Team.java b/src/main/java/org/bukkit/scoreboard/Team.java
+index d5b39fb4fc16a342b5661e08df1506858168d20d..2b93692204a74ea0def513a54ddf77a40c64d3d2 100644
+--- a/src/main/java/org/bukkit/scoreboard/Team.java
++++ b/src/main/java/org/bukkit/scoreboard/Team.java
+@@ -301,9 +301,8 @@ public interface Team {
+      * @throws IllegalArgumentException if player is null
+      * @throws IllegalStateException if this team has been unregistered
+      * @see #addEntry(String)
+-     * @deprecated Teams can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     void addPlayer(@NotNull OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+ 
+     /**
+@@ -325,9 +324,8 @@ public interface Team {
+      * @throws IllegalArgumentException if player is null
+      * @throws IllegalStateException if this team has been unregistered
+      * @see #removeEntry(String)
+-     * @deprecated Teams can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     boolean removePlayer(@NotNull OfflinePlayer player) throws IllegalStateException, IllegalArgumentException;
+ 
+     /**
+@@ -355,9 +353,8 @@ public interface Team {
+      * @throws IllegalArgumentException if player is null
+      * @throws IllegalStateException if this team has been unregistered
+      * @see #hasEntry(String)
+-     * @deprecated Teams can contain entries that aren't players
+      */
+-    @Deprecated
++    // @Deprecated // Paper
+     boolean hasPlayer(@NotNull OfflinePlayer player) throws IllegalArgumentException, IllegalStateException;
+     /**
+      * Checks to see if the specified entry is a member of this team.
+@@ -388,6 +385,42 @@ public interface Team {
+      */
+     void setOption(@NotNull Option option, @NotNull OptionStatus status) throws IllegalStateException;
+ 
++    // Paper start
++    /**
++     * This puts the specified entity onto this team for the scoreboard.
++     * <p>
++     * This will remove the entity from any other team on the scoreboard.
++     *
++     * @param entity the entity to add
++     * @throws IllegalArgumentException if entity is null
++     * @throws IllegalStateException if this team has been unregistered
++     * @see #addEntry(String)
++     */
++    void addEntity(@NotNull org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException;
++
++    /**
++     * Removes the entity from this team.
++     *
++     * @param entity the entity to remove
++     * @return if the entity was on this team
++     * @throws IllegalArgumentException if entity is null
++     * @throws IllegalStateException if this team has been unregistered
++     * @see #removeEntry(String)
++     */
++    boolean removeEntity(@NotNull org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException;
++
++    /**
++     * Checks to see if the specified entity is a member of this team.
++     *
++     * @param entity the entity to search for
++     * @return true if the entity is a member of this team
++     * @throws IllegalArgumentException if entity is null
++     * @throws IllegalStateException if this team has been unregistered
++     * @see #hasEntry(String)
++     */
++    boolean hasEntity(@NotNull org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException;
++    // Paper end
++
+     /**
+      * Represents an option which may be applied to this team.
+      */

--- a/patches/server/0834-Improve-scoreboard-entries.patch
+++ b/patches/server/0834-Improve-scoreboard-entries.patch
@@ -1,0 +1,84 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 4 Nov 2021 12:31:24 -0700
+Subject: [PATCH] Improve scoreboard entries
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
+index 6752cd9b3bc246fc2a7764df0d2b40d3e638fa62..c5cf800ab8cbb5ebcf1b06ad591f08be75859b8c 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftObjective.java
+@@ -138,6 +138,14 @@ final class CraftObjective extends CraftScoreboardComponent implements Objective
+         return new CraftScore(this, entry);
+     }
+ 
++    // Paper start
++    @Override
++    public Score getScoreFor(org.bukkit.entity.Entity entity) throws IllegalArgumentException, IllegalStateException {
++        Validate.notNull(entity, "Entity cannot be null");
++        return getScore(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++    // Paper end
++
+     @Override
+     public void unregister() throws IllegalStateException {
+         CraftScoreboard scoreboard = this.checkState();
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
+index 7b61a2be2be0bdf06592b65be9acd4cbbae5bf7f..152bd54ebd0b0eeee4f3f7faf0c3043d83c01cc1 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScoreboard.java
+@@ -234,4 +234,23 @@ public final class CraftScoreboard implements org.bukkit.scoreboard.Scoreboard {
+     public Scoreboard getHandle() {
+         return this.board;
+     }
++    // Paper start
++    @Override
++    public ImmutableSet<Score> getScoresFor(org.bukkit.entity.Entity entity) throws IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        return this.getScores(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++
++    @Override
++    public void resetScoresFor(org.bukkit.entity.Entity entity) throws IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        this.resetScores(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++
++    @Override
++    public Team getEntityTeam(org.bukkit.entity.Entity entity) throws IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        return this.getEntryTeam(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+index 2b87a652798cb632fe76bf20e9e7f8cb8bfb3b7b..47f2e8824fff51f4271e7aa61e233d57e3ca2942 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftTeam.java
+@@ -302,6 +302,26 @@ final class CraftTeam extends CraftScoreboardComponent implements Team {
+         }
+     }
+ 
++    // Paper start
++    @Override
++    public void addEntity(org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        this.addEntry(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++
++    @Override
++    public boolean removeEntity(org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        return this.removeEntry(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++
++    @Override
++    public boolean hasEntity(org.bukkit.entity.Entity entity) throws IllegalStateException, IllegalArgumentException {
++        Validate.notNull(entity, "Entity cannot be null");
++        return this.hasEntry(((org.bukkit.craftbukkit.entity.CraftEntity) entity).getHandle().getScoreboardName());
++    }
++    // Paper end
++
+     public static Visibility bukkitToNotch(NameTagVisibility visibility) {
+         switch (visibility) {
+             case ALWAYS:


### PR DESCRIPTION
I think some of the scoreboard OfflinePlayer methods were deprecated for no reason, since they still work just fine, and just add confusion to people just starting out with scoreboards. Also, it was missing methods for adding any entity to a scoreboard which is also valid, and not something I think people know about. Some of the method names have to be different because getScore(Entity) and getScore(OfflinePlayer) would conflict if someone tried to get the score for a Player which implements both OfflinePlayer and Entity. can be avoided if they cast to one, but I think thats not worth having all the method names the same.