### PR TITLE
Add text filtering and allow server listing client options

### DIFF
--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -90,10 +90,10 @@ index 0000000000000000000000000000000000000000..4a0c39405d4fbed457787e3c6ded4cc6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..d4509813aa523bccce3c58cf55ed1144007d5d64
+index 0000000000000000000000000000000000000000..9521092cdcd954249e11833e91cf64befc6ca2e7
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
-@@ -0,0 +1,124 @@
+@@ -0,0 +1,125 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.destroystokyo.paper.ClientOption;
@@ -123,6 +123,7 @@ index 0000000000000000000000000000000000000000..d4509813aa523bccce3c58cf55ed1144
 +    private final boolean allowServerListings;
 +    private final boolean textFilteringEnabled;
 +
++    @Deprecated
 +    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull String locale, int viewDistance, @NotNull ChatVisibility chatVisibility, boolean chatColors, @NotNull SkinParts skinParts, @NotNull MainHand mainHand) {
 +        this(player, locale, viewDistance, chatVisibility, chatColors, skinParts, mainHand, false, false);
 +    }

--- a/patches/api/0194-Add-Player-Client-Options-API.patch
+++ b/patches/api/0194-Add-Player-Client-Options-API.patch
@@ -6,10 +6,10 @@ Subject: [PATCH] Add Player Client Options API
 
 diff --git a/src/main/java/com/destroystokyo/paper/ClientOption.java b/src/main/java/com/destroystokyo/paper/ClientOption.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..cedb51f9f3a9150035c2b44970a096448c441dd9
+index 0000000000000000000000000000000000000000..f89bfeba29e6988db849957a508ca97ff5322242
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/ClientOption.java
-@@ -0,0 +1,50 @@
+@@ -0,0 +1,52 @@
 +package com.destroystokyo.paper;
 +
 +import net.kyori.adventure.translation.Translatable;
@@ -26,6 +26,8 @@ index 0000000000000000000000000000000000000000..cedb51f9f3a9150035c2b44970a09644
 +    public static final ClientOption<String> LOCALE = new ClientOption<>(String.class);
 +    public static final ClientOption<MainHand> MAIN_HAND = new ClientOption<>(MainHand.class);
 +    public static final ClientOption<Integer> VIEW_DISTANCE = new ClientOption<>(Integer.class);
++    public static final ClientOption<Boolean> ALLOW_SERVER_LISTINGS = new ClientOption<>(Boolean.class);
++    public static final ClientOption<Boolean> TEXT_FILTERING_ENABLED = new ClientOption<>(Boolean.class);
 +
 +    private final Class<T> type;
 +
@@ -88,10 +90,10 @@ index 0000000000000000000000000000000000000000..4a0c39405d4fbed457787e3c6ded4cc6
 +}
 diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
 new file mode 100644
-index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f17202f28
+index 0000000000000000000000000000000000000000..d4509813aa523bccce3c58cf55ed1144007d5d64
 --- /dev/null
 +++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerClientOptionsChangeEvent.java
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,124 @@
 +package com.destroystokyo.paper.event.player;
 +
 +import com.destroystokyo.paper.ClientOption;
@@ -106,7 +108,7 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +import org.bukkit.inventory.MainHand;
 +
 +/**
-+ * Called when the player changes his client settings
++ * Called when the player changes their client settings
 + */
 +public class PlayerClientOptionsChangeEvent extends PlayerEvent {
 +
@@ -118,8 +120,14 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +    private final boolean chatColors;
 +    private final SkinParts skinparts;
 +    private final MainHand mainHand;
++    private final boolean allowServerListings;
++    private final boolean textFilteringEnabled;
 +
 +    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull String locale, int viewDistance, @NotNull ChatVisibility chatVisibility, boolean chatColors, @NotNull SkinParts skinParts, @NotNull MainHand mainHand) {
++        this(player, locale, viewDistance, chatVisibility, chatColors, skinParts, mainHand, false, false);
++    }
++
++    public PlayerClientOptionsChangeEvent(@NotNull Player player, @NotNull String locale, int viewDistance, @NotNull ChatVisibility chatVisibility, boolean chatColors, @NotNull SkinParts skinParts, @NotNull MainHand mainHand, boolean allowServerListings, boolean textFilteringEnabled) {
 +        super(player);
 +        this.locale = locale;
 +        this.viewDistance = viewDistance;
@@ -127,6 +135,8 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +        this.chatColors = chatColors;
 +        this.skinparts = skinParts;
 +        this.mainHand = mainHand;
++        this.allowServerListings = allowServerListings;
++        this.textFilteringEnabled = textFilteringEnabled;
 +    }
 +
 +    @NotNull
