### PR TITLE
Updated Upstream (Bukkit/CraftBukkit)

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -3377,10 +3377,10 @@ index 2a145d851ce30360aa39549745bd87590c034584..00000000000000000000000000000000
 -    // Spigot end
 -}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7d5236e39a74fd76b626e5f9c8f76c8fbb99439f..6c910e09eda6f4f08226ccc75189171015a72b85 100644
+index f7e92c45943bf3806025abad9f6b6fe858f92916..3da218eeaa2910487f643918d948264cf83c4337 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1414,7 +1414,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1419,7 +1419,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           */
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
@@ -3499,7 +3499,7 @@ index a09c3f71ca563b6f40a118ce1344d0eb273bed40..cf2f517765d8f2a23cc4a17d9ee2dcd8
                  eventSet.add(new TimedRegisteredListener(listener, executor, eh.priority(), plugin, eh.ignoreCancelled()));
              } else {
 diff --git a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
-index 993a8c02af014a46cf03eaa4b67b09c0c16bd78a..e77c616977a3dcaa72bb22c35f6092c1f00b2b85 100644
+index 6bdd9f1dcc4c69c1811622cddc82526d2f8d9e52..657243776c8a2abb5a57e5c407212a8387d649eb 100644
 --- a/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 +++ b/src/main/java/org/bukkit/plugin/java/PluginClassLoader.java
 @@ -29,7 +29,8 @@ import org.jetbrains.annotations.Nullable;

--- a/patches/api/0007-Adventure.patch
+++ b/patches/api/0007-Adventure.patch
@@ -1547,7 +1547,7 @@ index 25a6f9313a1953def7470e411b53016f2ca14bef..03d8ac1b41659540d7eb3d7e218cdfaa
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999cec151168 100644
+index 3da218eeaa2910487f643918d948264cf83c4337..d0a92eeb3ecfcacf529db8336f7902a66a5f408a 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -33,7 +33,28 @@ import org.jetbrains.annotations.Nullable;
@@ -1720,7 +1720,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      /**
       * Says a message (or runs a command).
       *
-@@ -475,6 +556,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -480,6 +561,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated
      public boolean sendChunkChange(@NotNull Location loc, int sx, int sy, int sz, @NotNull byte[] data);
  
@@ -1747,7 +1747,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      /**
       * Send a sign change. This fakes a sign change packet for a user at
       * a certain location. This will not actually change the world in any way.
-@@ -487,9 +588,75 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -492,9 +593,75 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param loc the location of the sign
       * @param lines the new text on the sign or null to clear it
@@ -1823,7 +1823,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines) throws IllegalArgumentException;
  
      /**
-@@ -508,7 +675,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -513,7 +680,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1833,7 +1833,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor) throws IllegalArgumentException;
  
      /**
-@@ -528,7 +697,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -533,7 +702,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException if location is null
       * @throws IllegalArgumentException if dyeColor is null
       * @throws IllegalArgumentException if lines is non-null and has a length less than 4
@@ -1843,7 +1843,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      public void sendSignChange(@NotNull Location loc, @Nullable String[] lines, @NotNull DyeColor dyeColor, boolean hasGlowingText) throws IllegalArgumentException;
  
      /**
-@@ -1020,7 +1191,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1025,7 +1196,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * @param title Title text
       * @param subtitle Subtitle text
@@ -1852,7 +1852,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
       */
      @Deprecated
      public void sendTitle(@Nullable String title, @Nullable String subtitle);
-@@ -1039,7 +1210,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1044,7 +1215,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param fadeIn time in ticks for titles to fade in. Defaults to 10.
       * @param stay time in ticks for titles to stay. Defaults to 70.
       * @param fadeOut time in ticks for titles to fade out. Defaults to 20.
@@ -1862,7 +1862,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      public void sendTitle(@Nullable String title, @Nullable String subtitle, int fadeIn, int stay, int fadeOut);
  
      /**
-@@ -1266,6 +1439,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1271,6 +1444,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public int getClientViewDistance();
  
@@ -1877,7 +1877,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      /**
       * Gets the player's estimated ping in milliseconds.
       *
-@@ -1291,8 +1472,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1296,8 +1477,10 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * they wish.
       *
       * @return the player's locale
@@ -1888,7 +1888,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      public String getLocale();
  
      /**
-@@ -1310,6 +1493,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1315,6 +1498,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void openBook(@NotNull ItemStack book);
  
@@ -1903,7 +1903,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
      // Spigot start
      public class Spigot extends Entity.Spigot {
  
-@@ -1364,11 +1555,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1369,11 +1560,13 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
              throw new UnsupportedOperationException("Not supported yet.");
          }
  
@@ -1917,7 +1917,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
          @Override
          public void sendMessage(@NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
-@@ -1379,7 +1572,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1384,7 +1577,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param component the components to send
@@ -1927,7 +1927,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1389,7 +1584,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1394,7 +1589,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           *
           * @param position the screen position
           * @param components the components to send
@@ -1937,7 +1937,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @NotNull net.md_5.bungee.api.chat.BaseComponent... components) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1400,7 +1597,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1405,7 +1602,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param component the components to send
@@ -1947,7 +1947,7 @@ index 6c910e09eda6f4f08226ccc75189171015a72b85..696bf438012fd93f38495024ca49999c
          public void sendMessage(@NotNull net.md_5.bungee.api.ChatMessageType position, @Nullable UUID sender, @NotNull net.md_5.bungee.api.chat.BaseComponent component) {
              throw new UnsupportedOperationException("Not supported yet.");
          }
-@@ -1411,7 +1610,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1416,7 +1615,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
           * @param position the screen position
           * @param sender the sender of the message
           * @param components the components to send

--- a/patches/api/0008-Player-affects-spawning-API.patch
+++ b/patches/api/0008-Player-affects-spawning-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player affects spawning API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 696bf438012fd93f38495024ca49999cec151168..210b3440518cbddd6c27a7b301b280d814404a2a 100644
+index d0a92eeb3ecfcacf529db8336f7902a66a5f408a..9381180b7ffce8f9c8f6697d9e0b6c47032ad8a4 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1478,6 +1478,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1483,6 +1483,22 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      @Deprecated // Paper
      public String getLocale();
  

--- a/patches/api/0013-Add-view-distance-API.patch
+++ b/patches/api/0013-Add-view-distance-API.patch
@@ -64,10 +64,10 @@ index 3f7658c5347aad369fde6750d969f5fa63e922de..49be21d2676a93c384f37c09fe84eba2
      public class Spigot {
  
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 210b3440518cbddd6c27a7b301b280d814404a2a..14f35121aaeb641ac90bcadc906816f225e165ac 100644
+index 9381180b7ffce8f9c8f6697d9e0b6c47032ad8a4..a351a6aeff52a406cae686e4525bea1d25285895 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1492,6 +1492,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1497,6 +1497,62 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param affects Whether the player can affect mob spawning
       */
      public void setAffectsSpawning(boolean affects);

--- a/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
+++ b/patches/api/0018-Graduate-bungeecord-chat-API-from-spigot-subclasses.patch
@@ -76,10 +76,10 @@ index 833be0b61a375cef5b53e8a35dc2a99bebd550ef..4db7cffbc1baaaece076cedb55aff07f
       * Gets the name of the update folder. The update folder is used to safely
       * update plugins at the right moment on a plugin load.
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 14f35121aaeb641ac90bcadc906816f225e165ac..a989f63b6862123dc2b1293b9fd901bd093c84d0 100644
+index a351a6aeff52a406cae686e4525bea1d25285895..c629a7acd5ff2950165bc672d1e4a5850dcce1ec 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -710,6 +710,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -715,6 +715,42 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void sendMap(@NotNull MapView map);
  

--- a/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
+++ b/patches/api/0020-Player-Tab-List-and-Title-APIs.patch
@@ -432,7 +432,7 @@ index 0000000000000000000000000000000000000000..9e90c3df567a65b48a0b9341f784eb90
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a989f63b6862123dc2b1293b9fd901bd093c84d0..adf57da082ef37c369ed327804148ff992841055 100644
+index c629a7acd5ff2950165bc672d1e4a5850dcce1ec..1a8e99c68e7d7f1344f65c9676bf7a7b2c9a992b 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -443,7 +443,7 @@ index a989f63b6862123dc2b1293b9fd901bd093c84d0..adf57da082ef37c369ed327804148ff9
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -744,6 +745,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -749,6 +750,131 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }

--- a/patches/api/0024-Complete-resource-pack-API.patch
+++ b/patches/api/0024-Complete-resource-pack-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index adf57da082ef37c369ed327804148ff992841055..2c3e43ccf862c9de27811de0a49a2dee85e5d459 100644
+index 1a8e99c68e7d7f1344f65c9676bf7a7b2c9a992b..4f1f9a40cf34dca1c0ace32546680867d9aa296d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -1220,7 +1220,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1225,7 +1225,9 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @throws IllegalArgumentException Thrown if the URL is null.
       * @throws IllegalArgumentException Thrown if the URL is too long. The
       *     length restriction is an implementation specific arbitrary value.
