### PR TITLE
Fix mis-placed processEnchantOrder from 1.18 update

### DIFF
--- a/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
+++ b/patches/server/0065-Handle-Item-Meta-Inconsistencies.patch
@@ -18,7 +18,7 @@ For consistency, the old API methods now forward to use the
 ItemMeta API equivalents, and should deprecate the old API's.
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 566f1b8a0acd679b2f776db2e80458b1c532f97e..c39d3f15ebc8956714f963ce7ed11e0f2b2bad4f 100644
+index 566f1b8a0acd679b2f776db2e80458b1c532f97e..d342ae7b4fc1f682a885f0dca7b7fc222905490d 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
 @@ -13,6 +13,8 @@ import java.text.DecimalFormatSymbols;
@@ -36,7 +36,7 @@ index 566f1b8a0acd679b2f776db2e80458b1c532f97e..c39d3f15ebc8956714f963ce7ed11e0f
  
 +    // Paper start
 +    private static final java.util.Comparator<? super CompoundTag> enchantSorter = java.util.Comparator.comparing(o -> o.getString("id"));
-+    private void processEnchantOrder(CompoundTag tag) {
++    private void processEnchantOrder(@Nullable CompoundTag tag) {
 +        if (tag == null || !tag.contains("Enchantments", 9)) {
 +            return;
 +        }
@@ -54,7 +54,7 @@ index 566f1b8a0acd679b2f776db2e80458b1c532f97e..c39d3f15ebc8956714f963ce7ed11e0f
      public ItemStack(ItemLike item) {
          this(item, 1);
      }
-@@ -195,9 +214,11 @@ public final class ItemStack {
+@@ -195,6 +214,7 @@ public final class ItemStack {
              // CraftBukkit start - make defensive copy as this data may be coming from the save thread
              this.tag = nbttagcompound.getCompound("tag").copy();
              // CraftBukkit end
@@ -62,7 +62,11 @@ index 566f1b8a0acd679b2f776db2e80458b1c532f97e..c39d3f15ebc8956714f963ce7ed11e0f
              this.getItem().verifyTagAfterLoad(this.tag);
          }
  
-+        processEnchantOrder(this.tag); // Paper
+@@ -749,6 +769,7 @@ public final class ItemStack {
+ 
+     public void setTag(@Nullable CompoundTag nbt) {
+         this.tag = nbt;
++        this.processEnchantOrder(this.tag); // Paper
          if (this.getItem().canBeDepleted()) {
              this.setDamageValue(this.getDamageValue());
          }

--- a/patches/server/0120-Optimize-ItemStack.isEmpty.patch
+++ b/patches/server/0120-Optimize-ItemStack.isEmpty.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimize ItemStack.isEmpty()
 Remove hashMap lookup every check, simplify code to remove ternary
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index c39d3f15ebc8956714f963ce7ed11e0f2b2bad4f..033f7486556f5928d902dd25cd3d5a38e0e8097e 100644
+index d342ae7b4fc1f682a885f0dca7b7fc222905490d..de3a7542403e0b42679ac7fab623611605f280b7 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -241,7 +241,7 @@ public final class ItemStack {
+@@ -240,7 +240,7 @@ public final class ItemStack {
      }
  
      public boolean isEmpty() {

--- a/patches/server/0262-Allow-chests-to-be-placed-with-NBT-data.patch
+++ b/patches/server/0262-Allow-chests-to-be-placed-with-NBT-data.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow chests to be placed with NBT data
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 033f7486556f5928d902dd25cd3d5a38e0e8097e..b8b77a3c8aa3feb433bd232d0f60867bfcae530d 100644
+index de3a7542403e0b42679ac7fab623611605f280b7..e546f212d0228171920a0b28f918020617dfd7ca 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -340,6 +340,7 @@ public final class ItemStack {
+@@ -339,6 +339,7 @@ public final class ItemStack {
                      enuminteractionresult = InteractionResult.FAIL; // cancel placement
                      // PAIL: Remove this when MC-99075 fixed
                      placeEvent.getPlayer().updateInventory();

--- a/patches/server/0349-Optimize-Hoppers.patch
+++ b/patches/server/0349-Optimize-Hoppers.patch
@@ -47,10 +47,10 @@ index 7576047ea9695434ca06ca8fefde0dce68980be8..f71a1401d229b32557f0444ce45cfa47
              this.profiler.push(() -> {
                  return worldserver + " " + worldserver.dimension().location();
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index b8b77a3c8aa3feb433bd232d0f60867bfcae530d..57a9106005413e6767f0fe291c463742ba9afb21 100644
+index e546f212d0228171920a0b28f918020617dfd7ca..d612d6e737d60e10b5a1504f363db214d3589594 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -605,11 +605,12 @@ public final class ItemStack {
+@@ -604,11 +604,12 @@ public final class ItemStack {
          return this.getItem().interactLivingEntity(this, user, entity, hand);
      }
  

--- a/patches/server/0500-PortalCreateEvent-needs-to-know-its-entity.patch
+++ b/patches/server/0500-PortalCreateEvent-needs-to-know-its-entity.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PortalCreateEvent needs to know its entity
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index 31439467f1730d96712e53a8e27892dfce017c70..c5286b3751c58df1b70d9ac01b0497b83c0f917a 100644
+index 2fdd19ec71bdf92e317196eab5426760d9c57278..a0d1877e9b5229bc04dba72fb629e26d25e85bfb 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -411,7 +411,7 @@ public final class ItemStack {
+@@ -410,7 +410,7 @@ public final class ItemStack {
                          net.minecraft.world.level.block.state.BlockState block = world.getBlockState(newblockposition);
  
                          if (!(block.getBlock() instanceof BaseEntityBlock)) { // Containers get placed automatically

--- a/patches/server/0711-Added-EntityDamageItemEvent.patch
+++ b/patches/server/0711-Added-EntityDamageItemEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added EntityDamageItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/item/ItemStack.java b/src/main/java/net/minecraft/world/item/ItemStack.java
-index c5286b3751c58df1b70d9ac01b0497b83c0f917a..8f2f516b1f473ce18a07e9f130b49b795dd6b46e 100644
+index a0d1877e9b5229bc04dba72fb629e26d25e85bfb..f9b7292c2eb2588c9769fcd8f56cc8da5259e7ce 100644
 --- a/src/main/java/net/minecraft/world/item/ItemStack.java
 +++ b/src/main/java/net/minecraft/world/item/ItemStack.java
-@@ -527,7 +527,7 @@ public final class ItemStack {
+@@ -526,7 +526,7 @@ public final class ItemStack {
          return this.getItem().getMaxDamage();
      }
  
@@ -17,7 +17,7 @@ index c5286b3751c58df1b70d9ac01b0497b83c0f917a..8f2f516b1f473ce18a07e9f130b49b79
          if (!this.isDamageableItem()) {
              return false;
          } else {
-@@ -545,8 +545,8 @@ public final class ItemStack {
+@@ -544,8 +544,8 @@ public final class ItemStack {
  
                  amount -= k;
                  // CraftBukkit start
@@ -28,7 +28,7 @@ index c5286b3751c58df1b70d9ac01b0497b83c0f917a..8f2f516b1f473ce18a07e9f130b49b79
                      event.getPlayer().getServer().getPluginManager().callEvent(event);
  
                      if (amount != event.getDamage() || event.isCancelled()) {
-@@ -557,6 +557,14 @@ public final class ItemStack {
+@@ -556,6 +556,14 @@ public final class ItemStack {
                      }
  
                      amount = event.getDamage();
@@ -43,7 +43,7 @@ index c5286b3751c58df1b70d9ac01b0497b83c0f917a..8f2f516b1f473ce18a07e9f130b49b79
                  }
                  // CraftBukkit end
                  if (amount <= 0) {
-@@ -564,8 +572,8 @@ public final class ItemStack {
+@@ -563,8 +571,8 @@ public final class ItemStack {
                  }
              }
  
@@ -54,7 +54,7 @@ index c5286b3751c58df1b70d9ac01b0497b83c0f917a..8f2f516b1f473ce18a07e9f130b49b79
              }
  
              j = this.getDamageValue() + amount;
-@@ -577,7 +585,7 @@ public final class ItemStack {
+@@ -576,7 +584,7 @@ public final class ItemStack {
      public <T extends LivingEntity> void hurtAndBreak(int amount, T entity, Consumer<T> breakCallback) {
          if (!entity.level.isClientSide && (!(entity instanceof net.minecraft.world.entity.player.Player) || !((net.minecraft.world.entity.player.Player) entity).getAbilities().instabuild)) {
              if (this.isDamageableItem()) {


### PR DESCRIPTION
See [this diff](https://github.com/PaperMC/Paper/commit/e9954ed32acc79784c60634b03067b9ae25228fb#diff-1ec43bda00eb892dce7d5d3e56deab50f887ce98b3c575c91b5f9c5a9ea0a920)
The line/column numbers were dropped putting the processEnchantOrder in the wrong place.

