### PR TITLE
Fix soul speed particles with hide-itemmeta enabled

### DIFF
--- a/patches/server/0811-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0811-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,7 +34,7 @@ index 703ac671b19636859648f16a5431b2700791e7d5..d8ef6137133716b9ee519e6e4668d2e1
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0c824a8c44cc9a2c848816450830b91d1199faff..430d4e98134dce62d30ddb31fcb125a69571fa5a 100644
+index 0c824a8c44cc9a2c848816450830b91d1199faff..860b531b9c5354a4b0162850fe8feba99a95f0bc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3067,7 +3067,10 @@ public abstract class LivingEntity extends Entity {
@@ -53,7 +53,7 @@ index 0c824a8c44cc9a2c848816450830b91d1199faff..430d4e98134dce62d30ddb31fcb125a6
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  
-+    // Paper end - prevent oversized data
++    // Paper start - prevent oversized data
 +    public static ItemStack sanitizeItemStack(final ItemStack itemStack, final boolean copyItemStack) {
 +        if (itemStack.isEmpty() || !itemStack.hasTag()) {
 +            return itemStack;

--- a/patches/server/0812-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0812-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,7 +36,7 @@ index d8ef6137133716b9ee519e6e4668d2e1ae5d9ca3..9a6c67b614944f841813ec2892381c33
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 430d4e98134dce62d30ddb31fcb125a69571fa5a..fe7e22d9a69d69dfcce63faa28e90945ea45fc49 100644
+index 860b531b9c5354a4b0162850fe8feba99a95f0bc..43378561cf48f969f5bf1fd0db349415f4d1c866 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -3069,7 +3069,7 @@ public abstract class LivingEntity extends Entity {
@@ -48,7 +48,7 @@ index 430d4e98134dce62d30ddb31fcb125a69571fa5a..fe7e22d9a69d69dfcce63faa28e90945
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3083,6 +3083,45 @@ public abstract class LivingEntity extends Entity {
+@@ -3083,6 +3083,51 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  
@@ -81,7 +81,13 @@ index 430d4e98134dce62d30ddb31fcb125a69571fa5a..fe7e22d9a69d69dfcce63faa28e90945
 +                if (tag.get("Enchantments") instanceof ListTag enchantmentsTag && !enchantmentsTag.isEmpty()) {
 +                    // The client still renders items with the enchantment glow if the enchantments tag contains at least one (empty) child.
 +                    ListTag enchantments = new ListTag();
-+                    enchantments.add(new CompoundTag());
++                    CompoundTag fakeEnchantment = new CompoundTag();
++                    // Soul speed boots generate client side particles.
++                    if (EnchantmentHelper.getItemEnchantmentLevel(Enchantments.SOUL_SPEED, itemStack) > 0) {
++                        fakeEnchantment.putString("id", org.bukkit.enchantments.Enchantment.SOUL_SPEED.getKey().asString());
++                        fakeEnchantment.putInt("lvl", 1);
++                    }
++                    enchantments.add(fakeEnchantment);
 +                    tag.put("Enchantments", enchantments);
 +                }
 +                tag.remove("AttributeModifiers");
@@ -91,6 +97,6 @@ index 430d4e98134dce62d30ddb31fcb125a69571fa5a..fe7e22d9a69d69dfcce63faa28e90945
 +    }
 +    // Paper end
 +
-     // Paper end - prevent oversized data
+     // Paper start - prevent oversized data
      public static ItemStack sanitizeItemStack(final ItemStack itemStack, final boolean copyItemStack) {
          if (itemStack.isEmpty() || !itemStack.hasTag()) {


### PR DESCRIPTION
Fixes #7238 by setting the fake, empty enchantment to a soulspeed enchantment with level 1 if the item has soulspeed.