### PR TITLE
fix powder snow cauldrons not turning to water

### DIFF
--- a/patches/server/0901-fix-powder-snow-cauldrons-not-turning-to-water.patch
+++ b/patches/server/0901-fix-powder-snow-cauldrons-not-turning-to-water.patch
@@ -1,0 +1,56 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Thu, 30 Dec 2021 14:02:13 -0800
+Subject: [PATCH] fix powder snow cauldrons not turning to water
+
+Powder snow cauldrons should turn to water when
+extinguishing an entity
+
+diff --git a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
+index c21b0e7265488f26179810ddb6a8a6992a2a4807..95946623bc4673363a008fea7a4b1eeae6e1dfdb 100644
+--- a/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/LayeredCauldronBlock.java
+@@ -63,7 +63,7 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
+         if (!world.isClientSide && entity.isOnFire() && this.isEntityInsideContent(state, pos, entity)) {
+             // CraftBukkit start
+             if (entity.mayInteract(world, pos)) {
+-                if (!LayeredCauldronBlock.lowerFillLevel(state, world, pos, entity, CauldronLevelChangeEvent.ChangeReason.EXTINGUISH)) {
++                if (!this.handleEntityOnFireInsideWithEvent(state, world, pos, entity)) { // Paper - fix powdered snow cauldron extinguishing entities
+                     return;
+                 }
+             }
+@@ -73,9 +73,15 @@ public class LayeredCauldronBlock extends AbstractCauldronBlock {
+ 
+     }
+ 
++    @Deprecated // Paper - use #handleEntityOnFireInsideWithEvent
+     protected void handleEntityOnFireInside(BlockState state, Level world, BlockPos pos) {
+         LayeredCauldronBlock.lowerFillLevel(state, world, pos);
+     }
++    // Paper start
++    protected boolean handleEntityOnFireInsideWithEvent(BlockState state, Level world, BlockPos pos, Entity entity) {
++        return LayeredCauldronBlock.lowerFillLevel(state, world, pos, entity, CauldronLevelChangeEvent.ChangeReason.EXTINGUISH);
++    }
++    // Paper end
+ 
+     public static void lowerFillLevel(BlockState state, Level world, BlockPos pos) {
+         // CraftBukkit start
+diff --git a/src/main/java/net/minecraft/world/level/block/PowderSnowCauldronBlock.java b/src/main/java/net/minecraft/world/level/block/PowderSnowCauldronBlock.java
+index 54c8f2ccadd685b43d7ee032a95bfcf193357ce9..7f6b240bbbb773ca49e0e6290169cc81f5529af5 100644
+--- a/src/main/java/net/minecraft/world/level/block/PowderSnowCauldronBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/PowderSnowCauldronBlock.java
+@@ -16,7 +16,14 @@ public class PowderSnowCauldronBlock extends LayeredCauldronBlock {
+     }
+ 
+     @Override
++    @Deprecated // Paper - use #handleEntityOnFireInsideWithEvent
+     protected void handleEntityOnFireInside(BlockState state, Level world, BlockPos pos) {
+         lowerFillLevel(Blocks.WATER_CAULDRON.defaultBlockState().setValue(LEVEL, state.getValue(LEVEL)), world, pos);
+     }
++    // Paper - replace powdered snow with water (taken from #handleEntityOnFireInside)
++    @Override
++    protected boolean handleEntityOnFireInsideWithEvent(BlockState state, Level world, BlockPos pos, net.minecraft.world.entity.Entity entity) {
++        return super.handleEntityOnFireInsideWithEvent(Blocks.WATER_CAULDRON.defaultBlockState().setValue(LEVEL, state.getValue(LEVEL)), world, pos, entity);
++    }
++    // Paper end
+ }


### PR DESCRIPTION
Powder snow cauldrons should turn to water when
extinguishing an entity

This diff could be a lot cleaner if we broke the signature of LayeredCauldronBlock#handleEntityOnFireInside to add an entity param and return a bool.