### PR TITLE
Improve behavior of filter-nbt-data-from-spawn-eggs-and-related config

### DIFF
--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,7 +5,6 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 
-
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index 80345730b8ccc11d3d0833485d25b03f614aeee2..6eb3678177834a4b34b78ba8e359528de7c0d2f0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -3,6 +3,8 @@ From: Zach Brown <zach.brown@destroystokyo.com>
 Date: Sat, 12 Nov 2016 23:25:22 -0600
 Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
+Co-authored-by: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 index 80345730b8ccc11d3d0833485d25b03f614aeee2..6eb3678177834a4b34b78ba8e359528de7c0d2f0 100644
@@ -21,26 +23,45 @@ index 80345730b8ccc11d3d0833485d25b03f614aeee2..6eb3678177834a4b34b78ba8e359528d
 +        }
 +    }
  }
+diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
+index 20cfdba68c200e87d00995a6a4e25a5fa8171f6c..719be4237fb260d0193b49a7f5fd60cbc10fbb0a 100644
+--- a/src/main/java/net/minecraft/world/entity/EntityType.java
++++ b/src/main/java/net/minecraft/world/entity/EntityType.java
+@@ -401,6 +401,7 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
+                     CompoundTag nbttagcompound1 = entity.saveWithoutId(new CompoundTag());
+                     UUID uuid = entity.getUUID();
+ 
++                    if (world.paperConfig.filterNBTFromSpawnEgg) { filterBadNbt(itemNbt.getCompound("EntityTag")); }
+                     nbttagcompound1.merge(itemNbt.getCompound("EntityTag"));
+                     entity.setUUID(uuid);
+                     entity.load(nbttagcompound1);
+@@ -408,6 +409,16 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
+             }
+         }
+     }
++    // Paper start - Filter bad NBT
++    private static void filterBadNbt(CompoundTag tag) {
++        tag.remove("Pos");
++        tag.remove("Motion");
++        tag.remove("Rotation");
++        tag.remove("SleepingX");
++        tag.remove("SleepingY");
++        tag.remove("SleepingZ");
++    }
++    // Paper end - Filter bad NBT
+ 
+     public boolean canSerialize() {
+         return this.serialize;
 diff --git a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-index 0366303a986ae6da8e95ed3051610c432a790194..a8a9cbcece45c3480120cb2fa0fa03523a87d317 100644
+index 0366303a986ae6da8e95ed3051610c432a790194..7b4a1adbf093df869d0a5654e1cd7501ae9f2bc4 100644
 --- a/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/FallingBlockEntity.java
-@@ -324,6 +324,18 @@ public class FallingBlockEntity extends Entity {
-     @Override
-     protected void readAdditionalSaveData(CompoundTag nbt) {
-         this.blockState = NbtUtils.readBlockState(nbt.getCompound("BlockState"));
-+        // Paper start - Block FallingBlocks with Command Blocks
-+        final Block b = this.blockState.getBlock();
-+        if (this.level.paperConfig.filterNBTFromSpawnEgg
-+            && (b == Blocks.COMMAND_BLOCK
-+            || b == Blocks.REPEATING_COMMAND_BLOCK
-+            || b == Blocks.CHAIN_COMMAND_BLOCK
-+            || b == Blocks.JIGSAW
-+            || b == Blocks.STRUCTURE_BLOCK
-+            || b instanceof net.minecraft.world.level.block.GameMasterBlock)) {
-+            this.blockState = Blocks.STONE.defaultBlockState();
-+        }
-+        // Paper end
-         this.time = nbt.getInt("Time");
-         if (nbt.contains("HurtEntities", 99)) {
-             this.hurtEntities = nbt.getBoolean("HurtEntities");
+@@ -337,7 +337,7 @@ public class FallingBlockEntity extends Entity {
+             this.dropItem = nbt.getBoolean("DropItem");
+         }
+ 
+-        if (nbt.contains("TileEntityData", 10)) {
++        if (nbt.contains("TileEntityData", 10) && !(this.level.paperConfig.filterNBTFromSpawnEgg && this.blockState.getBlock() instanceof net.minecraft.world.level.block.GameMasterBlock)) { // Paper - Filter bad NBT
+             this.blockData = nbt.getCompound("TileEntityData");
+         }
+ 

--- a/patches/server/0625-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0625-Entity-load-save-limit-per-chunk.patch
@@ -9,7 +9,7 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 716747f86cb7b4ee811c5e128c00b5319959cb64..3db7a4ad81db0475ce975c02c435a069abf2ad7e 100644
+index f372caad76d5f59f37d073bb245fca3a037c2bef..1fc750c1f33d8f25a65cf286fd88fd21ab46c0ef 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -8,6 +8,8 @@ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
@@ -61,10 +61,10 @@ index 716747f86cb7b4ee811c5e128c00b5319959cb64..3db7a4ad81db0475ce975c02c435a069
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/EntityType.java b/src/main/java/net/minecraft/world/entity/EntityType.java
-index d17bde781ff574799054d9696e4d4480fe04a52c..419a7e9614af2328ed401fc954196056243a984c 100644
+index c061cb3912f5cc218ea847289a9d4f2485608730..f90ad72fac79a92061fa45c348fd3a6cfce8c3b4 100644
 --- a/src/main/java/net/minecraft/world/entity/EntityType.java
 +++ b/src/main/java/net/minecraft/world/entity/EntityType.java
-@@ -560,9 +560,20 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
+@@ -571,9 +571,20 @@ public class EntityType<T extends Entity> implements EntityTypeTest<Entity, T> {
          final Spliterator<? extends net.minecraft.nbt.Tag> spliterator = entityNbtList.spliterator();
  
          return StreamSupport.stream(new Spliterator<Entity>() {


### PR DESCRIPTION
This patch seemed to no longer work exactly anymore, as at least the behavior of filtering is no longer in this patch.

This readds it, and also instead of completely making blocks like command blocks turn to stone instead just wipe all tile entity data (opinion wanted on this).

Other nbt tags to remove can be suggested!