### PR TITLE
Updated Upstream (Bukkit/CraftBukkit/Spigot)

### DIFF
--- a/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
+++ b/patches/api/0353-Remove-upstream-snakeyaml-fix.patch
@@ -1,0 +1,32 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Wed, 5 Jan 2022 12:12:58 -0800
+Subject: [PATCH] Remove upstream snakeyaml fix
+
+See Server Patch: Fix saving configs with more long comments
+
+diff --git a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+index df250bf41463c57b3ec7c288e134460a2295eed5..2159e7a49ed1bc01533e67ac9f6917801ec963e3 100644
+--- a/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
++++ b/src/main/java/org/bukkit/configuration/file/YamlConfiguration.java
+@@ -65,7 +65,7 @@ public class YamlConfiguration extends FileConfiguration {
+         yamlLoaderOptions = new LoaderOptions();
+         yamlLoaderOptions.setMaxAliasesForCollections(Integer.MAX_VALUE); // SPIGOT-5881: Not ideal, but was default pre SnakeYAML 1.26
+ 
+-        yaml = new BukkitYaml(constructor, representer, yamlDumperOptions, yamlLoaderOptions);
++        yaml = new /*BukkitYaml*/Yaml(constructor, representer, yamlDumperOptions, yamlLoaderOptions); // Paper - don't use upstream BukkitYaml fix, add the whole snakeyaml Emitter class itself with the fix
+     }
+ 
+     @NotNull
+diff --git a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
+index a0ff42abd3ced3513ee3343e14d5068cc5dd4532..9dd844fde37fe47b51cd30092e86b5b41a2344ef 100644
+--- a/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
++++ b/src/test/java/org/bukkit/configuration/file/YamlConfigurationTest.java
+@@ -146,6 +146,7 @@ public class YamlConfigurationTest extends FileConfigurationTest {
+     }
+ 
+     @Test
++    @org.junit.Ignore // Paper - ignore test because our fix doesn't work in testing environment
+     public void test100Comments() throws InvalidConfigurationException {
+         StringBuilder commentBuilder = new StringBuilder();
+         for (int i = 0; i < 100; i++) {

--- a/patches/server/0010-Timings-v2.patch
+++ b/patches/server/0010-Timings-v2.patch
@@ -1041,7 +1041,7 @@ index 4dd57007af218ba1c0e666117a49939c5884f2c6..a6cb949b6f048455acc50c897fdd93d3
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index f3a2a5dcd18d8abe370779f75106eacab498c3b6..67113f1bb622acde89c05d1ee0af88644f67e776 100644
+index ae93a5bd184e084720400a44a3d9b14910343333..d2f59b13121f1d105837e0a52be4aca5d110c15c 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -1,8 +1,10 @@
@@ -1217,7 +1217,7 @@ index be11caf7c0dcdb11e24cfb053cda45ac1867da63..8f5e9f1bdfd2e02512e1341f91b147b1
      }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index ce9ff034a281cd9cc76c26713b6d1eab3f6c9fe2..ae090f58bec25270e55f8da37355351783e69a7f 100644
+index 073cea951644f25c276ba05ff1fc48fda08593da..c7fe4b6aa8d68bd5dc394752a5ae635eb46c5f31 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1,6 +1,8 @@
@@ -1412,7 +1412,7 @@ index 8e4325abb2dda74c38b17bb27f9dcfcf97ba2de6..1be4b3ad18d314b0460ce61e01afd0d7
  
      public UserWhiteList getWhiteList() {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index fdf607c91ee31206839b14212a20ee81ec751776..3eb1f5e422002a48651a24d0e70884bf54de717e 100644
+index efb347d1a8ac45b13e1abfa712cbd204c64501ae..668fcdf95c92b439612d98f224ae4ac9bd055bdf 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -125,7 +125,6 @@ import org.bukkit.craftbukkit.event.CraftPortalEvent;
@@ -1424,7 +1424,7 @@ index fdf607c91ee31206839b14212a20ee81ec751776..3eb1f5e422002a48651a24d0e70884bf
  import org.bukkit.event.hanging.HangingBreakByEntityEvent;
  import org.bukkit.event.vehicle.VehicleBlockCollisionEvent;
 @@ -286,7 +285,6 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
-     public boolean forceExplosionKnockback; // SPIGOT-949
+     public boolean lastDamageCancelled; // SPIGOT-5339, SPIGOT-6252, SPIGOT-6777: Keep track if the event was canceled
      public boolean persistentInvisibility = false;
      public BlockPos lastLavaContact;
 -    public CustomTimingsHandler tickTimer = org.bukkit.craftbukkit.SpigotTimings.getEntityTimings(this); // Spigot
@@ -1504,7 +1504,7 @@ index e688949fc2f3031dc9c9817bc59554e9f5a436af..20cfdba68c200e87d00995a6a4e25a5f
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729c1d9b28c 100644
+index 5669d868f764dcdea8c510fc902cadea226ce473..46b40b08916369f8aa8b28144f07c48741c45101 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -137,7 +137,7 @@ import org.bukkit.event.entity.EntityTeleportEvent;
@@ -1516,7 +1516,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
  
  public abstract class LivingEntity extends Entity {
  
-@@ -2761,7 +2761,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2760,7 +2760,6 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void tick() {
@@ -1524,7 +1524,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
          super.tick();
          this.updatingUsingItem();
          this.updateSwimAmount();
-@@ -2802,9 +2801,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2801,9 +2800,7 @@ public abstract class LivingEntity extends Entity {
              }
          }
  
@@ -1534,7 +1534,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
          double d0 = this.getX() - this.xo;
          double d1 = this.getZ() - this.zo;
          float f = (float) (d0 * d0 + d1 * d1);
-@@ -2884,8 +2881,6 @@ public abstract class LivingEntity extends Entity {
+@@ -2883,8 +2880,6 @@ public abstract class LivingEntity extends Entity {
          if (this.isSleeping()) {
              this.setXRot(0.0F);
          }
@@ -1543,7 +1543,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
      }
  
      public void detectEquipmentUpdates() {
-@@ -3067,7 +3062,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3066,7 +3061,6 @@ public abstract class LivingEntity extends Entity {
  
          this.setDeltaMovement(d4, d5, d6);
          this.level.getProfiler().push("ai");
@@ -1551,7 +1551,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
          if (this.isImmobile()) {
              this.jumping = false;
              this.xxa = 0.0F;
-@@ -3077,7 +3071,6 @@ public abstract class LivingEntity extends Entity {
+@@ -3076,7 +3070,6 @@ public abstract class LivingEntity extends Entity {
              this.serverAiStep();
              this.level.getProfiler().pop();
          }
@@ -1559,7 +1559,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
  
          this.level.getProfiler().pop();
          this.level.getProfiler().push("jump");
-@@ -3112,9 +3105,9 @@ public abstract class LivingEntity extends Entity {
+@@ -3111,9 +3104,9 @@ public abstract class LivingEntity extends Entity {
          this.updateFallFlying();
          AABB axisalignedbb = this.getBoundingBox();
  
@@ -1571,7 +1571,7 @@ index e9e97cf0b202c84252fb3bada97890198fcc6bb9..2a65e7ae49f2fc1d56cdace60f72b729
          this.level.getProfiler().pop();
          this.level.getProfiler().push("freezing");
          boolean flag1 = this.getType().is(EntityTypeTags.FREEZE_HURTS_EXTRA_TYPES);
-@@ -3143,9 +3136,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3142,9 +3135,7 @@ public abstract class LivingEntity extends Entity {
              this.checkAutoSpinAttack(axisalignedbb, this.getBoundingBox());
          }
  
@@ -2145,10 +2145,10 @@ index 8cb510615bc8b4638b4aadfd9732c9a3d65b1fac..e0ba1608d83c6007717df3323b916a92
       * This helper class represents the different NBT Tags.
       * <p>
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396ffddc2f3 100644
+index a7675df12d509ae0ff585566b395165f55f8a8cf..38cf408899cef72bc9d2888109a7ac7ce0aec638 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -28,7 +28,7 @@ import net.minecraft.world.entity.projectile.ThrownTrident;
+@@ -27,7 +27,7 @@ import net.minecraft.world.entity.projectile.ThrownTrident;
  import net.minecraft.world.entity.raid.Raider;
  import net.minecraft.world.level.Level;
  import net.minecraft.world.phys.AABB;
@@ -2157,7 +2157,7 @@ index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396
  
  public class ActivationRange
  {
-@@ -72,8 +72,8 @@ public class ActivationRange
+@@ -71,8 +71,8 @@ public class ActivationRange
      /**
       * These entities are excluded from Activation range checks.
       *
@@ -2168,7 +2168,7 @@ index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396
       * @return boolean If it should always tick.
       */
      public static boolean initializeEntityActivationState(Entity entity, SpigotWorldConfig config)
-@@ -108,7 +108,7 @@ public class ActivationRange
+@@ -107,7 +107,7 @@ public class ActivationRange
       */
      public static void activateEntities(Level world)
      {
@@ -2177,7 +2177,7 @@ index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396
          final int miscActivationRange = world.spigotConfig.miscActivationRange;
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
-@@ -131,7 +131,7 @@ public class ActivationRange
+@@ -134,7 +134,7 @@ public class ActivationRange
  
              world.getEntities().get(maxBB, ActivationRange::activateEntity);
          }
@@ -2186,7 +2186,7 @@ index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396
      }
  
      /**
-@@ -226,10 +226,8 @@ public class ActivationRange
+@@ -229,10 +229,8 @@ public class ActivationRange
       */
      public static boolean checkIfActive(Entity entity)
      {
@@ -2197,7 +2197,7 @@ index 67f4ebf30d752fdc595fc847d695d8dad0e805d8..af66bb6b3733eaf722838de8b9f45396
              return true;
          }
  
-@@ -253,7 +251,6 @@ public class ActivationRange
+@@ -256,7 +254,6 @@ public class ActivationRange
          {
              isActive = false;
          }

--- a/patches/server/0031-Always-tick-falling-blocks.patch
+++ b/patches/server/0031-Always-tick-falling-blocks.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Always tick falling blocks
 
 
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index af66bb6b3733eaf722838de8b9f45396ffddc2f3..c3b7b1bc978eb0d40587682795e86b82981aed82 100644
+index 38cf408899cef72bc9d2888109a7ac7ce0aec638..07e5ece37af6b02210920ce6cc31738274d447a9 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -90,6 +90,7 @@ public class ActivationRange
+@@ -89,6 +89,7 @@ public class ActivationRange
                  || entity instanceof AbstractHurtingProjectile
                  || entity instanceof LightningBolt
                  || entity instanceof PrimedTnt

--- a/patches/server/0033-Fix-lag-from-explosions-processing-dead-entities.patch
+++ b/patches/server/0033-Fix-lag-from-explosions-processing-dead-entities.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix lag from explosions processing dead entities
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index a0e364c3f6d5c513c8b37de60ced9ef6433b6cda..996e02be9f3150ba125d52e3d544599c2b8dd968 100644
+index d2060ba62bebafce409e5ac64868abc5a5f98bcc..047864651dfbf009b66706e5cb0dd3d1749424bc 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -207,7 +207,7 @@ public class Explosion {
+@@ -208,7 +208,7 @@ public class Explosion {
          int i1 = Mth.floor(this.y + (double) f2 + 1.0D);
          int j1 = Mth.floor(this.z - (double) f2 - 1.0D);
          int k1 = Mth.floor(this.z + (double) f2 + 1.0D);

--- a/patches/server/0034-Optimize-explosions.patch
+++ b/patches/server/0034-Optimize-explosions.patch
@@ -37,10 +37,10 @@ index b86ceda8f7376334987955095234bdecec5af414..9d6daeba112e68c64c2b5d7d0c771776
  
          this.profiler.popPush("connection");
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 996e02be9f3150ba125d52e3d544599c2b8dd968..688ebb68209beb4550293f72b1fa7b39852be453 100644
+index 047864651dfbf009b66706e5cb0dd3d1749424bc..a901ce351c484820a8ca95889125e561023d9b31 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -226,7 +226,7 @@ public class Explosion {
+@@ -227,7 +227,7 @@ public class Explosion {
                          d8 /= d11;
                          d9 /= d11;
                          d10 /= d11;
@@ -49,7 +49,7 @@ index 996e02be9f3150ba125d52e3d544599c2b8dd968..688ebb68209beb4550293f72b1fa7b39
                          double d13 = (1.0D - d7) * d12;
  
                          // CraftBukkit start
-@@ -444,4 +444,84 @@ public class Explosion {
+@@ -465,4 +465,84 @@ public class Explosion {
  
          private BlockInteraction() {}
      }
@@ -135,7 +135,7 @@ index 996e02be9f3150ba125d52e3d544599c2b8dd968..688ebb68209beb4550293f72b1fa7b39
 +    // Paper end
  }
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index 8a2d18524e089cdc07125e424b37f1b629e591a6..4c049a41035824a9affdf25495a658a0c58dcd75 100644
+index cb115128ac988dc4b58f452532644dd8fcf37d4c..16f212b4005469dc99fdd83ed6e5810a5b6f8abf 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -156,6 +156,7 @@ public abstract class Level implements LevelAccessor, AutoCloseable {

--- a/patches/server/0035-Disable-explosion-knockback.patch
+++ b/patches/server/0035-Disable-explosion-knockback.patch
@@ -19,10 +19,10 @@ index 2b0a75dc2e292e655ca3300f64bc1211b3adeceb..5cae4a5caf9aba8c0e99f1cb6badc5e8
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 906c23068d1f5be76a6985b7255f6f155335b673..deef28110441cd2965c6b531bc255ee2aa994ace 100644
+index 46b40b08916369f8aa8b28144f07c48741c45101..7365ff9a52ddc302a68002a48c60ce526fcd547b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1375,6 +1375,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1374,6 +1374,7 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  
@@ -30,7 +30,7 @@ index 906c23068d1f5be76a6985b7255f6f155335b673..deef28110441cd2965c6b531bc255ee2
              if (flag1) {
                  if (flag) {
                      this.level.broadcastEntityEvent(this, (byte) 29);
-@@ -1395,6 +1396,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1394,6 +1395,7 @@ public abstract class LivingEntity extends Entity {
                          b0 = 2;
                      }
  
@@ -38,7 +38,7 @@ index 906c23068d1f5be76a6985b7255f6f155335b673..deef28110441cd2965c6b531bc255ee2
                      this.level.broadcastEntityEvent(this, b0);
                  }
  
-@@ -1418,6 +1420,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1417,6 +1419,7 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  
@@ -47,10 +47,10 @@ index 906c23068d1f5be76a6985b7255f6f155335b673..deef28110441cd2965c6b531bc255ee2
                  if (!this.checkTotemDeathProtection(source)) {
                      SoundEvent soundeffect = this.getDeathSound();
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 688ebb68209beb4550293f72b1fa7b39852be453..32c8403d6a5f5fbd52679b12b07936147744b8a4 100644
+index a901ce351c484820a8ca95889125e561023d9b31..09f17a7f4f78b09a44a6486923060623478a2b5e 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -241,14 +241,14 @@ public class Explosion {
+@@ -262,14 +262,14 @@ public class Explosion {
                          double d14 = d13;
  
                          if (entity instanceof LivingEntity) {

--- a/patches/server/0068-Custom-replacement-for-eaten-items.patch
+++ b/patches/server/0068-Custom-replacement-for-eaten-items.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Custom replacement for eaten items
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 09cea6b92aa8a0b60716163b7bda61823268bed7..76da306041b61f6c93e6f58f580054af7dfc234e 100644
+index c4bfeffbfefcb77c7727cb8466eb20c8ca0f2956..cb611587ad1b929627576a330e398d980595c48a 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3564,9 +3564,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3563,9 +3563,10 @@ public abstract class LivingEntity extends Entity {
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
@@ -20,7 +20,7 @@ index 09cea6b92aa8a0b60716163b7bda61823268bed7..76da306041b61f6c93e6f58f580054af
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {
-@@ -3580,6 +3581,13 @@ public abstract class LivingEntity extends Entity {
+@@ -3579,6 +3580,13 @@ public abstract class LivingEntity extends Entity {
                      } else {
                          itemstack = this.useItem.finishUsingItem(this.level, this);
                      }
@@ -34,7 +34,7 @@ index 09cea6b92aa8a0b60716163b7bda61823268bed7..76da306041b61f6c93e6f58f580054af
                      // CraftBukkit end
  
                      if (itemstack != this.useItem) {
-@@ -3587,6 +3595,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3586,6 +3594,11 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
+++ b/patches/server/0069-handle-NaN-health-absorb-values-and-repair-bad-data.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] handle NaN health/absorb values and repair bad data
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 76da306041b61f6c93e6f58f580054af7dfc234e..2277b06e3e13a1abb469064d5b23495a464fd7c0 100644
+index cb611587ad1b929627576a330e398d980595c48a..a1137e8602a2d2670df4ddff01d7aee5d3599991 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -759,7 +759,13 @@ public abstract class LivingEntity extends Entity {
@@ -34,7 +34,7 @@ index 76da306041b61f6c93e6f58f580054af7dfc234e..2277b06e3e13a1abb469064d5b23495a
          // CraftBukkit start - Handle scaled health
          if (this instanceof ServerPlayer) {
              org.bukkit.craftbukkit.entity.CraftPlayer player = ((ServerPlayer) this).getBukkitEntity();
-@@ -3398,7 +3408,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3397,7 +3407,7 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void setAbsorptionAmount(float amount) {
@@ -44,7 +44,7 @@ index 76da306041b61f6c93e6f58f580054af7dfc234e..2277b06e3e13a1abb469064d5b23495a
          }
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 339e36932e2e5ef13a9123322f2d4a0d43e0d030..da201f9f65760aa6b1d94b5bc078e26863545526 100644
+index 4cb1cd3bd5905735daab669206d51ebcdecaea10..6ca282bd204d3dbc4a63860f8603693fc2615f68 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 @@ -1778,6 +1778,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {

--- a/patches/server/0100-Fix-Old-Sign-Conversion.patch
+++ b/patches/server/0100-Fix-Old-Sign-Conversion.patch
@@ -9,7 +9,7 @@ Subject: [PATCH] Fix Old Sign Conversion
    This causes Igloos and such to render broken signs. We fix this by ignoring sign conversion for Defined Structures
 
 diff --git a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
-index 52b4c231faa2f33f766f50399e52e30184fb01a7..67315a86e5db51029d0f355c6dc223e93e4141db 100644
+index 14ac3c7b47525b7fd0345d817c9020b5a59d2ebc..1e416b23a38458f16add472cea09b0ac5ac91869 100644
 --- a/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 +++ b/src/main/java/net/minecraft/world/level/block/entity/BlockEntity.java
 @@ -33,6 +33,7 @@ public abstract class BlockEntity implements io.papermc.paper.util.KeyedObject {
@@ -34,10 +34,10 @@ index e390cfea5bed64284a97c88a717503f07f073a30..3a2e2adeefe73981b443216724270023
                  continue;
              }
 diff --git a/src/main/java/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java b/src/main/java/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java
-index 06b981d4c6b764d9298adb75ee9944e24a9ba195..2314d858fab555c8cafba6b7c2e8302961c77666 100644
+index 2aaa7bb03ab200a5df1ae1aab7b81ac8ce85d64c..ef8dd3fa4f7ac8f85ae508999264850659bf9606 100644
 --- a/src/main/java/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java
 +++ b/src/main/java/net/minecraft/world/level/levelgen/structure/templatesystem/StructureTemplate.java
-@@ -275,7 +275,9 @@ public class StructureTemplate {
+@@ -284,7 +284,9 @@ public class StructureTemplate {
                                          definedstructure_blockinfo.nbt.putLong("LootTableSeed", random.nextLong());
                                      }
  

--- a/patches/server/0109-Add-EntityZapEvent.patch
+++ b/patches/server/0109-Add-EntityZapEvent.patch
@@ -28,10 +28,10 @@ index e2ac5290751b8c219add3823251e0131c0d2b52e..8785a112519de49e0d61eab5ab5325f9
              entitywitch.finalizeSpawn(world, world.getCurrentDifficultyAt(entitywitch.blockPosition()), MobSpawnType.CONVERSION, (SpawnGroupData) null, (CompoundTag) null);
              entitywitch.setNoAi(this.isNoAi());
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 4da8af129b8c4f61617348b292166b9b1e300ac8..e65ea3fc9c95e50d787474340019fbdaf0c115f3 100644
+index 1e8c5b0194e1ba2f9a0f85dcaf6a3bcb632f6cbf..748989e26e57ab7606a355180a06e17e525df706 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1121,6 +1121,14 @@ public class CraftEventFactory {
+@@ -1133,6 +1133,14 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
+++ b/patches/server/0113-Add-source-to-PlayerExpChangeEvent.patch
@@ -18,10 +18,10 @@ index 687904d3e1b3ee7b514c707d9b2eeccabbf56603..f7cbe6819b8c4f7eaca2389de8eaceb5
  
                  --this.count;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 918ea9531e5cb37cc60ad00f78a1b4d31037704f..db16f9d4b65e64ead6728056e2528ea184c672db 100644
+index 748989e26e57ab7606a355180a06e17e525df706..a16bc51215be1f3342bb2f47e203eb01359f294c 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1080,6 +1080,17 @@ public class CraftEventFactory {
+@@ -1092,6 +1092,17 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0115-Add-ProjectileCollideEvent.patch
+++ b/patches/server/0115-Add-ProjectileCollideEvent.patch
@@ -87,10 +87,10 @@ index 88181c59e604ba3b132b9e695cef5eaf5b836029..94d09b05737679b133ec462815b010b1
  
          this.checkInsideBlocks();
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index db16f9d4b65e64ead6728056e2528ea184c672db..b370bbad550d6efda1fe391fb5d093a99f2a5532 100644
+index a16bc51215be1f3342bb2f47e203eb01359f294c..2b641a47f81c49dedc915d55dd43b7415f310582 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1224,6 +1224,16 @@ public class CraftEventFactory {
+@@ -1236,6 +1236,16 @@ public class CraftEventFactory {
          return CraftItemStack.asNMSCopy(bitem);
      }
  

--- a/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
+++ b/patches/server/0129-ExperienceOrbs-API-for-Reason-Source-Triggering-play.patch
@@ -129,10 +129,10 @@ index f7cbe6819b8c4f7eaca2389de8eaceb50bce4b15..90692df7e02346d4ba785d2eaf724d06
  
      @Override
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 30c47f64e938ccf90a68af421898fee99081f916..36aef3dbfe407ca6fa206bc3fc4390e5c2770aa3 100644
+index e0f3687f3ca7af59ee305cf167f829300bbb6fb1..11244493242b04209c67b3a41814687b1d64cdf7 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1699,7 +1699,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1698,7 +1698,8 @@ public abstract class LivingEntity extends Entity {
      protected void dropExperience() {
          // CraftBukkit start - Update getExpReward() above if the removed if() changes!
          if (true) {
@@ -230,7 +230,7 @@ index 9001d627060b9691b703b4c0e157124b0cdee6bb..1101989e93758294c1adebbef0ab12a3
  
      }
 diff --git a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
-index 54bd343def9f1ebc987640c5d756db906593f320..abab779379e60d4b775f7b39cc46943e91c8749c 100644
+index 4afc7ee0761733bbde66e6eed9c6964ddad783a0..0c21dbb304a31441f67ed4b008a145c1868da32c 100644
 --- a/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/src/main/java/net/minecraft/world/entity/projectile/FishingHook.java
 @@ -515,7 +515,7 @@ public class FishingHook extends Projectile {

--- a/patches/server/0130-Cap-Entity-Collisions.patch
+++ b/patches/server/0130-Cap-Entity-Collisions.patch
@@ -27,7 +27,7 @@ index f383f30b9dd1a7c6cf69d342f99118beec70b206..47b717e8741bb2b8f3aa776dcdc73a3e
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index b1d86df7002d6f6398288bc24c0d92a6349e0dcb..d6e1860772724347d62fb6990304ec8f4cde4035 100644
+index 1deb8dd7cbf0486225bf0efbd92fe871d933bec2..d7fcf267853114ff3ca0b4ab784649f3166031e1 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -308,6 +308,7 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -39,10 +39,10 @@ index b1d86df7002d6f6398288bc24c0d92a6349e0dcb..d6e1860772724347d62fb6990304ec8f
      private org.bukkit.util.Vector origin;
      @javax.annotation.Nullable
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 36aef3dbfe407ca6fa206bc3fc4390e5c2770aa3..e0fe53045da81fc9b2eac3b215d641cf0c722895 100644
+index 11244493242b04209c67b3a41814687b1d64cdf7..ab95fd2a0a274f7f838ddcf28b84aee5d5df8d72 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3227,8 +3227,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3226,8 +3226,11 @@ public abstract class LivingEntity extends Entity {
                  }
              }
  

--- a/patches/server/0144-Shoulder-Entities-Release-API.patch
+++ b/patches/server/0144-Shoulder-Entities-Release-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Shoulder Entities Release API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 84252d88469d045a776d1e51b05991463971f64d..cf799d47e905312a07f0cba9d3d60776681462cc 100644
+index 51666c237abda8cce63997a655f4f621dd50ccca..3e007cb4cfef94af14800c47b3f19496c504eca8 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1949,20 +1949,44 @@ public abstract class Player extends LivingEntity {
+@@ -1948,20 +1948,44 @@ public abstract class Player extends LivingEntity {
  
      }
  

--- a/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
+++ b/patches/server/0163-Send-attack-SoundEffects-only-to-players-who-can-see.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Send attack SoundEffects only to players who can see the
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230e9402da4 100644
+index 3e007cb4cfef94af14800c47b3f19496c504eca8..396c5040d5fc2b2d0955f2ffcf60deed29b710fc 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -30,6 +30,7 @@ import net.minecraft.network.chat.MutableComponent;
@@ -17,7 +17,7 @@ index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230
  import net.minecraft.network.syncher.EntityDataAccessor;
  import net.minecraft.network.syncher.EntityDataSerializers;
  import net.minecraft.network.syncher.SynchedEntityData;
-@@ -1179,7 +1180,7 @@ public abstract class Player extends LivingEntity {
+@@ -1178,7 +1179,7 @@ public abstract class Player extends LivingEntity {
                      int i = b0 + EnchantmentHelper.getKnockbackBonus(this);
  
                      if (this.isSprinting() && flag) {
@@ -26,7 +26,7 @@ index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230
                          ++i;
                          flag1 = true;
                      }
-@@ -1254,7 +1255,7 @@ public abstract class Player extends LivingEntity {
+@@ -1253,7 +1254,7 @@ public abstract class Player extends LivingEntity {
                                  }
                              }
  
@@ -35,7 +35,7 @@ index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230
                              this.sweepAttack();
                          }
  
-@@ -1282,15 +1283,15 @@ public abstract class Player extends LivingEntity {
+@@ -1281,15 +1282,15 @@ public abstract class Player extends LivingEntity {
                          }
  
                          if (flag2) {
@@ -54,7 +54,7 @@ index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230
                              }
                          }
  
-@@ -1342,7 +1343,7 @@ public abstract class Player extends LivingEntity {
+@@ -1341,7 +1342,7 @@ public abstract class Player extends LivingEntity {
  
                          this.causeFoodExhaustion(level.spigotConfig.combatExhaustion, EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value
                      } else {
@@ -63,7 +63,7 @@ index cf799d47e905312a07f0cba9d3d60776681462cc..801f59957524fb8dd7c45008a2810230
                          if (flag4) {
                              target.clearFire();
                          }
-@@ -1789,6 +1790,14 @@ public abstract class Player extends LivingEntity {
+@@ -1788,6 +1789,14 @@ public abstract class Player extends LivingEntity {
      public int getXpNeededForNextLevel() {
          return this.experienceLevel >= 30 ? 112 + (this.experienceLevel - 30) * 9 : (this.experienceLevel >= 15 ? 37 + (this.experienceLevel - 15) * 5 : 7 + this.experienceLevel * 2);
      }

--- a/patches/server/0164-Add-PlayerArmorChangeEvent.patch
+++ b/patches/server/0164-Add-PlayerArmorChangeEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add PlayerArmorChangeEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e0fe53045da81fc9b2eac3b215d641cf0c722895..1bc502eb058685f97d12a859fb8b189eabdf952f 100644
+index ab95fd2a0a274f7f838ddcf28b84aee5d5df8d72..9319c33e21ac28aecc5171fc3fcc77d46e1d4b18 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1,5 +1,6 @@
@@ -15,7 +15,7 @@ index e0fe53045da81fc9b2eac3b215d641cf0c722895..1bc502eb058685f97d12a859fb8b189e
  import com.google.common.base.Objects;
  import com.google.common.collect.ImmutableList;
  import com.google.common.collect.ImmutableMap;
-@@ -2940,6 +2941,13 @@ public abstract class LivingEntity extends Entity {
+@@ -2939,6 +2940,13 @@ public abstract class LivingEntity extends Entity {
              ItemStack itemstack1 = this.getItemBySlot(enumitemslot);
  
              if (!ItemStack.matches(itemstack1, itemstack)) {

--- a/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
+++ b/patches/server/0180-Toggleable-player-crits-helps-mitigate-hacked-client.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Toggleable player crits, helps mitigate hacked clients.
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 9884d11cef96630dbb1f2b82bc02bcb5cebcd91b..a60d3d62f7db7e91ba377fef6c28f4bde730f24a 100644
+index 99d09ff7e9eea776f8c78eda3e89a9613a722172..3bb339658d3253b1cbdcfb789ef234f37f8e0888 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -238,6 +238,11 @@ public class PaperWorldConfig {
@@ -21,10 +21,10 @@ index 9884d11cef96630dbb1f2b82bc02bcb5cebcd91b..a60d3d62f7db7e91ba377fef6c28f4bd
      private void allChunksAreSlimeChunks() {
          allChunksAreSlimeChunks = getBoolean("all-chunks-are-slime-chunks", false);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 801f59957524fb8dd7c45008a2810230e9402da4..a4bf57db506c5f94a76fd716499ad725aec80c19 100644
+index 396c5040d5fc2b2d0955f2ffcf60deed29b710fc..7324f94c96dc9eb0a06b6475c26c0fcf74713895 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1187,6 +1187,7 @@ public abstract class Player extends LivingEntity {
+@@ -1186,6 +1186,7 @@ public abstract class Player extends LivingEntity {
  
                      boolean flag2 = flag && this.fallDistance > 0.0F && !this.onGround && !this.onClimbable() && !this.isInWater() && !this.hasEffect(MobEffects.BLINDNESS) && !this.isPassenger() && target instanceof LivingEntity;
  

--- a/patches/server/0192-Configurable-sprint-interruption-on-attack.patch
+++ b/patches/server/0192-Configurable-sprint-interruption-on-attack.patch
@@ -6,7 +6,7 @@ Subject: [PATCH] Configurable sprint interruption on attack
 If the sprint interruption is disabled players continue sprinting when they attack entities.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index a60d3d62f7db7e91ba377fef6c28f4bde730f24a..861f9d6a42dbcc5a96c24b29b4bb80a450a69665 100644
+index 3bb339658d3253b1cbdcfb789ef234f37f8e0888..a9706dcb41a05fa69b5f7fa939d9fe02f6bfacd8 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -393,4 +393,9 @@ public class PaperWorldConfig {
@@ -20,10 +20,10 @@ index a60d3d62f7db7e91ba377fef6c28f4bde730f24a..861f9d6a42dbcc5a96c24b29b4bb80a4
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index a4bf57db506c5f94a76fd716499ad725aec80c19..935ea41483ff696dcc9a3b988bb75ade74b801a8 100644
+index 7324f94c96dc9eb0a06b6475c26c0fcf74713895..4a5488a252bb885842f37cc5e98121e1e1713033 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1236,7 +1236,11 @@ public abstract class Player extends LivingEntity {
+@@ -1235,7 +1235,11 @@ public abstract class Player extends LivingEntity {
                              }
  
                              this.setDeltaMovement(this.getDeltaMovement().multiply(0.6D, 1.0D, 0.6D));

--- a/patches/server/0210-Make-shield-blocking-delay-configurable.patch
+++ b/patches/server/0210-Make-shield-blocking-delay-configurable.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Make shield blocking delay configurable
 
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index d74c86f401c0161ac139f0dfd789d03bc616fe3b..97ad6c164281df845b3789e68287157c2a3d8ee8 100644
+index 8fc56818a2ba1aed73b8dda4da04ecac748c6ae6..1e9ffb5bc5c9d74c07be14435eb29ef998943814 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 @@ -404,4 +404,9 @@ public class PaperWorldConfig {
@@ -19,10 +19,10 @@ index d74c86f401c0161ac139f0dfd789d03bc616fe3b..97ad6c164281df845b3789e68287157c
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1bc502eb058685f97d12a859fb8b189eabdf952f..e0d958b2e23e1128b09a27c32836aa3fd012c49d 100644
+index 9319c33e21ac28aecc5171fc3fcc77d46e1d4b18..8abdc2807abe27c31c1f2c7316dad6c8457efbc4 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3670,12 +3670,24 @@ public abstract class LivingEntity extends Entity {
+@@ -3669,12 +3669,24 @@ public abstract class LivingEntity extends Entity {
          if (this.isUsingItem() && !this.useItem.isEmpty()) {
              Item item = this.useItem.getItem();
  

--- a/patches/server/0212-PlayerReadyArrowEvent.patch
+++ b/patches/server/0212-PlayerReadyArrowEvent.patch
@@ -7,10 +7,10 @@ Called when a player is firing a bow and the server is choosing an arrow to use.
 Plugins can skip selection of certain arrows and control which is used.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 935ea41483ff696dcc9a3b988bb75ade74b801a8..e6960d0504cda461e03c1cfaa8e146d473c640ee 100644
+index 4a5488a252bb885842f37cc5e98121e1e1713033..bfd454dfd450e5f9cb0e496ae654562169856de2 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -2182,6 +2182,17 @@ public abstract class Player extends LivingEntity {
+@@ -2181,6 +2181,17 @@ public abstract class Player extends LivingEntity {
          return ImmutableList.of(Pose.STANDING, Pose.CROUCHING, Pose.SWIMMING);
      }
  
@@ -28,7 +28,7 @@ index 935ea41483ff696dcc9a3b988bb75ade74b801a8..e6960d0504cda461e03c1cfaa8e146d4
      @Override
      public ItemStack getProjectile(ItemStack stack) {
          if (!(stack.getItem() instanceof ProjectileWeaponItem)) {
-@@ -2198,7 +2209,7 @@ public abstract class Player extends LivingEntity {
+@@ -2197,7 +2208,7 @@ public abstract class Player extends LivingEntity {
                  for (int i = 0; i < this.inventory.getContainerSize(); ++i) {
                      ItemStack itemstack2 = this.inventory.getItem(i);
  

--- a/patches/server/0213-Implement-EntityKnockbackByEntityEvent.patch
+++ b/patches/server/0213-Implement-EntityKnockbackByEntityEvent.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Implement EntityKnockbackByEntityEvent
 This event is called when an entity receives knockback by another entity.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index e0d958b2e23e1128b09a27c32836aa3fd012c49d..16936d7ce3faec09ccdde58b2bf2b6f9db0f9cd8 100644
+index 8abdc2807abe27c31c1f2c7316dad6c8457efbc4..8d6ff08f8546450a1fc746c3332bc427748cccb6 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1432,7 +1432,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1431,7 +1431,7 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.hurtDir = (float) (Mth.atan2(d1, d0) * 57.2957763671875D - (double) this.getYRot());
@@ -18,7 +18,7 @@ index e0d958b2e23e1128b09a27c32836aa3fd012c49d..16936d7ce3faec09ccdde58b2bf2b6f9
                  } else {
                      this.hurtDir = (float) ((int) (Math.random() * 2.0D) * 180);
                  }
-@@ -1480,7 +1480,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1479,7 +1479,7 @@ public abstract class LivingEntity extends Entity {
      }
  
      protected void blockedByShield(LivingEntity target) {
@@ -27,7 +27,7 @@ index e0d958b2e23e1128b09a27c32836aa3fd012c49d..16936d7ce3faec09ccdde58b2bf2b6f9
      }
  
      private boolean checkTotemDeathProtection(DamageSource source) {
-@@ -1733,6 +1733,11 @@ public abstract class LivingEntity extends Entity {
+@@ -1732,6 +1732,11 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void knockback(double strength, double x, double z) {
@@ -39,7 +39,7 @@ index e0d958b2e23e1128b09a27c32836aa3fd012c49d..16936d7ce3faec09ccdde58b2bf2b6f9
          strength *= 1.0D - this.getAttributeValue(Attributes.KNOCKBACK_RESISTANCE);
          if (strength > 0.0D) {
              this.hasImpulse = true;
-@@ -1740,6 +1745,15 @@ public abstract class LivingEntity extends Entity {
+@@ -1739,6 +1744,15 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d1 = (new Vec3(x, 0.0D, z)).normalize().scale(strength);
  
              this.setDeltaMovement(vec3d.x / 2.0D - vec3d1.x, this.onGround ? Math.min(0.4D, vec3d.y / 2.0D + strength) : vec3d.y, vec3d.z / 2.0D - vec3d1.z);
@@ -56,7 +56,7 @@ index e0d958b2e23e1128b09a27c32836aa3fd012c49d..16936d7ce3faec09ccdde58b2bf2b6f9
      }
  
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index f7223b224354fdb817497f0ea4268109e20562ac..4c2efb04ef00f638576cb1f0692e114620aaa889 100644
+index 82b8f626f8fa4a446257df4fdc41f17c612c5b74..b937ffef296beed853b47ded1672a2f408be674f 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1554,7 +1554,7 @@ public abstract class Mob extends LivingEntity {
@@ -82,10 +82,10 @@ index f6fd39823f04f8071c616d40a838b01e7159c5a1..e1cdf3ce38404d3f40be59e4cd3ad2b9
              serverLevel.playSound((Player)null, pathfinderMob, this.getImpactSound.apply(pathfinderMob), SoundSource.HOSTILE, 1.0F, 1.0F);
          } else {
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index e6960d0504cda461e03c1cfaa8e146d473c640ee..1a7f45c3faf5335efbdaf5a91ba61dc2b5e907d8 100644
+index bfd454dfd450e5f9cb0e496ae654562169856de2..e72657009686461a28d27883573ecff09a77ccee 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1230,7 +1230,7 @@ public abstract class Player extends LivingEntity {
+@@ -1229,7 +1229,7 @@ public abstract class Player extends LivingEntity {
                      if (flag5) {
                          if (i > 0) {
                              if (target instanceof LivingEntity) {
@@ -94,7 +94,7 @@ index e6960d0504cda461e03c1cfaa8e146d473c640ee..1a7f45c3faf5335efbdaf5a91ba61dc2
                              } else {
                                  target.push((double) (-Mth.sin(this.getYRot() * 0.017453292F) * (float) i * 0.5F), 0.1D, (double) (Mth.cos(this.getYRot() * 0.017453292F) * (float) i * 0.5F));
                              }
-@@ -1254,7 +1254,7 @@ public abstract class Player extends LivingEntity {
+@@ -1253,7 +1253,7 @@ public abstract class Player extends LivingEntity {
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo((Entity) entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
                                      if (entityliving.hurt(DamageSource.playerAttack(this).sweep(), f4)) {

--- a/patches/server/0219-InventoryCloseEvent-Reason-API.patch
+++ b/patches/server/0219-InventoryCloseEvent-Reason-API.patch
@@ -7,7 +7,7 @@ Allows you to determine why an inventory was closed, enabling plugin developers
 to "confirm" things based on if it was player triggered close or not.
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 377c8a43e063522478037c1368cefd71fec701cb..17eb43f6bb0a9bbc4e0abb991255b322a56f6160 100644
+index 11b0f1ef4aa02cf719e4d937c98d41b82ffca23a..9f3b3c34e625e27c9c56ccbfd244dd053c2e703f 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -1130,7 +1130,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -21,7 +21,7 @@ index 377c8a43e063522478037c1368cefd71fec701cb..17eb43f6bb0a9bbc4e0abb991255b322
          }
 @@ -2063,7 +2063,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot Start
-             if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {
+             if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message
                  for (org.bukkit.entity.HumanEntity h : Lists.newArrayList(((org.bukkit.inventory.InventoryHolder) entity.getBukkitEntity()).getInventory().getViewers())) {
 -                    h.closeInventory();
 +                    h.closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.UNLOADED); // Paper
@@ -118,7 +118,7 @@ index be65d315af3089f49d2f5c9fe59c9ec0e8d3e2f9..f2efbb954ca56040ed39937750c4a01a
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(entityplayer.getBukkitEntity(), net.kyori.adventure.text.Component.translatable("multiplayer.player.left", net.kyori.adventure.text.format.NamedTextColor.YELLOW, com.destroystokyo.paper.PaperConfig.useDisplayNameInQuit ? entityplayer.getBukkitEntity().displayName() : net.kyori.adventure.text.Component.text(entityplayer.getScoreboardName())));
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 1a7f45c3faf5335efbdaf5a91ba61dc2b5e907d8..0cd00d0b1017b2995f565ed6a871653a2644ffa1 100644
+index e72657009686461a28d27883573ecff09a77ccee..fcd66b668008a0c3be8d20f7f169b213fabe91a5 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
 @@ -262,7 +262,7 @@ public abstract class Player extends LivingEntity {
@@ -187,10 +187,10 @@ index c66767e94cb123d9286b43a115ba4fda7727337f..9495c5c41b1671fbc3930fb374efd7c7
  
          // Check if the fromWorld and toWorld are the same.
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 17757b90c440c2f181978f682ead2653ba7b7812..917d0804ff7ecb149a6c4524b2b6ecc6ae56b7e6 100644
+index 2b641a47f81c49dedc915d55dd43b7415f310582..b3a2a865f7b7346566cf84bc20d845d1ca481711 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1193,7 +1193,7 @@ public class CraftEventFactory {
+@@ -1205,7 +1205,7 @@ public class CraftEventFactory {
  
      public static AbstractContainerMenu callInventoryOpenEvent(ServerPlayer player, AbstractContainerMenu container, boolean cancelled) {
          if (player.containerMenu != player.inventoryMenu) { // fire INVENTORY_CLOSE if one already open
@@ -199,7 +199,7 @@ index 17757b90c440c2f181978f682ead2653ba7b7812..917d0804ff7ecb149a6c4524b2b6ecc6
          }
  
          CraftServer server = player.level.getCraftServer();
-@@ -1359,8 +1359,18 @@ public class CraftEventFactory {
+@@ -1371,8 +1371,18 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0231-Vanished-players-don-t-have-rights.patch
+++ b/patches/server/0231-Vanished-players-don-t-have-rights.patch
@@ -38,7 +38,7 @@ index c3fb7d41688855010c643b91c8d9496486dae089..8175bb6331727440da2232998bdad068
  
          BlockCanBuildEvent event = new BlockCanBuildEvent(CraftBlock.at(context.getLevel(), context.getClickedPos()), player, CraftBlockData.fromData(state), defaultReturn);
 diff --git a/src/main/java/net/minecraft/world/level/Level.java b/src/main/java/net/minecraft/world/level/Level.java
-index aba12f5a941fb07a2f4dd54af8f0a4310488ac78..aa8bbf6435c19013e3ccaa963118d71200b6efea 100644
+index b91b2c2336b40c2332e59c3f24e36ca6083ce3bd..c239a71a9d864107c3a8e9537e4160c50b3a76c9 100644
 --- a/src/main/java/net/minecraft/world/level/Level.java
 +++ b/src/main/java/net/minecraft/world/level/Level.java
 @@ -72,6 +72,10 @@ import net.minecraft.world.level.saveddata.maps.MapItemSavedData;
@@ -99,10 +99,10 @@ index aba12f5a941fb07a2f4dd54af8f0a4310488ac78..aa8bbf6435c19013e3ccaa963118d712
      public boolean isClientSide() {
          return this.isClientSide;
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 8e0b6910c97789b4d03ae62723dceb962487fc5a..4faf98079a6a6af662e11050a0088578ba65a5eb 100644
+index b3a2a865f7b7346566cf84bc20d845d1ca481711..3cc200e2d83543d24c40e36d23f29e2b9888fea4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1229,6 +1229,14 @@ public class CraftEventFactory {
+@@ -1241,6 +1241,14 @@ public class CraftEventFactory {
          Projectile projectile = (Projectile) entity.getBukkitEntity();
          org.bukkit.entity.Entity collided = position.getEntity().getBukkitEntity();
          com.destroystokyo.paper.event.entity.ProjectileCollideEvent event = new com.destroystokyo.paper.event.entity.ProjectileCollideEvent(projectile, collided);

--- a/patches/server/0258-Add-ray-tracing-methods-to-LivingEntity.patch
+++ b/patches/server/0258-Add-ray-tracing-methods-to-LivingEntity.patch
@@ -28,10 +28,10 @@ index 0cf818fceddd76e7704fdc6625456787856b2815..ccdee183f02ab55723e16f41efce55dc
          switch (enumDirection) {
              case DOWN:
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 16936d7ce3faec09ccdde58b2bf2b6f9db0f9cd8..cf4640f1e38f3e50b3a85692e032a78b4102d31e 100644
+index 8d6ff08f8546450a1fc746c3332bc427748cccb6..3582f2ebec124e0d56e478228946e2b7f6c7618b 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3691,6 +3691,23 @@ public abstract class LivingEntity extends Entity {
+@@ -3690,6 +3690,23 @@ public abstract class LivingEntity extends Entity {
      }
  
      // Paper start

--- a/patches/server/0260-Improve-death-events.patch
+++ b/patches/server/0260-Improve-death-events.patch
@@ -70,7 +70,7 @@ index fd1937f49312204d38510996a5be43b731f38bde..a2e2b6ea166bf64fe5b49672a6c6f86a
          }
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d23941f6d2 100644
+index 3582f2ebec124e0d56e478228946e2b7f6c7618b..78b7b24c9f3ecef248bf45f4ae3624394d9b41a2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -258,6 +258,7 @@ public abstract class LivingEntity extends Entity {
@@ -81,7 +81,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
  
      @Override
      public float getBukkitYaw() {
-@@ -1441,13 +1442,12 @@ public abstract class LivingEntity extends Entity {
+@@ -1440,13 +1441,12 @@ public abstract class LivingEntity extends Entity {
              if (knockbackCancelled) this.level.broadcastEntityEvent(this, (byte) 2); // Paper - Disable explosion knockback
              if (this.isDeadOrDying()) {
                  if (!this.checkTotemDeathProtection(source)) {
@@ -99,7 +99,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
                  }
              } else if (flag1) {
                  this.playHurtSound(source);
-@@ -1596,7 +1596,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1595,7 +1595,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.isRemoved() && !this.dead) {
              Entity entity = source.getEntity();
              LivingEntity entityliving = this.getKillCredit();
@@ -108,7 +108,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
              if (this.deathScore >= 0 && entityliving != null) {
                  entityliving.awardKillScore(this, this.deathScore, source);
              }
-@@ -1608,20 +1608,52 @@ public abstract class LivingEntity extends Entity {
+@@ -1607,20 +1607,52 @@ public abstract class LivingEntity extends Entity {
              if (!this.level.isClientSide && this.hasCustomName()) {
                  if (org.spigotmc.SpigotConfig.logNamedDeaths) LivingEntity.LOGGER.info("Named entity {} died: {}", this, this.getCombatTracker().getDeathMessage().getString()); // Spigot
              }
@@ -164,7 +164,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
          }
      }
  
-@@ -1629,7 +1661,7 @@ public abstract class LivingEntity extends Entity {
+@@ -1628,7 +1660,7 @@ public abstract class LivingEntity extends Entity {
          if (!this.level.isClientSide) {
              boolean flag = false;
  
@@ -173,7 +173,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
                  if (this.level.getGameRules().getBoolean(GameRules.RULE_MOBGRIEFING)) {
                      BlockPos blockposition = this.blockPosition();
                      BlockState iblockdata = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -1658,7 +1690,8 @@ public abstract class LivingEntity extends Entity {
+@@ -1657,7 +1689,8 @@ public abstract class LivingEntity extends Entity {
          }
      }
  
@@ -183,7 +183,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
          Entity entity = source.getEntity();
          int i;
  
-@@ -1673,18 +1706,23 @@ public abstract class LivingEntity extends Entity {
+@@ -1672,18 +1705,23 @@ public abstract class LivingEntity extends Entity {
          this.dropEquipment(); // CraftBukkit - from below
          if (this.shouldDropLoot() && this.level.getGameRules().getBoolean(GameRules.RULE_DOMOBLOOT)) {
              this.dropFromLootTable(source, flag);
@@ -209,7 +209,7 @@ index cf4640f1e38f3e50b3a85692e032a78b4102d31e..28ec62fd75abc04d4dc22204bfd999d2
      // CraftBukkit start
      public int getExpReward() {
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 4c2efb04ef00f638576cb1f0692e114620aaa889..95058ddac0dd75f84781227cc1061bcc325954e9 100644
+index b937ffef296beed853b47ded1672a2f408be674f..426b3afc7ba5229339f820062f17c1a0775a0df6 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1002,7 +1002,9 @@ public abstract class Mob extends LivingEntity {
@@ -315,7 +315,7 @@ index e216c9a84efdf3f3eb7145d6136dbe8d92c0dcc3..08093c890141fa146da00c413bd3509e
  
      public void injectScaledMaxHealth(Collection<AttributeInstance> collection, boolean force) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 47b125ba8924d25e97e34611bed3be819d9e1814..b4032ce470346915251d85d1aa7375a116efe771 100644
+index 483d841e5a0cb52f96f23c18c3bccc9e58439240..8752f8ac5fdbab6184fc2718876c6e3a8f319391 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -807,9 +807,16 @@ public class CraftEventFactory {

--- a/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
+++ b/patches/server/0273-Add-LivingEntity-getTargetEntity.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add LivingEntity#getTargetEntity
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 28ec62fd75abc04d4dc22204bfd999d23941f6d2..fdf759ee33b591ffce5385c424df7879a4e0a85f 100644
+index 78b7b24c9f3ecef248bf45f4ae3624394d9b41a2..0d4a1105345a56022fe92ca5077112fb96fed2fe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -113,6 +113,7 @@ import net.minecraft.world.level.storage.loot.LootTable;
@@ -16,7 +16,7 @@ index 28ec62fd75abc04d4dc22204bfd999d23941f6d2..fdf759ee33b591ffce5385c424df7879
  import net.minecraft.world.phys.HitResult;
  import net.minecraft.world.phys.Vec3;
  import net.minecraft.world.scores.PlayerTeam;
-@@ -3746,6 +3747,38 @@ public abstract class LivingEntity extends Entity {
+@@ -3745,6 +3746,38 @@ public abstract class LivingEntity extends Entity {
          return level.clip(raytrace);
      }
  

--- a/patches/server/0293-force-entity-dismount-during-teleportation.patch
+++ b/patches/server/0293-force-entity-dismount-during-teleportation.patch
@@ -41,7 +41,7 @@ index db7f2715534ed71a2b285de095238586fe6a35b0..f51c416e7938b7905f7efb154ab14cad
  
          if (entity1 != entity && this.connection != null) {
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 1ca2b4d0d0cd87c5b2eb7b490032f317e760bce2..f015b1990a509071b6154a9eb7405fa2cbacb111 100644
+index 37e5ef6b564ace0ae79c49f6474f2ce9fa21dd23..83698cbbe44405e80b787df6cd7a2921377e9bf7 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2238,11 +2238,16 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -93,10 +93,10 @@ index 1ca2b4d0d0cd87c5b2eb7b490032f317e760bce2..f015b1990a509071b6154a9eb7405fa2
              if (this.valid) {
                  Bukkit.getPluginManager().callEvent(event);
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index fdf759ee33b591ffce5385c424df7879a4e0a85f..75beea5653d04555b46c4b3a2054405c6aefc421 100644
+index 0d4a1105345a56022fe92ca5077112fb96fed2fe..f1d287f1fbb725a64e6252dedd4153199d0544a3 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3345,9 +3345,15 @@ public abstract class LivingEntity extends Entity {
+@@ -3344,9 +3344,15 @@ public abstract class LivingEntity extends Entity {
  
      @Override
      public void stopRiding() {
@@ -114,10 +114,10 @@ index fdf759ee33b591ffce5385c424df7879a4e0a85f..75beea5653d04555b46c4b3a2054405c
              this.dismountVehicle(entity);
          }
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index ab78cc99d0e814577cf65353997b7095e574a139..2c46f54751c49d9adce1a8724b93f06438544129 100644
+index fcd66b668008a0c3be8d20f7f169b213fabe91a5..7bc6518dd4da041d9f59affc5447a23312790917 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1094,7 +1094,13 @@ public abstract class Player extends LivingEntity {
+@@ -1093,7 +1093,13 @@ public abstract class Player extends LivingEntity {
  
      @Override
      public void removeVehicle() {

--- a/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
+++ b/patches/server/0338-Prevent-consuming-the-wrong-itemstack.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent consuming the wrong itemstack
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 75beea5653d04555b46c4b3a2054405c6aefc421..2b2258b8cc35385b857114d0e8a958cd24fa7d26 100644
+index f1d287f1fbb725a64e6252dedd4153199d0544a3..7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3567,9 +3567,14 @@ public abstract class LivingEntity extends Entity {
+@@ -3566,9 +3566,14 @@ public abstract class LivingEntity extends Entity {
      }
  
      public void startUsingItem(InteractionHand hand) {
@@ -24,7 +24,7 @@ index 75beea5653d04555b46c4b3a2054405c6aefc421..2b2258b8cc35385b857114d0e8a958cd
              this.useItem = itemstack;
              this.useItemRemaining = itemstack.getUseDuration();
              if (!this.level.isClientSide) {
-@@ -3648,6 +3653,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3647,6 +3652,7 @@ public abstract class LivingEntity extends Entity {
                  this.releaseUsingItem();
              } else {
                  if (!this.useItem.isEmpty() && this.isUsingItem()) {
@@ -32,7 +32,7 @@ index 75beea5653d04555b46c4b3a2054405c6aefc421..2b2258b8cc35385b857114d0e8a958cd
                      this.triggerItemUseEffects(this.useItem, 16);
                      // CraftBukkit start - fire PlayerItemConsumeEvent
                      ItemStack itemstack;
-@@ -3682,8 +3688,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3681,8 +3687,8 @@ public abstract class LivingEntity extends Entity {
                      }
  
                      this.stopUsingItem();

--- a/patches/server/0353-Lag-compensate-eating.patch
+++ b/patches/server/0353-Lag-compensate-eating.patch
@@ -7,10 +7,10 @@ When the server is lagging, players will wait longer when eating.
 Change to also use a time check instead if it passes.
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c98f086c1 100644
+index 7bbb0415e8e22f3ca0d22ed21b68e963213d3e3c..7694636ff03a303151ee59d83253cfeca502eca0 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3510,6 +3510,11 @@ public abstract class LivingEntity extends Entity {
+@@ -3509,6 +3509,11 @@ public abstract class LivingEntity extends Entity {
          return ((Byte) this.entityData.get(LivingEntity.DATA_LIVING_ENTITY_FLAGS) & 2) > 0 ? InteractionHand.OFF_HAND : InteractionHand.MAIN_HAND;
      }
  
@@ -22,7 +22,7 @@ index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c
      private void updatingUsingItem() {
          if (this.isUsingItem()) {
              if (ItemStack.isSameIgnoreDurability(this.getItemInHand(this.getUsedItemHand()), this.useItem)) {
-@@ -3527,8 +3532,12 @@ public abstract class LivingEntity extends Entity {
+@@ -3526,8 +3531,12 @@ public abstract class LivingEntity extends Entity {
          if (this.shouldTriggerItemUseEffects()) {
              this.triggerItemUseEffects(stack, 5);
          }
@@ -37,7 +37,7 @@ index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c
              this.completeUsingItem();
          }
  
-@@ -3576,7 +3585,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3575,7 +3584,10 @@ public abstract class LivingEntity extends Entity {
  
          if (!itemstack.isEmpty() && !this.isUsingItem() || forceUpdate) { // Paper use override flag
              this.useItem = itemstack;
@@ -49,7 +49,7 @@ index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c
              if (!this.level.isClientSide) {
                  this.setLivingEntityFlag(1, true);
                  this.setLivingEntityFlag(2, hand == InteractionHand.OFF_HAND);
-@@ -3600,7 +3612,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3599,7 +3611,10 @@ public abstract class LivingEntity extends Entity {
                  }
              } else if (!this.isUsingItem() && !this.useItem.isEmpty()) {
                  this.useItem = ItemStack.EMPTY;
@@ -61,7 +61,7 @@ index 2b2258b8cc35385b857114d0e8a958cd24fa7d26..41495db77a242f554fc085b3ac81509c
              }
          }
  
-@@ -3728,7 +3743,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3727,7 +3742,10 @@ public abstract class LivingEntity extends Entity {
          }
  
          this.useItem = ItemStack.EMPTY;

--- a/patches/server/0354-Optimize-call-to-getFluid-for-explosions.patch
+++ b/patches/server/0354-Optimize-call-to-getFluid-for-explosions.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Optimize call to getFluid for explosions
 
 
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 32c8403d6a5f5fbd52679b12b07936147744b8a4..548f103e648d9670d7434182c6598dc29ae77b57 100644
+index 09f17a7f4f78b09a44a6486923060623478a2b5e..e2bc9e91f03997884af381b3261b102a6e0bc5cb 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -173,7 +173,7 @@ public class Explosion {
+@@ -174,7 +174,7 @@ public class Explosion {
                          for (float f1 = 0.3F; f > 0.0F; f -= 0.22500001F) {
                              BlockPos blockposition = new BlockPos(d4, d5, d6);
                              BlockState iblockdata = this.level.getBlockState(blockposition);

--- a/patches/server/0357-Entity-Activation-Range-2.0.patch
+++ b/patches/server/0357-Entity-Activation-Range-2.0.patch
@@ -14,7 +14,7 @@ Adds flying monsters to control ghast and phantoms
 Adds villagers as separate config
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index c04402666b9219d508bfd32b4f2e3faea0c9b648..daeb483b7aa0356447381aec8d92f5dfa500d5b1 100644
+index 367e074dd5f85f824b7c4f5506d0ccac60580c1b..83c5b111b98e52f52b7e4cf607aac07be7043709 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2,7 +2,6 @@ package net.minecraft.server.level;
@@ -144,7 +144,7 @@ index aa5fdc74a3b06b8d8b82b86fb4f1469ddd4c629e..ae454b12a0671f6698ff2b889988348e
              movement = this.maybeBackOffFromEdge(movement, movementType);
              Vec3 vec3d1 = this.collide(movement);
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 95058ddac0dd75f84781227cc1061bcc325954e9..77d85265eb090f61476faedbffd4ad3d2e9ae38a 100644
+index 426b3afc7ba5229339f820062f17c1a0775a0df6..e803af4d27f3f005a56696175d7ae8a51d7005a6 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -206,6 +206,19 @@ public abstract class Mob extends LivingEntity {
@@ -335,13 +335,12 @@ index 6b29f66aec8a82b367a979b5b04857416b697c14..78d252b829e5c1f19532656a72862085
                              }
                          }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbabec3f2293 100644
+index 07e5ece37af6b02210920ce6cc31738274d447a9..84880151abd193be5f02b5e9abb3fa78f2aa2cac 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -1,40 +1,52 @@
+@@ -1,39 +1,52 @@
  package org.spigotmc;
  
--import java.util.Collection;
 +import net.minecraft.core.BlockPos;
  import net.minecraft.server.MinecraftServer;
 +import net.minecraft.server.level.ServerChunkCache;
@@ -395,7 +394,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
          MONSTER,
          ANIMAL,
          RAIDER,
-@@ -42,6 +54,43 @@ public class ActivationRange
+@@ -41,6 +54,43 @@ public class ActivationRange
  
          AABB boundingBox = new AABB( 0, 0, 0, 0, 0, 0 );
      }
@@ -439,7 +438,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
  
      static AABB maxBB = new AABB( 0, 0, 0, 0, 0, 0 );
  
-@@ -54,10 +103,13 @@ public class ActivationRange
+@@ -53,10 +103,13 @@ public class ActivationRange
       */
      public static ActivationType initializeEntityActivationType(Entity entity)
      {
@@ -454,7 +453,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
          {
              return ActivationType.MONSTER;
          } else if ( entity instanceof PathfinderMob || entity instanceof AmbientCreature )
-@@ -78,10 +130,14 @@ public class ActivationRange
+@@ -77,10 +130,14 @@ public class ActivationRange
       */
      public static boolean initializeEntityActivationState(Entity entity, SpigotWorldConfig config)
      {
@@ -473,7 +472,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
                  || entity instanceof Player
                  || entity instanceof ThrowableProjectile
                  || entity instanceof EnderDragon
-@@ -114,10 +170,25 @@ public class ActivationRange
+@@ -113,10 +170,25 @@ public class ActivationRange
          final int raiderActivationRange = world.spigotConfig.raiderActivationRange;
          final int animalActivationRange = world.spigotConfig.animalActivationRange;
          final int monsterActivationRange = world.spigotConfig.monsterActivationRange;
@@ -499,7 +498,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
          maxRange = Math.min( ( world.spigotConfig.simulationDistance << 4 ) - 8, maxRange );
  
          for ( Player player : world.players() )
-@@ -129,6 +200,11 @@ public class ActivationRange
+@@ -132,6 +204,11 @@ public class ActivationRange
              ActivationType.RAIDER.boundingBox = player.getBoundingBox().inflate( raiderActivationRange, 256, raiderActivationRange );
              ActivationType.ANIMAL.boundingBox = player.getBoundingBox().inflate( animalActivationRange, 256, animalActivationRange );
              ActivationType.MONSTER.boundingBox = player.getBoundingBox().inflate( monsterActivationRange, 256, monsterActivationRange );
@@ -511,7 +510,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
  
              world.getEntities().get(maxBB, ActivationRange::activateEntity);
          }
-@@ -163,60 +239,112 @@ public class ActivationRange
+@@ -166,60 +243,112 @@ public class ActivationRange
       * @param entity
       * @return
       */
@@ -641,7 +640,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
      }
  
      /**
-@@ -231,8 +359,19 @@ public class ActivationRange
+@@ -234,8 +363,19 @@ public class ActivationRange
          if ( entity instanceof FireworkRocketEntity ) {
              return true;
          }
@@ -662,7 +661,7 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
  
          // Should this entity tick?
          if ( !isActive )
-@@ -240,15 +379,19 @@ public class ActivationRange
+@@ -243,15 +383,19 @@ public class ActivationRange
              if ( ( MinecraftServer.currentTick - entity.activatedTick - 1 ) % 20 == 0 )
              {
                  // Check immunities every 20 ticks.
@@ -688,10 +687,10 @@ index c3b7b1bc978eb0d40587682795e86b82981aed82..ec9907947b13ca3367c7ef5cb006bbab
              isActive = false;
          }
 diff --git a/src/main/java/org/spigotmc/SpigotWorldConfig.java b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-index 21e0f9b4d3e1dc6e104bffdffcc23d62a739ab3c..58aaf0d98cbd6814ecdf00f46f8ff9fc7901006c 100644
+index 7acf96f2fbf807d4621ad3cfc9d9312adb255287..bc7eaf32867f743edf1644859f7cad063e646120 100644
 --- a/src/main/java/org/spigotmc/SpigotWorldConfig.java
 +++ b/src/main/java/org/spigotmc/SpigotWorldConfig.java
-@@ -199,13 +199,59 @@ public class SpigotWorldConfig
+@@ -199,14 +199,60 @@ public class SpigotWorldConfig
      public int monsterActivationRange = 32;
      public int raiderActivationRange = 48;
      public int miscActivationRange = 16;
@@ -716,6 +715,7 @@ index 21e0f9b4d3e1dc6e104bffdffcc23d62a739ab3c..58aaf0d98cbd6814ecdf00f46f8ff9fc
 +    public boolean villagersActiveForPanic = true;
 +    // Paper end
      public boolean tickInactiveVillagers = true;
+     public boolean ignoreSpectatorActivation = false;
      private void activationRange()
      {
 +        boolean hasAnimalsConfig = config.getInt("entity-activation-range.animals", this.animalActivationRange) != this.animalActivationRange; // Paper
@@ -749,5 +749,5 @@ index 21e0f9b4d3e1dc6e104bffdffcc23d62a739ab3c..58aaf0d98cbd6814ecdf00f46f8ff9fc
 +        this.villagersActiveForPanic = this.getBoolean( "entity-activation-range.villagers-active-for-panic", this.villagersActiveForPanic );
 +        // Paper end
          this.tickInactiveVillagers = this.getBoolean( "entity-activation-range.tick-inactive-villagers", this.tickInactiveVillagers );
-         this.log( "Entity Activation Range: An " + this.animalActivationRange + " / Mo " + this.monsterActivationRange + " / Ra " + this.raiderActivationRange + " / Mi " + this.miscActivationRange + " / Tiv " + this.tickInactiveVillagers );
-     }
+         this.ignoreSpectatorActivation = this.getBoolean( "entity-activation-range.ignore-spectators", this.ignoreSpectatorActivation );
+         this.log( "Entity Activation Range: An " + this.animalActivationRange + " / Mo " + this.monsterActivationRange + " / Ra " + this.raiderActivationRange + " / Mi " + this.miscActivationRange + " / Tiv " + this.tickInactiveVillagers + " / Isa " + this.ignoreSpectatorActivation );

--- a/patches/server/0371-Entity-Jump-API.patch
+++ b/patches/server/0371-Entity-Jump-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Entity Jump API
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 41495db77a242f554fc085b3ac81509c98f086c1..1b9b49caf8d0e2b77064273a4fa1975fa3d5238f 100644
+index 7694636ff03a303151ee59d83253cfeca502eca0..5fe23dc78d86f98c2952ff82f9502789d9009b8d 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3173,8 +3173,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3172,8 +3172,10 @@ public abstract class LivingEntity extends Entity {
              } else if (this.isInLava() && (!this.onGround || d7 > d8)) {
                  this.jumpInLiquid(FluidTags.LAVA);
              } else if ((this.onGround || flag && d7 <= d8) && this.noJumpDelay == 0) {

--- a/patches/server/0389-Dead-Player-s-shouldn-t-be-able-to-move.patch
+++ b/patches/server/0389-Dead-Player-s-shouldn-t-be-able-to-move.patch
@@ -7,10 +7,10 @@ This fixes a lot of game state issues where packets were delayed for processing
 due to 1.15's new queue but processed while dead.
 
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index 2c46f54751c49d9adce1a8724b93f06438544129..95b03fbdc0a5483761fce5c5542ce8f3187761c5 100644
+index 7bc6518dd4da041d9f59affc5447a23312790917..c0731e186ba23cd3d443a2d7fef65980b8d5e3a1 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1106,7 +1106,7 @@ public abstract class Player extends LivingEntity {
+@@ -1105,7 +1105,7 @@ public abstract class Player extends LivingEntity {
  
      @Override
      protected boolean isImmobile() {

--- a/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
+++ b/patches/server/0399-Don-t-run-entity-collision-code-if-not-needed.patch
@@ -7,10 +7,10 @@ Will not run if max entity craming is disabled and
 the max collisions per entity is less than or equal to 0
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 1b9b49caf8d0e2b77064273a4fa1975fa3d5238f..d5a70e9fc2a2a85d7262832687770b9693f05f41 100644
+index 5fe23dc78d86f98c2952ff82f9502789d9009b8d..415c577983e03ccd419ea8d7391be77e44e07a19 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3270,10 +3270,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3269,10 +3269,16 @@ public abstract class LivingEntity extends Entity {
      protected void serverAiStep() {}
  
      protected void pushEntities() {

--- a/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
+++ b/patches/server/0407-Add-PlayerAttackEntityCooldownResetEvent.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add PlayerAttackEntityCooldownResetEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index d5a70e9fc2a2a85d7262832687770b9693f05f41..0fc95a0ef5ed17b5cefcc72533783857faa2e749 100644
+index 415c577983e03ccd419ea8d7391be77e44e07a19..873eaa14eccca2813d8ef99a0484d409201f9204 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2048,7 +2048,16 @@ public abstract class LivingEntity extends Entity {
+@@ -2047,7 +2047,16 @@ public abstract class LivingEntity extends Entity {
  
              EntityDamageEvent event = CraftEventFactory.handleLivingEntityDamageEvent(this, damagesource, originalDamage, hardHatModifier, blockingModifier, armorModifier, resistanceModifier, magicModifier, absorptionModifier, hardHat, blocking, armor, resistance, magic, absorption);
              if (damagesource.getEntity() instanceof net.minecraft.world.entity.player.Player) {

--- a/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
+++ b/patches/server/0410-Fix-numerous-item-duplication-issues-and-teleport-is.patch
@@ -16,7 +16,7 @@ So even if something NEW comes up, it would be impossible to drop the
 same item twice because the source was destroyed.
 
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index 3ef63d278464d4b4ebd5bd1b69b68bf0c818b9ab..9336ad8bc5e11d6412869d597b5360c90be4df78 100644
+index 205102e43412c23bc7c4ead22c674e8c3cd6178b..f04c70c8d43a6a357f89aa7b8247d340c951de4c 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -2148,11 +2148,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -80,10 +80,10 @@ index 3ef63d278464d4b4ebd5bd1b69b68bf0c818b9ab..9336ad8bc5e11d6412869d597b5360c9
  
      public float getBlockExplosionResistance(Explosion explosion, BlockGetter world, BlockPos pos, BlockState blockState, FluidState fluidState, float max) {
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0fc95a0ef5ed17b5cefcc72533783857faa2e749..cd3bad5a767a060a498fa47b539e6e85ba282ca2 100644
+index 873eaa14eccca2813d8ef99a0484d409201f9204..3c27304ed44776e7256dc303a12eea5c0e5f2953 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -1621,9 +1621,9 @@ public abstract class LivingEntity extends Entity {
+@@ -1620,9 +1620,9 @@ public abstract class LivingEntity extends Entity {
                  // Paper start
                  org.bukkit.event.entity.EntityDeathEvent deathEvent = this.dropAllDeathLoot(source);
                  if (deathEvent == null || !deathEvent.isCancelled()) {
@@ -96,7 +96,7 @@ index 0fc95a0ef5ed17b5cefcc72533783857faa2e749..cd3bad5a767a060a498fa47b539e6e85
                      // Paper start - clear equipment if event is not cancelled
                      if (this instanceof Mob mob) {
                          java.util.Collections.fill(mob.handItems, ItemStack.EMPTY);
-@@ -1711,8 +1711,13 @@ public abstract class LivingEntity extends Entity {
+@@ -1710,8 +1710,13 @@ public abstract class LivingEntity extends Entity {
              this.dropCustomDeathLoot(source, i, flag);
              this.clearEquipmentSlots = true; // Paper
          }
@@ -135,7 +135,7 @@ index a3a900d10440ed5ebe24370a77ccb6cad911cfc9..0d468631b9c260091e732925da43c177
              }
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index aaea18e64db3851f98a7a391d9f9bb265d659d99..d74db5ac46314683b8c8713b8e6f6450ef7eb1b1 100644
+index a8b74b539eca41cb08cd79697a5732602401bb2f..de5f5856875fc4bfb051c7535344f18ded360ad3 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -810,6 +810,11 @@ public class CraftEventFactory {

--- a/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
+++ b/patches/server/0427-Protect-Bedrock-and-End-Portal-Frames-from-being-des.patch
@@ -33,10 +33,10 @@ index 6ee4d5377d3963c67c6da4e5b164e49949768f03..e849c9c9fccf928399478dc3727eba55
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index 548f103e648d9670d7434182c6598dc29ae77b57..f0c789d339fe8402c9c2a684d7e0415fa298b20e 100644
+index e2bc9e91f03997884af381b3261b102a6e0bc5cb..8325ccbcae2a5ed55f436163bb8136cc03db9df0 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -173,6 +173,7 @@ public class Explosion {
+@@ -174,6 +174,7 @@ public class Explosion {
                          for (float f1 = 0.3F; f > 0.0F; f -= 0.22500001F) {
                              BlockPos blockposition = new BlockPos(d4, d5, d6);
                              BlockState iblockdata = this.level.getBlockState(blockposition);
@@ -44,7 +44,7 @@ index 548f103e648d9670d7434182c6598dc29ae77b57..f0c789d339fe8402c9c2a684d7e0415f
                              FluidState fluid = iblockdata.getFluidState(); // Paper
  
                              if (!this.level.isInWorldBounds(blockposition)) {
-@@ -330,7 +331,7 @@ public class Explosion {
+@@ -351,7 +352,7 @@ public class Explosion {
                  BlockState iblockdata = this.level.getBlockState(blockposition);
                  Block block = iblockdata.getBlock();
  

--- a/patches/server/0468-Add-PrepareResultEvent.patch
+++ b/patches/server/0468-Add-PrepareResultEvent.patch
@@ -94,10 +94,10 @@ index cdebd0cdf6eb901464cf4c16089b10ea0147b54d..221b6ffb426edc034183dbaf37de29c6
  
      private void setupRecipeList(Container input, ItemStack stack) {
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index f49c636a7485a7f41aae7acb584dc1c7c1d2c3a2..dc65191f170954fbc93012bfc02401de36d8d1fd 100644
+index 0b054674aa97d9311b07889e2dc20ebc433c5718..e0e130052317bdd14349ef48ec44c1e31f90b24f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1562,19 +1562,44 @@ public class CraftEventFactory {
+@@ -1574,19 +1574,44 @@ public class CraftEventFactory {
          return event;
      }
  

--- a/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
+++ b/patches/server/0469-Don-t-check-chunk-for-portal-on-world-gen-entity-add.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Don't check chunk for portal on world gen entity add
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index cd3bad5a767a060a498fa47b539e6e85ba282ca2..5c8fa0f2488b26684ff25459f384e655ce0417c5 100644
+index 3c27304ed44776e7256dc303a12eea5c0e5f2953..15e45ddd4b570b5ea3aff735163dcc62ca711686 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3376,7 +3376,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3375,7 +3375,7 @@ public abstract class LivingEntity extends Entity {
          Entity entity = this.getVehicle();
  
          super.stopRiding(suppressCancellation); // Paper - suppress

--- a/patches/server/0491-Prevent-headless-pistons-from-being-created.patch
+++ b/patches/server/0491-Prevent-headless-pistons-from-being-created.patch
@@ -21,10 +21,10 @@ index 933d3ace21f5a313f1d5e4dfd86777f6fa235f3f..1fd89294fabcd2a390ba7f1502acbfeb
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/Explosion.java b/src/main/java/net/minecraft/world/level/Explosion.java
-index f0c789d339fe8402c9c2a684d7e0415fa298b20e..6795132318a4e8b4c7a33b6f4b89a730ea66b97f 100644
+index 8325ccbcae2a5ed55f436163bb8136cc03db9df0..97f99a06b8954b08af9f4156abe8abdad359349a 100644
 --- a/src/main/java/net/minecraft/world/level/Explosion.java
 +++ b/src/main/java/net/minecraft/world/level/Explosion.java
-@@ -34,6 +34,8 @@ import net.minecraft.world.level.block.BaseFireBlock;
+@@ -35,6 +35,8 @@ import net.minecraft.world.level.block.BaseFireBlock;
  import net.minecraft.world.level.block.Block;
  import net.minecraft.world.level.block.Blocks;
  import net.minecraft.world.level.block.entity.BlockEntity;
@@ -33,7 +33,7 @@ index f0c789d339fe8402c9c2a684d7e0415fa298b20e..6795132318a4e8b4c7a33b6f4b89a730
  import net.minecraft.world.level.block.state.BlockState;
  import net.minecraft.world.level.gameevent.GameEvent;
  import net.minecraft.world.level.material.FluidState;
-@@ -188,6 +190,15 @@ public class Explosion {
+@@ -189,6 +191,15 @@ public class Explosion {
  
                              if (f > 0.0F && this.damageCalculator.shouldBlockExplode(this, this.level, blockposition, iblockdata, f)) {
                                  set.add(blockposition);

--- a/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
+++ b/patches/server/0540-Climbing-should-not-bypass-cramming-gamerule.patch
@@ -21,7 +21,7 @@ index f56992472665b59e3ae22fab74d994686dc767f4..8a266d1276595d5b2bd0b60f08d99d4c
      private void keepLoadedRange() {
          keepLoadedRange = (short) (getInt("keep-spawn-loaded-range", Math.min(spigotConfig.viewDistance, 10)) * 16);
 diff --git a/src/main/java/net/minecraft/world/entity/Entity.java b/src/main/java/net/minecraft/world/entity/Entity.java
-index de984785361221dffece2a86c859ccf95a8b4af8..97bfbb01febae2cb4f9b4eb7b9540486d6eb94a2 100644
+index d394894ae506eafe6f363fa6c6592a92907d2492..6c32f51c649f0cdc56b672346a7ef6c15c899d12 100644
 --- a/src/main/java/net/minecraft/world/entity/Entity.java
 +++ b/src/main/java/net/minecraft/world/entity/Entity.java
 @@ -1737,6 +1737,12 @@ public abstract class Entity implements Nameable, EntityAccess, CommandSource, i
@@ -61,10 +61,10 @@ index 22f36cd3df49160f1b6668befdd05c2268edaa49..e39965c2e50bc8ee424ea07819346e06
              } else if (entity.level.isClientSide && (!(entity1 instanceof Player) || !((Player) entity1).isLocalPlayer())) {
                  return false;
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5c8fa0f2488b26684ff25459f384e655ce0417c5..bb1645fd1e6242cec7fbd32282062eacc9f9f593 100644
+index 15e45ddd4b570b5ea3aff735163dcc62ca711686..d651746955a5b8ee225788fafb818264c1c6edbe 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3290,7 +3290,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3289,7 +3289,7 @@ public abstract class LivingEntity extends Entity {
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -73,7 +73,7 @@ index 5c8fa0f2488b26684ff25459f384e655ce0417c5..bb1645fd1e6242cec7fbd32282062eac
  
          if (!list.isEmpty()) {
              // Paper - move up
-@@ -3461,9 +3461,16 @@ public abstract class LivingEntity extends Entity {
+@@ -3460,9 +3460,16 @@ public abstract class LivingEntity extends Entity {
          return !this.isRemoved() && this.collides; // CraftBukkit
      }
  

--- a/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
+++ b/patches/server/0569-Implemented-BlockFailedDispenseEvent.patch
@@ -32,10 +32,10 @@ index 4ae21aa6fc91f527d3dca508588d8257961b8d24..b3203049eade7d11602fa2a12a8104a7
          } else {
              ItemStack itemstack = tileentitydispenser.getItem(i);
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index 0bfe25bd5dee6853d624af6988d2b72155aed8c0..d4b772c1df839ad1ec2bfb514432ee1b12099193 100644
+index bae5e210cdc679189ad56a31e7734840c807c553..d7f865912feba5c88ed6d488554132edce0fb030 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1836,4 +1836,12 @@ public class CraftEventFactory {
+@@ -1848,4 +1848,12 @@ public class CraftEventFactory {
          EntitiesUnloadEvent event = new EntitiesUnloadEvent(new CraftChunk((ServerLevel) world, coords.x, coords.z), bukkitEntities);
          Bukkit.getPluginManager().callEvent(event);
      }

--- a/patches/server/0584-Implement-BlockPreDispenseEvent.patch
+++ b/patches/server/0584-Implement-BlockPreDispenseEvent.patch
@@ -17,10 +17,10 @@ index 07d357b5fcb30ed9ff074a196a19de1481fe3738..83ac86b3c1e7b9233f2db8e5488f97c5
                  tileentitydispenser.setItem(i, idispensebehavior.dispense(sourceblock, itemstack));
              }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index bfc3442e7952e1ec927f3ebdbefba153e7304e19..da0a74415dcaddc3f692106faf11403e27feee80 100644
+index 31fdf523fcb08d8fb6c146f7950838e753bfb447..068a14050d2512e88aeea81e6b0f8e5e1ce445b9 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1854,5 +1854,11 @@ public class CraftEventFactory {
+@@ -1866,5 +1866,11 @@ public class CraftEventFactory {
          io.papermc.paper.event.block.BlockFailedDispenseEvent event = new io.papermc.paper.event.block.BlockFailedDispenseEvent(block);
          return event.callEvent();
      }

--- a/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
+++ b/patches/server/0589-Add-dropLeash-variable-to-EntityUnleashEvent.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Add dropLeash variable to EntityUnleashEvent
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/Mob.java b/src/main/java/net/minecraft/world/entity/Mob.java
-index 77d85265eb090f61476faedbffd4ad3d2e9ae38a..4566037b8772e81cc28ed3cb3a6b756da85c7260 100644
+index e803af4d27f3f005a56696175d7ae8a51d7005a6..79c298334a1a2171ef6aca94114edf72ffb67ba1 100644
 --- a/src/main/java/net/minecraft/world/entity/Mob.java
 +++ b/src/main/java/net/minecraft/world/entity/Mob.java
 @@ -1230,12 +1230,15 @@ public abstract class Mob extends LivingEntity {
@@ -122,10 +122,10 @@ index cf932116a0cafd315e44159fbf7c5d25d43782ff..03bda898a5a263053ecd79f74799d370
                          }
                      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index da0a74415dcaddc3f692106faf11403e27feee80..afb6eb856d22845716351d5be7eff5991da72dd3 100644
+index 068a14050d2512e88aeea81e6b0f8e5e1ce445b9..3350575a5038de1185a636862df24e32f79e38c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-@@ -1495,8 +1495,10 @@ public class CraftEventFactory {
+@@ -1507,8 +1507,10 @@ public class CraftEventFactory {
          return itemInHand;
      }
  

--- a/patches/server/0592-EntityMoveEvent.patch
+++ b/patches/server/0592-EntityMoveEvent.patch
@@ -17,7 +17,7 @@ index b5b7bb3c0147f95ac4036e7d2aa8f26ac755f4df..18830fa8e43c70c9da417eb771d55335
  
              this.profiler.push(() -> {
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index 7f2f47c16b15be32347f0e1689ac69fc6d6d0c2d..2b6444711c39f042c21d374fc0dc507f1577fa1a 100644
+index 1486f93a476ed9b887c8d2b2ab3b1671cc772aae..558a202fb147f4c466d5c8b958105cbf43be0788 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -208,6 +208,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -29,10 +29,10 @@ index 7f2f47c16b15be32347f0e1689ac69fc6d6d0c2d..2b6444711c39f042c21d374fc0dc507f
          return new Throwable(entity + " Added to world at " + new java.util.Date());
      }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index bb1645fd1e6242cec7fbd32282062eacc9f9f593..5e2052dc1fbf2ee9976190868ed6e431ab56d34c 100644
+index d651746955a5b8ee225788fafb818264c1c6edbe..c01c349f872a6a7923e4b18c7f93ca3b8cf357dd 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3236,6 +3236,20 @@ public abstract class LivingEntity extends Entity {
+@@ -3235,6 +3235,20 @@ public abstract class LivingEntity extends Entity {
  
          this.pushEntities();
          this.level.getProfiler().pop();

--- a/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
+++ b/patches/server/0626-Fix-PlayerItemConsumeEvent-cancelling-properly.patch
@@ -9,10 +9,10 @@ till their item is switched.
 This patch clears the active item when the event is cancelled
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 5e2052dc1fbf2ee9976190868ed6e431ab56d34c..f84b897890ca51258cdf6cd04bfba3328096969c 100644
+index c01c349f872a6a7923e4b18c7f93ca3b8cf357dd..4c9a6bb5456fe5fa35e37a18b3e577003d901d71 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3722,6 +3722,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3721,6 +3721,7 @@ public abstract class LivingEntity extends Entity {
                          level.getCraftServer().getPluginManager().callEvent(event);
  
                          if (event.isCancelled()) {

--- a/patches/server/0677-Line-Of-Sight-Changes.patch
+++ b/patches/server/0677-Line-Of-Sight-Changes.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Line Of Sight Changes
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index f84b897890ca51258cdf6cd04bfba3328096969c..1879271ef55e07cd93ebab2d01bfeb7e7b247883 100644
+index 4c9a6bb5456fe5fa35e37a18b3e577003d901d71..2d57ee46e66fe8962177a3a18c890f4942752b33 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3447,7 +3447,8 @@ public abstract class LivingEntity extends Entity {
+@@ -3446,7 +3446,8 @@ public abstract class LivingEntity extends Entity {
              Vec3 vec3d = new Vec3(this.getX(), this.getEyeY(), this.getZ());
              Vec3 vec3d1 = new Vec3(entity.getX(), entity.getEyeY(), entity.getZ());
  

--- a/patches/server/0699-Improve-boat-collision-performance.patch
+++ b/patches/server/0699-Improve-boat-collision-performance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Improve boat collision performance
 
 
 diff --git a/src/main/java/net/minecraft/Util.java b/src/main/java/net/minecraft/Util.java
-index cc565d1f766d5a6e0fe674ee9e453dbcb890116e..5bdd1958dff2fc9321bf858e6aa4cc5ad0a5a9ca 100644
+index 6c87ad6e015729db5b10f795b59aa785dff4368a..4605e80bb7dc5408daafb5ccba52efa138ca7cdd 100644
 --- a/src/main/java/net/minecraft/Util.java
 +++ b/src/main/java/net/minecraft/Util.java
 @@ -84,6 +84,7 @@ public class Util {
@@ -17,7 +17,7 @@ index cc565d1f766d5a6e0fe674ee9e453dbcb890116e..5bdd1958dff2fc9321bf858e6aa4cc5a
      };
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 2b0ba27fbded68270421f31037f71bb81f98d139..3f210da11885a292e999ede1f894ecf5f4930117 100644
+index d10edbda254e17a555e1ad00040e1693be7c5182..5a180c90d0704f1e1850bad07b863e9230866fcc 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
 @@ -1316,7 +1316,7 @@ public abstract class LivingEntity extends Entity {
@@ -29,7 +29,7 @@ index 2b0ba27fbded68270421f31037f71bb81f98d139..3f210da11885a292e999ede1f894ecf5
                          this.blockUsingShield((LivingEntity) entity);
                      }
                  }
-@@ -1425,11 +1425,12 @@ public abstract class LivingEntity extends Entity {
+@@ -1424,11 +1424,12 @@ public abstract class LivingEntity extends Entity {
                  }
  
                  if (entity1 != null) {
@@ -44,7 +44,7 @@ index 2b0ba27fbded68270421f31037f71bb81f98d139..3f210da11885a292e999ede1f894ecf5
                          d0 = (Math.random() - Math.random()) * 0.01D;
                      }
  
-@@ -2099,7 +2100,7 @@ public abstract class LivingEntity extends Entity {
+@@ -2098,7 +2099,7 @@ public abstract class LivingEntity extends Entity {
                  this.hurtCurrentlyUsedShield((float) -event.getDamage(DamageModifier.BLOCKING));
                  Entity entity = damagesource.getDirectEntity();
  

--- a/patches/server/0724-Add-critical-damage-API.patch
+++ b/patches/server/0724-Add-critical-damage-API.patch
@@ -29,10 +29,10 @@ index 80d19af2ad423bd3de0e039c5bb8f97af536aaa9..a828cad27fcd39f8bfbaefa97052a2a3
      public static DamageSource sting(LivingEntity attacker) {
          return new EntityDamageSource("sting", attacker);
 diff --git a/src/main/java/net/minecraft/world/entity/player/Player.java b/src/main/java/net/minecraft/world/entity/player/Player.java
-index ef18f69b54b68da84f6ab9f70aa47e2f716cf9a5..2a61de30508266768fc2b55420d5272ab538330c 100644
+index 0748142a70a677413eb53a7fc7d72e4490243db8..7a5a55353a259c4756fb6b8b3f432f42218a8465 100644
 --- a/src/main/java/net/minecraft/world/entity/player/Player.java
 +++ b/src/main/java/net/minecraft/world/entity/player/Player.java
-@@ -1215,7 +1215,7 @@ public abstract class Player extends LivingEntity {
+@@ -1214,7 +1214,7 @@ public abstract class Player extends LivingEntity {
                          flag1 = true;
                      }
  
@@ -41,7 +41,7 @@ index ef18f69b54b68da84f6ab9f70aa47e2f716cf9a5..2a61de30508266768fc2b55420d5272a
  
                      flag2 = flag2 && !level.paperConfig.disablePlayerCrits; // Paper
                      flag2 = flag2 && !this.isSprinting();
-@@ -1255,7 +1255,7 @@ public abstract class Player extends LivingEntity {
+@@ -1254,7 +1254,7 @@ public abstract class Player extends LivingEntity {
                      }
  
                      Vec3 vec3d = target.getDeltaMovement();
@@ -50,7 +50,7 @@ index ef18f69b54b68da84f6ab9f70aa47e2f716cf9a5..2a61de30508266768fc2b55420d5272a
  
                      if (flag5) {
                          if (i > 0) {
-@@ -1283,7 +1283,7 @@ public abstract class Player extends LivingEntity {
+@@ -1282,7 +1282,7 @@ public abstract class Player extends LivingEntity {
  
                                  if (entityliving != this && entityliving != target && !this.isAlliedTo((Entity) entityliving) && (!(entityliving instanceof ArmorStand) || !((ArmorStand) entityliving).isMarker()) && this.distanceToSqr((Entity) entityliving) < 9.0D) {
                                      // CraftBukkit start - Only apply knockback if the damage hits
@@ -72,7 +72,7 @@ index b436103957113bff5e553dacb869c775a3f8b059..3d3dcb47720055f550d17d1f106a2c0e
          int k = entity.getRemainingFireTicks();
  
 diff --git a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
-index ee0e27500187d695ac6cfaf5fb5d2e844f230b32..c667baa2da8222eb66344c8f1cc0fed416c4df01 100644
+index cca472eb7c0df93e295125d35ede43b897e9d2b0..35cc150adf51f79e2fccef8b094c90554aafbee2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 +++ b/src/main/java/org/bukkit/craftbukkit/event/CraftEventFactory.java
 @@ -970,7 +970,7 @@ public class CraftEventFactory {
@@ -84,7 +84,7 @@ index ee0e27500187d695ac6cfaf5fb5d2e844f230b32..c667baa2da8222eb66344c8f1cc0fed4
              }
              event.setCancelled(cancelled);
  
-@@ -995,7 +995,7 @@ public class CraftEventFactory {
+@@ -997,7 +997,7 @@ public class CraftEventFactory {
                  cause = DamageCause.THORNS;
              }
  
@@ -93,7 +93,7 @@ index ee0e27500187d695ac6cfaf5fb5d2e844f230b32..c667baa2da8222eb66344c8f1cc0fed4
          } else if (source == DamageSource.OUT_OF_WORLD) {
              EntityDamageEvent event = new EntityDamageByBlockEvent(null, entity.getBukkitEntity(), DamageCause.VOID, modifiers, modifierFunctions);
              event.setCancelled(cancelled);
-@@ -1050,7 +1050,7 @@ public class CraftEventFactory {
+@@ -1058,7 +1058,7 @@ public class CraftEventFactory {
              } else {
                  throw new IllegalStateException(String.format("Unhandled damage of %s by %s from %s", entity, damager.getHandle(), source.msgId));
              }
@@ -102,7 +102,7 @@ index ee0e27500187d695ac6cfaf5fb5d2e844f230b32..c667baa2da8222eb66344c8f1cc0fed4
              event.setCancelled(cancelled);
              CraftEventFactory.callEvent(event);
              if (!event.isCancelled()) {
-@@ -1093,20 +1093,28 @@ public class CraftEventFactory {
+@@ -1103,20 +1103,28 @@ public class CraftEventFactory {
          }
  
          if (cause != null) {

--- a/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
+++ b/patches/server/0747-Rewrite-entity-bounding-box-lookup-calls.patch
@@ -914,7 +914,7 @@ index 0000000000000000000000000000000000000000..3ba094e640d7fe7803e2bbdab8ff3beb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index bc6f48892290ac3e6909fb401a559b1148b405b4..5e65df1a9a8282c4ffa06801379b79ab0ed1b45c 100644
+index f2d3d35dc7cde7717986ffb6da40a6680308fe39..9362b39f4cc321bf0d4fc272bc3fb0463c47d4ce 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -428,7 +428,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
@@ -1282,10 +1282,10 @@ index 9ab8159975f58a0014edbe3a368490b3590882ea..4c6cbfbcb5a7876e6b556b59c54e9a4c
 +    // Paper end
  }
 diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
-index ec9907947b13ca3367c7ef5cb006bbabec3f2293..1732e753ea7748a66abecafb2136f93383f5ec4e 100644
+index 84880151abd193be5f02b5e9abb3fa78f2aa2cac..54a55cc05776af8de63b492bbda58182bb4c3726 100644
 --- a/src/main/java/org/spigotmc/ActivationRange.java
 +++ b/src/main/java/org/spigotmc/ActivationRange.java
-@@ -206,7 +206,13 @@ public class ActivationRange
+@@ -210,7 +210,13 @@ public class ActivationRange
              ActivationType.VILLAGER.boundingBox = player.getBoundingBox().inflate( villagerActivationRange, 256, villagerActivationRange );
              // Paper end
  

--- a/patches/server/0781-Fix-merchant-inventory-not-closing-on-entity-removal.patch
+++ b/patches/server/0781-Fix-merchant-inventory-not-closing-on-entity-removal.patch
@@ -5,13 +5,13 @@ Subject: [PATCH] Fix merchant inventory not closing on entity removal
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
-index f17c0f501c89c07651a40673ad5ecfe6c7168fce..28f605c3daa969c1a54745e552d55ecb874120a9 100644
+index d14948b581f0a659511ba482015a03388f4aa3c0..a2abb8aa1a257ccd2b5dbddc037fffc6eb600758 100644
 --- a/src/main/java/net/minecraft/server/level/ServerLevel.java
 +++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
 @@ -2475,6 +2475,11 @@ public class ServerLevel extends Level implements WorldGenLevel {
              // Spigot end
              // Spigot Start
-             if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder) {
+             if (entity.getBukkitEntity() instanceof org.bukkit.inventory.InventoryHolder && (!(entity instanceof ServerPlayer) || entity.getRemovalReason() != Entity.RemovalReason.KILLED)) { // SPIGOT-6876: closeInventory clears death message
 +                // Paper start
 +                if (entity.getBukkitEntity() instanceof org.bukkit.inventory.Merchant merchant && merchant.getTrader() != null) {
 +                    merchant.getTrader().closeInventory(org.bukkit.event.inventory.InventoryCloseEvent.Reason.UNLOADED);

--- a/patches/server/0795-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
+++ b/patches/server/0795-Dont-count-named-piglins-and-hoglins-towards-mob-cap.patch
@@ -4,16 +4,25 @@ Date: Fri, 20 Aug 2021 18:36:02 -0700
 Subject: [PATCH] Dont count named piglins and hoglins towards mob cap
 
 
-diff --git a/src/main/java/net/minecraft/world/level/NaturalSpawner.java b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-index c6bddf5e08376f1f254a27fc38647587eefcb00a..302803aa25b713cb087bdb2991cb0803dfe6005b 100644
---- a/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-+++ b/src/main/java/net/minecraft/world/level/NaturalSpawner.java
-@@ -83,7 +83,7 @@ public final class NaturalSpawner {
-                 Mob entityinsentient = (Mob) entity;
+diff --git a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+index c5b9c0c650df5f4b7e3d2a431dc900e210104dea..373ec915412899e4893aa182abd6fb63f3dff0aa 100644
+--- a/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
++++ b/src/main/java/net/minecraft/world/entity/monster/hoglin/Hoglin.java
+@@ -123,7 +123,7 @@ public class Hoglin extends Animal implements Enemy, HoglinBase {
  
-                 // CraftBukkit - Split out persistent check, don't apply it to special persistent mobs
--                if (entityinsentient.removeWhenFarAway(0) && entityinsentient.isPersistenceRequired()) {
-+                if ((entityinsentient instanceof net.minecraft.world.entity.monster.piglin.Piglin || entityinsentient instanceof net.minecraft.world.entity.monster.hoglin.Hoglin || entityinsentient.removeWhenFarAway(0)) && entityinsentient.isPersistenceRequired()) { // Paper - what a jank fix, CBs like totally tried to change what removeWhenFarAway does, that method isnt even called here in vanilla, idk wtf is going on
-                     continue;
-                 }
-             }
+     @Override
+     public Brain<Hoglin> getBrain() {
+-        return super.getBrain();
++        return (Brain<Hoglin>) super.getBrain(); // Paper - decompile fix
+     }
+ 
+     @Override
+@@ -181,7 +181,7 @@ public class Hoglin extends Animal implements Enemy, HoglinBase {
+ 
+     @Override
+     public boolean removeWhenFarAway(double distanceSquared) {
+-        return !this.isPersistenceRequired();
++        return /*!this.isPersistenceRequired();*/ true; // Paper - what a jank fix, CBs like totally tried to change what removeWhenFarAway does, that method isnt even called in NaturalSpawner in vanilla, idk wtf is going on, there are so many places where this is done, for whatever reason
+     }
+ 
+     @Override

--- a/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
+++ b/patches/server/0805-Prevent-excessive-velocity-through-repeated-crits.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Prevent excessive velocity through repeated crits
 
 
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 3f210da11885a292e999ede1f894ecf5f4930117..0c824a8c44cc9a2c848816450830b91d1199faff 100644
+index 5a180c90d0704f1e1850bad07b863e9230866fcc..87993c38984906f06df926e0837294e642f7b845 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -2584,14 +2584,27 @@ public abstract class LivingEntity extends Entity {
+@@ -2583,14 +2583,27 @@ public abstract class LivingEntity extends Entity {
          return this.hasEffect(MobEffects.JUMP) ? (double) (0.1F * (float) (this.getEffect(MobEffects.JUMP).getAmplifier() + 1)) : 0.0D;
      }
  

--- a/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
+++ b/patches/server/0810-Prevent-sending-oversized-item-data-in-equipment-and.patch
@@ -34,10 +34,10 @@ index 703ac671b19636859648f16a5431b2700791e7d5..d8ef6137133716b9ee519e6e4668d2e1
              }
  
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 0c824a8c44cc9a2c848816450830b91d1199faff..860b531b9c5354a4b0162850fe8feba99a95f0bc 100644
+index 87993c38984906f06df926e0837294e642f7b845..5e26b3ce1da37f9b93da91061f4e0aa92b80e2f2 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3067,7 +3067,10 @@ public abstract class LivingEntity extends Entity {
+@@ -3066,7 +3066,10 @@ public abstract class LivingEntity extends Entity {
          equipmentChanges.forEach((enumitemslot, itemstack) -> {
              ItemStack itemstack1 = itemstack.copy();
  
@@ -49,7 +49,7 @@ index 0c824a8c44cc9a2c848816450830b91d1199faff..860b531b9c5354a4b0162850fe8feba9
              switch (enumitemslot.getType()) {
                  case HAND:
                      this.setLastHandItem(enumitemslot, itemstack1);
-@@ -3080,6 +3083,34 @@ public abstract class LivingEntity extends Entity {
+@@ -3079,6 +3082,34 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
+++ b/patches/server/0811-Hide-unnecessary-itemmeta-from-clients.patch
@@ -36,10 +36,10 @@ index d8ef6137133716b9ee519e6e4668d2e1ae5d9ca3..9a6c67b614944f841813ec2892381c33
                  }
              }
 diff --git a/src/main/java/net/minecraft/world/entity/LivingEntity.java b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-index 860b531b9c5354a4b0162850fe8feba99a95f0bc..43378561cf48f969f5bf1fd0db349415f4d1c866 100644
+index 5e26b3ce1da37f9b93da91061f4e0aa92b80e2f2..572f9ca81b78c6229725f6693940ac0a70ecdfd5 100644
 --- a/src/main/java/net/minecraft/world/entity/LivingEntity.java
 +++ b/src/main/java/net/minecraft/world/entity/LivingEntity.java
-@@ -3069,7 +3069,7 @@ public abstract class LivingEntity extends Entity {
+@@ -3068,7 +3068,7 @@ public abstract class LivingEntity extends Entity {
  
              // Paper start - prevent oversized data
              ItemStack toSend = sanitizeItemStack(itemstack1, true);
@@ -48,7 +48,7 @@ index 860b531b9c5354a4b0162850fe8feba99a95f0bc..43378561cf48f969f5bf1fd0db349415
              // Paper end
              switch (enumitemslot.getType()) {
                  case HAND:
-@@ -3083,6 +3083,51 @@ public abstract class LivingEntity extends Entity {
+@@ -3082,6 +3082,51 @@ public abstract class LivingEntity extends Entity {
          ((ServerLevel) this.level).getChunkSource().broadcast(this, new ClientboundSetEquipmentPacket(this.getId(), list));
      }
  

--- a/patches/server/0845-Add-config-option-for-worlds-affected-by-time-cmd.patch
+++ b/patches/server/0845-Add-config-option-for-worlds-affected-by-time-cmd.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sun, 2 Jan 2022 22:34:51 -0800
+Subject: [PATCH] Add config option for worlds affected by time cmd
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index 1d3cc8836d2ccbec4a8660f86501be35c76e8b0b..61ea1c9881ea30c05580044af9496a65fe95d94e 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -645,4 +645,9 @@ public class PaperConfig {
+     private static void sendFullPosForHardCollidingEntities() {
+         sendFullPosForHardCollidingEntities = getBoolean("settings.send-full-pos-for-hard-colliding-entities", true);
+     }
++
++    public static boolean timeCommandAffectsAllWorlds = false; // See https://hub.spigotmc.org/stash/projects/SPIGOT/repos/craftbukkit/commits/aeaeb359317e6ba25b7c45cf6d70ff945a3777cf
++    private static void timeCommandAffectsAllWorlds() {
++        timeCommandAffectsAllWorlds = getBoolean("settings.time-command-affects-all-worlds", timeCommandAffectsAllWorlds);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/server/commands/TimeCommand.java b/src/main/java/net/minecraft/server/commands/TimeCommand.java
+index ad4860bf64979e6b10bc6aecc4ac67a5c069e030..da854c5bfaf9e791b272a497caf864748f3dfbda 100644
+--- a/src/main/java/net/minecraft/server/commands/TimeCommand.java
++++ b/src/main/java/net/minecraft/server/commands/TimeCommand.java
+@@ -51,7 +51,7 @@ public class TimeCommand {
+     }
+ 
+     public static int setTime(CommandSourceStack source, int time) {
+-        Iterator iterator = com.google.common.collect.Iterators.singletonIterator(source.getLevel()); // CraftBukkit - SPIGOT-6496: Only set the time for the world the command originates in
++        Iterator iterator = com.destroystokyo.paper.PaperConfig.timeCommandAffectsAllWorlds ? source.getServer().getAllLevels().iterator() : com.google.common.collect.Iterators.singletonIterator(source.getLevel()); // CraftBukkit - SPIGOT-6496: Only set the time for the world the command originates in // Paper - add config option for spigot's change
+ 
+         while (iterator.hasNext()) {
+             ServerLevel worldserver = (ServerLevel) iterator.next();
+@@ -70,7 +70,7 @@ public class TimeCommand {
+     }
+ 
+     public static int addTime(CommandSourceStack source, int time) {
+-        Iterator iterator = com.google.common.collect.Iterators.singletonIterator(source.getLevel()); // CraftBukkit - SPIGOT-6496: Only set the time for the world the command originates in
++        Iterator iterator = com.destroystokyo.paper.PaperConfig.timeCommandAffectsAllWorlds ? source.getServer().getAllLevels().iterator() : com.google.common.collect.Iterators.singletonIterator(source.getLevel()); // CraftBukkit - SPIGOT-6496: Only set the time for the world the command originates in // Paper - add config option for spigot's change
+ 
+         while (iterator.hasNext()) {
+             ServerLevel worldserver = (ServerLevel) iterator.next();


### PR DESCRIPTION
Updated Upstream (Bukkit/CraftBukkit/Spigot)

Upstream has released updates that appear to apply and compile correctly.
This update has not been tested by PaperMC and as with ANY update, please do your own testing

Bukkit Changes:
8c956b8d SPIGOT-6886: Restore previous behaviour of loading unusual config keys
3dbfebef Fix saving configs which are only a header
fde55ab8 PR-705: Add PDC to Structures
a7505b3c Add workaround for SnakeYAML 100 comment limit
9db6df7d PR-703: Fix/test yaml anchors and merge
129c3c54 SPIGOT-6875: Update references to old world height limits

CraftBukkit Changes:
f3828bbe PR-989: Add PDC to Structures
cc86ab18 SPIGOT-5339, SPIGOT-6252, SPIGOT-6777: Only cancel knockback if the damage event was canceled
aeaeb359 SPIGOT-6496: /time functions affect entire server, not just the origin world
a1b1dc81 Put Discord rather than IRC in config files
fb92f345 SPIGOT-6278: Persistent piglins count towards mob cap

Spigot Changes:
f4ff00ff Rebuild patches
54b4afaa SPIGOT-6881: Add option to ignore spectators in entity-activation-range
71b293bc Put Discord rather than IRC in config files
9fd34ab9 SPIGOT-6876: Death screen message disappears after a few seconds