### PR TITLE
Update the rewriteForIde for new cb package version

### DIFF
--- a/patches/server/0001-Setup-Gradle-project.patch
+++ b/patches/server/0001-Setup-Gradle-project.patch
@@ -58,6 +58,7 @@ index 0000000000000000000000000000000000000000..75c858870a55f7282a0e3500f803cb33
 +    testImplementation("org.hamcrest:hamcrest-library:1.3")
 +}
 +
++val craftbukkitPackageVersion = "1_18_R2" // Paper
 +tasks.jar {
 +    archiveClassifier.set("dev")
 +
@@ -89,8 +90,7 @@ index 0000000000000000000000000000000000000000..75c858870a55f7282a0e3500f803cb33
 +
 +relocation {
 +    // Order matters here - e.g. craftbukkit proper must be relocated before any of the libs are relocated into the cb package
-+    val packageVersion = "1_18_R2"
-+    relocate("org.bukkit.craftbukkit" to "org.bukkit.craftbukkit.v$packageVersion") {
++    relocate("org.bukkit.craftbukkit" to "org.bukkit.craftbukkit.v$craftbukkitPackageVersion") {
 +        exclude("org.bukkit.craftbukkit.Main*")
 +    }
 +}

--- a/patches/server/0003-Build-system-changes.patch
+++ b/patches/server/0003-Build-system-changes.patch
@@ -21,7 +21,7 @@ index 75c858870a55f7282a0e3500f803cb330b462f37..d39ed9a8a32913193aec1bba2a59a352
      runtimeOnly("org.xerial:sqlite-jdbc:3.36.0.3")
      runtimeOnly("mysql:mysql-connector-java:8.0.27")
  
-@@ -32,6 +31,7 @@ tasks.jar {
+@@ -33,6 +32,7 @@ tasks.jar {
          val gitHash = git("rev-parse", "--short=7", "HEAD").getText().trim()
          val implementationVersion = System.getenv("BUILD_NUMBER") ?: "\"$gitHash\""
          val date = git("show", "-s", "--format=%ci", gitHash).getText().trim() // Paper
@@ -29,12 +29,13 @@ index 75c858870a55f7282a0e3500f803cb330b462f37..d39ed9a8a32913193aec1bba2a59a352
          attributes(
              "Main-Class" to "org.bukkit.craftbukkit.Main",
              "Implementation-Title" to "CraftBukkit",
-@@ -40,6 +40,8 @@ tasks.jar {
+@@ -41,6 +41,9 @@ tasks.jar {
              "Specification-Title" to "Bukkit",
              "Specification-Version" to project.version,
              "Specification-Vendor" to "Bukkit Team",
 +            "Git-Branch" to gitBranch, // Paper
 +            "Git-Commit" to gitHash, // Paper
++            "CraftBukkit-Package-Version" to craftbukkitPackageVersion, // Paper
          )
          for (tld in setOf("net", "com", "org")) {
              attributes("$tld/bukkit", "Sealed" to true)

--- a/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
+++ b/patches/server/0266-Hook-into-CB-plugin-rewrites.patch
@@ -8,7 +8,7 @@ our own relocation. Also lets us rewrite NMS calls for when we're
 debugging in an IDE pre-relocate.
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
-index a679133a3de51e26eb19932ece9ade292879aefd..d5330d1dff2d02e585eba3ec7c48bf261cdce8ef 100644
+index a679133a3de51e26eb19932ece9ade292879aefd..89a32de0a3fbb7465b078b2aa1cc1d156a4a174d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 +++ b/src/main/java/org/bukkit/craftbukkit/util/Commodore.java
 @@ -6,7 +6,9 @@ import java.io.FileOutputStream;
@@ -43,18 +43,18 @@ index a679133a3de51e26eb19932ece9ade292879aefd..d5330d1dff2d02e585eba3ec7c48bf26
  
 +    // Paper start - Plugin rewrites
 +    private static final Map<String, String> SEARCH_AND_REMOVE = initReplacementsMap();
++    private static final java.util.jar.Manifest manifest = io.papermc.paper.util.JarManifests.manifest(Commodore.class);
 +    private static Map<String, String> initReplacementsMap()
 +    {
 +        Map<String, String> getAndRemove = new HashMap<>();
 +        // Be wary of maven shade's relocations
 +        getAndRemove.put( "org/bukkit/".concat( "craftbukkit/libs/it/unimi/dsi/fastutil/" ), "org/bukkit/".concat( "craftbukkit/libs/" ) ); // Remap fastutil to our location
 +
-+        if ( Boolean.getBoolean( "debug.rewriteForIde" ) )
++        if ( Boolean.getBoolean( "debug.rewriteForIde" ) && manifest != null)
 +        {
 +            // unversion incoming calls for pre-relocate debug work
-+            final String NMS_REVISION_PACKAGE = "v1_16_R3/";
++            final String NMS_REVISION_PACKAGE = "v" + manifest.getMainAttributes().getValue("CraftBukkit-Package-Version") + "/";
 +
-+            getAndRemove.put( "net/minecraft/".concat( "server/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );
 +            getAndRemove.put( "org/bukkit/".concat( "craftbukkit/" + NMS_REVISION_PACKAGE ), NMS_REVISION_PACKAGE );
 +        }
 +

--- a/patches/server/0412-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
+++ b/patches/server/0412-Deobfuscate-stacktraces-in-log-messages-crash-report.patch
@@ -33,7 +33,7 @@ index 1d7bbff8711bfb991046ecc66dce328a5f643c2d..2ea3af07a18094d0bc7e4898c0bb97ec
      testImplementation("junit:junit:4.13.2")
      testImplementation("org.hamcrest:hamcrest-library:1.3")
  }
-@@ -88,6 +93,45 @@ tasks.shadowJar {
+@@ -89,6 +94,45 @@ tasks.shadowJar {
      }
  }
  


### PR DESCRIPTION
I'm pretty sure this is still a useful thing. For example, taking the [paperweight-test-plugin](https://github.com/PaperMC/paperweight-test-plugin) and loading the non-reobf'd plugin jar on a mojmapped server without relocations will currently fail because its not rewriting the relocations. But with this (and running the server with `-Ddebug.rewriteForIde` it now works.

Not sure on the best way to automatically know the cb package, so I just threw it in the manifest, prob some better way to do it with gradle that I just don't know.