### PR TITLE
Fix setPatternColor on tropical fish bucket meta

### DIFF
--- a/patches/server/0840-Fix-setPatternColor-on-tropical-fish-bucket-meta.patch
+++ b/patches/server/0840-Fix-setPatternColor-on-tropical-fish-bucket-meta.patch
@@ -1,0 +1,71 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Bjarne Koll <lynxplay101@gmail.com>
+Date: Sat, 6 Nov 2021 23:15:20 +0100
+Subject: [PATCH] Fix setPatternColor on tropical fish bucket meta
+
+Prior to this commit, the tropical fish bucket meta would set the body
+color to the previous metas pattern colour when updating the pattern
+colour.
+
+This commit hence simply fixes this by using the proper body colour
+value when updating the pattern color.
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
+index ad9f19ab7d2acf314e87e2cfc6671583de2cfab9..0ea574121c505479607772d761ea829bb6ddb380 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftMetaTropicalFishBucket.java
+@@ -113,7 +113,7 @@ class CraftMetaTropicalFishBucket extends CraftMetaItem implements TropicalFishB
+         if (this.variant == null) {
+             this.variant = 0;
+         }
+-        this.variant = CraftTropicalFish.getData(color, this.getPatternColor(), this.getPattern());
++        this.variant = CraftTropicalFish.getData(color, this.getBodyColor(), this.getPattern()); // Paper - properly set tropical fish pattern color without mutating body color
+     }
+ 
+     @Override
+diff --git a/src/test/java/io/papermc/paper/inventory/CraftMetaTropicalFishBucketTest.java b/src/test/java/io/papermc/paper/inventory/CraftMetaTropicalFishBucketTest.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..2e7f8ef88ae74c7cbfdb7f397951cbc8479a995f
+--- /dev/null
++++ b/src/test/java/io/papermc/paper/inventory/CraftMetaTropicalFishBucketTest.java
+@@ -0,0 +1,40 @@
++package io.papermc.paper.inventory;
++
++import org.bukkit.DyeColor;
++import org.bukkit.Material;
++import org.bukkit.entity.TropicalFish;
++import org.bukkit.inventory.ItemStack;
++import org.bukkit.inventory.meta.TropicalFishBucketMeta;
++import org.bukkit.support.AbstractTestingBase;
++import org.junit.Assert;
++import org.junit.Test;
++
++public class CraftMetaTropicalFishBucketTest extends AbstractTestingBase {
++
++    @Test
++    public void testAllCombinations() {
++        final var rawMeta = new ItemStack(Material.TROPICAL_FISH_BUCKET).getItemMeta();
++        Assert.assertTrue("Meta was not a tropical fish bucket", rawMeta instanceof TropicalFishBucketMeta);
++
++        final var meta = (TropicalFishBucketMeta) rawMeta;
++
++        for (final var bodyColor : DyeColor.values()) {
++            for (final var pattern : TropicalFish.Pattern.values()) {
++                for (final var patternColor : DyeColor.values()) {
++                    meta.setBodyColor(bodyColor);
++                    Assert.assertEquals("Body color did not match post body color!", bodyColor, meta.getBodyColor());
++
++                    meta.setPattern(pattern);
++                    Assert.assertEquals("Pattern did not match post pattern!", pattern, meta.getPattern());
++                    Assert.assertEquals("Body color did not match post pattern!", bodyColor, meta.getBodyColor());
++
++                    meta.setPatternColor(patternColor);
++                    Assert.assertEquals("Pattern did not match post pattern color!", pattern, meta.getPattern());
++                    Assert.assertEquals("Body color did not match post pattern color!", bodyColor, meta.getBodyColor());
++                    Assert.assertEquals("Pattern color did not match post pattern color!", patternColor, meta.getPatternColor());
++                }
++            }
++        }
++    }
++
++}


### PR DESCRIPTION
Prior to this commit, the tropical fish bucket meta would set the body
color to the previous metas pattern colour when updating the pattern
colour.

This commit hence simply fixes this by using the proper body colour
value when updating the pattern color.