### PR TITLE
Respect x-ray permission in World#refreshChunk

### DIFF
--- a/patches/server/0355-Anti-Xray.patch
+++ b/patches/server/0355-Anti-Xray.patch
@@ -1616,26 +1616,25 @@ index 669e4b41cf0751afb67d94b6a511bcfd18ce7ef4..3ff85d9d8518db712ca1d2977a5865da
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..f3a5f08541cb792aed21d3820aade1adde670252 100644
+index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..6bdf3679ea9461475b139a0622857b1dc56ea5b2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -401,11 +401,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -401,11 +401,16 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return;
  
 -                ClientboundLevelChunkWithLightPacket refreshPacket = new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null, true);
-+                Map<Object, ClientboundLevelChunkWithLightPacket> cacheMap = new HashMap<>(); // Paper - Xray refreshChunk
++                // Paper start - Anti-Xray - Bypass
++                Map<Object, ClientboundLevelChunkWithLightPacket> refreshPackets = new HashMap<>();
                  for (ServerPlayer player : playersInRange) {
                      if (player.connection == null) continue;
  
 -                    player.connection.send(refreshPacket);
-+                    // Paper start - Xray refreshChunk
 +                    Boolean shouldModify = chunk.getLevel().chunkPacketBlockController.shouldModify(player, chunk);
-+
-+                    player.connection.send(cacheMap.computeIfAbsent(shouldModify, (s) -> { // Use  connection to prevent creating firing event
++                    player.connection.send(refreshPackets.computeIfAbsent(shouldModify, s -> { // Use connection to prevent creating firing event
 +                        return new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null, true, (Boolean) s);
 +                    }));
-+                    // Paper end - Xray refreshChunk
++                    // Paper end
                  }
              });
          });

--- a/patches/server/0355-Anti-Xray.patch
+++ b/patches/server/0355-Anti-Xray.patch
@@ -1616,10 +1616,10 @@ index 669e4b41cf0751afb67d94b6a511bcfd18ce7ef4..3ff85d9d8518db712ca1d2977a5865da
  
      @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 706d5718997181279f7ec715526b4d8f2b6162a2..05142efad717698f72220fd8f421a2e28576c867 100644
+index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..f3a5f08541cb792aed21d3820aade1adde670252 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -390,11 +390,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -401,11 +401,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
                  if (playersInRange.isEmpty()) return;
  

--- a/patches/server/0355-Anti-Xray.patch
+++ b/patches/server/0355-Anti-Xray.patch
@@ -1615,6 +1615,30 @@ index 669e4b41cf0751afb67d94b6a511bcfd18ce7ef4..3ff85d9d8518db712ca1d2977a5865da
      }
  
      @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+index 706d5718997181279f7ec715526b4d8f2b6162a2..05142efad717698f72220fd8f421a2e28576c867 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
+@@ -390,11 +390,17 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+                 List<ServerPlayer> playersInRange = playerChunk.playerProvider.getPlayers(playerChunk.getPos(), false);
+                 if (playersInRange.isEmpty()) return;
+ 
+-                ClientboundLevelChunkWithLightPacket refreshPacket = new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null, true);
++                Map<Object, ClientboundLevelChunkWithLightPacket> cacheMap = new HashMap<>(); // Paper - Xray refreshChunk
+                 for (ServerPlayer player : playersInRange) {
+                     if (player.connection == null) continue;
+ 
+-                    player.connection.send(refreshPacket);
++                    // Paper start - Xray refreshChunk
++                    Boolean shouldModify = chunk.getLevel().chunkPacketBlockController.shouldModify(player, chunk);
++
++                    player.connection.send(cacheMap.computeIfAbsent(shouldModify, (s) -> { // Use  connection to prevent creating firing event
++                        return new ClientboundLevelChunkWithLightPacket(chunk, this.world.getLightEngine(), null, null, true, (Boolean) s);
++                    }));
++                    // Paper end - Xray refreshChunk
+                 }
+             });
+         });
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java b/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java
 index 960405935e395a31c0300773c41413801cf0d290..6f6bf950cd15b34031618782c82824cf0b191ff8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/OldCraftChunkData.java

