### PR TITLE
Move VehicleCollisionEvent HandlerList up

### DIFF
--- a/patches/api/0347-Move-VehicleCollisionEvent-HandlerList-up.patch
+++ b/patches/api/0347-Move-VehicleCollisionEvent-HandlerList-up.patch
@@ -1,0 +1,87 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Mon, 13 Dec 2021 14:35:27 -0800
+Subject: [PATCH] Move VehicleCollisionEvent HandlerList up
+
+
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
+index 316f625aa595d2ada16529b16d09f013fc4daeac..7ff9aec7ed341c01feddb8d71170b177e1fde47b 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleBlockCollisionEvent.java
+@@ -9,7 +9,7 @@ import org.jetbrains.annotations.NotNull;
+  * Raised when a vehicle collides with a block.
+  */
+ public class VehicleBlockCollisionEvent extends VehicleCollisionEvent {
+-    private static final HandlerList handlers = new HandlerList();
++    // private static final HandlerList handlers = new HandlerList(); // Paper - move HandlerList to VehicleCollisionEvent
+     private final Block block;
+ 
+     public VehicleBlockCollisionEvent(@NotNull final Vehicle vehicle, @NotNull final Block block) {
+@@ -26,15 +26,4 @@ public class VehicleBlockCollisionEvent extends VehicleCollisionEvent {
+     public Block getBlock() {
+         return block;
+     }
+-
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
+ }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleCollisionEvent.java
+index 9d493c155ad5c26430c1e404fcf0db5f734679e4..aa1d74eade479195bde8095aafcc91a83635102d 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleCollisionEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleCollisionEvent.java
+@@ -7,7 +7,18 @@ import org.jetbrains.annotations.NotNull;
+  * Raised when a vehicle collides.
+  */
+ public abstract class VehicleCollisionEvent extends VehicleEvent {
++    private static final org.bukkit.event.HandlerList HANDLER_LIST = new org.bukkit.event.HandlerList(); // Paper
+     public VehicleCollisionEvent(@NotNull final Vehicle vehicle) {
+         super(vehicle);
+     }
++    // Paper start
++    @Override
++    public org.bukkit.event.@org.jetbrains.annotations.NotNull HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    public static org.bukkit.event.@NotNull HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++    // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java b/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
+index 6bafc62e2235a6b783cbf96f4dabeeaf02bd5178..089c644caf10a4d55a5db4f7aa7d9b5c9764c17a 100644
+--- a/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
++++ b/src/main/java/org/bukkit/event/vehicle/VehicleEntityCollisionEvent.java
+@@ -10,7 +10,7 @@ import org.jetbrains.annotations.NotNull;
+  * Raised when a vehicle collides with an entity.
+  */
+ public class VehicleEntityCollisionEvent extends VehicleCollisionEvent implements Cancellable {
+-    private static final HandlerList handlers = new HandlerList();
++    // private static final HandlerList handlers = new HandlerList(); // Paper - move HandlerList to VehicleCollisionEvent
+     private final Entity entity;
+     private boolean cancelled = false;
+     private boolean cancelledPickup = false;
+@@ -51,15 +51,4 @@ public class VehicleEntityCollisionEvent extends VehicleCollisionEvent implement
+     public void setCollisionCancelled(boolean cancel) {
+         cancelledCollision = cancel;
+     }
+-
+-    @NotNull
+-    @Override
+-    public HandlerList getHandlers() {
+-        return handlers;
+-    }
+-
+-    @NotNull
+-    public static HandlerList getHandlerList() {
+-        return handlers;
+-    }
+ }


### PR DESCRIPTION
Allow plugins to listen to VehicleCollisionEvent for both blocks and entities