@@ -179,6 +189,22 @@ index 0000000000000000000000000000000000000000..f7f171c4ee0b8339b2f8fbe82442d65f
 +
 +    public boolean hasMainHandChanged() {
 +        return mainHand != player.getClientOption(ClientOption.MAIN_HAND);
++    }
++
++    public boolean allowsServerListings() {
++        return allowServerListings;
++    }
++
++    public boolean hasServerListingsChanged() {
++        return allowServerListings != player.getClientOption(ClientOption.ALLOW_SERVER_LISTINGS);
++    }
++
++    public boolean hasTextFilteringEnabled() {
++        return textFilteringEnabled;
++    }
++
++    public boolean hasTextFilteringChanged() {
++        return textFilteringEnabled != player.getClientOption(ClientOption.TEXT_FILTERING_ENABLED);
 +    }
 +
 +    @Override

--- a/patches/server/0400-Implement-Player-Client-Options-API.patch
+++ b/patches/server/0400-Implement-Player-Client-Options-API.patch
@@ -85,22 +85,22 @@ index 0000000000000000000000000000000000000000..b6f4400df3d8ec7e06a996de54f8cabb
 +    }
 +}
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index 9cbca14b0a111e57a1d01bcbcf2164ab8b53b1a5..cdb0eb8e21299ca70ed7ed5c1195d07f44e47838 100644
+index 9cbca14b0a111e57a1d01bcbcf2164ab8b53b1a5..5dba4021e993db1fc7e8dfd89411c6e02b2df5dc 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1830,6 +1830,7 @@ public class ServerPlayer extends Player {
      public String locale = null; // CraftBukkit - add, lowercase // Paper - default to null
      public java.util.Locale adventure$locale = java.util.Locale.US; // Paper
      public void updateOptions(ServerboundClientInformationPacket packet) {
-+        new com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent(getBukkitEntity(), packet.language, packet.viewDistance, com.destroystokyo.paper.ClientOption.ChatVisibility.valueOf(packet.chatVisibility().name()), packet.chatColors(), new com.destroystokyo.paper.PaperSkinParts(packet.modelCustomisation()), packet.mainHand() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT).callEvent(); // Paper - settings event
++        new com.destroystokyo.paper.event.player.PlayerClientOptionsChangeEvent(getBukkitEntity(), packet.language, packet.viewDistance, com.destroystokyo.paper.ClientOption.ChatVisibility.valueOf(packet.chatVisibility().name()), packet.chatColors(), new com.destroystokyo.paper.PaperSkinParts(packet.modelCustomisation()), packet.mainHand() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT, packet.allowsListing(), packet.textFilteringEnabled()).callEvent(); // Paper - settings event
          // CraftBukkit start
          if (getMainArm() != packet.mainHand()) {
              PlayerChangedMainHandEvent event = new PlayerChangedMainHandEvent(this.getBukkitEntity(), getMainArm() == HumanoidArm.LEFT ? MainHand.LEFT : MainHand.RIGHT);
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index b04aaab4f7cb7367d0fbc6268b0db269b55b2d17..3f25e799ba13d8280c644a943ca0d191fde9eb7b 100644
+index b04aaab4f7cb7367d0fbc6268b0db269b55b2d17..384530bb7ebd6e43467d93ed12137f162011640a 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -546,6 +546,24 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -546,6 +546,28 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      public void setSendViewDistance(int viewDistance) {
          throw new NotImplementedException("Per-Player View Distance APIs need further understanding to properly implement (There are per world view distances though!)"); // TODO
      }
@@ -119,6 +119,10 @@ index b04aaab4f7cb7367d0fbc6268b0db269b55b2d17..3f25e799ba13d8280c644a943ca0d191
 +            return type.getType().cast(getMainHand());
 +        } else if(com.destroystokyo.paper.ClientOption.VIEW_DISTANCE.equals(type)) {
 +            return type.getType().cast(getClientViewDistance());
++        } else if (com.destroystokyo.paper.ClientOption.ALLOW_SERVER_LISTINGS.equals(type)) {
++            return type.getType().cast(isAllowingServerListings());
++        } else if (com.destroystokyo.paper.ClientOption.TEXT_FILTERING_ENABLED.equals(type)) {
++            return type.getType().cast(getHandle().isTextFilteringEnabled());
 +        }
 +        throw new RuntimeException("Unknown settings type");
 +    }

--- a/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
+++ b/patches/server/0470-Implement-Chunk-Priority-Urgency-System-for-Chunks.patch
@@ -360,7 +360,7 @@ index 9e96b0465717bfa761289c255fd8d2f1df1be3d8..87271552aa85626f22f7f8569c8fb48f
          return this.isEntityTickingReady;
      }
 diff --git a/src/main/java/net/minecraft/server/level/ChunkMap.java b/src/main/java/net/minecraft/server/level/ChunkMap.java
