### PR TITLE
Skip stripping metadata from empty stacks

### DIFF
--- a/patches/server/0817-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0817-Hide-unnecessary-itemmeta-from-clients.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Hide unnecessary itemmeta from clients
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 21e502716f312849b5232d1a3c5c87dc76394fee..43fe9b31b0e64304711c7cead4100e988bafcb87 100644
+index fd5927247e23878fd8bf6ab62a2eb477d07f4cc3..19ee843fa118a3b1b2c6b5551e9c6af7e7fcca11 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -916,6 +916,13 @@ public class PaperWorldConfig {
@@ -35,7 +35,7 @@ index 3eb6bf4258b1de4697f96c2011df493cf7414a0c..0feadee6077dd6a8d8fd05b7a7d15ec1
          }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 62daf918d4ab00963041ca869ae718f14f2e3337..50d0280f3df59952d682f137197fd73644ba2cfe 100644
+index 62daf918d4ab00963041ca869ae718f14f2e3337..09f3b7eba463a647c38ce0f87af6ad5c1c8ed0c0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3047,11 +3047,59 @@ public abstract class LivingEntity extends Entity {
@@ -43,7 +43,7 @@ index 62daf918d4ab00963041ca869ae718f14f2e3337..50d0280f3df59952d682f137197fd736
      }
  
 +    public static void stripMeta(ItemStack itemStack, @org.jetbrains.annotations.Nullable Level level) {
-+        if (itemStack.getTag() != null) {
++        if (itemStack.getTag() != null && !itemStack.isEmpty()) {
 +            CompoundTag nbt = itemStack.getTag();
 +            if (level != null && level.paperConfig.hideDurabilityFromClients) {
 +                // Only show damage values for elytra's, since they show a different texture when broken.


### PR DESCRIPTION
I couldn't figure out how exactly to reproduce the error, somehow an Empty itemstack makes it way into the equipment change handler. Best to skip them entirely I think.

Fixes https://paste.gg/p/anonymous/10bf03f791284577924a792e72bf0c8b