### PR TITLE
Use team display name for quit message

### DIFF
--- a/patches/server/0009-Adventure.patch
+++ b/patches/server/0009-Adventure.patch
@@ -2349,7 +2349,7 @@ index be097f13dba5d408f58d6fada893bed2638d4219..3d7d1ba148dbc3591d8c76b99a2ee7d9
  
                  @Override
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index c9497bead11bf2b3b859f1c91c9692ce6007e5ed..5481a029a4a710eb20a4689633d5a4ec509d49d8 100644
+index c9497bead11bf2b3b859f1c91c9692ce6007e5ed..046560b409c73c73f2c8e645625697bde3e564c2 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -8,6 +8,7 @@ import com.mojang.logging.LogUtils;
@@ -2408,7 +2408,7 @@ index c9497bead11bf2b3b859f1c91c9692ce6007e5ed..5481a029a4a710eb20a4689633d5a4ec
          }
  
 -        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), entityplayer.kickLeaveMessage != null ? entityplayer.kickLeaveMessage : "\u00A7e" + entityplayer.getScoreboardName() + " left the game");
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName()))); // Paper - Adventure
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/patches/server/0217-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0217-InventoryCloseEvent-Reason-API.patch
@@ -104,7 +104,7 @@ index 217961627f32d19e1b4ebe56d7132613fa613fe4..6c74c37f396459d25672b6ad7574393d
          this.player.doCloseContainer();
      }
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 216ad4d729d8996bb4f5bc696fd168f65b076994..0f33c4bf3cb52f192d5dfe8b55a72c7a5a2f9311 100644
+index 591cf187fb23bb2319e89b5ad0021aa9ec2af012..195f7969e9fbe2469701cf127219e8f6145e6f40 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -516,7 +516,7 @@ public abstract class PlayerList {
@@ -115,7 +115,7 @@ index 216ad4d729d8996bb4f5bc696fd168f65b076994..0f33c4bf3cb52f192d5dfe8b55a72c7a
 +            entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
-         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
+         PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName()))); // Paper - Adventure
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
 index 26709e64ffbe1a41516908e4b3fc9d21d4c0dff0..a46a6b76b6821be9d8983633cd0c6b9fa3aa349c 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
@@ -173,7 +173,7 @@ index 7ea4a2d4e691e0a0a4d9ef3189a29a4a4ca4374b..883b6245f44f3fb82d7678e1092177ca
      @Override
      public boolean isBlocking() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index bc8738811465d61e41580c5718d85c34e11b609b..5057a65e1f9b4f5646db83b4311636c963c39515 100644
+index 4bd0bf1afef245976082287b7e3a5b758fefdcf4..e9c8148495dcea8c6ba143ee2d5bd0430a5c94dd 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1161,7 +1161,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
@@ -186,7 +186,7 @@ index bc8738811465d61e41580c5718d85c34e11b609b..5057a65e1f9b4f5646db83b4311636c9
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 2dce08e8680562a19f86909bfe21d91753f9455d..97edf72d799f73d5e6a4bd7bee9fd20dabcb3533 100644
+index 24814f91088b835e398d4d5fa1c895a3b1cdb086..fab613b7c4ee48c3f0eac1405bca7bd53da19060 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1230,7 +1230,7 @@ public class CraftEventFactory {

--- a/patches/server/0503-Add-API-for-quit-reason.patch
+++ b/patches/server/0503-Add-API-for-quit-reason.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add API for quit reason
 
 
 diff --git a/src/main/java/net/minecraft/network/Connection.java b/src/main/java/net/minecraft/network/Connection.java
-index 4487b4329cf09a6538e272c44207dda492ceb099..43fd36b2ed8e58a2e6213d749a8612a98be421b2 100644
+index 501d17ba798c5928279a93c45de3eb6e8a3f99d6..5fa1b0d609ffc43b03f66d710a2702c2597786fc 100644
 --- a/src/main/java/net/minecraft/network/Connection.java
 +++ b/src/main/java/net/minecraft/network/Connection.java
 @@ -170,12 +170,15 @@ public class Connection extends SimpleChannelInboundHandler<Packet<?>> {
@@ -49,15 +49,15 @@ index ebce5372a4961b8518b3c5ee1f727705c8b68152..4e9ae442a838e685e96d436e0f14ff2d
              this.connection.disconnect(ichatbasecomponent);
          }));
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index f36019234a85c177d3d863979bbc653f89384cd4..a9f61042c961dc4ffc12b9e8ff66001205e41511 100644
+index e9846135153cfd1e4eb34cd70c23ba811ca1ee9f..cf84c48aad4765633333a56b369568fca51ebffc 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -552,7 +552,7 @@ public abstract class PlayerList {
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())), entityplayer.quitReason); // Paper - quit reason
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName()))); // Paper - Adventure
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName())), entityplayer.quitReason); // Paper - Adventure & quit reason
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  