@@ -18,7 +18,7 @@ index adf57da082ef37c369ed327804148ff992841055..2c3e43ccf862c9de27811de0a49a2dee
      public void setResourcePack(@NotNull String url);
  
      /**
-@@ -1733,6 +1735,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1738,6 +1740,124 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      default net.kyori.adventure.text.event.HoverEvent<net.kyori.adventure.text.event.HoverEvent.ShowEntity> asHoverEvent(final @NotNull java.util.function.UnaryOperator<net.kyori.adventure.text.event.HoverEvent.ShowEntity> op) {
          return net.kyori.adventure.text.event.HoverEvent.showEntity(op.apply(net.kyori.adventure.text.event.HoverEvent.ShowEntity.of(this.getType().getKey(), this.getUniqueId(), this.displayName())));
      }

--- a/patches/api/0044-Add-String-based-Action-Bar-API.patch
+++ b/patches/api/0044-Add-String-based-Action-Bar-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add String based Action Bar API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df2c4387bd 100644
+index 4f1f9a40cf34dca1c0ace32546680867d9aa296d..877c9a14b66e1c9282b0150de7373decba3ef718 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -3,6 +3,7 @@ package org.bukkit.entity;
@@ -16,7 +16,7 @@ index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -712,6 +713,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -717,6 +718,39 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start
@@ -56,7 +56,7 @@ index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df
      /**
       * Sends the component to the player
       *
-@@ -739,9 +773,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -744,9 +778,11 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      /**
       * Sends an array of components as a single message to the specified screen position of this player
       *
@@ -68,7 +68,7 @@ index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df
      public default void sendMessage(net.md_5.bungee.api.ChatMessageType position, net.md_5.bungee.api.chat.BaseComponent... components) {
          spigot().sendMessage(position, components);
      }
-@@ -1924,6 +1960,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1929,6 +1965,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends the component to the specified screen position of this player
           *
@@ -76,7 +76,7 @@ index 2c3e43ccf862c9de27811de0a49a2dee85e5d459..d39e5da511b8cc2239ad2eeb300762df
           * @param position the screen position
           * @param component the components to send
           * @deprecated use {@code sendMessage} methods that accept {@link net.kyori.adventure.text.Component}
-@@ -1936,6 +1973,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1941,6 +1978,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          /**
           * Sends an array of components as a single message to the specified screen position of this player
           *

--- a/patches/api/0053-Fix-upstream-javadocs.patch
+++ b/patches/api/0053-Fix-upstream-javadocs.patch
@@ -76,10 +76,10 @@ index be9334a8b5fba9181ad63c211697e798be63da25..0514a141cb93a650be38c63d4336d46e
       * Instructs this Mob to set the specified LivingEntity as its target.
       * <p>
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index d39e5da511b8cc2239ad2eeb300762df2c4387bd..dac2db2d953f1897ad79ea985a391d78d992dd84 100644
+index 877c9a14b66e1c9282b0150de7373decba3ef718..2d2289f823e916b4d049eec6b8851d70a57388b8 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -730,7 +730,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -735,7 +735,7 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *
       * Use supplied alternative character to the section symbol to represent legacy color codes.
       *

--- a/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/api/0079-Ability-to-apply-mending-to-XP-API.patch
@@ -10,10 +10,10 @@ of giving the player experience points.
 Both an API To standalone mend, and apply mending logic to .giveExp has been added.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 146487d04db8a52f489cafa919a7e731671f825d..b98a0bfe2c58377e0b3b135ef4e6250c3a59cc7f 100644
+index e3c91878cb6d8f6f9ab13f3d439c7b2ab08248af..b74342d1b6e5fe9f2d642ea1862c979f80399ee1 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -988,12 +988,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -993,12 +993,33 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      public void resetPlayerWeather();
  

--- a/patches/api/0090-Player.setPlayerProfile-API.patch
+++ b/patches/api/0090-Player.setPlayerProfile-API.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Player.setPlayerProfile API
 This can be useful for changing name or skins after a player has logged in.
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index b98a0bfe2c58377e0b3b135ef4e6250c3a59cc7f..5379b34f82bc36604d53f527b949a93c42ff441f 100644
+index b74342d1b6e5fe9f2d642ea1862c979f80399ee1..7a1d829b19b1a2f130614d7e4f54876a78887c4e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -4,6 +4,7 @@ import java.net.InetSocketAddress;
@@ -17,7 +17,7 @@ index b98a0bfe2c58377e0b3b135ef4e6250c3a59cc7f..5379b34f82bc36604d53f527b949a93c
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -1910,6 +1911,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -1915,6 +1916,20 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       *         was {@link org.bukkit.event.player.PlayerResourcePackStatusEvent.Status#SUCCESSFULLY_LOADED}
       */
      boolean hasResourcePack();

--- a/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
+++ b/patches/api/0094-Add-Ban-Methods-to-Player-Objects.patch
@@ -74,7 +74,7 @@ index 58313929f81509030216a0e5e3869da63e11108e..6cf05fed701c67a2c797a4e0839c7958
      /**
       * Checks if this player is whitelisted or not
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 5379b34f82bc36604d53f527b949a93c42ff441f..debe69ccb0da02815dfcb5288eb37b22ce55cb90 100644
+index 7a1d829b19b1a2f130614d7e4f54876a78887c4e..65b888dea914f75aa0c2a243f08996416839fbae 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -5,6 +5,10 @@ import java.util.UUID;
@@ -88,7 +88,7 @@ index 5379b34f82bc36604d53f527b949a93c42ff441f..debe69ccb0da02815dfcb5288eb37b22
  import org.bukkit.DyeColor;
  import org.bukkit.Effect;
  import org.bukkit.GameMode;
-@@ -714,6 +718,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -719,6 +723,162 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      public void sendMap(@NotNull MapView map);
  
      // Paper start

--- a/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/api/0148-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index debe69ccb0da02815dfcb5288eb37b22ce55cb90..63691e910ef8cbd81a8c73bd8d799c4e76591f44 100644
+index 65b888dea914f75aa0c2a243f08996416839fbae..9ada8b83bd1a04b5802fcc887cc20cd79de22d11 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2085,6 +2085,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2090,6 +2090,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * @param profile The new profile to use
       */
      void setPlayerProfile(@NotNull PlayerProfile profile);

--- a/patches/api/0197-Add-Player-Client-Options-API.patch
+++ b/patches/api/0197-Add-Player-Client-Options-API.patch
@@ -193,7 +193,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 63691e910ef8cbd81a8c73bd8d799c4e76591f44..6fa1b87f08165b90fb49fc4f1343bdeb7c5e5abb 100644
+index 9ada8b83bd1a04b5802fcc887cc20cd79de22d11..3719cb69ea39414ac5eb0a877d3311c4d1d4b74e 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -2,6 +2,7 @@ package org.bukkit.entity;
@@ -204,7 +204,7 @@ index 63691e910ef8cbd81a8c73bd8d799c4e76591f44..6fa1b87f08165b90fb49fc4f1343bdeb
  import com.destroystokyo.paper.Title; // Paper
  import net.kyori.adventure.text.Component;
  import com.destroystokyo.paper.profile.PlayerProfile; // Paper
-@@ -2105,6 +2106,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2110,6 +2111,12 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       * Reset the cooldown counter to 0, effectively starting the cooldown period.
       */
      void resetCooldown();

--- a/patches/api/0222-Brand-support.patch
+++ b/patches/api/0222-Brand-support.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 6fa1b87f08165b90fb49fc4f1343bdeb7c5e5abb..a4be2f8a53913ec315907694c31dcf9f8d5b3676 100644
+index 3719cb69ea39414ac5eb0a877d3311c4d1d4b74e..1f1f87c0e40c05d95132685aebdb42633d170986 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2240,6 +2240,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2245,6 +2245,16 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
          // Paper end
      }
  

--- a/patches/api/0231-Player-elytra-boost-API.patch
+++ b/patches/api/0231-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index a4be2f8a53913ec315907694c31dcf9f8d5b3676..88182db3de76905d6553e8c1034ae52b2a2be930 100644
+index 1f1f87c0e40c05d95132685aebdb42633d170986..82426f6f25e812062f1f9649b1756834a925e37d 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2112,6 +2112,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2117,6 +2117,19 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @NotNull
      <T> T getClientOption(@NotNull ClientOption<T> option);

--- a/patches/api/0260-Add-sendOpLevel-API.patch
+++ b/patches/api/0260-Add-sendOpLevel-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add sendOpLevel API
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 88182db3de76905d6553e8c1034ae52b2a2be930..7e3acf07b180622d5078051009492a90a2794beb 100644
+index 82426f6f25e812062f1f9649b1756834a925e37d..c79183e6499808af04962df48b05846f9c764682 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
-@@ -2125,6 +2125,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2130,6 +2130,17 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
       */
      @Nullable
      Firework boostElytra(@NotNull ItemStack firework);

--- a/patches/api/0275-Expose-Tracked-Players.patch
+++ b/patches/api/0275-Expose-Tracked-Players.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
-index 7e3acf07b180622d5078051009492a90a2794beb..6503bb08731fb2dcfc4f771e802c41be7f3fd4cb 100644
+index c79183e6499808af04962df48b05846f9c764682..38c4fbe41d964b9404e79ebd7cb3ea8c2f514935 100644
 --- a/src/main/java/org/bukkit/entity/Player.java
 +++ b/src/main/java/org/bukkit/entity/Player.java
 @@ -1,6 +1,7 @@
@@ -16,7 +16,7 @@ index 7e3acf07b180622d5078051009492a90a2794beb..6503bb08731fb2dcfc4f771e802c41be
  import java.util.UUID;
  import com.destroystokyo.paper.ClientOption; // Paper
  import com.destroystokyo.paper.Title; // Paper
-@@ -2138,6 +2139,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+@@ -2143,6 +2144,14 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
      void sendOpLevel(byte level);
      // Paper end
  

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -772,7 +772,7 @@ index b3a6aeba2363d283f03982cf749f25cfa11a5052..449f1b2f5dca350dc0912e14c8c2bf3e
                      PacketUtils.LOGGER.debug("Ignoring packet due to disconnection: {}", packet);
                  }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index dab59e1a523ab14f28764b179931a7a54e1bf52e..5de0b15ee206ad01b1b4522b2d375fae08d2486f 100644
+index 54cd91eab5c3a6c4919844245e5bbce6b27ce687..7a553e63fb19a08a56c6342f23c515a64893b351 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -182,7 +182,7 @@ import org.bukkit.craftbukkit.generator.CustomWorldChunkManager;
@@ -1049,7 +1049,7 @@ index fac993d58bd6e3bb19fd69881092a863c8952c65..2b062beaad39f2e86801fdd5b0cc84b2
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index ed21bd46262ac33801c17e6135dd22f99dd78504..d3213114aaaaef575efb79f0c66d5c23baf8614d 100644
+index feea5986de6b579b0da81c2c5233adbdb30f08fa..2923c90c52cc507bf312ff8d0837ad510a7b21cf 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,7 +1,9 @@
@@ -1237,7 +1237,7 @@ index 77d98bfa0ad9fc92a8e794b5a4e00c3e471c123a..3e2a5f83afcc3b9c9fe62748895d4891
  
      private void getFullChunk(long pos, Consumer<LevelChunk> chunkConsumer) {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 837d4b3a56b68b1546ccf0a08994cb63acaf0300..dce882d993fc51d4281bc88398d82ac3326d5cd9 100644
+index 8115e016109f560f2de78c69285342a42ebd119a..53b5da62d7f869183272f3fde4dab61642f5a733 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1366,7 +1366,7 @@ index 837d4b3a56b68b1546ccf0a08994cb63acaf0300..dce882d993fc51d4281bc88398d82ac3
                  this.entityManager.saveAll();
              } else {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index d6bef66d1cc0e3915ca5a9b9d5fc6e645eb5a7de..401520c47e63c3d2055e320daaeb1e74b1f627e1 100644
+index eecbfe8d1dc4cdc7fc2867208f8f2de7606f390b..0ed1d4b09b4d540a0bf420d8f63eb31fcfc7b8c2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -208,6 +208,7 @@ import org.bukkit.inventory.EquipmentSlot;
@@ -1445,7 +1445,7 @@ index a1aa84d408e805fe9b28f8241f23edec49adddee..956fed13f641d87a8d117ba30e84a413
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 264d216429c164798d5e645c044b95892b3b615e..1b8563be119498b8a9199ebd6fd4ad405577e0ee 100644
+index 110479daccf4bb64d290f1057f4caad16025060c..70154157221dcdd0d228a934aee2213d4ea2545a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -126,7 +126,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1537,7 +1537,7 @@ index 7f3d83d3d071f6b441ad119b1c93be035e911e70..28f1a53a2b9ebe9948509dabbf1a4ae8
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fd8c35e896cc03a21c41e846dc5413ce00da47b0..c57aa9226cee48d5ca0928c159a55e1c1fd42c3f 100644
+index d6f820f50b84dd4375746d981acfb6887c90c364..2e1857e80797c9012e203f69f44d5a6126d48ea7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -140,7 +140,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1795,7 +1795,7 @@ index b645a2fc839dbf922ce73b23b7d53e9a5fe1a2ee..03190535999d30aea0428631ae576b18
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index dc52fa7a78e79e0fbe087f89d7250225bb30228f..b6985eec04fb790bd4dd65f836b6e75728810b29 100644
+index fea5e7abcb5e429a3de5dd8968773fe5043a4448..421fbc0cf660d5d743ca34d5d759becea3fd666f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2256,12 +2256,31 @@ public final class CraftServer implements Server {
@@ -2000,10 +2000,10 @@ index b0ffa23faf62629043dfd613315eaf9c5fcc2cfe..00000000000000000000000000000000
 -    }
 -}
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 94bbf386aadd1d6e73ee3ff629e8f47c99ba3072..cdc13a38400e1e564c1d2388f0fb46e6d66f55d1 100644
+index 137889f545bc9f77a1752dd0bce4fcbc3889d665..654d9fd062ef8c98d87b025d48a1a9f709dd3db0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1826,6 +1826,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1833,6 +1833,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              packet.components = components;
              CraftPlayer.this.getHandle().connection.send(packet);
          }

