### PR TITLE
Remove java 8 and prior reflection code from CustomTimingsHandler

### DIFF
--- a/patches/api/0006-Timings-v2.patch
+++ b/patches/api/0006-Timings-v2.patch
@@ -3536,10 +3536,10 @@ index 5ca863b3692b2e1b58e7fb4d82f554a92cc4f01e..612958a331575d1da2715531ebdf6b11
 +
 +}
 diff --git a/src/main/java/org/spigotmc/CustomTimingsHandler.java b/src/main/java/org/spigotmc/CustomTimingsHandler.java
-index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3e2931061 100644
+index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..123647bb10fc89508437d7a0bd3fd31d58ee7c82 100644
 --- a/src/main/java/org/spigotmc/CustomTimingsHandler.java
 +++ b/src/main/java/org/spigotmc/CustomTimingsHandler.java
-@@ -1,3 +1,26 @@
+@@ -1,137 +1,67 @@
 +/*
 + * This file is licensed under the MIT License (MIT).
 + *
@@ -3565,21 +3565,19 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 + */
  package org.spigotmc;
  
- import java.io.PrintStream;
-@@ -5,133 +28,84 @@ import java.util.Queue;
- import java.util.concurrent.ConcurrentLinkedQueue;
+-import java.io.PrintStream;
+-import java.util.Queue;
+-import java.util.concurrent.ConcurrentLinkedQueue;
  import org.bukkit.Bukkit;
- import org.bukkit.World;
+-import org.bukkit.World;
 -import org.bukkit.command.defaults.TimingsCommand;
  import org.jetbrains.annotations.NotNull;
- import org.jetbrains.annotations.Nullable;
+-import org.jetbrains.annotations.Nullable;
 +import org.bukkit.plugin.AuthorNagException;
-+import org.bukkit.plugin.Plugin;
 +import co.aikar.timings.Timing;
 +import co.aikar.timings.Timings;
 +import co.aikar.timings.TimingsManager;
 +
-+import java.lang.reflect.InvocationTargetException;
 +import java.lang.reflect.Method;
 +import java.util.logging.Level;
  
