### PR TITLE
Fully remove spigot's tick limiters

### DIFF
--- a/patches/server/0044-Disable-spigot-tick-limiters.patch
+++ b/patches/server/0044-Disable-spigot-tick-limiters.patch
@@ -5,10 +5,36 @@ Subject: [PATCH] Disable spigot tick limiters
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 809f1ac0aca97d484e2f92ebf38a0303499f08ae..db226fe9515e904b8520a063b6dcde62b315a9b1 100644
+index 16f212b4005469dc99fdd83ed6e5810a5b6f8abf..7ec372adae2ea59b71af9c503c12ac1e0786dd47 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -704,9 +704,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -153,8 +153,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+ 
+     public final co.aikar.timings.WorldTimingsHandler timings; // Paper
+     public static BlockPos lastPhysicsProblem; // Spigot
+-    private org.spigotmc.TickLimiter entityLimiter;
+-    private org.spigotmc.TickLimiter tileLimiter;
++    // Paper start - Disable tick limiters
++    // private org.spigotmc.TickLimiter entityLimiter;
++    // private org.spigotmc.TickLimiter tileLimiter;
++    // Paper end
+     private int tileTickPosition;
+     public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
+ 
+@@ -242,8 +244,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+         // CraftBukkit end
+         timings = new co.aikar.timings.WorldTimingsHandler(this); // Paper - code below can generate new world and access timings
+         this.keepSpawnInMemory = this.paperConfig.keepSpawnInMemory; // Paper
+-        this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
+-        this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
++        // Paper start - Disable tick limiters
++        // this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
++        // this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
++        // Paper end
+     }
+ 
+     @Override
+@@ -704,9 +708,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Spigot start
          // Iterator iterator = this.blockEntityTickers.iterator();
          int tilesThisCycle = 0;
@@ -19,3 +45,51 @@ index 809f1ac0aca97d484e2f92ebf38a0303499f08ae..db226fe9515e904b8520a063b6dcde62
              this.tileTickPosition = (this.tileTickPosition < this.blockEntityTickers.size()) ? this.tileTickPosition : 0;
              TickingBlockEntity tickingblockentity = (TickingBlockEntity) this.blockEntityTickers.get(tileTickPosition);
              // Spigot start
+diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+index 6c5113545914842ffb310522a7549ae7dd2466b2..3bc6d46f36691ccdc019a17f41dd8e614a7b30ab 100644
+--- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
++++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
+@@ -370,6 +370,8 @@ public class SpigotWorldConfig
+         this.hangingTickFrequency = this.getInt( "hanging-tick-frequency", 100 );
+     }
+ 
++    // Paper start - Disable tick limiters
++    /*
+     public int tileMaxTickTime;
+     public int entityMaxTickTime;
+     private void maxTickTimes()
+@@ -378,6 +380,8 @@ public class SpigotWorldConfig
+         this.entityMaxTickTime = this.getInt("max-tick-time.entity", 50);
+         this.log("Tile Max Tick Time: " + this.tileMaxTickTime + "ms Entity max Tick Time: " + this.entityMaxTickTime + "ms");
+     }
++    */
++    // Paper end
+ 
+     public int thunderChance;
+     private void thunderChance()
+diff --git a/src/main/java/org/spigotmc/TickLimiter.java b/src/main/java/org/spigotmc/TickLimiter.java
+deleted file mode 100644
+index 4074538ea6090bf99d8ab04b1e98c2832a0e9a98..0000000000000000000000000000000000000000
+--- a/src/main/java/org/spigotmc/TickLimiter.java
++++ /dev/null
+@@ -1,20 +0,0 @@
+-package org.spigotmc;
+-
+-public class TickLimiter {
+-
+-    private final int maxTime;
+-    private long startTime;
+-
+-    public TickLimiter(int maxtime) {
+-        this.maxTime = maxtime;
+-    }
+-
+-    public void initTick() {
+-        this.startTime = System.currentTimeMillis();
+-    }
+-
+-    public boolean shouldContinue() {
+-        long remaining = System.currentTimeMillis() - this.startTime;
+-        return remaining < this.maxTime;
+-    }
+-}

