### PR TITLE
Don't populate a useless spigot.yml field

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -661,7 +661,7 @@ index 2599fbabd5e5c0d10d0c915016f7cc982bda0e20..4dd57007af218ba1c0e666117a49939c
          this.setPvpAllowed(dedicatedserverproperties.pvp);
          this.setFlightAllowed(dedicatedserverproperties.allowFlight);
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 39776bf6e4e01ed3737706ea3ae1d4df3a6ff591..bdc774e3fbb949290fbc94c4b0cbc8f2c09f5bd8 100644
+index a44b47c8ed611078764841a5b591877242c10db1..d672c467267ef4d96184e104c35d0379116880db 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -337,6 +337,12 @@ public class ServerChunkCache extends ChunkSource {
@@ -795,3 +795,24 @@ index 09c33e8613d31f4519109f29b44cfea754184c3f..aa4b21c9d3c4af08c4d3a309f948692c
              }
          };
  
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index af8c42ed04d9a79cd426bdaa8c2ee3feac1163e3..6c5113545914842ffb310522a7549ae7dd2466b2 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -58,8 +58,14 @@ public class SpigotWorldConfig
+ 
+     public int getInt(String path, int def)
+     {
+-        this.config.addDefault( "world-settings.default." + path, def );
+-        return this.config.getInt( "world-settings." + this.worldName + "." + path, this.config.getInt( "world-settings.default." + path ) );
++        // Paper start - get int without setting default
++        return this.getInt(path, def, true);
++    }
++    public int getInt(String path, int def, boolean setDef)
++    {
++        if (setDef) this.config.addDefault( "world-settings.default." + path, def );
++        return this.config.getInt( "world-settings." + this.worldName + "." + path, this.config.getInt( "world-settings.default." + path, def ) );
++        // Paper end
+     }
+ 
+     public <T> List getList(String path, T def)

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,7 +12,7 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f383f30b9dd1a7c6cf69d342f99118beec70b206..7cd6a36e000d9e1958d260739e6fcfb064402b4d 100644
+index f383f30b9dd1a7c6cf69d342f99118beec70b206..47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -370,4 +370,10 @@ public class PaperWorldConfig {
@@ -20,9 +20,9 @@ index f383f30b9dd1a7c6cf69d342f99118beec70b206..7cd6a36e000d9e1958d260739e6fcfb0
          }
      }
 +
-+    public int maxCollisionsPerEntity;
++    public int maxCollisionsPerEntity = 8;
 +    private void maxEntityCollision() {
-+        maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
++        maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", this.maxCollisionsPerEntity, false) );
 +        log( "Max Entity Collisions: " + maxCollisionsPerEntity );
 +    }
  }

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,11 +11,11 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7cd6a36e000d9e1958d260739e6fcfb064402b4d..506539188aa1a2c7aa21b8ba3e0769a09d6ad134 100644
+index 47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960..9dad1efab44b8a23f274aa89c85944d98e9a6c51 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -376,4 +376,10 @@ public class PaperWorldConfig {
-         maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", 8) );
+         maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", this.maxCollisionsPerEntity, false) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }
 +

--- a/patches/server/0249-Restore-vanlla-default-mob-spawn-range-and-water-ani.patch
+++ b/patches/server/0249-Restore-vanlla-default-mob-spawn-range-and-water-ani.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Restore vanlla default mob-spawn-range and water animals
 
 
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index af8c42ed04d9a79cd426bdaa8c2ee3feac1163e3..1414c7cd14ef3d8ce22e6c146c942d12901d4811 100644
+index 35f6619081e5a1053c9d655f18359927b2fc6d6b..a6d07b9b8f4fc45d737a2769eeb5ad6eacba978e 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-@@ -178,7 +178,7 @@ public class SpigotWorldConfig
+@@ -184,7 +184,7 @@ public class SpigotWorldConfig
      public byte mobSpawnRange;
      private void mobSpawnRange()
      {

--- a/patches/server/0360-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0360-Entity-Activation-Range-2.0.patch
@@ -690,10 +690,10 @@ index 84ce3d38d5decb4a2f9fae78e0ef5d715860dc7d..e0302f82356e8cba848aa8cec1e821e0
              isActive = false;
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 1414c7cd14ef3d8ce22e6c146c942d12901d4811..6dd8adabc23931c8e4b8f448bd867207ed25c385 100644
+index a6d07b9b8f4fc45d737a2769eeb5ad6eacba978e..54911d9b26c8cfbecf48f4187b0c914481fbcb27 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-@@ -193,13 +193,59 @@ public class SpigotWorldConfig
+@@ -199,13 +199,59 @@ public class SpigotWorldConfig
      public int monsterActivationRange = 32;
      public int raiderActivationRange = 48;
      public int miscActivationRange = 16;


### PR DESCRIPTION
Spigot removed the `max-entity-collisions` from their yml file, but paper adds it back and tries to migrate from the spigot.yml file. This, previous to this PR, caused a default to be set in the spigot yml which caused the value to be saved to the file. This prevents the adding of that default so as to not cause confusion with the same `max-entity-collisions` appearing in both `spigot.yml` and `paper.yml`.