### PR TITLE
Update paperclip and yarn mappings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -46,10 +46,10 @@ repositories {
 }
 
 dependencies {
-    paramMappings("net.fabricmc:yarn:1.18-rc3+build.1:mergedv2")
+    paramMappings("net.fabricmc:yarn:1.18-rc3+build.2:mergedv2")
     remapper("net.fabricmc:tiny-remapper:0.7.0:fat")
     decompiler("net.minecraftforge:forgeflower:1.5.498.22")
-    paperclip("io.papermc:paperclip:3.0.1")
+    paperclip("io.papermc:paperclip:3.0.2-SNAPSHOT")
 }
 
 paperweight {

--- a/patches/server/0006-MC-Utils.patch
+++ b/patches/server/0006-MC-Utils.patch
@@ -5067,7 +5067,7 @@ index 18f1bfed979e756a62ff8f5ee434d8270ab987d4..2361a92630d2639d602bc1434b061ad9
              } catch (Throwable throwable) {
                  // Spigot Start
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index eebebd52353cd6b6fcb297151d7dcc03d2805505..b3ac5e2932f4b3de812b0c34655028d6adc36195 100644
+index 40dd2077f26a2c1fa15f21861204faa53748140e..45de5e508540b4ba622985d530f1aadaa7eb4535 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -49,9 +49,9 @@ public class ChunkHolder {
@@ -6541,7 +6541,7 @@ index aeceb5106dd5af79236cfb724c7837448897138d..7cceac53e445fe199f59a619a69a96ef
          this.levelHeightAccessor = heightLimitView;
          this.sections = new LevelChunkSection[heightLimitView.getSectionsCount()];
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 0c029abf45afb7cd90477728e5e8274122a7dd21..a26306c6077da40c719c2ef2e17f00c230c886d1 100644
+index 903b0298e9b30c85f95ed86e89955a58face6824..e8be9a1ae4b0b4ebb35b6feec5b41e6e7ca0d388 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -24,6 +24,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -6660,8 +6660,8 @@ index 0c029abf45afb7cd90477728e5e8274122a7dd21..a26306c6077da40c719c2ef2e17f00c2
 +    }
 +    // Paper end
 +
-     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor chunk_c) {
-         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), chunk_c, protoChunk.getBlendingData());
+     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor entityLoader) {
+         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), entityLoader, protoChunk.getBlendingData());
          Iterator iterator = protoChunk.getBlockEntities().values().iterator();
 @@ -224,6 +329,18 @@ public class LevelChunk extends ChunkAccess {
          }
@@ -7087,7 +7087,7 @@ index d40c0d8be1b0153d62021b8bcb6e8b37fd0acb4e..e38e57b1f9ef27020de35d7ddcb36a66
      public void clear() {
          // Create new array to reset memory usage to initial capacity
 diff --git a/src/main/java/org/spigotmc/SpigotConfig.java b/src/main/java/org/spigotmc/SpigotConfig.java
-index acf13887957c899b986a9aabe859bf2405e464ac..58c9ab2f6db97bfbf280efc56f9c9be791604a75 100644
+index beea7aa621bc00d30a448fbbb684b05e229dc6ea..c90db55aadb1d16f6cc4e02e57a13a3c3fe6a420 100644
 --- a/src/main/java/org/spigotmc/SpigotConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotConfig.java
 @@ -118,7 +118,11 @@ public class SpigotConfig

--- a/patches/server/0774-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0774-Optimise-nearby-player-lookups.patch
@@ -9,7 +9,7 @@ since the penalty of a map lookup could outweigh the benefits of
 searching less players (as it basically did in the outside range patch).
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index c70e1018c5e5b65911ee430be123e38f03666df2..3e526ba04f52e39591016dc107dd8913220cb343 100644
+index 454018b973bde7131353d23920a1e65693b04a65..fe618afd578e4b2af6a0879e84f2b10985dbf639 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -83,6 +83,12 @@ public class ChunkHolder {
@@ -309,7 +309,7 @@ index 928025438af179711c42381fc3eaeac74cd20c59..c48d0773e7f1af4bc247d777eccc8a42
  
      private static Boolean isValidSpawnPostitionForType(ServerLevel world, MobCategory group, StructureFeatureManager structureAccessor, ChunkGenerator chunkGenerator, MobSpawnSettings.SpawnerData spawnEntry, BlockPos.MutableBlockPos pos, double squaredDistance) { // Paper
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index ddf362fc14fcf83b22536b76cfc6ac1387b4c57a..0435c750ec03f65bad3f904070960d56c2ed4832 100644
+index 9c33c0b10e8854822605c65cde54b93747bf629d..376099c21d9e0ddeeeac28a7c3c21200c657404b 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -237,6 +237,93 @@ public class LevelChunk extends ChunkAccess {
@@ -404,5 +404,5 @@ index ddf362fc14fcf83b22536b76cfc6ac1387b4c57a..0435c750ec03f65bad3f904070960d56
 +    }
 +    // Paper end - optimise checkDespawn
  
-     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor chunk_c) {
-         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), chunk_c, protoChunk.getBlendingData());
+     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor entityLoader) {
+         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), entityLoader, protoChunk.getBlendingData());

