### PR TITLE
Sleep Message API + Config

### DIFF
--- a/patches/api/0351-Sleep-Message-API.patch
+++ b/patches/api/0351-Sleep-Message-API.patch
@@ -1,0 +1,114 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 26 Dec 2021 00:22:29 -0500
+Subject: [PATCH] Sleep Message API
+
+
+diff --git a/src/main/java/io/papermc/paper/event/player/PlayerSleepMessageEvent.java b/src/main/java/io/papermc/paper/event/player/PlayerSleepMessageEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..bbc8be31d9054f9300c45bd5bfba002e12470f37
+--- /dev/null
++++ b/src/main/java/io/papermc/paper/event/player/PlayerSleepMessageEvent.java
+@@ -0,0 +1,102 @@
++package io.papermc.paper.event.player;
++
++import net.kyori.adventure.text.Component;
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.jetbrains.annotations.NotNull;
++
++
++/**
++ * Called when the player receives a message on the current
++ * sleeping status.
++ *
++ * This will be called with cancelled as true by default if the player has the message disabled
++ * in their config.
++ */
++public class PlayerSleepMessageEvent extends PlayerEvent implements Cancellable {
++
++    private static final HandlerList HANDLER_LIST = new HandlerList();
++
++    private Component component;
++    private final SleepMessageType type;
++    private boolean cancelled;
++
++    public PlayerSleepMessageEvent(@NotNull Player player, @NotNull SleepMessageType type, @NotNull Component component, boolean cancelled) {
++        super(player);
++        this.type = type;
++        this.component = component;
++        this.cancelled = cancelled;
++    }
++
++    /**
++     * Gets the type of sleeping message that is displayed
++     * to the player.
++     * @return sleeping message type
++     */
++    @NotNull
++    public SleepMessageType getMessageType() {
++        return type;
++    }
++
++    /**
++     * Sets the message that is displayed to the user in the
++     * action bar.
++     *
++     * @param component message
++     */
++    public void setMessage(@NotNull Component component) {
++        this.component = component;
++    }
++
++    /**
++     * Gets the message that is displayed to the user in the
++     * action bar.
++     *
++     * @return message
++     */
++    @NotNull
++    public Component getMessage() {
++        return component;
++    }
++
++    @Override
++    public boolean isCancelled() {
++        return cancelled;
++    }
++
++    @Override
++    public void setCancelled(boolean cancel) {
++        this.cancelled = cancel;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return HANDLER_LIST;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return HANDLER_LIST;
++    }
++
++    /**
++     * Represents the action bar message that is sent to the player
++     * when they attempt to sleep.
++     */
++    public enum SleepMessageType {
++        /**
++         * Represents the message that are sent to players if they are currently
++         * skipping the night.
++         */
++        SKIPPING_NIGHT,
++        /**
++         * Represents the message that are sent to players if there
++         * are a certain number of players that are needed to sleep.
++         */
++        PLAYERS_SLEEPING_COUNT,
++        ;
++    }
++}

--- a/patches/server/0839-Sleep-Message-API.patch
+++ b/patches/server/0839-Sleep-Message-API.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Owen1212055 <23108066+Owen1212055@users.noreply.github.com>
+Date: Sun, 26 Dec 2021 00:22:36 -0500
+Subject: [PATCH] Sleep Message API
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..4746263918a61c53a22248a2e67b2a3755681c82 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -1019,4 +1019,14 @@ public class PaperWorldConfig {
+     private void minBlockLightForMobSpawning() {
+         this.maxBlockLightForMonsterSpawning = getInt("monster-spawn-max-light-level", maxBlockLightForMonsterSpawning);
+     }
++
++    public boolean skippingNightMessage = true;
++    private void skippingNightMessage() {
++        this.skippingNightMessage = getBoolean("sleep-skipping-night-message", skippingNightMessage);
++    }
++
++    public boolean playersSleepingMessage = true;
++    private void playersSleepingMessage() {
++        this.playersSleepingMessage = getBoolean("sleep-players-sleeping-message", playersSleepingMessage);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 28f605c3daa969c1a54745e552d55ecb874120a9..86843a5a3fd3b53e0b0078cfd70c5c333d60310f 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -898,18 +898,32 @@ public class ServerLevel extends Level implements WorldGenLevel {
+                 int i = this.getGameRules().getInt(GameRules.RULE_PLAYERS_SLEEPING_PERCENTAGE);
+                 TranslatableComponent chatmessage;
+ 
++                io.papermc.paper.event.player.PlayerSleepMessageEvent.SleepMessageType messageType; // Paper - Sleep Message API
+                 if (this.sleepStatus.areEnoughSleeping(i)) {
+                     chatmessage = new TranslatableComponent("sleep.skipping_night");
++                    messageType = io.papermc.paper.event.player.PlayerSleepMessageEvent.SleepMessageType.SKIPPING_NIGHT; // Paper - Sleep Message API
+                 } else {
+                     chatmessage = new TranslatableComponent("sleep.players_sleeping", new Object[]{this.sleepStatus.amountSleeping(), this.sleepStatus.sleepersNeeded(i)});
++                    messageType = io.papermc.paper.event.player.PlayerSleepMessageEvent.SleepMessageType.PLAYERS_SLEEPING_COUNT; // Paper - Sleep Message API
+                 }
++                // Paper Start - Sleep Message API
++                boolean shouldDisplayMessage =
++                    (messageType == io.papermc.paper.event.player.PlayerSleepMessageEvent.SleepMessageType.SKIPPING_NIGHT && paperConfig.skippingNightMessage)
++                    || (messageType == io.papermc.paper.event.player.PlayerSleepMessageEvent.SleepMessageType.PLAYERS_SLEEPING_COUNT && paperConfig.playersSleepingMessage);
++                var adventureComponent = io.papermc.paper.adventure.PaperAdventure.asAdventure(chatmessage);
++                // Paper End - Sleep Message API
+ 
+                 Iterator iterator = this.players.iterator();
+ 
+                 while (iterator.hasNext()) {
+                     ServerPlayer entityplayer = (ServerPlayer) iterator.next();
+ 
+-                    entityplayer.displayClientMessage(chatmessage, true);
++                    // Paper Start - Sleep Message API
++                    var event = new io.papermc.paper.event.player.PlayerSleepMessageEvent(entityplayer.getBukkitEntity(), messageType, adventureComponent, !shouldDisplayMessage);
++                    if (event.callEvent()) {
++                    entityplayer.displayClientMessage(io.papermc.paper.adventure.PaperAdventure.asVanilla(event.getMessage()), true);
++                    }
++                    // Paper End - Sleep Message API
+                 }
+ 
+             }


### PR DESCRIPTION
Resolves: https://github.com/PaperMC/Paper/issues/6863

Called per-player, allows for modifying the message and getting what type it represents. 
This also adds a configuration option, which will disable/enable these messages. If they are disabled the event will be called canceled by default.

```java
@EventHandler
    public void event(PlayerSleepMessageEvent event) {
        Player player = event.getPlayer();
        
        player.sendMessage(event.getMessageType().toString());
        player.sendMessage(event.getMessage());
        event.setMessage(Component.text("haha night go skippy"));
    }
```

![image](https://user-images.githubusercontent.com/23108066/147399713-c677c75d-4d36-4f5d-9dc8-4f106335f25e.png)
![image](https://user-images.githubusercontent.com/23108066/147399714-f2e97be8-2a60-4a7e-8da2-92b7e52eef09.png)
