### PR TITLE
Fix configs that relied on outdated min/max y levels

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -923,10 +923,10 @@ index 0000000000000000000000000000000000000000..69add4a7f1147015806bc9b63a8340d1
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989fc45af03
+index 0000000000000000000000000000000000000000..1055a079a061d8761be13d3b9efbbd90d193caa2
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/PaperConfigurations.java
-@@ -0,0 +1,432 @@
+@@ -0,0 +1,435 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.base.Suppliers;
@@ -947,11 +947,12 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +import io.papermc.paper.configuration.transformation.global.LegacyPaperConfig;
 +import io.papermc.paper.configuration.transformation.world.FeatureSeedsGeneration;
 +import io.papermc.paper.configuration.transformation.world.LegacyPaperWorldConfig;
++import io.papermc.paper.configuration.transformation.world.ZeroWorldHeight;
 +import io.papermc.paper.configuration.type.BooleanOrDefault;
 +import io.papermc.paper.configuration.type.DoubleOrDefault;
 +import io.papermc.paper.configuration.type.Duration;
 +import io.papermc.paper.configuration.type.EngineMode;
-+import io.papermc.paper.configuration.type.IntOrDefault;
++import io.papermc.paper.configuration.type.IntOr;
 +import io.papermc.paper.configuration.type.fallback.FallbackValueSerializer;
 +import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 +import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
@@ -965,7 +966,6 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +import net.minecraft.world.item.Item;
 +import net.minecraft.world.level.levelgen.feature.ConfiguredFeature;
 +import org.apache.commons.lang3.RandomStringUtils;
-+import org.bukkit.command.Command;
 +import org.bukkit.configuration.ConfigurationSection;
 +import org.bukkit.configuration.file.YamlConfiguration;
 +import org.jetbrains.annotations.VisibleForTesting;
@@ -988,9 +988,7 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +import java.nio.file.Files;
 +import java.nio.file.Path;
 +import java.nio.file.StandardCopyOption;
-+import java.util.HashMap;
 +import java.util.List;
-+import java.util.Map;
 +import java.util.function.Function;
 +import java.util.function.Supplier;
 +
@@ -1135,7 +1133,8 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +                    .register(new TypeToken<Reference2LongMap<?>>() {}, new FastutilMapSerializer.SomethingToPrimitive<Reference2LongMap<?>>(Reference2LongOpenHashMap::new, Long.TYPE))
 +                    .register(new TypeToken<Table<?, ?, ?>>() {}, new TableSerializer())
 +                    .register(new StringRepresentableSerializer())
-+                    .register(IntOrDefault.SERIALIZER)
++                    .register(IntOr.Default.SERIALIZER)
++                    .register(IntOr.Disabled.SERIALIZER)
 +                    .register(DoubleOrDefault.SERIALIZER)
 +                    .register(BooleanOrDefault.SERIALIZER)
 +                    .register(Duration.SERIALIZER)
@@ -1162,7 +1161,11 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +            builder.addAction(path, TransformAction.remove());
 +        }
 +        builder.build().apply(node);
-+        // ADD FUTURE TRANSFORMS HERE
++
++        final ConfigurationTransformation.VersionedBuilder versionedBuilder = Transformations.versionedBuilder();
++        ZeroWorldHeight.apply(versionedBuilder);
++        // ADD FUTURE VERSIONED TRANSFORMS TO versionedBuilder HERE
++        versionedBuilder.build().apply(node);
 +    }
 +
 +    @Override
@@ -1171,8 +1174,8 @@ index 0000000000000000000000000000000000000000..18c64590b35a26a27a884494d6905989
 +        for (NodePath path : RemovedConfigurations.REMOVED_GLOBAL_PATHS) {
 +            builder.addAction(path, TransformAction.remove());
 +        }
++        // ADD FUTURE TRANSFORMS TO builder HERE
 +        builder.build().apply(node);
-+        // ADD FUTURE TRANSFORMS HERE
 +    }
 +
 +    private static final List<Transformations.DefaultsAware> DEFAULT_AWARE_TRANSFORMATIONS = List.of(FeatureSeedsGeneration::apply);
@@ -1430,10 +1433,10 @@ index 0000000000000000000000000000000000000000..1bb16fc7598cd53e822d84b69d6a9727
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d0873f2be139
+index 0000000000000000000000000000000000000000..3d2e67dc559ee3910b17ca86a46030ec05232250
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/WorldConfiguration.java
-@@ -0,0 +1,467 @@
+@@ -0,0 +1,466 @@
 +package io.papermc.paper.configuration;
 +
 +import com.google.common.collect.HashBasedTable;
@@ -1449,13 +1452,18 @@ index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d087
 +import io.papermc.paper.configuration.type.DoubleOrDefault;
 +import io.papermc.paper.configuration.type.Duration;
 +import io.papermc.paper.configuration.type.EngineMode;
-+import io.papermc.paper.configuration.type.IntOrDefault;
++import io.papermc.paper.configuration.type.IntOr;
 +import io.papermc.paper.configuration.type.fallback.ArrowDespawnRate;
 +import io.papermc.paper.configuration.type.fallback.AutosavePeriod;
 +import it.unimi.dsi.fastutil.objects.Reference2IntMap;
 +import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
 +import it.unimi.dsi.fastutil.objects.Reference2LongMap;
 +import it.unimi.dsi.fastutil.objects.Reference2LongOpenHashMap;
++import java.util.Arrays;
++import java.util.List;
++import java.util.Map;
++import java.util.function.Function;
++import java.util.stream.Collectors;
 +import net.minecraft.Util;
 +import net.minecraft.core.Holder;
 +import net.minecraft.core.Registry;
@@ -1475,16 +1483,10 @@ index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d087
 +import org.spongepowered.configurate.objectmapping.meta.Required;
 +import org.spongepowered.configurate.objectmapping.meta.Setting;
 +
-+import java.util.Arrays;
-+import java.util.List;
-+import java.util.Map;
-+import java.util.function.Function;
-+import java.util.stream.Collectors;
-+
 +@SuppressWarnings({"FieldCanBeLocal", "FieldMayBeFinal", "NotNullFieldNotInitialized", "InnerClassMayBeStatic"})
 +public class WorldConfiguration extends ConfigurationPart {
 +    private static final Logger LOGGER = LogUtils.getLogger();
-+    static final int CURRENT_VERSION = 28;
++    static final int CURRENT_VERSION = 29; // (when you change the version, change the comment, so it conflicts on rebases): zero height fixes
 +
 +    private transient final SpigotWorldConfig spigotConfig;
 +    private transient final ResourceLocation worldKey;
@@ -1575,8 +1577,8 @@ index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d087
 +            public WaterAnimalSpawnHeight wateranimalSpawnHeight;
 +
 +            public class WaterAnimalSpawnHeight extends ConfigurationPart {
-+                public IntOrDefault maximum = IntOrDefault.USE_DEFAULT;
-+                public IntOrDefault minimum = IntOrDefault.USE_DEFAULT;
++                public IntOr.Default maximum = IntOr.Default.USE_DEFAULT;
++                public IntOr.Default minimum = IntOr.Default.USE_DEFAULT;
 +            }
 +
 +            public SlimeSpawnHeight slimeSpawnHeight;
@@ -1775,7 +1777,7 @@ index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d087
 +        public int portalCreateRadius = 16;
 +        public boolean portalSearchVanillaDimensionScaling = true;
 +        public boolean disableTeleportationSuffocationCheck = false;
-+        public int netherCeilingVoidDamageHeight = 0;
++        public IntOr.Disabled netherCeilingVoidDamageHeight = IntOr.Disabled.DISABLED;
 +    }
 +
 +    public Spawn spawn;
@@ -1802,8 +1804,8 @@ index 0000000000000000000000000000000000000000..e2c612dd55fcb2769fb06f7878b8d087
 +        public boolean preventTntFromMovingInWater = false;
 +        public boolean splitOverstackedLoot = true;
 +        public boolean fixCuringZombieVillagerDiscountExploit = true;
