### PR TITLE
Updated log4j2 to latest version

### DIFF
--- a/patches/server/0831-Updated-log4j2-to-2.16.0.patch
+++ b/patches/server/0831-Updated-log4j2-to-2.16.0.patch
@@ -1,0 +1,30 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Alexander <AlexMl@users.noreply.github.com>
+Date: Tue, 14 Dec 2021 10:40:49 -0500
+Subject: [PATCH] Updated log4j2 to 2.16.0
+
+Since the 2.15 update of log4j2, the apache team improved security against log4shell further.
+This update is recommended and shouldn't cause any new issues or regressions for Paper and forks.
+
+https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index ed05c831fcf8dfb8669ce57248b469fa9c9edef5..8e941079410a1a0b347fa811190fb6771a185319 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -29,11 +29,11 @@ dependencies {
+           all its classes to check if they are plugins.
+           Scanning takes about 1-2 seconds so adding this speeds up the server start.
+      */
+-    implementation("org.apache.logging.log4j:log4j-core:2.15.0") // Paper - implementation
+-    annotationProcessor("org.apache.logging.log4j:log4j-core:2.15.0") // Paper - Needed to generate meta for our Log4j plugins
++    implementation("org.apache.logging.log4j:log4j-core:2.16.0") // Paper - implementation
++    annotationProcessor("org.apache.logging.log4j:log4j-core:2.16.0") // Paper - Needed to generate meta for our Log4j plugins
+     // Paper end
+-    implementation("org.apache.logging.log4j:log4j-iostreams:2.15.0") // Paper
+-    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.15.0") // Paper
++    implementation("org.apache.logging.log4j:log4j-iostreams:2.16.0") // Paper
++    implementation("org.apache.logging.log4j:log4j-slf4j18-impl:2.16.0") // Paper
+     implementation("org.ow2.asm:asm:9.2")
+     implementation("org.ow2.asm:asm-commons:9.2") // Paper - ASM event executor generation
+     runtimeOnly("org.xerial:sqlite-jdbc:3.36.0.3")


### PR DESCRIPTION
Since the 2.15 update of log4j2, the apache team improved security against log4shell further in their new release 2.16.0. With new ways of people using the exploit, we need to keep up to date with this dependency.
I recommend this version update and it shouldn't cause any new issues or regressions for Paper and forks.

The release notes are found here: https://logging.apache.org/log4j/2.x/changes-report.html#a2.16.0