### PR TITLE
Make water animal spawn height configurable

### DIFF
--- a/patches/server/0843-Make-water-animal-spawn-height-configurable.patch
+++ b/patches/server/0843-Make-water-animal-spawn-height-configurable.patch
@@ -1,0 +1,50 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Brokkonaut <hannos17@gmx.de>
+Date: Sat, 18 Dec 2021 08:26:55 +0100
+Subject: [PATCH] Make water animal spawn height configurable
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..cd5a7bac92a1e733d69340f09bc35906138a6ce3 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -385,6 +385,24 @@ public class PaperWorldConfig {
+         mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
+     }
+ 
++    public Integer waterAnimalMaxSpawnHeight;
++    private void waterAnimalMaxSpawnHeight() {
++        String v = getString("wateranimal-spawn-height.maximum", "default");
++        try {
++            waterAnimalMaxSpawnHeight = Integer.parseInt(v);
++        } catch (NumberFormatException ignored) {
++        }
++    }
++
++    public Integer waterAnimalMinSpawnHeight;
++    private void waterAnimalMinSpawnHeight() {
++        String v = getString("wateranimal-spawn-height.minimum", "default");
++        try {
++            waterAnimalMinSpawnHeight = Integer.parseInt(v);
++        } catch (NumberFormatException ignored) {
++        }
++    }
++
+     public int containerUpdateTickRate;
+     private void containerUpdateTickRate() {
+         containerUpdateTickRate = getInt("container-update-tick-rate", 1);
+diff --git a/src/main/java/net/minecraft/world/entity/animal/WaterAnimal.java b/src/main/java/net/minecraft/world/entity/animal/WaterAnimal.java
+index 6963cf94909a74522706c984d063faeba0e76112..c3bba52a5c7a618fd9731045268fa9ccebff14f4 100644
+--- a/src/main/java/net/minecraft/world/entity/animal/WaterAnimal.java
++++ b/src/main/java/net/minecraft/world/entity/animal/WaterAnimal.java
+@@ -79,6 +79,10 @@ public abstract class WaterAnimal extends PathfinderMob {
+     public static boolean checkSurfaceWaterAnimalSpawnRules(EntityType<? extends WaterAnimal> type, LevelAccessor world, MobSpawnType reason, BlockPos pos, Random random) {
+         int i = world.getSeaLevel();
+         int j = i - 13;
++        // Paper start
++        i = world.getMinecraftWorld().paperConfig.waterAnimalMaxSpawnHeight != null ? world.getMinecraftWorld().paperConfig.waterAnimalMaxSpawnHeight : i;
++        j = world.getMinecraftWorld().paperConfig.waterAnimalMinSpawnHeight != null ? world.getMinecraftWorld().paperConfig.waterAnimalMinSpawnHeight : j;
++        // Paper end
+         return world.getFluidState(pos.below()).is(FluidTags.WATER) && world.getBlockState(pos.above()).is(Blocks.WATER) && pos.getY() >= j && pos.getY() <= i;
+     }
+ }


### PR DESCRIPTION
Somehow a successor for https://github.com/PaperMC/Paper/blob/master/patches/removed/1.18/No%20longer%20needed/0170-Make-max-squid-spawn-height-configurable.patch