-+        public int fallingBlockHeightNerf = 0;
-+        public int tntEntityHeightNerf = 0;
++        public IntOr.Disabled fallingBlockHeightNerf = IntOr.Disabled.DISABLED;
++        public IntOr.Disabled tntEntityHeightNerf = IntOr.Disabled.DISABLED;
 +    }
 +
 +    public UnsupportedSettings unsupportedSettings;
@@ -2910,16 +2912,18 @@ index 0000000000000000000000000000000000000000..10d3dd361cd26dc849ebd53c1235aa8e
 +}
 diff --git a/src/main/java/io/papermc/paper/configuration/transformation/Transformations.java b/src/main/java/io/papermc/paper/configuration/transformation/Transformations.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..0300fb1e09d41465e4a50bfdc987b9571289d399
+index 0000000000000000000000000000000000000000..96e8d03bd4a4d43633a94bb251054610ac07315a
 --- /dev/null
 +++ b/src/main/java/io/papermc/paper/configuration/transformation/Transformations.java
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,41 @@
 +package io.papermc.paper.configuration.transformation;
 +
++import io.papermc.paper.configuration.Configuration;
 +import io.papermc.paper.configuration.Configurations;
 +import org.spongepowered.configurate.ConfigurationNode;
 +import org.spongepowered.configurate.NodePath;
 +import org.spongepowered.configurate.transformation.ConfigurationTransformation;
++import org.spongepowered.configurate.transformation.TransformAction;
 +
 +import static org.spongepowered.configurate.NodePath.path;
 +
@@ -2942,6 +2946,10 @@ index 0000000000000000000000000000000000000000..0300fb1e09d41465e4a50bfdc987b957
 +            System.arraycopy(parents, 0, newPath, 0, parents.length);
 +            return newPath;
 +        });
++    }
++
++    public static ConfigurationTransformation.VersionedBuilder versionedBuilder() {
++        return ConfigurationTransformation.versionedBuilder().versionKey(Configuration.VERSION_FIELD);
 +    }
 +
 +    @FunctionalInterface
@@ -3581,6 +3589,58 @@ index 0000000000000000000000000000000000000000..6af307481a6752529d87869760945cb1
 +        moveFromRootAndRename(builder, path("game-mechanics", oldKey), newKey, parents);
 +    }
 +}
+diff --git a/src/main/java/io/papermc/paper/configuration/transformation/world/ZeroWorldHeight.java b/src/main/java/io/papermc/paper/configuration/transformation/world/ZeroWorldHeight.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..dcb1f3722de215800ddb0285538bc188d02af054
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/configuration/transformation/world/ZeroWorldHeight.java
+@@ -0,0 +1,46 @@
++package io.papermc.paper.configuration.transformation.world;
++
++import io.papermc.paper.configuration.type.IntOr;
++import org.checkerframework.checker.nullness.qual.Nullable;
++import org.spongepowered.configurate.ConfigurateException;
++import org.spongepowered.configurate.ConfigurationNode;
++import org.spongepowered.configurate.NodePath;
++import org.spongepowered.configurate.transformation.ConfigurationTransformation;
++import org.spongepowered.configurate.transformation.TransformAction;
++
++import static org.spongepowered.configurate.NodePath.path;
++
++/**
++ * Several configurations that set a y-level used '0' as the "disabled" value.
++ * Since 0 is now a valid value, they need to be updated.
++ */
++public class ZeroWorldHeight implements TransformAction {
++
++    private static final int VERSION = 29;
++
++    private static final String FIXES_KEY = "fixes";
++    private static final String FALLING_BLOCK_HEIGHT_NERF_KEY = "falling-block-height-nerf";
++    private static final String TNT_ENTITY_HEIGHT_NERF_KEY = "tnt-entity-height-nerf";
++
++    private static final String ENVIRONMENT_KEY = "environment";
++    private static final String NETHER_CEILING_VOID_DAMAGE_HEIGHT_KEY = "nether-ceiling-void-damage-height";
++
++    private static final ZeroWorldHeight INSTANCE = new ZeroWorldHeight();
++
++    public static void apply(ConfigurationTransformation.VersionedBuilder builder) {
++        final ConfigurationTransformation transformation = ConfigurationTransformation.builder()
++            .addAction(path(FIXES_KEY, FALLING_BLOCK_HEIGHT_NERF_KEY), INSTANCE)
++            .addAction(path(FIXES_KEY, TNT_ENTITY_HEIGHT_NERF_KEY), INSTANCE)
++            .addAction(path(ENVIRONMENT_KEY, NETHER_CEILING_VOID_DAMAGE_HEIGHT_KEY), INSTANCE)
++            .build();
++        builder.addVersion(VERSION, transformation);
++    }
++
++    @Override
++    public Object @Nullable [] visitPath(NodePath path, ConfigurationNode value) throws ConfigurateException {
++        if (value.getInt() == 0) {
++            value.set(IntOr.Disabled.DISABLED);
++        }
++        return null;
++    }
++}
 diff --git a/src/main/java/io/papermc/paper/configuration/type/BooleanOrDefault.java b/src/main/java/io/papermc/paper/configuration/type/BooleanOrDefault.java
 new file mode 100644
 index 0000000000000000000000000000000000000000..3e422b74a377fa3edaf82dd960e7449c998c2912
@@ -3857,64 +3917,97 @@ index 0000000000000000000000000000000000000000..99e90636051fa0c770ee2eafb7f0d29c
 +        return description;
 +    }
 +}
-diff --git a/src/main/java/io/papermc/paper/configuration/type/IntOrDefault.java b/src/main/java/io/papermc/paper/configuration/type/IntOrDefault.java
+diff --git a/src/main/java/io/papermc/paper/configuration/type/IntOr.java b/src/main/java/io/papermc/paper/configuration/type/IntOr.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..3278045dbf081cc4099e2eac3a6c4fac3012be4b
+index 0000000000000000000000000000000000000000..a03e82fa80a548e18634ac2f536a995c3f518498
 --- /dev/null
-+++ b/src/main/java/io/papermc/paper/configuration/type/IntOrDefault.java
-@@ -0,0 +1,56 @@
++++ b/src/main/java/io/papermc/paper/configuration/type/IntOr.java
+@@ -0,0 +1,89 @@
 +package io.papermc.paper.configuration.type;
 +
 +import com.mojang.logging.LogUtils;
++import java.lang.reflect.Type;
++import java.util.OptionalInt;
++import java.util.function.Function;
++import java.util.function.IntPredicate;
++import java.util.function.Predicate;
 +import org.apache.commons.lang3.math.NumberUtils;
 +import org.slf4j.Logger;
 +import org.spongepowered.configurate.serialize.ScalarSerializer;
 +import org.spongepowered.configurate.serialize.SerializationException;
 +
