### PR TITLE
Optimize Util#sequence

### DIFF
--- a/patches/server/0831-Optimize-Util-sequence.patch
+++ b/patches/server/0831-Optimize-Util-sequence.patch
@@ -6,18 +6,10 @@ Subject: [PATCH] Optimize Util#sequence
 Original method allocates O(n^2) memory on n-size list.
 
 diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
-index f6561599391583ba7d669af42b5716cda0df2d68..d7a167245c0ec72d435f0eef72c7801fe8905e2f 100644
+index f6561599391583ba7d669af42b5716cda0df2d68..15b6e36242fd91c66bc15f7407c22b6d78a24457 100644
 --- a/src/main/java/net/minecraft/Util.java
 +++ b/src/main/java/net/minecraft/Util.java
-@@ -27,6 +27,7 @@ import java.security.PrivilegedActionException;
- import java.security.PrivilegedExceptionAction;
- import java.time.Duration;
- import java.time.Instant;
-+import java.util.ArrayList;
- import java.util.Arrays;
- import java.util.Iterator;
- import java.util.List;
-@@ -391,21 +392,16 @@ public class Util {
+@@ -391,21 +391,16 @@ public class Util {
      }
  
      public static <V> CompletableFuture<List<V>> sequence(List<? extends CompletableFuture<? extends V>> futures) {
@@ -37,7 +29,7 @@ index f6561599391583ba7d669af42b5716cda0df2d68..d7a167245c0ec72d435f0eef72c7801f
 +        // Paper start - optimize
 +        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
 +            .thenApply(v -> {
-+                var list = new ArrayList<V>(futures.size());
++                var list = Lists.<V>newArrayListWithCapacity(futures.size());
 +                for (CompletableFuture<? extends V> future : futures) {
 +                    list.add(future.join());
 +                }

--- a/patches/server/0831-Optimize-Util-sequence.patch
+++ b/patches/server/0831-Optimize-Util-sequence.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: IzzelAliz <csh2001331@126.com>
+Date: Tue, 14 Dec 2021 12:43:03 +0800
+Subject: [PATCH] Optimize Util#sequence
+
+Original method allocates O(n^2) memory on n-size list.
+
+diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
+index f6561599391583ba7d669af42b5716cda0df2d68..d7a167245c0ec72d435f0eef72c7801fe8905e2f 100644
+--- a/src/main/java/net/minecraft/Util.java
++++ b/src/main/java/net/minecraft/Util.java
+@@ -27,6 +27,7 @@ import java.security.PrivilegedActionException;
+ import java.security.PrivilegedExceptionAction;
+ import java.time.Duration;
+ import java.time.Instant;
++import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Iterator;
+ import java.util.List;
+@@ -391,21 +392,16 @@ public class Util {
+     }
+ 
+     public static <V> CompletableFuture<List<V>> sequence(List<? extends CompletableFuture<? extends V>> futures) {
+-        return futures.stream().reduce(CompletableFuture.completedFuture(Lists.newArrayList()), (completableFuture, completableFuture2) -> {
+-            return completableFuture2.thenCombine(completableFuture, (object, list) -> {
+-                List<V> list2 = Lists.newArrayListWithCapacity(list.size() + 1);
+-                list2.addAll(list);
+-                list2.add(object);
+-                return list2;
+-            });
+-        }, (completableFuture, completableFuture2) -> {
+-            return completableFuture.thenCombine(completableFuture2, (list, list2) -> {
+-                List<V> list3 = Lists.newArrayListWithCapacity(list.size() + list2.size());
+-                list3.addAll(list);
+-                list3.addAll(list2);
+-                return list3;
++        // Paper start - optimize
++        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
++            .thenApply(v -> {
++                var list = new ArrayList<V>(futures.size());
++                for (CompletableFuture<? extends V> future : futures) {
++                    list.add(future.join());
++                }
++                return list;
+             });
+-        });
++        // Paper end
+     }
+ 
+     public static <V> CompletableFuture<List<V>> sequenceFailFast(List<? extends CompletableFuture<? extends V>> futures) {

--- a/patches/server/0864-Optimize-Util-sequence.patch
+++ b/patches/server/0864-Optimize-Util-sequence.patch
@@ -6,12 +6,14 @@ Subject: [PATCH] Optimize Util#sequence
 Original method allocates O(n^2) memory on n-size list.
 
 diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
-index f6561599391583ba7d669af42b5716cda0df2d68..15b6e36242fd91c66bc15f7407c22b6d78a24457 100644
+index 9c111d479bbcc101886c12950c97f10941125ae7..34e571b702684673b89103176838dc246ff9b24d 100644
 --- a/src/main/java/net/minecraft/Util.java
 +++ b/src/main/java/net/minecraft/Util.java
-@@ -391,21 +391,16 @@ public class Util {
+@@ -390,22 +390,18 @@ public class Util {
+         return (Strategy<K>) Util.IdentityStrategy.INSTANCE; // Paper - decompile fix
      }
  
++    private static final CompletableFuture<?>[] EMPTY_FUTURE = new CompletableFuture[0]; // Paper
      public static <V> CompletableFuture<List<V>> sequence(List<? extends CompletableFuture<? extends V>> futures) {
 -        return futures.stream().reduce(CompletableFuture.completedFuture(Lists.newArrayList()), (completableFuture, completableFuture2) -> {
 -            return completableFuture2.thenCombine(completableFuture, (object, list) -> {
@@ -27,9 +29,9 @@ index f6561599391583ba7d669af42b5716cda0df2d68..15b6e36242fd91c66bc15f7407c22b6d
 -                list3.addAll(list2);
 -                return list3;
 +        // Paper start - optimize
-+        return CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
++        return CompletableFuture.allOf(futures.toArray(EMPTY_FUTURE))
 +            .thenApply(v -> {
-+                var list = Lists.<V>newArrayListWithCapacity(futures.size());
++                List<V> list = Lists.newArrayListWithCapacity(futures.size());
 +                for (CompletableFuture<? extends V> future : futures) {
 +                    list.add(future.join());
 +                }


### PR DESCRIPTION
There's a huge increase on startup memory footprint after updating to 1.18. Investigation shows that `net.minecraft.Util#sequence` allocates O(n^2) memory on n-size list.

After some rough testing, my optimization can reduce at least 500mb startup RAM usage, as well as a slightly increased chunk loading speed.

Allocation record:
![allocate](https://user-images.githubusercontent.com/21029868/145935592-1ca07eaa-13e3-45f6-8778-eea7e827683e.png)

Original implementation:
![orig](https://user-images.githubusercontent.com/21029868/145935628-de377aeb-8ce8-4cfe-889e-cc335972d882.png)

Optimization:
![opti](https://user-images.githubusercontent.com/21029868/145935634-e8c316ac-5dd2-4b51-94e3-493fe40dcf55.png)

