### PR TITLE
Sanitize Sent BlockEntity NBT

### DIFF
--- a/patches/server/0819-Sanitize-Sent-BlockEntity-NBT.patch
+++ b/patches/server/0819-Sanitize-Sent-BlockEntity-NBT.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Fri, 3 Dec 2021 16:55:50 -0500
+Subject: [PATCH] Sanitize Sent BlockEntity NBT
+
+
+diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
+index 43220caaa331eade5b183f68f09d94542b4bc3db..8c87020e422acfb6b862d9d77e74114770f1b342 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
++++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundBlockEntityDataPacket.java
+@@ -17,7 +17,7 @@ public class ClientboundBlockEntityDataPacket implements Packet<ClientGamePacket
+     private final CompoundTag tag;
+ 
+     public static ClientboundBlockEntityDataPacket create(BlockEntity blockEntity, Function<BlockEntity, CompoundTag> nbtGetter) {
+-        return new ClientboundBlockEntityDataPacket(blockEntity.getBlockPos(), blockEntity.getType(), nbtGetter.apply(blockEntity));
++        return new ClientboundBlockEntityDataPacket(blockEntity.getBlockPos(), blockEntity.getType(), blockEntity.sanitizeSentNbt(nbtGetter.apply(blockEntity))); // Paper - Sanitize sent data
+     }
+ 
+     public static ClientboundBlockEntityDataPacket create(BlockEntity blockEntity) {
+diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
+index 0e75764c108c24b3e2c453f2b4f14e798add0eb4..0fa057b70c2dc843115cb7ffe7ddb6abe4bff3bf 100644
+--- a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
++++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
+@@ -184,6 +184,7 @@ public class ClientboundLevelChunkPacketData {
+             BlockPos blockPos = blockEntity.getBlockPos();
+             if (blockEntity instanceof net.minecraft.world.level.block.entity.SkullBlockEntity) { net.minecraft.world.level.block.entity.SkullBlockEntity.sanitizeTileEntityUUID(compoundTag); } // Paper
+             int i = SectionPos.sectionRelative(blockPos.getX()) << 4 | SectionPos.sectionRelative(blockPos.getZ());
++            blockEntity.sanitizeSentNbt(compoundTag); // Paper - Sanitize sent data
+             return new ClientboundLevelChunkPacketData.BlockEntityInfo(i, blockPos.getY(), blockEntity.getType(), compoundTag.isEmpty() ? null : compoundTag);
+         }
+     }
+diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
+index 5601d0c2fe635a2a4f073c333531e1a8adf1833c..b6bba77accfe21926999fb4b0d049f6dceeb60b2 100644
+--- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
++++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
+@@ -276,4 +276,12 @@ public abstract class BlockEntity implements io.papermc.paper.util.KeyedObject {
+         return null;
+     }
+     // CraftBukkit end
++    // Paper start
++    public CompoundTag sanitizeSentNbt(CompoundTag tag) {
++        tag.remove("PublicBukkitValues");
++
++        return tag;
++    }
++    // Paper end
++
+ }

--- a/patches/server/0908-Sanitize-Sent-BlockEntity-NBT.patch
+++ b/patches/server/0908-Sanitize-Sent-BlockEntity-NBT.patch
@@ -18,7 +18,7 @@ index 43220caaa331eade5b183f68f09d94542b4bc3db..8c87020e422acfb6b862d9d77e741147
  
      public static ClientboundBlockEntityDataPacket create(BlockEntity blockEntity) {
 diff --git a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
-index 0e75764c108c24b3e2c453f2b4f14e798add0eb4..0fa057b70c2dc843115cb7ffe7ddb6abe4bff3bf 100644
+index 52f68d7611862b0e904305f8a16f04422b2b5b3f..07b64291c3b0390b746433dd42c32534a2b05018 100644
 --- a/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 +++ b/src/main/java/net/minecraft/network/protocol/game/ClientboundLevelChunkPacketData.java
 @@ -184,6 +184,7 @@ public class ClientboundLevelChunkPacketData {
@@ -30,10 +30,10 @@ index 0e75764c108c24b3e2c453f2b4f14e798add0eb4..0fa057b70c2dc843115cb7ffe7ddb6ab
          }
      }
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 5601d0c2fe635a2a4f073c333531e1a8adf1833c..b6bba77accfe21926999fb4b0d049f6dceeb60b2 100644
+index d62181bd8bccfcfdd7da8f635bdf7ebc36294705..b96d57b0bcf21508f8e03e96b7553eb486fdf212 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-@@ -276,4 +276,12 @@ public abstract class BlockEntity implements io.papermc.paper.util.KeyedObject {
+@@ -256,4 +256,12 @@ public abstract class BlockEntity {
          return null;
      }
      // CraftBukkit end


### PR DESCRIPTION
The method BlockEntity#saveWithoutMetadata applies the PersistentDataContainer tag to the given tag.
A lot of block entities use this method in the getUpdateTag() method in order to receive certain data (like sign lines) on the client.


This removes this data sent to the client (this applies to lots of tile entities).
I also am wondering, should I move this method into the patch that adds
``` if (blockEntity instanceof net.minecraft.world.level.block.entity.SkullBlockEntity) { net.minecraft.world.level.block.entity.SkullBlockEntity.sanitizeTileEntityUUID(compoundTag); } // Paper```?

Although this issue was fixed, I was told it was supposed to be kept. Not sure what to do here about that.

