### PR TITLE
Fix multiple ItemStack array nullability mistakes

### DIFF
--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -105,8 +105,31 @@ index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..e669ad8ecd182c6899c7820414e6ee1f
      @NotNull
      public int[] getExpLevelCostsOffered() {
          int[] levelOffers = new int[offers.length];
+diff --git a/src/main/java/org/bukkit/inventory/CraftingInventory.java b/src/main/java/org/bukkit/inventory/CraftingInventory.java
+index df81bac9ecff697f98941e5c8490e10391e90090..a32977ba3ba60a1c9aee6e469d5d6cd1887c55a2 100644
+--- a/src/main/java/org/bukkit/inventory/CraftingInventory.java
++++ b/src/main/java/org/bukkit/inventory/CraftingInventory.java
+@@ -21,8 +21,7 @@ public interface CraftingInventory extends Inventory {
+      *
+      * @return The contents. Individual entries may be null.
+      */
+-    @NotNull
+-    ItemStack[] getMatrix();
++    @Nullable ItemStack @NotNull [] getMatrix(); // Paper - make array elements nullable instead array
+ 
+     /**
+      * Set the item in the result slot of the crafting inventory.
+@@ -38,7 +37,7 @@ public interface CraftingInventory extends Inventory {
+      * @throws IllegalArgumentException if the length of contents is greater
+      *     than the size of the crafting matrix.
+      */
+-    void setMatrix(@NotNull ItemStack[] contents);
++    void setMatrix(@Nullable ItemStack @NotNull [] contents); // Paper - make array elements nullable instead array
+ 
+     /**
+      * Get the current recipe formed on the crafting inventory, if any.
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..a98a4f2415fedcd20f42b2a6c4997867275d3c96 100644
+index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..875c401153349b0f2468525e54cf10ca86430087 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -158,8 +158,7 @@ public interface Inventory extends Iterable<ItemStack> {
@@ -128,8 +151,27 @@ index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..a98a4f2415fedcd20f42b2a6c4997867
  
      /**
       * Return the contents from the section of the inventory where items can
+@@ -183,8 +182,7 @@ public interface Inventory extends Iterable<ItemStack> {
+      *
+      * @return inventory storage contents. Individual items may be null.
+      */
+-    @NotNull
+-    public ItemStack[] getStorageContents();
++    public @Nullable ItemStack @NotNull [] getStorageContents(); // Paper - make array elements nullable instead array
+ 
+     /**
+      * Put the given ItemStacks into the storage slots
+@@ -193,7 +191,7 @@ public interface Inventory extends Iterable<ItemStack> {
+      * @throws IllegalArgumentException If the array has more items than the
+      * inventory.
+      */
+-    public void setStorageContents(@NotNull ItemStack[] items) throws IllegalArgumentException;
++    public void setStorageContents(@Nullable ItemStack @NotNull [] items) throws IllegalArgumentException; // Paper - make array elements nullable instead array
+ 
+     /**
+      * Checks if the inventory contains any ItemStacks with the given
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
-index 71e5ee496a947fbd8e3ec579833b157c76b51833..d773e8594f91017bddd7ea8aada3a1ff2781d05b 100644
+index 9750c52309b32b4b12ecd277300aa4f9998b8072..9ba084c0aefb8d8d654880268cdb7266b4237bbb 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java
 +++ b/src/main/java/org/bukkit/inventory/ItemFactory.java
 @@ -3,6 +3,7 @@ package org.bukkit.inventory;
@@ -150,7 +192,7 @@ index 71e5ee496a947fbd8e3ec579833b157c76b51833..d773e8594f91017bddd7ea8aada3a1ff
  
      /**
 diff --git a/src/main/java/org/bukkit/inventory/ItemStack.java b/src/main/java/org/bukkit/inventory/ItemStack.java
-index 686e2a0b9fe061816b41435ef2337870dbdca8e5..aacf8ea85909299355d16cad0386072ec542a70e 100644
+index 487e6a6391123a4792c3bdeba869aa2bcb5922cc..3dd8205dd070901be82c2bef390df5df58b2a9a0 100644
 --- a/src/main/java/org/bukkit/inventory/ItemStack.java
 +++ b/src/main/java/org/bukkit/inventory/ItemStack.java
 @@ -8,6 +8,7 @@ import java.util.Set; // Paper
@@ -178,6 +220,30 @@ index 686e2a0b9fe061816b41435ef2337870dbdca8e5..aacf8ea85909299355d16cad0386072e
      public ItemMeta getItemMeta() {
          return this.meta == null ? Bukkit.getItemFactory().getItemMeta(this.type) : this.meta.clone();
      }
+diff --git a/src/main/java/org/bukkit/inventory/PlayerInventory.java b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+index 515587a958041e94f03c48ae87812abc39e1791c..5652786f43c10d03b3b1cf065548efb1a950ed7a 100644
+--- a/src/main/java/org/bukkit/inventory/PlayerInventory.java
++++ b/src/main/java/org/bukkit/inventory/PlayerInventory.java
+@@ -14,8 +14,7 @@ public interface PlayerInventory extends Inventory {
+      *
+      * @return All the ItemStacks from the armor slots. Individual items can be null.
+      */
+-    @NotNull
+-    public ItemStack[] getArmorContents();
++    public @Nullable ItemStack @NotNull [] getArmorContents(); // Paper - make array elements nullable instead array
+ 
+     /**
+      * Get all additional ItemStacks stored in this inventory.
+@@ -26,8 +25,7 @@ public interface PlayerInventory extends Inventory {
+      *
+      * @return All additional ItemStacks. Individual items can be null.
+      */
+-    @NotNull
+-    public ItemStack[] getExtraContents();
++    public @Nullable ItemStack @NotNull [] getExtraContents(); // Paper - make array elements nullable instead array
+ 
+     /**
+      * Return the ItemStack from the helmet slot
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 index 01b462fccce71cef3398dd43944046f322b8e57e..8c48a5c61b5afb5407ebf5d734858a0177e3ffa1 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java

--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -106,7 +106,7 @@ index 2ff1b1308571d8f8056d3359e8a8ba4a589c3726..e669ad8ecd182c6899c7820414e6ee1f
      public int[] getExpLevelCostsOffered() {
          int[] levelOffers = new int[offers.length];
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..c0ff615fe7ce8b398d49f52937c378eda8e79914 100644
+index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..a98a4f2415fedcd20f42b2a6c4997867275d3c96 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
 @@ -158,8 +158,7 @@ public interface Inventory extends Iterable<ItemStack> {
@@ -119,6 +119,15 @@ index 9c6a5bdac8c3ab682bbfae04ff24b76a62bc2883..c0ff615fe7ce8b398d49f52937c378ed
  
      /**
       * Completely replaces the inventory's contents. Removes all existing
+@@ -170,7 +169,7 @@ public interface Inventory extends Iterable<ItemStack> {
+      * @throws IllegalArgumentException If the array has more items than the
+      *     inventory.
+      */
+-    public void setContents(@NotNull ItemStack[] items) throws IllegalArgumentException;
++    public void setContents(@Nullable ItemStack @NotNull [] items) throws IllegalArgumentException; // Paper - make array elements nullable instead array
+ 
+     /**
+      * Return the contents from the section of the inventory where items can
 diff --git a/src/main/java/org/bukkit/inventory/ItemFactory.java b/src/main/java/org/bukkit/inventory/ItemFactory.java
 index 71e5ee496a947fbd8e3ec579833b157c76b51833..d773e8594f91017bddd7ea8aada3a1ff2781d05b 100644
 --- a/src/main/java/org/bukkit/inventory/ItemFactory.java

--- a/patches/api/0206-Inventory-getHolder-method-without-block-snapshot.patch
+++ b/patches/api/0206-Inventory-getHolder-method-without-block-snapshot.patch
@@ -28,10 +28,10 @@ index 83a4642119c3f33749e04c774cf2b39839f797e2..a39d2f1acbbd84ae0e2cf29f85594e09
      public Location getLocation() {
          return getInventory().getLocation();
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index c0ff615fe7ce8b398d49f52937c378eda8e79914..3fa4fa4170633abf472a60d5bd07fb3ac7c58947 100644
+index 875c401153349b0f2468525e54cf10ca86430087..960626dd64ec9b0c5f4638c1ada463fd20c6b5fc 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -383,6 +383,17 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -382,6 +382,17 @@ public interface Inventory extends Iterable<ItemStack> {
      @Nullable
      public InventoryHolder getHolder();
  

--- a/patches/api/0293-Inventory-close.patch
+++ b/patches/api/0293-Inventory-close.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Inventory#close
 
 
 diff --git a/src/main/java/org/bukkit/inventory/Inventory.java b/src/main/java/org/bukkit/inventory/Inventory.java
-index 3fa4fa4170633abf472a60d5bd07fb3ac7c58947..8864124c4a6ba48523ff217a78b9bac676da592f 100644
+index 960626dd64ec9b0c5f4638c1ada463fd20c6b5fc..1b577c03c3152d22b70f8bdb321b28ad8fbbc3af 100644
 --- a/src/main/java/org/bukkit/inventory/Inventory.java
 +++ b/src/main/java/org/bukkit/inventory/Inventory.java
-@@ -353,6 +353,15 @@ public interface Inventory extends Iterable<ItemStack> {
+@@ -352,6 +352,15 @@ public interface Inventory extends Iterable<ItemStack> {
       */
      public void clear();
  


### PR DESCRIPTION
`setContents` requires non null ItemStacks, so, if you want to restore an inventory's content, it is kinda messy:
```kotlin
val inventoryContents = player.inventory.contents // Array<ItemStack?>
player.inventory.setContents(inventoryContents) // doesn't work because it requires a Array<ItemStack>
player.inventory.setContents(inventoryContents.map { it ?: ItemStack(Material.AIR) }.toTypedArray())
```

This PR changes `setContents(...)` to match the `getContents()` return type.

Here's the discussion about this on Paper's Discord server: https://canary.discord.com/channels/289587909051416579/555462289851940864/917552139650351144