### PR TITLE
Library Loader Improvements

### DIFF
--- a/patches/api/0351-Library-Loader-Improvements.patch
+++ b/patches/api/0351-Library-Loader-Improvements.patch
@@ -1,0 +1,52 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: darbyjack <admin@glaremasters.me>
+Date: Wed, 22 Dec 2021 14:21:25 -0600
+Subject: [PATCH] Library Loader Improvements
+
+
+diff --git a/src/main/java/org/bukkit/UnsafeValues.java b/src/main/java/org/bukkit/UnsafeValues.java
+index 558b00b5876396cf3bca748b6317d7fb9b8c039a..c4b7ea18e5091dd6dcceed5a51fcbeb1bd2b1d19 100644
+--- a/src/main/java/org/bukkit/UnsafeValues.java
++++ b/src/main/java/org/bukkit/UnsafeValues.java
+@@ -217,5 +217,13 @@ public interface UnsafeValues {
+      * @throws IllegalArgumentException if {@link Material#isBlock()} is false
+      */
+     boolean isCollidable(@org.jetbrains.annotations.NotNull Material material);
++
++
++    /**
++     * Obtains the list of all extra Maven Repositories to resolve in LibraryLoader
++     *
++     * @return list of repositories
++     */
++    java.util.List<String> getLibraryLoaderRepos();
+     // Paper end
+ }
+diff --git a/src/main/java/org/bukkit/plugin/java/LibraryLoader.java b/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
+index 6d634b0ea813ccb19f1562a7d0e5a59cea4eab21..1e620ae3194e1fd325503095fd3252e938806c76 100644
+--- a/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
++++ b/src/main/java/org/bukkit/plugin/java/LibraryLoader.java
+@@ -6,7 +6,6 @@ import java.net.MalformedURLException;
+ import java.net.URL;
+ import java.net.URLClassLoader;
+ import java.util.ArrayList;
+-import java.util.Arrays;
+ import java.util.List;
+ import java.util.logging.Level;
+ import java.util.logging.Logger;
+@@ -67,7 +66,14 @@ class LibraryLoader
+         } );
+         session.setReadOnly();
+ 
+-        this.repositories = repository.newResolutionRepositories( session, Arrays.asList( new RemoteRepository.Builder( "central", "default", "https://repo.maven.apache.org/maven2" ).build() ) );
++        // Paper start - library loader improvements
++        final List<RemoteRepository> extra = new ArrayList<>();
++        for (String repo : org.bukkit.Bukkit.getUnsafe().getLibraryLoaderRepos()) {
++            extra.add(new RemoteRepository.Builder(repo, "default", repo).build());
++        }
++
++        this.repositories = repository.newResolutionRepositories( session, extra );
++        // Paper end - library loader improvements
+     }
+ 
+     @Nullable

--- a/patches/server/0839-Library-Loader-Improvements.patch
+++ b/patches/server/0839-Library-Loader-Improvements.patch
@@ -1,0 +1,45 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: darbyjack <admin@glaremasters.me>
+Date: Wed, 22 Dec 2021 14:21:10 -0600
+Subject: [PATCH] Library Loader Improvements
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 6d02910a903f2c6352202c49149172e3eee3ed86..d76310be24361e888a9d0813b814a28bee98619d 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -260,6 +260,11 @@ public class PaperConfig {
+                 " - Server Name: " + timingsServerName);
+     }
+ 
++    public static List<String> repos = new java.util.ArrayList<>();
++    private static void loadRepos() {
++        repos = getList("settings.library-loader.repos", Lists.newArrayList("https://papermc.io/repo/repository/maven-public/"));
++    }
++
+     public static boolean useDisplayNameInQuit = false;
+     private static void useDisplayNameInQuit() {
+         if (version < 21) {
+diff --git a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+index 7978b4aa50f3abbcb9e07a0207c897b6be2a6129..e3d444bd8e0e1ff2ad712a57d618e3a292f4858d 100644
+--- a/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
++++ b/src/main/java/org/bukkit/craftbukkit/util/CraftMagicNumbers.java
+@@ -1,5 +1,6 @@
+ package org.bukkit.craftbukkit.util;
+ 
++import com.destroystokyo.paper.PaperConfig;
+ import com.google.common.base.Charsets;
+ import com.google.common.base.Preconditions;
+ import com.google.common.collect.Maps;
+@@ -558,6 +559,11 @@ public final class CraftMagicNumbers implements UnsafeValues {
+         Preconditions.checkArgument(material.isBlock(), material + " is not a block");
+         return getBlock(material).hasCollision;
+     }
++
++    @Override
++    public List<String> getLibraryLoaderRepos() {
++        return PaperConfig.repos;
++    }
+     // Paper end
+ 
+     /**


### PR DESCRIPTION
This PR will be initially created a draft so a discussion can be made.

**Background**: 
Towards the end of the 1.16.5 era, Spigot introduced a new preview feature for runtime library downloading. The way this works is an author can specify libraries in their plugin.yml that will then be pulled from Maven Central on the startup of the plugin.

**Problem**:
The current situation is that all libraries are pulled directly from Maven Central, which can be classified as a violation of their TOS (<https://repo1.maven.org/terms.html>) under "excessive requests and bandwidth usage" (other projects have already been yelled at by Maven Central for this).

The other problem here is that not everyone has the ability to deploy their artifacts to Maven Central. A lot of people will run their own nexus instance and host their artifacts there.

**Solution**:
The original implementation for this PR was going to be to add a new section to the individual plugin.yml to allow developers to add extra repositories there, but after having a discussion with @zml2008 , the concept of it being potentially dangerous to allow developers to specify their own maven repositories came into play. Given that, we decided it should be up to the server owner themselves to specify any extra repositories to download from, therefore being implemented as a setting in the Paper configuration file.

**Example**:

```YAML
settings:
  repos:
  - https://papermc.io/repo/repository/maven-public/
```
