### PR TITLE
Deprecate localized name API

### DIFF
--- a/patches/api/0177-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0177-Fix-Spigot-annotation-mistakes.patch
@@ -169,6 +169,42 @@ index 686e2a0b9fe061816b41435ef2337870dbdca8e5..aacf8ea85909299355d16cad0386072e
      public ItemMeta getItemMeta() {
          return this.meta == null ? Bukkit.getItemFactory().getItemMeta(this.type) : this.meta.clone();
      }
+diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+index 01b462fccce71cef3398dd43944046f322b8e57e..3ab4fa1fe924aa49fedc63241d7b629eb596f35a 100644
+--- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
++++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
+@@ -74,8 +74,10 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+     /**
+      * Checks for existence of a localized name.
+      *
++     * @deprecated Use {@link ItemMeta#displayName()} and check if it is instanceof a {@link net.kyori.adventure.text.TranslatableComponent}.
+      * @return true if this has a localized name
+      */
++    @Deprecated // Paper - Deprecate old localized API
+     boolean hasLocalizedName();
+ 
+     /**
+@@ -84,16 +86,20 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+      * Plugins should check that hasLocalizedName() returns <code>true</code>
+      * before calling this method.
+      *
++     * @deprecated Use {@link ItemMeta#displayName()} and cast it to a {@link net.kyori.adventure.text.TranslatableComponent}. No longer used by the client.
+      * @return the localized name that is set
+      */
++    @Deprecated // Paper - Deprecate old localized API
+     @NotNull
+     String getLocalizedName();
+ 
+     /**
+      * Sets the localized name.
+      *
++     * @deprecated Use {@link ItemMeta#displayName(Component)} with a {@link net.kyori.adventure.text.TranslatableComponent}. No longer used by the client.
+      * @param name the name to set
+      */
++    @Deprecated // Paper - Deprecate old localized API
+     void setLocalizedName(@Nullable String name);
+ 
+     /**
 diff --git a/src/main/java/org/bukkit/material/Step.java b/src/main/java/org/bukkit/material/Step.java
 index 9f502e7ee05d0512e190a1722cc112ece068c4e2..10c0465cf58d680bfa9a0f9233f94e8b6d5a9b93 100644
 --- a/src/main/java/org/bukkit/material/Step.java

--- a/patches/api/0211-Support-components-in-ItemMeta.patch
+++ b/patches/api/0211-Support-components-in-ItemMeta.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Support components in ItemMeta
 
 
 diff --git a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
-index 01b462fccce71cef3398dd43944046f322b8e57e..f093f991f1fedd20fcef041b093398250b7fb286 100644
+index 3ab4fa1fe924aa49fedc63241d7b629eb596f35a..10c649a491ad90288975f278c8d1ba3fe17d69e5 100644
 --- a/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 +++ b/src/main/java/org/bukkit/inventory/meta/ItemMeta.java
 @@ -5,6 +5,7 @@ import java.util.Collection;
@@ -54,7 +54,7 @@ index 01b462fccce71cef3398dd43944046f322b8e57e..f093f991f1fedd20fcef041b09339825
      /**
       * Checks for existence of a localized name.
       *
-@@ -134,6 +159,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -140,6 +165,19 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Nullable
      List<String> getLore();
  
@@ -74,7 +74,7 @@ index 01b462fccce71cef3398dd43944046f322b8e57e..f093f991f1fedd20fcef041b09339825
      /**
       * Sets the lore for this item.
       * Removes lore when given null.
-@@ -144,6 +182,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
+@@ -150,6 +188,16 @@ public interface ItemMeta extends Cloneable, ConfigurationSerializable, Persiste
      @Deprecated // Paper
      void setLore(@Nullable List<String> lore);
  


### PR DESCRIPTION
This has been unused since 1.13 (see V1458 datafixer).
![image](https://user-images.githubusercontent.com/23108066/147508200-26d478e7-855a-4c57-8a40-85fdd15ff44d.png)

Because of how long this has been broken, it's not even worth fixing it IMO, just point towards adventure stuff.