### PR TITLE
Add translation keys to GameMode enum

### DIFF
--- a/patches/api/0220-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0220-Add-methods-to-get-translation-keys.patch
@@ -86,6 +86,38 @@ index 4a97e73ce59c0eee77661967f1d3ac23508aae3e..d543b2b6aa131efec9b978d0b71a228f
      }
  
      /**
+diff --git a/src/main/java/org/bukkit/GameMode.java b/src/main/java/org/bukkit/GameMode.java
+index 938c3217f92e6d3ef9a637269c469f8359af6347..ef49495909a37d718a87d5dfbcd644d46e27fa88 100644
+--- a/src/main/java/org/bukkit/GameMode.java
++++ b/src/main/java/org/bukkit/GameMode.java
+@@ -9,7 +9,7 @@ import org.jetbrains.annotations.Nullable;
+  * Represents the various type of game modes that {@link HumanEntity}s may
+  * have
+  */
+-public enum GameMode {
++public enum GameMode implements net.kyori.adventure.translation.Translatable { // Paper - implement Translatable
+     /**
+      * Creative mode may fly, build instantly, become invulnerable and create
+      * free items.
+@@ -35,9 +35,18 @@ public enum GameMode {
+ 
+     private final int value;
+     private static final Map<Integer, GameMode> BY_ID = Maps.newHashMap();
++    // Paper start - translation keys
++    private final String translationKey;
++
++    @Override
++    public @org.jetbrains.annotations.NotNull String translationKey() {
++        return this.translationKey;
++    }
++    // Paper end
+ 
+     private GameMode(final int value) {
+         this.value = value;
++        this.translationKey = "gameMode." +  this.name().toLowerCase(java.util.Locale.ENGLISH); // Paper
+     }
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/GameRule.java b/src/main/java/org/bukkit/GameRule.java
 index 442db40bc6ea2cfd2f724807544a080bb62bd8c5..d3365e44e64c2e72416d3a50be20ada79320ba2a 100644
 --- a/src/main/java/org/bukkit/GameRule.java
@@ -112,7 +144,7 @@ index 442db40bc6ea2cfd2f724807544a080bb62bd8c5..d3365e44e64c2e72416d3a50be20ada7
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/Material.java b/src/main/java/org/bukkit/Material.java
-index a8561434d56f7db7e4f52283759b282e9c2116a2..1d01bf9b193a031439343835bff07f2a0d26346f 100644
+index 88d9ca5d5c240bb6810a843c27eb1613235bffdd..f2ca0a11f0d7f8c48f7464045eded5486c1128af 100644
 --- a/src/main/java/org/bukkit/Material.java
 +++ b/src/main/java/org/bukkit/Material.java
 @@ -104,7 +104,7 @@ import org.jetbrains.annotations.Nullable;
@@ -149,7 +181,7 @@ index a8561434d56f7db7e4f52283759b282e9c2116a2..1d01bf9b193a031439343835bff07f2a
  
      /**
 diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
-index f9434c19c1bf355a734b3a1ddf32c81fb7abf9eb..580e73c3fc0e647ad128ab7d845c15fbe80484a3 100644
+index 1b5f36b78d81b688ded88ab91e36d9df8c5d64ee..e10edf17a87d18e9d9a22c6793d6ac78054d841b 100644
 --- a/src/main/java/org/bukkit/UnsafeValues.java
 +++ b/src/main/java/org/bukkit/UnsafeValues.java
 @@ -111,5 +111,34 @@ public interface UnsafeValues {

--- a/patches/server/0495-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0495-Add-methods-to-get-translation-keys.patch
@@ -42,7 +42,7 @@ index eb99e0c2462a2d1ab4508a5c3f1580b6e31d7465..c536eceef3365a7b726cd970df345ba1
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
-index 3b4764986302194882e009fe20a9d6406cf2be8e..008c15164a7affb785964f604f8fea93d28344ac 100644
+index b38e0ac6a2eafc0d98bb81665bdc2eafbac2d7d8..048163598018ee58a9aa2ca811ed44ac194ac880 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
 @@ -478,6 +478,30 @@ public final class CraftMagicNumbers implements UnsafeValues {
@@ -77,16 +77,18 @@ index 3b4764986302194882e009fe20a9d6406cf2be8e..008c15164a7affb785964f604f8fea93
  
      /**
 diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..a5a4026a09b45d7af70a56ce65b8382ac4b22efc 100644
+index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..3a569514f051d9941cb9c2d7ed3d59633f7b8493 100644
 --- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 +++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-@@ -3,11 +3,20 @@ package io.papermc.paper.world;
+@@ -3,11 +3,22 @@ package io.papermc.paper.world;
  import com.destroystokyo.paper.ClientOption;
  import net.minecraft.network.chat.TranslatableComponent;
  import net.minecraft.world.entity.player.ChatVisiblity;
 +import net.minecraft.world.item.CreativeModeTab;
++import net.minecraft.world.level.GameType;
  import org.bukkit.Difficulty;
 +import org.bukkit.FireworkEffect;
++import org.bukkit.GameMode;
 +import org.bukkit.GameRule;
 +import org.bukkit.attribute.Attribute;
 +import org.bukkit.craftbukkit.inventory.CraftCreativeCategory;
@@ -102,7 +104,7 @@ index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..a5a4026a09b45d7af70a56ce65b8382a
  
      @Test
      public void testChatVisibilityKeys() {
-@@ -16,4 +25,43 @@ public class TranslationKeyTest {
+@@ -16,4 +27,52 @@ public class TranslationKeyTest {
              Assert.assertEquals(chatVisibility + "'s translation key doesn't match", ChatVisiblity.valueOf(chatVisibility.name()).getKey(), chatVisibility.translationKey());
          }
      }
@@ -143,6 +145,15 @@ index 6cd015dc5a2e012ac827c2b2d9aa5542b0591afb..a5a4026a09b45d7af70a56ce65b8382a
 +            }
 +            CreativeCategory category = Objects.requireNonNull(CraftCreativeCategory.fromNMS(tab));
 +            Assert.assertEquals("translation key mismatch for " + category, ((TranslatableComponent) tab.getDisplayName()).getKey(), category.translationKey());
++        }
++    }
++
++    @Test
++    public void testGameMode() {
++        for (GameType nms : GameType.values()) {
++            GameMode bukkit = GameMode.getByValue(nms.getId());
++            Assert.assertNotNull(bukkit);
++            Assert.assertEquals("translation key mismatch for " + bukkit, ((TranslatableComponent) nms.getLongDisplayName()).getKey(), bukkit.translationKey());
 +        }
 +    }
  }


### PR DESCRIPTION
GameMode's really have two associated translation keys, a longer form (one that includes the "Mode" word at the end) and a shorter form. The short form is only used on the client, so I opted for the long format to be default via the `Translatable` interface, but added two methods for clarity.