### PR TITLE
Provide option to disable username validation (Closes #7250)

### DIFF
--- a/patches/server/0842-Validate-usernames.patch
+++ b/patches/server/0842-Validate-usernames.patch
@@ -4,8 +4,25 @@ Date: Sat, 1 Jan 2022 05:19:37 -0800
 Subject: [PATCH] Validate usernames
 
 
+diff --git a/src/main/java/com/destroystokyo/paper/PaperConfig.java b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+index d5aa95846e7f52108a03e3731023527281b21d73..1d3cc8836d2ccbec4a8660f86501be35c76e8b0b 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperConfig.java
+@@ -493,6 +493,12 @@ public class PaperConfig {
+         set("settings.unsupported-settings.allow-tnt-duplication", null);
+     }
+ 
++    public static boolean performUsernameValidation;
++    private static void performUsernameValidation() {
++        performUsernameValidation = getBoolean("settings.unsupported-settings.perform-username-validation", true);
++    }
++
++
+     public static int playerAutoSaveRate = -1;
+     public static int maxPlayerAutoSavePerTick = 10;
+     private static void playerAutoSaveRate() {
 diff --git a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
-index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..96593919db8b140e55fe1a120c2835b679771e92 100644
+index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..462d8c36166c63a4dc8fa74ac7f82859e6f4b83a 100644
 --- a/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 +++ b/src/main/java/net/minecraft/server/network/ServerLoginPacketListenerImpl.java
 @@ -230,10 +230,38 @@ public class ServerLoginPacketListenerImpl implements ServerLoginPacketListener
@@ -37,7 +54,7 @@ index 33a29890435d6065a2cc4f8e8bf8209c01d5d114..96593919db8b140e55fe1a120c2835b6
          Validate.validState(this.state == ServerLoginPacketListenerImpl.State.HELLO, "Unexpected hello packet", new Object[0]);
          this.gameProfile = packet.getGameProfile();
 +        // Paper start - validate usernames
-+        if (com.destroystokyo.paper.PaperConfig.isProxyOnlineMode()) {
++        if (com.destroystokyo.paper.PaperConfig.isProxyOnlineMode() && com.destroystokyo.paper.PaperConfig.performUsernameValidation) {
 +            if (!validateUsername(this.gameProfile.getName())) {
 +                ServerLoginPacketListenerImpl.this.disconnect("Failed to verify username!");
 +                return;


### PR DESCRIPTION
I hate this, but, I don't see any other sane option especially for oddball setups which blatantly violate mojangs apis. This is an unsupported setting for various reasons