### PR TITLE
cleanup: Add hand to bucket events patch

### DIFF
--- a/build-data/reobf-mappings-patch.tiny
+++ b/build-data/reobf-mappings-patch.tiny
@@ -19,10 +19,6 @@ c	net/minecraft/server/level/ServerLevel	net/minecraft/server/level/WorldServer
 c	net/minecraft/world/level/chunk/LevelChunk	net/minecraft/world/level/chunk/Chunk
 	f	Lnet/minecraft/server/level/ServerLevel;	level	i
 
-# Paper moves method up from ServerLevel to Level
-c	net/minecraft/world/level/Level	net/minecraft/world/level/World
-	m	()Lnet/minecraft/core/BlockPos;	getSharedSpawnPos	getSpawn
-
 # Paper changes type
 c	net/minecraft/core/MappedRegistry	net/minecraft/core/RegistryMaterials
 	f	Lit/unimi/dsi/fastutil/objects/Reference2IntOpenHashMap;	toId	bw

--- a/patches/server/0239-Add-hand-to-bucket-events.patch
+++ b/patches/server/0239-Add-hand-to-bucket-events.patch
@@ -4,37 +4,6 @@ Date: Thu, 2 Aug 2018 08:44:35 -0500
 Subject: [PATCH] Add hand to bucket events
 
 
-diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c4aa14e81151ada49e61f4dd25267f7eb10450a6..dd2710f2a093fcca9f80edf41866459d63bac94c 100644
---- a/src/main/java/net/minecraft/server/level/ServerLevel.java
-+++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1465,15 +1465,17 @@ public class ServerLevel extends Level implements WorldGenLevel {
-         this.getServer().getPlayerList().broadcastAll(new ClientboundSetDefaultSpawnPositionPacket(pos, angle));
-     }
- 
--    public BlockPos getSharedSpawnPos() {
--        BlockPos blockposition = new BlockPos(this.levelData.getXSpawn(), this.levelData.getYSpawn(), this.levelData.getZSpawn());
--
--        if (!this.getWorldBorder().isWithinBounds(blockposition)) {
--            blockposition = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, new BlockPos(this.getWorldBorder().getCenterX(), 0.0D, this.getWorldBorder().getCenterZ()));
--        }
--
--        return blockposition;
--    }
-+    // Paper - moved up to Level
-+    //public BlockPosition getSpawn() {
-+    //    BlockPosition blockposition = new BlockPosition(this.worldData.a(), this.worldData.b(), this.worldData.c());
-+    //
-+    //    if (!this.getWorldBorder().a(blockposition)) {
-+    //        blockposition = this.getHighestBlockYAt(HeightMap.Type.MOTION_BLOCKING, new BlockPosition(this.getWorldBorder().getCenterX(), 0.0D, this.getWorldBorder().getCenterZ()));
-+    //    }
-+    //
-+    //    return blockposition;
-+    //}
-+    // Paper end
- 
-     public float getSharedSpawnAngle() {
-         return this.levelData.getSpawnAngle();
 diff --git a/src/main/java/net/minecraft/world/entity/animal/Cow.java b/src/main/java/net/minecraft/world/entity/animal/Cow.java
 index 0cf990f220fad6e945bda590263b78ea2e5a3b03..a43349c47292154dfc56c72c58ba9f29f6765d83 100644
 --- a/src/main/java/net/minecraft/world/entity/animal/Cow.java
@@ -116,41 +85,10 @@ index 5870023250ed2dba16b2fa5c6a8be6f36cebc640..650b59b69eb12112bc71e5ff164767e3
              } else if (world.dimensionType().ultraWarm() && this.content.is((Tag) FluidTags.WATER)) {
                  int i = blockposition.getX();
                  int j = blockposition.getY();
-diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b5aa61cecf15e38105cf4bef92b6859aaa450dbd..2647b88ffffa393e744d9e003032468acc92668a 100644
---- a/src/main/java/net/minecraft/world/level/Level.java
-+++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -294,6 +294,17 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-         return true;
-     }
-     // Paper end
-+    // Paper start - moved up from ServerLevel
-+    public BlockPos getSharedSpawnPos() {
-+        BlockPos blockposition = new BlockPos(this.levelData.getXSpawn(), this.levelData.getYSpawn(), this.levelData.getZSpawn());
-+
-+        if (!this.getWorldBorder().isWithinBounds(blockposition)) {
-+            blockposition = this.getHeightmapPos(Heightmap.Types.MOTION_BLOCKING, new BlockPos(this.getWorldBorder().getCenterX(), 0.0D, this.getWorldBorder().getCenterZ()));
-+        }
-+
-+        return blockposition;
-+    }
-+    // Paper end
-     @Override
-     public boolean isClientSide() {
-         return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4faf98079a6a6af662e11050a0088578ba65a5eb..e094b1b00d5fb73da73abcadb02ffd98b91fb869 100644
+index 4faf98079a6a6af662e11050a0088578ba65a5eb..0d1c6f609a5198c21c895e8f6ace467355b0f166 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -227,7 +227,7 @@ public class CraftEventFactory {
-     public static Entity entityDamage; // For use in EntityDamageByEntityEvent
- 
-     // helper methods
--    private static boolean canBuild(ServerLevel world, Player player, int x, int z) {
-+    private static boolean canBuild(Level world, Player player, int x, int z) {
-         int spawnSize = Bukkit.getServer().getSpawnRadius();
- 
-         if (world.dimension() != Level.OVERWORLD) return true;
 @@ -421,6 +421,20 @@ public class CraftEventFactory {
      }
  
@@ -159,15 +97,15 @@ index 4faf98079a6a6af662e11050a0088578ba65a5eb..e094b1b00d5fb73da73abcadb02ffd98
 +        return getPlayerBucketEvent(isFilling, world, who, changed, clicked, clickedFace, itemstack, item, null);
 +    }
 +
-+    public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, InteractionHand enumHand) {
++    public static PlayerBucketEmptyEvent callPlayerBucketEmptyEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, InteractionHand enumHand) {
 +        return (PlayerBucketEmptyEvent) getPlayerBucketEvent(false, world, who, changed, clicked, clickedFace, itemstack, Items.BUCKET, enumHand);
 +    }
 +
-+    public static PlayerBucketFillEvent callPlayerBucketFillEvent(Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand, net.minecraft.world.item.Item bucket, InteractionHand enumHand) {
++    public static PlayerBucketFillEvent callPlayerBucketFillEvent(ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemInHand, net.minecraft.world.item.Item bucket, InteractionHand enumHand) {
 +        return (PlayerBucketFillEvent) getPlayerBucketEvent(true, world, who, clicked, changed, clickedFace, itemInHand, bucket, enumHand);
 +    }
 +
-+    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, Level world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item, InteractionHand enumHand) {
++    private static PlayerEvent getPlayerBucketEvent(boolean isFilling, ServerLevel world, net.minecraft.world.entity.player.Player who, BlockPos changed, BlockPos clicked, Direction clickedFace, ItemStack itemstack, net.minecraft.world.item.Item item, InteractionHand enumHand) {
 +        // Paper end
          Player player = (Player) who.getBukkitEntity();
          CraftItemStack itemInHand = CraftItemStack.asNewCraftStack(item);

--- a/patches/server/0306-BlockDestroyEvent.patch
+++ b/patches/server/0306-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 76cb42b147e05595e64c4ff6f13881780a1a9be4..63d2412719175f451fb995b54cd54b202d91fca7 100644
+index 414375c118e604f88e1d283dc7b2287c2cb9e274..7b522b984a0152bc43be1589d26478ecf4988696 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -22,7 +22,7 @@ index 76cb42b147e05595e64c4ff6f13881780a1a9be4..63d2412719175f451fb995b54cd54b20
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ServerLevel;
-@@ -574,8 +575,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -563,8 +564,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);

--- a/patches/server/0323-Optimize-Captured-TileEntity-Lookup.patch
+++ b/patches/server/0323-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 63d2412719175f451fb995b54cd54b202d91fca7..f4163020d09b221625d9f49fddefe9544018cc17 100644
+index 7b522b984a0152bc43be1589d26478ecf4988696..be63e37b9adef56f78c58efca262c8ab94489f8e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -877,9 +877,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -866,9 +866,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getTileEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0367-Anti-Xray.patch
+++ b/patches/server/0367-Anti-Xray.patch
@@ -1107,7 +1107,7 @@ index 1197c510211b725742d48152443178eea94058a8..5bbdf56179d2e5fd0b42c37c84c9d4bc
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index bf499e746652127700950cdbbf18df692987b389..4b9b708812ee502815dd6879412e8b942595344e 100644
+index 085d807881e92149c3b31b6f76b2a5539ee629fa..1b342701b410a508323286944508e7faa175ab43 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -378,7 +378,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1142,7 +1142,7 @@ index 6219634a57976a6a0a9b32ed08d56107d6b5d1c3..31e3534d6e15f91d781fabb0670e53ef
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 13efcae91a863f9c7255472d1c45ce16be371c6d..92313e70c30ca5acc0e7b54d55a972f024bad162 100644
+index a8772b168eedca4933b4b4132ea81afd6bcaafa2..35209090439d5ab3bf5c37de28a39e60d482b64c 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -166,6 +166,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1172,7 +1172,7 @@ index 13efcae91a863f9c7255472d1c45ce16be371c6d..92313e70c30ca5acc0e7b54d55a972f0
      }
  
      // Paper start
-@@ -451,6 +455,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -440,6 +444,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit end
  
              BlockState iblockdata1 = chunk.setType(pos, state, (flags & 64) != 0, (flags & 1024) == 0); // CraftBukkit custom NO_PLACE flag

--- a/patches/server/0368-No-Tick-view-distance-implementation.patch
+++ b/patches/server/0368-No-Tick-view-distance-implementation.patch
@@ -545,10 +545,10 @@ index a2eb7689eafe20db59357ab3fad0e59cdef3481a..c0e8e863708ac794b7271765cdae99dc
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 92313e70c30ca5acc0e7b54d55a972f024bad162..7023d83b2c0d36c5a56af47b69ca43f44dd9e47f 100644
+index 35209090439d5ab3bf5c37de28a39e60d482b64c..f196a184c05d5f87faee78323343d1fe19287c07 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -530,8 +530,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -519,8 +519,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  this.setBlocksDirty(blockposition, iblockdata1, iblockdata2);
              }
  

--- a/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0371-Fix-items-vanishing-through-end-portal.patch
@@ -13,7 +13,7 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3268187f77b78a04191628b06dc7693b08b8d642..eec286fd4607c1d9a68c9063535bb630f92b6f4a 100644
+index 2aa4f6f30e12162f7cfae5180e40f7a32fc6f24d..06597d10c640daca400da9d5a4c186cc95bca1bf 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -3015,6 +3015,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -21,7 +21,7 @@ index 3268187f77b78a04191628b06dc7693b08b8d642..eec286fd4607c1d9a68c9063535bb630
  
              if (flag1) {
 +                // Paper start - Ensure spawn chunk is always loaded before calculating Y coordinate
-+                this.level.getChunkAt(this.level.getSharedSpawnPos());
++                this.level.getChunkAt(((ServerLevel) this.level).getSharedSpawnPos());
 +                // Paper end
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0373-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/patches/server/0373-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -14,10 +14,10 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7023d83b2c0d36c5a56af47b69ca43f44dd9e47f..0e70bce9f030b0bc058b52301860dbb2f0b1b7ed 100644
+index f196a184c05d5f87faee78323343d1fe19287c07..8306d6628c5b7507ee80cb2bff660e0badf84660 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -996,7 +996,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -985,7 +985,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  }
              }
  

