### PR TITLE
Expose saturation in FoodLevelChangeEvent

### DIFF
--- a/patches/api/0351-FoodLevelChangeEvent-Expose-Saturation.patch
+++ b/patches/api/0351-FoodLevelChangeEvent-Expose-Saturation.patch
@@ -1,0 +1,67 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sat, 25 Dec 2021 23:04:06 -0500
+Subject: [PATCH] FoodLevelChangeEvent Expose Saturation
+
+
+diff --git a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
+index 7f4c5ea8607b08f8676528cc71b0b312575809ed..b1f5ed6656d9d80a3dcca2a5bacf9fc8079ab321 100644
+--- a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
++++ b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
+@@ -15,16 +15,27 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
+     private boolean cancel = false;
+     private int level;
+     private final ItemStack item;
++    private float saturationModifier; // Paper - Expose Saturation
+ 
+     public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level) {
+         this(what, level, null);
+     }
+ 
++    @Deprecated // Paper - Expose Saturation
+     public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level, @Nullable final ItemStack item) {
+         super(what);
+         this.level = level;
+         this.item = item;
++        this.saturationModifier = what.getSaturation(); // Just incase, make sure the player's saturation doesn't change. // Paper - Expose Saturation
+     }
++    // Paper Start - Expose Saturation
++    public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level, @Nullable final ItemStack item, final float saturationModifier) {
++        super(what);
++        this.level = level;
++        this.item = item;
++        this.saturationModifier = saturationModifier;
++    }
++    // Paper End - Expose Saturation
+ 
+     @NotNull
+     @Override
+@@ -67,6 +78,28 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
+         this.level = level;
+     }
+ 
++    // Paper Start - Expose Saturation
++    /**
++     * Gets the saturation modifier that the entity
++     * involved in this event should be set to.
++     *
++     * @return saturation modifier
++     */
++    public float getSaturationModifier() {
++        return saturationModifier;
++    }
++
++    /**
++     * Sets the satuartion modifier that the entity
++     * involved in this event will be set to.
++     *
++     * @param saturationModifier new saturation modifier
++     */
++    public void setSaturationModifier(float saturationModifier) {
++        this.saturationModifier = saturationModifier;
++    }
++    // Paper End - Expose Saturation
++
+     @Override
+     public boolean isCancelled() {
+         return cancel;

--- a/patches/api/0351-FoodLevelChangeEvent-Expose-Saturation.patch
+++ b/patches/api/0351-FoodLevelChangeEvent-Expose-Saturation.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] FoodLevelChangeEvent Expose Saturation
 
 
 diff --git a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
-index 7f4c5ea8607b08f8676528cc71b0b312575809ed..b1f5ed6656d9d80a3dcca2a5bacf9fc8079ab321 100644
+index 7f4c5ea8607b08f8676528cc71b0b312575809ed..963396f5f70a1b896faae00c6d6b565f9f25ab68 100644
 --- a/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
 +++ b/src/main/java/org/bukkit/event/entity/FoodLevelChangeEvent.java
 @@ -15,16 +15,27 @@ public class FoodLevelChangeEvent extends EntityEvent implements Cancellable {
      private boolean cancel = false;
      private int level;
      private final ItemStack item;
-+    private float saturationModifier; // Paper - Expose Saturation
++    private float saturationLevel; // Paper - Expose Saturation
  
      public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level) {
          this(what, level, null);
@@ -23,14 +23,14 @@ index 7f4c5ea8607b08f8676528cc71b0b312575809ed..b1f5ed6656d9d80a3dcca2a5bacf9fc8
          super(what);
          this.level = level;
          this.item = item;
-+        this.saturationModifier = what.getSaturation(); // Just incase, make sure the player's saturation doesn't change. // Paper - Expose Saturation
++        this.saturationLevel = what.getSaturation(); // Just incase, make sure the player's saturation doesn't change. // Paper - Expose Saturation
      }
 +    // Paper Start - Expose Saturation
