### PR TITLE
Add method for getting a sound's subtitle key

### DIFF
--- a/patches/api/0407-Add-subtitle-translation-keys.patch
+++ b/patches/api/0407-Add-subtitle-translation-keys.patch
@@ -1,0 +1,51 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 31 Dec 2021 17:41:29 -0800
+Subject: [PATCH] Add subtitle translation keys
+
+
+diff --git a/src/main/java/org/bukkit/Sound.java b/src/main/java/org/bukkit/Sound.java
+index da844079a9d3efd1a92c892de79fc7b3aeecaf4b..32c14a571acb2020f89ba2b45970275f95d7da11 100644
+--- a/src/main/java/org/bukkit/Sound.java
++++ b/src/main/java/org/bukkit/Sound.java
+@@ -1334,6 +1334,24 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+     WEATHER_RAIN("weather.rain"),
+     WEATHER_RAIN_ABOVE("weather.rain.above");
+ 
++    // Paper start
++    private static final java.util.Map<String, String> SUBTITLE_TRANSLATION_KEYS;
++
++    static {
++        java.util.Map<String, String> map = new java.util.LinkedHashMap<>();
++        java.io.InputStream stream = Sound.class.getResourceAsStream("/assets/paper/data/sounds.json");
++        if (stream != null) {
++            com.google.gson.JsonObject sounds = new com.google.gson.Gson().fromJson(new java.io.BufferedReader(new java.io.InputStreamReader(stream)), com.google.gson.JsonObject.class);
++            for (String key : sounds.keySet()) {
++                if (sounds.get(key).getAsJsonObject().has("subtitle")) {
++                    map.put(key, sounds.get(key).getAsJsonObject().get("subtitle").getAsString());
++                }
++            }
++        }
++        SUBTITLE_TRANSLATION_KEYS = java.util.Collections.unmodifiableMap(map);
++    }
++    // Paper end
++
+     private final NamespacedKey key;
+ 
+     private Sound(String key) {
+@@ -1352,5 +1370,15 @@ public enum Sound implements Keyed, net.kyori.adventure.sound.Sound.Type { // Pa
+     public net.kyori.adventure.key.@org.checkerframework.checker.nullness.qual.NonNull Key key() {
+         return this.key;
+     }
++
++    /**
++     * Get the subtitle translation key for this sound. Not all sounds
++     * have a subtitle and some sounds have the same as others.
++     *
++     * @return the subtitle translation key or null if none
++     */
++    public @org.jetbrains.annotations.Nullable String subtitleTranslationKey() {
++        return SUBTITLE_TRANSLATION_KEYS.get(this.key.getKey());
++    }
+     // Paper end
+ }

--- a/patches/server/0941-Add-subtitle-translation-keys.patch
+++ b/patches/server/0941-Add-subtitle-translation-keys.patch
@@ -1,0 +1,112 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Fri, 31 Dec 2021 17:41:32 -0800
+Subject: [PATCH] Add subtitle translation keys
+
+
+diff --git a/build.gradle.kts b/build.gradle.kts
+index b0e4f11e8af4b909a56bb5576d05ef0537fb25f7..c290d5afb2cb834430b791f359c40c9659cfc69c 100644
+--- a/build.gradle.kts
++++ b/build.gradle.kts
+@@ -1,4 +1,7 @@
+ import io.papermc.paperweight.util.*
++import io.papermc.paperweight.util.constants.*
++import io.papermc.paperweight.tasks.*
++import java.nio.file.Files
+ 
+ plugins {
+     java
+@@ -50,6 +53,78 @@ dependencies {
+ }
+ 
+ val craftbukkitPackageVersion = "1_19_R1" // Paper
++
++// Paper start - include mc assets inside jar
++abstract class SetupResources : BaseTask() {
++    @get:InputFile
++    abstract val soundsJson: RegularFileProperty
++
++    @get:OutputDirectory
++    abstract val resourcesOut: DirectoryProperty
++
++    @TaskAction
++    fun run() {
++        resourcesOut.path.deleteRecursively()
++        Files.createDirectories(resourcesOut.path)
++
++        val dest = "assets/paper/data"
++        val destDir = resourcesOut.path.resolve(dest).also { Files.createDirectories(it) }
++        Files.copy(soundsJson.path, destDir.resolve("sounds.json"))
++    }
++}
++
++fun defaultOutput(name: String, ext: String): RegularFileProperty {
++    return objects.fileProperty().convention {
++        layout.cache.resolve(paperTaskOutput(name, ext)).toFile()
++    }
++}
++
++fun DefaultTask.defaultOutput(ext: String): RegularFileProperty {
++    return defaultOutput(name, ext)
++}
++
++val mcAssets = layout.buildDirectory.dir("mc-assets")
++val downloadAssetsIndex = tasks.register("downloadMcAssetsIndex", DownloadTask::class) {
++    url.set(
++        rootProject.tasks.named("downloadMcVersionManifest", DownloadTask::class).flatMap { it.outputFile }
++            .map { f ->
++                Files.newBufferedReader(f.path)
++                    .use { gson.fromJson(it, paper.libs.com.google.gson.JsonObject::class.java) }
++                    .get("assetIndex").asJsonObject.get("url").asString
++            }
++    )
++    outputFile.set(defaultOutput("json"))
++    downloader.set(project.download)
++}
++
++val downloadSoundsJson = tasks.register("downloadSoundsJson", DownloadTask::class) {
++    url.set(
++        downloadAssetsIndex.flatMap { it.outputFile }
++            .map { f ->
++                val resource = Files.newBufferedReader(f.path)
++                    .use { gson.fromJson(it, paper.libs.com.google.gson.JsonObject::class.java) }
++                    .get("objects").asJsonObject.get("minecraft/sounds.json").asJsonObject
++                val resourceHash = resource.get("hash").asString
++                "https://resources.download.minecraft.net/${resourceHash.take(2)}/$resourceHash"
++            }
++    )
++    outputFile.set(defaultOutput("json"))
++    downloader.set(project.download)
++}
++
++tasks.register("setupSoundsJson", SetupResources::class) {
++    soundsJson.set(downloadSoundsJson.flatMap { it.outputFile })
++    resourcesOut.set(mcAssets)
++}
++
++sourceSets.main {
++    output.dir(
++        mcAssets,
++        "builtBy" to "setupSoundsJson",
++    )
++}
++// Paper end
++
+ tasks.jar {
+     archiveClassifier.set("dev")
+ 
+diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
+index 9292a0119499d14c9ed170999ac3b8dfdd1f839a..0a64115cbd1934a400302fd9fea6bd8d7632a091 100644
+--- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
++++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
+@@ -88,4 +88,10 @@ public class TranslationKeyTest extends AbstractTestingBase {
+             Assert.assertEquals("translation key mismatch for " + bukkit, nms.getKey().location().toLanguageKey("biome"), bukkit.translationKey());
+         }
+     }
++
++    @Test
++    public void testSoundSubtitle() {
++        Assert.assertEquals("subtitles.block.generic.break", org.bukkit.Sound.BLOCK_AMETHYST_BLOCK_BREAK.subtitleTranslationKey());
++        Assert.assertNull(org.bukkit.Sound.AMBIENT_WARPED_FOREST_MOOD.subtitleTranslationKey());
++    }
+ }


### PR DESCRIPTION
Soooooo since the client uses one of the many resources it downloads for associated a sound with a subtitle key, the test makes a request to mojangs resources api. idk how good that is, maybe the test should be disabled most of the time or smth. But, it works. I also wrote a function that generates the big switch statement thats commented out of the test by default cause most of the time it doesnt need to be run.