### PR TITLE
[ci skip] Remove reobfJar from paper-server publication

### DIFF
--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -28,10 +28,10 @@ index 67fb370cad6924895a6b27052dbd5c1767e3f0c9..bb338269c9e3bef4c274157c490d8b8f
 +/.factorypath
 diff --git a/build.gradle.kts b/build.gradle.kts
 new file mode 100644
-index 0000000000000000000000000000000000000000..139f377673414e1d0213129549e94934b511aa57
+index 0000000000000000000000000000000000000000..9c4382ef7373110b6e72163779316ff40234a992
 --- /dev/null
 +++ b/build.gradle.kts
-@@ -0,0 +1,144 @@
+@@ -0,0 +1,141 @@
 +import io.papermc.paperweight.util.*
 +
 +plugins {
@@ -87,9 +87,6 @@ index 0000000000000000000000000000000000000000..139f377673414e1d0213129549e94934
 +
 +publishing {
 +    publications.create<MavenPublication>("maven") {
-+        artifact(tasks.reobfJar) {
-+            classifier = null
-+        }
 +        artifact(tasks.shadowJar)
 +    }
 +}

--- a/patches/server/0420-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0420-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Deobfuscate stacktraces in log messages, crash reports, and
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index fc59f56860d02ef8c11082feae042a39e3924f45..79d80e5a5e52d2bc45f63eeb81c6f4fd858f7ffc 100644
+index 6e47e915134bccb7efa9555d7f33fbe82a25c003..30f31973478175fe62877e21ab6a5473801a58dc 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -1,4 +1,6 @@
@@ -45,7 +45,7 @@ index fc59f56860d02ef8c11082feae042a39e3924f45..79d80e5a5e52d2bc45f63eeb81c6f4fd
      testImplementation("junit:junit:4.13.1")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
  }
-@@ -95,6 +105,45 @@ tasks.shadowJar {
+@@ -92,6 +102,45 @@ tasks.shadowJar {
      }
  }
  


### PR DESCRIPTION
As of 1.18, runtime mappings are not even valid to compile against, so no point in publishing this artifact