### PR TITLE
Make BlockData creation thread safe again

### DIFF
--- a/patches/server/0502-Cache-block-data-strings.patch
+++ b/patches/server/0502-Cache-block-data-strings.patch
@@ -17,29 +17,15 @@ index 95842327aa08d4717f86e9dcc0519ab24c41ca14..135b3e44fb6054d360327a0ce46decc4
  
          if (this.isSameThread()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 3594f432a25b580173e8577bf324be954f5eddd1..dc51181dde6e49d2cbed9f21c007b8256a8910c6 100644
+index 3594f432a25b580173e8577bf324be954f5eddd1..d62ba8d02228b2a00202190ff16a0efc342c7b83 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -8,11 +8,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
- import java.util.HashMap;
- import java.util.Map;
- import java.util.Set;
-+import java.util.concurrent.ConcurrentHashMap;
- import java.util.stream.Collectors;
- import net.minecraft.commands.arguments.blocks.BlockStateParser;
- import net.minecraft.core.Direction;
- import net.minecraft.core.Registry;
- import net.minecraft.nbt.CompoundTag;
-+import net.minecraft.resources.ResourceLocation;
- import net.minecraft.util.StringRepresentable;
- import net.minecraft.world.level.block.Block;
- import net.minecraft.world.level.block.state.BlockState;
-@@ -494,9 +496,39 @@ public class CraftBlockData implements BlockData {
+@@ -494,9 +494,39 @@ public class CraftBlockData implements BlockData {
          Preconditions.checkState(CraftBlockData.MAP.put(nms, bukkit) == null, "Duplicate mapping %s->%s", nms, bukkit);
      }
  
 +    // Paper start - cache block data strings
-+    private static Map<String, CraftBlockData> stringDataCache = new ConcurrentHashMap<>();
++    private static Map<String, CraftBlockData> stringDataCache = new java.util.concurrent.ConcurrentHashMap<>();
 +
 +    static {
 +        // cache all of the default states at startup, will not cache ones with the custom states inside of the
@@ -60,7 +46,7 @@ index 3594f432a25b580173e8577bf324be954f5eddd1..dc51181dde6e49d2cbed9f21c007b825
 +        if (material != null) {
 +            Block block = CraftMagicNumbers.getBlock(material);
 +            if (block != null) {
-+                ResourceLocation key = Registry.BLOCK.getKey(block);
++                net.minecraft.resources.ResourceLocation key = Registry.BLOCK.getKey(block);
 +                data = data == null ? key.toString() : key + data;
 +            }
 +        }

--- a/patches/server/0502-Cache-block-data-strings.patch
+++ b/patches/server/0502-Cache-block-data-strings.patch
@@ -17,10 +17,16 @@ index 95842327aa08d4717f86e9dcc0519ab24c41ca14..135b3e44fb6054d360327a0ce46decc4
  
          if (this.isSameThread()) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 3594f432a25b580173e8577bf324be954f5eddd1..6dc8f9f269db6971b8b46819e017357899ccd118 100644
+index 3594f432a25b580173e8577bf324be954f5eddd1..dc51181dde6e49d2cbed9f21c007b8256a8910c6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -13,6 +13,7 @@ import net.minecraft.commands.arguments.blocks.BlockStateParser;
+@@ -8,11 +8,13 @@ import com.mojang.brigadier.exceptions.CommandSyntaxException;
+ import java.util.HashMap;
+ import java.util.Map;
+ import java.util.Set;
++import java.util.concurrent.ConcurrentHashMap;
+ import java.util.stream.Collectors;
+ import net.minecraft.commands.arguments.blocks.BlockStateParser;
  import net.minecraft.core.Direction;
  import net.minecraft.core.Registry;
  import net.minecraft.nbt.CompoundTag;
@@ -28,12 +34,12 @@ index 3594f432a25b580173e8577bf324be954f5eddd1..6dc8f9f269db6971b8b46819e0173578
  import net.minecraft.util.StringRepresentable;
  import net.minecraft.world.level.block.Block;
  import net.minecraft.world.level.block.state.BlockState;
-@@ -494,9 +495,39 @@ public class CraftBlockData implements BlockData {
+@@ -494,9 +496,39 @@ public class CraftBlockData implements BlockData {
          Preconditions.checkState(CraftBlockData.MAP.put(nms, bukkit) == null, "Duplicate mapping %s->%s", nms, bukkit);
      }
  
 +    // Paper start - cache block data strings
-+    private static Map<String, CraftBlockData> stringDataCache = new HashMap<>();
++    private static Map<String, CraftBlockData> stringDataCache = new ConcurrentHashMap<>();
 +
 +    static {
 +        // cache all of the default states at startup, will not cache ones with the custom states inside of the

--- a/patches/server/0515-Optimise-getType-calls.patch
+++ b/patches/server/0515-Optimise-getType-calls.patch
@@ -67,10 +67,10 @@ index 0a755f38fae9dc84440f43113920c5b4c6d8218b..7b9e943b391c061782fccd2b8d705cee
  
      public void setFlag(int flag) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index 6dc8f9f269db6971b8b46819e017357899ccd118..7f49c7c7048b5778f20ddce1d844d4b389e6597f 100644
+index dc51181dde6e49d2cbed9f21c007b8256a8910c6..fbaac0414ffae6547be1a7025df3365f475f1cb1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -45,7 +45,7 @@ public class CraftBlockData implements BlockData {
+@@ -46,7 +46,7 @@ public class CraftBlockData implements BlockData {
  
      @Override
      public Material getMaterial() {

--- a/patches/server/0515-Optimise-getType-calls.patch
+++ b/patches/server/0515-Optimise-getType-calls.patch
@@ -67,10 +67,10 @@ index 0a755f38fae9dc84440f43113920c5b4c6d8218b..7b9e943b391c061782fccd2b8d705cee
  
      public void setFlag(int flag) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-index dc51181dde6e49d2cbed9f21c007b8256a8910c6..fbaac0414ffae6547be1a7025df3365f475f1cb1 100644
+index 0949ce5ea6aa8e28494e4435e3a7f3ee07052d34..4e06795e3a74c2c3467376bd6c95aecdef125ea4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/data/CraftBlockData.java
-@@ -46,7 +46,7 @@ public class CraftBlockData implements BlockData {
+@@ -44,7 +44,7 @@ public class CraftBlockData implements BlockData {
  
      @Override
      public Material getMaterial() {


### PR DESCRIPTION
As the caching of already created `CraftBlockData`-instances makes `CraftBlockData#newData` overall faster and more efficient, it breaks the thread safety of `CraftBlockData#newData`.

This change for the patch aims to re-establish the thread safety for plugins calling `Bukkit#createBlockData` in an asynchronous context. As `CraftBlockData#newData` does not modify anything server-related the method should stay thread-safe. Calling the named method asynchronous is a well-known pattern for plugins like world generators, where they put the load for BlockData creation onto other threads to ensure a smooth experience. 

Also relates to https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6784