### PR TITLE
Save value for setCanMobPickup

### DIFF
--- a/patches/server/0139-Item-canEntityPickup.patch
+++ b/patches/server/0139-Item-canEntityPickup.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Item#canEntityPickup
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index a2310dc7b045d4e4c3924d656a4dcf0a1d66c095..3eda6821d12bf616037f6c00815602428afbcdaf 100644
+index 405ed6034c894bdff889307d9bbf8900f7085a94..bd00b33e4e8e4f8177ad6c8056d2e693effa9965 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -622,6 +622,11 @@ public abstract class Mob extends LivingEntity {
@@ -21,17 +21,34 @@ index a2310dc7b045d4e4c3924d656a4dcf0a1d66c095..3eda6821d12bf616037f6c0081560242
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 8d3242a1436b0622d0aebb0a61a447ddf5819273..6df6204c9d4099afeb8ff07dd747f756d8e380d6 100644
+index 8d3242a1436b0622d0aebb0a61a447ddf5819273..0f06996a9d088fb5c705d465eeb68f53d5c6194d 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -52,6 +52,7 @@ public class ItemEntity extends Entity {
+@@ -52,6 +52,8 @@ public class ItemEntity extends Entity {
      private UUID owner;
      public final float bobOffs;
      private int lastTick = MinecraftServer.currentTick - 1; // CraftBukkit
 +    public boolean canMobPickup = true; // Paper
++    private static final String PAPER_CAN_MOB_PICKUP_TAG = "Paper.canMobPickup"; // Paper
  
      public ItemEntity(EntityType<? extends ItemEntity> type, Level world) {
          super(type, world);
+@@ -336,6 +338,7 @@ public class ItemEntity extends Entity {
+             nbt.putUUID("Owner", this.getOwner());
+         }
+ 
++        nbt.putBoolean(PAPER_CAN_MOB_PICKUP_TAG, this.canMobPickup); // Paper
+         if (!this.getItem().isEmpty()) {
+             nbt.put("Item", this.getItem().save(new CompoundTag()));
+         }
+@@ -358,6 +361,7 @@ public class ItemEntity extends Entity {
+             this.thrower = nbt.getUUID("Thrower");
+         }
+ 
++        this.canMobPickup = !nbt.contains(PAPER_CAN_MOB_PICKUP_TAG) || nbt.getBoolean(PAPER_CAN_MOB_PICKUP_TAG); // Paper
+         CompoundTag nbttagcompound1 = nbt.getCompound("Item");
+ 
+         this.setItem(ItemStack.of(nbttagcompound1));
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java
 index b9044654d22a47cfa952dcf25754ad0d87fc0844..0d262c99c7e9ef06e297612b1802c493700f64ae 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftItem.java

--- a/patches/server/0140-PlayerPickupItemEvent-setFlyAtPlayer.patch
+++ b/patches/server/0140-PlayerPickupItemEvent-setFlyAtPlayer.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] PlayerPickupItemEvent#setFlyAtPlayer
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 6df6204c9d4099afeb8ff07dd747f756d8e380d6..68fdfba22ebb35023299c776d4764d4f1555f435 100644
+index 0f06996a9d088fb5c705d465eeb68f53d5c6194d..1f35c32f0fa2c105f90b02b231b4889b27242aba 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -378,6 +378,7 @@ public class ItemEntity extends Entity {
+@@ -381,6 +381,7 @@ public class ItemEntity extends Entity {
              // CraftBukkit start - fire PlayerPickupItemEvent
              int canHold = player.getInventory().canHold(itemstack);
              int remaining = i - canHold;
@@ -16,7 +16,7 @@ index 6df6204c9d4099afeb8ff07dd747f756d8e380d6..68fdfba22ebb35023299c776d4764d4f
  
              if (this.pickupDelay <= 0 && canHold > 0) {
                  itemstack.setCount(canHold);
-@@ -385,8 +386,14 @@ public class ItemEntity extends Entity {
+@@ -388,8 +389,14 @@ public class ItemEntity extends Entity {
                  PlayerPickupItemEvent playerEvent = new PlayerPickupItemEvent((org.bukkit.entity.Player) player.getBukkitEntity(), (org.bukkit.entity.Item) this.getBukkitEntity(), remaining);
                  playerEvent.setCancelled(!playerEvent.getPlayer().getCanPickupItems());
                  this.level.getCraftServer().getPluginManager().callEvent(playerEvent);
@@ -31,7 +31,7 @@ index 6df6204c9d4099afeb8ff07dd747f756d8e380d6..68fdfba22ebb35023299c776d4764d4f
                      return;
                  }
  
-@@ -416,7 +423,11 @@ public class ItemEntity extends Entity {
+@@ -419,7 +426,11 @@ public class ItemEntity extends Entity {
              // CraftBukkit end
  
              if (this.pickupDelay == 0 && (this.owner == null || this.owner.equals(player.getUUID())) && player.getInventory().add(itemstack)) {

--- a/patches/server/0141-PlayerAttemptPickupItemEvent.patch
+++ b/patches/server/0141-PlayerAttemptPickupItemEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] PlayerAttemptPickupItemEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 68fdfba22ebb35023299c776d4764d4f1555f435..db42d22f58df5daefc41720206405dda4f7ad633 100644
+index 1f35c32f0fa2c105f90b02b231b4889b27242aba..83e1f796229d8ac0eb48d9667fadfbcb405e0939 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 @@ -36,6 +36,7 @@ import net.minecraft.util.Mth;
@@ -16,7 +16,7 @@ index 68fdfba22ebb35023299c776d4764d4f1555f435..db42d22f58df5daefc41720206405dda
  
  public class ItemEntity extends Entity {
  
-@@ -380,6 +381,22 @@ public class ItemEntity extends Entity {
+@@ -383,6 +384,22 @@ public class ItemEntity extends Entity {
              int remaining = i - canHold;
              boolean flyAtPlayer = false; // Paper
  

--- a/patches/server/0222-Avoid-item-merge-if-stack-size-above-max-stack-size.patch
+++ b/patches/server/0222-Avoid-item-merge-if-stack-size-above-max-stack-size.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Avoid item merge if stack size above max stack size
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index db42d22f58df5daefc41720206405dda4f7ad633..2716fb59e83e2e2bca845bd1b58c5aefb7aa89a0 100644
+index 83e1f796229d8ac0eb48d9667fadfbcb405e0939..f79d48bcb4904280eb4d404c876e358ba77712c9 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -222,6 +222,10 @@ public class ItemEntity extends Entity {
+@@ -223,6 +223,10 @@ public class ItemEntity extends Entity {
  
      private void mergeWithNeighbours() {
          if (this.isMergable()) {

--- a/patches/server/0319-don-t-go-below-0-for-pickupDelay-breaks-picking-up-i.patch
+++ b/patches/server/0319-don-t-go-below-0-for-pickupDelay-breaks-picking-up-i.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] don't go below 0 for pickupDelay, breaks picking up items
 vanilla checks for == 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 2716fb59e83e2e2bca845bd1b58c5aefb7aa89a0..f3991a30f634122020ca6334bc6f2ca84e93ecac 100644
+index f79d48bcb4904280eb4d404c876e358ba77712c9..c1a489df62a1061e8348777e38ad979e803000f4 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -106,6 +106,7 @@ public class ItemEntity extends Entity {
+@@ -107,6 +107,7 @@ public class ItemEntity extends Entity {
              // CraftBukkit start - Use wall time for pickup and despawn timers
              int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
              if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;
@@ -17,7 +17,7 @@ index 2716fb59e83e2e2bca845bd1b58c5aefb7aa89a0..f3991a30f634122020ca6334bc6f2ca8
              if (this.age != -32768) this.age += elapsedTicks;
              this.lastTick = MinecraftServer.currentTick;
              // CraftBukkit end
-@@ -192,6 +193,7 @@ public class ItemEntity extends Entity {
+@@ -193,6 +194,7 @@ public class ItemEntity extends Entity {
          // CraftBukkit start - Use wall time for pickup and despawn timers
          int elapsedTicks = MinecraftServer.currentTick - this.lastTick;
          if (this.pickupDelay != 32767) this.pickupDelay -= elapsedTicks;

--- a/patches/server/0355-Fix-items-not-falling-correctly.patch
+++ b/patches/server/0355-Fix-items-not-falling-correctly.patch
@@ -15,10 +15,10 @@ This patch resolves the conflict by offsetting checking an item's
 move method from Spigot's entity activation range check.
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index f3991a30f634122020ca6334bc6f2ca84e93ecac..1378c8ab35b3828f7c0ad504e64bb72484a1026d 100644
+index c1a489df62a1061e8348777e38ad979e803000f4..088ac63e43b805a0e9995e28ea459a2ad61aa439 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -134,7 +134,7 @@ public class ItemEntity extends Entity {
+@@ -135,7 +135,7 @@ public class ItemEntity extends Entity {
                  }
              }
  

--- a/patches/server/0364-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0364-Implement-alternative-item-despawn-rate.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6b8f7fec3307bc643a1bdd1fb9f0572fdb9da560..5a1e82727e4861681736c2bb3ed01637c4c42e4d 100644
+index 1cdfba84abcee02c0ac49367c97544bc4758715b..619f5c11ae8e21b060b52b60d681db6dd9cb5816 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -565,5 +565,52 @@ public class PaperWorldConfig {
@@ -63,10 +63,10 @@ index 6b8f7fec3307bc643a1bdd1fb9f0572fdb9da560..5a1e82727e4861681736c2bb3ed01637
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 1378c8ab35b3828f7c0ad504e64bb72484a1026d..5a6534904e977b5ffbd55d05c4b65f02b3995910 100644
+index 088ac63e43b805a0e9995e28ea459a2ad61aa439..80d42ecad52055238cf619c48750dfe099eca273 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -174,7 +174,7 @@ public class ItemEntity extends Entity {
+@@ -175,7 +175,7 @@ public class ItemEntity extends Entity {
                  }
              }
  
@@ -75,7 +75,7 @@ index 1378c8ab35b3828f7c0ad504e64bb72484a1026d..5a6534904e977b5ffbd55d05c4b65f02
                  // CraftBukkit start - fire ItemDespawnEvent
                  if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
                      this.age = 0;
-@@ -198,7 +198,7 @@ public class ItemEntity extends Entity {
+@@ -199,7 +199,7 @@ public class ItemEntity extends Entity {
          this.lastTick = MinecraftServer.currentTick;
          // CraftBukkit end
  
@@ -84,7 +84,7 @@ index 1378c8ab35b3828f7c0ad504e64bb72484a1026d..5a6534904e977b5ffbd55d05c4b65f02
              // CraftBukkit start - fire ItemDespawnEvent
              if (org.bukkit.craftbukkit.event.CraftEventFactory.callItemDespawnEvent(this).isCancelled()) {
                  this.age = 0;
-@@ -558,9 +558,16 @@ public class ItemEntity extends Entity {
+@@ -561,9 +561,16 @@ public class ItemEntity extends Entity {
  
      public void makeFakeItem() {
          this.setNeverPickUp();

--- a/patches/server/0674-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0674-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index fb6eaddccc5153037680840f6a7ec29dff733dee..1305c1a7ae6505c1c89d2a4c2a3fbae2111e2e81 100644
+index 9b9b2a70a33639c7e24ec8fee68b20a979bea37d..04c91116d88b7c7b8a5886cc54f21be645998e38 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -833,4 +833,9 @@ public class PaperWorldConfig {
@@ -19,10 +19,10 @@ index fb6eaddccc5153037680840f6a7ec29dff733dee..1305c1a7ae6505c1c89d2a4c2a3fbae2
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 5a6534904e977b5ffbd55d05c4b65f02b3995910..7897b3324bc8d5a33cd3cd144b9fae9ffdc9241e 100644
+index 80d42ecad52055238cf619c48750dfe099eca273..cbf8aea231dd0c836b5b6a9827e5e918d6135937 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -240,6 +240,14 @@ public class ItemEntity extends Entity {
+@@ -241,6 +241,14 @@ public class ItemEntity extends Entity {
                  ItemEntity entityitem = (ItemEntity) iterator.next();
  
                  if (entityitem.isMergable()) {

--- a/patches/server/0717-Respect-despawn-rate-in-item-merge-check.patch
+++ b/patches/server/0717-Respect-despawn-rate-in-item-merge-check.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Respect despawn rate in item merge check
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-index 7897b3324bc8d5a33cd3cd144b9fae9ffdc9241e..0ac107d7a360a5812a43488c611498d12546eed9 100644
+index cbf8aea231dd0c836b5b6a9827e5e918d6135937..e95ec8d4b48d24dfe954f0565e369db8b54e78b8 100644
 --- a/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/item/ItemEntity.java
-@@ -261,7 +261,7 @@ public class ItemEntity extends Entity {
+@@ -262,7 +262,7 @@ public class ItemEntity extends Entity {
      private boolean isMergable() {
          ItemStack itemstack = this.getItem();
  


### PR DESCRIPTION
Closes #6929 

If there is a expectation that this isn't saved, which isn't made clear anywhere in the javadocs, then this might be too big a break with existing behavior. It was always my expectation that methods like this WERE persisted to loads/unloads of the entity, but that might just be me.