### PR TITLE
Use DataConverter for itemstack/entity deserialization

### DIFF
--- a/patches/server/0762-Rewrite-dataconverter-system.patch
+++ b/patches/server/0762-Rewrite-dataconverter-system.patch
@@ -22745,3 +22745,28 @@ index d785efd61caa2237e05d9ce3dbf84d86076ff047..601f8099f74e81c17600566b3c9b7a6d
          }
  
          return nbttagcompound;
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 5b05ef93a02e8a8525cf1558273d0f8963407862..1545703c4b03bded7e2e0478e59555964c053963 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -453,8 +453,8 @@ public final class CraftMagicNumbers implements UnsafeValues {
+ 
+         CompoundTag compound = deserializeNbtFromBytes(data);
+         int dataVersion = compound.getInt("DataVersion");
+-        Dynamic<Tag> converted = DataFixers.getDataFixer().update(References.ITEM_STACK, new Dynamic<Tag>(NbtOps.INSTANCE, compound), dataVersion, getDataVersion());
+-        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of((CompoundTag) converted.getValue()));
++        compound = ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ITEM_STACK, compound, dataVersion, getDataVersion()); // Paper - rewrite dataconverter
++        return CraftItemStack.asCraftMirror(net.minecraft.world.item.ItemStack.of(compound));
+     }
+ 
+     @Override
+@@ -474,8 +474,7 @@ public final class CraftMagicNumbers implements UnsafeValues {
+ 
+         CompoundTag compound = deserializeNbtFromBytes(data);
+         int dataVersion = compound.getInt("DataVersion");
+-        Dynamic<Tag> converted = DataFixers.getDataFixer().update(References.ENTITY_TREE, new Dynamic<>(NbtOps.INSTANCE, compound), dataVersion, getDataVersion());
+-        compound = (CompoundTag) converted.getValue();
++        compound = ca.spottedleaf.dataconverter.minecraft.MCDataConverter.convertTag(ca.spottedleaf.dataconverter.minecraft.datatypes.MCTypeRegistry.ENTITY, compound, dataVersion, getDataVersion()); // Paper - rewrite dataconverter
+         if (!preserveUUID) compound.remove("UUID"); // Generate a new UUID so we don't have to worry about deserializing the same entity twice
+         return net.minecraft.world.entity.EntityType.create(compound, ((org.bukkit.craftbukkit.CraftWorld) world).getHandle())
+             .orElseThrow(() -> new IllegalArgumentException("An ID was not found for the data. Did you downgrade?")).getBukkitEntity();


### PR DESCRIPTION
In 1.17, the deserializeEntity method in UnsafeValues used the dataconverter system over the builtin datafixer. Until the failing cb tests can be addressed using the new (since 1.18-pre5 for DataConverter) hooks, probably should restore that same behavior here.