-+    public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level, @Nullable final ItemStack item, final float saturationModifier) {
++    public FoodLevelChangeEvent(@NotNull final HumanEntity what, final int level, @Nullable final ItemStack item, final float saturationLevel) {
 +        super(what);
 +        this.level = level;
 +        this.item = item;
-+        this.saturationModifier = saturationModifier;
++        this.saturationLevel = saturationLevel;
 +    }
 +    // Paper End - Expose Saturation
  
@@ -42,23 +42,23 @@ index 7f4c5ea8607b08f8676528cc71b0b312575809ed..b1f5ed6656d9d80a3dcca2a5bacf9fc8
  
 +    // Paper Start - Expose Saturation
 +    /**
-+     * Gets the saturation modifier that the entity
-+     * involved in this event should be set to.
++     * Gets the saturation that the entity
++     * involved in this event would be set to.
 +     *
-+     * @return saturation modifier
++     * @return saturation level
 +     */
-+    public float getSaturationModifier() {
-+        return saturationModifier;
++    public float getSaturationLevel() {
++        return saturationLevel;
 +    }
 +
 +    /**
-+     * Sets the satuartion modifier that the entity
++     * Sets the saturation that the entity
 +     * involved in this event will be set to.
 +     *
-+     * @param saturationModifier new saturation modifier
++     * @param saturationLevel new saturation level
 +     */
-+    public void setSaturationModifier(float saturationModifier) {
-+        this.saturationModifier = saturationModifier;
++    public void setSaturationLevel(float saturationLevel) {
++        this.saturationLevel = saturationLevel;
 +    }
 +    // Paper End - Expose Saturation
 +

--- a/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation-Level.patch
+++ b/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation-Level.patch
@@ -1,94 +1,48 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
 Date: Sat, 25 Dec 2021 23:04:14 -0500
-Subject: [PATCH] FoodLevelChangeEvent Expose Saturation
+Subject: [PATCH] FoodLevelChangeEvent Expose Saturation Level
 
 
 diff --git a/src/main/java/net/minecraft/world/effect/MobEffect.java b/src/main/java/net/minecraft/world/effect/MobEffect.java
-index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..c06978640578f988a30e34603399bf4830f6b9fb 100644
+index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..3935cc5c35c2bc3a86fcbcac247cbe52547d3cf3 100644
 --- a/src/main/java/net/minecraft/world/effect/MobEffect.java
 +++ b/src/main/java/net/minecraft/world/effect/MobEffect.java
-@@ -63,13 +63,19 @@ public class MobEffect {
+@@ -63,13 +63,7 @@ public class MobEffect {
              if (!entity.level.isClientSide) {
                  // CraftBukkit start
                  Player entityhuman = (Player) entity;
 -                int oldFoodLevel = entityhuman.getFoodData().foodLevel;
-+                // Paper start - Expose Saturation
-+                var foodData = entityhuman.getFoodData();
- 
+-
 -                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, amplifier + 1 + oldFoodLevel);
-+                foodData.captureEating = true;
-+                foodData.eat(1, 1.0F);
-+                foodData.captureEating = false;
- 
-+                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodData.capturedFoodLevel, foodData.capturedSaturation);
-                 if (!event.isCancelled()) {
+-
+-                if (!event.isCancelled()) {
 -                    entityhuman.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 1.0F);
-+                    foodData.saturationLevel = event.getSaturationLevel();
-+                    foodData.foodLevel = event.getFoodLevel();
-                 }
-+                // Paper end - Expose Saturation
+-                }
++                CraftEventFactory.handleFoodChange(entityhuman, 1, 1.0F, null); // Paper - Expose Saturation
  
                  ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
                  // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/food/FoodData.java b/src/main/java/net/minecraft/world/food/FoodData.java
-index 2934b6de1f1fb914a532ee20184df99d1acd8e65..865ff408a4d2e23fa32de3c2f679f37ee5dff5f9 100644
+index 2934b6de1f1fb914a532ee20184df99d1acd8e65..d1b843b5d5281010bb180470d494da4afff86576 100644
 --- a/src/main/java/net/minecraft/world/food/FoodData.java
 +++ b/src/main/java/net/minecraft/world/food/FoodData.java
-@@ -23,6 +23,11 @@ public class FoodData {
-     public int starvationRate = 80;
-     // CraftBukkit end
-     private int lastFoodLevel = 20;
-+    // Paper start - Expose Saturation
-+    public boolean captureEating = false;
-+    public float capturedSaturation;
-+    public int capturedFoodLevel;
-+    // Paper end - Expose Saturation
- 
-     public FoodData() { throw new AssertionError("Whoopsie, we missed the bukkit."); } // CraftBukkit start - throw an error
- 
-@@ -34,21 +39,35 @@ public class FoodData {
-     // CraftBukkit end
- 
-     public void eat(int food, float saturationModifier) {
--        this.foodLevel = Math.min(food + this.foodLevel, 20);
--        this.saturationLevel = Math.min(this.saturationLevel + (float) food * saturationModifier * 2.0F, (float) this.foodLevel);
-+        // Paper start - Expose Saturation
-+        int foodLevel = Math.min(food + this.foodLevel, 20);
-+        float saturationLevel = Math.min(this.saturationLevel + (float) food * saturationModifier * 2.0F, (float) this.foodLevel);
-+        if (captureEating) {
-+            this.capturedFoodLevel = foodLevel;
-+            this.capturedSaturation = saturationLevel;
-+        } else {
-+            this.foodLevel = foodLevel;
-+            this.saturationLevel = saturationLevel;
-+        }
-+        // Paper end - Expose Saturation
-     }
- 
-     public void eat(Item item, ItemStack stack) {
+@@ -42,13 +42,7 @@ public class FoodData {
          if (item.isEdible()) {
              FoodProperties foodinfo = item.getFoodProperties();
              // CraftBukkit start
 -            int oldFoodLevel = this.foodLevel;
-+            // Paper start - Expose Saturation
-+            captureEating = true;
-+            eat(foodinfo.getNutrition(), foodinfo.getSaturationModifier()); // Go through logic
-+            captureEating = false;
- 
+-
 -            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodinfo.getNutrition() + oldFoodLevel, stack);
-+            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, this.capturedFoodLevel, this.capturedSaturation, stack);
- 
-             if (!event.isCancelled()) {
+-
+-            if (!event.isCancelled()) {
 -                this.eat(event.getFoodLevel() - oldFoodLevel, foodinfo.getSaturationModifier());
-+                this.foodLevel = event.getFoodLevel();
-+                this.saturationLevel = event.getSaturationLevel();
-             }
-+            // Paper end - Expose Saturation
+-            }
++            org.bukkit.craftbukkit.event.CraftEventFactory.handleFoodChange(entityhuman, foodinfo.getNutrition(), foodinfo.getSaturationModifier(), stack); // Paper - Expose Saturation
  
              ((ServerPlayer) this.entityhuman).getBukkitEntity().sendHealthUpdate();
              // CraftBukkit end
-@@ -63,13 +82,28 @@ public class FoodData {
+@@ -63,13 +57,28 @@ public class FoodData {
          if (this.exhaustionLevel > 4.0F) {
              this.exhaustionLevel -= 4.0F;
              if (this.saturationLevel > 0.0F) {
@@ -119,43 +73,52 @@ index 2934b6de1f1fb914a532ee20184df99d1acd8e65..865ff408a4d2e23fa32de3c2f679f37e
  
                  ((ServerPlayer) player).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) player).getBukkitEntity().getScaledHealth(), this.foodLevel, this.saturationLevel));
 diff --git a/src/main/java/net/minecraft/world/level/block/CakeBlock.java b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
-index 1a87a1553bb94e33c86b9d8947cf39fd193e7859..5bbaec248ee4bb30ed1422fe1fccea7f249963cb 100644
+index 1a87a1553bb94e33c86b9d8947cf39fd193e7859..0d5ac99e78f4b41d48f828bf95e87db3e88b8948 100644
 --- a/src/main/java/net/minecraft/world/level/block/CakeBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
-@@ -87,13 +87,19 @@ public class CakeBlock extends Block {
+@@ -87,13 +87,7 @@ public class CakeBlock extends Block {
              player.awardStat(Stats.EAT_CAKE_SLICE);
              // CraftBukkit start
              // entityhuman.getFoodData().eat(2, 0.1F);
 -            int oldFoodLevel = player.getFoodData().foodLevel;
-+            // Paper start - Expose Saturation
-+            var foodData = player.getFoodData();
- 
+-
 -            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, 2 + oldFoodLevel);
-+            foodData.captureEating = true;
-+            foodData.eat(2, 0.1F);
-+            foodData.captureEating = false;
- 
-+            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, foodData.capturedFoodLevel, foodData.capturedSaturation);
-             if (!event.isCancelled()) {
+-
+-            if (!event.isCancelled()) {
 -                player.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 0.1F);
-+                foodData.saturationLevel = event.getSaturationLevel();
-+                foodData.foodLevel = event.getFoodLevel();
-             }
-+            // Paper end - Expose Saturation
+-            }
++            org.bukkit.craftbukkit.event.CraftEventFactory.handleFoodChange(player, 2, 0.1F, null); // Paper - Expose Saturation
  
              ((net.minecraft.server.level.ServerPlayer) player).getBukkitEntity().sendHealthUpdate();
              // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c667baa2da8222eb66344c8f1cc0fed416c4df01..68cb12090ef5db06fcc188e43d6ca082ce9d3cbb 100644
+index c667baa2da8222eb66344c8f1cc0fed416c4df01..6ba1916421ab9cfc042dd4fa0c1df90c8c9cc55b 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1235,12 +1235,14 @@ public class CraftEventFactory {
+@@ -1235,12 +1235,31 @@ public class CraftEventFactory {
          return event;
      }
  
 -    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level) {
 -        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, null);
 +    // Paper start - Expose Saturation
++    public static void handleFoodChange(net.minecraft.world.entity.player.Player player, int level, float saturationModifier, @Nullable ItemStack item) {
++        var foodData = player.getFoodData();
++
++        float oldSaturationLevel = foodData.saturationLevel;
++        int oldFoodLevel = foodData.foodLevel;
++        foodData.eat(level, saturationModifier);
++
++        org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(player, foodData.foodLevel, foodData.saturationLevel, item);
++        if (!event.isCancelled()) {
++            foodData.saturationLevel = event.getSaturationLevel();
++            foodData.foodLevel = event.getFoodLevel();
++        } else {
++            foodData.saturationLevel = oldSaturationLevel;
++            foodData.foodLevel = oldFoodLevel;
++        }
++    }
++
 +    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationLevel) {
 +        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, saturationLevel, null);
      }

--- a/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
+++ b/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
@@ -1,0 +1,89 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sat, 25 Dec 2021 23:04:14 -0500
+Subject: [PATCH] FoodLevelChangeEvent Expose Saturation
+
+
+diff --git a/src/main/java/net/minecraft/world/effect/MobEffect.java b/src/main/java/net/minecraft/world/effect/MobEffect.java
+index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..a6f311c6ed4ad64a3e0857121a1f6ef250c7bbf2 100644
+--- a/src/main/java/net/minecraft/world/effect/MobEffect.java
++++ b/src/main/java/net/minecraft/world/effect/MobEffect.java
+@@ -65,10 +65,10 @@ public class MobEffect {
+                 Player entityhuman = (Player) entity;
+                 int oldFoodLevel = entityhuman.getFoodData().foodLevel;
+ 
+-                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, amplifier + 1 + oldFoodLevel);
++                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, amplifier + 1 + oldFoodLevel, 1.0F); // Paper - Expose Saturation
+ 
+                 if (!event.isCancelled()) {
+-                    entityhuman.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 1.0F);
++                    entityhuman.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, event.getSaturationModifier()); // Paper - Expose Saturation
+                 }
+ 
+                 ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
+diff --git a/src/main/java/net/minecraft/world/food/FoodData.java b/src/main/java/net/minecraft/world/food/FoodData.java
+index 2934b6de1f1fb914a532ee20184df99d1acd8e65..a5af470bc89c9f27807b24026fbf1051917e4efe 100644
+--- a/src/main/java/net/minecraft/world/food/FoodData.java
++++ b/src/main/java/net/minecraft/world/food/FoodData.java
+@@ -44,10 +44,10 @@ public class FoodData {
+             // CraftBukkit start
+             int oldFoodLevel = this.foodLevel;
+ 
+-            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodinfo.getNutrition() + oldFoodLevel, stack);
++            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodinfo.getNutrition() + oldFoodLevel, foodinfo.getSaturationModifier(), stack); // Paper - Expose Saturation
+ 
+             if (!event.isCancelled()) {
+-                this.eat(event.getFoodLevel() - oldFoodLevel, foodinfo.getSaturationModifier());
++                this.eat(event.getFoodLevel() - oldFoodLevel, event.getSaturationModifier()); // Paper - Expose Saturation
+             }
+ 
+             ((ServerPlayer) this.entityhuman).getBukkitEntity().sendHealthUpdate();
+@@ -66,10 +66,11 @@ public class FoodData {
+                 this.saturationLevel = Math.max(this.saturationLevel - 1.0F, 0.0F);
+             } else if (enumdifficulty != Difficulty.PEACEFUL) {
+                 // CraftBukkit start
+-                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0));
++                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0), this.saturationLevel); // Paper - Expose Saturation
+ 
+                 if (!event.isCancelled()) {
+                     this.foodLevel = event.getFoodLevel();
++                    this.saturationLevel = event.getSaturationModifier(); // Paper - Expose Saturation
+                 }
+ 
+                 ((ServerPlayer) player).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) player).getBukkitEntity().getScaledHealth(), this.foodLevel, this.saturationLevel));
+diff --git a/src/main/java/net/minecraft/world/level/block/CakeBlock.java b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
+index 1a87a1553bb94e33c86b9d8947cf39fd193e7859..5dd54ae207e30fa0d7e1bfd10165feb58c3182c1 100644
+--- a/src/main/java/net/minecraft/world/level/block/CakeBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
+@@ -89,7 +89,7 @@ public class CakeBlock extends Block {
+             // entityhuman.getFoodData().eat(2, 0.1F);
+             int oldFoodLevel = player.getFoodData().foodLevel;
+ 
+-            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, 2 + oldFoodLevel);
++            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, 2 + oldFoodLevel, 0.1F); // Paper - Expose Saturation
+ 
+             if (!event.isCancelled()) {
+                 player.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 0.1F);
+diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+index c667baa2da8222eb66344c8f1cc0fed416c4df01..525bf21785e4d8d09e904757c40fde912313a92b 100644
+--- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
++++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
+@@ -1235,12 +1235,14 @@ public class CraftEventFactory {
+         return event;
+     }
+ 
+-    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level) {
+-        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, null);
++    // Paper start - Expose Saturation
++    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationModifier) {
++        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, saturationModifier, null);
+     }
+ 
+-    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, ItemStack item) {
+-        FoodLevelChangeEvent event = new FoodLevelChangeEvent(entity.getBukkitEntity(), level, (item == null) ? null : CraftItemStack.asBukkitCopy(item));
++    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationModifier, ItemStack item) {
++        FoodLevelChangeEvent event = new FoodLevelChangeEvent(entity.getBukkitEntity(), level, (item == null) ? null : CraftItemStack.asBukkitCopy(item), saturationModifier);
++        // Paper end - Expose Saturation
+         entity.getBukkitEntity().getServer().getPluginManager().callEvent(event);
+         return event;
+     }