--- a/patches/server/0056-Add-exception-reporting-event.patch
+++ b/patches/server/0056-Add-exception-reporting-event.patch
@@ -108,7 +108,7 @@ index 4cde8d630a0951f297622af4ef781f5b3fabf9af..7044d8c71e85551e11bf2d96b767e088
              }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ad4b29c96113d15b284aed78e5768588802e468c..731e1cefd2a9c829bfe82ec87038d9333ef21fb3 100644
+index 7ec372adae2ea59b71af9c503c12ac1e0786dd47..76bb077e9279a303c3da1a9b256fe86700d171c4 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -1,5 +1,10 @@
@@ -122,7 +122,7 @@ index ad4b29c96113d15b284aed78e5768588802e468c..731e1cefd2a9c829bfe82ec87038d933
  import com.google.common.collect.Lists;
  import com.mojang.serialization.Codec;
  import java.io.IOException;
-@@ -740,6 +745,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -744,6 +749,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper start - Prevent tile entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level.getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
              MinecraftServer.LOGGER.error(msg, throwable);

--- a/patches/server/0067-Add-World-Util-Methods.patch
+++ b/patches/server/0067-Add-World-Util-Methods.patch
@@ -19,10 +19,10 @@ index c8ba29065b2e195bdb2570806763e299108725af..b106dfc16820d89b9c9792ad85d09fd6
      }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 731e1cefd2a9c829bfe82ec87038d9333ef21fb3..648642a30b499532f55f80a103f759740d815691 100644
+index 76bb077e9279a303c3da1a9b256fe86700d171c4..d7e51e0af808f162188b97d727fc0d0682b2504e 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -320,6 +320,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -324,6 +324,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
+++ b/patches/server/0072-Optimize-isInWorldBounds-and-getBlockState-for-inlin.patch
@@ -29,10 +29,10 @@ index 543d5a67e76a3114f6eac29a053ff04ceecb6256..cf7cbab325865c8e0d114187a5a15f73
          this.x = x;
          this.y = y;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index de1bb9ecb8891b66b2c469f2ee52b9eee9d7ddea..c28285ab7e698a214aea6ff4a5ff6d4f8b8b52bd 100644
