### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/patches/server/0414-Villager-Restocks-API.patch
+++ b/patches/server/0414-Villager-Restocks-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Villager Restocks API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index 503c547451b8754342197d8b6f9bb0f1298f83c2..e9a51b5b387ff91b5840bbd13ed6c5b776283ed9 100644
+index c5fdb1b956ffbd90b119c821a8a11e4dfff33058..0cd83a20ab565c9a5a38f19eed016289237e72ab 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-@@ -83,6 +83,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -90,6 +90,18 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
          this.getHandle().setVillagerXp(experience);
      }
  

--- a/patches/server/0422-Add-villager-reputation-API.patch
+++ b/patches/server/0422-Add-villager-reputation-API.patch
@@ -62,7 +62,7 @@ index 284608f404d1bd588dd9f4c0cd86a21d46394627..971ef3d98057ede1316e07cc1e9dcb27
  
      static class GossipEntry {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
-index e9a51b5b387ff91b5840bbd13ed6c5b776283ed9..67cf86dfad91ee5afea3b4b48f89224af3ea2354 100644
+index 0cd83a20ab565c9a5a38f19eed016289237e72ab..dbc1ea96223675fbe03585598a9c7f51acc61d2e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftVillager.java
 @@ -16,6 +16,13 @@ import org.bukkit.entity.Villager;
@@ -79,7 +79,7 @@ index e9a51b5b387ff91b5840bbd13ed6c5b776283ed9..67cf86dfad91ee5afea3b4b48f89224a
  public class CraftVillager extends CraftAbstractVillager implements Villager {
  
      public CraftVillager(CraftServer server, net.minecraft.world.entity.npc.Villager entity) {
-@@ -132,4 +139,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
+@@ -139,4 +146,45 @@ public class CraftVillager extends CraftAbstractVillager implements Villager {
      public static VillagerProfession bukkitToNmsProfession(Profession bukkit) {
          return Registry.VILLAGER_PROFESSION.get(CraftNamespacedKey.toMinecraft(bukkit.getKey()));
      }


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
4b5f9882 Fix when bundler directory is a symlink
6f3509d1 Release POIs when villagers are removed by plugins