-index 326a3b312d3446b813e325867f852e0cf6786945..3e6cc16ff6f6c7993b15bd807257c0554afb6c77 100644
+index cac9c9ede6024653f4ae83cbbdd9939f75ccad48..01ce18ba387f1f73e894268c08b19cced6b5ea26 100644
 --- a/src/main/java/net/minecraft/server/level/ChunkMap.java
 +++ b/src/main/java/net/minecraft/server/level/ChunkMap.java
 @@ -128,6 +128,7 @@ public class ChunkMap extends ChunkStorage implements ChunkHolder.PlayerProvider
@@ -796,7 +796,7 @@ index 73b1018b0aca377ed0ff188e74040cef57036b0b..3b0e254f569576a6193750811c06f1c1
          boolean flag1 = this.chunkMap.promoteChunkMap();
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index d2280b9e9f107dca890bc76f0c58e7070ce4b38c..c68b95ef0d4c3e0d942e61bfccf23a00d0d8afd9 100644
+index 4b7a82c3d49e8a5d2c380395dd589f4e2b8e580f..3d8475bbcb30883650af10f99555cb2fd8d62236 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -186,6 +186,7 @@ public class ServerPlayer extends Player {
@@ -1210,10 +1210,10 @@ index c11bdc266434aa9d90e5ab25e185dc1a1ba57d9b..eea11a2bf87d409f484f07f207c57c86
              net.minecraft.world.level.chunk.LevelChunk chunk = (net.minecraft.world.level.chunk.LevelChunk) either.left().orElse(null);
              if (chunk != null) addTicket(x, z); // Paper
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3f25e799ba13d8280c644a943ca0d191fde9eb7b..d22662c5d12f03196b00e8342b063f346d86f76a 100644
+index 384530bb7ebd6e43467d93ed12137f162011640a..53797aa0ed7ac88b0add0ad815fc276b2d80ba6e 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -909,6 +909,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -913,6 +913,16 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          throw new UnsupportedOperationException("Cannot set rotation of players. Consider teleporting instead.");
      }
  

--- a/patches/server/0484-Brand-support.patch
+++ b/patches/server/0484-Brand-support.patch
@@ -72,10 +72,10 @@ index 4a17f98d06f061a2253dc75e313c618e550ed100..f9073eaa82c79f0b8ad738213b53f991
          return (!this.player.joining && !this.connection.isConnected()) || this.processedDisconnect; // Paper
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index d22662c5d12f03196b00e8342b063f346d86f76a..08d6dfbbf62e7adb801a7bf49dd1a1f611e768c6 100644
+index 53797aa0ed7ac88b0add0ad815fc276b2d80ba6e..7010277472df4c1a0aebb7e7ac391034baa38571 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2563,6 +2563,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2567,6 +2567,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          // Paper end
      };
  

--- a/patches/server/0521-Player-elytra-boost-API.patch
+++ b/patches/server/0521-Player-elytra-boost-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Player elytra boost API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 08d6dfbbf62e7adb801a7bf49dd1a1f611e768c6..3cb295a37f8cd1a84712a0b2b6b2c09dfafca162 100644
+index 7010277472df4c1a0aebb7e7ac391034baa38571..9ae35f27cd7fd232a930361d48a8106ceb89affe 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -564,6 +564,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -568,6 +568,20 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          throw new RuntimeException("Unknown settings type");
      }

--- a/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
+++ b/patches/server/0536-Fix-Player-spawnParticle-x-y-z-precision-loss.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Fix Player spawnParticle x/y/z precision loss
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 3cb295a37f8cd1a84712a0b2b6b2c09dfafca162..a06fd29b6006459edf0069ce8d1dddcb36ca3104 100644
+index 9ae35f27cd7fd232a930361d48a8106ceb89affe..d3eb0f4be1631be06e126fb69da15ad7b54576c7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2134,7 +2134,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2138,7 +2138,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          if (data != null && !particle.getDataType().isInstance(data)) {
              throw new IllegalArgumentException("data should be " + particle.getDataType() + " got " + data.getClass());
          }

