### PR TITLE
Load effect amplifiers greater than 127 correctly

### DIFF
--- a/patches/server/0838-Load-effect-amplifiers-greater-than-127-correctly.patch
+++ b/patches/server/0838-Load-effect-amplifiers-greater-than-127-correctly.patch
@@ -1,0 +1,20 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Tue, 21 Dec 2021 22:13:26 -0800
+Subject: [PATCH] Load effect amplifiers greater than 127 correctly
+
+MOJIRA: MC-118857
+
+diff --git a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+index 1493cff2087080a53210349e9d13e81594c24a04..0dadea0c9559d99c7de04dbda68b3e743c9eeecb 100644
+--- a/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
++++ b/src/main/java/net/minecraft/world/effect/MobEffectInstance.java
+@@ -235,7 +235,7 @@ public class MobEffectInstance implements Comparable<MobEffectInstance> {
+     }
+ 
+     private static MobEffectInstance loadSpecifiedEffect(MobEffect type, CompoundTag nbt) {
+-        int i = nbt.getByte("Amplifier");
++        int i = Byte.toUnsignedInt(nbt.getByte("Amplifier")); // Paper - correctly load amplifiers > 127
+         int j = nbt.getInt("Duration");
+         boolean bl = nbt.getBoolean("Ambient");
+         boolean bl2 = true;


### PR DESCRIPTION
effect amplifier is stored as a signed byte -128 to 127, but then read into an int so an effect amplifier of 128 (stored as -128) is read as int -128 which is reset back to 0.

Amplifier 0-127 stored as 0-127 (byte) and 127-255 stored as -128 to -1