### PR TITLE
[ci skip] Change test logging settings to log by default

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,8 +31,6 @@ subprojects {
         filteringCharset = Charsets.UTF_8.name()
     }
     tasks.withType<Test> {
-        exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
-
         testLogging {
             showStackTraces = true
             exceptionFormat = TestExceptionFormat.FULL

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat;
+import org.gradle.api.tasks.testing.logging.TestLogEvent;
+
 plugins {
     java
     `maven-publish`
@@ -26,6 +29,15 @@ subprojects {
     }
     tasks.withType<ProcessResources> {
         filteringCharset = Charsets.UTF_8.name()
+    }
+    tasks.withType<Test> {
+        exclude("org/bukkit/craftbukkit/inventory/ItemStack*Test.class")
+
+        testLogging {
+            showStackTraces = true
+            exceptionFormat = TestExceptionFormat.FULL
+            events(TestLogEvent.STANDARD_OUT)
+        }
     }
 
     if (name == "Paper-MojangAPI") {


### PR DESCRIPTION
Currently, when tests fail in builds it doesn't actually give you any information about that test.

Before: 
![image](https://user-images.githubusercontent.com/23108066/147419027-60a8f9e3-eeff-4f9d-833e-cd3d312805cb.png)

After:
![image](https://user-images.githubusercontent.com/23108066/147420001-90f36f1d-50da-463e-9523-0271fcd13be1.png)
