### PR TITLE
Fix FurnaceInventory for smokers and blast furnaces

### DIFF
--- a/patches/server/0907-Fix-FurnaceInventory-for-smokers-and-blast-furnaces.patch
+++ b/patches/server/0907-Fix-FurnaceInventory-for-smokers-and-blast-furnaces.patch
@@ -1,0 +1,49 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
+Date: Sat, 1 Jan 2022 23:11:26 -0800
+Subject: [PATCH] Fix FurnaceInventory for smokers and blast furnaces
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+index 54e61b9b058bee2167461aaaf828ed7a00949c29..53421f780ac8bc2a67f64671fcad632fcdb8bede 100644
+--- a/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
++++ b/src/main/java/org/bukkit/craftbukkit/inventory/util/CraftTileInventoryConverter.java
+@@ -65,7 +65,7 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+         return new CraftInventory(tileEntity);
+     }
+ 
+-    public static class Furnace extends CraftTileInventoryConverter {
++    public static class Furnace extends AbstractFurnaceInventoryConverter { // Paper - Furnace, BlastFurnace, and Smoker are pretty much identical
+ 
+         @Override
+         public Container getTileEntity() {
+@@ -73,6 +73,11 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+             return furnace;
+         }
+ 
++    // Paper start - abstract furnace converter to apply to all 3 furnaces
++    }
++
++    public static abstract class AbstractFurnaceInventoryConverter extends CraftTileInventoryConverter {
++    // Paper end
+         // Paper start
+         @Override
+         public Inventory createInventory(InventoryHolder owner, InventoryType type, net.kyori.adventure.text.Component title) {
+@@ -170,7 +175,7 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+         }
+     }
+ 
+-    public static class BlastFurnace extends CraftTileInventoryConverter {
++    public static class BlastFurnace extends AbstractFurnaceInventoryConverter { // Paper - Furnace, BlastFurnace, and Smoker are pretty much identical
+ 
+         @Override
+         public Container getTileEntity() {
+@@ -186,7 +191,7 @@ public abstract class CraftTileInventoryConverter implements CraftInventoryCreat
+         }
+     }
+ 
+-    public static class Smoker extends CraftTileInventoryConverter {
++    public static class Smoker extends AbstractFurnaceInventoryConverter { // Paper - Furnace, BlastFurnace, and Smoker are pretty much identical
+ 
+         @Override
+         public Container getTileEntity() {


### PR DESCRIPTION
creating an inventory of type smoker or blast furnace should return an instance of CraftInventoryFurnace, but I noticed when I tried to cast it, it was a CraftInventory. This is not correct, because literally everything that applies to Furnace furnaces applies to the other 2 as well. The ctor for CraftInventoryFurnace even takes the AbstractFurnaceBlockEntity so all existing methods work as they should.