--- a/patches/server/0011-Adventure.patch
+++ b/patches/server/0011-Adventure.patch
@@ -1238,7 +1238,7 @@ index 762a9392ffac3042356709dddd15bb3516048bed..3544e2dc2522e9d6305d727d56e73490
          buf.writeComponent(this.footer);
      }
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 89c718e5b975a83b07a114b2b2c6fe31c75cb580..d1efa7b3fb2b22bd77fd01ffd137ddc975e5fe60 100644
+index 5f243953d6d9710280bd099b7560c18d30dddfa0..0e7c09c80509c83a52f32f735a1b19960bb369ee 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -146,6 +146,7 @@ import net.minecraft.world.scores.Score;
@@ -1312,7 +1312,7 @@ index 89c718e5b975a83b07a114b2b2c6fe31c75cb580..d1efa7b3fb2b22bd77fd01ffd137ddc9
          // CraftBukkit end
          this.chatVisibility = packet.getChatVisibility();
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 80b3757f9326ce8fb77384501e8f10a64a8442a2..9e8c2c7a5df76a4b14b2d368f5c61c2b138656d9 100644
+index 0ed1d4b09b4d540a0bf420d8f63eb31fcfc7b8c2..fbf2a0d697b1ece82983154cdf585a101df391f4 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -161,6 +161,8 @@ import org.apache.logging.log4j.LogManager;
@@ -1696,7 +1696,7 @@ index d289e8321a62f7c8d1e5b83f038e7331a26fc24e..58716ba8f8d12a410bdc66ccef6a61c6
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
-index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c3777d152 100644
+index 4dd30c5090c55b1b963903e510c96c88d49de16e..1fcdd5aa930afc2039356582ab56aeec7f838e4e 100644
 --- a/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 +++ b/src/main/java/net/minecraft/world/level/saveddata/maps/MapItemSavedData.java
 @@ -33,6 +33,7 @@ import org.apache.logging.log4j.LogManager;
