### PR TITLE
Fix NPE when getting destroy speed of air

### DIFF
--- a/patches/server/0538-Add-Destroy-Speed-API.patch
+++ b/patches/server/0538-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-index e69b1831cbfdff3f2b1e4be4d5de313bfe724795..f0d5c3a182acc8a2ccb936e98376f2840892be28 100644
+index e69b1831cbfdff3f2b1e4be4d5de313bfe724795..fcaf05af6cfd15e0e313c4ffeb5dfd604806afbd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
 +++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
-@@ -635,5 +635,23 @@ public class CraftBlock implements Block {
+@@ -635,5 +635,26 @@ public class CraftBlock implements Block {
      public String translationKey() {
          return org.bukkit.Bukkit.getUnsafe().getTranslationKey(this);
      }
@@ -19,10 +19,13 @@ index e69b1831cbfdff3f2b1e4be4d5de313bfe724795..f0d5c3a182acc8a2ccb936e98376f284
 +        net.minecraft.world.item.ItemStack nmsItemStack;
 +        if (itemStack instanceof CraftItemStack) {
 +            nmsItemStack = ((CraftItemStack) itemStack).handle;
++            if (nmsItemStack == null) {
++                nmsItemStack = net.minecraft.world.item.ItemStack.EMPTY;
++            }
 +        } else {
 +            nmsItemStack = CraftItemStack.asNMSCopy(itemStack);
 +        }
-+        float speed = nmsItemStack.getItem().getDestroySpeed(nmsItemStack, this.getNMS().getBlock().defaultBlockState());
++        float speed = nmsItemStack.getDestroySpeed(this.getNMS().getBlock().defaultBlockState());
 +        if (speed > 1.0F && considerEnchants) {
 +            int enchantLevel = net.minecraft.world.item.enchantment.EnchantmentHelper.getItemEnchantmentLevel(net.minecraft.world.item.enchantment.Enchantments.BLOCK_EFFICIENCY, nmsItemStack);
 +            if (enchantLevel > 0) {


### PR DESCRIPTION
Prevents `java.lang.NullPointerException: Cannot invoke "net.minecraft.world.item.ItemStack.getItem()" because "nmsItemStack" is null` when calling `Block#getDestroySpeed(ItemStack itemStack)` for air.