### PR TITLE
rename legacy dragon check config setting

### DIFF
--- a/patches/server/0004-Paper-config-files.patch
+++ b/patches/server/0004-Paper-config-files.patch
@@ -298,7 +298,7 @@ index 0000000000000000000000000000000000000000..bee2fa2bfbb61209381f24ed6508d3d1
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..e4368db074da7b5e48b47d41875c1e63b9745c2a
+index 0000000000000000000000000000000000000000..5c7b2850d311e4d54236ba9acce148bca05672fd
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -0,0 +1,188 @@
@@ -364,8 +364,8 @@ index 0000000000000000000000000000000000000000..e4368db074da7b5e48b47d41875c1e63
 +        commands = new HashMap<String, Command>();
 +        commands.put("paper", new PaperCommand("paper"));
 +
-+        version = getInt("config-version", 24);
-+        set("config-version", 24);
++        version = getInt("config-version", 25);
++        set("config-version", 25);
 +        readConfig(PaperConfig.class, null);
 +    }
 +
@@ -492,10 +492,10 @@ index 0000000000000000000000000000000000000000..e4368db074da7b5e48b47d41875c1e63
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..4adf44026fc6269934dfa4513f06a7f8a3b41f90
+index 0000000000000000000000000000000000000000..86411fca9c200d59fb5360b69f7ef360c81adc40
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -0,0 +1,94 @@
+@@ -0,0 +1,119 @@
 +package com.destroystokyo.paper;
 +
 +import java.util.List;
@@ -536,6 +536,25 @@ index 0000000000000000000000000000000000000000..4adf44026fc6269934dfa4513f06a7f8
 +        }
 +    }
 +
