### PR TITLE
Updated Upstream (CraftBukkit)

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -714,7 +714,7 @@ index aaf71bfb582d1d86d67205618825411babd2625a..f18ae5b80c930c3a7c2da079b9926ab2
          this.world = new CraftWorld((ServerLevel) this, gen, biomeProvider, env);
          this.ticksPerAnimalSpawns = this.getCraftServer().getTicksPerAnimalSpawns(); // CraftBukkit
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index ae0e8dc6fd3f8323c34df83450a16fc3c44a9e5e..980e5abe159ebfdf5334332b8d8201c0c0b66a7b 100644
+index 63a45a3bcde978bc34d14c498e2ec026975af94e..204f3ece37ebbc5159e80c2161801e45fa08dcd6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -842,6 +842,7 @@ public final class CraftServer implements Server {
@@ -740,7 +740,7 @@ index ae0e8dc6fd3f8323c34df83450a16fc3c44a9e5e..980e5abe159ebfdf5334332b8d8201c0
          this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
          this.ignoreVanillaPermissions = this.commandsConfiguration.getBoolean("ignore-vanilla-permissions");
  
-@@ -2293,4 +2296,35 @@ public final class CraftServer implements Server {
+@@ -2287,4 +2290,35 @@ public final class CraftServer implements Server {
          return this.spigot;
      }
      // Spigot end

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1713,10 +1713,10 @@ index ed639dbb4ea94839390778654c7dd0437bac41ac..1729af83b979e35a585c8d049b14dc23
          };
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 980e5abe159ebfdf5334332b8d8201c0c0b66a7b..59e619f745f62dec5a5fe304bbea75690a0b1663 100644
+index 204f3ece37ebbc5159e80c2161801e45fa08dcd6..95046f9499a1dee5bcb4e2aab03ca6b11b4b145b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2265,12 +2265,31 @@ public final class CraftServer implements Server {
+@@ -2259,12 +2259,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0012-Adventure.patch
+++ b/patches/server/0012-Adventure.patch
@@ -1718,7 +1718,7 @@ index 9af14095fa8dbc75fadb84c5a1d263039994e441..3b35ec1df648a3de920ea0c159623880
                  }
                  collection = icons;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6f238f489 100644
+index 7d1ff7636d5e91249c71303da708e754c90f0b92..693d92e3c72e8f76b12a14083efde0b5c6656050 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -624,8 +624,10 @@ public final class CraftServer implements Server {
@@ -1732,7 +1732,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
      }
  
      @Override
-@@ -1460,7 +1462,15 @@ public final class CraftServer implements Server {
+@@ -1454,7 +1456,15 @@ public final class CraftServer implements Server {
          return this.configuration.getInt("settings.spawn-radius", -1);
      }
  
@@ -1748,7 +1748,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
      }
-@@ -1618,7 +1628,20 @@ public final class CraftServer implements Server {
+@@ -1612,7 +1622,20 @@ public final class CraftServer implements Server {
      }
  
      @Override
@@ -1769,7 +1769,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
          Set<CommandSender> recipients = new HashSet<>();
          for (Permissible permissible : this.getPluginManager().getPermissionSubscriptions(permission)) {
              if (permissible instanceof CommandSender && permissible.hasPermission(permission)) {
-@@ -1626,14 +1649,14 @@ public final class CraftServer implements Server {
+@@ -1620,14 +1643,14 @@ public final class CraftServer implements Server {
              }
          }
  
@@ -1786,7 +1786,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
  
          for (CommandSender recipient : recipients) {
              recipient.sendMessage(message);
-@@ -1869,6 +1892,14 @@ public final class CraftServer implements Server {
+@@ -1863,6 +1886,14 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, type);
      }
  
@@ -1801,7 +1801,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
      @Override
      public Inventory createInventory(InventoryHolder owner, InventoryType type, String title) {
          Validate.isTrue(type.isCreatable(), "Cannot open an inventory of type ", type);
-@@ -1881,13 +1912,28 @@ public final class CraftServer implements Server {
+@@ -1875,13 +1906,28 @@ public final class CraftServer implements Server {
          return CraftInventoryCreator.INSTANCE.createInventory(owner, size);
      }
  
@@ -1830,7 +1830,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
      public Merchant createMerchant(String title) {
          return new CraftMerchantCustom(title == null ? InventoryType.MERCHANT.getDefaultTitle() : title);
      }
-@@ -1936,6 +1982,12 @@ public final class CraftServer implements Server {
+@@ -1930,6 +1976,12 @@ public final class CraftServer implements Server {
          return Thread.currentThread().equals(console.serverThread) || this.console.hasStopped() || !org.spigotmc.AsyncCatcher.enabled; // All bets are off if we have shut down (e.g. due to watchdog)
      }
  
@@ -1843,7 +1843,7 @@ index 23cba4bd17742733659aef498aa39d12ef48ca1d..cf79b158c7fbbb3ccddd4472eceb27d6
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2379,5 +2431,15 @@ public final class CraftServer implements Server {
+@@ -2373,5 +2425,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -144,10 +144,10 @@ index f1dfb56d0158d36b583b5ee5596235540b2cb11c..b86ceda8f7376334987955095234bdec
                      this.startMetricsRecordingTick();
                      this.profiler.push("tick");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index cfdc78fe0820d47d8af055e844b08ea003d74368..528687b7672ebf6e25fc0fc120fffe158e543bb3 100644
+index 50ed646021808e23876735d50c727a0f300f596e..3fdfa7750436f78ce6f0c5bac68ee0e602e8ec67 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2347,6 +2347,17 @@ public final class CraftServer implements Server {
+@@ -2341,6 +2341,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0049-Expose-server-CommandMap.patch
+++ b/patches/server/0049-Expose-server-CommandMap.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose server CommandMap
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 99c1ca9a93092465c08723b919aa61dff747bd66..d30b04375eaed44ae63b3e60ab9ac8a42478a604 100644
+index 9284b5a3b303222df23bee4b66551c08f4c55c1f..1f9e896b70888708d6420c060d8657b9ff7e60c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1965,6 +1965,7 @@ public final class CraftServer implements Server {
+@@ -1959,6 +1959,7 @@ public final class CraftServer implements Server {
          return this.helpMap;
      }
  

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Custom Permissions
 https://github.com/PaperMC/Paper/issues/49
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fb220fb9567bbbbeb0ec5515359a5b5308df2e1b..8e0e98506a647428a06b1cda094c7e00990bdfe8 100644
+index f473ec0852648198a1633fb5c916ed2bfc49630d..9e6bfd8e5ca42bb72d3d56ae7eb82c0f704f15e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2477,5 +2477,23 @@ public final class CraftServer implements Server {
+@@ -2471,5 +2471,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
+++ b/patches/server/0103-Add-setting-for-proxy-online-mode-status.patch
@@ -67,10 +67,10 @@ index 876658b685ea09adb4c01d436da56daadb7eedaa..5445cb5910ec63408dc4379eec5e12d3
          } else {
              String[] astring1 = astring;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 448544b7d290e8e98322833ec55b467e43209cae..921fc7003d2a77f195f5febe674383803950fb96 100644
+index dd5bf92faef1f7a9c5cf48eb9b1cc04272d2bd70..8b438464892f9d78457a2b09cb4670da2e356549 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1708,7 +1708,7 @@ public final class CraftServer implements Server {
+@@ -1702,7 +1702,7 @@ public final class CraftServer implements Server {
              // Spigot Start
              GameProfile profile = null;
              // Only fetch an online UUID in online mode

--- a/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0112-Allow-Reloading-of-Command-Aliases.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Allow Reloading of Command Aliases
 Reload the aliases stored in commands.yml
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 921fc7003d2a77f195f5febe674383803950fb96..2faf65a0bf3a14c891b9c603f831b66926bde87e 100644
+index 8b438464892f9d78457a2b09cb4670da2e356549..53e3ab7845934e0bbc1923be84eeb34e72794777 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2503,5 +2503,24 @@ public final class CraftServer implements Server {
+@@ -2497,5 +2497,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0136-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -20,10 +20,10 @@ index 5e23ff0c5e44427a996281ae42fc12c28649e158..7a69f9d9bb9c05474d8fbab22d626529
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 2faf65a0bf3a14c891b9c603f831b66926bde87e..93e3d587f7d1d621e8aedb8e53f38a8df21b5587 100644
+index 53e3ab7845934e0bbc1923be84eeb34e72794777..39e99daae4bb16fca5e14edf86f300f040d535eb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2522,5 +2522,10 @@ public final class CraftServer implements Server {
+@@ -2516,5 +2516,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0143-Basic-PlayerProfile-API.patch
+++ b/patches/server/0143-Basic-PlayerProfile-API.patch
@@ -460,7 +460,7 @@ index ff4def7ec3dcfa30fdc0135bd1add8e47989fb36..4f45ac04a219e619c13b31befd2c4e45
       * Calculates distance between 2 entities
       * @param e1
 diff --git a/src/main/java/net/minecraft/server/Main.java b/src/main/java/net/minecraft/server/Main.java
-index a497b281d03c097587b21e9f141a6a66f36e4dad..4ab820c43ddc79f5a280e2d4b322a667b9ba725f 100644
+index 156fa293626119caf0cf414505fdf0e96eaa08b7..e98492adfb83c24e1baa6cab24cca55f3ec151bf 100644
 --- a/src/main/java/net/minecraft/server/Main.java
 +++ b/src/main/java/net/minecraft/server/Main.java
 @@ -135,7 +135,7 @@ public class Main {
@@ -491,7 +491,7 @@ index 00f783aafd81fa7e836e4eea5bfeac7434f33b0f..3789441e2df9410aa1c6efe59054aaba
          String s1 = name.toLowerCase(Locale.ROOT);
          GameProfileCache.GameProfileInfo usercache_usercacheentry = (GameProfileCache.GameProfileInfo) this.profilesByName.get(s1);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e873cc1e27fc3fe65e7bb07c5bec7f599c32be32..0c1378bbee14a9fc3c81288e963e2709238830ae 100644
+index 23941b3ef194818483f0903b5b4793391c16f705..f824c8725ac104c93e0c24c90d3825bfb153cd2a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -248,6 +248,9 @@ import org.yaml.snakeyaml.error.MarkedYAMLException;
@@ -504,7 +504,7 @@ index e873cc1e27fc3fe65e7bb07c5bec7f599c32be32..0c1378bbee14a9fc3c81288e963e2709
  public final class CraftServer implements Server {
      private final String serverName = "Paper"; // Paper
      private final String serverVersion;
-@@ -2537,5 +2540,24 @@ public final class CraftServer implements Server {
+@@ -2531,5 +2534,24 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0169-AsyncTabCompleteEvent.patch
+++ b/patches/server/0169-AsyncTabCompleteEvent.patch
@@ -72,10 +72,10 @@ index c63bb524cbcceb926fa7f0b72bfffb670e560c5a..fd7242648da5acbb6b7c5f4c182c1e04
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0c1378bbee14a9fc3c81288e963e2709238830ae..57feb89a7dffb14f1e006b62e131604bd67797f9 100644
+index f824c8725ac104c93e0c24c90d3825bfb153cd2a..36001fea693200fb2f7d1b5b8f4d851f4fc7b480 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2057,7 +2057,7 @@ public final class CraftServer implements Server {
+@@ -2051,7 +2051,7 @@ public final class CraftServer implements Server {
              offers = this.tabCompleteChat(player, message);
          }
  

--- a/patches/server/0185-getPlayerUniqueId-API.patch
+++ b/patches/server/0185-getPlayerUniqueId-API.patch
@@ -9,10 +9,10 @@ In Offline Mode, will return an Offline UUID
 This is a more performant way to obtain a UUID for a name than loading an OfflinePlayer
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 57feb89a7dffb14f1e006b62e131604bd67797f9..03cd3fa77ca0f4c6c1f84a7866c7cd72c8f81f2e 100644
+index 36001fea693200fb2f7d1b5b8f4d851f4fc7b480..ee14922b588dfb5fe65f8c6b67ba8795219cbfba 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1710,6 +1710,25 @@ public final class CraftServer implements Server {
+@@ -1704,6 +1704,25 @@ public final class CraftServer implements Server {
          return recipients.size();
      }
  

--- a/patches/server/0292-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0292-Make-the-default-permission-message-configurable.patch
@@ -42,10 +42,10 @@ index 1015fcc6c77bd64c3f3cbf234e85a6602dbfa0d7..769353df1fcdaacecd80085165a1d72f
          Object val = config.get("settings.save-player-data");
          if (val instanceof Boolean) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 5eaf046724b7354b84c9a40f73c2f4d3d21fc601..fac71467445f192eed02118495c423b62fe486dc 100644
+index df29e226904111e9fba1cee5a29b952c6f8362ad..0e8b290f92c0d66968fd9428aac19ca233dfdde1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2562,6 +2562,11 @@ public final class CraftServer implements Server {
+@@ -2556,6 +2556,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0327-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
+++ b/patches/server/0327-Fix-CraftServer-isPrimaryThread-and-MinecraftServer-.patch
@@ -29,10 +29,10 @@ index bc9937642a46ecd766a45ccb037de993dafa3608..bd8e654c1580a0ac7dd411b9f1dcad4a
  
      public boolean isDebugging() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index fac71467445f192eed02118495c423b62fe486dc..e41d52071bbfbcb6cb37920fe5edf164dc281567 100644
+index 0e8b290f92c0d66968fd9428aac19ca233dfdde1..1f7ac7b4d2d26ecf1f3ab8f5eec0e0e2dcc679c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2046,7 +2046,7 @@ public final class CraftServer implements Server {
+@@ -2040,7 +2040,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0334-Expose-the-internal-current-tick.patch
+++ b/patches/server/0334-Expose-the-internal-current-tick.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Expose the internal current tick
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index e41d52071bbfbcb6cb37920fe5edf164dc281567..20214d98ab5449798c3d045b4d1133ff5d939c11 100644
+index 1f7ac7b4d2d26ecf1f3ab8f5eec0e0e2dcc679c1..f4f3e9e964effd856a9456b6d5759bf0bf0aa7a7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2585,5 +2585,10 @@ public final class CraftServer implements Server {
+@@ -2579,5 +2579,10 @@ public final class CraftServer implements Server {
          }
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(uuid, name);
      }

--- a/patches/server/0363-Anti-Xray.patch
+++ b/patches/server/0363-Anti-Xray.patch
@@ -1596,10 +1596,10 @@ index 7bc1219523eeb0880493e6fb42692f1fdb30c110..d6efa18ba9c032858071f6c87f1bdc0c
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 20214d98ab5449798c3d045b4d1133ff5d939c11..0287df105ee4a2d415a343e1b54b4dd9e369e5d0 100644
+index f4f3e9e964effd856a9456b6d5759bf0bf0aa7a7..14102e929bb8c91e50a6ea3175512dfb01ccac27 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2201,7 +2201,7 @@ public final class CraftServer implements Server {
+@@ -2195,7 +2195,7 @@ public final class CraftServer implements Server {
      public ChunkGenerator.ChunkData createChunkData(World world) {
          Validate.notNull(world, "World cannot be null");
          ServerLevel handle = ((CraftWorld) world).getHandle();

--- a/patches/server/0384-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0384-Add-tick-times-API-and-mspt-command.patch
@@ -146,10 +146,10 @@ index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0287df105ee4a2d415a343e1b54b4dd9e369e5d0..3a741fd48aea32b017b2a14e64c47ef1b0af04c7 100644
+index 14102e929bb8c91e50a6ea3175512dfb01ccac27..47f69b5ce833003d70b0c9a46a69b007a62f3dcd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2423,6 +2423,16 @@ public final class CraftServer implements Server {
+@@ -2417,6 +2417,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0385-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0385-Expose-MinecraftServer-isRunning.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Expose MinecraftServer#isRunning
 This allows for plugins to detect if the server is actually turning off in onDisable rather than just plugins reloading.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 3a741fd48aea32b017b2a14e64c47ef1b0af04c7..8a0e1e7ac1c447d6e9b8807054aaa86820171e7b 100644
+index 47f69b5ce833003d70b0c9a46a69b007a62f3dcd..709666558393b60e9655718c0e2a812821fccd3e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2600,5 +2600,10 @@ public final class CraftServer implements Server {
+@@ -2594,5 +2594,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0396-Improved-Watchdog-Support.patch
+++ b/patches/server/0396-Improved-Watchdog-Support.patch
@@ -323,10 +323,10 @@ index 8cfe47012b78eb582afff23ffcf758ca2e9dec95..d70bdf21dd7bdf01b34d0fd38e79f9b3
                          final String msg = String.format("BlockEntity threw exception at %s:%s,%s,%s", LevelChunk.this.getLevel().getWorld().getName(), this.getPos().getX(), this.getPos().getY(), this.getPos().getZ());
                          net.minecraft.server.MinecraftServer.LOGGER.error(msg, throwable);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 8a0e1e7ac1c447d6e9b8807054aaa86820171e7b..264d1202d2efc6aeb89be17f74c0f1423d80be1d 100644
+index 709666558393b60e9655718c0e2a812821fccd3e..d260e8d47915752c3b99d0fce952503ff0dca3a4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2046,7 +2046,7 @@ public final class CraftServer implements Server {
+@@ -2040,7 +2040,7 @@ public final class CraftServer implements Server {
  
      @Override
      public boolean isPrimaryThread() {

--- a/patches/server/0421-Implement-Mob-Goal-API.patch
+++ b/patches/server/0421-Implement-Mob-Goal-API.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Mob Goal API
 
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index 79d80e5a5e52d2bc45f63eeb81c6f4fd858f7ffc..a5e3868343f6dd0c483d59962b0aed301b973cc6 100644
+index 30f31973478175fe62877e21ab6a5473801a58dc..3381ac7c25323d662935c98aa444195c49cf4e8e 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -45,6 +45,7 @@ dependencies {
@@ -785,10 +785,10 @@ index 4379b9948f1eecfe6fd7dea98e298ad5f761019a..3f081183521603824430709886a9cc31
          LOOK,
          JUMP,
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 134f9efd6267c3baeabc110f75d7182b0f78fa77..1fc14d579e00534c5eb6ffb67fd61fd0685edb5a 100644
+index cd09ec4a75166553470f83f249b6d1e6ee944b50..f0dd163b4af8034a2eaf9298a38a418fe5e05a70 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2613,5 +2613,11 @@ public final class CraftServer implements Server {
+@@ -2607,5 +2607,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0527-Add-getOfflinePlayerIfCached-String.patch
+++ b/patches/server/0527-Add-getOfflinePlayerIfCached-String.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add getOfflinePlayerIfCached(String)
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 80843004e01ae8ce66823daa1062c997f135baf3..8535bb6523ef8736970f064ee2b52563a4c9726f 100644
+index 1b49560b8323ab5fc3f02963b2911473e36e3cba..538fd5553c6d8ebea5ae83d47fcfbdd4b2ada611 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1805,6 +1805,28 @@ public final class CraftServer implements Server {
+@@ -1799,6 +1799,28 @@ public final class CraftServer implements Server {
          return result;
      }
  

--- a/patches/server/0657-Add-basic-Datapack-API.patch
+++ b/patches/server/0657-Add-basic-Datapack-API.patch
@@ -92,7 +92,7 @@ index 0000000000000000000000000000000000000000..cf4374493c11057451a62a655514415c
 +    }
 +}
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 203ba9f883941cd4f421b2c53ee153ecc02cd16c..c1a28d8d52afcfd60223b59107ce92e1037f5ba6 100644
+index 8a4c15afceb96e319b80b7506e401f60275b5116..8fe8a761b76972fbc586fa7bb3e08fbeabd5bda0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -290,6 +290,7 @@ public final class CraftServer implements Server {
@@ -111,7 +111,7 @@ index 203ba9f883941cd4f421b2c53ee153ecc02cd16c..c1a28d8d52afcfd60223b59107ce92e1
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2686,5 +2688,11 @@ public final class CraftServer implements Server {
+@@ -2680,5 +2682,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0816-Fix-removing-recipes-from-RecipeIterator.patch
+++ b/patches/server/0816-Fix-removing-recipes-from-RecipeIterator.patch
@@ -1,21 +1,9 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jake <jake.m.potrebic@gmail.com>
 Date: Tue, 30 Nov 2021 12:01:56 -0800
-Subject: [PATCH] Fix removing recipes
+Subject: [PATCH] Fix removing recipes from RecipeIterator
 
 
-diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 88166a778b30e7d3ff6a63e1162232b68a11f17f..02e25451737841001363f4697fd05b1e2c6240cd 100644
---- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -1531,6 +1531,7 @@ public final class CraftServer implements Server {
-         ResourceLocation mcKey = CraftNamespacedKey.toMinecraft(recipeKey);
-         for (Object2ObjectLinkedOpenHashMap<ResourceLocation, net.minecraft.world.item.crafting.Recipe<?>> recipes : this.getServer().getRecipeManager().recipes.values()) {
-             if (recipes.remove(mcKey) != null) {
-+                this.getServer().getRecipeManager().byName.remove(mcKey); // Paper
-                 return true;
-             }
-         }
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/RecipeIterator.java b/src/main/java/org/bukkit/craftbukkit/inventory/RecipeIterator.java
 index 24f336c89b548c5ba2a95372db0d7c83b5c4ec47..91895c639c33a1cafd2a35bab7b5fd83e558468d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/RecipeIterator.java

--- a/patches/server/0824-Allow-delegation-to-vanilla-chunk-gen.patch
+++ b/patches/server/0824-Allow-delegation-to-vanilla-chunk-gen.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow delegation to vanilla chunk gen
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 02e25451737841001363f4697fd05b1e2c6240cd..d91abf93f2a06f73d3124f4fcff2491fe8d36655 100644
+index 3c17a2da92d8268564af075916c3503b82ba492f..b70a6d126e80d775870cfececf6724cde89d4554 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2287,6 +2287,107 @@ public final class CraftServer implements Server {
+@@ -2280,6 +2280,107 @@ public final class CraftServer implements Server {
          return new OldCraftChunkData(world.getMinHeight(), world.getMaxHeight(), handle.registryAccess().registryOrThrow(Registry.BIOME_REGISTRY), world); // Paper - Anti-Xray - Add parameters
      }
  


### PR DESCRIPTION
Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

CraftBukkit Changes:
dad85171 SPIGOT-6851: removeRecipe not unregistering recipe ID