### PR TITLE
Add API for resetting a single score

### DIFF
--- a/patches/api/0347-Add-API-for-resetting-a-single-score.patch
+++ b/patches/api/0347-Add-API-for-resetting-a-single-score.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Fri, 5 Nov 2021 21:01:36 +0100
+Subject: [PATCH] Add API for resetting a single score
+
+It was only possible to reset all scores for a specific entry, instead of resetting only specific scores.
+
+diff --git a/src/main/java/org/bukkit/scoreboard/Score.java b/src/main/java/org/bukkit/scoreboard/Score.java
+index d25b4d04932da7e7562cd1acf67ebec33af5b6ef..07bfad4a908de26e9aa6291e4ad20006e88ffe87 100644
+--- a/src/main/java/org/bukkit/scoreboard/Score.java
++++ b/src/main/java/org/bukkit/scoreboard/Score.java
+@@ -73,4 +73,14 @@ public interface Score {
+      */
+     @Nullable
+     Scoreboard getScoreboard();
++
++    // Paper start
++    /**
++     * Resets this score, if a value has been set.
++     *
++     * @throws IllegalStateException if the associated objective has been
++     *     unregistered
++     */
++    void resetScore() throws IllegalStateException;
++    // Paper end
+ }

--- a/patches/server/0844-Add-API-for-resetting-a-single-score.patch
+++ b/patches/server/0844-Add-API-for-resetting-a-single-score.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: booky10 <boooky10@gmail.com>
+Date: Fri, 5 Nov 2021 21:01:36 +0100
+Subject: [PATCH] Add API for resetting a single score
+
+It was only possible to reset all scores for a specific entry, instead of resetting only specific scores.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScore.java b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScore.java
+index 2c4ffed5e828f051c44f494a8ed599a8197d7450..3b26793b67282c3a20c023b9c13a2a9b54d5d932 100644
+--- a/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScore.java
++++ b/src/main/java/org/bukkit/craftbukkit/scoreboard/CraftScore.java
+@@ -68,4 +68,12 @@ final class CraftScore implements Score {
+     public CraftScoreboard getScoreboard() {
+         return this.objective.getScoreboard();
+     }
++
++    // Paper start
++    @Override
++    public void resetScore() {
++        Scoreboard board = this.objective.checkState().board;
++        board.resetPlayerScore(entry, this.objective.getHandle());
++    }
++    // Paper end
+ }


### PR DESCRIPTION
It was only possible to reset all scores for a specific entry, instead of resetting only specific scores.