### PR TITLE
[ci skip] Correct reobf bundler jar location in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ How To (Compiling Jar From Source)
 ------
 To compile Paper, you need JDK 17 and an internet connection.
 
-Clone this repo, run `./gradlew applyPatches`, then `./gradlew createReobfBundlerJar` from your terminal. You can find the compiled jar in the `Paper-Server/build/libs` directory.
+Clone this repo, run `./gradlew applyPatches`, then `./gradlew createReobfBundlerJar` from your terminal. You can find the compiled jar in the `build/libs` directory.
 
 To get a full list of tasks, run `./gradlew tasks`.
 


### PR DESCRIPTION
kenny did a dum, the reobfuscated bundler jar is saved in `build/libs`, not `Paper-Server/build/libs`