### PR TITLE
[ci skip] Add nullable annotation to field

### DIFF
--- a/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -79,7 +79,7 @@ index 2a11514554b6aea819046282cfcaeeb43d1ed920..2981a29b011cb1a08a776abc5ec6a942
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
  
-+    public @javax.annotation.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
++    public @org.jetbrains.annotations.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
 +    public Throwable addedToWorldStack; // Paper - entity debug
      public CraftEntity getBukkitEntity() {
          if (this.bukkitEntity == null) {

--- a/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
+++ b/patches/server/0242-Add-Debug-Entities-option-to-debug-dupe-uuid-issues.patch
@@ -79,7 +79,7 @@ index 2a11514554b6aea819046282cfcaeeb43d1ed920..2981a29b011cb1a08a776abc5ec6a942
      public com.destroystokyo.paper.loottable.PaperLootableInventoryData lootableData; // Paper
      private CraftEntity bukkitEntity;
  
-+    public net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
++    public @javax.annotation.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
 +    public Throwable addedToWorldStack; // Paper - entity debug
      public CraftEntity getBukkitEntity() {
          if (this.bukkitEntity == null) {

--- a/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
@@ -26,7 +26,7 @@ index 81aee8c195307fd3cd4a89c29ebb7ebc25436c83..2458619f7f377398322459e00a49f7f4
              entityplayer1.setPos(entityplayer1.getX(), entityplayer1.getY() + 1.0D, entityplayer1.getZ());
          }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 497fec66a9bb22ca9e4c8eea6c588bb42f64b320..fa4242cb9bd5b8b5a088585a6709d0b27835a261 100644
+index bd45dea99ea38b07577e2dbf399b87856bc28573..333686cdcedd612ddbd33ec0ef8a3beb326d41b3 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -171,6 +171,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -36,7 +36,7 @@ index 497fec66a9bb22ca9e4c8eea6c588bb42f64b320..fa4242cb9bd5b8b5a088585a6709d0b2
 +    public boolean collisionLoadChunks = false; // Paper
      private CraftEntity bukkitEntity;
  
-     public net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
+     public @javax.annotation.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
 diff --git a/src/main/java/net/minecraft/world/level/BlockCollisions.java b/src/main/java/net/minecraft/world/level/BlockCollisions.java
 index 8390ce194ccc692139c0e870c16a7fb76ac8ba68..a733c91700a38634806e9155c693b227e6aa16b6 100644
 --- a/src/main/java/net/minecraft/world/level/BlockCollisions.java

--- a/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
+++ b/patches/server/0393-Optimize-Collision-to-not-load-chunks.patch
@@ -36,7 +36,7 @@ index bd45dea99ea38b07577e2dbf399b87856bc28573..333686cdcedd612ddbd33ec0ef8a3beb
 +    public boolean collisionLoadChunks = false; // Paper
      private CraftEntity bukkitEntity;
  
-     public @javax.annotation.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
+     public @org.jetbrains.annotations.Nullable net.minecraft.server.level.ChunkMap.TrackedEntity tracker; // Paper
 diff --git a/src/main/java/net/minecraft/world/level/BlockCollisions.java b/src/main/java/net/minecraft/world/level/BlockCollisions.java
 index 8390ce194ccc692139c0e870c16a7fb76ac8ba68..a733c91700a38634806e9155c693b227e6aa16b6 100644
 --- a/src/main/java/net/minecraft/world/level/BlockCollisions.java


### PR DESCRIPTION
Not sure if this change needs to go through, but it's just a one-line change. 

Intellij always marks this field as not able to be null, and although it's not null when the entity is alive it can be null when it's dead. Generally just a bit misleading.