### PR TITLE
Fix AnvilPrepareEvent not working with zero xp

### DIFF
--- a/patches/server/0845-Fix-anvil-prepare-event-not-working-with-zero-xp.patch
+++ b/patches/server/0845-Fix-anvil-prepare-event-not-working-with-zero-xp.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Tuck <jan@tuck.dk>
+Date: Mon, 15 Nov 2021 15:20:41 -0500
+Subject: [PATCH] Fix anvil prepare event not working with zero xp
+
+
+diff --git a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
+index 593e23c10f2b1616db7256158dfe564b2d289df1..b62c6b56867b645520cb3c3e382ec96d421e7e97 100644
+--- a/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/AnvilMenu.java
+@@ -60,7 +60,7 @@ public class AnvilMenu extends ItemCombinerMenu {
+ 
+     @Override
+     protected boolean mayPickup(Player player, boolean present) {
+-        return (player.getAbilities().instabuild || player.experienceLevel >= this.cost.get()) && this.cost.get() > 0;
++        return (player.getAbilities().instabuild || player.experienceLevel >= this.cost.get()) && this.cost.get() >= 0; // Paper - fix anvil prepare event not working with 0 xp
+     }
+ 
+     @Override


### PR DESCRIPTION
Ports #3818 to 1.17

On the 1.17 client, the hack to update the player's cursor is no longer needed.

Confirmed to work using same test code on OP.