--- a/patches/server/0810-Rewrite-the-light-engine.patch
+++ b/patches/server/0810-Rewrite-the-light-engine.patch
@@ -4405,7 +4405,7 @@ index 315bd2408e4a45993c9b2572e0ab5260a70522ec..c0d123bff1825366c30aadd3ad8a7fde
          Deque<ChunkPos> queue = new ArrayDeque<>(MCUtil.getSpiralOutChunks(center, radius));
          updateLight(sender, world, lightengine, queue);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkHolder.java b/src/main/java/net/minecraft/server/level/ChunkHolder.java
-index 3e526ba04f52e39591016dc107dd8913220cb343..7409199083367ebbf27b5f4f4419f229631a0ac2 100644
+index fe618afd578e4b2af6a0879e84f2b10985dbf639..31592058edcb27ba1557efcdd2eec7b8e2e7985c 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkHolder.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkHolder.java
 @@ -52,7 +52,7 @@ public class ChunkHolder {
@@ -4946,7 +4946,7 @@ index 7c5b3acd299c5b021bd20f17ff0b89c8208a6623..d29739c3a67e60741a06fb25bcaf7705
          super(wrapped.getPos(), UpgradeData.EMPTY, wrapped.levelHeightAccessor, wrapped.getLevel().registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), wrapped.getBlendingData());
          this.wrapped = wrapped;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 0435c750ec03f65bad3f904070960d56c2ed4832..0a0f6efe5687f35bff31e39746636738c1248533 100644
+index 376099c21d9e0ddeeeac28a7c3c21200c657404b..5ade22df6f8a2b839f494ab0898a87c3b7cd4e63 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -100,6 +100,10 @@ public class LevelChunk extends ChunkAccess {
@@ -4962,8 +4962,8 @@ index 0435c750ec03f65bad3f904070960d56c2ed4832..0a0f6efe5687f35bff31e39746636738
          this.level = (ServerLevel) world; // CraftBukkit - type
 @@ -327,6 +331,12 @@ public class LevelChunk extends ChunkAccess {
  
-     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor chunk_c) {
-         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), chunk_c, protoChunk.getBlendingData());
+     public LevelChunk(ServerLevel world, ProtoChunk protoChunk, @Nullable LevelChunk.PostLoadProcessor entityLoader) {
+         this(world, protoChunk.getPos(), protoChunk.getUpgradeData(), protoChunk.unpackBlockTicks(), protoChunk.unpackFluidTicks(), protoChunk.getInhabitedTime(), protoChunk.getSections(), entityLoader, protoChunk.getBlendingData());
 +        // Paper start - rewrite light engine
 +        this.setBlockNibbles(protoChunk.getBlockNibbles());
 +        this.setSkyNibbles(protoChunk.getSkyNibbles());
@@ -4974,7 +4974,7 @@ index 0435c750ec03f65bad3f904070960d56c2ed4832..0a0f6efe5687f35bff31e39746636738
  
          while (iterator.hasNext()) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
-index dea80ddba894453a0229888adfa235638cc9f659..8005df9339d3dca5bd4ec72e502a9cb516d161a4 100644
+index a7048235cdbca6970590d50c959782069169b4fa..6eebd1a7675bac3406536e80301fadf19a61cc1e 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/PalettedContainer.java
 @@ -127,7 +127,7 @@ public class PalettedContainer<T> implements PaletteResize<T> {


### PR DESCRIPTION
Updates paperclip to 3.0.2-SNAPSHOT (fixes an NPE)
updates yarn mappings and server patches accordingly