### PR TITLE
Fix block key with negative y unpacking

### DIFF
--- a/patches/api/0140-Allow-Blocks-to-be-accessed-via-a-long-key.patch
+++ b/patches/api/0140-Allow-Blocks-to-be-accessed-via-a-long-key.patch
@@ -48,7 +48,7 @@ index 36ed248f0716f2cc465c08ab851b7d83d4c7c0a7..58728a0f0722b378efa129e26f0c822b
       * @return A new location where X/Y/Z are the center of the block
       */
 diff --git a/src/main/java/org/bukkit/World.java b/src/main/java/org/bukkit/World.java
-index d3d0e4448135f6c0440c15e0dd3fc15c2616263a..7ed2442031cdcc429aabe91d639871566359ba53 100644
+index dbfa490c997c515007fc0d86ee5e2b4b98d174e5..4789dafc716c3db63983d49d7af75e3f374f4f51 100644
 --- a/src/main/java/org/bukkit/World.java
 +++ b/src/main/java/org/bukkit/World.java
 @@ -90,6 +90,38 @@ public interface World extends RegionAccessor, WorldInfo, PluginMessageRecipient
@@ -91,10 +91,10 @@ index d3d0e4448135f6c0440c15e0dd3fc15c2616263a..7ed2442031cdcc429aabe91d63987156
       * Gets the highest non-empty (impassable) coordinate at the given
       * coordinates.
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d88169939c986d8c 100644
+index 62ab55729e69bfac8eb4b40d877b945d95df27cd..50fb2c8cbed7a3875a81cf409238912d9b38d820 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -155,6 +155,72 @@ public interface Block extends Metadatable {
+@@ -155,6 +155,82 @@ public interface Block extends Metadatable {
       */
      int getZ();
  
@@ -104,7 +104,9 @@ index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d8816993
 +     * Computed via: {@code Block.getBlockKey(this.getX(), this.getY(), this.getZ())}
 +     * @see Block#getBlockKey(int, int, int)
 +     * @return This block's x, y, and z coordinates packed into a long value
++     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
++    @Deprecated
 +    public default long getBlockKey() {
 +        return Block.getBlockKey(this.getX(), this.getY(), this.getZ());
 +    }
@@ -122,13 +124,15 @@ index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d8816993
 +     * <br>
 +     * {@code int x = (int) ((packed << 37) >> 37);}
 +     * <br>
-+     * {@code int y = (int) (packed >>> 54);}
++     * {@code int y = (int) (packed >> 54);}
 +     * <br>
 +     * {@code int z = (int) ((packed << 10) >> 37);}
 +     * </p>
 +     *
 +     * @return This block's x, y, and z coordinates packed into a long value
++     * @deprecated only encodes y block ranges from -512 to 511 and represents an already changed implementation detail
 +     */
++    @Deprecated
 +    public static long getBlockKey(int x, int y, int z) {
 +        return ((long)x & 0x7FFFFFF) | (((long)z & 0x7FFFFFF) << 27) | ((long)y << 54);
 +    }
@@ -138,7 +142,9 @@ index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d8816993
 +     * @param packed The packed value, as computed by {@link Block#getBlockKey(int, int, int)}
 +     * @see Block#getBlockKey(int, int, int)
 +     * @return The x component from the packed value.
++     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
++    @Deprecated
 +    public static int getBlockKeyX(long packed) {
 +        return (int) ((packed << 37) >> 37);
 +    }
@@ -148,9 +154,11 @@ index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d8816993
 +     * @param packed The packed value, as computed by {@link Block#getBlockKey(int, int, int)}
 +     * @see Block#getBlockKey(int, int, int)
 +     * @return The y component from the packed value.
++     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
++    @Deprecated
 +    public static int getBlockKeyY(long packed) {
-+        return (int) (packed >>> 54);
++        return (int) (packed >> 54);
 +    }
 +
 +    /**
@@ -158,7 +166,9 @@ index 62ab55729e69bfac8eb4b40d877b945d95df27cd..79c0fa47a0d733d1547f8926d8816993
 +     * @param packed The packed value, as computed by {@link Block#getBlockKey(int, int, int)}
 +     * @see Block#getBlockKey(int, int, int)
 +     * @return The z component from the packed value.
++     * @deprecated see {@link #getBlockKey(int, int, int)}
 +     */
++    @Deprecated
 +    public static int getBlockKeyZ(long packed) {
 +        return (int) ((packed << 10) >> 37);
 +    }

--- a/patches/api/0182-Add-BlockSoundGroup-interface.patch
+++ b/patches/api/0182-Add-BlockSoundGroup-interface.patch
@@ -64,10 +64,10 @@ index 0000000000000000000000000000000000000000..8cf87d228a7006658d52ce0da16c2d74
 +    Sound getFallSound();
 +}
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 79c0fa47a0d733d1547f8926d88169939c986d8c..5e92f8f6ba5368ae934c24154ab13fbc6a46272f 100644
+index 50fb2c8cbed7a3875a81cf409238912d9b38d820..747303fd89aad344af0ed0767d3555b4894701dd 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -596,4 +596,16 @@ public interface Block extends Metadatable {
+@@ -606,4 +606,16 @@ public interface Block extends Metadatable {
       * @return <code>true</code> if the block data can be placed here
       */
      boolean canPlace(@NotNull BlockData data);

--- a/patches/api/0187-Add-effect-to-block-break-naturally.patch
+++ b/patches/api/0187-Add-effect-to-block-break-naturally.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add effect to block break naturally
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 5e92f8f6ba5368ae934c24154ab13fbc6a46272f..20463f92d83dea3130d4a3f0ac70e5f399c97711 100644
+index 747303fd89aad344af0ed0767d3555b4894701dd..2a862123a8b12d64a1cda39283b5fa501dd90f26 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -470,6 +470,26 @@ public interface Block extends Metadatable {
+@@ -480,6 +480,26 @@ public interface Block extends Metadatable {
       */
      boolean breakNaturally(@Nullable ItemStack tool);
  

--- a/patches/api/0222-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0222-Add-methods-to-get-translation-keys.patch
@@ -212,7 +212,7 @@ index 13eac9ad2c1672051635d1c35cc49239252e7a61..107e36ef02a9481954bd770ce9a55a0b
 +    // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 20463f92d83dea3130d4a3f0ac70e5f399c97711..9bc8e82c1f5192e32781958ecd17fe8467eaeb80 100644
+index 2a862123a8b12d64a1cda39283b5fa501dd90f26..893c6cef7dd8507b165be89c5182a1500afce631 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
 @@ -31,7 +31,7 @@ import org.jetbrains.annotations.Nullable;
@@ -224,7 +224,7 @@ index 20463f92d83dea3130d4a3f0ac70e5f399c97711..9bc8e82c1f5192e32781958ecd17fe84
  
      /**
       * Gets the metadata for this block
-@@ -627,5 +627,15 @@ public interface Block extends Metadatable {
+@@ -637,5 +637,15 @@ public interface Block extends Metadatable {
       */
      @NotNull
      com.destroystokyo.paper.block.BlockSoundGroup getSoundGroup();

--- a/patches/api/0235-Add-Destroy-Speed-API.patch
+++ b/patches/api/0235-Add-Destroy-Speed-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Destroy Speed API
 Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 9bc8e82c1f5192e32781958ecd17fe8467eaeb80..f53377f1d860ef89d016ffd9068f261a09a8a556 100644
+index 893c6cef7dd8507b165be89c5182a1500afce631..a403ee3eeadd8138b252d188773428037fde1fe7 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -637,5 +637,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -647,5 +647,29 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
      @NotNull
      @Deprecated
      String getTranslationKey();

--- a/patches/api/0246-Additional-Block-Material-API-s.patch
+++ b/patches/api/0246-Additional-Block-Material-API-s.patch
@@ -9,10 +9,10 @@ process to do this in the Bukkit API
 Adds API for buildable, replaceable, burnable too.
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index f53377f1d860ef89d016ffd9068f261a09a8a556..40fc747fa229d8ae682e8b126de98de6471eef6b 100644
+index a403ee3eeadd8138b252d188773428037fde1fe7..cd807331e55e3caded2a812eeda438c1a781a04f 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -428,6 +428,42 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -438,6 +438,42 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
       */
      boolean isLiquid();
  

--- a/patches/api/0277-Add-Block-isValidTool.patch
+++ b/patches/api/0277-Add-Block-isValidTool.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add Block#isValidTool
 
 
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index 40fc747fa229d8ae682e8b126de98de6471eef6b..e959f844581eaa88f581a4fabcb39148624bbe9b 100644
+index cd807331e55e3caded2a812eeda438c1a781a04f..d789f14d7af2fbe1a653040f3014748acfc3b240 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -219,6 +219,15 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -229,6 +229,15 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
      public static int getBlockKeyZ(long packed) {
          return (int) ((packed << 10) >> 37);
      }

--- a/patches/api/0339-Add-isCollidable-methods-to-various-places.patch
+++ b/patches/api/0339-Add-isCollidable-methods-to-various-places.patch
@@ -45,10 +45,10 @@ index 12b945dbae1d24c3e8a95037d17d0535108ec163..85296a8aa92465e1ee8a828d56a13407
      // Paper end
  }
 diff --git a/src/main/java/org/bukkit/block/Block.java b/src/main/java/org/bukkit/block/Block.java
-index e959f844581eaa88f581a4fabcb39148624bbe9b..0dd0beee6800fb34520dfa2d05e5bdda76624d64 100644
+index d789f14d7af2fbe1a653040f3014748acfc3b240..5f35ba35f8517ec28c1b21b3007c9a20dea097a7 100644
 --- a/src/main/java/org/bukkit/block/Block.java
 +++ b/src/main/java/org/bukkit/block/Block.java
-@@ -471,6 +471,13 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
+@@ -481,6 +481,13 @@ public interface Block extends Metadatable, net.kyori.adventure.translation.Tran
       * @return true if block is solid
       */
      boolean isSolid();


### PR DESCRIPTION
Fixes #7218

Changes y block range from 0-1023 to -512-511 on decoding. Ideally the whole encoding would be changed, but that would smell like breaking API