--- a/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
+++ b/patches/server/0392-Prevent-Double-PlayerChunkMap-adds-crashing-server.patch
@@ -7,7 +7,7 @@ Suspected case would be around the technique used in .stopRiding
 Stack will identify any causer of this and warn instead of crashing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index f604fd1a4eb9ac5b7f43962a583183441a680319..bc08adcbb681aef3d5f3fa52def018d085a129dc 100644
+index be9ae4f0f19da069ae44e45a772096bb09918219..764e33719471dcd8549e0feee2ceb5f5318316be 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1557,6 +1557,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -26,10 +26,10 @@ index f604fd1a4eb9ac5b7f43962a583183441a680319..bc08adcbb681aef3d5f3fa52def018d0
              EntityType<?> entitytypes = entity.getType();
              int i = entitytypes.clientTrackingRange() * 16;
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f3fa6b366fb749b8dfcfc2343d934da0647b861b..f3ba3c430a713fdef7e941b991ea8497de2e6a05 100644
+index 140014d0eb3b70f8415484afc36f700fd737d9d9..89e88a1de65a5724d05e926cd41733c9cd6cd740 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2151,7 +2151,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2149,7 +2149,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTrackingStart(Entity entity) {
              org.spigotmc.AsyncCatcher.catchOp("entity register"); // Spigot
@@ -38,7 +38,7 @@ index f3fa6b366fb749b8dfcfc2343d934da0647b861b..f3ba3c430a713fdef7e941b991ea8497
              if (entity instanceof ServerPlayer) {
                  ServerLevel.this.players.add((ServerPlayer) entity);
                  ServerLevel.this.updateSleepingPlayerList();
-@@ -2173,6 +2173,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2171,6 +2171,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              }
  
              entity.valid = true; // CraftBukkit

--- a/patches/server/0402-Improved-Watchdog-Support.patch
+++ b/patches/server/0402-Improved-Watchdog-Support.patch
@@ -71,7 +71,7 @@ index e3b605695e3b837246f72ccb364af06ea48bda45..62c3c597732e6fb30ed5367d902ea876
              cause = cause.getCause();
          }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 5edbb9132d2895da2b693fe35d4a25000982b636..42642e923b68e1074ee322d290983370cdf8881f 100644