--- a/patches/server/0577-Add-sendOpLevel-API.patch
+++ b/patches/server/0577-Add-sendOpLevel-API.patch
@@ -32,10 +32,10 @@ index 201f36b0f8ae391b2efbad5cc38f115537a761a2..0052a9c5d19db44331bb7ee93544d783
  
      // Paper start
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index a06fd29b6006459edf0069ce8d1dddcb36ca3104..198731f323baee319100cb537afb9f5bb9a6af3c 100644
+index d3eb0f4be1631be06e126fb69da15ad7b54576c7..830f2c844c051411c317904dfd6723921ecb01a5 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -578,6 +578,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -582,6 +582,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              ? (org.bukkit.entity.Firework) entity.getBukkitEntity()
              : null;
      }

--- a/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
+++ b/patches/server/0655-additions-to-PlayerGameModeChangeEvent.patch
@@ -45,7 +45,7 @@ index d75f78d2e3fb1376e8f6a8668c98a04a693c99e1..79f6089b934124c3309c6bee2e48b36b
          }
  
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index fd6eb3b3953ca0413af6a71c52503c9674917a9e..77ba7fe43ceffcb816d209da45ab0c5de2112ee3 100644
+index d1390fca4408cd246ebfe3f9df3690bbf5a5ad18..6b8919660459613004fac079546d0c17d8d3d78a 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1805,8 +1805,15 @@ public class ServerPlayer extends Player {
@@ -139,10 +139,10 @@ index 9f93ce18a0406321462fb5e4c4dbfab720b87da8..b12d7f8ac2ac446eb0cdfa1e73de6690
                      }
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 198731f323baee319100cb537afb9f5bb9a6af3c..ffa49594d4a137be7476677488605ce74c607bba 100644
+index 830f2c844c051411c317904dfd6723921ecb01a5..5ff8ff6577f232d268cf81e040e612cef1cea36f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1269,7 +1269,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1273,7 +1273,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
              throw new IllegalArgumentException("Mode cannot be null");
          }
  

--- a/patches/server/0702-Add-PlayerSetSpawnEvent.patch
+++ b/patches/server/0702-Add-PlayerSetSpawnEvent.patch
@@ -18,7 +18,7 @@ index e95f2222814e104bf9194a96385737dffe2cb2b5..249ab7357aa19d87179fa4c3ae89d9d3
  
          String string = resourceKey.location().toString();
 diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
-index e87d4071604a642c0a08129b469e707a609bf83d..6c0c1f7f4f3407164ee39abf4c87ffcc057994fd 100644
+index 7faba67ef25de9e781cb2aedc9223cf89a4b3570..ce8c6afbbab4125554310ac24e757a49c25ef023 100644
 --- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
 +++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
 @@ -1276,7 +1276,7 @@ public class ServerPlayer extends Player {
@@ -93,10 +93,10 @@ index d620f559cdd1bd0e161a99123ef6c6f64e3302df..07e893f1859abe3c2a765694c21309d6
                      return InteractionResult.SUCCESS;
                  }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 43bfae712369c3c895a0007041d3821bb6257ccd..261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a 100644
+index 04fcb6fba42a8d41393b9bc5951ed3d763d2b3f4..c926490430caa4c511ea04f627d6df6defd18ad6 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1089,9 +1089,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -1093,9 +1093,9 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
      @Override
      public void setBedSpawnLocation(Location location, boolean override) {
          if (location == null) {

--- a/patches/server/0815-Add-player-health-update-API.patch
+++ b/patches/server/0815-Add-player-health-update-API.patch
@@ -5,10 +5,10 @@ Subject: [PATCH] Add player health update API
 
 
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a..8de4ad9f2120d22b78202981624abd1d2fc70148 100644
+index c926490430caa4c511ea04f627d6df6defd18ad6..e00f76723d96336de105b4d3ee46accb0ac717e2 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2013,9 +2013,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2017,9 +2017,11 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          this.getHandle().maxHealthCache = getMaxHealth();
      }
  
@@ -22,7 +22,7 @@ index 261a2b4d750c0b57c3c83a82ee41a2bb7d770d8a..8de4ad9f2120d22b78202981624abd1d
          if (this.getHandle().queueHealthUpdatePacket) {
              this.getHandle().queuedHealthUpdatePacket = packet;
          } else {
-@@ -2023,7 +2025,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
+@@ -2027,7 +2029,13 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
          }
          // Paper end
      }


### PR DESCRIPTION
Might be useful for servers that implement custom chat filters and want to detect if they should filter chat by default for a particular person.

I don't have a Microsoft child account, so I tested this with the following pakkit script:
```java
exports.upstreamHandler = function (meta, data, server, client) {
  if (meta.name === 'settings') {
    data.enableTextFiltering = true
  }
  server.sendPacket(meta, data)
}

exports.downstreamHandler = function (meta, data, server, client) {
  client.sendPacket(meta, data)
}
```