+index d7e51e0af808f162188b97d727fc0d0682b2504e..0ed6d31462738013a95148a0b3c8c4dc0ec99b47 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -263,7 +263,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -267,7 +267,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      }
  
      public boolean isInWorldBounds(BlockPos pos) {
@@ -88,7 +88,7 @@ index ef74f37cae96e61d5648fce7bbd793fb67ba9e4a..e15263a152c88371ebc65b47f0be938f
      @Override
      public FluidState getFluidState(BlockPos pos) {
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index f9fbe225cc11b2bafa733e92d9537aaa7c1e007b..78cb2d16654cd679531bba9d7d9d0cb810e689e2 100644
+index 3ba9f8d7dc12709670dcd94df5d82b8d44f983fa..cbffb4eb93ba1888666d4b0de98b2fb05c1400a0 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -288,12 +288,29 @@ public class LevelChunk extends ChunkAccess {
@@ -138,7 +138,7 @@ index 6abd3cf0a388b158252628d8031b92bb8a6d65fb..50b6ecfea7a342be0d21e37ae87777a4
      private short tickingFluidCount;
      public final PalettedContainer<BlockState> states;
 diff --git a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
-index b7dbdcb0ce7948c6f98ec67d0cf2033a8e348085..150dd90598bbe4057b4e9ad17c87a4c07af3d56d 100644
+index 41530d0b759604716f739d10f41627871f2ba319..0dfa51c8826b9e984586a3e4e050a50a4fbb1bd3 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/ProtoChunk.java
 @@ -87,14 +87,18 @@ public class ProtoChunk extends ChunkAccess {

--- a/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
+++ b/patches/server/0073-Only-process-BlockPhysicsEvent-if-a-plugin-has-a-lis.patch
@@ -30,10 +30,10 @@ index 4e896cdc395cfb2b976e13ee3f0228d9f475069f..419f539109ca0b8103475e52d0fdda40
      @Override public LevelChunk getChunkIfLoaded(int x, int z) { // Paper - this was added in world too but keeping here for NMS ABI
          return this.chunkSource.getChunk(x, z, false);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 987962d1142c0ec0e28a9f2c7a62c8440bb10bd7..a0529181ab587c6675a6b6252efa12354c29316e 100644
+index 0ed6d31462738013a95148a0b3c8c4dc0ec99b47..0fef1844aa2290b7dbac9a93e810c6f4e48d8673 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -475,7 +475,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -479,7 +479,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  // CraftBukkit start
                  iblockdata1.updateIndirectNeighbourShapes(this, blockposition, k, j - 1); // Don't call an event for the old block to limit event spam
                  CraftWorld world = ((ServerLevel) this).getWorld();
@@ -42,7 +42,7 @@ index 987962d1142c0ec0e28a9f2c7a62c8440bb10bd7..a0529181ab587c6675a6b6252efa1235
                      BlockPhysicsEvent event = new BlockPhysicsEvent(world.getBlockAt(blockposition.getX(), blockposition.getY(), blockposition.getZ()), CraftBlockData.fromData(iblockdata));
                      this.getCraftServer().getPluginManager().callEvent(event);
  
-@@ -588,7 +588,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -592,7 +592,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              try {
                  // CraftBukkit start
                  CraftWorld world = ((ServerLevel) this).getWorld();

--- a/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
+++ b/patches/server/0081-Fix-Cancelling-BlockPlaceEvent-triggering-physics.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Cancelling BlockPlaceEvent triggering physics
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 2cc265cb984160047a44261ebbf5ff718bdf6b0c..2cec48979dafd3edf8c6744e2f5f65a922537b0f 100644
+index 0fef1844aa2290b7dbac9a93e810c6f4e48d8673..15c89e45542d2cf071f773b1766c9cbb479a7dce 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -546,6 +546,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -550,6 +550,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public void setBlocksDirty(BlockPos pos, BlockState old, BlockState updated) {}
  
      public void updateNeighborsAt(BlockPos pos, Block block) {

--- a/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
+++ b/patches/server/0097-Faster-redstone-torch-rapid-clock-removal.patch
@@ -6,11 +6,11 @@ Subject: [PATCH] Faster redstone torch rapid clock removal
 Only resize the the redstone torch list once, since resizing arrays / lists is costly
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 7c0437929964d95797c13b690a6167f2bce95736..8142f6c2d3bd17aec313d46141910f0743c6345e 100644
+index 15c89e45542d2cf071f773b1766c9cbb479a7dce..18df5addf90cd29918d1b2a82165bb023f80bfe6 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -162,6 +162,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-     private org.spigotmc.TickLimiter tileLimiter;
+@@ -164,6 +164,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+     // Paper end
      private int tileTickPosition;
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
 +    public java.util.ArrayDeque<net.minecraft.world.level.block.RedstoneTorchBlock.Toggle> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here

--- a/patches/server/0117-Optimize-World.isLoaded-BlockPosition-Z.patch
+++ b/patches/server/0117-Optimize-World.isLoaded-BlockPosition-Z.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Optimize World.isLoaded(BlockPosition)Z
 Reduce method invocations for World.isLoaded(BlockPosition)Z
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 11cd3fc535717f074c20a39b4248d623176f7445..7a392ab56a95bba28aca33be6a738136a6803e0c 100644
+index 18df5addf90cd29918d1b2a82165bb023f80bfe6..48c497feb1bf2a01353719d8558dc7f6b1b2bca8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -321,6 +321,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -325,6 +325,11 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return chunk == null ? null : chunk.getFluidState(blockposition);
      }
  

--- a/patches/server/0166-Fix-MC-117075-TE-Unload-Lag-Spike.patch
+++ b/patches/server/0166-Fix-MC-117075-TE-Unload-Lag-Spike.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix MC-117075: TE Unload Lag Spike
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77f7a44240 100644
+index 909926e1ad6ec1f5bbde3f74470dea9b2ceab910..552d6a1a1762eb3ff0dacc84192f8fe8292a9ee4 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -732,6 +732,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -736,6 +736,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          // Spigot start
          // Iterator iterator = this.blockEntityTickers.iterator();
          int tilesThisCycle = 0;
@@ -17,7 +17,7 @@ index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77
          for (tileTickPosition = 0; tileTickPosition < this.blockEntityTickers.size(); tileTickPosition++) { // Paper - Disable tick limiters
              this.tileTickPosition = (this.tileTickPosition < this.blockEntityTickers.size()) ? this.tileTickPosition : 0;
              TickingBlockEntity tickingblockentity = (TickingBlockEntity) this.blockEntityTickers.get(tileTickPosition);
-@@ -739,7 +741,6 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -743,7 +745,6 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (tickingblockentity == null) {
                  this.getCraftServer().getLogger().severe("Spigot has detected a null entity and has removed it, preventing a crash");
                  tilesThisCycle--;
@@ -25,7 +25,7 @@ index ea1e85fa125f2dd1a251e1589fff32d7083e2c13..73ff83f2c3a6b9796305abd5a98e8a77
                  continue;
              }
              // Spigot end
-@@ -747,12 +748,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -751,12 +752,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              if (tickingblockentity.isRemoved()) {
                  // Spigot start
                  tilesThisCycle--;

--- a/patches/server/0167-use-CB-BlockState-implementations-for-captured-block.patch
+++ b/patches/server/0167-use-CB-BlockState-implementations-for-captured-block.patch
@@ -18,7 +18,7 @@ the blockstate that will be valid for restoration, as opposed to dropping
 information on restoration when the event is cancelled.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174af9b180cb 100644
+index 552d6a1a1762eb3ff0dacc84192f8fe8292a9ee4..aeca9c356bcfa90f4bca4c0a6643c71552de06d1 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -142,7 +142,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -30,7 +30,7 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
      public Map<BlockPos, BlockEntity> capturedTileEntities = new HashMap<>();
      public List<ItemEntity> captureDrops;
      public long ticksPerAnimalSpawns;
-@@ -363,7 +363,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -367,7 +367,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {
@@ -39,7 +39,7 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
              if (blockstate == null) {
                  blockstate = CapturedBlockState.getTreeBlockState(this, pos, flags);
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
-@@ -383,7 +383,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -387,7 +387,8 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit start - capture blockstates
              boolean captured = false;
              if (this.captureBlockStates && !this.capturedBlockStates.containsKey(pos)) {
@@ -49,7 +49,7 @@ index 73ff83f2c3a6b9796305abd5a98e8a77f7a44240..cd2278765439f4dc1652d997c8e0174a
                  this.capturedBlockStates.put(pos.immutable(), blockstate);
                  captured = true;
              }
-@@ -652,7 +653,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -656,7 +657,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public BlockState getBlockState(BlockPos pos) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 825f8de6f5a6f6221724ba35dde265aadb15e4e8..391a4cd47438cf8fd72b43f6cb0b4e278fa844ad 100644
+index e203647884c20a8512a0aebdbad3488939226a8c..5993ea31ebdf1b37f85cee27f11234b7981f77fe 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -414,4 +414,9 @@ public class PaperWorldConfig {
@@ -31,10 +31,10 @@ index 138422903dcb3056cd011a72e0625a1a225b4280..b92c2d5f9ad3936f619b51c79379983e
  
          for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cd2278765439f4dc1652d997c8e0174af9b180cb..aba12f5a941fb07a2f4dd54af8f0a4310488ac78 100644
+index aeca9c356bcfa90f4bca4c0a6643c71552de06d1..bee224c4c3d4a3be34632ad7aef3f3d10b7070b0 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -776,6 +776,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -780,6 +780,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // Paper end
          }
      }

--- a/patches/server/0231-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0231-Vanished-players-don-t-have-rights.patch
@@ -38,7 +38,7 @@ index c3fb7d41688855010c643b91c8d9496486dae089..8175bb6331727440da2232998bdad068
  
          BlockCanBuildEvent event = new BlockCanBuildEvent(CraftBlock.at(context.getLevel(), context.getClickedPos()), player, CraftBlockData.fromData(state), defaultReturn);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c50b3a76c9 100644
+index bee224c4c3d4a3be34632ad7aef3f3d10b7070b0..f7c93ff84ee2391b1da5f33b607613a88ffc5a23 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -72,6 +72,10 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
@@ -52,8 +52,8 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
  import net.minecraft.world.scores.Scoreboard;
  import org.apache.logging.log4j.LogManager;
  import org.apache.logging.log4j.Logger;
-@@ -252,6 +256,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-         this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
+@@ -256,6 +260,45 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+         // Paper end
      }
  
 +    // Paper start
@@ -99,7 +99,7 @@ index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c5
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index b3a2a865f7b7346566cf84bc20d845d1ca481711..3cc200e2d83543d24c40e36d23f29e2b9888fea4 100644
+index 917d0804ff7ecb149a6c4524b2b6ecc6ae56b7e6..c6ab5ca7dcc3c7308d7d323a2c6f49949bc0c4fe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1241,6 +1241,14 @@ public class CraftEventFactory {

--- a/patches/server/0301-BlockDestroyEvent.patch
+++ b/patches/server/0301-BlockDestroyEvent.patch
@@ -11,7 +11,7 @@ floating in the air.
 This can replace many uses of BlockPhysicsEvent
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index ee5415574dea0712f08e2467ecf93aa1ce39a2e5..40a445f6aa0440307368aba8433e5e7c70753566 100644
+index 77abbe98ff86585dae15e194effc3e8e3076c31a..8dafc1405b14cd2b6912e27d45fd35bd0313f07a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -28,6 +28,7 @@ import net.minecraft.nbt.CompoundTag;
@@ -22,7 +22,7 @@ index ee5415574dea0712f08e2467ecf93aa1ce39a2e5..40a445f6aa0440307368aba8433e5e7c
  import net.minecraft.server.MinecraftServer;
  import net.minecraft.server.level.ChunkHolder;
  import net.minecraft.server.level.ServerLevel;
-@@ -565,8 +566,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -569,8 +570,20 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              return false;
          } else {
              FluidState fluid = this.getFluidState(pos);

--- a/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
+++ b/patches/server/0319-Optimize-Captured-TileEntity-Lookup.patch
@@ -10,10 +10,10 @@ Optimize to check if the captured list even has values in it, and also to
 just do a get call since the value can never be null.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 40a445f6aa0440307368aba8433e5e7c70753566..dac62bad9def39aba8fe7bebf1631eccde9cbf00 100644
+index 8dafc1405b14cd2b6912e27d45fd35bd0313f07a..83f63901f4f64c276740b4f16627e550b3983cdb 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -876,9 +876,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -880,9 +880,12 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Nullable
      public BlockEntity getBlockEntity(BlockPos blockposition, boolean validate) {

--- a/patches/server/0360-Anti-Xray.patch
+++ b/patches/server/0360-Anti-Xray.patch
@@ -1214,7 +1214,7 @@ index d0b54ebc05cac6535a023709c76efd802f7150f9..d87ee258db769bc072cbdae4298ebc08
  
      public void destroyAndAck(BlockPos pos, ServerboundPlayerActionPacket.Action action, String reason) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f596bfef780 100644
+index eab8579f1cf7ad21df3688d3eeb42a352b9986a6..e69c46f7d1f035ca137ccfa2ce4199a46e03ae98 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -167,6 +167,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
@@ -1225,7 +1225,7 @@ index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f59
  
      public final co.aikar.timings.WorldTimingsHandler timings; // Paper
      public static BlockPos lastPhysicsProblem; // Spigot
-@@ -186,7 +187,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -188,7 +189,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<LevelStem> getTypeKey();
  
@@ -1234,15 +1234,15 @@ index 615204f7e3095fcd65099a1b752635fa08d44d25..65bfcc218e50c05d5d1b90081b888f59
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName(), this.spigotConfig); // Paper
          this.generator = gen;
-@@ -262,6 +263,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-         this.keepSpawnInMemory = this.paperConfig.keepSpawnInMemory; // Paper
-         this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
-         this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
+@@ -266,6 +267,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+         // this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
+         // this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
+         // Paper end
 +        this.chunkPacketBlockController = this.paperConfig.antiXray ? new com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray(this, executor) : com.destroystokyo.paper.antixray.ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
      }
  
      // Paper start
-@@ -442,6 +444,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -446,6 +448,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
              // CraftBukkit end
  
              BlockState iblockdata1 = chunk.setBlockState(pos, state, (flags & 64) != 0, (flags & 1024) == 0); // CraftBukkit custom NO_PLACE flag

--- a/patches/server/0365-Avoid-hopper-searches-if-there-are-no-items.patch
+++ b/patches/server/0365-Avoid-hopper-searches-if-there-are-no-items.patch
@@ -14,10 +14,10 @@ And since minecart hoppers are used _very_ rarely near we can avoid alot of sear
 Combined, this adds up a lot.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 65bfcc218e50c05d5d1b90081b888f596bfef780..dbccf3c687cf52ca95934c274ae6949f600c7ca8 100644
+index e69c46f7d1f035ca137ccfa2ce4199a46e03ae98..3eaeadb01eb0a0a5756dfc7aa3ab2f8769aec9ff 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -988,7 +988,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -992,7 +992,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
                  }
              }
  

--- a/patches/server/0393-Improved-Watchdog-Support.patch
+++ b/patches/server/0393-Improved-Watchdog-Support.patch
@@ -299,10 +299,10 @@ index 7bf4bf5cb2c1b54a7e2733091f48f3a824336d36..dcce05d2f4ab16424db4ab103a12188e
          }
  
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index dbccf3c687cf52ca95934c274ae6949f600c7ca8..634a858e4e03968ada7c13e26e151d8f05ad611c 100644
+index 3eaeadb01eb0a0a5756dfc7aa3ab2f8769aec9ff..95b94616c81a1fa72c54f89d103e90042f88b645 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -834,6 +834,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -838,6 +838,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          try {
              tickConsumer.accept(entity);
          } catch (Throwable throwable) {

--- a/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -54,10 +54,10 @@ index e2bc9e91f03997884af381b3261b102a6e0bc5cb..8325ccbcae2a5ed55f436163bb8136cc
  
                      this.level.getProfiler().push("explosion_blocks");
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 634a858e4e03968ada7c13e26e151d8f05ad611c..ad9b48a0c89689a602c85f65e6cc68977af5ea29 100644
+index 95b94616c81a1fa72c54f89d103e90042f88b645..6b9827682e5ec50bcaafa3d2b46af8ac69b1537a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -416,6 +416,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -420,6 +420,10 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public boolean setBlock(BlockPos pos, BlockState state, int flags, int maxUpdateDepth) {
          // CraftBukkit start - tree generation
          if (this.captureTreeGeneration) {

--- a/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
+++ b/patches/server/0658-Fix-and-optimise-world-force-upgrading.patch
@@ -306,10 +306,10 @@ index 5de82c5d7da2ca6eeee4b804b916fa9d385cc25c..e03018882da878ddc51986733cfd6ea1
  
              if (dimensionKey == LevelStem.OVERWORLD) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index c76b508026c5ad54879ba400a9b6f8287f3f95b8..b7f9d6682c1dc5f03ae363b782ae9346f5bbe841 100644
+index c49133ad0b83a5e7151c819bfe0f657912756da8..add25af51c86d1e5756e6c4d9a5505811f4c705a 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -177,6 +177,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -179,6 +179,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public final Map<Explosion.CacheKey, Float> explosionDensityCache = new HashMap<>(); // Paper - Optimize explosions
      public java.util.ArrayDeque<net.minecraft.world.level.block.RedstoneTorchBlock.Toggle> redstoneUpdateInfos; // Paper - Move from Map in BlockRedstoneTorch to here
  
@@ -359,7 +359,7 @@ index 2ee32657a49937418b352a138aca21fbb27857e6..7b4f3c30cfc4bf68cc872598726f7f7e
          return this.regionCache.getAndMoveToFirst(ChunkPos.asLong(chunkcoordintpair.getRegionX(), chunkcoordintpair.getRegionZ()));
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 6513cb5f236d86097f078f8c72cc3d0a0ebc9617..dfeef8b13a86998599d17f84996e1368649c47b1 100644
+index 8fe8a761b76972fbc586fa7bb3e08fbeabd5bda0..3155d56a2b2e38a3963396441d7a73f187258350 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -1218,12 +1218,7 @@ public final class CraftServer implements Server {

--- a/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
+++ b/patches/server/0685-Use-getChunkIfLoadedImmediately-in-places.patch
@@ -34,10 +34,10 @@ index 87fd9e456bdef1becbadb0f368ccb39160986e37..b4d0b792f5476d567e317927c312f4db
                                  return;
                              }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index b7f9d6682c1dc5f03ae363b782ae9346f5bbe841..d63f4108012b4d3ed566298c7cda27bbbf018c6a 100644
+index add25af51c86d1e5756e6c4d9a5505811f4c705a..5886ff031bf87428d0af31e4aec85ea7990564bb 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -194,6 +194,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -196,6 +196,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return (CraftServer) Bukkit.getServer();
      }
  
@@ -51,7 +51,7 @@ index b7f9d6682c1dc5f03ae363b782ae9346f5bbe841..d63f4108012b4d3ed566298c7cda27bb
      public abstract ResourceKey<LevelStem> getTypeKey();
  
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
-@@ -1366,7 +1373,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1370,7 +1377,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
          for (int l1 = j; l1 <= l; ++l1) {
              for (int i2 = k; i2 <= i1; ++i2) {

--- a/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -1051,10 +1051,10 @@ index bc3bfe8d3c2f87e2e9f167b9ff34d9ca8a696391..30276959c0119813c27ee3f98e237c93
  
      <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> filter, AABB box, Predicate<? super T> predicate);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c7d654b3a 100644
+index 5886ff031bf87428d0af31e4aec85ea7990564bb..61628991e47acf5aaf271bc328c789136f4689b0 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -203,6 +203,48 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -205,6 +205,48 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      public abstract ResourceKey<LevelStem> getTypeKey();
  
@@ -1103,15 +1103,15 @@ index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c
      protected Level(WritableLevelData worlddatamutable, ResourceKey<Level> resourcekey, final DimensionType dimensionmanager, Supplier<ProfilerFiller> supplier, boolean flag, boolean flag1, long i, org.bukkit.generator.ChunkGenerator gen, org.bukkit.generator.BiomeProvider biomeProvider, org.bukkit.World.Environment env, java.util.concurrent.Executor executor) { // Paper - Async-Anti-Xray - Pass executor
          this.spigotConfig = new org.spigotmc.SpigotWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName()); // Spigot
          this.paperConfig = new com.destroystokyo.paper.PaperWorldConfig(((net.minecraft.world.level.storage.PrimaryLevelData) worlddatamutable).getLevelName(), this.spigotConfig); // Paper
-@@ -280,6 +322,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
-         this.entityLimiter = new org.spigotmc.TickLimiter(spigotConfig.entityMaxTickTime);
-         this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
+@@ -284,6 +326,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+         // this.tileLimiter = new org.spigotmc.TickLimiter(spigotConfig.tileMaxTickTime);
+         // Paper end
          this.chunkPacketBlockController = this.paperConfig.antiXray ? new com.destroystokyo.paper.antixray.ChunkPacketBlockControllerAntiXray(this, executor) : com.destroystokyo.paper.antixray.ChunkPacketBlockController.NO_OPERATION_INSTANCE; // Paper - Anti-Xray
 +        this.entitySliceManager = new io.papermc.paper.world.EntitySliceManager((ServerLevel)this); // Paper
      }
  
      // Paper start
-@@ -990,26 +1033,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -994,26 +1037,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public List<Entity> getEntities(@Nullable Entity except, AABB box, Predicate<? super Entity> predicate) {
          this.getProfiler().incrementCounter("getEntities");
          List<Entity> list = Lists.newArrayList();
@@ -1139,7 +1139,7 @@ index d63f4108012b4d3ed566298c7cda27bbbf018c6a..3831895e2219d846022500553d9b714c
          return list;
      }
  
-@@ -1018,27 +1042,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1022,27 +1046,22 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          this.getProfiler().incrementCounter("getEntities");
          List<T> list = Lists.newArrayList();
  

--- a/patches/server/0749-Execute-chunk-tasks-mid-tick.patch
+++ b/patches/server/0749-Execute-chunk-tasks-mid-tick.patch
@@ -143,10 +143,10 @@ index 5e65df1a9a8282c4ffa06801379b79ab0ed1b45c..7e837b2896cac64a982d9025c4e190df
      // CraftBukkit start
      private int tickPosition;
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 3831895e2219d846022500553d9b714c7d654b3a..86bcedec97f1bc95621380da6ad074bdcc4bfeab 100644
+index 61628991e47acf5aaf271bc328c789136f4689b0..d790678bd0d80f9745cd9f15fed604047d46f8a8 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -896,6 +896,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -900,6 +900,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public <T extends Entity> void guardEntityTick(Consumer<T> tickConsumer, T entity) {
          try {
              tickConsumer.accept(entity);

--- a/patches/server/0757-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
+++ b/patches/server/0757-Make-sure-inlined-getChunkAt-has-inlined-logic-for-l.patch
@@ -13,10 +13,10 @@ Paper recently reverted this optimisation, so it's been reintroduced
 here.
 
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 86bcedec97f1bc95621380da6ad074bdcc4bfeab..a8e0d2609978652cf07e865c1af555d47bdaaea6 100644
+index d790678bd0d80f9745cd9f15fed604047d46f8a8..9c839cebbea4a39897e60ffcac2b5a0b71ab93dc 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -397,6 +397,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -401,6 +401,15 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
  
      @Override
      public final LevelChunk getChunk(int chunkX, int chunkZ) { // Paper - final to help inline

--- a/patches/server/0770-Optimise-random-block-ticking.patch
+++ b/patches/server/0770-Optimise-random-block-ticking.patch
@@ -297,10 +297,10 @@ index 60e1111f3c2c43398f21c541248f38524f41f4fb..56e9c0d15249562ebea8eb451d4bcc9f
  
      public BlockPos getHomePos() {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index a8e0d2609978652cf07e865c1af555d47bdaaea6..103428df78d1efe805ab425f1b4085077239bdf6 100644
+index 9c839cebbea4a39897e60ffcac2b5a0b71ab93dc..f2e150c5b6ce43adfcb0380ffd611dbe9430d533 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -1355,10 +1355,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -1359,10 +1359,18 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
      public abstract TagContainer getTagManager();
  
      public BlockPos getBlockRandomPos(int x, int y, int z, int l) {

--- a/patches/server/0772-Optimise-nearby-player-lookups.patch
+++ b/patches/server/0772-Optimise-nearby-player-lookups.patch
@@ -213,10 +213,10 @@ index 736b51e411b009db0482d9a72f179cc7b6241265..031660f7d0ea270f87e5174a4fe65cca
              if (entityhuman != null) {
                  double d0 = entityhuman.distanceToSqr((Entity) this);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 103428df78d1efe805ab425f1b4085077239bdf6..4247dcb003626535dbb997f48ad9f61380bd17e9 100644
+index f2e150c5b6ce43adfcb0380ffd611dbe9430d533..9fd1c3a910545641ae2a911d6e89fddaf93d76da 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
-@@ -244,6 +244,69 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
+@@ -246,6 +246,69 @@ public abstract class Level implements LevelAccessor, AutoCloseable {
          return ret;
      }
      // Paper end


### PR DESCRIPTION
It seems some remnants of spigot's tick limiter (more specifically the config options and initializing them) were still in-place even though the actual usage of these tick limiters when ticking tile entities and entities was previously disabled. This PR simply fully removes that unnecessary code as it does nothing in Paper and the config option could cause some confusion with server owners as it no longer does anything.