### PR TITLE
Use isSensitiveToWater in nerfed check for water-sensitive mobs

### DIFF
--- a/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
+++ b/patches/server/0016-Allow-nerfed-mobs-to-jump-and-take-water-damage.patch
@@ -31,7 +31,7 @@ index 3eb1f5e422002a48651a24d0e70884bf54de717e..3efdf887ec70aa2d3486a1ddfc8e5e1c
          return this.isInWater() || this.isInRain() || this.isInBubbleColumn();
      }
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f286fcc2958a02c1e480b8fcf5d049bf0de27131..9cc9c11f2ef5aa386711a0ebc70b6a2d8e5c5b97 100644
+index f6c93812c30bd1637219c22c1a903e2ec93a9d72..36a4214615a0acf0aa4a9dc4411afc130bcfdbc1 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -105,6 +105,7 @@ public abstract class Mob extends LivingEntity {
@@ -52,7 +52,7 @@ index f286fcc2958a02c1e480b8fcf5d049bf0de27131..9cc9c11f2ef5aa386711a0ebc70b6a2d
 +                if (goalFloat.canUse()) goalFloat.tick();
 +                this.getJumpControl().tick();
 +            }
-+            if ((this instanceof net.minecraft.world.entity.monster.Blaze || this instanceof net.minecraft.world.entity.monster.EnderMan) && isInWaterRainOrBubble()) {
++            if (this.isSensitiveToWater() && isInWaterRainOrBubble()) {
 +                hurt(DamageSource.DROWN, 1.0F);
 +            }
 +            return;


### PR DESCRIPTION
saw this while browsing through the code and I thought this method made more sense
I assume this is unintended but https://github.com/PaperMC/Paper/pull/2847 for context for when relevant code was even added
(endermen and blazes also aren't the only mobs for which the method returns true)