### PR TITLE
Fix simulation distance

### DIFF
--- a/patches/server/0437-Optimize-ServerLevels-chunk-level-checking-methods.patch
+++ b/patches/server/0437-Optimize-ServerLevels-chunk-level-checking-methods.patch
@@ -7,8 +7,552 @@ These can be hot functions (i.e entity ticking and block ticking),
 so inline where possible, and avoid the abstraction of the
 Either class.
 
+diff --git a/src/main/java/co/aikar/timings/TimingsExport.java b/src/main/java/co/aikar/timings/TimingsExport.java
+index ee53453440177537fc653ea156785d7591498614..d73e053fedceb5c04d36c51d1a205d32866247f6 100644
+--- a/src/main/java/co/aikar/timings/TimingsExport.java
++++ b/src/main/java/co/aikar/timings/TimingsExport.java
+@@ -152,7 +152,7 @@ public class TimingsExport extends Thread {
+                 pair("gamerules", toObjectMapper(world.getWorld().getGameRules(), rule -> {
+                     return pair(rule, world.getWorld().getGameRuleValue(rule));
+                 })),
+-                pair("ticking-distance", world.getChunkSource().chunkMap.getEffectiveViewDistance())
++                pair("ticking-distance", world.getChunkSource().chunkMap.distanceManager.simulationDistance)
+             ));
+         }));
+ 
+diff --git a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
+index c89f6986eda5a132a948732ea1b6923370685317..a7d60690555537db9f0e0e5e09ae202f67959467 100644
+--- a/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
++++ b/src/main/java/com/destroystokyo/paper/util/misc/AreaMap.java
+@@ -17,10 +17,10 @@ public abstract class AreaMap<E> {
+     /* Tested via https://gist.github.com/Spottedleaf/520419c6f41ef348fe9926ce674b7217 */
+ 
+     protected final Object2LongOpenHashMap<E> objectToLastCoordinate = new Object2LongOpenHashMap<>();
+-    protected final Object2IntOpenHashMap<E> objectToViewDistance = new Object2IntOpenHashMap<>();
++    protected final Object2IntOpenHashMap<E> objectToDistance = new Object2IntOpenHashMap<>();
+ 
+     {
+-        this.objectToViewDistance.defaultReturnValue(-1);
++        this.objectToDistance.defaultReturnValue(-1);
+         this.objectToLastCoordinate.defaultReturnValue(Long.MIN_VALUE);
+     }
+ 
+@@ -73,8 +73,8 @@ public abstract class AreaMap<E> {
+     }
+ 
+     // -1 indicates the object is not mapped
+-    public final int getLastViewDistance(final E object) {
+-        return this.objectToViewDistance.getOrDefault(object, -1);
++    public final int getLastDistance(final E object) {
++        return this.objectToDistance.getOrDefault(object, -1);
+     }
+ 
+     // returns the total number of mapped chunks
+@@ -82,89 +82,89 @@ public abstract class AreaMap<E> {
+         return this.areaMap.size();
+     }
+ 
+-    public final void addOrUpdate(final E object, final int chunkX, final int chunkZ, final int viewDistance) {
+-        final int oldViewDistance = this.objectToViewDistance.put(object, viewDistance);
++    public final void addOrUpdate(final E object, final int chunkX, final int chunkZ, final int distance) {
++        final int oldDistance = this.objectToDistance.put(object, distance);
+         final long newPos = MCUtil.getCoordinateKey(chunkX, chunkZ);
+         final long oldPos = this.objectToLastCoordinate.put(object, newPos);
+ 
+-        if (oldViewDistance == -1) {
+-            this.addObject(object, chunkX, chunkZ, Integer.MIN_VALUE, Integer.MIN_VALUE, viewDistance);
+-            this.addObjectCallback(object, chunkX, chunkZ, viewDistance);
++        if (oldDistance == -1) {
++            this.addObject(object, chunkX, chunkZ, Integer.MIN_VALUE, Integer.MIN_VALUE, distance);
++            this.addObjectCallback(object, chunkX, chunkZ, distance);
+         } else {
+-            this.updateObject(object, oldPos, newPos, oldViewDistance, viewDistance);
+-            this.updateObjectCallback(object, oldPos, newPos, oldViewDistance, viewDistance);
++            this.updateObject(object, oldPos, newPos, oldDistance, distance);
++            this.updateObjectCallback(object, oldPos, newPos, oldDistance, distance);
+         }
+-        //this.validate(object, viewDistance);
++        //this.validate(object, distance);
+     }
+ 
+-    public final boolean update(final E object, final int chunkX, final int chunkZ, final int viewDistance) {
+-        final int oldViewDistance = this.objectToViewDistance.replace(object, viewDistance);
+-        if (oldViewDistance == -1) {
++    public final boolean update(final E object, final int chunkX, final int chunkZ, final int distance) {
++        final int oldDistance = this.objectToDistance.replace(object, distance);
++        if (oldDistance == -1) {
+             return false;
+         } else {
+             final long newPos = MCUtil.getCoordinateKey(chunkX, chunkZ);
+             final long oldPos = this.objectToLastCoordinate.put(object, newPos);
+-            this.updateObject(object, oldPos, newPos, oldViewDistance, viewDistance);
+-            this.updateObjectCallback(object, oldPos, newPos, oldViewDistance, viewDistance);
++            this.updateObject(object, oldPos, newPos, oldDistance, distance);
++            this.updateObjectCallback(object, oldPos, newPos, oldDistance, distance);
+         }
+-        //this.validate(object, viewDistance);
++        //this.validate(object, distance);
+         return true;
+     }
+ 
+     // called after the distance map updates
+-    protected void updateObjectCallback(final E Object, final long oldPosition, final long newPosition, final int oldViewDistance, final int newViewDistance) {
++    protected void updateObjectCallback(final E Object, final long oldPosition, final long newPosition, final int oldDistance, final int newDistance) {
+         if (newPosition != oldPosition && this.changeSourceCallback != null) {
+             this.changeSourceCallback.accept(Object, oldPosition, newPosition);
+         }
+     }
+ 
+-    public final boolean add(final E object, final int chunkX, final int chunkZ, final int viewDistance) {
+-        final int oldViewDistance = this.objectToViewDistance.putIfAbsent(object, viewDistance);
+-        if (oldViewDistance != -1) {
++    public final boolean add(final E object, final int chunkX, final int chunkZ, final int distance) {
++        final int oldDistance = this.objectToDistance.putIfAbsent(object, distance);
++        if (oldDistance != -1) {
+             return false;
+         }
+ 
+         final long newPos = MCUtil.getCoordinateKey(chunkX, chunkZ);
+         this.objectToLastCoordinate.put(object, newPos);
+-        this.addObject(object, chunkX, chunkZ, Integer.MIN_VALUE, Integer.MIN_VALUE, viewDistance);
+-        this.addObjectCallback(object, chunkX, chunkZ, viewDistance);
++        this.addObject(object, chunkX, chunkZ, Integer.MIN_VALUE, Integer.MIN_VALUE, distance);
++        this.addObjectCallback(object, chunkX, chunkZ, distance);
+ 
+-        //this.validate(object, viewDistance);
++        //this.validate(object, distance);
+ 
+         return true;
+     }
+ 
+     // called after the distance map updates
+-    protected void addObjectCallback(final E object, final int chunkX, final int chunkZ, final int viewDistance) {}
++    protected void addObjectCallback(final E object, final int chunkX, final int chunkZ, final int distance) {}
+ 
+     public final boolean remove(final E object) {
+         final long position = this.objectToLastCoordinate.removeLong(object);
+-        final int viewDistance = this.objectToViewDistance.removeInt(object);
++        final int distance = this.objectToDistance.removeInt(object);
+ 
+-        if (viewDistance == -1) {
++        if (distance == -1) {
+             return false;
+         }
+ 
+         final int currentX = MCUtil.getCoordinateX(position);
+         final int currentZ = MCUtil.getCoordinateZ(position);
+ 
+-        this.removeObject(object, currentX, currentZ, currentX, currentZ, viewDistance);
+-        this.removeObjectCallback(object, currentX, currentZ, viewDistance);
++        this.removeObject(object, currentX, currentZ, currentX, currentZ, distance);
++        this.removeObjectCallback(object, currentX, currentZ, distance);
+         //this.validate(object, -1);
+         return true;
+     }
+ 
+     // called after the distance map updates
+-    protected void removeObjectCallback(final E object, final int chunkX, final int chunkZ, final int viewDistance) {}
++    protected void removeObjectCallback(final E object, final int chunkX, final int chunkZ, final int distance) {}
+ 
+     protected abstract PooledLinkedHashSets.PooledObjectLinkedOpenHashSet<E> getEmptySetFor(final E object);
+ 
+     // expensive op, only for debug
+-    protected void validate(final E object, final int viewDistance) {
++    protected void validate(final E object, final int distance) {
+         int entiesGot = 0;
+-        int expectedEntries = (2 * viewDistance + 1);
++        int expectedEntries = (2 * distance + 1);
+         expectedEntries *= expectedEntries;
+-        if (viewDistance < 0) {
++        if (distance < 0) {
+             expectedEntries = 0;
+         }
+ 
+@@ -192,8 +192,8 @@ public abstract class AreaMap<E> {
+ 
+                 final int dist = Math.max(IntegerUtil.branchlessAbs(chunkX - centerX), IntegerUtil.branchlessAbs(chunkZ - centerZ));
+ 
+-                if (dist > viewDistance) {
+-                    throw new IllegalStateException("Expected view distance " + viewDistance + ", got " + dist);
++                if (dist > distance) {
++                    throw new IllegalStateException("Expected view distance " + distance + ", got " + dist);
+                 }
+             }
+         }
+@@ -269,11 +269,11 @@ public abstract class AreaMap<E> {
+         }
+     }
+ 
+-    private void addObject(final E object, final int chunkX, final int chunkZ, final int prevChunkX, final int prevChunkZ, final int viewDistance) {
+-        final int maxX = chunkX + viewDistance;
+-        final int maxZ = chunkZ + viewDistance;
+-        final int minX = chunkX - viewDistance;
+-        final int minZ = chunkZ - viewDistance;
++    private void addObject(final E object, final int chunkX, final int chunkZ, final int prevChunkX, final int prevChunkZ, final int distance) {
++        final int maxX = chunkX + distance;
++        final int maxZ = chunkZ + distance;
++        final int minX = chunkX - distance;
++        final int minZ = chunkZ - distance;
+         for (int x = minX; x <= maxX; ++x) {
+             for (int z = minZ; z <= maxZ; ++z) {
+                 this.addObjectTo(object, x, z, chunkX, chunkZ, prevChunkX, prevChunkZ);
+@@ -281,11 +281,11 @@ public abstract class AreaMap<E> {
+         }
+     }
+ 
+-    private void removeObject(final E object, final int chunkX, final int chunkZ, final int currentChunkX, final int currentChunkZ, final int viewDistance) {
+-        final int maxX = chunkX + viewDistance;
+-        final int maxZ = chunkZ + viewDistance;
+-        final int minX = chunkX - viewDistance;
+-        final int minZ = chunkZ - viewDistance;
++    private void removeObject(final E object, final int chunkX, final int chunkZ, final int currentChunkX, final int currentChunkZ, final int distance) {
++        final int maxX = chunkX + distance;
++        final int maxZ = chunkZ + distance;
++        final int minX = chunkX - distance;
++        final int minZ = chunkZ - distance;
+         for (int x = minX; x <= maxX; ++x) {
+             for (int z = minZ; z <= maxZ; ++z) {
+                 this.removeObjectFrom(object, x, z, currentChunkX, currentChunkZ, chunkX, chunkZ);
+@@ -298,7 +298,7 @@ public abstract class AreaMap<E> {
+         return 1 | (val >> (Integer.SIZE - 1));
+     }
+ 
+-    private void updateObject(final E object, final long oldPosition, final long newPosition, final int oldViewDistance, final int newViewDistance) {
++    private void updateObject(final E object, final long oldPosition, final long newPosition, final int oldDistance, final int newDistance) {
+         final int toX = MCUtil.getCoordinateX(newPosition);
+         final int toZ = MCUtil.getCoordinateZ(newPosition);
+         final int fromX = MCUtil.getCoordinateX(oldPosition);
+@@ -310,25 +310,25 @@ public abstract class AreaMap<E> {
+         final int totalX = IntegerUtil.branchlessAbs(fromX - toX);
+         final int totalZ = IntegerUtil.branchlessAbs(fromZ - toZ);
+ 
+-        if (Math.max(totalX, totalZ) > (2 * Math.max(newViewDistance, oldViewDistance))) {
++        if (Math.max(totalX, totalZ) > (2 * Math.max(newDistance, oldDistance))) {
+             // teleported?
+-            this.removeObject(object, fromX, fromZ, fromX, fromZ, oldViewDistance);
+-            this.addObject(object, toX, toZ, fromX, fromZ, newViewDistance);
++            this.removeObject(object, fromX, fromZ, fromX, fromZ, oldDistance);
++            this.addObject(object, toX, toZ, fromX, fromZ, newDistance);
+             return;
+         }
+ 
+-        if (oldViewDistance != newViewDistance) {
++        if (oldDistance != newDistance) {
+             // remove loop
+ 
+-            final int oldMinX = fromX - oldViewDistance;
+-            final int oldMinZ = fromZ - oldViewDistance;
+-            final int oldMaxX = fromX + oldViewDistance;
+-            final int oldMaxZ = fromZ + oldViewDistance;
++            final int oldMinX = fromX - oldDistance;
++            final int oldMinZ = fromZ - oldDistance;
++            final int oldMaxX = fromX + oldDistance;
++            final int oldMaxZ = fromZ + oldDistance;
+             for (int currX = oldMinX; currX <= oldMaxX; ++currX) {
+                 for (int currZ = oldMinZ; currZ <= oldMaxZ; ++currZ) {
+ 
+                     // only remove if we're outside the new view distance...
+-                    if (Math.max(IntegerUtil.branchlessAbs(currX - toX), IntegerUtil.branchlessAbs(currZ - toZ)) > newViewDistance) {
++                    if (Math.max(IntegerUtil.branchlessAbs(currX - toX), IntegerUtil.branchlessAbs(currZ - toZ)) > newDistance) {
+                         this.removeObjectFrom(object, currX, currZ, toX, toZ, fromX, fromZ);
+                     }
+                 }
+@@ -336,15 +336,15 @@ public abstract class AreaMap<E> {
+ 
+             // add loop
+ 
+-            final int newMinX = toX - newViewDistance;
+-            final int newMinZ = toZ - newViewDistance;
+-            final int newMaxX = toX + newViewDistance;
+-            final int newMaxZ = toZ + newViewDistance;
++            final int newMinX = toX - newDistance;
++            final int newMinZ = toZ - newDistance;
++            final int newMaxX = toX + newDistance;
++            final int newMaxZ = toZ + newDistance;
+             for (int currX = newMinX; currX <= newMaxX; ++currX) {
+                 for (int currZ = newMinZ; currZ <= newMaxZ; ++currZ) {
+ 
+                     // only add if we're outside the old view distance...
+-                    if (Math.max(IntegerUtil.branchlessAbs(currX - fromX), IntegerUtil.branchlessAbs(currZ - fromZ)) > oldViewDistance) {
++                    if (Math.max(IntegerUtil.branchlessAbs(currX - fromX), IntegerUtil.branchlessAbs(currZ - fromZ)) > oldDistance) {
+                         this.addObjectTo(object, currX, currZ, toX, toZ, fromX, fromZ);
+                     }
+                 }
+@@ -379,10 +379,10 @@ public abstract class AreaMap<E> {
+         if (dx != 0) {
+             // handle right addition
+ 
+-            maxX = toX + (oldViewDistance * right) + right; // exclusive
+-            minX = fromX + (oldViewDistance * right) + right; // inclusive
+-            maxZ = fromZ + (oldViewDistance * up) + up; // exclusive
+-            minZ = toZ - (oldViewDistance * up); // inclusive
++            maxX = toX + (oldDistance * right) + right; // exclusive
++            minX = fromX + (oldDistance * right) + right; // inclusive
++            maxZ = fromZ + (oldDistance * up) + up; // exclusive
++            minZ = toZ - (oldDistance * up); // inclusive
+ 
+             for (int currX = minX; currX != maxX; currX += right) {
+                 for (int currZ = minZ; currZ != maxZ; currZ += up) {
+@@ -394,10 +394,10 @@ public abstract class AreaMap<E> {
+         if (dz != 0) {
+             // handle up addition
+ 
+-            maxX = toX + (oldViewDistance * right) + right; // exclusive
+-            minX = toX - (oldViewDistance * right); // inclusive
+-            maxZ = toZ + (oldViewDistance * up) + up; // exclusive
+-            minZ = fromZ + (oldViewDistance * up) + up; // inclusive
++            maxX = toX + (oldDistance * right) + right; // exclusive
++            minX = toX - (oldDistance * right); // inclusive
++            maxZ = toZ + (oldDistance * up) + up; // exclusive
++            minZ = fromZ + (oldDistance * up) + up; // inclusive
+ 
+             for (int currX = minX; currX != maxX; currX += right) {
+                 for (int currZ = minZ; currZ != maxZ; currZ += up) {
+@@ -409,10 +409,10 @@ public abstract class AreaMap<E> {
+         if (dx != 0) {
+             // handle left removal
+ 
+-            maxX = toX - (oldViewDistance * right); // exclusive
+-            minX = fromX - (oldViewDistance * right); // inclusive
+-            maxZ = fromZ + (oldViewDistance * up) + up; // exclusive
+-            minZ = toZ - (oldViewDistance * up); // inclusive
++            maxX = toX - (oldDistance * right); // exclusive
++            minX = fromX - (oldDistance * right); // inclusive
++            maxZ = fromZ + (oldDistance * up) + up; // exclusive
++            minZ = toZ - (oldDistance * up); // inclusive
+ 
+             for (int currX = minX; currX != maxX; currX += right) {
+                 for (int currZ = minZ; currZ != maxZ; currZ += up) {
+@@ -424,10 +424,10 @@ public abstract class AreaMap<E> {
+         if (dz != 0) {
+             // handle down removal
+ 
+-            maxX = fromX + (oldViewDistance * right) + right; // exclusive
+-            minX = fromX - (oldViewDistance * right); // inclusive
+-            maxZ = toZ - (oldViewDistance * up); // exclusive
+-            minZ = fromZ - (oldViewDistance * up); // inclusive
++            maxX = fromX + (oldDistance * right) + right; // exclusive
++            minX = fromX - (oldDistance * right); // inclusive
++            maxZ = toZ - (oldDistance * up); // exclusive
++            minZ = fromZ - (oldDistance * up); // inclusive
+ 
+             for (int currX = minX; currX != maxX; currX += right) {
+                 for (int currZ = minZ; currZ != maxZ; currZ += up) {
+diff --git a/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java b/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java
+index eacec5074ab1237986635c6cb19a4d34a89d4d3f..adc3de532f6d64cf31e6099c1b9351c2db1b9913 100644
+--- a/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java
++++ b/src/main/java/com/destroystokyo/paper/util/misc/DistanceTrackingAreaMap.java
+@@ -93,11 +93,11 @@ public abstract class DistanceTrackingAreaMap<E> extends AreaMap<E> {
+     }
+ 
+     @Override
+-    protected void addObjectCallback(final E object, final int chunkX, final int chunkZ, final int viewDistance) {
+-        final int maxX = chunkX + viewDistance;
+-        final int maxZ = chunkZ + viewDistance;
+-        final int minX = chunkX - viewDistance;
+-        final int minZ = chunkZ - viewDistance;
++    protected void addObjectCallback(final E object, final int chunkX, final int chunkZ, final int distance) {
++        final int maxX = chunkX + distance;
++        final int maxZ = chunkZ + distance;
++        final int minX = chunkX - distance;
++        final int minZ = chunkZ - distance;
+         for (int x = minX; x <= maxX; ++x) {
+             for (int z = minZ; z <= maxZ; ++z) {
+                 this.recalculateDistance(x, z);
+@@ -106,11 +106,11 @@ public abstract class DistanceTrackingAreaMap<E> extends AreaMap<E> {
+     }
+ 
+     @Override
+-    protected void removeObjectCallback(final E object, final int chunkX, final int chunkZ, final int viewDistance) {
+-        final int maxX = chunkX + viewDistance;
+-        final int maxZ = chunkZ + viewDistance;
+-        final int minX = chunkX - viewDistance;
+-        final int minZ = chunkZ - viewDistance;
++    protected void removeObjectCallback(final E object, final int chunkX, final int chunkZ, final int distance) {
++        final int maxX = chunkX + distance;
++        final int maxZ = chunkZ + distance;
++        final int minX = chunkX - distance;
++        final int minZ = chunkZ - distance;
+         for (int x = minX; x <= maxX; ++x) {
+             for (int z = minZ; z <= maxZ; ++z) {
+                 this.recalculateDistance(x, z);
+@@ -119,8 +119,8 @@ public abstract class DistanceTrackingAreaMap<E> extends AreaMap<E> {
+     }
+ 
+     @Override
+-    protected void updateObjectCallback(final E object, final long oldPosition, final long newPosition, final int oldViewDistance, final int newViewDistance) {
+-        if (oldPosition == newPosition && newViewDistance == oldViewDistance) {
++    protected void updateObjectCallback(final E object, final long oldPosition, final long newPosition, final int oldDistance, final int newDistance) {
++        if (oldPosition == newPosition && newDistance == oldDistance) {
+             return;
+         }
+ 
+@@ -132,24 +132,24 @@ public abstract class DistanceTrackingAreaMap<E> extends AreaMap<E> {
+         final int totalX = IntegerUtil.branchlessAbs(fromX - toX);
+         final int totalZ = IntegerUtil.branchlessAbs(fromZ - toZ);
+ 
+-        if (Math.max(totalX, totalZ) > (2 * Math.max(newViewDistance, oldViewDistance))) {
++        if (Math.max(totalX, totalZ) > (2 * Math.max(newDistance, oldDistance))) {
+             // teleported?
+-            this.removeObjectCallback(object, fromX, fromZ, oldViewDistance);
+-            this.addObjectCallback(object, toX, toZ, newViewDistance);
++            this.removeObjectCallback(object, fromX, fromZ, oldDistance);
++            this.addObjectCallback(object, toX, toZ, newDistance);
+             return;
+         }
+ 
+-        final int minX = Math.min(fromX - oldViewDistance, toX - newViewDistance);
+-        final int maxX = Math.max(fromX + oldViewDistance, toX + newViewDistance);
+-        final int minZ = Math.min(fromZ - oldViewDistance, toZ - newViewDistance);
+-        final int maxZ = Math.max(fromZ + oldViewDistance, toZ + newViewDistance);
++        final int minX = Math.min(fromX - oldDistance, toX - newDistance);
++        final int maxX = Math.max(fromX + oldDistance, toX + newDistance);
++        final int minZ = Math.min(fromZ - oldDistance, toZ - newDistance);
++        final int maxZ = Math.max(fromZ + oldDistance, toZ + newDistance);
+ 
+         for (int x = minX; x <= maxX; ++x) {
+             for (int z = minZ; z <= maxZ; ++z) {
+                 final int distXOld = IntegerUtil.branchlessAbs(x - fromX);
+                 final int distZOld = IntegerUtil.branchlessAbs(z - fromZ);
+ 
+-                if (Math.max(distXOld, distZOld) <= oldViewDistance) {
++                if (Math.max(distXOld, distZOld) <= oldDistance) {
+                     this.recalculateDistance(x, z);
+                     continue;
+                 }
+@@ -157,7 +157,7 @@ public abstract class DistanceTrackingAreaMap<E> extends AreaMap<E> {
+                 final int distXNew = IntegerUtil.branchlessAbs(x - toX);
+                 final int distZNew = IntegerUtil.branchlessAbs(z - toZ);
+ 
+-                if (Math.max(distXNew, distZNew) <= newViewDistance) {
++                if (Math.max(distXNew, distZNew) <= newDistance) {
+                     this.recalculateDistance(x, z);
+                     continue;
+                 }
+diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
+index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9ea21661c0215eda42d3bf11f1a39baa54101eae 100644
+--- a/src/main/java/net/minecraft/server/level/ChunkMap.java
++++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
+@@ -210,18 +210,19 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+     void addPlayerToDistanceMaps(ServerPlayer player) {
+         int chunkX = MCUtil.getChunkCoordinate(player.getX());
+         int chunkZ = MCUtil.getChunkCoordinate(player.getZ());
++        int upperLimit = Math.max(distanceManager.simulationDistance, level.spigotConfig.mobSpawnRange);
+         // Paper start - use distance map to optimise entity tracker
+         for (int i = 0, len = TRACKING_RANGE_TYPES.length; i < len; ++i) {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.add(player, chunkX, chunkZ, Math.min(trackRange, upperLimit));
+         }
+         // Paper end - use distance map to optimise entity tracker
+         // Note: players need to be explicitly added to distance maps before they can be updated
+         // Paper start - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
+-        this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE);
+-        this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE);
++        this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, distanceManager.simulationDistance);
++        this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, distanceManager.simulationDistance);
+         // Paper end - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
+     }
+ 
+@@ -240,16 +241,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+     void updateMaps(ServerPlayer player) {
+         int chunkX = MCUtil.getChunkCoordinate(player.getX());
+         int chunkZ = MCUtil.getChunkCoordinate(player.getZ());
++        int upperLimit = Math.max(distanceManager.simulationDistance, level.spigotConfig.mobSpawnRange);
+         // Note: players need to be explicitly added to distance maps before they can be updated
+         // Paper start - use distance map to optimise entity tracker
+         for (int i = 0, len = TRACKING_RANGE_TYPES.length; i < len; ++i) {
+             com.destroystokyo.paper.util.misc.PlayerAreaMap trackMap = this.playerEntityTrackerTrackMaps[i];
+             int trackRange = this.entityTrackerTrackRanges[i];
+ 
+-            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, this.getEffectiveViewDistance()));
++            trackMap.update(player, chunkX, chunkZ, Math.min(trackRange, upperLimit));
+         }
+         // Paper end - use distance map to optimise entity tracker
+-        this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE); // Paper - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
++        this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, distanceManager.simulationDistance); // Paper - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
+     }
+     // Paper end
+     // Paper start
+@@ -541,14 +543,6 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         }
+     }
+ 
+-    // Paper start
+-    public final int getEffectiveViewDistance() {
+-        // TODO this needs to be checked on update
+-        // Mojang currently sets it to +1 of the configured view distance. So subtract one to get the one we really want.
+-        return this.viewDistance - 1;
+-    }
+-    // Paper end
+-
+     private CompletableFuture<Either<List<ChunkAccess>, ChunkHolder.ChunkLoadingFailure>> getChunkRangeFuture(ChunkPos centerChunk, int margin, IntFunction<ChunkStatus> distanceToStatus) {
+         List<CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>>> list = new ArrayList();
+         List<ChunkHolder> list1 = new ArrayList();
+@@ -1503,7 +1497,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+                 }
+             }
+         } else {
+-            final double range = (DistanceManager.MOB_SPAWN_RANGE * 16) * (DistanceManager.MOB_SPAWN_RANGE * 16);
++            final double range = (level.spigotConfig.mobSpawnRange * 16) * (level.spigotConfig.mobSpawnRange * 16);
+             // before spigot, mob spawn range was actually mob spawn range + tick range, but it was split
+             for (int i = 0, len = backingSet.length; i < len; ++i) {
+                 Object raw = backingSet[i];
+@@ -1528,12 +1522,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+             return List.of();
+         } else {
+             Builder<ServerPlayer> builder = ImmutableList.builder();
++            double distSq = (level.spigotConfig.mobSpawnRange * 16.0) * (level.spigotConfig.mobSpawnRange * 16.0); // Paper
+             Iterator iterator = this.playerMap.getPlayers(i).iterator();
+ 
+             while (iterator.hasNext()) {
+                 ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+ 
+-                if (this.playerIsCloseEnoughForSpawning(entityplayer, pos, 16384.0D)) { // Spigot
++                if (this.playerIsCloseEnoughForSpawning(entityplayer, pos, distSq)) { // Spigot // Paper
+                     builder.add(entityplayer);
+                 }
+             }
+diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
+index 95f195980e28bb59f43e5ca1d5e79ebe8c3ddaea..9b6e2ca7cf8e84969b632beec145af2d4d575013 100644
+--- a/src/main/java/net/minecraft/server/level/DistanceManager.java
++++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
+@@ -67,7 +67,7 @@ public abstract class DistanceManager {
+     final LongSet ticketsToRelease = new LongOpenHashSet();
+     final Executor mainThreadExecutor;
+     private long ticketTickCounter;
+-    private int simulationDistance = 10;
++    public int simulationDistance = 10; // Paper private -> public
+     private final ChunkMap chunkMap; // Paper
+ 
+     protected DistanceManager(Executor workerExecutor, Executor mainThreadExecutor, ChunkMap chunkMap) {
+diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
+index 24d0b02264e4cced08a60f36b5c41bb350a1dc60..0ef60c307aa2ab92b8676013598a5d4707a5fe55 100644
+--- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
++++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
+@@ -889,16 +889,13 @@ public class ServerChunkCache extends ChunkSource {
+                     continue;
+                 }
+ 
+-                int viewDistance = this.chunkMap.getEffectiveViewDistance();
+-
+                 // copied and modified from isOutisdeRange
+                 int chunkRange = level.spigotConfig.mobSpawnRange;
+-                chunkRange = (chunkRange > viewDistance) ? (byte)viewDistance : chunkRange;
+-                chunkRange = (chunkRange > DistanceManager.MOB_SPAWN_RANGE) ? DistanceManager.MOB_SPAWN_RANGE : chunkRange;
++                chunkRange = (chunkRange > distanceManager.simulationDistance) ? (byte)distanceManager.simulationDistance : chunkRange;
+ 
+                 com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent event = new com.destroystokyo.paper.event.entity.PlayerNaturallySpawnCreaturesEvent(player.getBukkitEntity(), (byte)chunkRange);
+                 event.callEvent();
+-                if (event.isCancelled() || event.getSpawnRadius() < 0 || playerChunkMap.playerChunkTickRangeMap.getLastViewDistance(player) == -1) {
++                if (event.isCancelled() || event.getSpawnRadius() < 0 || playerChunkMap.playerChunkTickRangeMap.getLastDistance(player) == -1) {
+                     playerChunkMap.playerMobSpawnMap.remove(player);
+                     continue;
+                 }
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 3d4961418f3ee7e2d421738d8a8104aac09361d6..fe572c99263a44a23e2dc5141295d98973684a88 100644
+index 3fea7315ed3caf7363dd9349f8e977282dfa4c07..2758cfbef294887a86daa38aef8ac97da0829cd7 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2139,15 +2139,18 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0459-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0459-incremental-chunk-and-player-saving.patch
@@ -165,7 +165,7 @@ index 626bcbc6dd013260c3f8b38a1d14e7ba35dc1e01..9e96b0465717bfa761289c255fd8d2f1
          for (int i = 0; i < this.futures.length(); ++i) {
              CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = (CompletableFuture) this.futures.get(i);
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb22dd52716 100644
+index 9ea21661c0215eda42d3bf11f1a39baa54101eae..b5e375800a16cdfe2e80258adece1d5f440971eb 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -101,6 +101,7 @@ import net.minecraft.world.level.levelgen.structure.templatesystem.StructureMana
@@ -176,7 +176,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
  import org.apache.commons.lang3.mutable.MutableBoolean;
  import org.apache.commons.lang3.mutable.MutableObject;
  import org.apache.logging.log4j.LogManager;
-@@ -677,6 +678,64 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -671,6 +672,64 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      }
  
@@ -241,7 +241,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
      protected void saveAllChunks(boolean flush) {
          if (flush) {
              List<ChunkHolder> list = (List) this.visibleChunkMap.values().stream().filter(ChunkHolder::wasAccessibleSinceLastSave).peek(ChunkHolder::refreshAccessibility).collect(Collectors.toList());
-@@ -772,7 +831,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -766,7 +825,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          int l = 0;
          ObjectIterator objectiterator = this.visibleChunkMap.values().iterator();
  
@@ -250,7 +250,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
              if (this.saveChunkIfNeeded((ChunkHolder) objectiterator.next())) {
                  ++l;
              }
-@@ -814,6 +873,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -808,6 +867,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                          this.level.unload(chunk);
                      }
@@ -258,7 +258,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
  
                      this.lightEngine.updateChunkStatus(ichunkaccess.getPos());
                      this.lightEngine.tryScheduleUpdate();
-@@ -1211,6 +1271,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1205,6 +1265,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              asyncSaveData, chunk);
  
          chunk.setUnsaved(false);
@@ -266,7 +266,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
      }
      // Paper end
  
-@@ -1220,6 +1281,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1214,6 +1275,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          if (!chunk.isUnsaved()) {
              return false;
          } else {
@@ -275,7 +275,7 @@ index b1ae9e1aa68aaa0435ecdd50d78f82d4e36441bf..9a247feffce5ba08064afaa96053feb2
              ChunkPos chunkcoordintpair = chunk.getPos();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 76b56ea346d843aba482c52c4bfe877fdf0e9225..eb0c5ceb05f37bc653ea0cc91cc778866861688a 100644
+index 0ef60c307aa2ab92b8676013598a5d4707a5fe55..83dd23e1f4f8fae5df7e599fbb51aac017f00f85 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -825,6 +825,15 @@ public class ServerChunkCache extends ChunkSource {
@@ -295,7 +295,7 @@ index 76b56ea346d843aba482c52c4bfe877fdf0e9225..eb0c5ceb05f37bc653ea0cc91cc77886
      public void close() throws IOException {
          // CraftBukkit start
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index fe572c99263a44a23e2dc5141295d98973684a88..d21a910f2cca26adedab0732d04c8613e5afcd4f 100644
+index 2758cfbef294887a86daa38aef8ac97da0829cd7..38a1ada7cf0f3b960fa334deafebc8fd3296b6b5 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1055,6 +1055,37 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -337,7 +337,7 @@ index fe572c99263a44a23e2dc5141295d98973684a88..d21a910f2cca26adedab0732d04c8613
          ServerChunkCache chunkproviderserver = this.getChunkSource();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 2f13055a39c26fe12d2c1094103186635e536166..4b83617a81db1749faaf49fc3ee77e44846dce1a 100644
+index 6b0cb662d9163c360035e19c5faad59fc72af3c1..d2280b9e9f107dca890bc76f0c58e7070ce4b38c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -171,6 +171,7 @@ public class ServerPlayer extends Player {
@@ -349,7 +349,7 @@ index 2f13055a39c26fe12d2c1094103186635e536166..4b83617a81db1749faaf49fc3ee77e44
      private static final int NEUTRAL_MOB_DEATH_NOTIFICATION_RADII_Y = 10;
      public ServerGamePacketListenerImpl connection;
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 9b7fcd8be912cd211b6226386bd3340076953442..a8048e3af5bccb4cabe1ed1bc774aac6b8486bec 100644
+index f3926ee149e5e42d48e33759202d8297e3afd1d4..8c0faa9ee28943c7750dc33947e3f096b45a2026 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -556,6 +556,7 @@ public abstract class PlayerList {
@@ -385,7 +385,7 @@ index 9b7fcd8be912cd211b6226386bd3340076953442..a8048e3af5bccb4cabe1ed1bc774aac6
          MinecraftTimings.savePlayers.stopTiming(); // Paper
          return null; }); // Paper - ensure main
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
-index 0a2f9e93666a5b2123f84e5cf409e4355d3cad86..e3a92021b32aa74a37287504e0e539af5ec8216f 100644
+index 2fff34e573f57aab374a2cb9117313d2543f0bdc..e0dd98ddb33c78de0daba47d3ba23b88787ffdd2 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ChunkAccess.java
 @@ -457,6 +457,7 @@ public abstract class ChunkAccess implements BlockGetter, BiomeManager.NoiseBiom
@@ -397,7 +397,7 @@ index 0a2f9e93666a5b2123f84e5cf409e4355d3cad86..e3a92021b32aa74a37287504e0e539af
      // CraftBukkit start - decompile error
      public static record TicksToSave(SerializableTickContainer<Block> blocks, SerializableTickContainer<Fluid> fluids) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index f7388d37b467d1c153fcf8002eedd20417f93d52..ed22486dafcecae454a932c1354cf26c31e95636 100644
+index fde6405831ed0d90734ac3861939209025baa419..5e2cf3795415f1f1a54ebbda1e404347cc24fcc2 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -87,6 +87,12 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0473-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0473-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -360,7 +360,7 @@ index 9e96b0465717bfa761289c255fd8d2f1df1be3d8..87271552aa85626f22f7f8569c8fb48f
          return this.isEntityTickingReady;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b08376afcff8e 100644
+index b5e375800a16cdfe2e80258adece1d5f440971eb..4e9210ac60d3ba27c0d162c781bbe3419ec2659a 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -128,6 +128,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -371,7 +371,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
      public ChunkGenerator generator;
      public final Supplier<DimensionDataStorage> overworldDataStorage;
      private final PoiManager poiManager;
-@@ -302,6 +303,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -304,6 +305,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          this.level = world;
          this.generator = chunkGenerator;
          this.mainThreadExecutor = mainThreadExecutor;
@@ -387,7 +387,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
          ProcessorMailbox<Runnable> threadedmailbox = ProcessorMailbox.create(executor, "worldgen");
  
          Objects.requireNonNull(mainThreadExecutor);
-@@ -413,6 +423,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -415,6 +425,37 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          });
      }
  
@@ -425,7 +425,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
      // Paper start
      public void updatePlayerMobTypeMap(Entity entity) {
          if (!this.level.paperConfig.perPlayerMobSpawns) {
-@@ -555,6 +596,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -549,6 +590,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          List<ChunkHolder> list1 = new ArrayList();
          int j = centerChunk.x;
          int k = centerChunk.z;
@@ -433,7 +433,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
  
          for (int l = -margin; l <= margin; ++l) {
              for (int i1 = -margin; i1 <= margin; ++i1) {
-@@ -573,6 +615,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -567,6 +609,14 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                  ChunkStatus chunkstatus = (ChunkStatus) distanceToStatus.apply(j1);
                  CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = playerchunk.getOrScheduleFuture(chunkstatus, this);
@@ -448,7 +448,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
  
                  list1.add(playerchunk);
                  list.add(completablefuture);
-@@ -913,11 +963,19 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -907,11 +957,19 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          if (requiredStatus == ChunkStatus.EMPTY) {
              return this.scheduleChunkLoad(chunkcoordintpair);
          } else {
@@ -469,7 +469,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
  
              if (optional.isPresent() && ((ChunkAccess) optional.get()).getStatus().isOrAfter(requiredStatus)) {
                  CompletableFuture<Either<ChunkAccess, ChunkHolder.ChunkLoadingFailure>> completablefuture = requiredStatus.load(this.level, this.structureManager, this.lightEngine, (ichunkaccess) -> {
-@@ -929,6 +987,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -923,6 +981,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              } else {
                  return this.scheduleChunkGeneration(holder, requiredStatus);
              }
@@ -477,7 +477,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
          }
      }
  
-@@ -985,14 +1044,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -979,14 +1038,24 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          };
  
          CompletableFuture<CompoundTag> chunkSaveFuture = this.level.asyncChunkTaskManager.getChunkSaveFuture(pos.x, pos.z);
@@ -507,7 +507,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
          return ret;
          // Paper end
      }
-@@ -1044,7 +1113,10 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1038,7 +1107,10 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  this.releaseLightTicket(chunkcoordintpair);
                  return CompletableFuture.completedFuture(Either.right(playerchunk_failure));
              });
@@ -519,7 +519,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
      }
  
      protected void releaseLightTicket(ChunkPos pos) {
-@@ -1128,7 +1200,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1122,7 +1194,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              long i = chunkHolder.getPos().toLong();
  
              Objects.requireNonNull(chunkHolder);
@@ -529,7 +529,7 @@ index 9a247feffce5ba08064afaa96053feb22dd52716..807914712faf6dc98ff138ffa31b0837
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 84dc1e94b4f7b8315d8422634dd49b1f85044d18..451d5e9b5906e662a0c2e04b407068ea49d1089e 100644
+index 1a455e68b04670d43b78c30fd10957dc5396af99..d4126ab375506dccc864c32e7aa467ff74a17c8c 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -113,6 +113,7 @@ public abstract class DistanceManager {
@@ -711,7 +711,7 @@ index 84dc1e94b4f7b8315d8422634dd49b1f85044d18..451d5e9b5906e662a0c2e04b407068ea
          Ticket<ChunkPos> ticket = new Ticket<>(TicketType.FORCED, 31, pos);
          long i = pos.toLong();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index eb0c5ceb05f37bc653ea0cc91cc778866861688a..364375f5da5a3daea200c97c5dca86cbb8be5fb9 100644
+index 83dd23e1f4f8fae5df7e599fbb51aac017f00f85..4a4527c5e30c49eb69d771b1ccf60a2d33a0a82e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -601,6 +601,26 @@ public class ServerChunkCache extends ChunkSource {
@@ -796,7 +796,7 @@ index eb0c5ceb05f37bc653ea0cc91cc778866861688a..364375f5da5a3daea200c97c5dca86cb
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 4b83617a81db1749faaf49fc3ee77e44846dce1a..968b8180f92066a43f06bff8dd1d49b03bd08f5b 100644
+index d2280b9e9f107dca890bc76f0c58e7070ce4b38c..c68b95ef0d4c3e0d942e61bfccf23a00d0d8afd9 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -186,6 +186,7 @@ public class ServerPlayer extends Player {

--- a/patches/server/0493-Improve-Chunk-Status-Transition-Speed.patch
+++ b/patches/server/0493-Improve-Chunk-Status-Transition-Speed.patch
@@ -54,10 +54,10 @@ index 87271552aa85626f22f7f8569c8fb48fe4b30bf3..80aae4303e011dad13ce818136f0383e
      public ChunkHolder(ChunkPos pos, int level, LevelHeightAccessor world, LevelLightEngine lightingProvider, ChunkHolder.LevelChangeListener levelUpdateListener, ChunkHolder.PlayerProvider playersWatchingChunkProvider) {
          this.futures = new AtomicReferenceArray(ChunkHolder.CHUNK_STATUSES.size());
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 807914712faf6dc98ff138ffa31b08376afcff8e..a1b667084f710230d3f94ee0e5f5750de1d71e29 100644
+index 4e9210ac60d3ba27c0d162c781bbe3419ec2659a..d05945089823d1a7aacd045f66c12bc1d2b3c415 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -674,7 +674,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -668,7 +668,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              return either.mapLeft((list) -> {
                  return (LevelChunk) list.get(list.size() / 2);
              });
@@ -66,7 +66,7 @@ index 807914712faf6dc98ff138ffa31b08376afcff8e..a1b667084f710230d3f94ee0e5f5750d
      }
  
      @Nullable
-@@ -1084,6 +1084,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1078,6 +1078,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              return "chunkGenerate " + requiredStatus.getName();
          });
          Executor executor = (runnable) -> {

--- a/patches/server/0593-Skip-distance-map-update-when-spawning-disabled.patch
+++ b/patches/server/0593-Skip-distance-map-update-when-spawning-disabled.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Skip distance map update when spawning disabled.
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 364375f5da5a3daea200c97c5dca86cbb8be5fb9..f7abb67568cf1034dae3fe9e0adff9bcc36b96e7 100644
+index 4a4527c5e30c49eb69d771b1ccf60a2d33a0a82e..776028e7d135e1ff373b7aea991f529d1f45e931 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -966,7 +966,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -963,7 +963,7 @@ public class ServerChunkCache extends ChunkSource {
              int l = this.distanceManager.getNaturalSpawnChunkCount();
              // Paper start - per player mob spawning
              NaturalSpawner.SpawnState spawnercreature_d; // moved down

--- a/patches/server/0743-Fix-chunks-refusing-to-unload-at-low-TPS.patch
+++ b/patches/server/0743-Fix-chunks-refusing-to-unload-at-low-TPS.patch
@@ -10,10 +10,10 @@ chunk future to complete. We can simply schedule to the immediate
 executor to get this effect, rather than the main mailbox.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index b8066eec2a1481059ee0c25756e14449e3007b6b..c9563c0a5f230753dda469530cabde67fdb13f83 100644
+index c6858c3734daa7d6e133134c86ec4373f962ec5a..6cd66c29c265dcfe4715bcee0ab5873100a33fe7 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -1297,9 +1297,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1291,9 +1291,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
                  return chunk;
              });

--- a/patches/server/0744-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
+++ b/patches/server/0744-Do-not-allow-ticket-level-changes-while-unloading-pl.patch
@@ -8,10 +8,10 @@ Sync loading the chunk at this stage would cause it to load
 older data, as well as screwing our region state.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index c9563c0a5f230753dda469530cabde67fdb13f83..5157eac0190c6e1458dedfb1cb2eddee5639407e 100644
+index 6cd66c29c265dcfe4715bcee0ab5873100a33fe7..690e9cbab9cd6c9d59a850fdb5851204b6027c49 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -296,6 +296,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -298,6 +298,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      }
      // Paper end
  
@@ -19,7 +19,7 @@ index c9563c0a5f230753dda469530cabde67fdb13f83..5157eac0190c6e1458dedfb1cb2eddee
      public ChunkMap(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor executor, BlockableEventLoop<Runnable> mainThreadExecutor, LightChunkGetter chunkProvider, ChunkGenerator chunkGenerator, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkStatusChangeListener, Supplier<DimensionDataStorage> persistentStateManagerFactory, int viewDistance, boolean dsync) {
          super(session.getDimensionPath(world.dimension()).resolve("region"), dataFixer, dsync);
          this.visibleChunkMap = this.updatingChunkMap.clone();
-@@ -690,6 +691,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -684,6 +685,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      @Nullable
      ChunkHolder updateChunkScheduling(long pos, int level, @Nullable ChunkHolder holder, int k) {
@@ -27,7 +27,7 @@ index c9563c0a5f230753dda469530cabde67fdb13f83..5157eac0190c6e1458dedfb1cb2eddee
          if (k > ChunkMap.MAX_CHUNK_DISTANCE && level > ChunkMap.MAX_CHUNK_DISTANCE) {
              return holder;
          } else {
-@@ -908,6 +910,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -902,6 +904,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              if (completablefuture1 != completablefuture) {
                  this.scheduleUnload(pos, holder);
              } else {
@@ -40,7 +40,7 @@ index c9563c0a5f230753dda469530cabde67fdb13f83..5157eac0190c6e1458dedfb1cb2eddee
                  // Paper start
                  boolean removed;
                  if ((removed = this.pendingUnloads.remove(pos, holder)) && ichunkaccess != null) {
-@@ -944,6 +952,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -938,6 +946,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                          this.regionManagers.get(index).removeChunk(holder.pos.x, holder.pos.z);
                      }
                  } // Paper end
@@ -49,7 +49,7 @@ index c9563c0a5f230753dda469530cabde67fdb13f83..5157eac0190c6e1458dedfb1cb2eddee
              }
          };
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 2099769f54b53129f350856a227db4c475b4c903..e13a8e3dc11292aed13ff12ee8e0f9d6a95f0c34 100644
+index ed8f8c064c7473f76a46dda808ef3e957031ffbd..da8fd7556e4a33cc7881a8d9f2e431fd59da549c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -820,6 +820,7 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0756-Do-not-copy-visible-chunks.patch
+++ b/patches/server/0756-Do-not-copy-visible-chunks.patch
@@ -35,7 +35,7 @@ index 35949e9c15eb998aa89842d34d0999cd973590e0..15f0c85ba9f4f9666e94e67dde43eb2e
              List<ChunkHolder> allChunks = new ArrayList<>(visibleChunks.values());
              List<ServerPlayer> players = world.players;
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14ffc8ec338 100644
+index 690e9cbab9cd6c9d59a850fdb5851204b6027c49..695f33699941a844cac88f5c11a6e91ce1579323 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -120,9 +120,11 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -52,7 +52,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
      private final Long2ObjectLinkedOpenHashMap<ChunkHolder> pendingUnloads;
      public final LongSet entitiesInLevel;
      public final ServerLevel level;
-@@ -299,7 +301,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -301,7 +303,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      boolean unloadingPlayerChunk = false; // Paper - do not allow ticket level changes while unloading chunks
      public ChunkMap(ServerLevel world, LevelStorageSource.LevelStorageAccess session, DataFixer dataFixer, StructureManager structureManager, Executor executor, BlockableEventLoop<Runnable> mainThreadExecutor, LightChunkGetter chunkProvider, ChunkGenerator chunkGenerator, ChunkProgressListener worldGenerationProgressListener, ChunkStatusUpdateListener chunkStatusChangeListener, Supplier<DimensionDataStorage> persistentStateManagerFactory, int viewDistance, boolean dsync) {
          super(session.getDimensionPath(world.dimension()).resolve("region"), dataFixer, dsync);
@@ -61,7 +61,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
          this.pendingUnloads = new Long2ObjectLinkedOpenHashMap();
          this.entitiesInLevel = new LongOpenHashSet();
          this.toDrop = new LongOpenHashSet();
-@@ -554,12 +556,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -556,12 +558,17 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      @Nullable
      public ChunkHolder getUpdatingChunkIfPresent(long pos) {
@@ -81,7 +81,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
      }
  
      protected IntSupplier getChunkQueueLevel(long pos) {
-@@ -721,7 +728,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -715,7 +722,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                      // Paper end
                  }
  
@@ -90,7 +90,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
                  this.modified = true;
              }
  
-@@ -801,7 +808,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -795,7 +802,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
      protected void saveAllChunks(boolean flush) {
          if (flush) {
@@ -99,7 +99,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
              MutableBoolean mutableboolean = new MutableBoolean();
  
              do {
-@@ -832,7 +839,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -826,7 +833,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              //this.flushWorker(); // Paper - nuke IOWorker
              this.level.asyncChunkTaskManager.flush(); // Paper - flush to preserve behavior compat with pre-async behaviour
          } else {
@@ -108,7 +108,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
          }
  
      }
-@@ -866,7 +873,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -860,7 +867,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          while (longiterator.hasNext()) { // Spigot
              long j = longiterator.nextLong();
              longiterator.remove(); // Spigot
@@ -117,7 +117,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
  
              if (playerchunk != null) {
                  this.pendingUnloads.put(j, playerchunk);
-@@ -892,7 +899,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -886,7 +893,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
  
          int l = 0;
@@ -126,7 +126,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
  
          while (false && l < 20 && shouldKeepTicking.getAsBoolean() && objectiterator.hasNext()) { // Paper - incremental chunk and player saving
              if (this.saveChunkIfNeeded((ChunkHolder) objectiterator.next())) {
-@@ -971,7 +978,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -965,7 +972,12 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          if (!this.modified) {
              return false;
          } else {
@@ -140,7 +140,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
              this.modified = false;
              return true;
          }
-@@ -1449,7 +1461,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1443,7 +1455,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
  
              this.viewDistance = j;
              this.distanceManager.updatePlayerTickets(this.viewDistance);
@@ -149,7 +149,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
  
              while (objectiterator.hasNext()) {
                  ChunkHolder playerchunk = (ChunkHolder) objectiterator.next();
-@@ -1491,7 +1503,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1485,7 +1497,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      }
  
      public int size() {
@@ -158,7 +158,7 @@ index 5157eac0190c6e1458dedfb1cb2eddee5639407e..800191e9ed63773333b5650d8ffcb14f
      }
  
      public DistanceManager getDistanceManager() {
-@@ -1499,13 +1511,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -1493,13 +1505,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      }
  
      protected Iterable<ChunkHolder> getChunks() {

--- a/patches/server/0768-Consolidate-flush-calls-for-entity-tracker-packets.patch
+++ b/patches/server/0768-Consolidate-flush-calls-for-entity-tracker-packets.patch
@@ -22,10 +22,10 @@ With this change I could get all 200 on at 0ms ping.
 So in general this patch should reduce Netty I/O thread load.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 0d9f8180110b072e54d6c0f8c64df584b40776b9..758bb0fae0f9ba9672250e4a65c27f1175eab12d 100644
+index 93af4877087fb43140eb1a08a979cbf8df52cd6d..6c92cc7ba27521a74ce43efec8615ab8a3a58e88 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -1053,7 +1053,24 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1050,7 +1050,24 @@ public class ServerChunkCache extends ChunkSource {
              });
              gameprofilerfiller.pop();
              gameprofilerfiller.pop();

--- a/patches/server/0773-Oprimise-map-impl-for-tracked-players.patch
+++ b/patches/server/0773-Oprimise-map-impl-for-tracked-players.patch
@@ -7,7 +7,7 @@ Reference2BooleanOpenHashMap is going to have
 better lookups than HashMap.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 800191e9ed63773333b5650d8ffcb14ffc8ec338..9ab37d95b0dbd13dfe31b34b2a91c2a7bc7f6e64 100644
+index 695f33699941a844cac88f5c11a6e91ce1579323..d9e5cd46536ffd049aa4da4bb64e3ab03e3184b2 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -108,6 +108,7 @@ import org.apache.logging.log4j.LogManager;
@@ -18,7 +18,7 @@ index 800191e9ed63773333b5650d8ffcb14ffc8ec338..9ab37d95b0dbd13dfe31b34b2a91c2a7
  
  public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider {
  
-@@ -2141,7 +2142,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -2136,7 +2137,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          final Entity entity;
          private final int range;
          SectionPos lastSectionPos;

--- a/patches/server/0778-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0778-Optimise-nearby-player-lookups.patch
@@ -26,7 +26,7 @@ index bb411853cb9e0120bcaa82e878724ee17167057b..7f663523b8c43b356763d6d5249e1aec
      // Paper end - optimise anyPlayerCloseEnoughForSpawning
      long lastAutoSaveTime; // Paper - incremental autosave
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 9ab37d95b0dbd13dfe31b34b2a91c2a7bc7f6e64..27e9bd7dabb5f827b8baf126565d1efb9eb2c2ef 100644
+index d9e5cd46536ffd049aa4da4bb64e3ab03e3184b2..946448ac4a2fb10b1a92399dee63d99451e97982 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -159,6 +159,13 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -43,15 +43,15 @@ index 9ab37d95b0dbd13dfe31b34b2a91c2a7bc7f6e64..27e9bd7dabb5f827b8baf126565d1efb
      // CraftBukkit start - recursion-safe executor for Chunk loadCallback() and unloadCallback()
      public final CallbackExecutor callbackExecutor = new CallbackExecutor();
      public static final class CallbackExecutor implements java.util.concurrent.Executor, Runnable {
-@@ -239,6 +246,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
-         this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE);
-         this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE);
+@@ -240,6 +247,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+         this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, distanceManager.simulationDistance);
+         this.playerChunkTickRangeMap.add(player, chunkX, chunkZ, distanceManager.simulationDistance);
          // Paper end - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
 +        this.playerGeneralAreaMap.add(player, chunkX, chunkZ, GENERAL_AREA_MAP_SQUARE_RADIUS); // Paper - optimise checkDespawn
      }
  
      void removePlayerFromDistanceMaps(ServerPlayer player) {
-@@ -251,6 +259,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -252,6 +260,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          this.playerMobSpawnMap.remove(player);
          this.playerChunkTickRangeMap.remove(player);
          // Paper end - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
@@ -59,15 +59,15 @@ index 9ab37d95b0dbd13dfe31b34b2a91c2a7bc7f6e64..27e9bd7dabb5f827b8baf126565d1efb
      }
  
      void updateMaps(ServerPlayer player) {
-@@ -266,6 +275,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -268,6 +277,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
          }
          // Paper end - use distance map to optimise entity tracker
-         this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, DistanceManager.MOB_SPAWN_RANGE); // Paper - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
+         this.playerChunkTickRangeMap.update(player, chunkX, chunkZ, distanceManager.simulationDistance); // Paper - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
 +        this.playerGeneralAreaMap.update(player, chunkX, chunkZ, GENERAL_AREA_MAP_SQUARE_RADIUS); // Paper - optimise checkDespawn
      }
      // Paper end
      // Paper start
-@@ -421,6 +431,23 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -423,6 +433,23 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  }
              });
          // Paper end - optimise ChunkMap#anyPlayerCloseEnoughForSpawning
@@ -92,7 +92,7 @@ index 9ab37d95b0dbd13dfe31b34b2a91c2a7bc7f6e64..27e9bd7dabb5f827b8baf126565d1efb
  
      protected ChunkGenerator generator() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 0e8bfceeb2eae9b465e8810c67073e11ff882ea7..c525d8aed8f0671ad6cfef67cadaeb311a4d5e97 100644
+index 17b01c1592ec2481d1ff444ff12dbc3790e09368..3ce8055f0fb8c5b605356e4e85ee1dbdcc73ba0e 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -396,6 +396,83 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -309,7 +309,7 @@ index 928025438af179711c42381fc3eaeac74cd20c59..c48d0773e7f1af4bc247d777eccc8a42
  
      private static Boolean isValidSpawnPostitionForType(ServerLevel world, MobCategory group, StructureFeatureManager structureAccessor, ChunkGenerator chunkGenerator, MobSpawnSettings.SpawnerData spawnEntry, BlockPos.MutableBlockPos pos, double squaredDistance) { // Paper
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index b641bf5b2d02bfc1443a84af3cb98aff0dc7a575..c9cd9121e0ca7402c812e803ffd417c1887a4823 100644
+index e9542a4683e1fef470ae37819d6d7a8c72afe4c8..b39904f011d86f6ced80e4d3fb48c26ccfa7f828 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -235,6 +235,93 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0779-Optimise-WorldServer-notify.patch
+++ b/patches/server/0779-Optimise-WorldServer-notify.patch
@@ -8,10 +8,10 @@ Instead, only iterate over navigators in the current region that are
 eligible for repathing.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 27e9bd7dabb5f827b8baf126565d1efb9eb2c2ef..a14effa7f8f56a27bccd4479baad82fcb67e55c5 100644
+index 946448ac4a2fb10b1a92399dee63d99451e97982..a56f84ad28fba99a5bbfcb431b2f6f9ceedb66e6 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -283,15 +283,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -285,15 +285,81 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      public final io.papermc.paper.chunk.SingleThreadChunkRegionManager dataRegionManager;
  
      public static final class DataRegionData implements io.papermc.paper.chunk.SingleThreadChunkRegionManager.RegionData {
@@ -93,7 +93,7 @@ index 27e9bd7dabb5f827b8baf126565d1efb9eb2c2ef..a14effa7f8f56a27bccd4479baad82fc
          }
  
          @Override
-@@ -301,6 +367,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -303,6 +369,15 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
              final DataRegionSectionData sectionData = (DataRegionSectionData)section.sectionData;
              final DataRegionData oldRegionData = oldRegion == null ? null : (DataRegionData)oldRegion.regionData;
              final DataRegionData newRegionData = (DataRegionData)newRegion.regionData;
@@ -110,7 +110,7 @@ index 27e9bd7dabb5f827b8baf126565d1efb9eb2c2ef..a14effa7f8f56a27bccd4479baad82fc
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c525d8aed8f0671ad6cfef67cadaeb311a4d5e97..0cf1c9203addc602f3ed0cf7a3c439b98bc73e9b 100644
+index 3ce8055f0fb8c5b605356e4e85ee1dbdcc73ba0e..051c32968d5b134f6f83dd9ac7db7e608ec1a4f2 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1090,6 +1090,7 @@ public class ServerLevel extends Level implements WorldGenLevel {

--- a/patches/server/0797-Do-not-overload-I-O-threads-with-chunk-data-while-fl.patch
+++ b/patches/server/0797-Do-not-overload-I-O-threads-with-chunk-data-while-fl.patch
@@ -12,10 +12,10 @@ time to save, as flush saving performs a full flush at
 the end anyways.
 
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index a14effa7f8f56a27bccd4479baad82fcb67e55c5..30f3d7571c021ed9c0d7d96b53752dd453704b20 100644
+index a56f84ad28fba99a5bbfcb431b2f6f9ceedb66e6..c250f45d032cb80ae510b50e5d7e3d27b6b92e20 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
-@@ -910,6 +910,16 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -904,6 +904,16 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
      // Paper end
  
      protected void saveAllChunks(boolean flush) {
@@ -32,7 +32,7 @@ index a14effa7f8f56a27bccd4479baad82fcb67e55c5..30f3d7571c021ed9c0d7d96b53752dd4
          if (flush) {
              List<ChunkHolder> list = (List) this.updatingChunks.getVisibleValuesCopy().stream().filter(ChunkHolder::wasAccessibleSinceLastSave).peek(ChunkHolder::refreshAccessibility).collect(Collectors.toList()); // Paper
              MutableBoolean mutableboolean = new MutableBoolean();
-@@ -932,6 +942,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
+@@ -926,6 +936,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
                  }).filter((ichunkaccess) -> {
                      return ichunkaccess instanceof ImposterProtoChunk || ichunkaccess instanceof LevelChunk;
                  }).filter(this::save).forEach((ichunkaccess) -> {

--- a/patches/server/0827-Optimise-chunk-tick-iteration.patch
+++ b/patches/server/0827-Optimise-chunk-tick-iteration.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimise chunk tick iteration
 Use a dedicated list of entity ticking chunks to reduce the cost
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 51c4ca36221e9af074fa92f6ab94fa7ba5403080..8d38a5a4c74d3f9298ba4f215e978fbc25ba91f0 100644
+index 6c92cc7ba27521a74ce43efec8615ab8a3a58e88..540ff2cfd2d5aab3db56934e7b03282799db188c 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-@@ -1001,34 +1001,46 @@ public class ServerChunkCache extends ChunkSource {
+@@ -998,34 +998,46 @@ public class ServerChunkCache extends ChunkSource {
  
              this.lastSpawnState = spawnercreature_d;
              gameprofilerfiller.popPush("filteringLoadedChunks");
@@ -72,7 +72,7 @@ index 51c4ca36221e9af074fa92f6ab94fa7ba5403080..8d38a5a4c74d3f9298ba4f215e978fbc
                          NaturalSpawner.spawnForChunk(this.level, chunk1, spawnercreature_d, this.spawnFriendlies, this.spawnEnemies, flag1);
                      }
  
-@@ -1036,7 +1048,16 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1033,7 +1045,16 @@ public class ServerChunkCache extends ChunkSource {
                          this.level.tickChunk(chunk1, k);
                      }
                  }
@@ -89,7 +89,7 @@ index 51c4ca36221e9af074fa92f6ab94fa7ba5403080..8d38a5a4c74d3f9298ba4f215e978fbc
              this.level.timings.chunkTicks.stopTiming(); // Paper
              gameprofilerfiller.popPush("customSpawners");
              if (flag2) {
-@@ -1045,13 +1066,7 @@ public class ServerChunkCache extends ChunkSource {
+@@ -1042,13 +1063,7 @@ public class ServerChunkCache extends ChunkSource {
                  } // Paper - timings
              }
  

--- a/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
+++ b/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
@@ -61,26 +61,3 @@ index e371ffb1f88e08883a1a2460260ff368c0cfe853..6730144edc0d1eb92dde8686892b8b40
          ChunkHolder chunkHolder = this.chunkSource.chunkMap.getVisibleChunkIfPresent(chunkPos);
          return chunkHolder != null && chunkHolder.isTickingReady() && this.areEntitiesLoaded(chunkPos);
          // Paper end
-diff --git a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
-index 954b86bea345a8e0e3a8dd425f356db6f5cd496f..17076e87aa74a6819316f0662210eef98ec26cc6 100644
---- a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
-+++ b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
-@@ -8,14 +8,18 @@ import java.util.WeakHashMap;
- import net.minecraft.core.BlockPos;
- import net.minecraft.core.Direction;
- import net.minecraft.core.particles.DustParticleOptions;
-+import net.minecraft.server.level.ChunkHolder;
- import net.minecraft.server.level.ServerLevel;
- import net.minecraft.world.level.BlockGetter;
-+import net.minecraft.world.level.ChunkPos;
- import net.minecraft.world.level.Level;
- import net.minecraft.world.level.block.state.BlockBehaviour;
- import net.minecraft.world.level.block.state.BlockState;
- import net.minecraft.world.level.block.state.StateDefinition;
- import net.minecraft.world.level.block.state.properties.BlockStateProperties;
- import net.minecraft.world.level.block.state.properties.BooleanProperty;
-+import net.minecraft.world.level.chunk.ChunkAccess;
-+import org.apache.logging.log4j.LogManager;
- import org.bukkit.event.block.BlockRedstoneEvent; // CraftBukkit
- 
- public class RedstoneTorchBlock extends TorchBlock {

--- a/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
+++ b/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
@@ -61,3 +61,26 @@ index e371ffb1f88e08883a1a2460260ff368c0cfe853..6730144edc0d1eb92dde8686892b8b40
          ChunkHolder chunkHolder = this.chunkSource.chunkMap.getVisibleChunkIfPresent(chunkPos);
          return chunkHolder != null && chunkHolder.isTickingReady() && this.areEntitiesLoaded(chunkPos);
          // Paper end
+diff --git a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
+index 954b86bea345a8e0e3a8dd425f356db6f5cd496f..17076e87aa74a6819316f0662210eef98ec26cc6 100644
+--- a/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/RedstoneTorchBlock.java
+@@ -8,14 +8,18 @@ import java.util.WeakHashMap;
+ import net.minecraft.core.BlockPos;
+ import net.minecraft.core.Direction;
+ import net.minecraft.core.particles.DustParticleOptions;
++import net.minecraft.server.level.ChunkHolder;
+ import net.minecraft.server.level.ServerLevel;
+ import net.minecraft.world.level.BlockGetter;
++import net.minecraft.world.level.ChunkPos;
+ import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.block.state.BlockBehaviour;
+ import net.minecraft.world.level.block.state.BlockState;
+ import net.minecraft.world.level.block.state.StateDefinition;
+ import net.minecraft.world.level.block.state.properties.BlockStateProperties;
+ import net.minecraft.world.level.block.state.properties.BooleanProperty;
++import net.minecraft.world.level.chunk.ChunkAccess;
++import org.apache.logging.log4j.LogManager;
+ import org.bukkit.event.block.BlockRedstoneEvent; // CraftBukkit
+ 
+ public class RedstoneTorchBlock extends TorchBlock {

--- a/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
+++ b/patches/server/0828-Fix-simulation-distance-for-block-ticking.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: "Rafael S. M. Santos" <eu@rafaelsms.com>
+Date: Sun, 5 Dec 2021 23:56:03 -0300
+Subject: [PATCH] Fix simulation distance for block ticking
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
+index 540ff2cfd2d5aab3db56934e7b03282799db188c..90a507636dbfd2c94077fe1d795574bdbbd89f8d 100644
+--- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
++++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
+@@ -983,7 +983,7 @@ public class ServerChunkCache extends ChunkSource {
+             if ((this.spawnFriendlies || this.spawnEnemies) && this.chunkMap.playerMobDistanceMap != null) { // don't update when animals and monsters are disabled
+                 // update distance map
+                 this.level.timings.playerMobDistanceMapUpdate.startTiming();
+-                this.chunkMap.playerMobDistanceMap.update(this.level.players, this.chunkMap.viewDistance);
++                this.chunkMap.playerMobDistanceMap.update(this.level.players, distanceManager.simulationDistance);
+                 this.level.timings.playerMobDistanceMapUpdate.stopTiming();
+                 // re-set mob counts
+                 for (ServerPlayer player : this.level.players) {
+@@ -1011,10 +1011,10 @@ public class ServerChunkCache extends ChunkSource {
+             // Paper start - optimise chunk tick iteration
+             Iterator<LevelChunk> iterator1;
+             if (this.level.paperConfig.perPlayerMobSpawns) {
+-                iterator1 = this.entityTickingChunks.iterator();
++                iterator1 = this.tickingChunks.iterator();
+             } else {
+-                iterator1 = this.entityTickingChunks.unsafeIterator();
+-                List<LevelChunk> shuffled = Lists.newArrayListWithCapacity(this.entityTickingChunks.size());
++                iterator1 = this.tickingChunks.unsafeIterator();
++                List<LevelChunk> shuffled = Lists.newArrayListWithCapacity(this.tickingChunks.size());
+                 while (iterator1.hasNext()) {
+                     shuffled.add(iterator1.next());
+                 }
+@@ -1035,13 +1035,13 @@ public class ServerChunkCache extends ChunkSource {
+                 // Paper end - optimise chunk tick iteration
+                 ChunkPos chunkcoordintpair = chunk1.getPos();
+ 
+-                if ((true || this.level.isPositionEntityTicking(chunkcoordintpair)) && this.chunkMap.anyPlayerCloseEnoughForSpawning(holder, chunkcoordintpair, false)) { // Paper - optimise anyPlayerCloseEnoughForSpawning & optimise chunk tick iteration
++                if (true || this.chunkMap.anyPlayerCloseEnoughForSpawning(holder, chunkcoordintpair, false)) { // Paper - optimise anyPlayerCloseEnoughForSpawning & optimise chunk tick iteration
+                     chunk1.incrementInhabitedTime(j);
+                     if (flag2 && (this.spawnEnemies || this.spawnFriendlies) && this.level.getWorldBorder().isWithinBounds(chunkcoordintpair) && this.chunkMap.anyPlayerCloseEnoughForSpawning(holder, chunkcoordintpair, true)) { // Spigot // Paper - optimise anyPlayerCloseEnoughForSpawning & optimise chunk tick iteration
+                         NaturalSpawner.spawnForChunk(this.level, chunk1, spawnercreature_d, this.spawnFriendlies, this.spawnEnemies, flag1);
+                     }
+ 
+-                    if (this.level.shouldTickBlocksAt(chunkcoordintpair.toLong())) {
++                    if (true || this.level.shouldTickBlocksAt(chunkcoordintpair.toLong())) {
+                         this.level.tickChunk(chunk1, k);
+                     }
+                 }
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index e371ffb1f88e08883a1a2460260ff368c0cfe853..6730144edc0d1eb92dde8686892b8b4051a280bd 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2342,6 +2342,9 @@ public class ServerLevel extends Level implements WorldGenLevel {
+ 
+     private boolean isPositionTickingWithEntitiesLoaded(long chunkPos) {
+         // Paper start - optimize is ticking ready type functions
++        if (!this.shouldTickBlocksAt(chunkPos)) {
++            return false;
++        }
+         ChunkHolder chunkHolder = this.chunkSource.chunkMap.getVisibleChunkIfPresent(chunkPos);
+         return chunkHolder != null && chunkHolder.isTickingReady() && this.areEntitiesLoaded(chunkPos);
+         // Paper end


### PR DESCRIPTION
Previously some block ticking was occurring outside of simulation distance and tickChunks was called only for entity ticking chunks, which is 1 chunk radius lower than block ticking chunks.

Also, I renamed viewDistance to distance on AreaMap, but now I don't think it is necessary. I am not very good with patches and git, so I don't know how to merge this and upstream/master since this PR breaks some patches (I used rebuild patches).

The git commit message about low TPS was fixed by allocating more ram (who knew, Xmx=1GB is not enough for 32 view distance even for debugging!)