### PR TITLE
Add method to set noclip on arrows

### DIFF
--- a/patches/api/0207-Improve-Arrow-API.patch
+++ b/patches/api/0207-Improve-Arrow-API.patch
@@ -1,14 +1,18 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nesaak <52047222+Nesaak@users.noreply.github.com>
 Date: Fri, 22 May 2020 13:35:21 -0400
-Subject: [PATCH] Expose Arrow getItemStack
+Subject: [PATCH] Improve Arrow API
 
+Add method to get the arrow's itemstack and a method
+to set the arrow's "noclip" status
+
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/entity/AbstractArrow.java b/src/main/java/org/bukkit/entity/AbstractArrow.java
-index e8e56e89e32d84af0639fe2e9b0eeabd747b6007..b1d8007eed489aa061c1a6813bcdafc101231e56 100644
+index e8e56e89e32d84af0639fe2e9b0eeabd747b6007..225a24898acd25038ea2a8448f9f3b57643d3026 100644
 --- a/src/main/java/org/bukkit/entity/AbstractArrow.java
 +++ b/src/main/java/org/bukkit/entity/AbstractArrow.java
-@@ -143,6 +143,14 @@ public interface AbstractArrow extends Projectile {
+@@ -143,6 +143,28 @@ public interface AbstractArrow extends Projectile {
      }
  
      // Paper start
@@ -19,6 +23,20 @@ index e8e56e89e32d84af0639fe2e9b0eeabd747b6007..b1d8007eed489aa061c1a6813bcdafc1
 +     */
 +    @NotNull
 +    org.bukkit.inventory.ItemStack getItemStack();
++
++    /**
++     * Sets this arrow to "noclip" status.
++     *
++     * @param noPhysics true to set "noclip"
++     */
++    void setNoPhysics(boolean noPhysics);
++
++    /**
++     * Gets if this arrow has "noclip".
++     *
++     * @return true if noclip is active
++     */
++    boolean hasNoPhysics();
 +
      /**
       * Gets the {@link PickupRule} for this arrow.

--- a/patches/server/0446-Improve-Arrow-API.patch
+++ b/patches/server/0446-Improve-Arrow-API.patch
@@ -1,14 +1,18 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Nesaak <52047222+Nesaak@users.noreply.github.com>
 Date: Sat, 23 May 2020 10:31:11 -0400
-Subject: [PATCH] Expose Arrow getItemStack
+Subject: [PATCH] Improve Arrow API
 
+Add method to get the arrow's itemstack and a method
+to set the arrow's "noclip" status
+
+Co-authored-by: Jake Potrebic <jake.m.potrebic@gmail.com>
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-index 376885c8148da619a3b203145d315ebaf44994fb..454c8fab2f0b60aa3afd73805ea3586881605450 100644
+index 376885c8148da619a3b203145d315ebaf44994fb..15abd085eeb0a31a925c1a8d6de903c9d4625a29 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftArrow.java
-@@ -102,6 +102,13 @@ public class CraftArrow extends AbstractProjectile implements AbstractArrow {
+@@ -102,6 +102,23 @@ public class CraftArrow extends AbstractProjectile implements AbstractArrow {
          this.getHandle().pickup = net.minecraft.world.entity.projectile.AbstractArrow.Pickup.byOrdinal(status.ordinal());
      }
  
@@ -16,6 +20,16 @@ index 376885c8148da619a3b203145d315ebaf44994fb..454c8fab2f0b60aa3afd73805ea35868
 +    @Override
 +    public org.bukkit.craftbukkit.inventory.CraftItemStack getItemStack() {
 +        return org.bukkit.craftbukkit.inventory.CraftItemStack.asCraftMirror(getHandle().getPickupItem());
++    }
++
++    @Override
++    public void setNoPhysics(boolean noPhysics) {
++        this.getHandle().setNoPhysics(noPhysics);
++    }
++
++    @Override
++    public boolean hasNoPhysics() {
++        return this.getHandle().isNoPhysics();
 +    }
 +    // Paper end
 +


### PR DESCRIPTION
Tested by firing one of each of the 3 arrows, (regular, spectral, and tipped) and a trident. The arrows work as expected, the trident just immediately returns to the player without going anywhere. Should that be documented?