### PR TITLE
Fix riding distance statistics (#7021/SPIGOT-6475)

### DIFF
--- a/build-data/paper.at
+++ b/build-data/paper.at
@@ -295,3 +295,6 @@ public net.minecraft.world.entity.monster.Skeleton inPowderSnowTime
 
 # Add health methods for item entities
 public net.minecraft.world.entity.item.ItemEntity health
+
+# Fix riding distance statistics
+public net.minecraft.world.entity.player.Player checkRidingStatistics(DDD)V

--- a/patches/server/0843-Fix-riding-distance-statistics.patch
+++ b/patches/server/0843-Fix-riding-distance-statistics.patch
@@ -1,0 +1,46 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Marvin Rieple <derrieple@gmail.com>
+Date: Sun, 5 Dec 2021 16:42:07 +0100
+Subject: [PATCH] Fix riding distance statistics
+
+Fixes entity ride distance stats not being awarded correctly.
+Based upon https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/pull-requests/900
+
+diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+index b9e0dc98243bee3de7eb291dd3fb25049c0a8f2b..3c7e3d5b06409bf2e98a35d678564f0e477481a9 100644
+--- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
++++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
+@@ -608,7 +608,14 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+                 Location curPos = this.getCraftPlayer().getLocation(); // Spigot
+ 
+                 entity.absMoveTo(d3, d4, d5, f, f1);
+-                this.player.absMoveTo(d3, d4, d5, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
++                // Paper start - SPIGOT-4396: Synchronize player and vehicle
++                // Based upon https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/pull-requests/900
++                Vec3 oldPlayerPosition = this.player.position();
++                entity.positionRider(this.player);
++                this.player.xo = oldPlayerPosition.x;
++                this.player.yo = oldPlayerPosition.y;
++                this.player.zo = oldPlayerPosition.z;
++                // Paper end
+                 // Paper start - optimise out extra getCubes
+                 boolean teleportBack = flag1; // violating this is always a fail
+                 if (!teleportBack) {
+@@ -620,10 +627,16 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
+                 }
+                 if (teleportBack) { // Paper end - optimise out extra getCubes
+                     entity.absMoveTo(d0, d1, d2, f, f1);
+-                    this.player.absMoveTo(d0, d1, d2, this.player.getYRot(), this.player.getXRot()); // CraftBukkit
++                    // Paper start - SPIGOT-6475
++                    entity.positionRider(this.player);
++                    this.player.xo = oldPlayerPosition.x;
++                    this.player.yo = oldPlayerPosition.y;
++                    this.player.zo = oldPlayerPosition.z;
++                    // Paper end
+                     this.connection.send(new ClientboundMoveVehiclePacket(entity));
+                     return;
+                 }
++                player.checkRidingStatistics(player.getX() - oldPlayerPosition.x, player.getY() - oldPlayerPosition.y, player.getZ() - oldPlayerPosition.z); // Paper - SPIGOT-6475: Update riding statistic
+ 
+                 // CraftBukkit start - fire PlayerMoveEvent
+                 Player player = this.getCraftPlayer();


### PR DESCRIPTION
This PR ports a slightly simplified version of [craftbukkit#900](https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/pull-requests/900) to 1.18. As described in the Spigot PR,
Spigot synchronizes the position of the vehicle and the player. However, these locations may not
always match up. Later down the line, the player position gets set to the correct position, and the player
gets the difference between the correct and incorrect value added to the statistic.

Thanks to @TDWilkinson99 for making such a detailed and easy to reproduce issue report ![](https://cdn.discordapp.com/emojis/844628007825965088.png?size=16)