--- a/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -22,7 +22,7 @@ wants it to collect even faster, they can restore that setting back to 1 instead
 Not adding it to .getType() though to keep behavior consistent with vanilla for performance reasons.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index d4d8eee914f71d9a33feda82ef54cb0c40b0e60c..28a04d21801a9bb1e4311e6da28eae26283a2e36 100644
+index 8c61da70f609cd8cd5939cd12edc118d65fc734a..017e351e14a6a3a4c711df84f81936c296da13e1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -359,7 +359,7 @@ public final class CraftServer implements Server {
@@ -44,7 +44,7 @@ index d4d8eee914f71d9a33feda82ef54cb0c40b0e60c..28a04d21801a9bb1e4311e6da28eae26
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5ed5b60b7d 100644
+index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877dbeb87d7ad 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -277,8 +277,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -79,7 +79,7 @@ index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5e
          }
  
          return true;
-@@ -423,9 +436,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -429,9 +442,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5e
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -433,7 +449,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -439,7 +455,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5e
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -459,7 +475,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -465,7 +481,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index 0edb08a391f806e56ed1bd4812eb9c9d2b966bd7..b50a05ada2e759cfdeb2af036337bf5e
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1979,6 +1995,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1985,6 +2001,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
+++ b/patches/server/0450-Add-Plugin-Tickets-to-API-Chunk-Methods.patch
@@ -44,7 +44,7 @@ index 8c61da70f609cd8cd5939cd12edc118d65fc734a..017e351e14a6a3a4c711df84f81936c2
          this.printSaveWarning = false;
          console.autosavePeriod = this.configuration.getInt("ticks-per.autosave");
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877dbeb87d7ad 100644
+index 6bdf3679ea9461475b139a0622857b1dc56ea5b2..3c3959240c72fe705db5ee79cf8faaaddd361ee9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 @@ -277,8 +277,21 @@ public class CraftWorld extends CraftRegionAccessor implements World {
@@ -79,7 +79,7 @@ index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877db
          }
  
          return true;
-@@ -429,9 +442,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -428,9 +441,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          org.spigotmc.AsyncCatcher.catchOp("chunk load"); // Spigot
          // Paper start - Optimize this method
          ChunkPos chunkPos = new ChunkPos(x, z);
@@ -93,7 +93,7 @@ index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877db
              if (immediate == null) {
                  immediate = world.getChunkSource().chunkMap.getUnloadingChunk(x, z);
              }
-@@ -439,7 +455,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -438,7 +454,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
                  if (!(immediate instanceof ImposterProtoChunk) && !(immediate instanceof net.minecraft.world.level.chunk.LevelChunk)) {
                      return false; // not full status
                  }
@@ -102,7 +102,7 @@ index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877db
                  world.getChunk(x, z); // make sure we're at ticket level 32 or lower
                  return true;
              }
-@@ -465,7 +481,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -464,7 +480,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              // we do this so we do not re-read the chunk data on disk
          }
  
@@ -111,7 +111,7 @@ index f3a5f08541cb792aed21d3820aade1adde670252..5509e3bcad98fb4094aaa7cd041877db
          world.getChunkSource().getChunk(x, z, ChunkStatus.FULL, true);
          return true;
          // Paper end
