### PR TITLE
Expose isFuel and canSmelt methods to FurnaceInventory

### DIFF
--- a/patches/api/0351-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
+++ b/patches/api/0351-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose isFuel and canSmelt methods to FurnaceInventory
 
 
 diff --git a/src/main/java/org/bukkit/inventory/FurnaceInventory.java b/src/main/java/org/bukkit/inventory/FurnaceInventory.java
-index 3f46259c1e0f82941ffc3038d1b51be199114abd..f469f1718c8649f9e5ff2444fbbb9c6d8eae62be 100644
+index 3f46259c1e0f82941ffc3038d1b51be199114abd..b9d4f05980d924a4831b1d213d4963199f5b9a5d 100644
 --- a/src/main/java/org/bukkit/inventory/FurnaceInventory.java
 +++ b/src/main/java/org/bukkit/inventory/FurnaceInventory.java
 @@ -53,6 +53,24 @@ public interface FurnaceInventory extends Inventory {
@@ -19,7 +19,7 @@ index 3f46259c1e0f82941ffc3038d1b51be199114abd..f469f1718c8649f9e5ff2444fbbb9c6d
 +     * @param item Item to check
 +     * @return True if a valid fuel source
 +     */
-+    public boolean isFuel(org.bukkit.inventory.ItemStack item);
++    public boolean isFuel(@Nullable ItemStack item);
 +
 +    /**
 +     * Check if an item can be smelted in this furnace container
@@ -27,7 +27,7 @@ index 3f46259c1e0f82941ffc3038d1b51be199114abd..f469f1718c8649f9e5ff2444fbbb9c6d
 +     * @param item Item to check
 +     * @return True if can be smelt
 +     */
-+    public boolean canSmelt(org.bukkit.inventory.ItemStack item);
++    public boolean canSmelt(@Nullable ItemStack item);
 +    // Paper end
 +
      @Override

--- a/patches/api/0351-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
+++ b/patches/api/0351-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
@@ -1,0 +1,35 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Thu, 23 Dec 2021 15:32:40 -0600
+Subject: [PATCH] Expose isFuel and canSmelt methods to FurnaceInventory
+
+
+diff --git a/src/main/java/org/bukkit/inventory/FurnaceInventory.java b/src/main/java/org/bukkit/inventory/FurnaceInventory.java
+index 3f46259c1e0f82941ffc3038d1b51be199114abd..f469f1718c8649f9e5ff2444fbbb9c6d8eae62be 100644
+--- a/src/main/java/org/bukkit/inventory/FurnaceInventory.java
++++ b/src/main/java/org/bukkit/inventory/FurnaceInventory.java
+@@ -53,6 +53,24 @@ public interface FurnaceInventory extends Inventory {
+      */
+     void setSmelting(@Nullable ItemStack stack);
+ 
++    // Paper start
++    /**
++     * Check if an item can be used as a fuel source in this furnace container
++     *
++     * @param item Item to check
++     * @return True if a valid fuel source
++     */
++    public boolean isFuel(org.bukkit.inventory.ItemStack item);
++
++    /**
++     * Check if an item can be smelted in this furnace container
++     *
++     * @param item Item to check
++     * @return True if can be smelt
++     */
++    public boolean canSmelt(org.bukkit.inventory.ItemStack item);
++    // Paper end
++
+     @Override
+     @Nullable
+     Furnace getHolder();

--- a/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
+++ b/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose isFuel and canSmelt methods to FurnaceInventory
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
-index 05c29a788c96282fc18066ae253cf0b5be37e95c..e427187d714cc44ddb5801d8a47766e075a2350a 100644
+index 05c29a788c96282fc18066ae253cf0b5be37e95c..e8e53d3c7d8b1bba7d77dc0c76d242eb177ad851 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
 @@ -40,6 +40,20 @@ public class CraftInventoryFurnace extends CraftInventory implements FurnaceInve
@@ -15,14 +15,14 @@ index 05c29a788c96282fc18066ae253cf0b5be37e95c..e427187d714cc44ddb5801d8a47766e0
 +    // Paper start
 +    @Override
 +    public boolean isFuel(ItemStack stack) {
-+        return stack != null && !stack.getType().isEmpty() && AbstractFurnaceBlockEntity.isFuel(((org.bukkit.craftbukkit.inventory.CraftItemStack) stack).handle);
++        return stack != null && !stack.getType().isEmpty() && AbstractFurnaceBlockEntity.isFuel(CraftItemStack.asNMSCopy(stack));
 +    }
 +
 +    @Override
 +    public boolean canSmelt(ItemStack stack) {
 +        // data packs are always loaded in the main world
 +        net.minecraft.server.level.ServerLevel world = ((org.bukkit.craftbukkit.CraftWorld) org.bukkit.Bukkit.getWorlds().get(0)).getHandle();
-+        return stack != null && !stack.getType().isEmpty() && world.getRecipeManager().getRecipeFor(((AbstractFurnaceBlockEntity) this.inventory).recipeType, new net.minecraft.world.SimpleContainer(((CraftItemStack) stack).handle), world).isPresent();
++        return stack != null && !stack.getType().isEmpty() && world.getRecipeManager().getRecipeFor(((AbstractFurnaceBlockEntity) this.inventory).recipeType, new net.minecraft.world.SimpleContainer(CraftItemStack.asNMSCopy(stack)), world).isPresent();
 +    }
 +    // Paper end
 +

--- a/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
+++ b/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Expose isFuel and canSmelt methods to FurnaceInventory
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
-index 05c29a788c96282fc18066ae253cf0b5be37e95c..4fa0350617c780dff33bfe570b6c8f8b40fe7e89 100644
+index 05c29a788c96282fc18066ae253cf0b5be37e95c..e427187d714cc44ddb5801d8a47766e075a2350a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
 +++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
 @@ -40,6 +40,20 @@ public class CraftInventoryFurnace extends CraftInventory implements FurnaceInve
@@ -22,7 +22,7 @@ index 05c29a788c96282fc18066ae253cf0b5be37e95c..4fa0350617c780dff33bfe570b6c8f8b
 +    public boolean canSmelt(ItemStack stack) {
 +        // data packs are always loaded in the main world
 +        net.minecraft.server.level.ServerLevel world = ((org.bukkit.craftbukkit.CraftWorld) org.bukkit.Bukkit.getWorlds().get(0)).getHandle();
-+        return stack != null && !stack.getType().isEmpty() && world.getRecipeManager().getRecipeFor(((AbstractFurnaceBlockEntity) inventory).recipeType, this.inventory, world).isPresent();
++        return stack != null && !stack.getType().isEmpty() && world.getRecipeManager().getRecipeFor(((AbstractFurnaceBlockEntity) this.inventory).recipeType, new net.minecraft.world.SimpleContainer(((CraftItemStack) stack).handle), world).isPresent();
 +    }
 +    // Paper end
 +

--- a/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
+++ b/patches/server/0839-Expose-isFuel-and-canSmelt-methods-to-FurnaceInvento.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: BillyGalbreath <blake.galbreath@gmail.com>
+Date: Thu, 23 Dec 2021 15:32:50 -0600
+Subject: [PATCH] Expose isFuel and canSmelt methods to FurnaceInventory
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
+index 05c29a788c96282fc18066ae253cf0b5be37e95c..4fa0350617c780dff33bfe570b6c8f8b40fe7e89 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryFurnace.java
+@@ -40,6 +40,20 @@ public class CraftInventoryFurnace extends CraftInventory implements FurnaceInve
+         setItem(0, stack);
+     }
+ 
++    // Paper start
++    @Override
++    public boolean isFuel(ItemStack stack) {
++        return stack != null && !stack.getType().isEmpty() && AbstractFurnaceBlockEntity.isFuel(((org.bukkit.craftbukkit.inventory.CraftItemStack) stack).handle);
++    }
++
++    @Override
++    public boolean canSmelt(ItemStack stack) {
++        // data packs are always loaded in the main world
++        net.minecraft.server.level.ServerLevel world = ((org.bukkit.craftbukkit.CraftWorld) org.bukkit.Bukkit.getWorlds().get(0)).getHandle();
++        return stack != null && !stack.getType().isEmpty() && world.getRecipeManager().getRecipeFor(((AbstractFurnaceBlockEntity) inventory).recipeType, this.inventory, world).isPresent();
++    }
++    // Paper end
++
+     @Override
+     public Furnace getHolder() {
+         return (Furnace) inventory.getOwner();


### PR DESCRIPTION
I'm adding this to solve https://github.com/EngineHub/CraftBook/issues/221#issuecomment-597388101 for CraftBook, but these methods can be valuable to many other plugins.

Example use-case is `canSmelt` would replace all [this](https://github.com/EngineHub/CraftBook/blob/f3c9a57d3fca4054c166fb0104a8a671bfca1c8b/src/main/java/com/sk89q/craftbook/util/ItemUtil.java#L462-L636), and `isFuel` would replace all [this](https://github.com/EngineHub/CraftBook/blob/f3c9a57d3fca4054c166fb0104a8a671bfca1c8b/src/main/java/com/sk89q/craftbook/util/ItemUtil.java#L692-L763) and would add the ability for recipes added via API and data packs to work correctly.

CC: @me4502 ;)