--- a/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
+++ b/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
@@ -32,7 +32,7 @@ index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..c06978640578f988a30e34603399bf48
                  ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
                  // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/food/FoodData.java b/src/main/java/net/minecraft/world/food/FoodData.java
-index 2934b6de1f1fb914a532ee20184df99d1acd8e65..01544a6aff7a89cd57a7d8115e71b925206fb2df 100644
+index 2934b6de1f1fb914a532ee20184df99d1acd8e65..865ff408a4d2e23fa32de3c2f679f37ee5dff5f9 100644
 --- a/src/main/java/net/minecraft/world/food/FoodData.java
 +++ b/src/main/java/net/minecraft/world/food/FoodData.java
 @@ -23,6 +23,11 @@ public class FoodData {
@@ -92,9 +92,9 @@ index 2934b6de1f1fb914a532ee20184df99d1acd8e65..01544a6aff7a89cd57a7d8115e71b925
          if (this.exhaustionLevel > 4.0F) {
              this.exhaustionLevel -= 4.0F;
              if (this.saturationLevel > 0.0F) {
-+                float lastSaturationLevel = this.saturationLevel;
++                float lastSaturationLevel = this.saturationLevel; // Paper - Expose Saturation
                  this.saturationLevel = Math.max(this.saturationLevel - 1.0F, 0.0F);
-+                // Paper start
++                // Paper start - Expose Saturation
 +                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, this.foodLevel, this.saturationLevel);
 +
 +                // Only saturation is modified in this call
@@ -106,7 +106,7 @@ index 2934b6de1f1fb914a532ee20184df99d1acd8e65..01544a6aff7a89cd57a7d8115e71b925
 +                }
 +
 +                ((ServerPlayer) player).getBukkitEntity().sendHealthUpdate();
-+                // Paper end
++                // Paper end - Expose Saturation
              } else if (enumdifficulty != Difficulty.PEACEFUL) {
                  // CraftBukkit start
 -                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0));