-@@ -1985,6 +2001,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1984,6 +2000,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          return this.world.getChunkSource().getChunkAtAsynchronously(x, z, gen, urgent).thenComposeAsync((either) -> {
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1177,10 +1177,10 @@ index b9ad77606d88d7ca41c0070063b8599ecc048422..0388b89a5f67ebaf344de53464922dad
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index b50a05ada2e759cfdeb2af036337bf5ed5b60b7d..03d2ff6e1595453d57b42da1b508da813f73b2bf 100644
+index 5509e3bcad98fb4094aaa7cd041877dbeb87d7ad..33baa09c634638ae48bb86d4de78eea268e2a1f1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1993,6 +1993,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1999,6 +1999,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  

--- a/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0465-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -1177,10 +1177,10 @@ index b9ad77606d88d7ca41c0070063b8599ecc048422..0388b89a5f67ebaf344de53464922dad
          org.bukkit.event.world.ChunkUnloadEvent unloadEvent = new org.bukkit.event.world.ChunkUnloadEvent(this.bukkitChunk, this.isUnsaved());
          server.getPluginManager().callEvent(unloadEvent);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5509e3bcad98fb4094aaa7cd041877dbeb87d7ad..33baa09c634638ae48bb86d4de78eea268e2a1f1 100644
+index 3c3959240c72fe705db5ee79cf8faaaddd361ee9..3571f8406630c268b8a6ad48d2f4351e2f8fc617 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1999,6 +1999,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1998,6 +1998,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              return future;
          }
  

--- a/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 33baa09c634638ae48bb86d4de78eea268e2a1f1..dff7a1dd4a729cb2404a820946450e607080b60f 100644
+index 3571f8406630c268b8a6ad48d2f4351e2f8fc617..198ddc0747470313e4cbab132a8e523155cfe0c1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2094,6 +2094,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2093,6 +2093,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
+++ b/patches/server/0475-Add-missing-strikeLighting-call-to-World-spigot-stri.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add missing strikeLighting call to
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 03d2ff6e1595453d57b42da1b508da813f73b2bf..e9353aa51d24e06c3bd67417215cdfb0c97a6d60 100644
+index 33baa09c634638ae48bb86d4de78eea268e2a1f1..dff7a1dd4a729cb2404a820946450e607080b60f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2088,6 +2088,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2094,6 +2094,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
              lightning.moveTo( loc.getX(), loc.getY(), loc.getZ() );
              lightning.visualOnly = true;
              lightning.isSilent = isSilent;

--- a/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 74e10d581f8c1b0b026d8f940194971efbdef434..798afc145c54306fcf0838d8daef2bdf
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8a5bb077ffb2e88bea813fd89023f2d057526417..f56a0c203b7d459b7a59419d0cf8bc33002289f4 100644
+index d0e42d933537a989529d07de41e72fc057d70848..5d67a853b28123adecc4ca59ecb8c6dae8651bea 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1798,8 +1798,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1804,8 +1804,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index 8a5bb077ffb2e88bea813fd89023f2d057526417..f56a0c203b7d459b7a59419d0cf8bc33
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1834,8 +1839,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1840,8 +1845,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
+++ b/patches/server/0561-Added-WorldGameRuleChangeEvent.patch
@@ -64,10 +64,10 @@ index 74e10d581f8c1b0b026d8f940194971efbdef434..798afc145c54306fcf0838d8daef2bdf
  
          public int get() {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d0e42d933537a989529d07de41e72fc057d70848..5d67a853b28123adecc4ca59ecb8c6dae8651bea 100644
+index c39d5dd9602fe35b4936f01089a3b2048ef0c9bf..b0e5da5c4515b580b2655cf5a9cb74d1bd9dd9a1 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1804,8 +1804,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1803,8 +1803,13 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule)) return false;
  
@@ -82,7 +82,7 @@ index d0e42d933537a989529d07de41e72fc057d70848..5d67a853b28123adecc4ca59ecb8c6da
          handle.onChanged(this.getHandle().getServer());
          return true;
      }
-@@ -1840,8 +1845,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1839,8 +1844,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
          if (!this.isGameRule(rule.getName())) return false;
  

--- a/patches/server/0630-More-World-API.patch
+++ b/patches/server/0630-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 5d67a853b28123adecc4ca59ecb8c6dae8651bea..8416da461e99376e8e8bb98e85a0ea67f096cd29 100644
+index b0e5da5c4515b580b2655cf5a9cb74d1bd9dd9a1..cda29b242989153f32f8f1a87d5cfd5dc9b2f599 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1973,6 +1973,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1972,6 +1972,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0630-More-World-API.patch
+++ b/patches/server/0630-More-World-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] More World API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f56a0c203b7d459b7a59419d0cf8bc33002289f4..f759c29be097095d757120528edb72f91ed7f054 100644
+index 5d67a853b28123adecc4ca59ecb8c6dae8651bea..8416da461e99376e8e8bb98e85a0ea67f096cd29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1967,6 +1967,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1973,6 +1973,65 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (nearest == null) ? null : new Location(this, nearest.getX(), nearest.getY(), nearest.getZ());
      }
  

