### PR TITLE
Expose internal ids for entity types

### DIFF
--- a/patches/api/0347-Expose-entity-type-ids.patch
+++ b/patches/api/0347-Expose-entity-type-ids.patch
@@ -1,0 +1,24 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yive <admin@yive.me>
+Date: Mon, 6 Dec 2021 01:28:13 -0800
+Subject: [PATCH] Expose entity type ids
+
+
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index 014c9984018ad5e51a26228a137e1ba4eb3e80c8..551719c8bca5314160de3b4dbb4713c1e7cf43ce 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -217,5 +217,13 @@ public interface UnsafeValues {
+      * @throws IllegalArgumentException if {@link Material#isBlock()} is false
+      */
+     boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
++
++    /**
++     * Gets the id of entity types used in packets
++     *
++     * @param type the entity type
++     * @return entity type id
++     */
++    int getEntityProtocolId(org.bukkit.entity.EntityType type);
+     // Paper end
+ }

--- a/patches/server/0829-Expose-entity-type-ids.patch
+++ b/patches/server/0829-Expose-entity-type-ids.patch
@@ -1,0 +1,22 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Yive <admin@yive.me>
+Date: Mon, 6 Dec 2021 01:28:23 -0800
+Subject: [PATCH] Expose entity type ids
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index d51c63496b55d64ac7ee6175bc364012df897891..75989fd3a07a8210b418089adae06b2b9bed1f3d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -558,6 +558,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         Preconditions.checkArgument(material.isBlock(), material + " is not a block");
+         return getBlock(material).hasCollision;
+     }
++
++    @Override
++    public int getEntityProtocolId(org.bukkit.entity.EntityType type) {
++        return net.minecraft.core.Registry.ENTITY_TYPE.getId(getEntityTypes(type));
++    }
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
Entity types IDs in the Bukkit API rarely match the internal entity type IDs in the NMS. This will allow for plugins that make use of packets to no longer need reflection or Burger to get the proper entity type IDs for the server's version.