### PR TITLE
Fix breakNaturally for fluid-logged blocks

### DIFF
--- a/patches/server/0832-Fix-fluid-logging-on-Block-breakNaturally.patch
+++ b/patches/server/0832-Fix-fluid-logging-on-Block-breakNaturally.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 21 Dec 2021 16:28:17 -0800
+Subject: [PATCH] Fix fluid-logging on Block#breakNaturally
+
+Leaves fluid if the block broken was fluid-logged which is what
+happens if a player breaks a fluid-logged block
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+index 89cfa5093d53e1a249efc64aa1b449755c6eecd9..7cf7b845620ab5b118da79f6057c0d80a254585e 100644
+--- a/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
++++ b/src/main/java/org/bukkit/craftbukkit/block/CraftBlock.java
+@@ -508,6 +508,7 @@ public class CraftBlock implements Block {
+         net.minecraft.world.level.block.state.BlockState iblockdata = this.getNMS();
+         net.minecraft.world.level.block.Block block = iblockdata.getBlock();
+         net.minecraft.world.item.ItemStack nmsItem = CraftItemStack.asNMSCopy(item);
++        net.minecraft.world.level.material.FluidState fluidState = this.world.getFluidState(this.position); // Paper
+         boolean result = false;
+ 
+         // Modelled off EntityHuman#hasBlock
+@@ -518,7 +519,7 @@ public class CraftBlock implements Block {
+         }
+ 
+         // SPIGOT-6778: Directly call setBlock instead of setTypeAndData, so that the tile entiy is not removed and custom remove logic is run.
+-        return this.world.setBlock(position, Blocks.AIR.defaultBlockState(), 3) && result;
++        return this.world.setBlock(position, fluidState.createLegacyBlock(), 3) && result; // Paper - leave liquid if waterlogged
+     }
+ 
+     @Override


### PR DESCRIPTION
When a player breaks a fluid-logged block, the fluid remains. This is not currently the case for breakNaturally. I think this isn't a breaking change cause the method is **supposed** to simulate to the best it can, a block being broken by a player.