--- a/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
+++ b/patches/server/0839-FoodLevelChangeEvent-Expose-Saturation.patch
@@ -5,41 +5,108 @@ Subject: [PATCH] FoodLevelChangeEvent Expose Saturation
 
 
 diff --git a/src/main/java/net/minecraft/world/effect/MobEffect.java b/src/main/java/net/minecraft/world/effect/MobEffect.java
-index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..a6f311c6ed4ad64a3e0857121a1f6ef250c7bbf2 100644
+index 8bbb9bdcf95989f1737714655f6f6a269d46d7f2..c06978640578f988a30e34603399bf4830f6b9fb 100644
 --- a/src/main/java/net/minecraft/world/effect/MobEffect.java
 +++ b/src/main/java/net/minecraft/world/effect/MobEffect.java
-@@ -65,10 +65,10 @@ public class MobEffect {
+@@ -63,13 +63,19 @@ public class MobEffect {
+             if (!entity.level.isClientSide) {
+                 // CraftBukkit start
                  Player entityhuman = (Player) entity;
-                 int oldFoodLevel = entityhuman.getFoodData().foodLevel;
+-                int oldFoodLevel = entityhuman.getFoodData().foodLevel;
++                // Paper start - Expose Saturation
++                var foodData = entityhuman.getFoodData();
  
 -                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, amplifier + 1 + oldFoodLevel);
-+                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, amplifier + 1 + oldFoodLevel, 1.0F); // Paper - Expose Saturation
++                foodData.captureEating = true;
++                foodData.eat(1, 1.0F);
++                foodData.captureEating = false;
  
++                org.bukkit.event.entity.FoodLevelChangeEvent event = CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodData.capturedFoodLevel, foodData.capturedSaturation);
                  if (!event.isCancelled()) {
 -                    entityhuman.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 1.0F);
