### PR TITLE
Properly pass SplashPotion entity to damage source

### DIFF
--- a/patches/server/0683-Fix-PotionSplashEvent-for-water-splash-potions.patch
+++ b/patches/server/0683-Fix-PotionSplashEvent-for-water-splash-potions.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Fix PotionSplashEvent for water splash potions
 Fixes SPIGOT-6221: https://hub.spigotmc.org/jira/projects/SPIGOT/issues/SPIGOT-6221
 
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
-index 517a0f6bf847c5bf01851ae326d1b12332c2672c..1adcc0321b5528a4a173027be67139a9e9be5770 100644
+index 517a0f6bf847c5bf01851ae326d1b12332c2672c..c9fbfeaa8b5a4e4e2863b556a02d3e8e86f17d25 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/ThrownPotion.java
 @@ -125,6 +125,7 @@ public class ThrownPotion extends ThrowableItemProjectile implements ItemSupplie
@@ -34,7 +34,7 @@ index 517a0f6bf847c5bf01851ae326d1b12332c2672c..1adcc0321b5528a4a173027be67139a9
 +        if (!event.isCancelled()) {
 +            for (LivingEntity affectedEntity : event.getAffectedEntities()) {
 +                net.minecraft.world.entity.LivingEntity entityliving = ((CraftLivingEntity) affectedEntity).getHandle();
-+                entityliving.hurt(DamageSource.indirectMagic(entityliving, this.getOwner()), 1.0F);
++                entityliving.hurt(DamageSource.indirectMagic(this, this.getOwner()), 1.0F);
 +            }
 +        }
 +        // Paper end


### PR DESCRIPTION
This commit modifies the potion splash event fixes added by paper, as
they passed the affected entity as the entity to the damage source,
meaning the entity would technically attempt to hurt itself.

This change fixes this by now properly passing the splash potion to the
damage source, allowing custom damage logic like the enderman water
damage logic, to properly detect the entity that is attempting to hurt
the affected target.