--- a/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 1bd338c7860adf3b846cd6caa33312b3269ac3ef..95635cc7367b757d149bb2c81326a041
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8416da461e99376e8e8bb98e85a0ea67f096cd29..8db2868600ef1be76e4f42cc79ce0708c8d3e428 100644
+index cda29b242989153f32f8f1a87d5cfd5dc9b2f599..19e4abd0175a19e75521b5adc9ea47bb00abf3c9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1195,7 +1195,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1194,7 +1194,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index 8416da461e99376e8e8bb98e85a0ea67f096cd29..8db2868600ef1be76e4f42cc79ce0708
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1217,7 +1217,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1216,7 +1216,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
+++ b/patches/server/0656-Add-cause-to-Weather-ThunderChangeEvents.patch
@@ -95,10 +95,10 @@ index 1bd338c7860adf3b846cd6caa33312b3269ac3ef..95635cc7367b757d149bb2c81326a041
              if (weather.isCancelled()) {
                  return;
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f759c29be097095d757120528edb72f91ed7f054..83e54e62d54e140cef5234396f40796b12ac8355 100644
+index 8416da461e99376e8e8bb98e85a0ea67f096cd29..8db2868600ef1be76e4f42cc79ce0708c8d3e428 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1189,7 +1189,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1195,7 +1195,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setStorm(boolean hasStorm) {
@@ -107,7 +107,7 @@ index f759c29be097095d757120528edb72f91ed7f054..83e54e62d54e140cef5234396f40796b
          this.setWeatherDuration(0); // Reset weather duration (legacy behaviour)
          this.setClearWeatherDuration(0); // Reset clear weather duration (reset "/weather clear" commands)
      }
-@@ -1211,7 +1211,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1217,7 +1217,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      @Override
      public void setThundering(boolean thundering) {

--- a/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index 384222f321f1678803d62187b76bf3dee1970c0c..b10c0099ba0691cb167e78b8decafe39
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f30286bb421d7467304c7a8c506c458f14b65f14..f69882f1c90682566dc27653a6afcf67b2ed624b 100644
+index 3806dc7330c1f15a478dc997be2993263f22707d..6ace62db3cd5608c81d90327ad6325d692f09c73 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -703,6 +703,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -709,6 +709,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
+++ b/patches/server/0711-Add-methods-to-find-targets-for-lightning-strikes.patch
@@ -29,10 +29,10 @@ index 384222f321f1678803d62187b76bf3dee1970c0c..b10c0099ba0691cb167e78b8decafe39
                      blockposition1 = blockposition1.above(2);
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3806dc7330c1f15a478dc997be2993263f22707d..6ace62db3cd5608c81d90327ad6325d692f09c73 100644
+index cff763bd0ac8dff62c8d6e7ad94fc0e453df7abe..31110d739f0b3436461c267a62db1d592f4904a2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -709,6 +709,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -708,6 +708,23 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          return (LightningStrike) lightning.getBukkitEntity();
      }
  

--- a/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -309,10 +309,10 @@ index 674154ae0ceb8da37e41be69179b546ab2872be5..c0427bfe4f93b501aaacb66c131d2736
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6ace62db3cd5608c81d90327ad6325d692f09c73..29ec0f3a6000c585d267c6f06061a3061f073dac 100644
+index 31110d739f0b3436461c267a62db1d592f4904a2..f316bd615b2801365c0c2d23521ba471ed320968 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1724,9 +1724,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1723,9 +1723,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
+++ b/patches/server/0733-Add-paper-mobcaps-and-paper-playermobcaps.patch
@@ -293,7 +293,7 @@ index ce6051531f021bf20851bc5ab763e732ee10427d..87d1f5b2717fc82203b5674ac0bf2704
      public static void spawnCategoryForChunk(MobCategory group, ServerLevel world, LevelChunk chunk, NaturalSpawner.SpawnPredicate checker, NaturalSpawner.AfterSpawnCallback runner) {
          spawnCategoryForChunk(group, world, chunk, checker, runner, Integer.MAX_VALUE, null);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-index 0bf0bdc72c85bbf726fa86a778c8bcf5ed534be0..c99a522c7839b2a9cf131913172baabfc0658eeb 100644
+index 674154ae0ceb8da37e41be69179b546ab2872be5..c0427bfe4f93b501aaacb66c131d2736dce6b5e0 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 @@ -2149,6 +2149,11 @@ public final class CraftServer implements Server {
@@ -309,10 +309,10 @@ index 0bf0bdc72c85bbf726fa86a778c8bcf5ed534be0..c99a522c7839b2a9cf131913172baabf
      }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index f69882f1c90682566dc27653a6afcf67b2ed624b..05352f89399d7c90ff029984889bddd73c31a7d1 100644
+index 6ace62db3cd5608c81d90327ad6325d692f09c73..29ec0f3a6000c585d267c6f06061a3061f073dac 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1718,9 +1718,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1724,9 +1724,14 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(spawnCategory, "SpawnCategory cannot be null");
          Validate.isTrue(CraftSpawnCategory.isValidForLimits(spawnCategory), "SpawnCategory." + spawnCategory + " are not supported.");
  

--- a/patches/server/0853-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0853-Replace-player-chunk-loader-system.patch
@@ -2120,10 +2120,10 @@ index 72b5d63127fbcd2913309f2c3c438b88728b4673..f667dafd44b6652788d3367cbbc76eef
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 7b5e099f73dae3846a1190523e769530ffac2f28..dc9a98d2aa894b2ff9b032d1d0707ad493bdca29 100644
+index 6da658863636ca4c63e82fa037b10de39872ee28..8d17b1e0e0fdc13c4fcd9f648e10b259c1c6a11d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2214,43 +2214,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2220,43 +2220,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0853-Replace-player-chunk-loader-system.patch
+++ b/patches/server/0853-Replace-player-chunk-loader-system.patch
@@ -2120,10 +2120,10 @@ index 72b5d63127fbcd2913309f2c3c438b88728b4673..f667dafd44b6652788d3367cbbc76eef
  
      @Nullable
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 6da658863636ca4c63e82fa037b10de39872ee28..8d17b1e0e0fdc13c4fcd9f648e10b259c1c6a11d 100644
+index bde90fa06a77e403ee97f2ed3b9fd1d6e5a4af81..d09e7a0470799acbca59723444fbf03f6e9593d7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2220,43 +2220,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2219,43 +2219,56 @@ public class CraftWorld extends CraftRegionAccessor implements World {
      // Spigot start
      @Override
      public int getViewDistance() {

--- a/patches/server/0864-Fix-World-locateNearestStructure.patch
+++ b/patches/server/0864-Fix-World-locateNearestStructure.patch
@@ -45,10 +45,10 @@ index 344c5bafe291a2542c4940e4d80232644de7b877..00e6f60e13f50c727530de37ab9692ad
                  return pair != null ? (BlockPos) pair.getFirst() : null;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index dc9a98d2aa894b2ff9b032d1d0707ad493bdca29..85f2dfcd7f4ccba9c6a719c3fb66bbb9d5e9b0a7 100644
+index 8d17b1e0e0fdc13c4fcd9f648e10b259c1c6a11d..d7b70e392d2cf3b964885a2ead757f0881a3838e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2072,10 +2072,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2078,10 +2078,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      }
  

--- a/patches/server/0864-Fix-World-locateNearestStructure.patch
+++ b/patches/server/0864-Fix-World-locateNearestStructure.patch
@@ -45,10 +45,10 @@ index 344c5bafe291a2542c4940e4d80232644de7b877..00e6f60e13f50c727530de37ab9692ad
                  return pair != null ? (BlockPos) pair.getFirst() : null;
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 8d17b1e0e0fdc13c4fcd9f648e10b259c1c6a11d..d7b70e392d2cf3b964885a2ead757f0881a3838e 100644
+index d09e7a0470799acbca59723444fbf03f6e9593d7..19175ed6adabfa4417e5db4947ba797b78c21ba8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -2078,10 +2078,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -2077,10 +2077,22 @@ public class CraftWorld extends CraftRegionAccessor implements World {
  
      }
  

--- a/patches/server/0866-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0866-Fix-falling-block-spawn-methods.patch
@@ -21,10 +21,10 @@ index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index d7b70e392d2cf3b964885a2ead757f0881a3838e..3fc12c83376798745737c014ab0ff612541a8032 100644
+index 19175ed6adabfa4417e5db4947ba797b78c21ba8..3d8a06f9725f1f39e86f3f1ac78f39f58d975288 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1429,7 +1429,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1428,7 +1428,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
@@ -38,7 +38,7 @@ index d7b70e392d2cf3b964885a2ead757f0881a3838e..3fc12c83376798745737c014ab0ff612
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1438,7 +1443,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1437,7 +1442,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
          Validate.notNull(data, "BlockData cannot be null");
  

--- a/patches/server/0866-Fix-falling-block-spawn-methods.patch
+++ b/patches/server/0866-Fix-falling-block-spawn-methods.patch
@@ -21,10 +21,10 @@ index 850131e601047ab1c585a6f8883ac3c0d0e97ba1..99cb7625d50d5da4ce0999e10fb84403
              if (Snowball.class.isAssignableFrom(clazz)) {
                  entity = new net.minecraft.world.entity.projectile.Snowball(world, x, y, z);
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 85f2dfcd7f4ccba9c6a719c3fb66bbb9d5e9b0a7..99c39f3271d0c3bfb0f854962b79a689cd560b9d 100644
+index d7b70e392d2cf3b964885a2ead757f0881a3838e..3fc12c83376798745737c014ab0ff612541a8032 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1423,7 +1423,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1429,7 +1429,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(material, "Material cannot be null");
          Validate.isTrue(material.isBlock(), "Material must be a block");
  
@@ -38,7 +38,7 @@ index 85f2dfcd7f4ccba9c6a719c3fb66bbb9d5e9b0a7..99c39f3271d0c3bfb0f854962b79a689
          return (FallingBlock) entity.getBukkitEntity();
      }
  
-@@ -1432,7 +1437,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1438,7 +1443,12 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          Validate.notNull(location, "Location cannot be null");
          Validate.notNull(data, "BlockData cannot be null");
  

--- a/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -18,7 +18,7 @@ index e28e09aae1d95d9bed50a137e999e6d457e62478..257c94f7c1cb00c9a91ab82e311dfd8e
  
              if (dedicatedserverproperties.enableQuery) {
 diff --git a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
-index 1ab83b8ef05ef8dfdabb17f33cffa728d631dff2..829842f40f5587aa4135ce4f2688e3acfe17a3da 100644
+index 12ed3dbbc95906e628acebeb3ad16e3018db1477..26be88d8826fc44ffd23e2853fbbd582c8c40425 100644
 --- a/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerGamePacketListenerImpl.java
 @@ -2604,7 +2604,7 @@ public class ServerGamePacketListenerImpl implements ServerPlayerConnection, Ser
@@ -158,10 +158,10 @@ index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 99c39f3271d0c3bfb0f854962b79a689cd560b9d..b6770f6dbd88990151513c44259d926381983cff 100644
+index 3fc12c83376798745737c014ab0ff612541a8032..c0ec00d8f4b5a3235da0af59517c3ea5dba2ea85 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1927,7 +1927,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1933,7 +1933,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 99c39f3271d0c3bfb0f854962b79a689cd560b9d..b6770f6dbd88990151513c44259d9263
          return true;
      }
  
-@@ -1967,7 +1967,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1973,7 +1973,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper

--- a/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
+++ b/patches/server/0891-Pass-ServerLevel-for-gamerule-callbacks.patch
@@ -158,10 +158,10 @@ index 798afc145c54306fcf0838d8daef2bdf17763da9..22feab6477bad023c2d6cc9ac99d392d
              this.onChanged(server);
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-index 3fc12c83376798745737c014ab0ff612541a8032..c0ec00d8f4b5a3235da0af59517c3ea5dba2ea85 100644
+index 3d8a06f9725f1f39e86f3f1ac78f39f58d975288..15d740a605c7257bcc7117c7dfb3612b472ba664 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftWorld.java
-@@ -1933,7 +1933,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1932,7 +1932,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule));
          handle.deserialize(event.getValue()); // Paper
@@ -170,7 +170,7 @@ index 3fc12c83376798745737c014ab0ff612541a8032..c0ec00d8f4b5a3235da0af59517c3ea5
          return true;
      }
  
-@@ -1973,7 +1973,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
+@@ -1972,7 +1972,7 @@ public class CraftWorld extends CraftRegionAccessor implements World {
          // Paper end
          GameRules.Value<?> handle = this.getHandle().getGameRules().getRule(CraftWorld.getGameRulesNMS().get(rule.getName()));
          handle.deserialize(event.getValue()); // Paper


### PR DESCRIPTION
Fixes: https://github.com/PaperMC/Paper/issues/5551

I guess the old behavior of this method was that the anti-xray was not run. However, around a month ago this method was fixed which caused it to use the x-ray behavior by default. This disables this, however, it is possible a new API method could be added to exclude Xray, but I am not sure. Opinions appreciated.