-+import java.lang.reflect.Type;
-+import java.util.OptionalInt;
-+import java.util.function.Predicate;
++public interface IntOr {
 +
-+public record IntOrDefault(OptionalInt value) {
-+    private static final String DEFAULT_VALUE = "default";
-+    private static final Logger LOGGER = LogUtils.getLogger();
-+    public static final IntOrDefault USE_DEFAULT = new IntOrDefault(OptionalInt.empty());
-+    public static final ScalarSerializer<IntOrDefault> SERIALIZER = new Serializer();
++    Logger LOGGER = LogUtils.getLogger();
 +
-+    public int or(final int fallback) {
-+        return this.value.orElse(fallback);
++    default int or(final int fallback) {
++        return this.value().orElse(fallback);
 +    }
 +
-+    private static final class Serializer extends ScalarSerializer<IntOrDefault> {
-+        Serializer() {
-+            super(IntOrDefault.class);
++    OptionalInt value();
++
++    default int intValue() {
++        return this.value().orElseThrow();
++    }
++
++    record Default(OptionalInt value) implements IntOr {
++        private static final String DEFAULT_VALUE = "default";
++        public static final Default USE_DEFAULT = new Default(OptionalInt.empty());
++        public static final ScalarSerializer<Default> SERIALIZER = new Serializer<>(Default.class, Default::new, DEFAULT_VALUE, USE_DEFAULT);
++    }
++
++    record Disabled(OptionalInt value) implements IntOr {
++        private static final String DISABLED_VALUE = "disabled";
++        public static final Disabled DISABLED = new Disabled(OptionalInt.empty());
++        public static final ScalarSerializer<Disabled> SERIALIZER = new Serializer<>(Disabled.class, Disabled::new, DISABLED_VALUE, DISABLED);
++
++        public boolean test(IntPredicate predicate) {
++            return this.value.isPresent() && predicate.test(this.value.getAsInt());
++        }
++
++        public boolean enabled() {
++            return this.value.isPresent();
++        }
++    }
++
++    final class Serializer<T extends IntOr> extends ScalarSerializer<T> {
++
++        private final Function<OptionalInt, T> creator;
++        private final String otherSerializedValue;
++        private final T otherValue;
++
++        public Serializer(Class<T> classOfT, Function<OptionalInt, T> creator, String otherSerializedValue, T otherValue) {
++            super(classOfT);
++            this.creator = creator;
++            this.otherSerializedValue = otherSerializedValue;
++            this.otherValue = otherValue;
 +        }
 +
 +        @Override
-+        public IntOrDefault deserialize(final Type type, final Object obj) throws SerializationException {
++        public T deserialize(Type type, Object obj) throws SerializationException {
 +            if (obj instanceof String string) {
-+                if (DEFAULT_VALUE.equalsIgnoreCase(string)) {
-+                    return USE_DEFAULT;
++                if (this.otherSerializedValue.equalsIgnoreCase(string)) {
++                    return this.otherValue;
 +                }
 +                if (NumberUtils.isParsable(string)) {
-+                    return new IntOrDefault(OptionalInt.of(Integer.parseInt(string)));
++                    return this.creator.apply(OptionalInt.of(Integer.parseInt(string)));
 +                }
 +            } else if (obj instanceof Number num) {
 +                if (num.intValue() != num.doubleValue() || num.intValue() != num.longValue()) {
 +                    LOGGER.error("{} cannot be converted to an integer without losing information", num);
 +                }
-+                return new IntOrDefault(OptionalInt.of(num.intValue()));
++                return this.creator.apply(OptionalInt.of(num.intValue()));
 +            }
-+            throw new SerializationException(obj + "(" + type + ") is not a integer or '" + DEFAULT_VALUE + "'");
++            throw new SerializationException(obj + "(" + type + ") is not a integer or '" + this.otherSerializedValue + "'");
 +        }
 +
 +        @Override
-+        protected Object serialize(final IntOrDefault item, final Predicate<Class<?>> typeSupported) {
++        protected Object serialize(T item, Predicate<Class<?>> typeSupported) {
 +            final OptionalInt value = item.value();
 +            if (value.isPresent()) {
 +                return value.getAsInt();
 +            } else {
-+                return DEFAULT_VALUE;
++                return this.otherSerializedValue;
 +            }
 +        }
 +    }

--- a/patches/server/0024-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0024-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -3,10 +3,10 @@ From: Byteflux <byte@byteflux.net>
 Date: Tue, 1 Mar 2016 14:14:15 -0600
 Subject: [PATCH] Drop falling block and tnt entities at the specified height
 
-* Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 7e1594e8df4fd09cd1aecbc5f3784797b04a8337..bd357c3e6fcbd82f3c53ecc8dab46aa5d3708bc2 100644
+index 7e1594e8df4fd09cd1aecbc5f3784797b04a8337..ba5f365cc0ae9773e63ff58ad0a8f8bb4087889a 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -137,6 +137,17 @@ public class FallingBlockEntity extends Entity {
@@ -15,7 +15,7 @@ index 7e1594e8df4fd09cd1aecbc5f3784797b04a8337..bd357c3e6fcbd82f3c53ecc8dab46aa5
              this.move(MoverType.SELF, this.getDeltaMovement());
 +
 +            // Paper start - Configurable EntityFallingBlock height nerf
-+            if (this.level.paperConfig().fixes.fallingBlockHeightNerf != 0 && this.getY() > this.level.paperConfig().fixes.fallingBlockHeightNerf) {
++            if (this.level.paperConfig().fixes.fallingBlockHeightNerf.test(v -> this.getY() > v)) {
 +                if (this.dropItem && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {
 +                    this.spawnAtLocation(block);
 +                }
@@ -28,7 +28,7 @@ index 7e1594e8df4fd09cd1aecbc5f3784797b04a8337..bd357c3e6fcbd82f3c53ecc8dab46aa5
                  BlockPos blockposition = this.blockPosition();
                  boolean flag = this.blockState.getBlock() instanceof ConcretePowderBlock;
 diff --git a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
-index e24b46820394c5f220d5bf7c4e763ef95ff9e9ab..2d4a990da2402a6c24c03e8be7e518e33db99c8f 100644
+index e24b46820394c5f220d5bf7c4e763ef95ff9e9ab..54a8548e8d3ddee049d3fed41332c94e368ba2c4 100644
 --- a/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 +++ b/src/main/java/net/minecraft/world/entity/item/PrimedTnt.java
 @@ -68,6 +68,12 @@ public class PrimedTnt extends Entity {
@@ -36,7 +36,7 @@ index e24b46820394c5f220d5bf7c4e763ef95ff9e9ab..2d4a990da2402a6c24c03e8be7e518e3
  
          this.move(MoverType.SELF, this.getDeltaMovement());
 +        // Paper start - Configurable TNT entity height nerf
-+        if (this.level.paperConfig().fixes.tntEntityHeightNerf != 0 && this.getY() > this.level.paperConfig().fixes.tntEntityHeightNerf) {
++        if (this.level.paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
 +            this.discard();
 +            return;
 +        }
@@ -45,7 +45,7 @@ index e24b46820394c5f220d5bf7c4e763ef95ff9e9ab..2d4a990da2402a6c24c03e8be7e518e3
          if (this.onGround) {
              this.setDeltaMovement(this.getDeltaMovement().multiply(0.7D, -0.5D, 0.7D));
 diff --git a/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java b/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
-index c10c28eb441e65c6285c25b5d4760c876909c724..136bd0168b573079dfad127d02ca8ba72c02fafb 100644
+index c10c28eb441e65c6285c25b5d4760c876909c724..ed457aeccb91c290bbd2191c9e3e52b499dc8200 100644
 --- a/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
 +++ b/src/main/java/net/minecraft/world/entity/vehicle/MinecartTNT.java
 @@ -46,6 +46,12 @@ public class MinecartTNT extends AbstractMinecart {
@@ -53,7 +53,7 @@ index c10c28eb441e65c6285c25b5d4760c876909c724..136bd0168b573079dfad127d02ca8ba7
          super.tick();
          if (this.fuse > 0) {
 +            // Paper start - Configurable TNT entity height nerf
-+            if (this.level.paperConfig().fixes.tntEntityHeightNerf != 0 && this.getY() > this.level.paperConfig().fixes.tntEntityHeightNerf) {
++            if (this.level.paperConfig().fixes.tntEntityHeightNerf.test(v -> this.getY() > v)) {
 +                this.discard();
 +                return;
 +            }

--- a/patches/server/0033-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0033-Configurable-top-of-nether-void-damage.patch
@@ -3,22 +3,47 @@ From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Tue, 1 Mar 2016 23:58:50 -0600
 Subject: [PATCH] Configurable top of nether void damage
 
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ab2671c21f2f44973fb2507b178ac8e1e03bc8dc..ce5f30b761ddaa2b3b241903d75770d0c5050d92 100644
+index ab2671c21f2f44973fb2507b178ac8e1e03bc8dc..3273b29bdd37a5dac5c8a1be38f514bdbdffbeeb 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -705,7 +705,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -705,7 +705,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void checkOutOfWorld() {
 -        if (this.getY() < (double) (this.level.getMinBuildHeight() - 64)) {
 +        // Paper start - Configurable nether ceiling damage
 +        if (this.getY() < (double) (this.level.getMinBuildHeight() - 64) || (this.level.getWorld().getEnvironment() == org.bukkit.World.Environment.NETHER
-+            && level.paperConfig().environment.netherCeilingVoidDamageHeight > 0
-+            && this.getY() >= this.level.paperConfig().environment.netherCeilingVoidDamageHeight
++            && this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> this.getY() >= v)
 +            && (!(this instanceof Player player) || !player.getAbilities().invulnerable))) {
 +            // Paper end
              this.outOfWorld();
          }
+ 
+diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+index bb05ea288432ece497957c3503c3435655ce8997..f9cddc20563c2d44fdb1f91ae2b2f9b2321e4d81 100644
+--- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
++++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
+@@ -55,7 +55,7 @@ public class PortalForcer {
+         Optional<PoiRecord> optional = villageplace.getInSquare((holder) -> {
+             return holder.is(PoiTypes.NETHER_PORTAL);
+         }, blockposition, i, PoiManager.Occupancy.ANY).filter((villageplacerecord) -> {
+-            return worldborder.isWithinBounds(villageplacerecord.getPos());
++            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v); // Paper - don't teleport into void damage
+         }).sorted(Comparator.comparingDouble((PoiRecord villageplacerecord) -> { // CraftBukkit - decompile error
+             return villageplacerecord.getPos().distSqr(blockposition);
+         }).thenComparingInt((villageplacerecord) -> {
+@@ -90,6 +90,11 @@ public class PortalForcer {
+         BlockPos blockposition2 = null;
+         WorldBorder worldborder = this.level.getWorldBorder();
+         int i = Math.min(this.level.getMaxBuildHeight(), this.level.getMinBuildHeight() + this.level.getLogicalHeight()) - 1;
++        // Paper start - if ceiling void damage is enabled, make sure the max height doesn't exceed the void damage height
++        if (this.level.paperConfig().environment.netherCeilingVoidDamageHeight.enabled()) {
++            i = Math.min(i, this.level.paperConfig().environment.netherCeilingVoidDamageHeight.intValue() - 1);
++        }
++        // Paper end
+         BlockPos.MutableBlockPos blockposition_mutableblockposition = blockposition.mutable();
+         Iterator iterator = BlockPos.spiralAround(blockposition, createRadius, Direction.EAST, Direction.SOUTH).iterator(); // CraftBukkit
  

--- a/patches/server/0056-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0056-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ce5f30b761ddaa2b3b241903d75770d0c5050d92..5723bddfe94f4b064ba25911dab474cad11eac17 100644
+index 3273b29bdd37a5dac5c8a1be38f514bdbdffbeeb..dc29c677e21a71b5ba1a48c7aea8acadc2689c77 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3004,7 +3004,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3003,7 +3003,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  double d0 = DimensionType.getTeleportationScale(this.level.dimensionType(), destination.dimensionType());
                  BlockPos blockposition = worldborder.clampToBounds(this.getX() * d0, this.getY(), this.getZ() * d0);
                  // CraftBukkit start
@@ -24,7 +24,7 @@ index ce5f30b761ddaa2b3b241903d75770d0c5050d92..5723bddfe94f4b064ba25911dab474ca
                      return null;
                  }
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-index bb05ea288432ece497957c3503c3435655ce8997..7aa6181237eaec1df2ed2fdcd3b1137dfe89ce69 100644
+index f9cddc20563c2d44fdb1f91ae2b2f9b2321e4d81..953a1dfd71605ac123133dc1d4e8133a33884f4a 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 @@ -43,7 +43,7 @@ public class PortalForcer {

--- a/patches/server/0061-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0061-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5723bddfe94f4b064ba25911dab474cad11eac17..551365ae91c5e595ff00eb9f26bd91e99491233e 100644
+index dc29c677e21a71b5ba1a48c7aea8acadc2689c77..70275d1db39c9809a5fc93cebb49beb32d616476 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2642,6 +2642,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2641,6 +2641,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
      @Nullable
      public Team getTeam() {
@@ -23,7 +23,7 @@ index 5723bddfe94f4b064ba25911dab474cad11eac17..551365ae91c5e595ff00eb9f26bd91e9
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 87b8a9bb1493d4ff048f0283151cfc5c8ea7d7ef..4e192c98b7beb23ac75b7442883eba7bb98dc475 100644
+index 1d0f6aec5b34208c6bbda23789238b3a27c33c4c..f513e9abb929fbabe12e40bb56af708745ea1ad9 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -823,6 +823,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0127-Don-t-allow-entities-to-ride-themselves-572.patch
+++ b/patches/server/0127-Don-t-allow-entities-to-ride-themselves-572.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't allow entities to ride themselves - #572
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3cc3ee1a997992ea53445a656d0ab9fb9e0ae9e8..d43a6fa8c25382bef7127f1106e3bde0341472b0 100644
+index a6b5527e97e8a5b2eeca762477a7b695223a0d4d..86fa079f9f1f958ed586c966467d26a44e09b11c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2386,6 +2386,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2385,6 +2385,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0146-Entity-fromMobSpawner.patch
+++ b/patches/server/0146-Entity-fromMobSpawner.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#fromMobSpawner()
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8e9530e5c37bbab8d9ad016f25ce1da6623e3b8e..5c54729fbf8fa0a58260fcb1f52f9b95bab4aadf 100644
+index 58256b341aa15e946abef464453c0ffcaf55b372..36beb42ccdb348c91020502f935b3a1590a7472e 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -380,6 +380,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -16,7 +16,7 @@ index 8e9530e5c37bbab8d9ad016f25ce1da6623e3b8e..5c54729fbf8fa0a58260fcb1f52f9b95
      @javax.annotation.Nullable
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
-@@ -2021,6 +2022,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2020,6 +2021,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -27,7 +27,7 @@ index 8e9530e5c37bbab8d9ad016f25ce1da6623e3b8e..5c54729fbf8fa0a58260fcb1f52f9b95
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2160,6 +2165,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2159,6 +2164,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.originWorld = originWorld;
                  origin = new org.bukkit.util.Vector(originTag.getDouble(0), originTag.getDouble(1), originTag.getDouble(2));
              }

--- a/patches/server/0221-add-more-information-to-Entity.toString.patch
+++ b/patches/server/0221-add-more-information-to-Entity.toString.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add more information to Entity.toString()
 UUID, ticks lived, valid, dead
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 5c54729fbf8fa0a58260fcb1f52f9b95bab4aadf..38031c5d034333cbeaba3f3e271d7b3bc2c2b0da 100644
+index 36beb42ccdb348c91020502f935b3a1590a7472e..f67480cc4ff05d23a16b63dbe986d0d96739496b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2969,7 +2969,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2968,7 +2968,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public String toString() {
          String s = this.level == null ? "~NULL~" : this.level.toString();
  

--- a/patches/server/0287-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0287-force-entity-dismount-during-teleportation.patch
@@ -41,10 +41,10 @@ index 32aba4c822742d6a2ebbc25b169ffb665e9413f7..135e61ffa69a56e7c5edcd9e2066334a
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 304aac869261548681956fa7137578d73384a789..9257d639b41b1c66f64cc2d1f7ce534cc8354c93 100644
+index f174af45cd593d8f74205472e25db081b5289ee9..fb67f1d76d683694db13b29bab1d69606b414950 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2382,11 +2382,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2381,11 +2381,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void removeVehicle() {
@@ -62,7 +62,7 @@ index 304aac869261548681956fa7137578d73384a789..9257d639b41b1c66f64cc2d1f7ce534c
          }
  
      }
-@@ -2449,7 +2454,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2448,7 +2453,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return true; // CraftBukkit
      }
  
@@ -74,7 +74,7 @@ index 304aac869261548681956fa7137578d73384a789..9257d639b41b1c66f64cc2d1f7ce534c
          if (entity.getVehicle() == this) {
              throw new IllegalStateException("Use x.stopRiding(y), not y.removePassenger(x)");
          } else {
-@@ -2459,7 +2467,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2458,7 +2466,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (this.getBukkitEntity() instanceof Vehicle && entity.getBukkitEntity() instanceof LivingEntity) {
                  VehicleExitEvent event = new VehicleExitEvent(
                          (Vehicle) this.getBukkitEntity(),
@@ -83,7 +83,7 @@ index 304aac869261548681956fa7137578d73384a789..9257d639b41b1c66f64cc2d1f7ce534c
                  );
                  // Suppress during worldgen
                  if (this.valid) {
-@@ -2473,7 +2481,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2472,7 +2480,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
              // CraftBukkit end
              // Spigot start

--- a/patches/server/0305-Entity-getEntitySpawnReason.patch
+++ b/patches/server/0305-Entity-getEntitySpawnReason.patch
@@ -35,7 +35,7 @@ index 45cd4ac70bf322a3bb256579f795db46b9beb7a0..80b6eb1e010559c02c9e7624a5c131d1
              });
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 9257d639b41b1c66f64cc2d1f7ce534cc8354c93..91cac068ed56ded6e786698fbbfb00fc3670fdd0 100644
+index fb67f1d76d683694db13b29bab1d69606b414950..d83fc656e70612bbfa93f5ef2cc1161103915004 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -74,6 +74,8 @@ import net.minecraft.world.InteractionHand;
@@ -55,7 +55,7 @@ index 9257d639b41b1c66f64cc2d1f7ce534cc8354c93..91cac068ed56ded6e786698fbbfb00fc
  
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
-@@ -2024,6 +2027,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2023,6 +2026,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  }
                  nbt.put("Paper.Origin", this.newDoubleList(origin.getX(), origin.getY(), origin.getZ()));
              }
@@ -65,7 +65,7 @@ index 9257d639b41b1c66f64cc2d1f7ce534cc8354c93..91cac068ed56ded6e786698fbbfb00fc
              // Save entity's from mob spawner status
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
-@@ -2169,6 +2175,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2168,6 +2174,26 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0345-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0345-Entity-Activation-Range-2.0.patch
@@ -108,7 +108,7 @@ index faee1edda215fa72f5b7e1bdbbeb01004d019b0d..4a06da72c8b769c683e9eb03817bd938
          } else {
              passenger.stopRiding();
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 91cac068ed56ded6e786698fbbfb00fc3670fdd0..993108ff719f29b819ccb2da338977c9d2b32219 100644
+index d83fc656e70612bbfa93f5ef2cc1161103915004..c453a7df75d4486bf0123bc4932c441a707998b0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -384,6 +384,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -120,7 +120,7 @@ index 91cac068ed56ded6e786698fbbfb00fc3670fdd0..993108ff719f29b819ccb2da338977c9
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -910,6 +912,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -909,6 +911,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              this.wasOnFire = this.isOnFire();
              if (movementType == MoverType.PISTON) {
@@ -129,7 +129,7 @@ index 91cac068ed56ded6e786698fbbfb00fc3670fdd0..993108ff719f29b819ccb2da338977c9
                  movement = this.limitPistonMovement(movement);
                  if (movement.equals(Vec3.ZERO)) {
                      return;
-@@ -922,6 +926,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -921,6 +925,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.stuckSpeedMultiplier = Vec3.ZERO;
                  this.setDeltaMovement(Vec3.ZERO);
              }

--- a/patches/server/0350-Fix-items-vanishing-through-end-portal.patch
+++ b/patches/server/0350-Fix-items-vanishing-through-end-portal.patch
@@ -13,10 +13,10 @@ Quickly loading the exact world spawn chunk before searching the
 heightmap resolves the issue without having to load all spawn chunks.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 993108ff719f29b819ccb2da338977c9d2b32219..1d933c0302c1ca4752c837b7da802f752a53b437 100644
+index c453a7df75d4486bf0123bc4932c441a707998b0..e707f3afe4cded677ab8d712e38063de2b5be90d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3176,6 +3176,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3175,6 +3175,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (flag1) {
                  blockposition1 = ServerLevel.END_SPAWN_POINT;
              } else {

--- a/patches/server/0358-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0358-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1d933c0302c1ca4752c837b7da802f752a53b437..6aa075103b599980d2ee6ba1f898b6cbf59754cd 100644
+index e707f3afe4cded677ab8d712e38063de2b5be90d..e3075bbf737905c3a61ce900fc525d4ed9484b79 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -386,6 +386,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -16,7 +16,7 @@ index 1d933c0302c1ca4752c837b7da802f752a53b437..6aa075103b599980d2ee6ba1f898b6cb
      protected int numCollisions = 0; // Paper
      public boolean spawnedViaMobSpawner; // Paper - Yes this name is similar to above, upstream took the better one
      @javax.annotation.Nullable
-@@ -2045,6 +2046,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2044,6 +2045,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnedViaMobSpawner) {
                  nbt.putBoolean("Paper.FromMobSpawner", true);
              }
@@ -26,7 +26,7 @@ index 1d933c0302c1ca4752c837b7da802f752a53b437..6aa075103b599980d2ee6ba1f898b6cb
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2186,6 +2190,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2185,6 +2189,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              spawnedViaMobSpawner = nbt.getBoolean("Paper.FromMobSpawner"); // Restore entity's from mob spawner status

--- a/patches/server/0388-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
+++ b/patches/server/0388-Move-player-to-spawn-point-if-spawn-in-unloaded-worl.patch
@@ -7,10 +7,10 @@ The code following this has better support for null worlds to move
 them back to the world spawn.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 89e3a1421d3658a42bca24e6c3ed76d207b6c3ea..cbf5995e7fdea520080501368d968e7f9ad749c8 100644
+index 5de420c0a2f0881abb03c16b2621d081ef7ad4fd..58a8bbda3ddff1ed561d9035d45176c6ca689115 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2163,9 +2163,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2162,9 +2162,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      bworld = server.getWorld(worldName);
                  }
  

--- a/patches/server/0392-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0392-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,10 +16,10 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f1727083fc13342 100644
+index 58a8bbda3ddff1ed561d9035d45176c6ca689115..32623f90a5bc4fb6fe99897c682ef4f55f056dea 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2293,11 +2293,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2292,11 +2292,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          } else {
              // CraftBukkit start - Capture drops for death event
              if (this instanceof net.minecraft.world.entity.LivingEntity && !((net.minecraft.world.entity.LivingEntity) this).forceDrops) {
@@ -34,7 +34,7 @@ index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f172708
  
              entityitem.setDefaultPickUpDelay();
              // CraftBukkit start
-@@ -3061,6 +3062,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3060,6 +3061,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      @Nullable
      public Entity teleportTo(ServerLevel worldserver, PositionImpl location) {
          // CraftBukkit end
@@ -47,7 +47,7 @@ index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f172708
          if (this.level instanceof ServerLevel && !this.isRemoved()) {
              this.level.getProfiler().push("changeDimension");
              // CraftBukkit start
-@@ -3087,6 +3094,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3086,6 +3093,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  // CraftBukkit end
  
                  this.level.getProfiler().popPush("reloading");
@@ -59,7 +59,7 @@ index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f172708
                  Entity entity = this.getType().create(worldserver);
  
                  if (entity != null) {
-@@ -3100,10 +3112,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3099,10 +3111,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      // CraftBukkit start - Forward the CraftEntity to the new entity
                      this.getBukkitEntity().setHandle(entity);
                      entity.bukkitEntity = this.getBukkitEntity();
@@ -70,7 +70,7 @@ index cbf5995e7fdea520080501368d968e7f9ad749c8..7778f8b1e439e47bbe7658239f172708
                      // CraftBukkit end
                  }
  
-@@ -3224,7 +3232,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3223,7 +3231,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean canChangeDimensions() {

--- a/patches/server/0410-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0410-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -150,10 +150,10 @@ index 61a792c5ccf3688d4f78c6e7461090f63a0cc26a..b2ab7749e3ddf124d5ef97271a76dc87
  
          public boolean isSolidRender(BlockGetter world, BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-index 7aa6181237eaec1df2ed2fdcd3b1137dfe89ce69..1311d69bb2fa7b3617936e6ad6eb5236fedc260d 100644
+index 953a1dfd71605ac123133dc1d4e8133a33884f4a..1369d4f818d203e3092fd6ba4def106dda16d6d2 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-@@ -210,6 +210,13 @@ public class PortalForcer {
+@@ -215,6 +215,13 @@ public class PortalForcer {
          for (int j = -1; j < 3; ++j) {
              for (int k = -1; k < 4; ++k) {
                  temp.setWithOffset(pos, portalDirection.getStepX() * j + enumdirection1.getStepX() * distanceOrthogonalToPortal, k, portalDirection.getStepZ() * j + enumdirection1.getStepZ() * distanceOrthogonalToPortal);

--- a/patches/server/0422-Fix-sand-duping.patch
+++ b/patches/server/0422-Fix-sand-duping.patch
@@ -7,7 +7,7 @@ If the falling block dies during teleportation (entity#move), then we need
 to detect that by placing a check after the move.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 18d81e8e8f387a7fb531652cb78c61a9bd5ae600..f6405e862b15b71dbb96215e604610fe5ff59bfc 100644
+index 108c9ea0eb4a7f381042bfe0203ac40a9c4f27a7..da00fab453f3fb580acc9de65a0853656f9b6fc4 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 @@ -126,6 +126,11 @@ public class FallingBlockEntity extends Entity {
@@ -33,5 +33,5 @@ index 18d81e8e8f387a7fb531652cb78c61a9bd5ae600..f6405e862b15b71dbb96215e604610fe
 +            // Paper end - fix sand duping
 +
              // Paper start - Configurable EntityFallingBlock height nerf
-             if (this.level.paperConfig().fixes.fallingBlockHeightNerf != 0 && this.getY() > this.level.paperConfig().fixes.fallingBlockHeightNerf) {
+             if (this.level.paperConfig().fixes.fallingBlockHeightNerf.test(v -> this.getY() > v)) {
                  if (this.dropItem && this.level.getGameRules().getBoolean(GameRules.RULE_DOENTITYDROPS)) {

--- a/patches/server/0430-Ensure-Entity-AABB-s-are-never-invalid.patch
+++ b/patches/server/0430-Ensure-Entity-AABB-s-are-never-invalid.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Ensure Entity AABB's are never invalid
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 326928fec8c0a1b8892091e02be7ddf73b92ff26..8f7cdc52f5c1888a69e714f948fdc46412b2ab50 100644
+index 6a86125c6f6daa0a443601db4fea19531225ad33..9fcd1808ea0dbfd6b5f0d09700d4aa4b1a21eed3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -713,8 +713,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -19,7 +19,7 @@ index 326928fec8c0a1b8892091e02be7ddf73b92ff26..8f7cdc52f5c1888a69e714f948fdc464
      }
  
      protected AABB makeBoundingBox() {
-@@ -3946,6 +3946,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3945,6 +3945,11 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public final void setPosRaw(double x, double y, double z) {
@@ -31,7 +31,7 @@ index 326928fec8c0a1b8892091e02be7ddf73b92ff26..8f7cdc52f5c1888a69e714f948fdc464
          // Paper start - rewrite chunk system
          if (this.updatingSectionStatus) {
              LOGGER.error("Refusing to update position for entity " + this + " to position " + new Vec3(x, y, z) + " since it is processing a section status update", new Throwable());
-@@ -3969,6 +3974,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3968,6 +3973,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              this.levelCallback.onMove();
          }
  

--- a/patches/server/0481-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
+++ b/patches/server/0481-Fix-Entity-Teleportation-and-cancel-velocity-if-tele.patch
@@ -31,7 +31,7 @@ index da6a0171bd63ac68635de1c23fc9eafa732503bd..214771e661ca3303af167fda3b623d83
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8f7cdc52f5c1888a69e714f948fdc46412b2ab50..f7db3233c3f63f3383930f80ebeba6d8b48e05bc 100644
+index 9fcd1808ea0dbfd6b5f0d09700d4aa4b1a21eed3..4639f888850128771d726c1f7755093211af50db 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -158,6 +158,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -42,7 +42,7 @@ index 8f7cdc52f5c1888a69e714f948fdc46412b2ab50..f7db3233c3f63f3383930f80ebeba6d8
      static boolean isLevelAtLeast(CompoundTag tag, int level) {
          return tag.contains("Bukkit.updateLevel") && tag.getInt("Bukkit.updateLevel") >= level;
      }
-@@ -1717,6 +1718,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1716,6 +1717,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void moveTo(double x, double y, double z, float yaw, float pitch) {

--- a/patches/server/0485-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
+++ b/patches/server/0485-Expose-the-Entity-Counter-to-allow-plugins-to-use-va.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose the Entity Counter to allow plugins to use valid and
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f7db3233c3f63f3383930f80ebeba6d8b48e05bc..4be4326103311fc73e2539cb655b44f7feb20f2a 100644
+index 4639f888850128771d726c1f7755093211af50db..23ec6c64579b1e682ec30ea6d4ec196ddb9ed403 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4163,4 +4163,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4162,4 +4162,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
          void accept(Entity entity, double x, double y, double z);
      }

--- a/patches/server/0487-Entity-isTicking.patch
+++ b/patches/server/0487-Entity-isTicking.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Entity#isTicking
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 4be4326103311fc73e2539cb655b44f7feb20f2a..742ff6a0585b1ac58bcbc15224a07f78838a9f1d 100644
+index 23ec6c64579b1e682ec30ea6d4ec196ddb9ed403..353f8b46b45b152b83afb2a832cd94c8807ce858 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -59,6 +59,7 @@ import net.minecraft.resources.ResourceKey;
@@ -16,7 +16,7 @@ index 4be4326103311fc73e2539cb655b44f7feb20f2a..742ff6a0585b1ac58bcbc15224a07f78
  import net.minecraft.server.level.ServerLevel;
  import net.minecraft.server.level.ServerPlayer;
  import net.minecraft.server.level.TicketType;
-@@ -4168,5 +4169,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4167,5 +4168,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public static int nextEntityId() {
          return ENTITY_COUNTER.incrementAndGet();
      }

--- a/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0517-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 742ff6a0585b1ac58bcbc15224a07f78838a9f1d..3f29f53c23055036f75926f263030ff91a2d9452 100644
+index 353f8b46b45b152b83afb2a832cd94c8807ce858..447ff449725e6f347b9efce551b71ee70a198610 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1898,6 +1898,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1897,6 +1897,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public boolean isPushable() {

--- a/patches/server/0530-MC-4-Fix-item-position-desync.patch
+++ b/patches/server/0530-MC-4-Fix-item-position-desync.patch
@@ -27,10 +27,10 @@ index 3768a71491ef7836b9739bdaec7a077c523dbacd..a57957ace1a72b3308487f180a366c38
  
      public Vec3 decode(long x, long y, long z) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3f29f53c23055036f75926f263030ff91a2d9452..c8657fbba5294c55d09163e87fa59e9fdca3e6ce 100644
+index 447ff449725e6f347b9efce551b71ee70a198610..8b64afcdb2f7419a0fd7cecb0d2fb364a508a161 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3972,6 +3972,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3971,6 +3971,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              return;
          }
          // Paper end - rewrite chunk system

--- a/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0557-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index c8657fbba5294c55d09163e87fa59e9fdca3e6ce..e7f57353e121ba964a9f8f5d6e095ec82aceafa4 100644
+index 8b64afcdb2f7419a0fd7cecb0d2fb364a508a161..2adf73d2fe9e687d7a487bc9af531a3d42896257 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1781,6 +1781,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1780,6 +1780,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      public void push(Entity entity) {
          if (!this.isPassengerOfSameVehicle(entity)) {
              if (!entity.noPhysics && !this.noPhysics) {

--- a/patches/server/0649-Fix-dangerous-end-portal-logic.patch
+++ b/patches/server/0649-Fix-dangerous-end-portal-logic.patch
@@ -11,7 +11,7 @@ Move the tick logic into the post tick, where portaling was
 designed to happen in the first place.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index e7f57353e121ba964a9f8f5d6e095ec82aceafa4..f7397e1deaa714781541075ebbf5d61223e2fb17 100644
+index 2adf73d2fe9e687d7a487bc9af531a3d42896257..263f9a9b21d20733d94a5f1e176bdb5aad94b9d4 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -510,6 +510,36 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -51,7 +51,7 @@ index e7f57353e121ba964a9f8f5d6e095ec82aceafa4..f7397e1deaa714781541075ebbf5d612
  
      public Entity(EntityType<?> type, Level world) {
          this.id = Entity.ENTITY_COUNTER.incrementAndGet();
-@@ -2687,6 +2717,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2686,6 +2716,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              }
  
              this.processPortalCooldown();

--- a/patches/server/0682-Optimize-indirect-passenger-iteration.patch
+++ b/patches/server/0682-Optimize-indirect-passenger-iteration.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize indirect passenger iteration
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f7397e1deaa714781541075ebbf5d61223e2fb17..bce565c170c37f8009303bda9c5eb7c2a83ef795 100644
+index 263f9a9b21d20733d94a5f1e176bdb5aad94b9d4..d7dadeb5b1f021969d3e1ccfb1d3a647e54b65c0 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3662,20 +3662,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3661,20 +3661,34 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Stream<Entity> getIndirectPassengersStream() {
@@ -43,7 +43,7 @@ index f7397e1deaa714781541075ebbf5d61223e2fb17..bce565c170c37f8009303bda9c5eb7c2
          return () -> {
              return this.getIndirectPassengersStream().iterator();
          };
-@@ -3692,6 +3706,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3691,6 +3705,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      // Paper end - rewrite chunk system
  
      public boolean hasExactlyOnePlayerPassenger() {

--- a/patches/server/0692-Add-back-EntityPortalExitEvent.patch
+++ b/patches/server/0692-Add-back-EntityPortalExitEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add back EntityPortalExitEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index bce565c170c37f8009303bda9c5eb7c2a83ef795..ad51baf7d9e22f7181f718a332b3ae23d7e4d1b5 100644
+index d7dadeb5b1f021969d3e1ccfb1d3a647e54b65c0..8a2d0a8dce8510fda7a9ca6c33454abc5fe015ba 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3164,6 +3164,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3163,6 +3163,23 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              } else {
                  // CraftBukkit start
                  worldserver = shapedetectorshape.world;
@@ -32,7 +32,7 @@ index bce565c170c37f8009303bda9c5eb7c2a83ef795..ad51baf7d9e22f7181f718a332b3ae23
                  if (worldserver == this.level) {
                      // SPIGOT-6782: Just move the entity if a plugin changed the world to the one the entity is already in
                      this.moveTo(shapedetectorshape.pos.x, shapedetectorshape.pos.y, shapedetectorshape.pos.z, shapedetectorshape.yRot, shapedetectorshape.xRot);
-@@ -3183,8 +3200,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3182,8 +3199,8 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
  
                  if (entity != null) {
                      entity.restoreFrom(this);

--- a/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
+++ b/patches/server/0703-Add-Raw-Byte-Entity-Serialization.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Raw Byte Entity Serialization
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index ad51baf7d9e22f7181f718a332b3ae23d7e4d1b5..fac8512645c8845855b709471c098cd568970b75 100644
+index 8a2d0a8dce8510fda7a9ca6c33454abc5fe015ba..884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1987,6 +1987,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1986,6 +1986,15 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
      }
  

--- a/patches/server/0711-Optimise-general-POI-access.patch
+++ b/patches/server/0711-Optimise-general-POI-access.patch
@@ -993,7 +993,7 @@ index 27f766fc72d779cff1b5a88a79961aa7ef91b11f..2d208f1b85193497027c4d04ab9e8cb1
              return Optional.empty();
          } else {
 diff --git a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
-index 1311d69bb2fa7b3617936e6ad6eb5236fedc260d..386a73f32f2504af81107852307dcd393d4d8a11 100644
+index 1369d4f818d203e3092fd6ba4def106dda16d6d2..b7cb9fbb15c83cd4225a241e44132279d9308f96 100644
 --- a/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 +++ b/src/main/java/net/minecraft/world/level/portal/PortalForcer.java
 @@ -51,18 +51,39 @@ public class PortalForcer {
@@ -1004,7 +1004,7 @@ index 1311d69bb2fa7b3617936e6ad6eb5236fedc260d..386a73f32f2504af81107852307dcd39
 -        Optional<PoiRecord> optional = villageplace.getInSquare((holder) -> {
 -            return holder.is(PoiTypes.NETHER_PORTAL);
 -        }, blockposition, i, PoiManager.Occupancy.ANY).filter((villageplacerecord) -> {
--            return worldborder.isWithinBounds(villageplacerecord.getPos());
+-            return worldborder.isWithinBounds(villageplacerecord.getPos()) && !this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> villageplacerecord.getPos().getY() >= v); // Paper - don't teleport into void damage
 -        }).sorted(Comparator.comparingDouble((PoiRecord villageplacerecord) -> { // CraftBukkit - decompile error
 -            return villageplacerecord.getPos().distSqr(blockposition);
 -        }).thenComparingInt((villageplacerecord) -> {
@@ -1025,7 +1025,7 @@ index 1311d69bb2fa7b3617936e6ad6eb5236fedc260d..386a73f32f2504af81107852307dcd39
 +                    // why would we generate the chunk?
 +                    return false;
 +                }
-+                if (!worldborder.isWithinBounds(pos)) {
++                if (!worldborder.isWithinBounds(pos) || this.level.paperConfig().environment.netherCeilingVoidDamageHeight.test(v -> pos.getY() >= v)) { // Paper - don't teleport into void damage
 +                    return false;
 +                }
 +                return lowest.getBlockState(pos).hasProperty(BlockStateProperties.HORIZONTAL_AXIS);

--- a/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
+++ b/patches/server/0716-Detail-more-information-in-watchdog-dumps.patch
@@ -124,10 +124,10 @@ index b4b7aa2f7d602fe996ebc320ab9641866b672abe..f7841aea38707cebaaab2637454a0db8
  
      private void tickPassenger(Entity vehicle, Entity passenger) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fac8512645c8845855b709471c098cd568970b75..95f9fe6d958b9bdd1e544120a8a7165b44aaa2a8 100644
+index 884d055c66e1f6f47b7bcf6a7bcc3b1271292d5b..9d696ea3bfcd6f4159bf431043f55d199a94ec6a 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -973,7 +973,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -972,7 +972,42 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.onGround;
      }
  
@@ -170,7 +170,7 @@ index fac8512645c8845855b709471c098cd568970b75..95f9fe6d958b9bdd1e544120a8a7165b
          if (this.noPhysics) {
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
          } else {
-@@ -1146,6 +1181,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1145,6 +1180,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  this.level.getProfiler().pop();
              }
          }
@@ -184,7 +184,7 @@ index fac8512645c8845855b709471c098cd568970b75..95f9fe6d958b9bdd1e544120a8a7165b
      }
  
      protected boolean isHorizontalCollisionMinor(Vec3 adjustedMovement) {
-@@ -3974,7 +4016,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3973,7 +4015,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void setDeltaMovement(Vec3 velocity) {
@@ -194,7 +194,7 @@ index fac8512645c8845855b709471c098cd568970b75..95f9fe6d958b9bdd1e544120a8a7165b
      }
  
      public void setDeltaMovement(double x, double y, double z) {
-@@ -4056,7 +4100,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4055,7 +4099,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          }
          // Paper end - fix MC-4
          if (this.position.x != x || this.position.y != y || this.position.z != z) {

--- a/patches/server/0749-Update-head-rotation-in-missing-places.patch
+++ b/patches/server/0749-Update-head-rotation-in-missing-places.patch
@@ -8,10 +8,10 @@ This is because bukkit uses a separate head rotation field for yaw.
 This issue only applies to players.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 95f9fe6d958b9bdd1e544120a8a7165b44aaa2a8..dff601f09007b15ea1fd6a12412c5153613546dc 100644
+index 9d696ea3bfcd6f4159bf431043f55d199a94ec6a..6b6af080e9adc0c95908460213ef392351c6530f 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1765,6 +1765,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1764,6 +1764,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(Mth.clamp(pitch, -90.0F, 90.0F) % 360.0F);
          this.yRotO = this.getYRot();
          this.xRotO = this.getXRot();
@@ -19,7 +19,7 @@ index 95f9fe6d958b9bdd1e544120a8a7165b44aaa2a8..dff601f09007b15ea1fd6a12412c5153
      }
  
      public void absMoveTo(double x, double y, double z) {
-@@ -1803,6 +1804,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1802,6 +1803,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          this.setXRot(pitch);
          this.setOldPosAndRot();
          this.reapplyPosition();

--- a/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
+++ b/patches/server/0771-Highly-optimise-single-and-multi-AABB-VoxelShapes-an.patch
@@ -1215,10 +1215,10 @@ index 3e870218321a701b814a4dac97ff1af12142600e..4277f7fdd8f27e57708a8dee59bf1b90
          }
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b0f512681fc67986a87b75170c140119ef4b9ec0..10c1da2d76d48c30eab310a38227f31d1f75168f 100644
+index b5fdac1a1f4a356d4eaf5ea944d3ed6582b094ee..9dbe61ef5cea1b39216551462ea79cc8658839ed 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -1162,9 +1162,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1161,9 +1161,44 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  float f2 = this.getBlockSpeedFactor();
  
                  this.setDeltaMovement(this.getDeltaMovement().multiply((double) f2, 1.0D, (double) f2));
@@ -1266,7 +1266,7 @@ index b0f512681fc67986a87b75170c140119ef4b9ec0..10c1da2d76d48c30eab310a38227f31d
                      if (this.remainingFireTicks <= 0) {
                          this.setRemainingFireTicks(-this.getFireImmuneTicks());
                      }
-@@ -1308,32 +1343,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -1307,32 +1342,78 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      private Vec3 collide(Vec3 movement) {
@@ -1366,7 +1366,7 @@ index b0f512681fc67986a87b75170c140119ef4b9ec0..10c1da2d76d48c30eab310a38227f31d
      }
  
      public static Vec3 collideBoundingBox(@Nullable Entity entity, Vec3 movement, AABB entityBoundingBox, Level world, List<VoxelShape> collisions) {
-@@ -2456,11 +2537,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2455,11 +2536,30 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              float f = this.dimensions.width * 0.8F;
              AABB axisalignedbb = AABB.ofSize(this.getEyePosition(), (double) f, 1.0E-6D, (double) f);
  

--- a/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
+++ b/patches/server/0779-Forward-CraftEntity-in-teleport-command.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Forward CraftEntity in teleport command
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 10c1da2d76d48c30eab310a38227f31d1f75168f..210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0 100644
+index 9dbe61ef5cea1b39216551462ea79cc8658839ed..b92924de92af850c67b72112f3747cafcaaef07b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -3278,6 +3278,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3277,6 +3277,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      public void restoreFrom(Entity original) {
@@ -22,7 +22,7 @@ index 10c1da2d76d48c30eab310a38227f31d1f75168f..210b58b78e7ebe8dd24bc0e289bd5b33
          CompoundTag nbttagcompound = original.saveWithoutId(new CompoundTag());
  
          nbttagcompound.remove("Dimension");
-@@ -3359,10 +3366,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -3358,10 +3365,10 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      if (worldserver.getTypeKey() == LevelStem.END) { // CraftBukkit
                          ServerLevel.makeObsidianPlatform(worldserver, this); // CraftBukkit
                      }

--- a/patches/server/0805-Freeze-Tick-Lock-API.patch
+++ b/patches/server/0805-Freeze-Tick-Lock-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Freeze Tick Lock API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0..f8bf2fc17d2a5b762437ca2fbe2fe0a05f521d2d 100644
+index b92924de92af850c67b72112f3747cafcaaef07b..6cf2f6539ece7509efe5ae0dc66e73231718976d 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -397,6 +397,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
@@ -25,7 +25,7 @@ index 210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0..f8bf2fc17d2a5b762437ca2fbe2fe0a0
                  this.setTicksFrozen(0);
                  this.level.levelEvent((Player) null, 1009, this.blockPosition, 1);
              }
-@@ -2263,6 +2264,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2262,6 +2263,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (fromNetherPortal) {
                  nbt.putBoolean("Paper.FromNetherPortal", true);
              }
@@ -35,7 +35,7 @@ index 210b58b78e7ebe8dd24bc0e289bd5b33e7a8bda0..f8bf2fc17d2a5b762437ca2fbe2fe0a0
              // Paper end
              return nbt;
          } catch (Throwable throwable) {
-@@ -2427,6 +2431,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2426,6 +2430,9 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              if (spawnReason == null) {
                  spawnReason = org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.DEFAULT;
              }

--- a/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
+++ b/patches/server/0840-Ensure-entity-passenger-world-matches-ridden-entity.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Ensure entity passenger world matches ridden entity
 Bad plugins doing this would cause some obvious problems...
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f8bf2fc17d2a5b762437ca2fbe2fe0a05f521d2d..8d80717589046271119552726e3b4bbd403dac65 100644
+index 6cf2f6539ece7509efe5ae0dc66e73231718976d..869c38119d030c849cff2b66b3fd26f143933782 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2686,6 +2686,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2685,6 +2685,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
      }
  
      protected boolean addPassenger(Entity entity) { // CraftBukkit

--- a/patches/server/0841-Guard-against-invalid-entity-positions.patch
+++ b/patches/server/0841-Guard-against-invalid-entity-positions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Guard against invalid entity positions
 Anything not finite should be blocked and logged
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 8d80717589046271119552726e3b4bbd403dac65..7f104aa35dce81d2299cb7b4a3e560e67105da4a 100644
+index 869c38119d030c849cff2b66b3fd26f143933782..445eebd06c2eb681c334bdf07c9fd6517705b128 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -4199,11 +4199,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -4198,11 +4198,33 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
          return this.getZ((2.0D * this.random.nextDouble() - 1.0D) * widthScale);
      }
  

--- a/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
+++ b/patches/server/0881-Add-various-missing-EntityDropItemEvent-calls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add various missing EntityDropItemEvent calls
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index f7eb87eb4e2a3fe0d07d61543a7cf23a30699222..870e628f8039ce0ee4bc850ce82cfb3b3fb3db65 100644
+index c2fe2722909ad25c97da90b4a94386b7c9b82244..07ed6d6e9064a1504d85ab2d1f3d8a288fd3372b 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2522,6 +2522,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2521,6 +2521,14 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
              stack.setCount(0); // Paper - destroy this item - if this ever leaks due to game bugs, ensure it doesn't dupe
  
              entityitem.setDefaultPickUpDelay();

--- a/patches/server/0887-Add-EntityPortalReadyEvent.patch
+++ b/patches/server/0887-Add-EntityPortalReadyEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add EntityPortalReadyEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 870e628f8039ce0ee4bc850ce82cfb3b3fb3db65..756b8e68c6b7c21c1ef78b68da9e41db4828c7c9 100644
+index 07ed6d6e9064a1504d85ab2d1f3d8a288fd3372b..a80f4abf8a0c6c395f407c8bf25b44a64b0b9fe3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
-@@ -2869,6 +2869,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2868,6 +2868,13 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                  if (true && !this.isPassenger() && this.portalTime++ >= i) { // CraftBukkit
                      this.level.getProfiler().push("portal");
                      this.portalTime = i;
@@ -22,7 +22,7 @@ index 870e628f8039ce0ee4bc850ce82cfb3b3fb3db65..756b8e68c6b7c21c1ef78b68da9e41db
                      this.setPortalCooldown();
                      // CraftBukkit start
                      if (this instanceof ServerPlayer) {
-@@ -2876,6 +2883,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
+@@ -2875,6 +2882,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource {
                      } else {
                          this.changeDimension(worldserver1);
                      }


### PR DESCRIPTION
Fixes #7208
Related to #6981

These 3 paper yml settings relied on outdated information about min/max y values which leads to valid values meaning "disabled". This refactors and adds migrations to have a separate boolean for toggling its enable status and a level for configuring the level.

I tested the migrations both with values in the default world-settings section and the specific world settings. 