@@ -3607,25 +3605,17 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 +@Deprecated
 +public final class CustomTimingsHandler {
 +    private final Timing handler;
-+    private static Boolean sunReflectAvailable;
-+    private static Method getCallerClass;
  
      public CustomTimingsHandler(@NotNull String name) {
 -        this(name, null);
 -    }
-+        if (sunReflectAvailable == null) {
-+            String javaVer = System.getProperty("java.version");
-+            String[] elements = javaVer.split("\\.");
- 
+-
 -    public CustomTimingsHandler(@NotNull String name, @Nullable CustomTimingsHandler parent) {
 -        this.name = name;
 -        this.parent = parent;
 -        HANDLERS.add(this);
 -    }
-+            int major = Integer.parseInt(elements.length >= 2 ? elements[1] : javaVer);
-+            if (major <= 8) {
-+                sunReflectAvailable = true;
- 
+-
 -    /**
 -     * Prints the timings and extra data to the given stream.
 -     *
@@ -3638,14 +3628,7 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -            long count = timings.count;
 -            if (count == 0) {
 -                continue;
-+                try {
-+                    Class<?> reflection = Class.forName("sun.reflect.Reflection");
-+                    getCallerClass = reflection.getMethod("getCallerClass", int.class);
-+                } catch (ClassNotFoundException | NoSuchMethodException ignored) {
-+                }
-+            } else {
-+                sunReflectAvailable = false;
-             }
+-            }
 -            long avg = time / count;
 -
 -            printStream.println("    " + timings.name + " Time: " + time + " Count: " + count + " Avg: " + avg + " Violations: " + timings.violations);
@@ -3656,11 +3639,11 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -        for (World world : Bukkit.getWorlds()) {
 -            entities += world.getEntities().size();
 -            livingEntities += world.getLivingEntities().size();
-         }
+-        }
 -        printStream.println("# Entities " + entities);
 -        printStream.println("# LivingEntities " + livingEntities);
 -    }
- 
+-
 -    /**
 -     * Resets all timings.
 -     */
@@ -3668,16 +3651,11 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -        if (Bukkit.getPluginManager().useTimings()) {
 -            for (CustomTimingsHandler timings : HANDLERS) {
 -                timings.reset();
-+        Class calling = null;
-+        if (sunReflectAvailable) {
-+            try {
-+                calling = (Class) getCallerClass.invoke(null, 2);
-+            } catch (IllegalAccessException | InvocationTargetException ignored) {
-             }
-         }
+-            }
+-        }
 -        TimingsCommand.timingStart = System.nanoTime();
 -    }
- 
+-
 -    /**
 -     * Ticked every tick by CraftBukkit to count the number of times a timer
 -     * caused TPS loss.
@@ -3705,12 +3683,18 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -            if (parent != null && ++parent.timingDepth == 1) {
 -                parent.start = start;
 -            }
--        }
--    }
-+        Plugin plugin = null;
++        new AuthorNagException("Deprecated use of CustomTimingsHandler. Please Switch to Timings.of ASAP").printStackTrace();
 +        try {
-+             plugin = TimingsManager.getPluginByClassloader(calling);
-+        } catch (Exception ignored) {}
++            final Method ofSafe = TimingsManager.class.getDeclaredMethod("getHandler", String.class, String.class, Timing.class);
++            ofSafe.setAccessible(true);
++            timing = (Timing) ofSafe.invoke(null,"Minecraft", "(Deprecated API) " + name, null);
++        } catch (Exception e) {
++            e.printStackTrace();
++            Bukkit.getLogger().log(Level.SEVERE, "This handler could not be registered");
++            timing = Timings.NULL_HANDLER;
+         }
++        handler = timing;
+     }
  
 -    /**
 -     * Stops timing a section of code.
@@ -3727,22 +3711,11 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -            start = 0;
 -            if (parent != null) {
 -                parent.stopTiming();
-+        new AuthorNagException("Deprecated use of CustomTimingsHandler. Please Switch to Timings.of ASAP").printStackTrace();
-+        if (plugin != null) {
-+            timing = Timings.of(plugin, "(Deprecated API) " + name);
-+        } else {
-+            try {
-+                final Method ofSafe = TimingsManager.class.getDeclaredMethod("getHandler", String.class, String.class, Timing.class);
-+                ofSafe.setAccessible(true);
-+                timing = (Timing) ofSafe.invoke(null,"Minecraft", "(Deprecated API) " + name, null);
-+            } catch (Exception e) {
-+                e.printStackTrace();
-+                Bukkit.getLogger().log(Level.SEVERE, "This handler could not be registered");
-+                timing = Timings.NULL_HANDLER;
-             }
-         }
-+        handler = timing;
-     }
+-            }
+-        }
+-    }
++    public void startTiming() { handler.startTiming(); }
++    public void stopTiming() { handler.stopTiming(); }
  
 -    /**
 -     * Reset this timer, setting all values to zero.
@@ -3755,7 +3728,4 @@ index 44badfedcc3fdc26bdc293b85d8c781d6f659faa..3cbe5c2bb55dead7968a6f165ef267e3
 -        start = 0;
 -        timingDepth = 0;
 -    }
-+    public void startTiming() { handler.startTiming(); }
-+    public void stopTiming() { handler.stopTiming(); }
-+
  }


### PR DESCRIPTION
For some unknown reason this wrong code got triggered for the first time, reported over at
https://github.com/aikar/commands/issues/353

As far as I can tell, this java version detection code has been broken forever. Anyway. Simple explanation on the issue is that it would detect java 17.0.1 as java 0 since the split would have 2 or more. It looks like this was written with the expectation that java.version wouldn't return these minor java versions.

Anyway, here is my fix. Let me know if anyone thinks it needs tweaking.