### PR TITLE
Fix kelp modifier changing growth for other crops

### DIFF
--- a/patches/server/0819-Fix-kelp-modifier-changing-growth-for-other-crops.patch
+++ b/patches/server/0819-Fix-kelp-modifier-changing-growth-for-other-crops.patch
@@ -1,0 +1,104 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jason Penilla <11360596+jpenilla@users.noreply.github.com>
+Date: Fri, 3 Dec 2021 17:09:24 -0800
+Subject: [PATCH] Fix kelp modifier changing growth for other crops
+
+Also add growth modifiers for twisting vines, weeping vines, cave vines,
+and glow berries
+
+diff --git a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
+index 87dabe3c80b48bff52f2e3dbbaceb37a1a21e431..effee89e308c9a663938ac5b00a8c6512ce407c2 100644
+--- a/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/CaveVinesBlock.java
+@@ -47,9 +47,17 @@ public class CaveVinesBlock extends GrowingPlantHeadBlock implements Bonemealabl
+ 
+     @Override
+     protected BlockState getGrowIntoState(BlockState state, Random random) {
+-        return (BlockState) super.getGrowIntoState(state, random).setValue(CaveVinesBlock.BERRIES, random.nextFloat() < 0.11F);
++        // Paper start
++        return this.getGrowIntoState(state, random, null);
+     }
+ 
++    @Override
++    protected BlockState getGrowIntoState(BlockState state, Random random, Level level) {
++        final boolean value = (level == null ? random.nextFloat() : random.nextFloat(100.00F / level.spigotConfig.glowBerryModifier)) < 0.11F;
++        return super.getGrowIntoState(state, random).setValue(CaveVinesBlock.BERRIES, value);
++    }
++    // Paper end
++
+     @Override
+     public ItemStack getCloneItemStack(BlockGetter world, BlockPos pos, BlockState state) {
+         return new ItemStack(Items.GLOW_BERRIES);
+diff --git a/src/main/java/net/minecraft/world/level/block/GrowingPlantHeadBlock.java b/src/main/java/net/minecraft/world/level/block/GrowingPlantHeadBlock.java
+index def3b62feada5cebae4049883fa967b12f6f32b4..d3dde8ce3f55bda0b7f55491aef3bc9aaad43dd3 100644
+--- a/src/main/java/net/minecraft/world/level/block/GrowingPlantHeadBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/GrowingPlantHeadBlock.java
+@@ -40,16 +40,36 @@ public abstract class GrowingPlantHeadBlock extends GrowingPlantBlock implements
+ 
+     @Override
+     public void randomTick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
+-        if ((Integer) state.getValue(GrowingPlantHeadBlock.AGE) < 25 && random.nextDouble() < (100.0D / world.spigotConfig.kelpModifier) * this.growPerTickProbability) { // Spigot
++        // Paper start
++        final int modifier;
++        if (state.is(Blocks.TWISTING_VINES) || state.is(Blocks.TWISTING_VINES_PLANT)) {
++            modifier = world.spigotConfig.twistingVinesModifier;
++        } else if (state.is(Blocks.WEEPING_VINES) || state.is(Blocks.WEEPING_VINES_PLANT)) {
++            modifier = world.spigotConfig.weepingVinesModifier;
++        } else if (state.is(Blocks.CAVE_VINES) || state.is(Blocks.CAVE_VINES_PLANT)) {
++            modifier = world.spigotConfig.caveVinesModifier;
++        } else if (state.is(Blocks.KELP) || state.is(Blocks.KELP_PLANT)) {
++            modifier = world.spigotConfig.kelpModifier;
++        } else {
++            modifier = 100; // Above cases are exhaustive as of 1.18
++        }
++        if ((Integer) state.getValue(GrowingPlantHeadBlock.AGE) < 25 && random.nextDouble() < (100.0D / modifier) * this.growPerTickProbability) { // Spigot
++            // Paper end
+             BlockPos blockposition1 = pos.relative(this.growthDirection);
+ 
+             if (this.canGrowInto(world.getBlockState(blockposition1))) {
+-                org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(world, pos, blockposition1, this.getGrowIntoState(state, world.random)); // CraftBukkit
++                org.bukkit.craftbukkit.event.CraftEventFactory.handleBlockSpreadEvent(world, pos, blockposition1, this.getGrowIntoState(state, world.random, world)); // CraftBukkit // Paper
+             }
+         }
+ 
+     }
+ 
++    // Paper start
++    protected BlockState getGrowIntoState(BlockState state, Random random, Level level) {
++        return this.getGrowIntoState(state, random);
++    }
++    // Paper end
++
+     protected BlockState getGrowIntoState(BlockState state, Random random) {
+         return (BlockState) state.cycle(GrowingPlantHeadBlock.AGE);
+     }
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index 9f7541cb62600f022da75cba74731ff4e57f7f36..f144ca888518f1bdb84ee811410937cba994245c 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -103,6 +103,12 @@ public class SpigotWorldConfig
+     public int bambooModifier;
+     public int sweetBerryModifier;
+     public int kelpModifier;
++    // Paper start
++    public int twistingVinesModifier;
++    public int weepingVinesModifier;
++    public int caveVinesModifier;
++    public int glowBerryModifier;
++    // Paper end
+     private int getAndValidateGrowth(String crop)
+     {
+         int modifier = this.getInt( "growth." + crop.toLowerCase(java.util.Locale.ENGLISH) + "-modifier", 100 );
+@@ -133,6 +139,12 @@ public class SpigotWorldConfig
+         this.bambooModifier = this.getAndValidateGrowth( "Bamboo" );
+         this.sweetBerryModifier = this.getAndValidateGrowth( "SweetBerry" );
+         this.kelpModifier = this.getAndValidateGrowth( "Kelp" );
++        // Paper start
++        this.twistingVinesModifier = this.getAndValidateGrowth("TwistingVines");
++        this.weepingVinesModifier = this.getAndValidateGrowth("WeepingVines");
++        this.caveVinesModifier = this.getAndValidateGrowth("CaveVines");
++        this.glowBerryModifier = this.getAndValidateGrowth("GlowBerry");
++        // Paper end
+     }
+ 
+     public double itemMerge;


### PR DESCRIPTION
Also add growth modifiers for twisting vines, weeping vines, cave vines,
and glow berries

fixes #6807

currently the configs for kelp, and twisting/weeping/cave vines have the inverse effect to the rest of the growth modifier configs, #6806 aims to address that (will need a rebase however)