### PR TITLE
Fix: Use simulation distance for per-player mob spawns

### DIFF
--- a/patches/server/0364-implement-optional-per-player-mob-spawns.patch
+++ b/patches/server/0364-implement-optional-per-player-mob-spawns.patch
@@ -592,8 +592,25 @@ index 0c82b270c7095c7e4666a8078ecc7142503795c4..0583d7ee24f694fbf5138dfae9f7b8c8
      private static double euclideanDistanceSquared(ChunkPos pos, Entity entity) {
          double d0 = (double) SectionPos.sectionToBlockCoord(pos.x, 8);
          double d1 = (double) SectionPos.sectionToBlockCoord(pos.z, 8);
+diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
+index f0dac1f596911eb2109192ef16a619f8ae71d1f7..07b616d9d7cde77c001f5c627daef0731d883e61 100644
+--- a/src/main/java/net/minecraft/server/level/DistanceManager.java
++++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
+@@ -323,6 +323,12 @@ public abstract class DistanceManager {
+ 
+     }
+ 
++    // Paper start
++    public int getSimulationDistance() {
++        return this.simulationDistance;
++    }
++    // Paper end
++
+     public int getNaturalSpawnChunkCount() {
+         this.naturalSpawnChunkCounter.runAllUpdates();
+         return this.naturalSpawnChunkCounter.chunks.size();
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 7b391d6ab84eeaed7bdd27ea70d5e3f9690a0abf..17a36ee61aacfc41e2d926335c460350cd25ab42 100644
+index 7b391d6ab84eeaed7bdd27ea70d5e3f9690a0abf..d9405456f61b954f9b6fa2fa7939fc3a36ec6fc6 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -916,7 +916,22 @@ public class ServerChunkCache extends ChunkSource {
@@ -606,7 +623,7 @@ index 7b391d6ab84eeaed7bdd27ea70d5e3f9690a0abf..17a36ee61aacfc41e2d926335c460350
 +            if (this.chunkMap.playerMobDistanceMap != null) {
 +                // update distance map
 +                this.level.timings.playerMobDistanceMapUpdate.startTiming();
-+                this.chunkMap.playerMobDistanceMap.update(this.level.players, this.chunkMap.viewDistance);
++                this.chunkMap.playerMobDistanceMap.update(this.level.players, this.distanceManager.getSimulationDistance());
 +                this.level.timings.playerMobDistanceMapUpdate.stopTiming();
 +                // re-set mob counts
 +                for (ServerPlayer player : this.level.players) {

--- a/patches/server/0432-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
+++ b/patches/server/0432-Optimize-anyPlayerCloseEnoughForSpawning-to-use-dist.patch
@@ -207,7 +207,7 @@ index 62a8482b73796f2c6b76c0e039cb21e799bc9416..87b612c25f865af4c8da72c761b70094
  
      public List<ServerPlayer> getPlayersCloseForSpawning(ChunkPos pos) {
 diff --git a/src/main/java/net/minecraft/server/level/DistanceManager.java b/src/main/java/net/minecraft/server/level/DistanceManager.java
-index 8868ffcda194e8c2300181a2cdda9337dbde6284..95f195980e28bb59f43e5ca1d5e79ebe8c3ddaea 100644
+index f11e9421d393ef5a04f24c78a1214359710cc2f8..3865146697051e01a778414064425ea0e5162b8d 100644
 --- a/src/main/java/net/minecraft/server/level/DistanceManager.java
 +++ b/src/main/java/net/minecraft/server/level/DistanceManager.java
 @@ -48,7 +48,7 @@ public abstract class DistanceManager {
@@ -246,8 +246,8 @@ index 8868ffcda194e8c2300181a2cdda9337dbde6284..95f195980e28bb59f43e5ca1d5e79ebe
              this.playerTicketManager.update(i, Integer.MAX_VALUE, false);
              this.tickingTicketsTracker.removeTicket(TicketType.PLAYER, chunkcoordintpair, this.getPlayerTicketLevel(), chunkcoordintpair);
          }
-@@ -324,13 +324,17 @@ public abstract class DistanceManager {
-     }
+@@ -330,13 +330,17 @@ public abstract class DistanceManager {
+     // Paper end
  
      public int getNaturalSpawnChunkCount() {
 -        this.naturalSpawnChunkCounter.runAllUpdates();
@@ -269,7 +269,7 @@ index 8868ffcda194e8c2300181a2cdda9337dbde6284..95f195980e28bb59f43e5ca1d5e79ebe
  
      public String getDebugStatus() {
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 66dfe3d79fa3273a2bab64193f73f2b38002c18c..1115df1f148bcb079edb9eb397de3fab725bf83b 100644
+index 50f3be85039c698bb2f73116a397d6ddaeea6dbd..b10ed9f87e58983863864161457cd415bb782bfd 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -881,6 +881,37 @@ public class ServerChunkCache extends ChunkSource {

--- a/patches/server/0590-Skip-distance-map-update-when-spawning-disabled.patch
+++ b/patches/server/0590-Skip-distance-map-update-when-spawning-disabled.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Skip distance map update when spawning disabled.
 
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerChunkCache.java b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
-index 42cecd0f072505c80b65ccf26e5d838750d21e28..dcb65eb4e5790e12ebe83b0d25b5a8c7a8bfbb6b 100644
+index 1ff2d926ca5de9334b1e5aa5defb73d7fbc1c3af..8e87cc36b57bc5e8f8eb5583e02bbede4eb9ce54 100644
 --- a/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 +++ b/src/main/java/net/minecraft/server/level/ServerChunkCache.java
 @@ -966,7 +966,7 @@ public class ServerChunkCache extends ChunkSource {
@@ -16,4 +16,4 @@ index 42cecd0f072505c80b65ccf26e5d838750d21e28..dcb65eb4e5790e12ebe83b0d25b5a8c7
 +            if ((this.spawnFriendlies || this.spawnEnemies) && this.chunkMap.playerMobDistanceMap != null) { // don't update when animals and monsters are disabled
                  // update distance map
                  this.level.timings.playerMobDistanceMapUpdate.startTiming();
-                 this.chunkMap.playerMobDistanceMap.update(this.level.players, this.chunkMap.viewDistance);
+                 this.chunkMap.playerMobDistanceMap.update(this.level.players, this.distanceManager.getSimulationDistance());


### PR DESCRIPTION
I'm not sure I understand how the `PlayerMobDistanceMap` exactly works, however on my server I've noticed that the per player mob spawns don't really work that well. I assume this to be because we have a 32 view distance and that thus multiple players, even when far away, will overlap and have their mob spawns merged. Giving the map the simulation distance seems more sensible.