### PR TITLE
Configurable max block light for monster spawning

### DIFF
--- a/patches/server/0838-Configurable-max-block-light-for-monster-spawning.patch
+++ b/patches/server/0838-Configurable-max-block-light-for-monster-spawning.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nassim Jahnke <jahnke.nassim@gmail.com>
+Date: Thu, 16 Dec 2021 09:40:39 +0100
+Subject: [PATCH] Configurable max block light for monster spawning
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index d71cd626bcbefc576f9c05b8885acc9fb2a33cd5..5a5db15493cd9b83815c36487c2f38cb8ac76f3a 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -1014,4 +1014,9 @@ public class PaperWorldConfig {
+         Integer rate = table.get(columnKey, rowKey);
+         return rate != null && rate > -1 ? rate : def;
+     }
++
++    public int maxBlockLightForMonsterSpawning = -1;
++    private void minBlockLightForMobSpawning() {
++        this.maxBlockLightForMonsterSpawning = getInt("monster-spawn-max-light-level", maxBlockLightForMonsterSpawning);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/world/entity/monster/Monster.java b/src/main/java/net/minecraft/world/entity/monster/Monster.java
+index 457880c9e894a83d88505cf0b7235df919eea591..1d66588cfe94d190a34dc376b4b5bff9461a3529 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/Monster.java
++++ b/src/main/java/net/minecraft/world/entity/monster/Monster.java
+@@ -90,7 +90,7 @@ public abstract class Monster extends PathfinderMob implements Enemy {
+     public static boolean isDarkEnoughToSpawn(ServerLevelAccessor world, BlockPos pos, Random random) {
+         if (world.getBrightness(LightLayer.SKY, pos) > random.nextInt(32)) {
+             return false;
+-        } else if (world.getBrightness(LightLayer.BLOCK, pos) > 0) {
++        } else if (world.getBrightness(LightLayer.BLOCK, pos) > (world.getLevel().paperConfig.maxBlockLightForMonsterSpawning >= 0 ? world.getLevel().paperConfig.maxBlockLightForMonsterSpawning : 0)) { // Paper - configurable max block light level
+             return false;
+         } else {
+             int i = world.getLevel().isThundering() ? world.getMaxLocalRawBrightness(pos, 10) : world.getMaxLocalRawBrightness(pos);


### PR DESCRIPTION
So people can revert this to how it was before 1.18
https://github.com/PaperMC/PaperDocs/pull/138

Not using Math.max so it's obvious 0 is the Vanilla default when looking at code, used when the config is set to -1