+index ec0921c1a24c3408fefd03d452cafa6d51eacb54..79267dace0130350e172cd03c9041048f4eb6705 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -299,7 +299,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -262,7 +262,7 @@ index b6ccc8cacb615a35a60c73f145b7bd1cf0b891ee..a335d48467d1730bfed25eb5fd9046e1
  
      @Override
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index bc08adcbb681aef3d5f3fa52def018d085a129dc..41f8afe938ea4fc9ceb4e57867bde5ae9aa6530e 100644
+index 764e33719471dcd8549e0feee2ceb5f5318316be..862729188385dec47b43dcfed53c49897569b662 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -581,6 +581,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -274,7 +274,7 @@ index bc08adcbb681aef3d5f3fa52def018d085a129dc..41f8afe938ea4fc9ceb4e57867bde5ae
                  list.stream().map((playerchunk) -> {
                      CompletableFuture completablefuture;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 6f3187aae34c24c6a9b22074d487006926afe524..11079851f8a375d987933b53409b789030b3220d 100644
+index 0f2bfc82e715e18f1501da4d0e28b35f5d3faa77..d7e99d7dab0590cfa62ae450e93c600fd1ea4770 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -513,7 +513,7 @@ public abstract class PlayerList {
@@ -299,10 +299,10 @@ index 7bf4bf5cb2c1b54a7e2733091f48f3a824336d36..dcce05d2f4ab16424db4ab103a12188e
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 0e70bce9f030b0bc058b52301860dbb2f0b1b7ed..b2b433218d280b2abac40c90397633ef78bc9510 100644
+index 8306d6628c5b7507ee80cb2bff660e0badf84660..c1f545f48cea7afea53342e3053c669d295851f0 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -850,6 +850,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -839,6 +839,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {
@@ -323,7 +323,7 @@ index 016c2302d8bcf121eafd1be7eb4f3b206dbdbeec..1de1566b76c73ddfaf7e022296068db0
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6de0c6aa40b2962237584156c6270489fdbaa45a..6b1bc025d0072aa5d0c7609d1da355b9eae7df2d 100644
+index b0e4f6cb9fe7c199afdd29ea1cd80c93134df426..02f0c3bdf516638bcbcfa86cf71ab79a52c50b11 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2004,7 +2004,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0441-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -54,10 +54,10 @@ index a861b4b55862b1c5583101fe7f28a3a43c547468..1575fb0bbad6e11f25fb9ce51fd1f15a
  
                      this.level.getProfiler().push("explosion_blocks");
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b2b433218d280b2abac40c90397633ef78bc9510..1dd4ee6cf037dcc6a8683d79b623165d1be62d57 100644
+index c1f545f48cea7afea53342e3053c669d295851f0..d01687250a9a022000b4e57b839b8c0751caef29 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -427,6 +427,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -416,6 +416,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -135,7 +135,7 @@ index c345bd7542f3ffa09719864887e1516f1182e7e3..4eac07022a7d896ee8921afa6d35cba7
  
              world.playSound((Player) null, pos, SoundEvents.PISTON_CONTRACT, SoundSource.BLOCKS, 0.5F, world.random.nextFloat() * 0.15F + 0.6F);
 diff --git a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
-index a087eec747bb355afd627c6042d20440c3e43e1b..bea9c7ac0fe08c3ca3309e8311f192cc557ca67d 100644
+index 6e34d0fb002e61460ab21edcbd23a6d00ac2730c..e218e4f1dfc399cff4131cc5210184af85855d57 100644
 --- a/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 +++ b/src/main/java/net/minecraft/world/level/block/state/BlockBehaviour.java
 @@ -206,7 +206,7 @@ public abstract class BlockBehaviour {

--- a/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0446-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -8,10 +8,10 @@ so inline where possible, and avoid the abstraction of the
 Either class.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index d61c97f2eb8ecf52a624ac2e9f314c783b74d2e8..320cd209ab725a9ad4d5dff70987d7efabae5798 100644
+index 89e88a1de65a5724d05e926cd41733c9cd6cd740..09d06ffb0d3c9920f80843c65e2d0831b9d94f95 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2120,15 +2120,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2118,15 +2118,18 @@ public class ServerLevel extends Level implements WorldGenLevel {
      public boolean isPositionTickingWithEntitiesLoaded(BlockPos blockposition) {
          long i = ChunkPos.asLong(blockposition);
  

--- a/patches/server/0596-Remove-stale-POIs.patch
+++ b/patches/server/0596-Remove-stale-POIs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Remove stale POIs
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3563690e404a68b8940d9c06a0198dd0a4b2d220..aedb1d7a0b60fba72a952fa140569b72795660e4 100644
+index e404203a6f330131cab38f7861bff9676fe5c52c..ec583ee3b9e0ffed230f219283e384035e73828d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -1789,6 +1789,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -1787,6 +1787,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              });
              optional1.ifPresent((villageplacetype) -> {
                  this.getServer().execute(() -> {

--- a/patches/server/0712-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0712-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -8,7 +8,7 @@ ticket level 33 (yes getChunkIfLoaded will actually perform a chunk
 load in that case).
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f28aefd9192b26f39e71826fa87cca60a799be39..f8c0574137cab33d0b5efe5d532efb132dcb914a 100644
+index 5f28cca2793cc9b9c795033e112043d89642c858..43a740eb644629bf88d60d7ab559793a1965f9d8 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -203,7 +203,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -21,7 +21,7 @@ index f28aefd9192b26f39e71826fa87cca60a799be39..f8c0574137cab33d0b5efe5d532efb13
  
      // Paper start
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 373280eed4acd146a3c71d944030382bc3c5067e..e639cbdf9cf070e749da4c90ff475b250ab8e2c9 100644
+index d4f0fcff776012841798a0962207e2cb951ac28e..d40c4c491c4ce19b59cb095cdb5f5e83373356f1 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -1310,7 +1310,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -34,7 +34,7 @@ index 373280eed4acd146a3c71d944030382bc3c5067e..e639cbdf9cf070e749da4c90ff475b25
                                  return;
                              }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index acc8625790f8852391725ebe49057d3924bf908e..59703eb6610c21df22f25c22cc884c4450f0316c 100644
+index 4dae0525be49bedadd75276c2668209b602ff967..d0cfa782498eca8a13ce7d7f28d5e55ae4e402fa 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -193,6 +193,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -51,7 +51,7 @@ index acc8625790f8852391725ebe49057d3924bf908e..59703eb6610c21df22f25c22cc884c44
      public ResourceKey<DimensionType> getTypeKey() {
          return this.typeKey;
      }
-@@ -1373,7 +1380,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1362,7 +1369,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          for (int l1 = j; l1 <= l; ++l1) {
              for (int i2 = k; i2 <= i1; ++i2) {

--- a/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0763-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -914,7 +914,7 @@ index 0000000000000000000000000000000000000000..3ba094e640d7fe7803e2bbdab8ff3beb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index aeee3ea62164661b762b52a8abcdb5fdc013e373..2eb1a5d951fbc126b66a96d39099cac4a03e7e2c 100644
+index ac3ef76f0db5a2d0f02b5e48a8bf511d9b0104d4..5c588c39de11bbabdc2f50ef4204007c622fdc6a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -437,7 +437,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -955,7 +955,7 @@ index 0f6b534a4c789a2f09f6c4624e5d58b99c7ed0e6..21d1e0c9c471e9e556b5bd70166a769b
          this.generatingStatus = chunkstatus;
          this.writeRadiusCutoff = i;
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f29b34e1467ff0e48049fd4b9a80e6c10d4cd97e..10e4d34e43abc7b67ba73c4f0d354e6905db2329 100644
+index e9eacba3816ff3b76c51e9d3011c739b24864355..b7b802053c48c740161747c89cc55ade80094cb7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -417,6 +417,56 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, n
@@ -1077,7 +1077,7 @@ index 325e244c46ec208a2e7e18d71ccbbfcc25fc1bce..94130509e3a7980c378cc95c46821cf0
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 59703eb6610c21df22f25c22cc884c4450f0316c..bdd50c28a76576be7950e3ccf8e00b622f3860d1 100644
+index d0cfa782498eca8a13ce7d7f28d5e55ae4e402fa..1dd2e968bde16da2d2da63ca3c30515e1fd5b620 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -204,6 +204,50 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1139,7 +1139,7 @@ index 59703eb6610c21df22f25c22cc884c4450f0316c..bdd50c28a76576be7950e3ccf8e00b62
      }
  
      // Paper start
-@@ -998,26 +1043,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -987,26 +1032,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -1167,7 +1167,7 @@ index 59703eb6610c21df22f25c22cc884c4450f0316c..bdd50c28a76576be7950e3ccf8e00b62
          return list;
      }
  
-@@ -1026,26 +1052,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1015,26 +1041,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getProfiler().incrementCounter("getEntities");
          List<T> list = Lists.newArrayList();
  

--- a/patches/server/0766-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0766-Execute-chunk-tasks-mid-tick.patch
@@ -31,7 +31,7 @@ index 5fdaefc128956581be4bb9b34199fd6410563991..b7edc1121797bc1c57e25f540ed0124f
                  // start copy from TickListServer // TODO check on update
                  CrashReport crashreport = CrashReport.forThrowable(thr, "Exception while ticking");
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
-index 71181012314d20e3505543a6d2abe88cb8e17a27..4778d45d14317d78ae1988de18f675d997d28c98 100644
+index 98eb8318413014f0650dc5c80125aa84b51cfc93..57cb2722e973cfc8edc845bc7154b8b8bbb11e12 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java
 +++ b/src/main/java/net/minecraft/server/MinecraftServer.java
 @@ -330,6 +330,76 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -140,7 +140,7 @@ index 7ea86cbeb72f08d751c14006f428fe5921916061..108f2212f8bd00247bf73ff4f3ba4283
              } // Paper start - optimise chunk tick iteration
              } finally {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 675fca76f5f7319d45e0d4f03b74d27bf2a5a647..9c4f8d59ece0222bb2b7c8aa3b0a0044b8205e77 100644
+index 5c588c39de11bbabdc2f50ef4204007c622fdc6a..e219e385df356531639cb1b4bf993dca9034aa1d 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -190,7 +190,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -155,10 +155,10 @@ index 675fca76f5f7319d45e0d4f03b74d27bf2a5a647..9c4f8d59ece0222bb2b7c8aa3b0a0044
      // CraftBukkit start
      private int tickPosition;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index bdd50c28a76576be7950e3ccf8e00b622f3860d1..6818de8db716a3d4bcf8a6ee4dc6acccf441cddb 100644
+index 1dd2e968bde16da2d2da63ca3c30515e1fd5b620..3a6f79233cec7aee87be20787b6deae4b313f0ac 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -914,6 +914,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -903,6 +903,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/0769-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0769-Replace-player-chunk-loader-system.patch
@@ -1109,7 +1109,7 @@ index 0000000000000000000000000000000000000000..4eadc15f747528b59349f095171dd5a6
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 103657ad936f1a75ffbb92ca5eafb816e977e363..23757f466da571aec35a373112dcbba0d1f46dcb 100644
+index 0b47144cb8ad72efebf10e163f5b442995ef213e..03c6cdec727b03c2f61eaae339a2ff58c64d5ebc 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -93,6 +93,28 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -1163,7 +1163,7 @@ index 103657ad936f1a75ffbb92ca5eafb816e977e363..23757f466da571aec35a373112dcbba0
      // Paper end
  
 diff --git a/src/main/java/net/minecraft/server/MCUtil.java b/src/main/java/net/minecraft/server/MCUtil.java
-index d2ea11d35ea111c349df5aa375d7ee8831658262..c4117dcffd705d044f07eb5840a177b1b5825bb9 100644
+index 82a233b413791eff4bc6b9140b5bbf99354ed671..15fb4ee2066df1c8ce341913a64f350fb8b9718c 100644
 --- a/src/main/java/net/minecraft/server/MCUtil.java
 +++ b/src/main/java/net/minecraft/server/MCUtil.java
 @@ -642,7 +642,7 @@ public final class MCUtil {
@@ -1176,7 +1176,7 @@ index d2ea11d35ea111c349df5aa375d7ee8831658262..c4117dcffd705d044f07eb5840a177b1
              worldData.addProperty("keep-spawn-loaded-range", world.paperConfig.keepLoadedRange);
              worldData.addProperty("visible-chunk-count", visibleChunks.size());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 54822e418e319db551bfea3218d00faf0e043f43..de0c6316c9b75a2ecc7d6abf7bcca24e25de0ac0 100644
+index a98d7b5e755da7ad98d133fc50785e1bf70b4ddd..3db72a4416d3125c37f6c1dc2c3803fbb14b9c97 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -491,7 +491,7 @@ public class ChunkHolder {
@@ -1205,7 +1205,7 @@ index 54822e418e319db551bfea3218d00faf0e043f43..de0c6316c9b75a2ecc7d6abf7bcca24e
              }
          }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 2f5ab00d26dcf027ec0e152a8bf17686a280ae50..09b214362f24cefe55e39f886b7fc3b9315b3982 100644
+index 4d18b217f21ce60b691c6bf964f81129718b8f56..a474e83df65bb48779fe135b14d6a9a3f74d1bf4 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -187,22 +187,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -1551,7 +1551,7 @@ index 108f2212f8bd00247bf73ff4f3ba42830abad459..0d8a47770435c27519af4ebd78835ec7
                  return true;
              } else {
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 52ffc39715def70a8ad3a99356be19bea5ef892b..4dfd185e47849c18c552e28370d93b48799d2eb9 100644
+index d0a6da33bb9152b6fafe6b3a788817d523c1fe49..6614954dd30efdd6a53d561fcb3cbfba8b168805 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -261,7 +261,7 @@ public class ServerPlayer extends Player {
@@ -1611,10 +1611,10 @@ index 7ccfe737fdf7f07b731ea0ff82e897564350705c..fe709bee0e657ff9bfc6deb6d4bd8ce4
                          double deltaZ = soundPos.getZ() - player.getZ();
                          double distanceSquared = deltaX * deltaX + deltaZ * deltaZ;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 6818de8db716a3d4bcf8a6ee4dc6acccf441cddb..01b8fc343d3a7dd68b6e54168de520b61e00da1f 100644
+index 3a6f79233cec7aee87be20787b6deae4b313f0ac..41be326b8ea5b7419dc09578e48c7c7f378e22cc 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -599,7 +599,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -588,7 +588,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  this.sendBlockUpdated(blockposition, iblockdata1, iblockdata, i);
                  // Paper start - per player view distance - allow block updates for non-ticking chunks in player view distance
                  // if copied from above
@@ -1740,7 +1740,7 @@ index b4cf0d44bda13625cfa8264043a49c1a0daf1054..e5e23c907d49ee64218f3302e2a2323d
      // Spigot start
      private final org.bukkit.World.Spigot spigot = new org.bukkit.World.Spigot()
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 9da0bf8cf59fd37837ba4febf93c022fb4f08278..c64911651f3d736c83cc83996de04920b091cc57 100644
+index b3ffda6f177e4a45f25772483e935a36b3f5f72a..4ff4143f3a7cd89ef92f4b8882fa3e5addfe0f06 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -517,15 +517,70 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0778-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0778-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -13,10 +13,10 @@ Paper recently reverted this optimisation, so it's been reintroduced
 here.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 01b8fc343d3a7dd68b6e54168de520b61e00da1f..a6891e051b3b2863fa8ca108af418892515d7295 100644
+index 41be326b8ea5b7419dc09578e48c7c7f378e22cc..30f42ed54d01b819fc9c6a6a10324108d36348b4 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -411,6 +411,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -400,6 +400,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Override
      public final LevelChunk getChunk(int chunkX, int chunkZ) { // Paper - final to help inline

--- a/patches/server/0790-Optimise-random-block-ticking.patch
+++ b/patches/server/0790-Optimise-random-block-ticking.patch
@@ -71,7 +71,7 @@ index 0000000000000000000000000000000000000000..e8b4053babe46999980b926431254050
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index deda6741a81151fe4acb87925edad2201a92b79e..1141e264862fb36c1a085c236f14f7fe1cf49c85 100644
+index 960aa86d64ce6bfc84fff06a7698490c7c32c5fa..2d322cc13dabc041911991e6c8dfde4374ac76bd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -743,6 +743,10 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -261,10 +261,10 @@ index 00dbe5046c3b93e402218a6903ea2f087410388b..7d001f42c448fd328b6384d133dcc4b7
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a6891e051b3b2863fa8ca108af418892515d7295..64d5e71a8a26116385cee195d86fce1ef1574a8c 100644
+index 30f42ed54d01b819fc9c6a6a10324108d36348b4..326ce282ae333d9b3ba3a2f9904ecaf62c0734be 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1365,10 +1365,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1354,10 +1354,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract TagContainer getTagManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/0794-Optimise-WorldServer-notify.patch
+++ b/patches/server/0794-Optimise-WorldServer-notify.patch
@@ -110,7 +110,7 @@ index bef7d5b4c8b99d2fbcd975127b16653e0f391338..19a853ceeded1c8803d182d035f0362a
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fba157221a54335dfd7b1a5911cebd5547a81712..08c6ea9f19fa9218af089ed3bd2dcda1e83591ed 100644
+index 89a8138e97ab6a399cfbc69cab0ecaa70bb2fe8d..c01b5611fe6946a24fe21eac6a80e3ddadf9f3c1 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1079,6 +1079,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -155,7 +155,7 @@ index fba157221a54335dfd7b1a5911cebd5547a81712..08c6ea9f19fa9218af089ed3bd2dcda1
  
          }
          } // Paper
-@@ -2326,10 +2342,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2324,10 +2340,12 @@ public class ServerLevel extends Level implements WorldGenLevel {
  
          public void onTickingStart(Entity entity) {
              ServerLevel.this.entityTickList.add(entity);

--- a/patches/server/0824-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0824-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 710a1064cec9c7ec93e1258b0786e74ab9af0c12..d572a0883938cd117d11a2bb0ee4e0d5b5e65361 100644
+index 536c53fd1d009b86d2c1c3ca2364f458448bc38c..d40a367670ccea01978cabf7d45f3c1a690662fc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
-@@ -2421,6 +2421,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
+@@ -2419,6 +2419,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
              if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {


### PR DESCRIPTION
I noticed a lot of diff in this patch that could easily be fixed by just changing some method param types to ServerLevel instead of Level. 

The whole getSharedSpawnPos method was moved up to Level and didnt need to be at all.

If its an issue, I can add back a method with the same signature to Level that then gets overriden by the one in ServerLevel. who knows if some plugin calls it for some reason.