### PR TITLE
[ci skip] Changing the order of the rebase with autosquash command in the contributing.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ move it under the line of the patch you wish to modify;
   assist you too.
    - Alternatively, if you only know the name of the patch, you can do
   `git commit -a --fixup "Subject of Patch name"`.
-1. Rebase with autosquash: `git rebase --autosquash -i base`.
+1. Rebase with autosquash: `git rebase -i --autosquash base`.
 This will automatically move your fixup commit to the right place, and you just
 need to "save" the changes.
 1. Type `./gradlew rebuildPatches` in the root directory;


### PR DESCRIPTION
I was attempting to edit an older patch to get the feel for doing so as I want to eventually assist with fixing bugs/creating new features. I ran into some weirdness when trying to rebuild my patches and that boiled down to the command listed for rebasing with autosquash [here](https://github.com/PaperMC/Paper/blob/master/CONTRIBUTING.md#automatic-method) acting weird on Windows(and maybe other systems). 

When rebasing using the command provided there I was ending up with Spigot patches in the end after rebuilding them. I posted in paper-dev and MM pointed out that it'd be caused by not rebasing with the `base`. Apparently, the order of the arguments needs to be quite specific otherwise it doesn't actually rebase using that tag. I tried changing the order to `git rebase -i --autosquash base` as told by MM and it worked properly and was only rebuilding Paper patches. 

Not too sure why it wasn't working properly but I thought of making a PR to update the contributing guide in case anyone else runs into that issue as it looks like the order doesn't affect Linux at all. 

Thanks and I hope to make more PRs in the future :D 