### PR TITLE
Implement Translatable on InventoryType

### DIFF
--- a/patches/api/0211-Add-methods-to-get-translation-keys.patch
+++ b/patches/api/0211-Add-methods-to-get-translation-keys.patch
@@ -398,6 +398,217 @@ index d841d94d46462e0ceb7c6b04cc8fc36792bd9201..8c8176121cafed0ed09239b6a7b392dc
      }
  
      // Paper start - Add villager reputation API
+diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+index 19ba2d948ad83baab2a14ae6f7b3ce43c3d4971f..293711e1ca784d1fdff8da4f8bfc88c3204e39fd 100644
+--- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
++++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
+@@ -19,136 +19,136 @@ import org.jetbrains.annotations.NotNull;
+  *
+  * @see org.bukkit.Bukkit#createInventory(InventoryHolder, InventoryType)
+  */
+-public enum InventoryType {
++public enum InventoryType implements net.kyori.adventure.translation.Translatable { // Paper - translations
+ 
+     /**
+      * A chest inventory, with 0, 9, 18, 27, 36, 45, or 54 slots of type
+      * CONTAINER.
+      */
+-    CHEST(27, "Chest"),
++    CHEST(27, "Chest", "container.chest"), // Paper
+     /**
+      * A dispenser inventory, with 9 slots of type CONTAINER.
+      */
+-    DISPENSER(9, "Dispenser"),
++    DISPENSER(9, "Dispenser", "container.dispenser"), // Paper
+     /**
+      * A dropper inventory, with 9 slots of type CONTAINER.
+      */
+-    DROPPER(9, "Dropper"),
++    DROPPER(9, "Dropper", "container.dropper"), // Paper
+     /**
+      * A furnace inventory, with a RESULT slot, a CRAFTING slot, and a FUEL
+      * slot.
+      */
+-    FURNACE(3, "Furnace"),
++    FURNACE(3, "Furnace", "container.furnace"), // Paper
+     /**
+      * A workbench inventory, with 9 CRAFTING slots and a RESULT slot.
+      */
+-    WORKBENCH(10, "Crafting"),
++    WORKBENCH(10, "Crafting", "container.crafting"), // Paper
+     /**
+      * A player's crafting inventory, with 4 CRAFTING slots and a RESULT slot.
+      * Also implies that the 4 ARMOR slots are accessible.
+      */
+-    CRAFTING(5, "Crafting", false),
++    CRAFTING(5, "Crafting", false, "container.crafting"), // Paper
+     /**
+      * An enchantment table inventory, with two CRAFTING slots and three
+      * enchanting buttons.
+      */
+-    ENCHANTING(2, "Enchanting"),
++    ENCHANTING(2, "Enchanting", "container.enchant"), // Paper
+     /**
+      * A brewing stand inventory, with one FUEL slot and four CRAFTING slots.
+      */
+-    BREWING(5, "Brewing"),
++    BREWING(5, "Brewing", "container.brewing"), // Paper
+     /**
+      * A player's inventory, with 9 QUICKBAR slots, 27 CONTAINER slots, 4 ARMOR
+      * slots and 1 offhand slot. The ARMOR and offhand slots may not be visible
+      * to the player, though.
+      */
+-    PLAYER(41, "Player"),
++    PLAYER(41, "Player", "container.crafting"), // Paper
+     /**
+      * The creative mode inventory, with only 9 QUICKBAR slots and nothing
+      * else. (The actual creative interface with the items is client-side and
+      * cannot be altered by the server.)
+      */
+-    CREATIVE(9, "Creative", false),
++    CREATIVE(9, "Creative", false, "container.creative"), // Paper
+     /**
+      * The merchant inventory, with 2 CRAFTING slots, and 1 RESULT slot.
+      */
+-    MERCHANT(3, "Villager", false),
++    MERCHANT(3, "Villager", false, null), // Paper
+     /**
+      * The ender chest inventory, with 27 slots.
+      */
+-    ENDER_CHEST(27, "Ender Chest"),
++    ENDER_CHEST(27, "Ender Chest", "container.enderchest"), // Paper
+     /**
+      * An anvil inventory, with 2 CRAFTING slots and 1 RESULT slot
+      */
+-    ANVIL(3, "Repairing"),
++    ANVIL(3, "Repairing", "container.repair"), // Paper
+     /**
+      * A smithing inventory, with 3 CRAFTING slots and 1 RESULT slot.
+      */
+-    SMITHING(4, "Upgrade Gear"),
++    SMITHING(4, "Upgrade Gear", "container.upgrade"), // Paper
+     /**
+      * A beacon inventory, with 1 CRAFTING slot
+      */
+-    BEACON(1, "container.beacon"),
++    BEACON(1, "Beacon", "container.beacon"), // Paper
+     /**
+      * A hopper inventory, with 5 slots of type CONTAINER.
+      */
+-    HOPPER(5, "Item Hopper"),
++    HOPPER(5, "Item Hopper", "container.hopper"), // Paper
+     /**
+      * A shulker box inventory, with 27 slots of type CONTAINER.
+      */
+-    SHULKER_BOX(27, "Shulker Box"),
++    SHULKER_BOX(27, "Shulker Box", "container.shulkerBox"), // Paper
+     /**
+      * A barrel box inventory, with 27 slots of type CONTAINER.
+      */
+-    BARREL(27, "Barrel"),
++    BARREL(27, "Barrel", "container.barrel"), // Paper
+     /**
+      * A blast furnace inventory, with a RESULT slot, a CRAFTING slot, and a
+      * FUEL slot.
+      */
+-    BLAST_FURNACE(3, "Blast Furnace"),
++    BLAST_FURNACE(3, "Blast Furnace", "container.blast_furnace"), // Paper
+     /**
+      * A lectern inventory, with 1 BOOK slot.
+      */
+-    LECTERN(1, "Lectern"),
++    LECTERN(1, "Lectern", "container.lectern"), // Paper
+     /**
+      * A smoker inventory, with a RESULT slot, a CRAFTING slot, and a FUEL slot.
+      */
+-    SMOKER(3, "Smoker"),
++    SMOKER(3, "Smoker", "container.smoker"), // Paper
+     /**
+      * Loom inventory, with 3 CRAFTING slots, and 1 RESULT slot.
+      */
+-    LOOM(4, "Loom"),
++    LOOM(4, "Loom", "container.loom"), // Paper
+     /**
+      * Cartography inventory with 2 CRAFTING slots, and 1 RESULT slot.
+      */
+-    CARTOGRAPHY(3, "Cartography Table"),
++    CARTOGRAPHY(3, "Cartography Table", "container.cartography_table"), // Paper
+     /**
+      * Grindstone inventory with 2 CRAFTING slots, and 1 RESULT slot.
+      */
+-    GRINDSTONE(3, "Repair & Disenchant"),
++    GRINDSTONE(3, "Repair & Disenchant", "container.grindstone_title"), // Paper
+     /**
+      * Stonecutter inventory with 1 CRAFTING slot, and 1 RESULT slot.
+      */
+-    STONECUTTER(2, "Stonecutter"),
++    STONECUTTER(2, "Stonecutter", "container.stonecutter"), // Paper
+     /**
+      * Pseudo composter inventory with 0 or 1 slots of undefined type.
+      */
+-    COMPOSTER(1, "Composter", false),
++    COMPOSTER(1, "Composter", false, null), // Paper
+     /**
+      * Pseudo chiseled bookshelf inventory, with 6 slots of undefined type.
+      */
+-    CHISELED_BOOKSHELF(6, "Chiseled Bookshelf", false),
++    CHISELED_BOOKSHELF(6, "Chiseled Bookshelf", false, null), // Paper
+     /**
+      * Pseudo jukebox inventory with 1 slot of undefined type.
+      */
+-    JUKEBOX(1, "Jukebox", false),
++    JUKEBOX(1, "Jukebox", false, null), // Paper
+     /**
+      * The new smithing inventory, with 3 CRAFTING slots and 1 RESULT slot.
+      *
+      * @deprecated use {@link #SMITHING}
+      */
+     @Deprecated
+-    SMITHING_NEW(4, "Upgrade Gear"),
++    SMITHING_NEW(4, "Upgrade Gear", "container.upgrade"), // Paper
+     ;
+ 
+     private final int size;
+@@ -157,6 +157,17 @@ public enum InventoryType {
+ 
+     // Paper start
+     private final net.kyori.adventure.text.Component defaultTitleComponent;
++    private final String translationKey;
++
++    /**
++     * @throws IllegalStateException if you call this on {@link #MERCHANT} or {@link #COMPOSTER}.
++     */
++    @Override
++    public @org.jetbrains.annotations.NotNull String translationKey() {
++        com.google.common.base.Preconditions.checkState(this.translationKey != null, this + " is not translatable");
++        return this.translationKey;
++    }
++
+ 
+     /**
+      * Gets the inventory's default title.
+@@ -166,16 +177,17 @@ public enum InventoryType {
+     public net.kyori.adventure.text.@NotNull Component defaultTitle() {
+         return defaultTitleComponent;
+     }
++    private InventoryType(int defaultSize, /*@NotNull*/ String defaultTitle, @org.jetbrains.annotations.Nullable String translationKey) {
++        this(defaultSize, defaultTitle, true, translationKey);
+     // Paper end
+-    private InventoryType(int defaultSize, /*@NotNull*/ String defaultTitle) {
+-        this(defaultSize, defaultTitle, true);
+     }
+ 
+-    private InventoryType(int defaultSize, /*@NotNull*/ String defaultTitle, boolean isCreatable) {
++    private InventoryType(int defaultSize, /*@NotNull*/ String defaultTitle, boolean isCreatable, @org.jetbrains.annotations.Nullable String translationKey) { // Paper
+         size = defaultSize;
+         title = defaultTitle;
+         this.isCreatable = isCreatable;
+-        this.defaultTitleComponent = net.kyori.adventure.text.Component.text(defaultTitle); // Paper - Adventure
++        this.defaultTitleComponent = translationKey != null ? net.kyori.adventure.text.Component.translatable(translationKey) : net.kyori.adventure.text.Component.text(defaultTitle); // Paper - Adventure
++        this.translationKey = translationKey; // Paper
+     }
+ 
+     public int getDefaultSize() {
 diff --git a/src/main/java/org/bukkit/inventory/CreativeCategory.java b/src/main/java/org/bukkit/inventory/CreativeCategory.java
 index 5bd252c0ae3b09fe141d131360c67bb9bfbf5422..78587d9fabe6371a23a7963917b054dbe7603694 100644
 --- a/src/main/java/org/bukkit/inventory/CreativeCategory.java

--- a/patches/api/0415-Properly-remove-the-experimental-smithing-inventory-.patch
+++ b/patches/api/0415-Properly-remove-the-experimental-smithing-inventory-.patch
@@ -5,16 +5,16 @@ Subject: [PATCH] Properly remove the experimental smithing inventory type
 
 
 diff --git a/src/main/java/org/bukkit/event/inventory/InventoryType.java b/src/main/java/org/bukkit/event/inventory/InventoryType.java
-index 19ba2d948ad83baab2a14ae6f7b3ce43c3d4971f..cbce826add9dc2b3187c7bea00c27b785d7517df 100644
+index 293711e1ca784d1fdff8da4f8bfc88c3204e39fd..4517b6121aa39f0e717cb90ea51a3e27aafc4070 100644
 --- a/src/main/java/org/bukkit/event/inventory/InventoryType.java
 +++ b/src/main/java/org/bukkit/event/inventory/InventoryType.java
-@@ -147,7 +147,7 @@ public enum InventoryType {
+@@ -147,7 +147,7 @@ public enum InventoryType implements net.kyori.adventure.translation.Translatabl
       *
       * @deprecated use {@link #SMITHING}
       */
 -    @Deprecated
 +    @Deprecated(forRemoval = true) // Paper
-     SMITHING_NEW(4, "Upgrade Gear"),
+     SMITHING_NEW(4, "Upgrade Gear", "container.upgrade"), // Paper
      ;
  
 diff --git a/src/main/java/org/bukkit/inventory/InventoryView.java b/src/main/java/org/bukkit/inventory/InventoryView.java

--- a/patches/server/0460-Add-methods-to-get-translation-keys.patch
+++ b/patches/server/0460-Add-methods-to-get-translation-keys.patch
@@ -41,7 +41,7 @@ index e8334e2264510f5101e80b4f130e7ae1442560d7..57decf4156f176ebcc988478c17856cb
  
      public net.minecraft.world.item.enchantment.Enchantment getHandle() {
 diff --git a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
-index fab3063fffa959ac7f0eb5937f2fae94d11b6591..ffc9776a8927d6255820d1384c9e66f99a7b692c 100644
+index fab3063fffa959ac7f0eb5937f2fae94d11b6591..ce96368f6634c8a31c10ceedd534a1e1fc6bac50 100644
 --- a/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 +++ b/src/test/java/io/papermc/paper/world/TranslationKeyTest.java
 @@ -1,12 +1,27 @@
@@ -73,7 +73,7 @@ index fab3063fffa959ac7f0eb5937f2fae94d11b6591..ffc9776a8927d6255820d1384c9e66f9
  
      @Test
      public void testChatVisibilityKeys() {
-@@ -15,4 +30,67 @@ public class TranslationKeyTest {
+@@ -15,4 +30,78 @@ public class TranslationKeyTest {
              Assert.assertEquals(chatVisibility + "'s translation key doesn't match", ChatVisiblity.valueOf(chatVisibility.name()).getKey(), chatVisibility.translationKey());
          }
      }
@@ -138,6 +138,17 @@ index fab3063fffa959ac7f0eb5937f2fae94d11b6591..ffc9776a8927d6255820d1384c9e66f9
 +            final MusicInstrument bukkit = MusicInstrument.getByKey(CraftNamespacedKey.fromMinecraft(nms));
 +            Assert.assertNotNull("Missing bukkit instrument for " + nms, bukkit);
 +            Assert.assertEquals("translation key mismatch for " + bukkit, nms.toLanguageKey("instrument"), bukkit.translationKey());
++        }
++    }
++
++    @Test
++    public void testInventoryType() {
++        for (org.bukkit.event.inventory.InventoryType type : org.bukkit.event.inventory.InventoryType.values()) {
++            if (!type.isCreatable() && type != org.bukkit.event.inventory.InventoryType.CRAFTING && type != org.bukkit.event.inventory.InventoryType.CREATIVE) {
++                Assert.assertThrows(type + " should throw when using translation key", IllegalStateException.class, type::translationKey);
++                continue;
++            }
++            Assert.assertNotEquals(type + " has an unresolved translation key", type.translationKey(), net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer.plainText().serialize(net.kyori.adventure.text.Component.translatable(type)));
 +        }
 +    }
  }


### PR DESCRIPTION
All but 2 of the bukkit InventoryType's can easily implement Translatable. The two that cant, Composter (which doesn't have a UI to begin with, no clue why its part of the bukkit enum) and Merchant which relies on the villager name. So can either to a nonnull method that returns an empty string for its translation key, or a nullable method and NOT implement Translatable, or have it throw an exception of there isn't one and someone tries to use the method.