-+                    entityhuman.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, event.getSaturationModifier()); // Paper - Expose Saturation
++                    foodData.saturationLevel = event.getSaturationLevel();
++                    foodData.foodLevel = event.getFoodLevel();
                  }
++                // Paper end - Expose Saturation
  
                  ((ServerPlayer) entityhuman).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) entityhuman).getBukkitEntity().getScaledHealth(), entityhuman.getFoodData().foodLevel, entityhuman.getFoodData().saturationLevel));
+                 // CraftBukkit end
 diff --git a/src/main/java/net/minecraft/world/food/FoodData.java b/src/main/java/net/minecraft/world/food/FoodData.java
-index 2934b6de1f1fb914a532ee20184df99d1acd8e65..a5af470bc89c9f27807b24026fbf1051917e4efe 100644
+index 2934b6de1f1fb914a532ee20184df99d1acd8e65..01544a6aff7a89cd57a7d8115e71b925206fb2df 100644
 --- a/src/main/java/net/minecraft/world/food/FoodData.java
 +++ b/src/main/java/net/minecraft/world/food/FoodData.java
-@@ -44,10 +44,10 @@ public class FoodData {
+@@ -23,6 +23,11 @@ public class FoodData {
+     public int starvationRate = 80;
+     // CraftBukkit end
+     private int lastFoodLevel = 20;
++    // Paper start - Expose Saturation
++    public boolean captureEating = false;
++    public float capturedSaturation;
++    public int capturedFoodLevel;
++    // Paper end - Expose Saturation
+ 
+     public FoodData() { throw new AssertionError("Whoopsie, we missed the bukkit."); } // CraftBukkit start - throw an error
+ 
+@@ -34,21 +39,35 @@ public class FoodData {
+     // CraftBukkit end
+ 
+     public void eat(int food, float saturationModifier) {
+-        this.foodLevel = Math.min(food + this.foodLevel, 20);
+-        this.saturationLevel = Math.min(this.saturationLevel + (float) food * saturationModifier * 2.0F, (float) this.foodLevel);
++        // Paper start - Expose Saturation
++        int foodLevel = Math.min(food + this.foodLevel, 20);
++        float saturationLevel = Math.min(this.saturationLevel + (float) food * saturationModifier * 2.0F, (float) this.foodLevel);
++        if (captureEating) {
++            this.capturedFoodLevel = foodLevel;
++            this.capturedSaturation = saturationLevel;
++        } else {
++            this.foodLevel = foodLevel;
++            this.saturationLevel = saturationLevel;
++        }
++        // Paper end - Expose Saturation
+     }
+ 
+     public void eat(Item item, ItemStack stack) {
+         if (item.isEdible()) {
+             FoodProperties foodinfo = item.getFoodProperties();
              // CraftBukkit start
-             int oldFoodLevel = this.foodLevel;
+-            int oldFoodLevel = this.foodLevel;
++            // Paper start - Expose Saturation
++            captureEating = true;
++            eat(foodinfo.getNutrition(), foodinfo.getSaturationModifier()); // Go through logic
++            captureEating = false;
  
 -            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodinfo.getNutrition() + oldFoodLevel, stack);
-+            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, foodinfo.getNutrition() + oldFoodLevel, foodinfo.getSaturationModifier(), stack); // Paper - Expose Saturation
++            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(entityhuman, this.capturedFoodLevel, this.capturedSaturation, stack);
  
              if (!event.isCancelled()) {
 -                this.eat(event.getFoodLevel() - oldFoodLevel, foodinfo.getSaturationModifier());
-+                this.eat(event.getFoodLevel() - oldFoodLevel, event.getSaturationModifier()); // Paper - Expose Saturation
++                this.foodLevel = event.getFoodLevel();
++                this.saturationLevel = event.getSaturationLevel();
              }
++            // Paper end - Expose Saturation
  
              ((ServerPlayer) this.entityhuman).getBukkitEntity().sendHealthUpdate();
-@@ -66,10 +66,11 @@ public class FoodData {
+             // CraftBukkit end
+@@ -63,13 +82,28 @@ public class FoodData {
+         if (this.exhaustionLevel > 4.0F) {
+             this.exhaustionLevel -= 4.0F;
+             if (this.saturationLevel > 0.0F) {
++                float lastSaturationLevel = this.saturationLevel;
                  this.saturationLevel = Math.max(this.saturationLevel - 1.0F, 0.0F);
++                // Paper start
++                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, this.foodLevel, this.saturationLevel);
++
++                // Only saturation is modified in this call
++                if (event.isCancelled()) {
++                    this.saturationLevel = lastSaturationLevel;
++                } else {
++                    this.foodLevel = event.getFoodLevel();
++                    this.saturationLevel = event.getSaturationLevel();
++                }
++
++                ((ServerPlayer) player).getBukkitEntity().sendHealthUpdate();
++                // Paper end
              } else if (enumdifficulty != Difficulty.PEACEFUL) {
                  // CraftBukkit start
 -                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0));
@@ -47,25 +114,39 @@ index 2934b6de1f1fb914a532ee20184df99d1acd8e65..a5af470bc89c9f27807b24026fbf1051
  
                  if (!event.isCancelled()) {
                      this.foodLevel = event.getFoodLevel();
-+                    this.saturationLevel = event.getSaturationModifier(); // Paper - Expose Saturation
++                    this.saturationLevel = event.getSaturationLevel(); // Paper - Expose Saturation
                  }
  
                  ((ServerPlayer) player).connection.send(new ClientboundSetHealthPacket(((ServerPlayer) player).getBukkitEntity().getScaledHealth(), this.foodLevel, this.saturationLevel));
 diff --git a/src/main/java/net/minecraft/world/level/block/CakeBlock.java b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
-index 1a87a1553bb94e33c86b9d8947cf39fd193e7859..5dd54ae207e30fa0d7e1bfd10165feb58c3182c1 100644
+index 1a87a1553bb94e33c86b9d8947cf39fd193e7859..5bbaec248ee4bb30ed1422fe1fccea7f249963cb 100644
 --- a/src/main/java/net/minecraft/world/level/block/CakeBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/CakeBlock.java
-@@ -89,7 +89,7 @@ public class CakeBlock extends Block {
+@@ -87,13 +87,19 @@ public class CakeBlock extends Block {
+             player.awardStat(Stats.EAT_CAKE_SLICE);
+             // CraftBukkit start
              // entityhuman.getFoodData().eat(2, 0.1F);
-             int oldFoodLevel = player.getFoodData().foodLevel;
+-            int oldFoodLevel = player.getFoodData().foodLevel;
++            // Paper start - Expose Saturation
++            var foodData = player.getFoodData();
  
 -            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, 2 + oldFoodLevel);
-+            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, 2 + oldFoodLevel, 0.1F); // Paper - Expose Saturation
++            foodData.captureEating = true;
++            foodData.eat(2, 0.1F);
++            foodData.captureEating = false;
  
++            org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, foodData.capturedFoodLevel, foodData.capturedSaturation);
              if (!event.isCancelled()) {
-                 player.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 0.1F);
+-                player.getFoodData().eat(event.getFoodLevel() - oldFoodLevel, 0.1F);
++                foodData.saturationLevel = event.getSaturationLevel();
++                foodData.foodLevel = event.getFoodLevel();
+             }
++            // Paper end - Expose Saturation
+ 
+             ((net.minecraft.server.level.ServerPlayer) player).getBukkitEntity().sendHealthUpdate();
+             // CraftBukkit end
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index c667baa2da8222eb66344c8f1cc0fed416c4df01..525bf21785e4d8d09e904757c40fde912313a92b 100644
+index c667baa2da8222eb66344c8f1cc0fed416c4df01..68cb12090ef5db06fcc188e43d6ca082ce9d3cbb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -1235,12 +1235,14 @@ public class CraftEventFactory {
@@ -75,14 +156,14 @@ index c667baa2da8222eb66344c8f1cc0fed416c4df01..525bf21785e4d8d09e904757c40fde91
 -    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level) {
 -        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, null);
 +    // Paper start - Expose Saturation
-+    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationModifier) {
-+        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, saturationModifier, null);
++    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationLevel) {
++        return CraftEventFactory.callFoodLevelChangeEvent(entity, level, saturationLevel, null);
      }
  
 -    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, ItemStack item) {
 -        FoodLevelChangeEvent event = new FoodLevelChangeEvent(entity.getBukkitEntity(), level, (item == null) ? null : CraftItemStack.asBukkitCopy(item));
-+    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationModifier, ItemStack item) {
-+        FoodLevelChangeEvent event = new FoodLevelChangeEvent(entity.getBukkitEntity(), level, (item == null) ? null : CraftItemStack.asBukkitCopy(item), saturationModifier);
++    public static FoodLevelChangeEvent callFoodLevelChangeEvent(net.minecraft.world.entity.player.Player entity, int level, float saturationLevel, ItemStack item) {
++        FoodLevelChangeEvent event = new FoodLevelChangeEvent(entity.getBukkitEntity(), level, (item == null) ? null : CraftItemStack.asBukkitCopy(item), saturationLevel);
 +        // Paper end - Expose Saturation
          entity.getBukkitEntity().getServer().getPluginManager().callEvent(event);
          return event;


### PR DESCRIPTION
Resolves https://github.com/PaperMC/Paper/issues/7193

It may just be better to add an entirely new event.. but I would like opinions on this. Although this mostly works fine, it gets a little wonky when it comes to canceling natural hunger decay. 
```
((ServerPlayer) this.entityhuman).getBukkitEntity().sendHealthUpdate();
@@ -66,10 +66,11 @@ public class FoodData {
                 this.saturationLevel = Math.max(this.saturationLevel - 1.0F, 0.0F);
             } else if (enumdifficulty != Difficulty.PEACEFUL) {
                 // CraftBukkit start
-                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0));
+                org.bukkit.event.entity.FoodLevelChangeEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.callFoodLevelChangeEvent(player, Math.max(this.foodLevel - 1, 0), this.saturationLevel); // Paper - Expose Saturation

                 if (!event.isCancelled()) {
                     this.foodLevel = event.getFoodLevel();
+                    this.saturationLevel = event.getSaturationModifier(); // Paper - Expose Saturation
                 }
```

Specifically here, I can't really "cancel" saturation modification since this would be a behavior change. 
So, it's either we can live with this slight issue, or we can just make an entirely new event that would be executed alongside FoodLevelChangeEvent, this would allow us to add an event for natural saturation decay as well. However, canceling the FoodLevelChangeEvent will also cancel modification of the saturation in some situations (like eating food). So I would like some pointers here.