++    private void setForWorld(String path, Object val) {
++        this.config.set("world-settings." + this.worldName + "." + path, val);
++    }
++
++    private boolean isSet(String world, String path) {
++        return this.config.isSet("world-settings." + world + "." + path);
++    }
++
++    private void clear(String path) {
++        clear("default", path);
++        if (this.config.isSet("world-settings." + this.worldName + "." + path)) {
++            clear(this.worldName, path);
++        }
++    }
++
++    private void clear(String world, String path) {
++        this.config.set("world-settings." + world  + "." + path, null);
++    }
++
 +    public void removeOldValues() {
 +        boolean needsSave = false;
 +
@@ -545,8 +564,14 @@ index 0000000000000000000000000000000000000000..4adf44026fc6269934dfa4513f06a7f8
 +    }
 +
 +    private boolean getBoolean(String path, boolean def) {
-+        config.addDefault("world-settings.default." + path, def);
-+        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
++        return this.getBoolean(path, def, true);
++    }
++
++    private boolean getBoolean(String path, boolean def, boolean setDefault) {
++        if (setDefault) {
++            config.addDefault("world-settings.default." + path, def);
++        }
++        return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path, def));
 +    }
 +
 +    private double getDouble(String path, double def) {

--- a/patches/server/0013-Configurable-cactus-bamboo-and-reed-growth-heights.patch
+++ b/patches/server/0013-Configurable-cactus-bamboo-and-reed-growth-heights.patch
@@ -7,10 +7,10 @@ Bamboo - Both the minimum fully-grown heights and the maximum are configurable
 - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4adf44026fc6269934dfa4513f06a7f8a3b41f90..791ccdebd5d37afd83eb87671034b3553e305f8f 100644
+index 86411fca9c200d59fb5360b69f7ef360c81adc40..6c6d6cc3dd4dcd0ae88d37a61004ddcfd8653fb9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -91,4 +91,16 @@ public class PaperWorldConfig {
+@@ -116,4 +116,16 @@ public class PaperWorldConfig {
          config.addDefault("world-settings.default." + path, def.stream().map(Enum::name).collect(Collectors.toList()));
          return ((List<String>) (config.getList("world-settings." + worldName + "." + path, config.getList("world-settings.default." + path)))).stream().map(s -> Enum.valueOf(type, s)).collect(Collectors.toList());
      }
@@ -99,7 +99,7 @@ index a851df8e25781963edb066c46ae75a87ef63a66d..00ada22889dafb7ae8e8740cd3eb8370
  
                  if (j >= (byte) range(3, ((100.0F / world.spigotConfig.cactusModifier) * 15) + 0.5F, 15)) { // Spigot
 diff --git a/src/main/java/net/minecraft/world/level/block/SugarCaneBlock.java b/src/main/java/net/minecraft/world/level/block/SugarCaneBlock.java
-index f57884fa5f0fbbdbf35c22e692da4f9b6f3f98cc..9b30b359f1559e5f97c3b2a7acffda5b39605e6b 100644
+index f57884fa5f0fbbdbf35c22e692da4f9b6f3f98cc..1da8baaac61bb462dcfcfa1a4cb671650e49f031 100644
 --- a/src/main/java/net/minecraft/world/level/block/SugarCaneBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/SugarCaneBlock.java
 @@ -53,7 +53,7 @@ public class SugarCaneBlock extends Block {

--- a/patches/server/0014-Configurable-baby-zombie-movement-speed.patch
+++ b/patches/server/0014-Configurable-baby-zombie-movement-speed.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable baby zombie movement speed
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 791ccdebd5d37afd83eb87671034b3553e305f8f..ec3fb557fa31b153de20c4990066182a774dd489 100644
+index 6c6d6cc3dd4dcd0ae88d37a61004ddcfd8653fb9..3de0178753332baf9ff10d1dfb3cc271a107a1d4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -103,4 +103,15 @@ public class PaperWorldConfig {
+@@ -128,4 +128,15 @@ public class PaperWorldConfig {
          bambooMinHeight = getInt("max-growth-height.bamboo.min", 11);
          log("Max height for cactus growth " + cactusMaxHeight + ". Max height for reed growth " + reedMaxHeight + ". Max height for bamboo growth " + bambooMaxHeight + ". Min height for fully-grown bamboo " + bambooMinHeight + ".");
      }

--- a/patches/server/0015-Configurable-fishing-time-ranges.patch
+++ b/patches/server/0015-Configurable-fishing-time-ranges.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable fishing time ranges
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ec3fb557fa31b153de20c4990066182a774dd489..5896b4e4646d722db5622a424fa26f42d3f8d9ff 100644
+index 3de0178753332baf9ff10d1dfb3cc271a107a1d4..b3d99e6e1c82757f289be478b9fd41477cb0b05b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -114,4 +114,12 @@ public class PaperWorldConfig {
+@@ -139,4 +139,12 @@ public class PaperWorldConfig {
  
          log("Baby zombies will move at the speed of " + babyZombieMovementModifier);
      }

--- a/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow nerfed mobs to jump and take water damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5896b4e4646d722db5622a424fa26f42d3f8d9ff..0a6e98ca5534430540044a32c280e5680ac9a28f 100644
+index b3d99e6e1c82757f289be478b9fd41477cb0b05b..8e805b54e7c4053ce1242ba2be8404e84a8cd9f3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -122,4 +122,9 @@ public class PaperWorldConfig {
+@@ -147,4 +147,9 @@ public class PaperWorldConfig {
          fishingMaxTicks = getInt("fishing-time-range.MaximumTicks", 600);
          log("Fishing time ranges are between " + fishingMinTicks +" and " + fishingMaxTicks + " ticks");
      }
@@ -31,7 +31,7 @@ index 3eb1f5e422002a48651a24d0e70884bf54de717e..3efdf887ec70aa2d3486a1ddfc8e5e1c
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f286fcc2958a02c1e480b8fcf5d049bf0de27131..9cc9c11f2ef5aa386711a0ebc70b6a2d8e5c5b97 100644
+index f6c93812c30bd1637219c22c1a903e2ec93a9d72..db76340c555e0c8113cef88f3ae9654b34031502 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -105,6 +105,7 @@ public abstract class Mob extends LivingEntity {

--- a/patches/server/0017-Add-configurable-despawn-distances-for-living-entiti.patch
+++ b/patches/server/0017-Add-configurable-despawn-distances-for-living-entiti.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add configurable despawn distances for living entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0a6e98ca5534430540044a32c280e5680ac9a28f..6ee62d06cc2b59c06d0f7acfb59384075aa6521c 100644
+index 8e805b54e7c4053ce1242ba2be8404e84a8cd9f3..3676f47dda625ef3e38cd51a08bc828d70060e62 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -3,6 +3,9 @@ package com.destroystokyo.paper;
@@ -18,7 +18,7 @@ index 0a6e98ca5534430540044a32c280e5680ac9a28f..6ee62d06cc2b59c06d0f7acfb5938407
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -41,6 +44,13 @@ public class PaperWorldConfig {
+@@ -60,6 +63,13 @@ public class PaperWorldConfig {
      public void removeOldValues() {
          boolean needsSave = false;
  
@@ -32,7 +32,7 @@ index 0a6e98ca5534430540044a32c280e5680ac9a28f..6ee62d06cc2b59c06d0f7acfb5938407
          if (needsSave) {
              saveConfig();
          }
-@@ -127,4 +137,31 @@ public class PaperWorldConfig {
+@@ -152,4 +162,31 @@ public class PaperWorldConfig {
      private void nerfedMobsShouldJump() {
          nerfedMobsShouldJump = getBoolean("spawner-nerfed-mobs-should-jump", false);
      }
@@ -65,7 +65,7 @@ index 0a6e98ca5534430540044a32c280e5680ac9a28f..6ee62d06cc2b59c06d0f7acfb5938407
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 9cc9c11f2ef5aa386711a0ebc70b6a2d8e5c5b97..d5d79927aeab04d24010b53f9b527fa7b05d8a47 100644
+index db76340c555e0c8113cef88f3ae9654b34031502..92fdccbcf472d99989eb47c0dac1b8c557c37165 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -778,14 +778,14 @@ public abstract class Mob extends LivingEntity {

--- a/patches/server/0018-Allow-for-toggling-of-spawn-chunks.patch
+++ b/patches/server/0018-Allow-for-toggling-of-spawn-chunks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow for toggling of spawn chunks
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6ee62d06cc2b59c06d0f7acfb59384075aa6521c..9b908c5c66dc454faa479430a908dda0745638c8 100644
+index 3676f47dda625ef3e38cd51a08bc828d70060e62..98b2479dfd549d39020723fdde28a05538ea7644 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -164,4 +164,10 @@ public class PaperWorldConfig {
+@@ -189,4 +189,10 @@ public class PaperWorldConfig {
              hardDespawnDistances.put(category, hardDistance);
          }
      }
@@ -20,7 +20,7 @@ index 6ee62d06cc2b59c06d0f7acfb59384075aa6521c..9b908c5c66dc454faa479430a908dda0
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 99685c3ad91ca0e3bf20fb6ca100466ec14b7a0f..e112598c854a2c93a8e6b6bda3cfdd4ee4091980 100644
+index a75171ecfd23df3f626ca651febb75da28079c2d..0511ad9b2ba35dcb1e6336f7da4b9226b16e1bed 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -240,6 +240,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0019-Drop-falling-block-and-tnt-entities-at-the-specified.patch
+++ b/patches/server/0019-Drop-falling-block-and-tnt-entities-at-the-specified.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Drop falling block and tnt entities at the specified height
 * Dec 2, 2020 Added tnt nerf for tnt minecarts - Machine_Maker
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b908c5c66dc454faa479430a908dda0745638c8..6dec1bb96d695f28aae6517e4d78249169d2351a 100644
+index 98b2479dfd549d39020723fdde28a05538ea7644..c7ce0b79b7a070ee36352ec488464919583de9ae 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -170,4 +170,14 @@ public class PaperWorldConfig {
+@@ -195,4 +195,14 @@ public class PaperWorldConfig {
          keepSpawnInMemory = getBoolean("keep-spawn-loaded", true);
          log("Keep spawn chunk loaded: " + keepSpawnInMemory);
      }

--- a/patches/server/0029-Configurable-top-of-nether-void-damage.patch
+++ b/patches/server/0029-Configurable-top-of-nether-void-damage.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable top of nether void damage
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6dec1bb96d695f28aae6517e4d78249169d2351a..1b090f2e38a8857ef74403e1f3db8c2ba7127297 100644
+index c7ce0b79b7a070ee36352ec488464919583de9ae..9945661c025b6893fbc1f6407b6cc123b9e07a99 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -180,4 +180,19 @@ public class PaperWorldConfig {
+@@ -205,4 +205,19 @@ public class PaperWorldConfig {
          if (fallingBlockHeightNerf != 0) log("Falling Block Height Limit set to Y: " + fallingBlockHeightNerf);
          if (entityTNTHeightNerf != 0) log("TNT Entity Height Limit set to Y: " + entityTNTHeightNerf);
      }

--- a/patches/server/0032-Configurable-end-credits.patch
+++ b/patches/server/0032-Configurable-end-credits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable end credits
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b090f2e38a8857ef74403e1f3db8c2ba7127297..bc35bdd9cbd544ae2ab27ad042d7d1b3166db9a6 100644
+index 9945661c025b6893fbc1f6407b6cc123b9e07a99..16564b4943142490777e6e4998dee9e39cfa1dcc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -195,4 +195,10 @@ public class PaperWorldConfig {
+@@ -220,4 +220,10 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/patches/server/0034-Optimize-explosions.patch
+++ b/patches/server/0034-Optimize-explosions.patch
@@ -10,10 +10,10 @@ This patch adds a per-tick cache that is used for storing and retrieving
 an entity's exposure during an explosion.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index bc35bdd9cbd544ae2ab27ad042d7d1b3166db9a6..2b0a75dc2e292e655ca3300f64bc1211b3adeceb 100644
+index 16564b4943142490777e6e4998dee9e39cfa1dcc..efc55a34157ebdd1111ed19582ece640eff2eb31 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -201,4 +201,10 @@ public class PaperWorldConfig {
+@@ -226,4 +226,10 @@ public class PaperWorldConfig {
          disableEndCredits = getBoolean("game-mechanics.disable-end-credits", false);
          log("End credits disabled: " + disableEndCredits);
      }
@@ -135,7 +135,7 @@ index 996e02be9f3150ba125d52e3d544599c2b8dd968..688ebb68209beb4550293f72b1fa7b39
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 8a2d18524e089cdc07125e424b37f1b629e591a6..4c049a41035824a9affdf25495a658a0c58dcd75 100644
+index cb115128ac988dc4b58f452532644dd8fcf37d4c..16f212b4005469dc99fdd83ed6e5810a5b6f8abf 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -156,6 +156,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0035-Disable-explosion-knockback.patch
+++ b/patches/server/0035-Disable-explosion-knockback.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable explosion knockback
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2b0a75dc2e292e655ca3300f64bc1211b3adeceb..5cae4a5caf9aba8c0e99f1cb6badc5e8374862c8 100644
+index efc55a34157ebdd1111ed19582ece640eff2eb31..bf9dc2cb55e3ce8b780ffb2c9f64c945eaf37dde 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -207,4 +207,9 @@ public class PaperWorldConfig {
+@@ -232,4 +232,9 @@ public class PaperWorldConfig {
          optimizeExplosions = getBoolean("optimize-explosions", false);
          log("Optimize explosions: " + optimizeExplosions);
      }
@@ -19,7 +19,7 @@ index 2b0a75dc2e292e655ca3300f64bc1211b3adeceb..5cae4a5caf9aba8c0e99f1cb6badc5e8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 906c23068d1f5be76a6985b7255f6f155335b673..deef28110441cd2965c6b531bc255ee2aa994ace 100644
+index 2a65e7ae49f2fc1d56cdace60f72b729c1d9b28c..181711ccb45ffaefddc846c374d5704696c31845 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1375,6 +1375,7 @@ public abstract class LivingEntity extends Entity {

--- a/patches/server/0036-Disable-thunder.patch
+++ b/patches/server/0036-Disable-thunder.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable thunder
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5cae4a5caf9aba8c0e99f1cb6badc5e8374862c8..1a9b4b08ea906adbfa25c3963a4634871d7ca2f6 100644
+index bf9dc2cb55e3ce8b780ffb2c9f64c945eaf37dde..56db9a18fe55117eef628a2db28c090da655d1b5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -212,4 +212,9 @@ public class PaperWorldConfig {
+@@ -237,4 +237,9 @@ public class PaperWorldConfig {
      private void disableExplosionKnockback(){
          disableExplosionKnockback = getBoolean("disable-explosion-knockback", false);
      }

--- a/patches/server/0037-Disable-ice-and-snow.patch
+++ b/patches/server/0037-Disable-ice-and-snow.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Disable ice and snow
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1a9b4b08ea906adbfa25c3963a4634871d7ca2f6..ceb1602afb90fc0a23d6cc8d22fc85fab3b8da14 100644
+index 56db9a18fe55117eef628a2db28c090da655d1b5..64f267156a3733106a91c66cb68a93cea082e6dc 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -217,4 +217,9 @@ public class PaperWorldConfig {
+@@ -242,4 +242,9 @@ public class PaperWorldConfig {
      private void disableThunder() {
          disableThunder = getBoolean("disable-thunder", false);
      }

--- a/patches/server/0038-Configurable-mob-spawner-tick-rate.patch
+++ b/patches/server/0038-Configurable-mob-spawner-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable mob spawner tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ceb1602afb90fc0a23d6cc8d22fc85fab3b8da14..e7b7f0a1a35f782a0da4627b4f02e673ca73693e 100644
+index 64f267156a3733106a91c66cb68a93cea082e6dc..825d802eb69a438c2a31908e8fa2951298138231 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -222,4 +222,9 @@ public class PaperWorldConfig {
+@@ -247,4 +247,9 @@ public class PaperWorldConfig {
      private void disableIceAndSnow(){
          disableIceAndSnow = getBoolean("disable-ice-and-snow", false);
      }
@@ -19,7 +19,7 @@ index ceb1602afb90fc0a23d6cc8d22fc85fab3b8da14..e7b7f0a1a35f782a0da4627b4f02e673
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/BaseSpawner.java b/src/main/java/net/minecraft/world/level/BaseSpawner.java
-index 08d9980a5b9b26f7dbdfcb6cda7a3995d58bea81..cdf226ee2ba179fde5229e44f22463bcc339601b 100644
+index 4be2833b03d24e5d87c23f04c248fbe4b0ca9e59..002144601e8f75766b9e462579123559e4d651fe 100644
 --- a/src/main/java/net/minecraft/world/level/BaseSpawner.java
 +++ b/src/main/java/net/minecraft/world/level/BaseSpawner.java
 @@ -42,6 +42,7 @@ public abstract class BaseSpawner {

--- a/patches/server/0042-Configurable-container-update-tick-rate.patch
+++ b/patches/server/0042-Configurable-container-update-tick-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable container update tick rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7b7f0a1a35f782a0da4627b4f02e673ca73693e..1b51f717ec2a0538d9037dd1d4328030bd9122c8 100644
+index 825d802eb69a438c2a31908e8fa2951298138231..2b60a12804d2397ee3473e214b93012505806ce8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -227,4 +227,9 @@ public class PaperWorldConfig {
+@@ -252,4 +252,9 @@ public class PaperWorldConfig {
      private void mobSpawnerTickRate() {
          mobSpawnerTickRate = getInt("mob-spawner-tick-rate", 1);
      }

--- a/patches/server/0046-Configurable-Disabling-Cat-Chest-Detection.patch
+++ b/patches/server/0046-Configurable-Disabling-Cat-Chest-Detection.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Disabling Cat Chest Detection
 Offers a gameplay feature to stop cats from blocking chests
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1b51f717ec2a0538d9037dd1d4328030bd9122c8..990757a8bbd27fa102c9b408246ed14d97a340dc 100644
+index 2b60a12804d2397ee3473e214b93012505806ce8..65df8c582eb8dd4fe03e204ff72d263906edf220 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -232,4 +232,9 @@ public class PaperWorldConfig {
+@@ -257,4 +257,9 @@ public class PaperWorldConfig {
      private void containerUpdateTickRate() {
          containerUpdateTickRate = getInt("container-update-tick-rate", 1);
      }

--- a/patches/server/0048-All-chunks-are-slime-spawn-chunks-toggle.patch
+++ b/patches/server/0048-All-chunks-are-slime-spawn-chunks-toggle.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] All chunks are slime spawn chunks toggle
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 990757a8bbd27fa102c9b408246ed14d97a340dc..1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b 100644
+index 65df8c582eb8dd4fe03e204ff72d263906edf220..d116f0d21319054eaeca5a9ec9e4c1a1662af915 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -237,4 +237,9 @@ public class PaperWorldConfig {
+@@ -262,4 +262,9 @@ public class PaperWorldConfig {
      private void disableChestCatDetection() {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }

--- a/patches/server/0053-Add-configurable-portal-search-radius.patch
+++ b/patches/server/0053-Add-configurable-portal-search-radius.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add configurable portal search radius
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1e3c39f0eeeb07f8d49e3651b18a152db9ccba7b..c248b66486044150c64eaddbef85fa6644494212 100644
+index d116f0d21319054eaeca5a9ec9e4c1a1662af915..99f64bd54337bd585d164e2b57d85ae0db6c51db 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -242,4 +242,13 @@ public class PaperWorldConfig {
+@@ -267,4 +267,13 @@ public class PaperWorldConfig {
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
      }

--- a/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
+++ b/patches/server/0055-Configurable-inter-world-teleportation-safety.patch
@@ -16,10 +16,10 @@ The wanted destination was on top of the emerald block however the player ended 
 This only is the case if the player is teleporting between worlds.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38fd2baf3e 100644
+index 99f64bd54337bd585d164e2b57d85ae0db6c51db..dcb806187e7c2a0e6afef784ab54d7378b6e407b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -251,4 +251,9 @@ public class PaperWorldConfig {
+@@ -276,4 +276,9 @@ public class PaperWorldConfig {
          portalCreateRadius = getInt("portal-create-radius", 16);
          portalSearchVanillaDimensionScaling = getBoolean("portal-search-vanilla-dimension-scaling", true);
      }
@@ -30,7 +30,7 @@ index c248b66486044150c64eaddbef85fa6644494212..ada624b5f58381122e59568c2087cf38
 +    }
  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 7df097f1703e3e3a866ba041a736a34d8dcd77f8..87a193e8f026166b5821710d5501eb11175744b0 100644
+index a13044c597da0b2167ade40ba021cd8b73209242..00e9f75a065b598358bc049027ee8896e168091f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -907,7 +907,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
+++ b/patches/server/0058-Disable-Scoreboards-for-non-players-by-default.patch
@@ -11,10 +11,10 @@ So avoid looking up scoreboards and short circuit to the "not on a team"
 logic which is most likely to be true.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ada624b5f58381122e59568c2087cf38fd2baf3e..5b55fce59db9ac3ab6030ebe8374c5147535d773 100644
+index dcb806187e7c2a0e6afef784ab54d7378b6e407b..40b28b64fb337e51cb641c840f2886d3c989da1e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -256,4 +256,9 @@ public class PaperWorldConfig {
+@@ -281,4 +281,9 @@ public class PaperWorldConfig {
      private void disableTeleportationSuffocationCheck() {
          disableTeleportationSuffocationCheck = getBoolean("disable-teleportation-suffocation-check", false);
      }

--- a/patches/server/0066-Configurable-Non-Player-Arrow-Despawn-Rate.patch
+++ b/patches/server/0066-Configurable-Non-Player-Arrow-Despawn-Rate.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Non Player Arrow Despawn Rate
 Can set a much shorter despawn rate for arrows that players can not pick up.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5b55fce59db9ac3ab6030ebe8374c5147535d773..71c672eafdce3547eaeb8e31fddcb142ad213094 100644
+index 40b28b64fb337e51cb641c840f2886d3c989da1e..995cefd0ecfc065da7bd5910f5c6901b2e75fd82 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -261,4 +261,19 @@ public class PaperWorldConfig {
+@@ -286,4 +286,19 @@ public class PaperWorldConfig {
      private void nonPlayerEntitiesOnScoreboards() {
          nonPlayerEntitiesOnScoreboards = getBoolean("allow-non-player-entities-on-scoreboards", false);
      }

--- a/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
+++ b/patches/server/0071-Configurable-spawn-chances-for-skeleton-horses.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable spawn chances for skeleton horses
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 71c672eafdce3547eaeb8e31fddcb142ad213094..aa8cd5965632626e4cbd4952acf9b349f79b2b1c 100644
+index 995cefd0ecfc065da7bd5910f5c6901b2e75fd82..d5a02391a272262d0207505fee287085da3cd2ec 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -276,4 +276,12 @@ public class PaperWorldConfig {
+@@ -301,4 +301,12 @@ public class PaperWorldConfig {
          log("Non Player Arrow Despawn Rate: " + nonPlayerArrowDespawnRate);
          log("Creative Arrow Despawn Rate: " + creativeArrowDespawnRate);
      }

--- a/patches/server/0075-Configurable-Chunk-Inhabited-Time.patch
+++ b/patches/server/0075-Configurable-Chunk-Inhabited-Time.patch
@@ -11,10 +11,10 @@ For people who want all chunks to be treated equally, you can chose a fixed valu
 This allows to fine-tune vanilla gameplay.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index aa8cd5965632626e4cbd4952acf9b349f79b2b1c..e7534ed3f995be64c99399ab76e98086cf37bb7f 100644
+index d5a02391a272262d0207505fee287085da3cd2ec..7e3368910fb7793cc6142c001a71c671fed15b48 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -284,4 +284,14 @@ public class PaperWorldConfig {
+@@ -309,4 +309,14 @@ public class PaperWorldConfig {
              skeleHorseSpawnChance = 0.01D; // Vanilla value
          }
      }
@@ -30,7 +30,7 @@ index aa8cd5965632626e4cbd4952acf9b349f79b2b1c..e7534ed3f995be64c99399ab76e98086
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 327b513c75e75d4b07d3c3b6deda9d1d00b6cd7f..2e04012bdea67baee7c541a9006a99cd4f454e79 100644
+index cbffb4eb93ba1888666d4b0de98b2fb05c1400a0..d6ed92f6af50ea5377b7772f8d34ba6b72232885 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -281,6 +281,13 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0080-Configurable-Grass-Spread-Tick-Rate.patch
+++ b/patches/server/0080-Configurable-Grass-Spread-Tick-Rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable Grass Spread Tick Rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e7534ed3f995be64c99399ab76e98086cf37bb7f..c008f1f7f0a1e1b8bf34f2702cb44c5f9d62f848 100644
+index 7e3368910fb7793cc6142c001a71c671fed15b48..ddb560fe83387bceb8869aac6d851d20544f8e01 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -294,4 +294,10 @@ public class PaperWorldConfig {
+@@ -319,4 +319,10 @@ public class PaperWorldConfig {
          }
          fixedInhabitedTime = getInt("fixed-chunk-inhabited-time", -1);
      }

--- a/patches/server/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
+++ b/patches/server/0083-Option-to-use-vanilla-per-world-scoreboard-coloring-.patch
@@ -12,10 +12,10 @@ for this on CB at one point but I can't find it. We may need to do this
 ourselves at some point in the future.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index c008f1f7f0a1e1b8bf34f2702cb44c5f9d62f848..97693c33ba5a7efe40f05e0494216ee105e8bf74 100644
+index ddb560fe83387bceb8869aac6d851d20544f8e01..4450f8fd73cfa27e5faa8664da71ec7f78a6bc2a 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -300,4 +300,9 @@ public class PaperWorldConfig {
+@@ -325,4 +325,9 @@ public class PaperWorldConfig {
          grassUpdateRate = Math.max(0, getInt("grass-spread-tick-rate", grassUpdateRate));
          log("Grass Spread Tick Rate: " + grassUpdateRate);
      }

--- a/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
+++ b/patches/server/0089-Add-ability-to-configure-frosted_ice-properties.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add ability to configure frosted_ice properties
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 97693c33ba5a7efe40f05e0494216ee105e8bf74..7d92c9830206dacf34fc0f2f02d9453b3e0c0a5e 100644
+index 4450f8fd73cfa27e5faa8664da71ec7f78a6bc2a..0356506d9af8a1c97fe301f607a16c37a94dd227 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -305,4 +305,14 @@ public class PaperWorldConfig {
+@@ -330,4 +330,14 @@ public class PaperWorldConfig {
      private void useVanillaScoreboardColoring() {
          useVanillaScoreboardColoring = getBoolean("use-vanilla-world-scoreboard-name-coloring", false);
      }

--- a/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
+++ b/patches/server/0092-LootTable-API-Replenishable-Lootables-Feature.patch
@@ -11,10 +11,10 @@ This feature is good for long term worlds so that newer players
 do not suffer with "Every chest has been looted"
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7d92c9830206dacf34fc0f2f02d9453b3e0c0a5e..7661e41950c38bce94a2c7de4269ba6ebb2f6c52 100644
+index 0356506d9af8a1c97fe301f607a16c37a94dd227..622bf83fe4e4632523155b22089bb8925a8e935c 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -315,4 +315,26 @@ public class PaperWorldConfig {
+@@ -340,4 +340,26 @@ public class PaperWorldConfig {
          this.frostedIceDelayMax = this.getInt("frosted-ice.delay.max", this.frostedIceDelayMax);
          log("Frosted Ice: " + (this.frostedIceEnabled ? "enabled" : "disabled") + " / delay: min=" + this.frostedIceDelayMin + ", max=" + this.frostedIceDelayMax);
      }

--- a/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
+++ b/patches/server/0096-Optional-TNT-doesn-t-move-in-water.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optional TNT doesn't move in water
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7661e41950c38bce94a2c7de4269ba6ebb2f6c52..d7734fbc6b684b14bc32c94e65947fb41aae126a 100644
+index 622bf83fe4e4632523155b22089bb8925a8e935c..0aa397ea5ad8658b0019f16f1e63b8fa75f5d1d6 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -337,4 +337,14 @@ public class PaperWorldConfig {
+@@ -362,4 +362,14 @@ public class PaperWorldConfig {
              );
          }
      }

--- a/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
+++ b/patches/server/0108-Option-to-remove-corrupt-tile-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option to remove corrupt tile entities
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d7734fbc6b684b14bc32c94e65947fb41aae126a..80345730b8ccc11d3d0833485d25b03f614aeee2 100644
+index 0aa397ea5ad8658b0019f16f1e63b8fa75f5d1d6..7ac703d44f7ac1d5e81ba905facf589890a5eb5d 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -347,4 +347,9 @@ public class PaperWorldConfig {
+@@ -372,4 +372,9 @@ public class PaperWorldConfig {
          preventTntFromMovingInWater = getBoolean("prevent-tnt-from-moving-in-water", false);
          log("Prevent TNT from moving in water: " + preventTntFromMovingInWater);
      }
@@ -19,7 +19,7 @@ index d7734fbc6b684b14bc32c94e65947fb41aae126a..80345730b8ccc11d3d0833485d25b03f
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
-index 614e3255394a0988bcb19afaf066b1c2322ca1f0..6611affe664150139780ac596eab698c8843490c 100644
+index d6ed92f6af50ea5377b7772f8d34ba6b72232885..ddd97d7b89d33f1d03de0b00681808e48cedd499 100644
 --- a/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 +++ b/src/main/java/net/minecraft/world/level/chunk/LevelChunk.java
 @@ -259,7 +259,7 @@ public class LevelChunk extends ChunkAccess {

--- a/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
+++ b/patches/server/0110-Filter-bad-data-from-ArmorStand-and-SpawnEgg-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Filter bad data from ArmorStand and SpawnEgg items
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 80345730b8ccc11d3d0833485d25b03f614aeee2..6eb3678177834a4b34b78ba8e359528de7c0d2f0 100644
+index 7ac703d44f7ac1d5e81ba905facf589890a5eb5d..23b6c44424d2a432df059246325e898ddd225349 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -352,4 +352,12 @@ public class PaperWorldConfig {
+@@ -377,4 +377,12 @@ public class PaperWorldConfig {
      private void removeCorruptTEs() {
          removeCorruptTEs = getBoolean("remove-corrupt-tile-entities", false);
      }

--- a/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
+++ b/patches/server/0119-Configurable-Cartographer-Treasure-Maps.patch
@@ -9,10 +9,10 @@ Also allow turning off treasure maps all together as they can eat up Map ID's
 which are limited in quantity.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 6eb3678177834a4b34b78ba8e359528de7c0d2f0..f383f30b9dd1a7c6cf69d342f99118beec70b206 100644
+index 23b6c44424d2a432df059246325e898ddd225349..0274138c651d1d095ff4bc32f16ed7ea1ca6f054 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -360,4 +360,14 @@ public class PaperWorldConfig {
+@@ -385,4 +385,14 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("Spawn Egg and Armor Stand NBT filtering disabled, this is a potential security risk");
          }
      }

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -12,10 +12,10 @@ just as it does in Vanilla, but entity pushing logic will be capped.
 You can set this to 0 to disable collisions.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f383f30b9dd1a7c6cf69d342f99118beec70b206..47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960 100644
+index 0274138c651d1d095ff4bc32f16ed7ea1ca6f054..b7afcaf42a41a1480d96f3e113a2a869200700ef 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -370,4 +370,10 @@ public class PaperWorldConfig {
+@@ -395,4 +395,10 @@ public class PaperWorldConfig {
              log("Treasure Maps will return already discovered locations");
          }
      }

--- a/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
+++ b/patches/server/0135-Add-option-to-make-parrots-stay-on-shoulders-despite.patch
@@ -11,10 +11,10 @@ I suspect Mojang may switch to this behavior before full release.
 To be converted into a Paper-API event at some point in the future?
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 47b717e8741bb2b8f3aa776dcdc73a3e7dbb5960..9dad1efab44b8a23f274aa89c85944d98e9a6c51 100644
+index b7afcaf42a41a1480d96f3e113a2a869200700ef..b4552713aea67b1b0e6fddf13f5a6e72f3a63fbd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -376,4 +376,10 @@ public class PaperWorldConfig {
+@@ -401,4 +401,10 @@ public class PaperWorldConfig {
          maxCollisionsPerEntity = getInt( "max-entity-collisions", this.spigotConfig.getInt("max-entity-collisions", this.maxCollisionsPerEntity, false) );
          log( "Max Entity Collisions: " + maxCollisionsPerEntity );
      }
@@ -44,7 +44,7 @@ index 0d473a405345d809742cb312068db8bf33ef17e7..57f1d97c77350757e1686023a422d343
              case RELEASE_SHIFT_KEY:
                  this.player.setShiftKeyDown(false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2862e75108b3304ab186ed89eb36801500e58b85..84252d88469d045a776d1e51b05991463971f64d 100644
+index 062a519334560bf11eb10ca29d7d423270ac900e..b5768712b07e27320edefa3ced01e52c10f5b8ea 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -577,7 +577,7 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
+++ b/patches/server/0138-provide-a-configurable-option-to-disable-creeper-lin.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] provide a configurable option to disable creeper lingering
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 506539188aa1a2c7aa21b8ba3e0769a09d6ad134..9884d11cef96630dbb1f2b82bc02bcb5cebcd91b 100644
+index b4552713aea67b1b0e6fddf13f5a6e72f3a63fbd..d29ac609f53508a00aed88010618ea4c9e024721 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -382,4 +382,10 @@ public class PaperWorldConfig {
+@@ -407,4 +407,10 @@ public class PaperWorldConfig {
          parrotsHangOnBetter = getBoolean("parrots-are-unaffected-by-player-movement", false);
          log("Parrots are unaffected by player movement: " + parrotsHangOnBetter);
      }

--- a/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9884d11cef96630dbb1f2b82bc02bcb5cebcd91b..a60d3d62f7db7e91ba377fef6c28f4bde730f24a 100644
+index d29ac609f53508a00aed88010618ea4c9e024721..7043bb461ef5e3e77ccddbbda2768a236ddc18ee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -238,6 +238,11 @@ public class PaperWorldConfig {
+@@ -263,6 +263,11 @@ public class PaperWorldConfig {
          disableChestCatDetection = getBoolean("game-mechanics.disable-chest-cat-detection", false);
      }
  
@@ -21,7 +21,7 @@ index 9884d11cef96630dbb1f2b82bc02bcb5cebcd91b..a60d3d62f7db7e91ba377fef6c28f4bd
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 801f59957524fb8dd7c45008a2810230e9402da4..a4bf57db506c5f94a76fd716499ad725aec80c19 100644
+index 1912c01554a020da83979050529754223212f774..eb0595c044e2983dcc4bcd0c8b0af03c290928cc 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1187,6 +1187,7 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0192-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0192-Configurable-sprint-interruption-on-attack.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a60d3d62f7db7e91ba377fef6c28f4bde730f24a..861f9d6a42dbcc5a96c24b29b4bb80a450a69665 100644
+index 7043bb461ef5e3e77ccddbbda2768a236ddc18ee..60ce3ca0c83b3dbfefc62fa43f5be66e972bcc15 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -393,4 +393,9 @@ public class PaperWorldConfig {
+@@ -418,4 +418,9 @@ public class PaperWorldConfig {
          disableCreeperLingeringEffect = getBoolean("disable-creeper-lingering-effect", false);
          log("Creeper lingering effect: " + disableCreeperLingeringEffect);
      }
@@ -20,7 +20,7 @@ index a60d3d62f7db7e91ba377fef6c28f4bde730f24a..861f9d6a42dbcc5a96c24b29b4bb80a4
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index a4bf57db506c5f94a76fd716499ad725aec80c19..935ea41483ff696dcc9a3b988bb75ade74b801a8 100644
+index eb0595c044e2983dcc4bcd0c8b0af03c290928cc..04ef0787c3f878677023637ac2712228ea24f64a 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -1236,7 +1236,11 @@ public abstract class Player extends LivingEntity {

--- a/patches/server/0196-Block-Enderpearl-Travel-Exploit.patch
+++ b/patches/server/0196-Block-Enderpearl-Travel-Exploit.patch
@@ -12,10 +12,10 @@ This disables that by not saving the thrower when the chunk is unloaded.
 This is mainly useful for survival servers that do not allow freeform teleporting.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 861f9d6a42dbcc5a96c24b29b4bb80a450a69665..d74c86f401c0161ac139f0dfd789d03bc616fe3b 100644
+index 60ce3ca0c83b3dbfefc62fa43f5be66e972bcc15..531f3e4285ceb8bb8531f7bad7f7d670d1fe40f8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -398,4 +398,10 @@ public class PaperWorldConfig {
+@@ -423,4 +423,10 @@ public class PaperWorldConfig {
      private void disableSprintInterruptionOnAttack() {
          disableSprintInterruptionOnAttack = getBoolean("game-mechanics.disable-sprint-interruption-on-attack", false);
      }

--- a/patches/server/0210-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0210-Make-shield-blocking-delay-configurable.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d74c86f401c0161ac139f0dfd789d03bc616fe3b..97ad6c164281df845b3789e68287157c2a3d8ee8 100644
+index 531f3e4285ceb8bb8531f7bad7f7d670d1fe40f8..b25521adfb1d28d8040dd378d93b97c3582fd3c1 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -404,4 +404,9 @@ public class PaperWorldConfig {
+@@ -429,4 +429,9 @@ public class PaperWorldConfig {
          disableEnderpearlExploit = getBoolean("game-mechanics.disable-unloaded-chunk-enderpearl-exploit", disableEnderpearlExploit);
          log("Disable Unloaded Chunk Enderpearl Exploit: " + (disableEnderpearlExploit ? "enabled" : "disabled"));
      }

--- a/patches/server/0217-Add-config-to-disable-ender-dragon-legacy-check.patch
+++ b/patches/server/0217-Add-config-to-disable-ender-dragon-legacy-check.patch
@@ -5,21 +5,41 @@ Subject: [PATCH] Add config to disable ender dragon legacy check
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 97ad6c164281df845b3789e68287157c2a3d8ee8..825f8de6f5a6f6221724ba35dde265aadb15e4e8 100644
+index b25521adfb1d28d8040dd378d93b97c3582fd3c1..278345dc65850d978cc8c462070c838434da8d71 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -409,4 +409,9 @@ public class PaperWorldConfig {
+@@ -70,6 +70,11 @@ public class PaperWorldConfig {
+             set("despawn-ranges.hard", null);
+         }
+ 
++        if (PaperConfig.version < 25) {
++            needsSave = true;
++            set(OLD_ENABLE_FIRST_DRAGON_SPAWN, null);
++        }
++
+         if (needsSave) {
+             saveConfig();
+         }
+@@ -434,4 +439,17 @@ public class PaperWorldConfig {
      private void shieldBlockingDelay() {
          shieldBlockingDelay = getInt("game-mechanics.shield-blocking-delay", 5);
      }
 +
-+    public boolean scanForLegacyEnderDragon = true;
++    private static final String OLD_ENABLE_FIRST_DRAGON_SPAWN = "game-mechanics.scan-for-legacy-ender-dragon";
++    private static final String ENABLE_FIRST_DRAGON_SPAWN = "game-mechanics.enable-first-dragon-spawn";
++    public boolean enableFirstDragonSpawn = true;
 +    private void scanForLegacyEnderDragon() {
-+        scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
++        if (PaperConfig.version < 25) {
++            this.enableFirstDragonSpawn = getBoolean(OLD_ENABLE_FIRST_DRAGON_SPAWN, this.enableFirstDragonSpawn, false);
++            if (isSet(this.worldName, OLD_ENABLE_FIRST_DRAGON_SPAWN)) {
++                setForWorld(ENABLE_FIRST_DRAGON_SPAWN, this.enableFirstDragonSpawn);
++            }
++        }
++        this.enableFirstDragonSpawn = getBoolean(ENABLE_FIRST_DRAGON_SPAWN, this.enableFirstDragonSpawn);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
-index 2b7ffbc125d01db093a31ed6147fc1d736a01e80..9a6b2c75b8622b0f9eda85011ef6f2f1dca574c9 100644
+index 2b7ffbc125d01db093a31ed6147fc1d736a01e80..12e38e7b9c7390640708b25f6630b725e4d55e6e 100644
 --- a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 @@ -88,6 +88,10 @@ public class EndDragonFight {
@@ -27,7 +47,7 @@ index 2b7ffbc125d01db093a31ed6147fc1d736a01e80..9a6b2c75b8622b0f9eda85011ef6f2f1
  
      public EndDragonFight(ServerLevel world, long gatewaysSeed, CompoundTag nbt) {
 +        // Paper start
-+        this.needsStateScanning = world.paperConfig.scanForLegacyEnderDragon;
++        this.needsStateScanning = world.paperConfig.enableFirstDragonSpawn;
 +        if (!this.needsStateScanning) this.dragonKilled = true;
 +        // Paper end
          this.level = world;

--- a/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
+++ b/patches/server/0230-Option-to-prevent-armor-stands-from-doing-entity-loo.patch
@@ -5,12 +5,12 @@ Subject: [PATCH] Option to prevent armor stands from doing entity lookups
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 825f8de6f5a6f6221724ba35dde265aadb15e4e8..391a4cd47438cf8fd72b43f6cb0b4e278fa844ad 100644
+index 278345dc65850d978cc8c462070c838434da8d71..1e8968fc537df0ee704eb895d1fabc08a63d61d3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -414,4 +414,9 @@ public class PaperWorldConfig {
-     private void scanForLegacyEnderDragon() {
-         scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
+@@ -452,4 +452,9 @@ public class PaperWorldConfig {
+         }
+         this.enableFirstDragonSpawn = getBoolean(ENABLE_FIRST_DRAGON_SPAWN, this.enableFirstDragonSpawn);
      }
 +
 +    public boolean armorStandEntityLookups = true;
@@ -31,7 +31,7 @@ index 138422903dcb3056cd011a72e0625a1a225b4280..b92c2d5f9ad3936f619b51c79379983e
  
          for (int i = 0; i < list.size(); ++i) {
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index cd2278765439f4dc1652d997c8e0174af9b180cb..aba12f5a941fb07a2f4dd54af8f0a4310488ac78 100644
+index 07fa89ff2b26de5b6555cc6e9c308a9b921a79f3..b91b2c2336b40c2332e59c3f24e36ca6083ce3bd 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -776,6 +776,13 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0232-Allow-disabling-armour-stand-ticking.patch
+++ b/patches/server/0232-Allow-disabling-armour-stand-ticking.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling armour stand ticking
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 391a4cd47438cf8fd72b43f6cb0b4e278fa844ad..719b87705577132389f262a1557e5e84d37374d0 100644
+index 1e8968fc537df0ee704eb895d1fabc08a63d61d3..3469e1167176b982a0d30267e4114b814b261bd4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -419,4 +419,10 @@ public class PaperWorldConfig {
+@@ -457,4 +457,10 @@ public class PaperWorldConfig {
      private void armorStandEntityLookups() {
          armorStandEntityLookups = getBoolean("armor-stands-do-collision-entity-lookups", true);
      }

--- a/patches/server/0251-Configurable-speed-for-water-flowing-over-lava.patch
+++ b/patches/server/0251-Configurable-speed-for-water-flowing-over-lava.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable speed for water flowing over lava
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 719b87705577132389f262a1557e5e84d37374d0..9c558fc727eb597612139820650a4226a7923cbb 100644
+index 3469e1167176b982a0d30267e4114b814b261bd4..234bac299b944384b86761ea45d07b008520a678 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -425,4 +425,10 @@ public class PaperWorldConfig {
+@@ -463,4 +463,10 @@ public class PaperWorldConfig {
          this.armorStandTick = this.getBoolean("armor-stands-tick", this.armorStandTick);
          log("ArmorStand ticking is " + (this.armorStandTick ? "enabled" : "disabled") + " by default");
      }

--- a/patches/server/0283-Add-option-to-prevent-players-from-moving-into-unloa.patch
+++ b/patches/server/0283-Add-option-to-prevent-players-from-moving-into-unloa.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add option to prevent players from moving into unloaded
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e57ab8a3e6efd78e12385042b7d91dcd27fef11d..eb44aef0aecf65f5c1b19f42bf85a3a263965a7c 100644
+index 234bac299b944384b86761ea45d07b008520a678..959c7f84c93bfcf7ddefda6ee0236c7e209b8e9f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -431,4 +431,9 @@ public class PaperWorldConfig {
+@@ -469,4 +469,9 @@ public class PaperWorldConfig {
          waterOverLavaFlowSpeed = getInt("water-over-lava-flow-speed", 5);
          log("Water over lava flow speed: " + waterOverLavaFlowSpeed);
      }

--- a/patches/server/0329-Configurable-Keep-Spawn-Loaded-range-per-world.patch
+++ b/patches/server/0329-Configurable-Keep-Spawn-Loaded-range-per-world.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Configurable Keep Spawn Loaded range per world
 This lets you disable it for some worlds and lower it for others.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index eb44aef0aecf65f5c1b19f42bf85a3a263965a7c..5589ee42959e3665dd5df9049fe108b6f6629608 100644
+index 959c7f84c93bfcf7ddefda6ee0236c7e209b8e9f..03b26ff170b474a29198b20fae37df6a9bf9a3f5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -56,6 +56,12 @@ public class PaperWorldConfig {
+@@ -80,6 +80,12 @@ public class PaperWorldConfig {
          }
      }
  
@@ -20,8 +20,8 @@ index eb44aef0aecf65f5c1b19f42bf85a3a263965a7c..5589ee42959e3665dd5df9049fe108b6
 +    }
 +
      private boolean getBoolean(String path, boolean def) {
-         config.addDefault("world-settings.default." + path, def);
-         return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
+         return this.getBoolean(path, def, true);
+     }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index bd8e654c1580a0ac7dd411b9f1dcad4a20d1d3e5..7576047ea9695434ca06ca8fefde0dce68980be8 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0336-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
+++ b/patches/server/0336-Only-count-Natural-Spawned-mobs-towards-natural-spaw.patch
@@ -17,10 +17,10 @@ This should fully solve all of the issues around it so that only natural
 influences natural spawns.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5589ee42959e3665dd5df9049fe108b6f6629608..e5365453655c0f394dea3d3b388afc24f7724b26 100644
+index 03b26ff170b474a29198b20fae37df6a9bf9a3f5..aa8078ff359fe1b926f77188d6cf59652a0f317e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -442,4 +442,15 @@ public class PaperWorldConfig {
+@@ -480,4 +480,15 @@ public class PaperWorldConfig {
      private void preventMovingIntoUnloadedChunks() {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }

--- a/patches/server/0337-Configurable-projectile-relative-velocity.patch
+++ b/patches/server/0337-Configurable-projectile-relative-velocity.patch
@@ -25,10 +25,10 @@ P3) Solutions for 1) and especially 2) might not be future-proof, while this
 server-internal fix makes this change future-proof.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e5365453655c0f394dea3d3b388afc24f7724b26..4cbb5e77dad6b096a7de818300c6fc112d983ceb 100644
+index aa8078ff359fe1b926f77188d6cf59652a0f317e..e34a623f2f3f4ecb9823266ce7d78ca458651315 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -452,5 +452,10 @@ public class PaperWorldConfig {
+@@ -490,5 +490,10 @@ public class PaperWorldConfig {
              log("Using improved mob spawn limits (Only Natural Spawns impact spawn limits for more natural spawns)");
          }
      }

--- a/patches/server/0342-Add-option-to-disable-pillager-patrols.patch
+++ b/patches/server/0342-Add-option-to-disable-pillager-patrols.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to disable pillager patrols
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 4cbb5e77dad6b096a7de818300c6fc112d983ceb..3510509a02b5c0de695b55792c035943ceaef222 100644
+index e34a623f2f3f4ecb9823266ce7d78ca458651315..aaabde3b2183a0ff82313ac32f88babe631ea4ea 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -457,5 +457,10 @@ public class PaperWorldConfig {
+@@ -495,5 +495,10 @@ public class PaperWorldConfig {
      private void disableRelativeProjectileVelocity() {
          disableRelativeProjectileVelocity = getBoolean("game-mechanics.disable-relative-projectile-velocity", false);
      }

--- a/patches/server/0344-Flat-bedrock-generator-settings.patch
+++ b/patches/server/0344-Flat-bedrock-generator-settings.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Flat bedrock generator settings
 Co-authored-by: Noah van der Aa <ndvdaa@gmail.com>
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3510509a02b5c0de695b55792c035943ceaef222..03fbe3ff215cc482108a8926960bb60150ffb80d 100644
+index aaabde3b2183a0ff82313ac32f88babe631ea4ea..7e5269bca096a05d389690c0337a8fd213afec17 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -462,5 +462,10 @@ public class PaperWorldConfig {
+@@ -500,5 +500,10 @@ public class PaperWorldConfig {
      private void pillagerSettings() {
          disablePillagerPatrols = getBoolean("game-mechanics.disable-pillager-patrols", disablePillagerPatrols);
      }

--- a/patches/server/0346-MC-145656-Fix-Follow-Range-Initial-Target.patch
+++ b/patches/server/0346-MC-145656-Fix-Follow-Range-Initial-Target.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] MC-145656 Fix Follow Range Initial Target
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 03fbe3ff215cc482108a8926960bb60150ffb80d..e4820ece5279a0324f1e7ebf0027dcb054b7ecc3 100644
+index 7e5269bca096a05d389690c0337a8fd213afec17..b65e7786e89fdb4dd96cc0ee0a6250bd6cbc6168 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -467,5 +467,10 @@ public class PaperWorldConfig {
+@@ -505,5 +505,10 @@ public class PaperWorldConfig {
      private void generatorSettings() {
          generateFlatBedrock = getBoolean("generator-settings.flat-bedrock", this.generateFlatBedrock);
      }

--- a/patches/server/0347-Duplicate-UUID-Resolve-Option.patch
+++ b/patches/server/0347-Duplicate-UUID-Resolve-Option.patch
@@ -33,10 +33,10 @@ But for those who are ok with leaving this inconsistent behavior, you may use WA
 It is recommended you regenerate the entities, as these were legit entities, and deserve your love.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e4820ece5279a0324f1e7ebf0027dcb054b7ecc3..3e3a48a636c225ec113c1c64f6ffc8a37ad9169e 100644
+index b65e7786e89fdb4dd96cc0ee0a6250bd6cbc6168..ba97c6fb6054dbd2e6c5ead0e982ecb8600e5551 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -443,6 +443,45 @@ public class PaperWorldConfig {
+@@ -481,6 +481,45 @@ public class PaperWorldConfig {
          preventMovingIntoUnloadedChunks = getBoolean("prevent-moving-into-unloaded-chunks", false);
      }
  

--- a/patches/server/0348-Optimize-Hoppers.patch
+++ b/patches/server/0348-Optimize-Hoppers.patch
@@ -13,10 +13,10 @@ Subject: [PATCH] Optimize Hoppers
 * Remove Streams from Item Suck In and restore restore 1.12 AABB checks which is simpler and no voxel allocations (was doing TWO Item Suck ins)
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3e3a48a636c225ec113c1c64f6ffc8a37ad9169e..94336c6a644bf913d366baa71c2372eb67b6e2cd 100644
+index ba97c6fb6054dbd2e6c5ead0e982ecb8600e5551..3c4a8c6287c0e1a093ba24fb7915af90fdb41807 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -511,5 +511,17 @@ public class PaperWorldConfig {
+@@ -549,5 +549,17 @@ public class PaperWorldConfig {
      private void entitiesTargetWithFollowRange() {
          entitiesTargetWithFollowRange = getBoolean("entities-target-with-follow-range", entitiesTargetWithFollowRange);
      }

--- a/patches/server/0360-Increase-Light-Queue-Size.patch
+++ b/patches/server/0360-Increase-Light-Queue-Size.patch
@@ -14,10 +14,10 @@ light engine on shutdown...
 The queue size only puts a cap on max loss, doesn't solve that problem.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 94336c6a644bf913d366baa71c2372eb67b6e2cd..723adafaf82a664b8bfff9d7d11e43e3eafafa6e 100644
+index 3c4a8c6287c0e1a093ba24fb7915af90fdb41807..9ead99ae058c7b0184124e4742102962761c2e0e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -523,5 +523,10 @@ public class PaperWorldConfig {
+@@ -561,5 +561,10 @@ public class PaperWorldConfig {
          hoppersIgnoreOccludingBlocks = getBoolean("hopper.ignore-occluding-blocks", hoppersIgnoreOccludingBlocks);
          log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }

--- a/patches/server/0362-Anti-Xray.patch
+++ b/patches/server/0362-Anti-Xray.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Anti-Xray
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 723adafaf82a664b8bfff9d7d11e43e3eafafa6e..1cdfba84abcee02c0ac49367c97544bc4758715b 100644
+index 9ead99ae058c7b0184124e4742102962761c2e0e..819d05d57bad5509401a955cc1ea7e432a09a817 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -1,11 +1,13 @@
@@ -22,7 +22,7 @@ index 723adafaf82a664b8bfff9d7d11e43e3eafafa6e..1cdfba84abcee02c0ac49367c97544bc
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -528,5 +530,40 @@ public class PaperWorldConfig {
+@@ -566,5 +568,40 @@ public class PaperWorldConfig {
      private void lightQueueSize() {
          lightQueueSize = getInt("light-queue-size", lightQueueSize);
      }
@@ -1565,7 +1565,7 @@ index cf86755050632b158576849b786079787db11763..1267e93d1e315d55086a87670fd098db
  
      public static CompoundTag write(ServerLevel world, ChunkAccess chunk) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
-index 7bc1219523eeb0880493e6fb42692f1fdb30c110..d6efa18ba9c032858071f6c87f1bdc0ce2ddb20f 100644
+index a1fe076d76fe5f84eca39ea68e9820096f58f5a7..155933ef7c324ea17c2349a1f73ede29169ec4f2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
 @@ -52,7 +52,7 @@ public class CraftChunk implements Chunk {

--- a/patches/server/0363-Implement-alternative-item-despawn-rate.patch
+++ b/patches/server/0363-Implement-alternative-item-despawn-rate.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Implement alternative item-despawn-rate
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1cdfba84abcee02c0ac49367c97544bc4758715b..619f5c11ae8e21b060b52b60d681db6dd9cb5816 100644
+index 819d05d57bad5509401a955cc1ea7e432a09a817..4fd9486448f8fccfb0f852d1cf1e674b9f38b02e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -565,5 +565,52 @@ public class PaperWorldConfig {
+@@ -603,5 +603,52 @@ public class PaperWorldConfig {
              Bukkit.getLogger().warning("You have enabled permission-based Anti-Xray checking - depending on your permission plugin, this may cause performance issues");
          }
      }

--- a/patches/server/0366-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0366-implement-optional-per-player-mob-spawns.patch
@@ -25,10 +25,10 @@ index fe79c0add4f7cb18d487c5bb9415c40c5b551ea2..8d9ddad1879e7616d980ca70de8aecac
          poiUnload = Timings.ofSafe(name + "Chunk unload - POI");
          chunkUnload = Timings.ofSafe(name + "Chunk unload - Chunk");
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 619f5c11ae8e21b060b52b60d681db6dd9cb5816..88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f 100644
+index 4fd9486448f8fccfb0f852d1cf1e674b9f38b02e..024e4a780fce03460c868de27c9ffe7dd7facb9b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -613,4 +613,12 @@ public class PaperWorldConfig {
+@@ -651,4 +651,12 @@ public class PaperWorldConfig {
              }
          }
      }

--- a/patches/server/0374-Add-option-to-nerf-pigmen-from-nether-portals.patch
+++ b/patches/server/0374-Add-option-to-nerf-pigmen-from-nether-portals.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to nerf pigmen from nether portals
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 88d140a03b6f28070b2f78588ee5ce4d5ac3cf0f..67dcc28e5c5f6bdcafaea4bfe317203ddee09454 100644
+index 024e4a780fce03460c868de27c9ffe7dd7facb9b..01d96304896bfeb24710501f0e4e41146881a490 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -526,6 +526,11 @@ public class PaperWorldConfig {
+@@ -564,6 +564,11 @@ public class PaperWorldConfig {
          log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  

--- a/patches/server/0379-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
+++ b/patches/server/0379-Add-option-to-allow-iron-golems-to-spawn-in-air.patch
@@ -5,11 +5,11 @@ Subject: [PATCH] Add option to allow iron golems to spawn in air
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 67dcc28e5c5f6bdcafaea4bfe317203ddee09454..e0ebea2f62db5d0723aa353db49cdc3854aa5dd7 100644
+index 01d96304896bfeb24710501f0e4e41146881a490..59acebdad9bb71cee667101449306716187a1a4f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -423,6 +423,11 @@ public class PaperWorldConfig {
-         scanForLegacyEnderDragon = getBoolean("game-mechanics.scan-for-legacy-ender-dragon", true);
+@@ -461,6 +461,11 @@ public class PaperWorldConfig {
+         this.enableFirstDragonSpawn = getBoolean(ENABLE_FIRST_DRAGON_SPAWN, this.enableFirstDragonSpawn);
      }
  
 +    public boolean ironGolemsCanSpawnInAir = false;

--- a/patches/server/0380-Configurable-chance-of-villager-zombie-infection.patch
+++ b/patches/server/0380-Configurable-chance-of-villager-zombie-infection.patch
@@ -8,10 +8,10 @@ This allows you to solve an issue in vanilla behavior where:
 * On normal difficulty they will have a 50% of getting infected or dying.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e0ebea2f62db5d0723aa353db49cdc3854aa5dd7..5fee3bdea651fcdd7ea01df4cfb8288a231f9236 100644
+index 59acebdad9bb71cee667101449306716187a1a4f..cb0ef16001209c1027dd6a68b444380d6efcc487 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -536,6 +536,11 @@ public class PaperWorldConfig {
+@@ -574,6 +574,11 @@ public class PaperWorldConfig {
          nerfNetherPortalPigmen = getBoolean("game-mechanics.nerf-pigmen-from-nether-portals", nerfNetherPortalPigmen);
      }
  

--- a/patches/server/0383-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0383-Add-tick-times-API-and-mspt-command.patch
@@ -75,7 +75,7 @@ index 0000000000000000000000000000000000000000..d0211d4f39f9d6af1d751ac66342b42c
 +    }
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index 4875e323e8ba52cf91259262b8418310061718ad..a074df5708624bd4b0bc2ad3dcbd4bc4ff737595 100644
+index a3c3656ba4e8bb85bfb3186d6284f02f09975b13..6cfaef1886b517c56ed9a96347be6e51efa84d9f 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -69,6 +69,7 @@ public class PaperConfig {
@@ -84,8 +84,8 @@ index 4875e323e8ba52cf91259262b8418310061718ad..a074df5708624bd4b0bc2ad3dcbd4bc4
          commands.put("paper", new PaperCommand("paper"));
 +        commands.put("mspt", new MSPTCommand("mspt"));
  
-         version = getInt("config-version", 24);
-         set("config-version", 24);
+         version = getInt("config-version", 25);
+         set("config-version", 25);
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index b3d3e023d10fe6bb964fe7a3d1cbb96d6a406283..51b8b23892d9a57c1502a7cd9dbde033bae1ff03 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0386-Pillager-patrol-spawn-settings-and-per-player-option.patch
+++ b/patches/server/0386-Pillager-patrol-spawn-settings-and-per-player-option.patch
@@ -10,10 +10,10 @@ When not per player it will use the Vanilla mechanic of one delay per
 world and the world age for the start day.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5fee3bdea651fcdd7ea01df4cfb8288a231f9236..7f09e1178b73b3c436aea9059162628bfa8a6911 100644
+index cb0ef16001209c1027dd6a68b444380d6efcc487..3516ea64594ab499a7331d75ac101eb1773442b4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -505,8 +505,18 @@ public class PaperWorldConfig {
+@@ -543,8 +543,18 @@ public class PaperWorldConfig {
      }
  
      public boolean disablePillagerPatrols = false;

--- a/patches/server/0411-Add-phantom-creative-and-insomniac-controls.patch
+++ b/patches/server/0411-Add-phantom-creative-and-insomniac-controls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add phantom creative and insomniac controls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 7f09e1178b73b3c436aea9059162628bfa8a6911..1ea83baba79254e11fc770a6a1c7fb740ac43d82 100644
+index 3516ea64594ab499a7331d75ac101eb1773442b4..7ce9c665c53251a3582357e6c09ab972edc6bff4 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -646,4 +646,11 @@ public class PaperWorldConfig {
+@@ -684,4 +684,11 @@ public class PaperWorldConfig {
          }
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }

--- a/patches/server/0422-Option-for-maximum-exp-value-when-merging-orbs.patch
+++ b/patches/server/0422-Option-for-maximum-exp-value-when-merging-orbs.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Option for maximum exp value when merging orbs
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1ea83baba79254e11fc770a6a1c7fb740ac43d82..65fcdbc5c1f637f809d3033b83e5b1c807472911 100644
+index 7ce9c665c53251a3582357e6c09ab972edc6bff4..3d87fefcb1bc25a94e714271345b651e2507a3a2 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -653,4 +653,10 @@ public class PaperWorldConfig {
+@@ -691,4 +691,10 @@ public class PaperWorldConfig {
          phantomIgnoreCreative = getBoolean("phantoms-do-not-spawn-on-creative-players", phantomIgnoreCreative);
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }

--- a/patches/server/0437-Delay-Chunk-Unloads-based-on-Player-Movement.patch
+++ b/patches/server/0437-Delay-Chunk-Unloads-based-on-Player-Movement.patch
@@ -17,10 +17,10 @@ This allows servers with smaller worlds who do less long distance exploring to s
 wasting cpu cycles on saving/unloading/reloading chunks repeatedly.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 65fcdbc5c1f637f809d3033b83e5b1c807472911..d6d549df6e8920c936dd0d1b7ba828dbebc60b32 100644
+index 3d87fefcb1bc25a94e714271345b651e2507a3a2..6461530687b9d4c7ba9056b39869b34d690a4243 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -659,4 +659,13 @@ public class PaperWorldConfig {
+@@ -697,4 +697,13 @@ public class PaperWorldConfig {
          expMergeMaxValue = getInt("experience-merge-max-value", -1);
          log("Experience Merge Max Value: " + expMergeMaxValue);
      }

--- a/patches/server/0458-incremental-chunk-and-player-saving.patch
+++ b/patches/server/0458-incremental-chunk-and-player-saving.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] incremental chunk and player saving
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
-index a545a882335094daa787ec5c7005939080195263..933d3ace21f5a313f1d5e4dfd86777f6fa235f3f 100644
+index df1337c89c943a80a31d127c844f061c1e56eb91..cb967380155d34ff511346d54b61e1c2109780f3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
 @@ -459,4 +459,14 @@ public class PaperConfig {
@@ -24,10 +24,10 @@ index a545a882335094daa787ec5c7005939080195263..933d3ace21f5a313f1d5e4dfd86777f6
 +    }
  }
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d6d549df6e8920c936dd0d1b7ba828dbebc60b32..8b4b521a84c8623665d21d0340bca7665953d20b 100644
+index 6461530687b9d4c7ba9056b39869b34d690a4243..334bea7451e4068e6630075881e6435bd7d49ae0 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -64,6 +64,21 @@ public class PaperWorldConfig {
+@@ -88,6 +88,21 @@ public class PaperWorldConfig {
          log( "Keep Spawn Loaded Range: " + (keepLoadedRange/16));
      }
  
@@ -47,8 +47,8 @@ index d6d549df6e8920c936dd0d1b7ba828dbebc60b32..8b4b521a84c8623665d21d0340bca766
 +    }
 +
      private boolean getBoolean(String path, boolean def) {
-         config.addDefault("world-settings.default." + path, def);
-         return config.getBoolean("world-settings." + worldName + "." + path, config.getBoolean("world-settings.default." + path));
+         return this.getBoolean(path, def, true);
+     }
 diff --git a/src/main/java/net/minecraft/server/MinecraftServer.java b/src/main/java/net/minecraft/server/MinecraftServer.java
 index 918fdf14080338983b8725bf2619088fd23c332a..95842327aa08d4717f86e9dcc0519ab24c41ca14 100644
 --- a/src/main/java/net/minecraft/server/MinecraftServer.java

--- a/patches/server/0495-Add-zombie-targets-turtle-egg-config.patch
+++ b/patches/server/0495-Add-zombie-targets-turtle-egg-config.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add zombie targets turtle egg config
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8b4b521a84c8623665d21d0340bca7665953d20b..786253c675bff5aee5c5d79db897a282e6fb4b65 100644
+index 334bea7451e4068e6630075881e6435bd7d49ae0..b1defc046c4b6dfa5e44c7dc4bbd1adc1a00f560 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -58,6 +58,11 @@ public class PaperWorldConfig {
+@@ -82,6 +82,11 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0497-Optimize-redstone-algorithm.patch
+++ b/patches/server/0497-Optimize-redstone-algorithm.patch
@@ -19,10 +19,10 @@ Aside from making the obvious class/function renames and obfhelpers I didn't nee
 Just added Bukkit's event system and took a few liberties with dead code and comment misspellings.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 786253c675bff5aee5c5d79db897a282e6fb4b65..21adf6cb4cef00bc5f16a6e065a43c7894e24ba9 100644
+index b1defc046c4b6dfa5e44c7dc4bbd1adc1a00f560..ffa8b6ce86cf2d25ac8473373dd0d29f76c4abee 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -63,6 +63,16 @@ public class PaperWorldConfig {
+@@ -87,6 +87,16 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0528-Toggle-for-removing-existing-dragon.patch
+++ b/patches/server/0528-Toggle-for-removing-existing-dragon.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Toggle for removing existing dragon
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 21adf6cb4cef00bc5f16a6e065a43c7894e24ba9..2953c4d8bdfc0a7e7570c8994fd1c6ced6eaf654 100644
+index ffa8b6ce86cf2d25ac8473373dd0d29f76c4abee..cebb899b72defd8cf62fef85832d3aefebb944e9 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -73,6 +73,14 @@ public class PaperWorldConfig {
+@@ -97,6 +97,14 @@ public class PaperWorldConfig {
          }
      }
  
@@ -24,7 +24,7 @@ index 21adf6cb4cef00bc5f16a6e065a43c7894e24ba9..2953c4d8bdfc0a7e7570c8994fd1c6ce
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
-index 01fb5d0c18d50e298a891a42428c5c87d6820194..ddfaaac55646527ccd5bb4f5b4d35aa3ddaf34f4 100644
+index 2e32fdb97acba702650f8d0cee8aba5a8508919b..194405dd233b4e30afe4ff0d87e26f4c03026c38 100644
 --- a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 @@ -216,7 +216,7 @@ public class EndDragonFight {

--- a/patches/server/0534-Add-Wandering-Trader-spawn-rate-config-options.patch
+++ b/patches/server/0534-Add-Wandering-Trader-spawn-rate-config-options.patch
@@ -11,10 +11,10 @@ in IWorldServerData are removed as they were only used in certain places, with h
 values used in other places.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 2953c4d8bdfc0a7e7570c8994fd1c6ced6eaf654..f56992472665b59e3ae22fab74d994686dc767f4 100644
+index cebb899b72defd8cf62fef85832d3aefebb944e9..6826c2d0cbbb2f5f343baa58a38452aae202e8fd 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -81,6 +81,19 @@ public class PaperWorldConfig {
+@@ -105,6 +105,19 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0542-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0542-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Climbing should not bypass cramming gamerule
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f56992472665b59e3ae22fab74d994686dc767f4..8a266d1276595d5b2bd0b60f08d99d4cceea929a 100644
+index 6826c2d0cbbb2f5f343baa58a38452aae202e8fd..981f047abb579dfd3456e83cda9ca6d021d88a79 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -94,6 +94,11 @@ public class PaperWorldConfig {
+@@ -118,6 +118,11 @@ public class PaperWorldConfig {
          wanderingTraderSpawnChanceMax = getInt("wandering-trader.spawn-chance-max", wanderingTraderSpawnChanceMax);
      }
  

--- a/patches/server/0545-Fix-curing-zombie-villager-discount-exploit.patch
+++ b/patches/server/0545-Fix-curing-zombie-villager-discount-exploit.patch
@@ -8,10 +8,10 @@ and curing a villager on repeat by simply resetting the relevant part of
 the reputation when it is cured.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8a266d1276595d5b2bd0b60f08d99d4cceea929a..0dafb6b4837f9b68249e64a9f0b7f8f727d58327 100644
+index 981f047abb579dfd3456e83cda9ca6d021d88a79..5654861acdb002b9844d7590d3b78fe4b0d51584 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -99,6 +99,11 @@ public class PaperWorldConfig {
+@@ -123,6 +123,11 @@ public class PaperWorldConfig {
          fixClimbingBypassingCrammingRule = getBoolean("fix-climbing-bypassing-cramming-rule", fixClimbingBypassingCrammingRule);
      }
  

--- a/patches/server/0560-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
+++ b/patches/server/0560-Allow-disabling-mob-spawner-spawn-egg-transformation.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow disabling mob spawner spawn egg transformation
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 0dafb6b4837f9b68249e64a9f0b7f8f727d58327..8df810594156944a2cb149af35863caf10edbb83 100644
+index 5654861acdb002b9844d7590d3b78fe4b0d51584..c0814ee0e6ba64544f6cfb0b7ac4ace4f17ba911 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -104,6 +104,11 @@ public class PaperWorldConfig {
+@@ -128,6 +128,11 @@ public class PaperWorldConfig {
          fixCuringZombieVillagerDiscountExploit = getBoolean("game-mechanics.fix-curing-zombie-villager-discount-exploit", fixCuringZombieVillagerDiscountExploit);
      }
  

--- a/patches/server/0570-Added-world-settings-for-mobs-picking-up-loot.patch
+++ b/patches/server/0570-Added-world-settings-for-mobs-picking-up-loot.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Added world settings for mobs picking up loot
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8df810594156944a2cb149af35863caf10edbb83..63d0971379f96e000ab9e7939f626c216cb6d12c 100644
+index c0814ee0e6ba64544f6cfb0b7ac4ace4f17ba911..dc10def108096451eb732be7aaac810de6a547fa 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -720,6 +720,14 @@ public class PaperWorldConfig {
+@@ -758,6 +758,14 @@ public class PaperWorldConfig {
          phantomOnlyAttackInsomniacs = getBoolean("phantoms-only-attack-insomniacs", phantomOnlyAttackInsomniacs);
      }
  

--- a/patches/server/0574-Configurable-door-breaking-difficulty.patch
+++ b/patches/server/0574-Configurable-door-breaking-difficulty.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable door breaking difficulty
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 63d0971379f96e000ab9e7939f626c216cb6d12c..95952806a544d38952b82f7078a46a5eeb622cd8 100644
+index dc10def108096451eb732be7aaac810de6a547fa..41cdd18a8f4655b672eb2a5466ef255b00418fa7 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -109,6 +109,25 @@ public class PaperWorldConfig {
+@@ -133,6 +133,25 @@ public class PaperWorldConfig {
          disableMobSpawnerSpawnEggTransformation = getBoolean("game-mechanics.disable-mob-spawner-spawn-egg-transformation", disableMobSpawnerSpawnEggTransformation);
      }
  

--- a/patches/server/0581-Collision-option-for-requiring-a-player-participant.patch
+++ b/patches/server/0581-Collision-option-for-requiring-a-player-participant.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Collision option for requiring a player participant
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 95952806a544d38952b82f7078a46a5eeb622cd8..19ae4ae82be4a5a387b0f6e1b18e36b24d0cbbdb 100644
+index 41cdd18a8f4655b672eb2a5466ef255b00418fa7..6ffa54a1cf9c257b42172d192223479937a2542b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -81,6 +81,18 @@ public class PaperWorldConfig {
+@@ -105,6 +105,18 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0585-Configurable-max-leash-distance.patch
+++ b/patches/server/0585-Configurable-max-leash-distance.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max leash distance
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 19ae4ae82be4a5a387b0f6e1b18e36b24d0cbbdb..671ca20b02097332ef98d2be2e7aaafeadaf2a2c 100644
+index 6ffa54a1cf9c257b42172d192223479937a2542b..c9c3f9492bf06cf75e8ffe830d4694ce5a7f1e40 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -301,6 +301,12 @@ public class PaperWorldConfig {
+@@ -331,6 +331,12 @@ public class PaperWorldConfig {
          }
      }
  

--- a/patches/server/0589-Add-toggle-for-always-placing-the-dragon-egg.patch
+++ b/patches/server/0589-Add-toggle-for-always-placing-the-dragon-egg.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add toggle for always placing the dragon egg
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 671ca20b02097332ef98d2be2e7aaafeadaf2a2c..a17dc48e0bddea3272120f4a129278b755834d40 100644
+index c9c3f9492bf06cf75e8ffe830d4694ce5a7f1e40..5c405ed0f832bf88b640f57a6f3301f70a2ba3ab 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -750,6 +750,11 @@ public class PaperWorldConfig {
+@@ -788,6 +788,11 @@ public class PaperWorldConfig {
          perPlayerMobSpawns = getBoolean("per-player-mob-spawns", true);
      }
  
@@ -21,7 +21,7 @@ index 671ca20b02097332ef98d2be2e7aaafeadaf2a2c..a17dc48e0bddea3272120f4a129278b7
      public boolean phantomOnlyAttackInsomniacs = true;
      private void phantomSettings() {
 diff --git a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
-index ddfaaac55646527ccd5bb4f5b4d35aa3ddaf34f4..619ce8161deab5b93e2a3c4e652b3249f499fd3b 100644
+index 194405dd233b4e30afe4ff0d87e26f4c03026c38..9a7418ec832cf20f649fc8112344ab75c04919ac 100644
 --- a/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 +++ b/src/main/java/net/minecraft/world/level/dimension/end/EndDragonFight.java
 @@ -367,7 +367,7 @@ public class EndDragonFight {

--- a/patches/server/0596-added-option-to-disable-pathfinding-updates-on-block.patch
+++ b/patches/server/0596-added-option-to-disable-pathfinding-updates-on-block.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] added option to disable pathfinding updates on block changes
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a17dc48e0bddea3272120f4a129278b755834d40..83d5bbf0a819d6a75d148de5a7f3679e3faad9ec 100644
+index 5c405ed0f832bf88b640f57a6f3301f70a2ba3ab..7b747997d55b22665372c5494a81991b314cccfb 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -755,6 +755,11 @@ public class PaperWorldConfig {
+@@ -793,6 +793,11 @@ public class PaperWorldConfig {
          enderDragonsDeathAlwaysPlacesDragonEgg = getBoolean("ender-dragons-death-always-places-dragon-egg", enderDragonsDeathAlwaysPlacesDragonEgg);
      }
  

--- a/patches/server/0615-Allow-using-signs-inside-spawn-protection.patch
+++ b/patches/server/0615-Allow-using-signs-inside-spawn-protection.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Allow using signs inside spawn protection
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 83d5bbf0a819d6a75d148de5a7f3679e3faad9ec..f372caad76d5f59f37d073bb245fca3a037c2bef 100644
+index 7b747997d55b22665372c5494a81991b314cccfb..85a1044743f973f04252f4a6a3399770269a500b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -789,4 +789,9 @@ public class PaperWorldConfig {
+@@ -827,4 +827,9 @@ public class PaperWorldConfig {
              delayChunkUnloadsBy *= 20;
          }
      }

--- a/patches/server/0624-Entity-load-save-limit-per-chunk.patch
+++ b/patches/server/0624-Entity-load-save-limit-per-chunk.patch
@@ -9,7 +9,7 @@ defaults are only included for certain entites, this allows setting
 limits for any entity type.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f372caad76d5f59f37d073bb245fca3a037c2bef..1fc750c1f33d8f25a65cf286fd88fd21ab46c0ef 100644
+index 85a1044743f973f04252f4a6a3399770269a500b..646d3c951ac2d927955d8601ad188931db24e088 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -8,6 +8,8 @@ import it.unimi.dsi.fastutil.objects.Reference2IntMap;
@@ -21,7 +21,7 @@ index f372caad76d5f59f37d073bb245fca3a037c2bef..1fc750c1f33d8f25a65cf286fd88fd21
  import org.bukkit.Bukkit;
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
-@@ -140,6 +142,38 @@ public class PaperWorldConfig {
+@@ -164,6 +166,38 @@ public class PaperWorldConfig {
          );
      }
  

--- a/patches/server/0668-Limit-item-frame-cursors-on-maps.patch
+++ b/patches/server/0668-Limit-item-frame-cursors-on-maps.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Limit item frame cursors on maps
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 1fc750c1f33d8f25a65cf286fd88fd21ab46c0ef..9b9b2a70a33639c7e24ec8fee68b20a979bea37d 100644
+index 646d3c951ac2d927955d8601ad188931db24e088..6e86697caa0f1d441b9272d251de1100277af041 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -828,4 +828,9 @@ public class PaperWorldConfig {
+@@ -866,4 +866,9 @@ public class PaperWorldConfig {
      private void allowUsingSignsInsideSpawnProtection() {
          allowUsingSignsInsideSpawnProtection = getBoolean("allow-using-signs-inside-spawn-protection", allowUsingSignsInsideSpawnProtection);
      }

--- a/patches/server/0673-Add-option-to-fix-items-merging-through-walls.patch
+++ b/patches/server/0673-Add-option-to-fix-items-merging-through-walls.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add option to fix items merging through walls
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9b9b2a70a33639c7e24ec8fee68b20a979bea37d..04c91116d88b7c7b8a5886cc54f21be645998e38 100644
+index 6e86697caa0f1d441b9272d251de1100277af041..3bbdb84e6738ae12831e3c76fa62fa420692766b 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -833,4 +833,9 @@ public class PaperWorldConfig {
+@@ -871,4 +871,9 @@ public class PaperWorldConfig {
      private void mapItemFrameCursorLimit() {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }

--- a/patches/server/0675-Fix-invulnerable-end-crystals.patch
+++ b/patches/server/0675-Fix-invulnerable-end-crystals.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Fix invulnerable end crystals
 MC-108513
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 04c91116d88b7c7b8a5886cc54f21be645998e38..478c93a4eae18047df037958720e56e94a131f1c 100644
+index 3bbdb84e6738ae12831e3c76fa62fa420692766b..fb2ff5b5b8f0c6ebb062154136ee64e8954b4d3e 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -838,4 +838,9 @@ public class PaperWorldConfig {
+@@ -876,4 +876,9 @@ public class PaperWorldConfig {
      private void fixItemsMergingThroughWalls() {
          fixItemsMergingThroughWalls = getBoolean("fix-items-merging-through-walls", fixItemsMergingThroughWalls);
      }

--- a/patches/server/0681-add-per-world-spawn-limits.patch
+++ b/patches/server/0681-add-per-world-spawn-limits.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] add per world spawn limits
 Taken from #2982. Credit to Chasewhip8
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 478c93a4eae18047df037958720e56e94a131f1c..feaabc6d65845b81a3a184dc332d115200bdcca3 100644
+index fb2ff5b5b8f0c6ebb062154136ee64e8954b4d3e..9f892bf27697b64438b281e4c345a78ca8e12072 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -53,6 +53,11 @@ public class PaperWorldConfig {
+@@ -72,6 +72,11 @@ public class PaperWorldConfig {
  
              set("despawn-ranges.soft", null);
              set("despawn-ranges.hard", null);
@@ -20,8 +20,8 @@ index 478c93a4eae18047df037958720e56e94a131f1c..feaabc6d65845b81a3a184dc332d1152
 +            set("spawn-limits.water-ambient", null);
          }
  
-         if (needsSave) {
-@@ -688,6 +693,21 @@ public class PaperWorldConfig {
+         if (PaperConfig.version < 25) {
+@@ -726,6 +731,21 @@ public class PaperWorldConfig {
          zombieVillagerInfectionChance = getDouble("zombie-villager-infection-chance", zombieVillagerInfectionChance);
      }
  

--- a/patches/server/0689-Fix-commands-from-signs-not-firing-command-events.patch
+++ b/patches/server/0689-Fix-commands-from-signs-not-firing-command-events.patch
@@ -10,10 +10,10 @@ This patch changes sign command logic so that `run_command` click events:
   - sends failure messages to the player who clicked the sign
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index feaabc6d65845b81a3a184dc332d115200bdcca3..3a83320bae86ba1acb189b9b2cf934ad0393c353 100644
+index 9f892bf27697b64438b281e4c345a78ca8e12072..fecb321443f01692c56c5671fff029690cda7545 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -863,4 +863,9 @@ public class PaperWorldConfig {
+@@ -901,4 +901,9 @@ public class PaperWorldConfig {
      private void fixInvulnerableEndCrystalExploit() {
          fixInvulnerableEndCrystalExploit = getBoolean("unsupported-settings.fix-invulnerable-end-crystal-exploit", fixInvulnerableEndCrystalExploit);
      }

--- a/patches/server/0692-Add-config-for-mobs-immune-to-default-effects.patch
+++ b/patches/server/0692-Add-config-for-mobs-immune-to-default-effects.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add config for mobs immune to default effects
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 3a83320bae86ba1acb189b9b2cf934ad0393c353..be7b7f9345a42007d6ccea6a31c93a4c874647b6 100644
+index fecb321443f01692c56c5671fff029690cda7545..8e69304f69e04eee2ea6f87a10f266ec76d66456 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -683,6 +683,21 @@ public class PaperWorldConfig {
+@@ -721,6 +721,21 @@ public class PaperWorldConfig {
          log("Hopper Ignore Occluding Blocks: " + (hoppersIgnoreOccludingBlocks ? "enabled" : "disabled"));
      }
  

--- a/patches/server/0694-Don-t-apply-cramming-damage-to-players.patch
+++ b/patches/server/0694-Don-t-apply-cramming-damage-to-players.patch
@@ -11,10 +11,10 @@ It does not make a lot of sense to damage players if they get crammed,
 For those who really want it a config option is provided.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index be7b7f9345a42007d6ccea6a31c93a4c874647b6..a374112dc1ecb55dc921d2a2202f6eab47be0d35 100644
+index 8e69304f69e04eee2ea6f87a10f266ec76d66456..e6f25084b93d687c4d6f8b08bd8532736cfd8d46 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -883,4 +883,9 @@ public class PaperWorldConfig {
+@@ -921,4 +921,9 @@ public class PaperWorldConfig {
      private void showSignClickCommandFailureMessagesToPlayer() {
          showSignClickCommandFailureMessagesToPlayer = getBoolean("show-sign-click-command-failure-msgs-to-player", showSignClickCommandFailureMessagesToPlayer);
      }

--- a/patches/server/0695-Rate-options-and-timings-for-sensors-and-behaviors.patch
+++ b/patches/server/0695-Rate-options-and-timings-for-sensors-and-behaviors.patch
@@ -28,7 +28,7 @@ index b47b7dce26805badd422c1867733ff4bfd00e9f4..b27021a42cbed3f0648a8d0903d00d03
       * Get a named timer for the specified tile entity type to track type specific timings.
       * @param entity
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a374112dc1ecb55dc921d2a2202f6eab47be0d35..9e31046c1e6f1138e75aee11647b0ff9bf45503d 100644
+index e6f25084b93d687c4d6f8b08bd8532736cfd8d46..73640a0ea194514058f80401483b6d225e3e6e58 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -9,8 +9,10 @@ import it.unimi.dsi.fastutil.objects.Reference2IntOpenHashMap;
@@ -42,7 +42,7 @@ index a374112dc1ecb55dc921d2a2202f6eab47be0d35..9e31046c1e6f1138e75aee11647b0ff9
  import org.bukkit.configuration.file.YamlConfiguration;
  import org.spigotmc.SpigotWorldConfig;
  
-@@ -888,4 +890,57 @@ public class PaperWorldConfig {
+@@ -926,4 +928,57 @@ public class PaperWorldConfig {
      private void playerCrammingDamage() {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }

--- a/patches/server/0708-Config-option-for-Piglins-guarding-chests.patch
+++ b/patches/server/0708-Config-option-for-Piglins-guarding-chests.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Config option for Piglins guarding chests
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9e31046c1e6f1138e75aee11647b0ff9bf45503d..e85835f3ec7bb5e5ef5a827a4cb6614780255326 100644
+index 73640a0ea194514058f80401483b6d225e3e6e58..82e174858133ce93e2089bd75b704c4226bc3722 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -72,6 +72,11 @@ public class PaperWorldConfig {
+@@ -96,6 +96,11 @@ public class PaperWorldConfig {
          zombiesTargetTurtleEggs = getBoolean("zombies-target-turtle-eggs", zombiesTargetTurtleEggs);
      }
  

--- a/patches/server/0712-Configurable-item-frame-map-cursor-update-interval.patch
+++ b/patches/server/0712-Configurable-item-frame-map-cursor-update-interval.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable item frame map cursor update interval
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index e85835f3ec7bb5e5ef5a827a4cb6614780255326..f0073bafac729f018ad3264f673c158c1ed5b0d7 100644
+index 82e174858133ce93e2089bd75b704c4226bc3722..a1eca41f67c17bb02418947cb90984de9c445bf5 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -876,6 +876,11 @@ public class PaperWorldConfig {
+@@ -914,6 +914,11 @@ public class PaperWorldConfig {
          mapItemFrameCursorLimit = getInt("map-item-frame-cursor-limit", mapItemFrameCursorLimit);
      }
  

--- a/patches/server/0795-Preserve-overstacked-loot.patch
+++ b/patches/server/0795-Preserve-overstacked-loot.patch
@@ -10,10 +10,10 @@ chunk bans via the large amount of NBT created by unstacking the items.
 Fixes GH-5140 and GH-4748.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index f0073bafac729f018ad3264f673c158c1ed5b0d7..ea67eb1099e6ec34426d80c95e9999f4aa8793b9 100644
+index a1eca41f67c17bb02418947cb90984de9c445bf5..30604a46ca4981378edf8eca966bc205f414cd30 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -901,6 +901,11 @@ public class PaperWorldConfig {
+@@ -939,6 +939,11 @@ public class PaperWorldConfig {
          allowPlayerCrammingDamage = getBoolean("allow-player-cramming-damage", allowPlayerCrammingDamage);
      }
  

--- a/patches/server/0802-Configurable-feature-seeds.patch
+++ b/patches/server/0802-Configurable-feature-seeds.patch
@@ -19,10 +19,10 @@ index ee53453440177537fc653ea156785d7591498614..5e3b7fb2e0b7608610555cd23e7ad25a
              }
              final Object val = config.get(key);
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index ea67eb1099e6ec34426d80c95e9999f4aa8793b9..8150330bc55a010c7d0f96421586226631eb72f7 100644
+index 30604a46ca4981378edf8eca966bc205f414cd30..2872a22c4608f566849772721e75c75528c1f7e3 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -946,6 +946,55 @@ public class PaperWorldConfig {
+@@ -984,6 +984,55 @@ public class PaperWorldConfig {
          return table;
      }
  

--- a/patches/server/0814-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0814-Hide-unnecessary-itemmeta-from-clients.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Hide unnecessary itemmeta from clients
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 8150330bc55a010c7d0f96421586226631eb72f7..d71cd626bcbefc576f9c05b8885acc9fb2a33cd5 100644
+index 2872a22c4608f566849772721e75c75528c1f7e3..c72d83baddeed9e9f9f11004c65d2126a799e256 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -916,6 +916,13 @@ public class PaperWorldConfig {
+@@ -954,6 +954,13 @@ public class PaperWorldConfig {
          behaviorTickRates = loadTickRates("behavior");
      }
  

--- a/patches/server/0836-Configurable-max-block-light-for-monster-spawning.patch
+++ b/patches/server/0836-Configurable-max-block-light-for-monster-spawning.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Configurable max block light for monster spawning
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d71cd626bcbefc576f9c05b8885acc9fb2a33cd5..5a5db15493cd9b83815c36487c2f38cb8ac76f3a 100644
+index c72d83baddeed9e9f9f11004c65d2126a799e256..a0446e330e836500f8d0d173db4967a03ef95174 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1014,4 +1014,9 @@ public class PaperWorldConfig {
+@@ -1052,4 +1052,9 @@ public class PaperWorldConfig {
          Integer rate = table.get(columnKey, rowKey);
          return rate != null && rate > -1 ? rate : def;
      }


### PR DESCRIPTION
Closes https://github.com/PaperMC/Paper/issues/6991

The old name doesn't really reflect what this does anymore since Mojang added a `NeedsStateScanning` field to the dragon fight nbt structure. The setting might be useful still, but I think it should be renamed.