### PR TITLE
[ci skip] Update log4j-api in Paper-API to 2.17.1

### DIFF
--- a/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
+++ b/patches/api/0069-Allow-plugins-to-use-SLF4J-for-logging.patch
@@ -14,14 +14,14 @@ it without having to shade it in the plugin and going through
 several layers of logging abstraction.
 
 diff --git a/build.gradle.kts b/build.gradle.kts
-index d8d459561cc75935136f8f9888ff27b45ad98f9e..a23b2bd8e1ca1ff8d0ad5ed5d5e41c89e4795090 100644
+index d8d459561cc75935136f8f9888ff27b45ad98f9e..001c2b963205012f340db0d539e4033c748124ce 100644
 --- a/build.gradle.kts
 +++ b/build.gradle.kts
 @@ -38,6 +38,8 @@ dependencies {
      apiAndDocs("net.kyori:adventure-text-serializer-gson")
      apiAndDocs("net.kyori:adventure-text-serializer-legacy")
      apiAndDocs("net.kyori:adventure-text-serializer-plain")
-+    api("org.apache.logging.log4j:log4j-api:2.17.0")
++    api("org.apache.logging.log4j:log4j-api:2.17.1")
 +    api("org.slf4j:slf4j-api:1.8.0-beta4")
  
      implementation("org.ow2.asm:asm:9.2")


### PR DESCRIPTION
Seems log4j-api in Paper-API was still on 2.17.0 instead of 2.17.1 (where it was bumped here: https://github.com/PaperMC/Paper/commit/1931bb53bfdb7395f8214c9a7b6d4d65046efdee for Paper-Server)