--- a/patches/server/0655-Fixes-kick-event-leave-message-not-being-sent.patch
+++ b/patches/server/0655-Fixes-kick-event-leave-message-not-being-sent.patch
@@ -59,7 +59,7 @@ index 1d84ee2afa76ecc1c7c07bf0a21c3d1ee7213515..3ccb8f290a842487da80ed24d04d5519
              this.server.getPlayerList().broadcastSystemMessage(PaperAdventure.asVanilla(quitMessage), false);
              // Paper end
 diff --git a/src/main/java/net/minecraft/server/players/PlayerList.java b/src/main/java/net/minecraft/server/players/PlayerList.java
-index 7bd0cfd60b983bbf3cb370f92aa5f2827c2572f8..8273055be92fbe96187721c95e5ff74c9e5daafe 100644
+index 5cd624e6dae63b31bdae849fa3190e967960b621..b486bb218438b7705cd27fb386622a5e0e59b347 100644
 --- a/src/main/java/net/minecraft/server/players/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/players/PlayerList.java
 @@ -543,6 +543,11 @@ public abstract class PlayerList {
@@ -67,7 +67,7 @@ index 7bd0cfd60b983bbf3cb370f92aa5f2827c2572f8..8273055be92fbe96187721c95e5ff74c
  
      public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer) { // Paper - return Component
 +        // Paper start
-+        return this.remove(entityplayer, net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
++        return this.remove(entityplayer, net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName())));
 +    }
 +    public net.kyori.adventure.text.Component remove(ServerPlayer entityplayer, net.kyori.adventure.text.Component leaveMessage) {
 +        // Paper end
@@ -78,8 +78,8 @@ index 7bd0cfd60b983bbf3cb370f92aa5f2827c2572f8..8273055be92fbe96187721c95e5ff74c
              entityplayer.closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
          }
  
--        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())), entityplayer.quitReason); // Paper - quit reason
-+        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), leaveMessage, entityplayer.quitReason); // Paper - quit reason
+-        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, io.papermc.paper.configuration.GlobalConfiguration.get().messages.useDisplayNameInQuitMessage ? entityplayer.getBukkitEntity().displayName() : PaperAdventure.asAdventure(entityplayer.getDisplayName())), entityplayer.quitReason); // Paper - Adventure & quit reason
++        PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), leaveMessage, entityplayer.quitReason); // Paper - Adventure & quit reason
          this.cserver.getPluginManager().callEvent(playerQuitEvent);
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  


### PR DESCRIPTION
Fixes #7123

This almost certainly goes in an earlier patch, maybe Adventure, not sure.

But its my understanding that the game profile name has been used in quit msgs for ever, hence the paper.yml setting to use display names, but that is only the "bukkit" display name, not the team display name formatted with team prefixes, colors, etc. So I think if we want to preserve the original behavior, the `use-display-name-in-quit-message` setting should be changed from a boolean to a multi-option setting, with options, NAME, BUKKIT_DISPLAY_NAME, and TEAM_DISPLAY_NAME or something like that.