### PR TITLE
Use LOSING_JOB change reason for villager career change event

### DIFF
--- a/patches/server/0815-Use-LOSING_JOB-change-reason-for-villager-career-cha.patch
+++ b/patches/server/0815-Use-LOSING_JOB-change-reason-for-villager-career-cha.patch
@@ -1,0 +1,19 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: roro1506HD <roro1506mcpro@gmail.com>
+Date: Tue, 30 Nov 2021 20:05:57 +0100
+Subject: [PATCH] Use LOSING_JOB change reason for villager career change event
+
+
+diff --git a/src/main/java/net/minecraft/world/entity/ai/behavior/ResetProfession.java b/src/main/java/net/minecraft/world/entity/ai/behavior/ResetProfession.java
+index 52a44661f9daf87777f3d82d155c9c4c9c1c9d97..fb070ae6ca869020268a14fe0fe0bcf5cad9c9d0 100644
+--- a/src/main/java/net/minecraft/world/entity/ai/behavior/ResetProfession.java
++++ b/src/main/java/net/minecraft/world/entity/ai/behavior/ResetProfession.java
+@@ -28,7 +28,7 @@ public class ResetProfession extends Behavior<Villager> {
+ 
+     protected void start(ServerLevel world, Villager entity, long time) {
+         // CraftBukkit start
+-        VillagerCareerChangeEvent event = CraftEventFactory.callVillagerCareerChangeEvent(entity, CraftVillager.nmsToBukkitProfession(VillagerProfession.NONE), VillagerCareerChangeEvent.ChangeReason.EMPLOYED);
++        VillagerCareerChangeEvent event = CraftEventFactory.callVillagerCareerChangeEvent(entity, CraftVillager.nmsToBukkitProfession(VillagerProfession.NONE), VillagerCareerChangeEvent.ChangeReason.LOSING_JOB); // Paper - use correct change reason
+         if (event.isCancelled()) {
+             return;
+         }


### PR DESCRIPTION
This PR fixes an issue with VillagerCareerChangeEvent. This event has two possible ChangeReason (EMPLOYED, LOSING_JOB) but the second one is never fired.

This PR also have an open [spigot JIRA ticket](https://hub.spigotmc.org/jira/browse/SPIGOT-6820) so it is very likely to be deleted soon.