@@ -1717,7 +1717,7 @@ index 7a0e7961df1e62b311ea2ecc76d7343a8646723b..6859fafa42527d45366018f737c19e6c
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index b6985eec04fb790bd4dd65f836b6e75728810b29..c92dd103f4a7f5d122ef5e49ac5582ec8fb156eb 100644
+index 421fbc0cf660d5d743ca34d5d759becea3fd666f..4a5031925e2fa5f646e898f65594b2a7319c9208 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -588,8 +588,10 @@ public final class CraftServer implements Server {
@@ -2362,7 +2362,7 @@ index 446fdca49a5a6999626a7ee3a1d5c168b15a09dd..f9863e138994f6c7a7975a852f106faa
      public boolean isOp() {
          return true;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4e2b7040a 100644
+index 654d9fd062ef8c98d87b025d48a1a9f709dd3db0..63abd7058bd770724145526a89a539f064079b81 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -244,14 +244,39 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -2475,7 +2475,7 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4
      @Override
      public void setCompassTarget(Location loc) {
          if (this.getHandle().connection == null) return;
-@@ -572,6 +608,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -579,6 +615,33 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().connection.send(packet);
      }
  
@@ -2509,7 +2509,7 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4
      @Override
      public void sendSignChange(Location loc, String[] lines) {
          this.sendSignChange(loc, lines, DyeColor.BLACK);
-@@ -599,14 +662,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -606,14 +669,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
  
          Component[] components = CraftSign.sanitizeLines(lines);
@@ -2527,7 +2527,7 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4
      }
  
      @Override
-@@ -1706,6 +1770,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1713,6 +1777,12 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return (this.getHandle().clientViewDistance == null) ? Bukkit.getViewDistance() : this.getHandle().clientViewDistance;
      }
  
@@ -2540,7 +2540,7 @@ index cdc13a38400e1e564c1d2388f0fb46e6d66f55d1..222b75f733c1ef8b7698264650fe03b4
      @Override
      public int getPing() {
          return this.getHandle().latency;
-@@ -1734,6 +1804,195 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1741,6 +1811,195 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          getInventory().setItemInMainHand(hand);
      }
  
@@ -2762,7 +2762,7 @@ index 02f7a3081e9366f62a957dde4ec6487e1f66fb51..e172f574d5a5ab848197a113167872ec
          return event;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
-index ceada296118643c79dfb94f08288ddbeca50c9dd..99d52dc4a3619200e8eb864e8ed8f4a6e469b443 100644
+index af9facfaa8bba614e37bd604ca0656a852d0325b..60fa587ce17e138d2baf8959c26e25ed1db17a4a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftContainer.java
 @@ -69,6 +69,13 @@ public class CraftContainer extends AbstractContainerMenu {

--- a/patches/server/0022-Player-affects-spawning-API.patch
+++ b/patches/server/0022-Player-affects-spawning-API.patch
@@ -117,10 +117,10 @@ index 389985e022b82c675fb21f363422471bd15b84b0..849616d9ad140285f7aa4d2ffafd6371
          for(Player player : this.players()) {
              if (EntitySelector.NO_SPECTATORS.test(player) && EntitySelector.LIVING_ENTITY_STILL_ALIVE.test(player)) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 222b75f733c1ef8b7698264650fe03b4e2b7040a..e24437fbbe76db4ed5892df45b0c211254cbb69d 100644
+index 63abd7058bd770724145526a89a539f064079b81..b139868f1c84a97d145634d37cf0f658871f93c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1784,8 +1784,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1791,8 +1791,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public String getLocale() {
          return this.getHandle().locale;

--- a/patches/server/0025-Only-refresh-abilities-if-needed.patch
+++ b/patches/server/0025-Only-refresh-abilities-if-needed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Only refresh abilities if needed
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e24437fbbe76db4ed5892df45b0c211254cbb69d..cb91db9a25b96b0ad2b9c6a61ba26cd6d638b8a0 100644
+index b139868f1c84a97d145634d37cf0f658871f93c6..767bb340e4d7c1cd96a097145c9a9ad0cd2509b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1453,12 +1453,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1460,12 +1460,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public void setFlying(boolean value) {

--- a/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0053-Configurable-inter-world-teleportation-safety.patch
@@ -30,10 +30,10 @@ index d80de8777ae4d21256578c039e3fbe65ca9ade7c..1fc5b40f59a7edb25b0bd95f205a8fdf
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index ca8987d38f1fcbc094f0f5f13f12dfbf7dd2718a..903bf3ad7d355013791ba72a6e34acd63bb5489c 100644
+index 5a90d36915ab14aea6bf6431a1894031a5c9ee96..8eac81867ff299d45427fd71d9b085439deb95d8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -891,7 +891,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -898,7 +898,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (fromWorld == toWorld) {
              entity.connection.teleport(to);
          } else {

--- a/patches/server/0057-Add-methods-for-working-with-arrows-stuck-in-living-.patch
+++ b/patches/server/0057-Add-methods-for-working-with-arrows-stuck-in-living-.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add methods for working with arrows stuck in living entities
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 8e97b3985056caa2aa692ec6250022e095d0b3a6..e955126fc82dfcdadb824c8d2d15e8b1f33bc67f 100644
+index 72ddddde1dafad3be501d0aba73e04515d218d18..5d5ad28d01ff66a8b9f608f82b5213d112243e4d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -713,4 +713,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -717,4 +717,16 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          this.getHandle().persistentInvisibility = invisible;
          this.getHandle().setSharedFlag(5, invisible);
      }

--- a/patches/server/0058-Complete-resource-pack-API.patch
+++ b/patches/server/0058-Complete-resource-pack-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Complete resource pack API
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de8b263e54 100644
+index d217c3b7a72127e6421b2bfa224536e86e27e260..b4bcceeaec778103e07d69f9565f21a9d7e50ff2 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1628,8 +1628,11 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -23,7 +23,7 @@ index 22c2c121bbcc7b0e15d73d20c9cc83d5fb085e5f..edb66e8c4507597ec8c35883460f88de
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 903bf3ad7d355013791ba72a6e34acd63bb5489c..8c5b710ea9efa78282c45c7d3469a75146f2e36d 100644
+index 8eac81867ff299d45427fd71d9b085439deb95d8..1a790c9913e8d83276ca3c3158562b2a03e2c82e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -126,6 +126,7 @@ import org.bukkit.metadata.MetadataValue;
@@ -45,7 +45,7 @@ index 903bf3ad7d355013791ba72a6e34acd63bb5489c..8c5b710ea9efa78282c45c7d3469a751
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
          super(server, entity);
-@@ -1902,6 +1907,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1909,6 +1914,45 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public boolean getAffectsSpawning() {
          return this.getHandle().affectsSpawning;
      }

--- a/patches/server/0067-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0067-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 4b41ad3d9feeaf7f75c8459fb8acdab9ac1fce61..407292123b29fbc558b6b826878bf739fba05436 100644
+index 2ded905b151e7d01859641fdeebcfb2027d60349..7baedf1fb800f2f1bc526377eb32b169beac275b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -764,7 +764,13 @@ public abstract class LivingEntity extends Entity {
@@ -44,10 +44,10 @@ index 4b41ad3d9feeaf7f75c8459fb8acdab9ac1fce61..407292123b29fbc558b6b826878bf739
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8c5b710ea9efa78282c45c7d3469a75146f2e36d..4ff2a7ddb99a12a5427526f23882307d5fa337b8 100644
+index 1a790c9913e8d83276ca3c3158562b2a03e2c82e..f65140c04efd036019c7f91643ecd9644cd498df 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1709,6 +1709,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1716,6 +1716,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setRealHealth(double health) {

--- a/patches/server/0083-Workaround-for-setting-passengers-on-players.patch
+++ b/patches/server/0083-Workaround-for-setting-passengers-on-players.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Workaround for setting passengers on players
 SPIGOT-1915 & GH-114
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 4ff2a7ddb99a12a5427526f23882307d5fa337b8..1c354db269cf74b799ead261b6186f5c70c78989 100644
+index f65140c04efd036019c7f91643ecd9644cd498df..4592ac12058e7cf575ceb47a0021528f5dd91b0a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -901,6 +901,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -908,6 +908,17 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return true;
      }
  

--- a/patches/server/0087-Implement-PlayerLocaleChangeEvent.patch
+++ b/patches/server/0087-Implement-PlayerLocaleChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement PlayerLocaleChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2b7dd46fe090db01aa4d1f0e4211bed769ad76dc..7e7bbb6817ceddbbb90c1ac45d8e974d3f95c089 100644
+index 3f3404d7d890864fcdcde7d65f726d288ddec688..da722cddaaa8c40715748de81104a5b213c2fea8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1709,7 +1709,7 @@ public class ServerPlayer extends Player {
@@ -30,10 +30,10 @@ index 2b7dd46fe090db01aa4d1f0e4211bed769ad76dc..7e7bbb6817ceddbbb90c1ac45d8e974d
          this.locale = packet.language;
          // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 1c354db269cf74b799ead261b6186f5c70c78989..d972f7b5faa5d865c0ab550c6605f9839a162c07 100644
+index 4592ac12058e7cf575ceb47a0021528f5dd91b0a..8fc027fbbc3f5fc3ecdd8fce4f3b2eb510fa76da 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1906,8 +1906,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1913,8 +1913,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
      @Override
      public String getLocale() {

--- a/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
+++ b/patches/server/0171-Ability-to-apply-mending-to-XP-API.patch
@@ -28,7 +28,7 @@ index 6f25e9f41d93a225acaa6575954967438a6cabbf..d439e8ce87bf7da03683a336941c7673
              return true;
          });
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e5e12d1672588138e4f56007fcdd14a1bb8ec1ca..95cee13664b28fabf89ab7ff17f2481b11ff1fe3 100644
+index 6b8ee829306ad22f52844ba29bf2a549558048bd..4c8617fbd2cd8e34c87634fe448d204ee7fb8a0f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -61,11 +61,14 @@ import net.minecraft.server.level.ServerPlayer;
@@ -46,7 +46,7 @@ index e5e12d1672588138e4f56007fcdd14a1bb8ec1ca..95cee13664b28fabf89ab7ff17f2481b
  import net.minecraft.world.level.GameType;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.SignBlockEntity;
-@@ -1209,8 +1212,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1216,8 +1219,37 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          return GameMode.getByValue(this.getHandle().gameMode.getGameModeForPlayer().getId());
      }
  

--- a/patches/server/0186-Player.setPlayerProfile-API.patch
+++ b/patches/server/0186-Player.setPlayerProfile-API.patch
@@ -39,7 +39,7 @@ index dbab4d28c49d22807dfc582fb83353232396555b..0ef9c95d40cd0cdff0d150121511e6f9
      private ItemStack lastItemInMainHand;
      private final ItemCooldowns cooldowns;
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 95cee13664b28fabf89ab7ff17f2481b11ff1fe3..b88405f21c09f56b0f94b407e3271e421f7a10c3 100644
+index 4c8617fbd2cd8e34c87634fe448d204ee7fb8a0f..95a1d83fb7cb9947beb56b951b0081e4db2de6c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -71,6 +71,7 @@ import net.minecraft.world.item.enchantment.EnchantmentHelper;
@@ -50,7 +50,7 @@ index 95cee13664b28fabf89ab7ff17f2481b11ff1fe3..b88405f21c09f56b0f94b407e3271e42
  import net.minecraft.world.level.block.entity.SignBlockEntity;
  import net.minecraft.world.level.saveddata.maps.MapDecoration;
  import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
-@@ -1340,8 +1341,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1347,8 +1348,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.hiddenPlayers.put(player.getUniqueId(), hidingPlugins);
  
          // Remove this player from the hidden player's EntityTrackerEntry
@@ -65,7 +65,7 @@ index 95cee13664b28fabf89ab7ff17f2481b11ff1fe3..b88405f21c09f56b0f94b407e3271e42
          ChunkMap.TrackedEntity entry = tracker.entityMap.get(other.getId());
          if (entry != null) {
              entry.removePlayer(this.getHandle());
-@@ -1382,8 +1388,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1389,8 +1395,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          this.hiddenPlayers.remove(player.getUniqueId());
  
@@ -80,7 +80,7 @@ index 95cee13664b28fabf89ab7ff17f2481b11ff1fe3..b88405f21c09f56b0f94b407e3271e42
  
          this.getHandle().connection.send(new ClientboundPlayerInfoPacket(ClientboundPlayerInfoPacket.Action.ADD_PLAYER, other));
  
-@@ -1392,6 +1403,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1399,6 +1410,50 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              entry.updatePlayer(this.getHandle());
          }
      }

--- a/patches/server/0191-Flag-to-disable-the-channel-limit.patch
+++ b/patches/server/0191-Flag-to-disable-the-channel-limit.patch
@@ -9,7 +9,7 @@ e.g. servers which allow and support the usage of mod packs.
 provide an optional flag to disable this check, at your own risk.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b88405f21c09f56b0f94b407e3271e421f7a10c3..fbb4d97e1f525570ae86d1754af3063899cd88e2 100644
+index 95a1d83fb7cb9947beb56b951b0081e4db2de6c9..c07916e07e09f1491c9bad7d13b127960dd167a6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -150,6 +150,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -20,7 +20,7 @@ index b88405f21c09f56b0f94b407e3271e421f7a10c3..fbb4d97e1f525570ae86d1754af30638
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1609,7 +1610,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1616,7 +1617,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void addChannel(String channel) {

--- a/patches/server/0211-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0211-Make-shield-blocking-delay-configurable.patch
@@ -19,7 +19,7 @@ index 10f7437d62bfa774309d6334ca791505254bcaf7..6d2d82c24c9f43fab2cddee03960325c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 375959ed616596e604dc07d3b30d708b08d7ce57..a7f6127aae3c35d3570cba31cbf7a9be34e303b2 100644
+index 669e621fdb0d05ee61dea5f212eb228f8be008ae..d1d3c11e105b65a4b7d300ef3c08d4f4f5b3dbfc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3669,12 +3669,24 @@ public abstract class LivingEntity extends Entity {
@@ -49,10 +49,10 @@ index 375959ed616596e604dc07d3b30d708b08d7ce57..a7f6127aae3c35d3570cba31cbf7a9be
          return this.isShiftKeyDown();
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 90b70935242757b5c302bac7777eb1428d69619e..1ffdc8785d1073511e58d4826457efa9d71c357d 100644
+index 3977069ccc96114ddae8d2f8f6578f74d8854127..a6e1edad4acd20b25f5e27afbbf580482efe29af 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -735,5 +735,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -739,5 +739,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setArrowsStuck(int arrows) {
          getHandle().setArrowCount(arrows);
      }

--- a/patches/server/0216-LivingEntity-Hand-Raised-Item-Use-API.patch
+++ b/patches/server/0216-LivingEntity-Hand-Raised-Item-Use-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] LivingEntity Hand Raised/Item Use API
 How long an entity has raised hands to charge an attack or use an item
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 1ffdc8785d1073511e58d4826457efa9d71c357d..918f87cc79062602e1db41d9368921c0092b1840 100644
+index a6e1edad4acd20b25f5e27afbbf580482efe29af..db3123b4a6582ad1667b24b9ff03caf671287857 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -745,5 +745,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -749,5 +749,30 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setShieldBlockingDelay(int delay) {
          getHandle().setShieldBlockingDelay(delay);
      }

--- a/patches/server/0220-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0220-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 86a5a4456be65b94b0c27a0355c3844cbd296a20..c4aa14e81151ada49e61f4dd25267f7eb10450a6 100644
+index d09556a6559a6984a7aec341eb5678222ed67da3..b524db142fdc9596e9a10bf0208877c556c5ecbe 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1107,7 +1107,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,7 +29,7 @@ index 86a5a4456be65b94b0c27a0355c3844cbd296a20..c4aa14e81151ada49e61f4dd25267f7e
              }
              // Spigot End
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 66434418fae67ff63450bc246796c7f3d4d09ae6..b34f9c039a3ac198ae450794b5486d5197d2cfea 100644
+index 3bcb8ae7391f405c11cf1c117848eeb9aae7bcaa..3d5db5ce2e60ca72ad202caebe49f3fc80d1af37 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -597,7 +597,7 @@ public class ServerPlayer extends Player {
@@ -75,7 +75,7 @@ index 66434418fae67ff63450bc246796c7f3d4d09ae6..b34f9c039a3ac198ae450794b5486d51
          this.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 4cbdf64b0e6271a1cf0f31d486d8fad4f941b913..897a950a5a0b669aff05387efb9c403764a0e8ea 100644
+index 23bd778a4b784c93115924afdd97852ca27cbdd5..e1123f0523fbf1e07cdc44d029c7837ada31194b 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -187,6 +187,7 @@ import org.bukkit.event.inventory.ClickType;
@@ -105,7 +105,7 @@ index 4cbdf64b0e6271a1cf0f31d486d8fad4f941b913..897a950a5a0b669aff05387efb9c4037
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 1ae11a88b2ab49c13155e2cf41252c8716f30b96..8be7cf4533792315965c4e227b0ef73d06c0577a 100644
+index 17f56157d60d33695c4eac0e4fc94120a2101214..c4940b2538e8adfe5f19cb5f1a5373319a1cb89b 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -502,7 +502,7 @@ public abstract class PlayerList {
@@ -174,10 +174,10 @@ index f1b1d1881d0598503a7ec1022ef5e00f848fb247..460828d29583ee21a7c5b716f9687a82
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index fbb4d97e1f525570ae86d1754af3063899cd88e2..02ba74a1f503a8f48c41754175b8e5ba2a468433 100644
+index c07916e07e09f1491c9bad7d13b127960dd167a6..7d87be1eb79045226cad3b7e62ff5d265160b866 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -928,7 +928,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -935,7 +935,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          // Close any foreign inventory
          if (this.getHandle().containerMenu != this.getHandle().inventoryMenu) {

--- a/patches/server/0249-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
+++ b/patches/server/0249-Ability-to-get-Tile-Entities-from-a-chunk-without-sn.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ability to get Tile Entities from a chunk without snapshots
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index b135f07389bafe9f0a107f8d4115824662fd20b0..1bf64e7961f794b2da7ab81b4afe162fb48a48cc 100644
+index f26bea2f0b5e9629087b50c855694a79d926a485..7467de2da7cbe79df49d9bd95df1891810a1431b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -3,8 +3,10 @@ package org.bukkit.craftbukkit;
@@ -17,9 +17,9 @@ index b135f07389bafe9f0a107f8d4115824662fd20b0..1bf64e7961f794b2da7ab81b4afe162f
  import java.util.Collection;
 +import java.util.List;
  import java.util.Objects;
- import java.util.function.Predicate;
- import net.minecraft.core.BlockPos;
-@@ -154,6 +156,13 @@ public class CraftChunk implements Chunk {
+ import java.util.concurrent.locks.LockSupport;
+ import java.util.function.BooleanSupplier;
+@@ -174,6 +176,13 @@ public class CraftChunk implements Chunk {
  
      @Override
      public BlockState[] getTileEntities() {
@@ -33,7 +33,7 @@ index b135f07389bafe9f0a107f8d4115824662fd20b0..1bf64e7961f794b2da7ab81b4afe162f
          if (!this.isLoaded()) {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
-@@ -168,7 +177,29 @@ public class CraftChunk implements Chunk {
+@@ -188,7 +197,29 @@ public class CraftChunk implements Chunk {
              }
  
              BlockPos position = (BlockPos) obj;

--- a/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
+++ b/patches/server/0262-Expose-attack-cooldown-methods-for-Player.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose attack cooldown methods for Player
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 02ba74a1f503a8f48c41754175b8e5ba2a468433..e9548f8009bdca7e6673cd03e252507c9f8563e9 100644
+index 7d87be1eb79045226cad3b7e62ff5d265160b866..3be9882ac1e96441f479f22099b77a25dd7cb8dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2289,6 +2289,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2296,6 +2296,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
  
          return this.adventure$pointers;
      }

--- a/patches/server/0263-Improve-death-events.patch
+++ b/patches/server/0263-Improve-death-events.patch
@@ -19,7 +19,7 @@ maybe more (please check patch overrides for drops for more):
 - players, armor stands, foxes, chested donkeys/llamas
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index b34f9c039a3ac198ae450794b5486d5197d2cfea..4cfbb920abad262d42553270455f0cd09dbdcb1a 100644
+index 3d5db5ce2e60ca72ad202caebe49f3fc80d1af37..91f8b8e8e2ed15481ceafc8695068c8dc5853b3c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -219,6 +219,10 @@ public class ServerPlayer extends Player {
@@ -70,7 +70,7 @@ index b34f9c039a3ac198ae450794b5486d5197d2cfea..4cfbb920abad262d42553270455f0cd0
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index a44a8856d9f6a71a789a7335501abebfd23635be..1c35ba0d74aa02b0a94400308c20485ccaad7a13 100644
+index db366a5d81dac6748bb0b20188117266aee095d1..f4828c1bdc7d5e67941926f8d772b1bbc83031cf 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -261,6 +261,7 @@ public abstract class LivingEntity extends Entity {
@@ -269,10 +269,10 @@ index f9375dbbeda6fdc92406fe5d93df0467e6e70672..b41e6fb0b7e02b50e5ad05555ed911d0
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index e9548f8009bdca7e6673cd03e252507c9f8563e9..22d223e8da8ab80baafdad387c058a33e014501f 100644
+index 3be9882ac1e96441f479f22099b77a25dd7cb8dd..7b7ceefbcc1f0be710dd8995f0afaad98f9c044d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1869,7 +1869,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1876,7 +1876,14 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void sendHealthUpdate() {

--- a/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
+++ b/patches/server/0302-Add-APIs-to-replace-OfflinePlayer-getLastPlayed.patch
@@ -16,7 +16,7 @@ intent to remove) and replace it with two new methods, clearly named and
 documented as to their purpose.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 42035548577b7c60806a557dd9f9931ca9584e8c..03257305e1364a6dbda3358ff2cfba5565b4d5da 100644
+index a45b21a882b34cce3f36ce71a5f803d53331deb0..936e8070f9612cc1d1d960ef873afa4df52911d7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -219,6 +219,7 @@ public class ServerPlayer extends Player {
@@ -28,7 +28,7 @@ index 42035548577b7c60806a557dd9f9931ca9584e8c..03257305e1364a6dbda3358ff2cfba55
      public boolean queueHealthUpdatePacket = false;
      public net.minecraft.network.protocol.game.ClientboundSetHealthPacket queuedHealthUpdatePacket;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 9ce6687635181ac3f28cf116fc0c3c6fda56f965..b345e46ac004b6854fa91b5c65ea873705e111ca 100644
+index 69c32801d219d992143ab6f90d01d93963b7ff5e..f8827ca44a6e099d0a8a05265b01e6f5da3567e0 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -172,6 +172,7 @@ public abstract class PlayerList {
@@ -106,7 +106,7 @@ index 93de44b05a698515457052c9c684c4ef44c5cc40..b20bfe5ab165bf86985e5ff2f93f415d
      public Location getBedSpawnLocation() {
          CompoundTag data = this.getData();
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 22d223e8da8ab80baafdad387c058a33e014501f..8da3e688db0df4644926c0d8335cd274d7f996c5 100644
+index 7b7ceefbcc1f0be710dd8995f0afaad98f9c044d..97dd1831cfa1a74ccd80fb79a222d228bc694072 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -151,6 +151,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -117,7 +117,7 @@ index 22d223e8da8ab80baafdad387c058a33e014501f..8da3e688db0df4644926c0d8335cd274
      // Paper end
  
      public CraftPlayer(CraftServer server, ServerPlayer entity) {
-@@ -1513,6 +1514,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1520,6 +1521,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.firstPlayed = firstPlayed;
      }
  
@@ -136,7 +136,7 @@ index 22d223e8da8ab80baafdad387c058a33e014501f..8da3e688db0df4644926c0d8335cd274
      public void readExtraData(CompoundTag nbttagcompound) {
          this.hasPlayedBefore = true;
          if (nbttagcompound.contains("bukkit")) {
-@@ -1535,6 +1548,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1542,6 +1555,8 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
  
      public void setExtraData(CompoundTag nbttagcompound) {
@@ -145,7 +145,7 @@ index 22d223e8da8ab80baafdad387c058a33e014501f..8da3e688db0df4644926c0d8335cd274
          if (!nbttagcompound.contains("bukkit")) {
              nbttagcompound.put("bukkit", new CompoundTag());
          }
-@@ -1549,6 +1564,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1556,6 +1571,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          data.putLong("firstPlayed", this.getFirstPlayed());
          data.putLong("lastPlayed", System.currentTimeMillis());
          data.putString("lastKnownName", handle.getScoreboardName());

--- a/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
+++ b/patches/server/0305-Block-Entity-remove-from-being-called-on-Players.patch
@@ -12,10 +12,10 @@ Player we will look at limiting the scope of this change. It appears to
 be unintentional in the few cases we've seen so far.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 8da3e688db0df4644926c0d8335cd274d7f996c5..c52101f871ca6ba45027964281516056775c4290 100644
+index 97dd1831cfa1a74ccd80fb79a222d228bc694072..0a5aeafbb47b4bd10a471572ef04b4b9f1e31ace 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2336,6 +2336,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2343,6 +2343,15 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void resetCooldown() {
          getHandle().resetAttackStrengthTicker();
      }

--- a/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0352-Duplicate-UUID-Resolve-Option.patch
@@ -83,7 +83,7 @@ index 2bfab88523bd5825db29b6a00b5bc1aa40324de8..031829d1ba1e859368878245fe0edb6f
      private void countAllMobsForSpawning() {
          countAllMobsForSpawning = getBoolean("count-all-mobs-for-spawning", false);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 0f88ab98f8f33265dc223d55f4afae60230d9afe..20a9d213b977cf8d8ada3815931bb0603d5571c9 100644
+index 41253d8adf85cf318fcb1cee36ac1763f440fca6..ba1514301a8b20fcc594ae5555b491e88a98e6dd 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,6 +1,7 @@
@@ -165,10 +165,10 @@ index 0f88ab98f8f33265dc223d55f4afae60230d9afe..20a9d213b977cf8d8ada3815931bb060
          ChunkPos chunkcoordintpair = holder.getPos();
          CompletableFuture<Either<List<ChunkAccess>, ChunkHolder.ChunkLoadingFailure>> completablefuture = this.getChunkRangeFuture(chunkcoordintpair, 1, (i) -> {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 02767e831301b9112a77e9c2eb786ddbd95edfbd..799a60df575b7c420b1583f0fea01407be9e30dd 100644
+index 23640964305b7f2ffd54ed3044712308f03c3d42..f698723f8f7feecc749df10a316118184391f31a 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -74,7 +74,22 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -78,7 +78,22 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
  
      private boolean addEntityUuid(T entity) {
          if (!this.knownUuids.add(entity.getUUID())) {

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1091,7 +1091,7 @@ index c28879f32b004f36ff746ea2274f91ddd9501e71..60d72e488bc77cd913328be400ca374a
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 2e17c387ca132c5ec7312a4f008d93d2bc8f2138..85a3ccce473604561b5550b2b2b1f4aa02a04415 100644
+index 1197c510211b725742d48152443178eea94058a8..5bbdf56179d2e5fd0b42c37c84c9d4bc5faaee24 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1534,7 +1534,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1104,7 +1104,7 @@ index 2e17c387ca132c5ec7312a4f008d93d2bc8f2138..85a3ccce473604561b5550b2b2b1f4aa
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 8a1df5b26a6ba0e2fa13a9974cf41384a8e6d4fe..0df81cbddf2e7f164861b95cf572f9d6d3f031ca 100644
+index bf499e746652127700950cdbbf18df692987b389..4b9b708812ee502815dd6879412e8b942595344e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -378,7 +378,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1405,10 +1405,10 @@ index 670e4f65680ca36fba1c84cb334c470ea8fa9b60..79f2b3942a3ccccd8fe8719db12de458
                  chunksection.getStates().read(nbttagcompound2.getList("Palette", 10), nbttagcompound2.getLongArray("BlockStates"));
                  chunksection.recalcBlockCounts();
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 1bf64e7961f794b2da7ab81b4afe162fb48a48cc..cce7250ebeaeeaedfd0cb0147526f4ce2dd34b73 100644
+index 7467de2da7cbe79df49d9bd95df1891810a1431b..46136c5daa1b4ea9103c736cc4b035195177368e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -47,7 +47,7 @@ public class CraftChunk implements Chunk {
+@@ -51,7 +51,7 @@ public class CraftChunk implements Chunk {
      private final ServerLevel worldServer;
      private final int x;
      private final int z;
@@ -1417,7 +1417,7 @@ index 1bf64e7961f794b2da7ab81b4afe162fb48a48cc..cce7250ebeaeeaedfd0cb0147526f4ce
      private static final byte[] emptyLight = new byte[2048];
  
      public CraftChunk(net.minecraft.world.level.chunk.LevelChunk chunk) {
-@@ -312,7 +312,7 @@ public class CraftChunk implements Chunk {
+@@ -332,7 +332,7 @@ public class CraftChunk implements Chunk {
                  CompoundTag data = new CompoundTag();
                  cs[i].getStates().write(data, "Palette", "BlockStates");
  

--- a/patches/server/0379-Entity-Jump-API.patch
+++ b/patches/server/0379-Entity-Jump-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 50d180daff7258795d476b9cd43412fba2fba50f..64403a0a1bddeb1f126b8e315187ea79a859582a 100644
+index 7fc15f7731b9a249f5a1b82278c4ad61105462ce..3837cdc92174914e503dc573f496ea3464c7b566 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3165,8 +3165,10 @@ public abstract class LivingEntity extends Entity {
@@ -34,10 +34,10 @@ index ddc32ee8112e318f913546fcaa1fd6b26d59a672..dadc202da2d5568dce051b9cb4aadf20
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index c396ad36084e46c4b812d970e07a9188aed16daf..e617e4ecd3763dea795d524b92f8a979fd7d3c48 100644
+index 814363d0dee4a91c2e1d5f91e67530fec383c0cb..05c36f6dbd4da2cf29cc4087e3c8a78ecff41337 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -820,5 +820,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -824,5 +824,19 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public org.bukkit.inventory.EquipmentSlot getHandRaised() {
          return getHandle().getUsedItemHand() == net.minecraft.world.InteractionHand.MAIN_HAND ? org.bukkit.inventory.EquipmentSlot.HAND : org.bukkit.inventory.EquipmentSlot.OFF_HAND;
      }

--- a/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
+++ b/patches/server/0388-Optimise-TickListServer-by-rewriting-it.patch
@@ -42,7 +42,7 @@ sets the excessive tick delay to the specified ticks (defaults to
 60 * 20 ticks, aka 60 seconds)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 34e82edf683a33f140f3b4580b3245f29a775fcd..86e16e39a9a996669989d990b76f69116bcee300 100644
+index 26c5ae72f63d930bf6de2ec18a964ddfeca16379..e9954fa75412a7077950e3813af4b201c084f68f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -372,6 +372,13 @@ public class PaperConfig {
@@ -889,7 +889,7 @@ index 0000000000000000000000000000000000000000..118988c39e58f28e8a2851792b9c014f
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 8d3cdd288eacc91f7c9a624f601284e5cd2a36cc..a3ba56f437fe9e4dac59370463052341eb9b7524 100644
+index 84f370e887a3e7ff49296bdf8d6d8de9cc194cfb..daeb5b175d17492f382d23af58a9cc46fbb49e60 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -86,6 +86,19 @@ public class ChunkHolder {
@@ -948,7 +948,7 @@ index c6213a7dfcf9aeccdb546eaf74fa8eb119a6a32c..ec0d8e58a518a20634b902769251d6d0
      // Paper start
      // this will try to avoid chunk neighbours for lighting
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 207bcd82065e4c1832e4d7814635017210bd9d4d..f3fa6b366fb749b8dfcfc2343d934da0647b861b 100644
+index 527ae7af221c031b4cdf481f097e9062c41af5ac..a19b3c039751da14f044f05fb5ebfa08c051abe4 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -381,6 +381,15 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1109,10 +1109,10 @@ index 3b8c04f6ffd7e6c197465aa1caf633ba92529472..1007bfc9c19641f42afd5526cfe7bdb6
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 799a60df575b7c420b1583f0fea01407be9e30dd..32303ac7950effe468ef675d74d9ad436c5183f0 100644
+index f698723f8f7feecc749df10a316118184391f31a..be65a8a5a853d4e014d44730a48ccf247acf08d2 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -304,6 +304,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -308,6 +308,12 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              List<Entity> entities = this.getEntities(chunkentities.getPos()); // PAIL rename getChunkPos
              CraftEventFactory.callEntitiesLoadEvent(((EntityStorage) this.permanentStorage).level, chunkentities.getPos(), entities);
              // CraftBukkit end

--- a/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -8,7 +8,7 @@ so inline where possible, and avoid the abstraction of the
 Either class.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f3ba3c430a713fdef7e941b991ea8497de2e6a05..35ba86f0104b39903804de86dc5dff81050003bc 100644
+index d61c97f2eb8ecf52a624ac2e9f314c783b74d2e8..320cd209ab725a9ad4d5dff70987d7efabae5798 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2120,15 +2120,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -47,10 +47,10 @@ index 439f82a48e6f6ce7b4773505ced32324cacb302d..2a99aa989ac5c19d99bb3cbc0934425e
  
      public static int getX(long pos) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 32303ac7950effe468ef675d74d9ad436c5183f0..522e913e77cab591d8b31cb56b6821806ab7b69d 100644
+index be65a8a5a853d4e014d44730a48ccf247acf08d2..573e5ba276d270b8f67727dc1fbe6bfd7f2a28b1 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -385,6 +385,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -389,6 +389,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      public LevelEntityGetter<T> getEntityGetter() {
          return this.entityGetter;
      }

--- a/patches/server/0478-Optimize-NibbleArray-to-use-pooled-buffers.patch
+++ b/patches/server/0478-Optimize-NibbleArray-to-use-pooled-buffers.patch
@@ -299,10 +299,10 @@ index 24030bcb3303d0419c7859ded7613608c5f82308..ec3837a64e8ac6892028611d57a111a7
                              int k = SectionPos.sectionToBlockCoord(SectionPos.y(l));
                              int m = SectionPos.sectionToBlockCoord(SectionPos.z(l));
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index cce7250ebeaeeaedfd0cb0147526f4ce2dd34b73..9292db5ebf706d89a69dff9ac1e26e06e4ea7cba 100644
+index 46136c5daa1b4ea9103c736cc4b035195177368e..5088c84f6518cb686241b1db54faa8d813cb3eaa 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -323,14 +323,14 @@ public class CraftChunk implements Chunk {
+@@ -343,14 +343,14 @@ public class CraftChunk implements Chunk {
                      sectionSkyLights[i] = CraftChunk.emptyLight;
                  } else {
                      sectionSkyLights[i] = new byte[2048];

--- a/patches/server/0487-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0487-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -68,7 +68,7 @@ index 18ae2e2b339d357fbe0f6f2b18bc14c0dfe4c222..3b7ba9c755c82a6f086d5542d32b3567
      }
  
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index 6ace1cac8aad9baef045f332d387bbd9a25f360a..436ea61d284120a43123709f0213ec56870147dc 100644
+index 1d469a9ea0049687d7686f88382ac14514ad3bee..14d31bc2fb19b1265ee3e72280f2aba22ec0a26d 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -676,6 +676,7 @@ public final class MCUtil {
@@ -80,7 +80,7 @@ index 6ace1cac8aad9baef045f332d387bbd9a25f360a..436ea61d284120a43123709f0213ec56
                  chunkData.addProperty("queued-for-unload", chunkMap.toDrop.contains(playerChunk.pos.longKey));
                  chunkData.addProperty("status", status == null ? "unloaded" : status.toString());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index fe8e6d66665dc8c38e74c0b264cf507f99f83091..e317c73b430105052cbf28502916adc3bd60846b 100644
+index 467449049359c721c27b7cd249b03acc5fb8f3cc..a88d54c2a97b8d9e3c0ba6c4595bcd25dc6f3b80 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -60,7 +60,7 @@ public class ChunkHolder {
@@ -361,7 +361,7 @@ index fe8e6d66665dc8c38e74c0b264cf507f99f83091..e317c73b430105052cbf28502916adc3
                  }
              }).exceptionally((throwable) -> {
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c3b927e612806b3de4ec57bd6f926af35ad1146a..f43e8bb6b1c6c204b35ea64b47f6d6f558d0f7a5 100644
+index d70d977290b07fca61fea965a907c9f60a393ba7..324fe352fd108ef1d9f63a224b61c362adafc8d0 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -122,6 +122,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1077,7 +1077,7 @@ index e5317a994cb9b30293ad54b8fc537f703ef994dc..eb6a802ea12a19a058fb7e23b7418b8b
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0f4f07513f4fe43c059a50257fcad5c30d1cc81d..74b68679d311017246d49c37f3cd17f938f3b57f 100644
+index 921a0edd8e778d34f08429c22dd410708addf36e..2ee07e5bb5b4081870ae46ba322e0ec9a4dfe0ec 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -189,6 +189,14 @@ public class ServerPlayer extends Player {
@@ -1424,7 +1424,7 @@ index 8770fe0db46b01e8b608637df4f1a669a3f4cdde..3c1698ba0d3bc412ab957777d9b5211d
      private final String name;
      private final Comparator<T> comparator;
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index f6ffefd6a15fdb64e620282fb73f9c811d7e2561..761ccf1c67578aa1099a3a5d72339bbf75f6ff1b 100644
+index 8d86b9cacfaf71ec04dd530f3c0d75ee46c517df..14d4ef096624112c732b4c4f15763dc7c287d576 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1545,6 +1545,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -1467,7 +1467,7 @@ index a5fb401e04bf194224d05020fe397e231e2f715c..0e3726495ef10717627dcf4297c944da
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3e1f34ed8c3b4bd4f6c3624332a5f2be62e196fe..8df955a0aa6cd0c7d10619fb63abd16af4754be8 100644
+index bed497f56b9b1fa16ef7b91744bb27d228fb5a66..3279ddbafef921e30d40874708acb4f7d32c060e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -223,7 +223,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -1526,10 +1526,10 @@ index 20d956c9a4e3b598ffebbe481a190158566343d9..228406d41c2e4d1615329752bbc9e609
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 991e9afd16de706ddc62ab2c121a87bc775142db..046a60f6fa85803418eea2690b997ccdcab100fc 100644
+index d1bb816bd718e09614bad435c50e9c882194a85d..21a2f83aa91a41ea1f4e9e87e804d587838c0d45 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -896,6 +896,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -903,6 +903,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0504-Brand-support.patch
+++ b/patches/server/0504-Brand-support.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Brand support
 
 
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 51303e89ec160f3715e538903ae98be993d59150..a80781a0525ef5b46a7c9af3011dab6662f06016 100644
+index 4b2ec9ff11fd1d164eb883a3ad2944804fb63eff..617d5c7ee88b6e652b4fbb73b3858cad8c15c1d9 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
@@ -72,10 +72,10 @@ index 51303e89ec160f3715e538903ae98be993d59150..a80781a0525ef5b46a7c9af3011dab66
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 046a60f6fa85803418eea2690b997ccdcab100fc..c661f6f29633fd5b28bb6ce71ed49463a3d7ecf0 100644
+index 21a2f83aa91a41ea1f4e9e87e804d587838c0d45..c15d0bc8df85b81f8dec2d17b3b6eee9ef9ad1c8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2477,6 +2477,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2484,6 +2484,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0506-Add-playPickupItemAnimation-to-LivingEntity.patch
+++ b/patches/server/0506-Add-playPickupItemAnimation-to-LivingEntity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add playPickupItemAnimation to LivingEntity
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 0d64e930f0a30e15b180cd845a692d3ff61c8927..d740442a054327d88c5fdda20d10b41a7d322f0e 100644
+index e6ea5c09adbb3a20114d42ab3ac01969b64dfb28..95f08ceb8cf7ea91a6b7b53ada22b30965384083 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -834,5 +834,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -838,5 +838,10 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
              ((Mob) getHandle()).getJumpControl().jump();
          }
      }

--- a/patches/server/0556-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0556-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 434fba86e04894a3a2c4daeb4582980319d64d8e..348bff6213939b9b98364dd971a3f5ef29aa6189 100644
+index 23ada9f9b9d4969c7a9e493906d51a4293462305..d082e6e43ac638c353ae22a46c128c151a39424d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2068,7 +2068,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2075,7 +2075,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0557-Add-LivingEntity-clearActiveItem.patch
+++ b/patches/server/0557-Add-LivingEntity-clearActiveItem.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add LivingEntity#clearActiveItem
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index d740442a054327d88c5fdda20d10b41a7d322f0e..eb97c5a8ffe6873bc16f852dd1bd5ded3cd9b3de 100644
+index 95f08ceb8cf7ea91a6b7b53ada22b30965384083..37d8519c9c653be0eb60563dc5811a1202a662dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -801,6 +801,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -805,6 +805,13 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
          return getHandle().getUseItem().asBukkitMirror();
      }
  

--- a/patches/server/0570-Expose-LivingEntity-hurt-direction.patch
+++ b/patches/server/0570-Expose-LivingEntity-hurt-direction.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose LivingEntity hurt direction
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index eb97c5a8ffe6873bc16f852dd1bd5ded3cd9b3de..7c8dba1c7d65b4b91eb5a83c029bc5b31750775f 100644
+index 37d8519c9c653be0eb60563dc5811a1202a662dd..154886c81830ef2133ea44a93df807375021e51a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -846,5 +846,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -850,5 +850,15 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void playPickupItemAnimation(org.bukkit.entity.Item item, int quantity) {
          getHandle().take(((CraftItem) item).getHandle(), quantity);
      }

--- a/patches/server/0624-Expose-Tracked-Players.patch
+++ b/patches/server/0624-Expose-Tracked-Players.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose Tracked Players
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d6aac3063cfd70188ab5fe0f09ad112d66265953..301f10414118e2e79fa4f87c75be83411dfd2e39 100644
+index ff9ef9741ccd561f8bf1c517f5c9671874e0a083..660fea802abee79414815f73e079a05b5be1b72a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2396,6 +2396,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2403,6 +2403,21 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      }
      // Paper end
  

--- a/patches/server/0679-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0679-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,7 +45,7 @@ index d75f78d2e3fb1376e8f6a8668c98a04a693c99e1..79f6089b934124c3309c6bee2e48b36b
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 0eb2df75889bcfcadd5e2b81617cb8b3abd4df50..d309e2c460654c2fa7a6668e9f31d330e8e35967 100644
+index 379c931d9f63c2273654f6f6f63c94b17df36e57..4b2ef3ed89b9fae04ccaee41e4accefab645e2f3 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1790,8 +1790,15 @@ public class ServerPlayer extends Player {
@@ -126,7 +126,7 @@ index da2ae74b6f5875200e22c42ed07431016a90845e..35d05cc4bddea5b168a6498add1de9bc
      }
  
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index b2925d150a98ffb25cbf3c72f6df2abd862dae44..b4e11d39cf1d9791a8fe4ccd297f6afde7a38c7b 100644
+index 39d709bf38121e3c2c6ac019cdbf898d4dc9c2d5..db8b9872a489aafb657e81674b399eb60f9c91fe 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2470,7 +2470,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -139,10 +139,10 @@ index b2925d150a98ffb25cbf3c72f6df2abd862dae44..b4e11d39cf1d9791a8fe4ccd297f6afd
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 301f10414118e2e79fa4f87c75be83411dfd2e39..7150db24248b72c5ce2006ecff949315c71821d0 100644
+index 660fea802abee79414815f73e079a05b5be1b72a..c6a0f72a430e81db34f1c49cedb3f69cb5f0402c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1256,7 +1256,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1263,7 +1263,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0681-More-Enchantment-API.patch
+++ b/patches/server/0681-More-Enchantment-API.patch
@@ -64,10 +64,10 @@ index c536eceef3365a7b726cd970df345ba1d055207d..11c1eb0e0bc326b28dc0cab16f67c413
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index 88c0e80be343614947bfa3a14e08c5400a2d4ccc..20e619baa4bce6a133ade5e5d6a6f04f49a1b176 100644
+index 7d4daacde249b622a10ceca54b4a6997cc00bd77..ee63e6a650f93c973ffb2034e04b974cc1350540 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-@@ -863,5 +863,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+@@ -867,5 +867,21 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
      public void setHurtDirection(float hurtDirection) {
          getHandle().hurtDir = hurtDirection;
      }

--- a/patches/server/0730-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0730-Add-PlayerSetSpawnEvent.patch
@@ -18,7 +18,7 @@ index e95f2222814e104bf9194a96385737dffe2cb2b5..249ab7357aa19d87179fa4c3ae89d9d3
  
          String string = resourceKey.location().toString();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 822c38033e9134d631b031e3571b05951a4625b1..9b02f054493ad69c7a595374e6fd600c3d64e61e 100644
+index e809fd6616e2b7a602be10f0a62d0261b4b3b0da..80f7ff6117d15d1e0f19a497a8a2172a75d14734 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1260,7 +1260,7 @@ public class ServerPlayer extends Player {
@@ -67,7 +67,7 @@ index 822c38033e9134d631b031e3571b05951a4625b1..9b02f054493ad69c7a595374e6fd600c
  
              this.respawnPosition = pos;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index eaae43ffe4701c10133ad4fd2256b22b565e6f51..cf8ed790e09987528178519ba99376f27b15245f 100644
+index 9ac7791709263479b87d1234b07e84d9a2a4c9d3..450dd486269450be88c9a9a4d895184199e655aa 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -893,7 +893,7 @@ public abstract class PlayerList {
@@ -93,10 +93,10 @@ index af4eb4a8814491afef449a2874521636957d7557..0a5d563700c9f806139001181f01fa9d
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index c775014177caf0d1138bde1cc5726dc657176325..9da0bf8cf59fd37837ba4febf93c022fb4f08278 100644
+index 2642f139e6212b0930032cbb8da9fe384b25c26f..869596be0e5d4d0fa82b97e668c7545629fdfd36 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1076,9 +1076,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1083,9 +1083,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0761-Add-more-async-catchers.patch
+++ b/patches/server/0761-Add-more-async-catchers.patch
@@ -31,10 +31,10 @@ index f01182a0ac8a14bcd5b1deb778306e7bf1bf70ed..b27c8db914cca3ff0ea8a24acddb9cb9
              throw new UnsupportedOperationException("Only one concurrent iteration supported");
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 522e913e77cab591d8b31cb56b6821806ab7b69d..6fe07e1c207efbf5dcec1bdfb1366764d99aa580 100644
+index 573e5ba276d270b8f67727dc1fbe6bfd7f2a28b1..e89396ea1d06f9e4a0a58d86cb7f9d857d50dc0a 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -162,6 +162,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -166,6 +166,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void updateChunkStatus(ChunkPos chunkPos, ChunkHolder.FullChunkStatus levelType) {

--- a/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -914,7 +914,7 @@ index 0000000000000000000000000000000000000000..3ba094e640d7fe7803e2bbdab8ff3beb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7e0b656c5df0e778d3f07befc853a5de6516f951..675fca76f5f7319d45e0d4f03b74d27bf2a5a647 100644
+index aeee3ea62164661b762b52a8abcdb5fdc013e373..2eb1a5d951fbc126b66a96d39099cac4a03e7e2c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -437,7 +437,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -955,7 +955,7 @@ index 0f6b534a4c789a2f09f6c4624e5d58b99c7ed0e6..21d1e0c9c471e9e556b5bd70166a769b
          this.generatingStatus = chunkstatus;
          this.writeRadiusCutoff = i;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b7c0574aa8e3aec3bc13064b59c5f7efb075cf13..74fcc1b45a9e57280da82f7c181530d4183872a5 100644
+index f29b34e1467ff0e48049fd4b9a80e6c10d4cd97e..10e4d34e43abc7b67ba73c4f0d354e6905db2329 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -417,6 +417,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -1210,7 +1210,7 @@ index 59703eb6610c21df22f25c22cc884c4450f0316c..bdd50c28a76576be7950e3ccf8e00b62
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841cc3fff3b4 100644
+index e89396ea1d06f9e4a0a58d86cb7f9d857d50dc0a..976d206a17add01a31ae38b966913368cf386cb1 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 @@ -49,8 +49,10 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
@@ -1225,7 +1225,7 @@ index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841c
          this.sectionStorage = new EntitySectionStorage<>(entityClass, this.chunkVisibility);
          this.chunkVisibility.defaultReturnValue(Visibility.HIDDEN);
          this.chunkLoadStatuses.defaultReturnValue(PersistentEntitySectionManager.ChunkLoadStatus.FRESH);
-@@ -108,6 +110,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -112,6 +114,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              EntitySection<T> entitysection = this.sectionStorage.getOrCreateSection(i);
  
              entitysection.add(entity); // CraftBukkit - decompile error
@@ -1233,7 +1233,7 @@ index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841c
              entity.setLevelCallback(new PersistentEntitySectionManager.Callback(entity, i, entitysection));
              if (!existing) {
                  this.callbacks.onCreated(entity);
-@@ -165,6 +168,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -169,6 +172,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          io.papermc.paper.util.TickThread.ensureTickThread("Asynchronous chunk ticking status update"); // Paper
          Visibility visibility = Visibility.fromFullChunkStatus(levelType);
  
@@ -1241,7 +1241,7 @@ index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841c
          this.updateChunkStatus(chunkPos, visibility);
      }
  
-@@ -457,6 +461,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -461,6 +465,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              long i = SectionPos.asLong(blockposition);
  
              if (i != this.currentSectionKey) {
@@ -1249,7 +1249,7 @@ index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841c
                  Visibility visibility = this.currentSection.getStatus();
  
                  if (!this.currentSection.remove(this.entity)) {
-@@ -505,6 +510,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -509,6 +514,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              if (!this.currentSection.remove(this.entity)) {
                  PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (destroying due to {})", this.entity, SectionPos.of(this.currentSectionKey), reason);
              }
@@ -1258,10 +1258,10 @@ index 6fe07e1c207efbf5dcec1bdfb1366764d99aa580..2276536a0c3e7c6e242400436e8e841c
              Visibility visibility = PersistentEntitySectionManager.getEffectiveStatus(this.entity, this.currentSection.getStatus());
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 9292db5ebf706d89a69dff9ac1e26e06e4ea7cba..87368816fdb23f804752351de502126f2cd062c7 100644
+index 5088c84f6518cb686241b1db54faa8d813cb3eaa..07dfe575dea0f41a75bb9dad0ee2d541e983f6d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -127,9 +127,7 @@ public class CraftChunk implements Chunk {
+@@ -131,9 +131,7 @@ public class CraftChunk implements Chunk {
          long pair = ChunkPos.asLong(x, z);
  
          if (entityManager.areEntitiesLoaded(pair)) { // PAIL rename isEntitiesLoaded
@@ -1272,9 +1272,9 @@ index 9292db5ebf706d89a69dff9ac1e26e06e4ea7cba..87368816fdb23f804752351de502126f
          }
  
          entityManager.ensureChunkQueuedForLoad(pair); // Start entity loading
-@@ -149,9 +147,7 @@ public class CraftChunk implements Chunk {
-             return entityManager.areEntitiesLoaded(pair);
-         });
+@@ -169,9 +167,7 @@ public class CraftChunk implements Chunk {
+             }
+         }
  
 -        return entityManager.getEntities(new ChunkPos(this.x, this.z)).stream()
 -                .map(net.minecraft.world.entity.Entity::getBukkitEntity)

--- a/patches/server/0794-Optimise-WorldServer-notify.patch
+++ b/patches/server/0794-Optimise-WorldServer-notify.patch
@@ -8,7 +8,7 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 10d1e1f728519ad49379895c7fd3668badcbfd5a..4b1797659f6bb5913b105641ecaac38954ce8bc0 100644
+index bef7d5b4c8b99d2fbcd975127b16653e0f391338..19a853ceeded1c8803d182d035f0362abfa29933 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -290,15 +290,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -214,10 +214,10 @@ index 61080352ef305a1f276dbc297aa680b3175a5da2..10505f32b71b723ed8dbfd9e1348a169
              Vec3 vec3 = new Vec3(((double)node.x + this.mob.getX()) / 2.0D, ((double)node.y + this.mob.getY()) / 2.0D, ((double)node.z + this.mob.getZ()) / 2.0D);
              if (pos.closerThan(vec3, (double)(this.path.getNodeCount() - this.path.getNextNodeIndex()))) {
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index 62a5007bce6c2337db9ddfd41d3df6b201f91800..ea6d16d36cc98c0de5ad9d8faa8cbd8984fb309d 100644
+index 976d206a17add01a31ae38b966913368cf386cb1..28c1f144f2cc8675ed61dc814456859309970480 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -67,6 +67,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -71,6 +71,65 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
      // CraftBukkit end
  
@@ -283,7 +283,7 @@ index 62a5007bce6c2337db9ddfd41d3df6b201f91800..ea6d16d36cc98c0de5ad9d8faa8cbd89
      void removeSectionIfEmpty(long sectionPos, EntitySection<T> section) {
          if (section.isEmpty()) {
              this.sectionStorage.remove(sectionPos);
-@@ -458,11 +517,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -462,11 +521,25 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
          @Override
          public void onMove() {
              BlockPos blockposition = this.entity.blockPosition();
@@ -311,7 +311,7 @@ index 62a5007bce6c2337db9ddfd41d3df6b201f91800..ea6d16d36cc98c0de5ad9d8faa8cbd89
  
                  if (!this.currentSection.remove(this.entity)) {
                      PersistentEntitySectionManager.LOGGER.warn("Entity {} wasn't found in section {} (moving to {})", this.entity, SectionPos.of(this.currentSectionKey), i);
-@@ -474,6 +547,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -478,6 +551,11 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
                  entitysection.add(this.entity); // CraftBukkit - decompile error
                  this.currentSection = entitysection;
                  this.currentSectionKey = i;

--- a/patches/server/0801-Do-not-process-entity-loads-in-CraftChunk-getEntitie.patch
+++ b/patches/server/0801-Do-not-process-entity-loads-in-CraftChunk-getEntitie.patch
@@ -16,10 +16,10 @@ of a chance that we're about to eat a dirtload of chunk load callbacks, thus
 making this issue much more of an issue
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 87368816fdb23f804752351de502126f2cd062c7..3eefcae565ced131ad2924290423fd0b3249ccde 100644
+index 07dfe575dea0f41a75bb9dad0ee2d541e983f6d7..f194dbf29fefab6c94fe5aa11f565349499f4706 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-@@ -123,30 +123,6 @@ public class CraftChunk implements Chunk {
+@@ -127,46 +127,6 @@ public class CraftChunk implements Chunk {
              this.getWorld().getChunkAt(x, z); // Transient load for this tick
          }
  
@@ -32,20 +32,36 @@ index 87368816fdb23f804752351de502126f2cd062c7..3eefcae565ced131ad2924290423fd0b
 -
 -        entityManager.ensureChunkQueuedForLoad(pair); // Start entity loading
 -
--        // now we wait until the entities are loaded,
--        // the converting from NBT to entity object is done on the main Thread which is why we wait
--        this.getCraftWorld().getHandle().getServer().managedBlock(() -> {
--            boolean status = entityManager.areEntitiesLoaded(pair);
+-        // SPIGOT-6772: Use entity mailbox and re-schedule entities if they get unloaded
+-        ProcessorMailbox<Runnable> mailbox = ((EntityStorage) entityManager.permanentStorage).entityDeserializerQueue;
+-        BooleanSupplier supplier = () -> {
 -            // only execute inbox if our entities are not present
--            if (status) {
+-            if (entityManager.areEntitiesLoaded(pair)) {
 -                return true;
 -            }
+-
+-            if (!entityManager.isPending(pair)) {
+-                // Our entities got unloaded, this should normally not happen.
+-                entityManager.ensureChunkQueuedForLoad(pair); // Re-start entity loading
+-            }
+-
 -            // tick loading inbox, which loads the created entities to the world
 -            // (if present)
 -            entityManager.tick();
 -            // check if our entities are loaded
 -            return entityManager.areEntitiesLoaded(pair);
--        });
+-        };
+-
+-        // now we wait until the entities are loaded,
+-        // the converting from NBT to entity object is done on the main Thread which is why we wait
+-        while (!supplier.getAsBoolean()) {
+-            if (mailbox.size() != 0) { // PAIL rename size
+-                mailbox.run();
+-            } else {
+-                Thread.yield();
+-                LockSupport.parkNanos("waiting for entity loading", 100000L);
+-            }
+-        }
 -
          return getCraftWorld().getHandle().getChunkEntities(this.x, this.z); // Paper - optimise this
      }

--- a/patches/server/0835-Async-catch-modifications-to-critical-entity-state.patch
+++ b/patches/server/0835-Async-catch-modifications-to-critical-entity-state.patch
@@ -8,10 +8,10 @@ Now in 1.17, this state is _even more_ critical than it was before,
 so these must exist to catch stupid plugins.
 
 diff --git a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c742f5d085 100644
+index 28c1f144f2cc8675ed61dc814456859309970480..8cb246863e06c5b95ba1442e2ec47095026c4f39 100644
 --- a/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
 +++ b/src/main/java/net/minecraft/world/level/entity/PersistentEntitySectionManager.java
-@@ -134,6 +134,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -138,6 +138,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private boolean addEntityUuid(T entity) {
@@ -19,7 +19,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          if (!this.knownUuids.add(entity.getUUID())) {
              // Paper start
              T conflict = this.visibleEntityStorage.getEntity(entity.getUUID());
-@@ -162,6 +163,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -166,6 +167,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private boolean addEntity(T entity, boolean existing) {
@@ -27,7 +27,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          if (!this.addEntityUuid(entity)) {
              return false;
          } else {
-@@ -206,19 +208,23 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -210,19 +212,23 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      void startTicking(T entity) {
@@ -51,7 +51,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          this.callbacks.onTrackingEnd(entity);
          this.visibleEntityStorage.remove(entity);
      }
-@@ -232,6 +238,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -236,6 +242,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void updateChunkStatus(ChunkPos chunkPos, Visibility trackingStatus) {
@@ -59,7 +59,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          long i = chunkPos.toLong();
  
          if (trackingStatus == Visibility.HIDDEN) {
-@@ -291,6 +298,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -295,6 +302,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
  
      private boolean storeChunkSections(long chunkPos, Consumer<T> action, boolean callEvent) {
          // CraftBukkit end
@@ -67,7 +67,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          PersistentEntitySectionManager.ChunkLoadStatus persistententitysectionmanager_b = (PersistentEntitySectionManager.ChunkLoadStatus) this.chunkLoadStatuses.get(chunkPos);
  
          if (persistententitysectionmanager_b == PersistentEntitySectionManager.ChunkLoadStatus.PENDING) {
-@@ -320,6 +328,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -324,6 +332,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private void requestChunkLoad(long chunkPos) {
@@ -75,7 +75,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          this.chunkLoadStatuses.put(chunkPos, PersistentEntitySectionManager.ChunkLoadStatus.PENDING);
          ChunkPos chunkcoordintpair = new ChunkPos(chunkPos);
          CompletableFuture completablefuture = this.permanentStorage.loadEntities(chunkcoordintpair);
-@@ -333,6 +342,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -337,6 +346,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private boolean processChunkUnload(long chunkPos) {
@@ -83,7 +83,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          boolean flag = this.storeChunkSections(chunkPos, (entityaccess) -> {
              entityaccess.getPassengersAndSelf().forEach(this::unloadEntity);
          }, true); // CraftBukkit - add boolean for event call
-@@ -357,6 +367,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -361,6 +371,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      private void processPendingLoads() {
@@ -91,7 +91,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          ChunkEntities<T> chunkentities; // CraftBukkit - decompile error
  
          while ((chunkentities = (ChunkEntities) this.loadingInbox.poll()) != null) {
-@@ -379,6 +390,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -383,6 +394,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void tick() {
@@ -99,7 +99,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          this.processPendingLoads();
          this.processUnloads();
      }
-@@ -399,6 +411,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -403,6 +415,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void autoSave() {
@@ -107,7 +107,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          this.getAllChunksToSave().forEach((java.util.function.LongConsumer) (i) -> { // CraftBukkit - decompile error
              boolean flag = this.chunkVisibility.get(i) == Visibility.HIDDEN;
  
-@@ -413,6 +426,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -417,6 +430,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
      }
  
      public void saveAll() {
@@ -115,7 +115,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
          LongSet longset = this.getAllChunksToSave();
  
          while (!longset.isEmpty()) {
-@@ -520,6 +534,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -524,6 +538,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
              long i = SectionPos.asLong(blockposition); final long newSectionPos = i; // Paper - diff on change, new position section
  
              if (i != this.currentSectionKey) {
@@ -123,7 +123,7 @@ index fe5739c0949636343ea68e403aa5f4bef89e9d9f..50916d29c98b988a206a692d2babd0c7
                  PersistentEntitySectionManager.this.entitySliceManager.moveEntity((Entity)this.entity); // Paper
                  Visibility visibility = this.currentSection.getStatus(); final Visibility oldVisibility = visibility; // Paper - diff on change - this should be OLD section visibility
                  // Paper start
-@@ -585,6 +600,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
+@@ -589,6 +604,7 @@ public class PersistentEntitySectionManager<T extends EntityAccess> implements A
  
          @Override
          public void onRemove(Entity.RemovalReason reason) {


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
cfd18bd0 SPIGOT-6436: Add Player#stopAllSounds

CraftBukkit Changes:
b58f4299 SPIGOT-6436: Add Player#stopAllSounds
eb191612 SPIGOT-6783: Items do not appear in custom anvil inventories
376edf4f SPIGOT-6779: Fix LivingEntity#attack for Player entities
747a73ec SPIGOT-6772: Use entity mailbox and re-schedule entities if they get unloaded