### PR TITLE
Make org.bukkit.Keyed extend Adventure's Keyed

### DIFF
--- a/patches/api/0008-Adventure.patch
+++ b/patches/api/0008-Adventure.patch
@@ -682,6 +682,36 @@ index cc42bfa74b41ef6d6374efa7b882f71677fb0824..ef06bd2972e0a4e7ffa0e91d2b0de5d7
      public static String getShutdownMessage() {
          return server.getShutdownMessage();
      }
+diff --git a/src/main/java/org/bukkit/Keyed.java b/src/main/java/org/bukkit/Keyed.java
+index 32c92621c2c15eec14c50965f5ecda00c46e6c80..e076d447da62445764a9776ee2554c077637d270 100644
+--- a/src/main/java/org/bukkit/Keyed.java
++++ b/src/main/java/org/bukkit/Keyed.java
+@@ -5,7 +5,7 @@ import org.jetbrains.annotations.NotNull;
+ /**
+  * Represents an object which has a {@link NamespacedKey} attached to it.
+  */
+-public interface Keyed {
++public interface Keyed extends net.kyori.adventure.key.Keyed { // Paper -- extend Adventure Keyed
+ 
+     /**
+      * Return the namespaced identifier for this object.
+@@ -14,4 +14,16 @@ public interface Keyed {
+      */
+     @NotNull
+     NamespacedKey getKey();
++
++    // Paper start
++    /**
++     * Returns the unique identifier for this object.
++     *
++     * @return this object's key
++     */
++    @Override
++    default net.kyori.adventure.key.@NotNull Key key() {
++        return this.getKey();
++    }
++    // Paper end
+ }
 diff --git a/src/main/java/org/bukkit/Nameable.java b/src/main/java/org/bukkit/Nameable.java
 index fee814e01a653d2b53c56e8b566383ca44aa5346..2acdf2a6d3955923c721222b9da784f3278f6418 100644
 --- a/src/main/java/org/bukkit/Nameable.java


### PR DESCRIPTION
Simple tweak which adds support for Adventure's Keyed interface for many classes like Material (since NamespacedKey already implements Key)