### PR TITLE
Fix some nullability things

### DIFF
--- a/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
+++ b/patches/api/0175-Fix-Spigot-annotation-mistakes.patch
@@ -9,7 +9,7 @@ a ton of noise to plugin developers.
 These do not help plugin developers if they bring moise noise than value.
 
 diff --git a/src/main/java/org/bukkit/Bukkit.java b/src/main/java/org/bukkit/Bukkit.java
-index ca6f3a18ca8902b99c1c8c21b6da5def7fdb2aa8..b4256e2c66e3f578a4499dc1fff50f213898b96b 100644
+index ca6f3a18ca8902b99c1c8c21b6da5def7fdb2aa8..d9f245ec7998655116c485b5607a130cb443765e 100644
 --- a/src/main/java/org/bukkit/Bukkit.java
 +++ b/src/main/java/org/bukkit/Bukkit.java
 @@ -1158,10 +1158,8 @@ public final class Bukkit {
@@ -32,15 +32,6 @@ index ca6f3a18ca8902b99c1c8c21b6da5def7fdb2aa8..b4256e2c66e3f578a4499dc1fff50f21
 +    @NotNull // Paper
      public static ScoreboardManager getScoreboardManager() {
          return server.getScoreboardManager();
-     }
-@@ -1996,7 +1994,7 @@ public final class Bukkit {
-      * @param clazz the class of the tag entries
-      * @return the tag or null
-      */
--    @Nullable
-+    @UndefinedNullability // Paper
-     public static <T extends Keyed> Tag<T> getTag(@NotNull String registry, @NotNull NamespacedKey tag, @NotNull Class<T> clazz) {
-         return server.getTag(registry, tag, clazz);
      }
 diff --git a/src/main/java/org/bukkit/GrassSpecies.java b/src/main/java/org/bukkit/GrassSpecies.java
 index f9c9ae463aacd593e3aa9caf037ea1e23d56c780..f8ae143acbf586d5279b44f7311ca97f3ae4ead2 100644

--- a/patches/server/0006-CB-fixes.patch
+++ b/patches/server/0006-CB-fixes.patch
@@ -1,16 +1,20 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: Spottedleaf <Spottedleaf@users.noreply.github.com>
+From: Jake Potrebic <jake.m.potrebic@gmail.com>
 Date: Fri, 25 Feb 2022 07:14:48 -0800
 Subject: [PATCH] CB fixes
 
 * Missing Level -> LevelStem generic in StructureCheck
-  Need to use the right for injectDatafixingContext
+  Need to use the right for injectDatafixingContext (Spottedleaf)
 
-* Removed incorrect parent perm for `minecraft.debugstick.always`
+* Removed incorrect parent perm for `minecraft.debugstick.always` (Machine_Maker)
 
-* Fixed method signature of Marker#addPassenger
+* Fixed method signature of Marker#addPassenger (Machine_Maker)
 
-* Removed unneeded UOE in CustomWorldChunkManager (extends BiomeSource)
+* Removed unneeded UOE in CustomWorldChunkManager (extends BiomeSource) (Machine_Maker)
+
+* Honor Server#getLootTable method contract (Machine_Maker)
+
+Co-authored-by: Spottedleaf <Spottedleaf@users.noreply.github.com>
 
 diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
 index a480e20ac456a3169c67d2d43c191b7807a8ef10..1427b76110a02cee15865173e06e7b7bb4231ae7 100644
@@ -62,6 +66,25 @@ index ac1373b8c4411298f881f9d569bf984704eeadc4..469d3d7fb69829595abd221c700fcf79
          this.storageAccess = chunkIoWorker;
          this.registryAccess = registryManager;
          this.structureManager = structureManager;
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..66e8fea6bd10af2e19a4f49c556e66a63e6205b6 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -2266,7 +2266,13 @@ public final class CraftServer implements Server {
+         Validate.notNull(key, "NamespacedKey cannot be null");
+ 
+         LootTables registry = this.getServer().getLootTables();
+-        return new CraftLootTable(key, registry.get(CraftNamespacedKey.toMinecraft(key)));
++        // Paper start - honor method contract
++        final ResourceLocation lootTableKey = CraftNamespacedKey.toMinecraft(key);
++        if (!registry.getIds().contains(lootTableKey)) {
++            return null;
++        }
++        return new CraftLootTable(key, registry.get(lootTableKey));
++        // Paper end
+     }
+ 
+     @Override
 diff --git a/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java b/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java
 index 6f1855d1fed73b694b0eaf581231359a66ae48e2..0238db9d5ffebe597534ec283f173ee2da19946d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/generator/CustomWorldChunkManager.java

--- a/patches/server/0008-Adventure.patch
+++ b/patches/server/0008-Adventure.patch
@@ -1783,13 +1783,13 @@ index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..e2270d75c1ffaf0b68300f0734987e86
      }
  
 +    // Paper start
-     @Override
++    @Override
 +    public net.kyori.adventure.text.Component shutdownMessage() {
 +        String msg = getShutdownMessage();
 +        return msg != null ? net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer.legacySection().deserialize(msg) : null;
 +    }
 +    // Paper end
-+    @Override
+     @Override
 +    @Deprecated // Paper
      public String getShutdownMessage() {
          return this.configuration.getString("settings.shutdown-message");
@@ -1889,7 +1889,7 @@ index d29c6d0536619fab5a48fbb52115dac09e7d7ca3..e2270d75c1ffaf0b68300f0734987e86
      @Override
      public String getMotd() {
          return this.console.getMotd();
-@@ -2364,5 +2416,15 @@ public final class CraftServer implements Server {
+@@ -2370,5 +2422,15 @@ public final class CraftServer implements Server {
              return null;
          }
      }

--- a/patches/server/0012-Timings-v2.patch
+++ b/patches/server/0012-Timings-v2.patch
@@ -1710,7 +1710,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index e2270d75c1ffaf0b68300f0734987e86ab6fedda..4a04536ecdeb055fd32272884f6057e5d04f1035 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2355,12 +2355,31 @@ public final class CraftServer implements Server {
+@@ -2361,12 +2361,31 @@ public final class CraftServer implements Server {
      private final org.bukkit.Server.Spigot spigot = new org.bukkit.Server.Spigot()
      {
  

--- a/patches/server/0025-Further-improve-server-tick-loop.patch
+++ b/patches/server/0025-Further-improve-server-tick-loop.patch
@@ -147,7 +147,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 85e9d97d8a805e7b86213d3460eb62f9b4a5e7b4..ec97233239d38b3e7b4256eb4e5d5f5c28b904c4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2385,6 +2385,17 @@ public final class CraftServer implements Server {
+@@ -2391,6 +2391,17 @@ public final class CraftServer implements Server {
          return CraftMagicNumbers.INSTANCE;
      }
  

--- a/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
+++ b/patches/server/0063-Allow-Reloading-of-Custom-Permissions.patch
@@ -9,7 +9,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 1ef1d0d9341ab8c633d3899336a990688b7f79dd..d317d6853e2b129e9b638f4e76b383f0d53d3cf7 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2515,5 +2515,23 @@ public final class CraftServer implements Server {
+@@ -2521,5 +2521,23 @@ public final class CraftServer implements Server {
          }
          return this.adventure$audiences;
      }

--- a/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
+++ b/patches/server/0109-Allow-Reloading-of-Command-Aliases.patch
@@ -9,7 +9,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index a380fb3b192dea5805126f616390da52312749c1..028f2e2d24a6a1eac07c04d79c44bbdfe87108cb 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2541,5 +2541,24 @@ public final class CraftServer implements Server {
+@@ -2547,5 +2547,24 @@ public final class CraftServer implements Server {
          DefaultPermissions.registerCorePermissions();
          CraftDefaultPermissions.registerCorePermissions();
      }

--- a/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
+++ b/patches/server/0132-Add-configuration-option-to-prevent-player-names-fro.patch
@@ -23,7 +23,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 028f2e2d24a6a1eac07c04d79c44bbdfe87108cb..e0460aa4154ea31743c6b99ff0ec009a37f7fee4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2560,5 +2560,10 @@ public final class CraftServer implements Server {
+@@ -2566,5 +2566,10 @@ public final class CraftServer implements Server {
          commandMap.registerServerAliases();
          return true;
      }

--- a/patches/server/0139-Basic-PlayerProfile-API.patch
+++ b/patches/server/0139-Basic-PlayerProfile-API.patch
@@ -642,7 +642,7 @@ index b28f2e8fa2c62562cf87cf264e97b6d7c233297b..e6db5d649d01c4952dc5e3bf08f9ce15
          CraftItemFactory.instance();
      }
  
-@@ -2574,5 +2578,37 @@ public final class CraftServer implements Server {
+@@ -2580,5 +2584,37 @@ public final class CraftServer implements Server {
      public boolean suggestPlayerNamesWhenNullTabCompletions() {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }

--- a/patches/server/0286-Make-the-default-permission-message-configurable.patch
+++ b/patches/server/0286-Make-the-default-permission-message-configurable.patch
@@ -45,7 +45,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index b0f7f44569f119d9e16bc468124b69244c61bf87..04457c57b971ef16b202768c26f6e98fe9b1602f 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2600,6 +2600,11 @@ public final class CraftServer implements Server {
+@@ -2606,6 +2606,11 @@ public final class CraftServer implements Server {
          return com.destroystokyo.paper.PaperConfig.suggestPlayersWhenNullTabCompletions;
      }
  

--- a/patches/server/0327-Expose-the-internal-current-tick.patch
+++ b/patches/server/0327-Expose-the-internal-current-tick.patch
@@ -8,7 +8,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 4323bbd4763b9bd5eebd3313c3de3c6070251c42..669e4b41cf0751afb67d94b6a511bcfd18ce7ef4 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2636,5 +2636,10 @@ public final class CraftServer implements Server {
+@@ -2642,5 +2642,10 @@ public final class CraftServer implements Server {
          profile.getProperties().putAll(((CraftPlayer)player).getHandle().getGameProfile().getProperties());
          return new com.destroystokyo.paper.profile.CraftPlayerProfile(profile);
      }

--- a/patches/server/0376-Add-tick-times-API-and-mspt-command.patch
+++ b/patches/server/0376-Add-tick-times-API-and-mspt-command.patch
@@ -184,7 +184,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 3ff85d9d8518db712ca1d2977a5865daef86f021..e270d7786eb1eae8970ff2ed5896789e05ca6613 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2461,6 +2461,16 @@ public final class CraftServer implements Server {
+@@ -2467,6 +2467,16 @@ public final class CraftServer implements Server {
                  net.minecraft.server.MinecraftServer.getServer().tps15.getAverage()
          };
      }

--- a/patches/server/0377-Expose-MinecraftServer-isRunning.patch
+++ b/patches/server/0377-Expose-MinecraftServer-isRunning.patch
@@ -9,7 +9,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index e270d7786eb1eae8970ff2ed5896789e05ca6613..a67fc9b0899f9d2128ac202ba0c12776653dfe28 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2651,5 +2651,10 @@ public final class CraftServer implements Server {
+@@ -2657,5 +2657,10 @@ public final class CraftServer implements Server {
      public int getCurrentTick() {
          return net.minecraft.server.MinecraftServer.currentTick;
      }

--- a/patches/server/0414-Implement-Mob-Goal-API.patch
+++ b/patches/server/0414-Implement-Mob-Goal-API.patch
@@ -788,7 +788,7 @@ diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/ja
 index 3a85c5884ebf0c8e1c4fe45925aca383f65531c8..9cdefc0cabae51d37149cda47fff5432c8c9ebed 100644
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -2664,5 +2664,11 @@ public final class CraftServer implements Server {
+@@ -2670,5 +2670,11 @@ public final class CraftServer implements Server {
      public boolean isStopping() {
          return net.minecraft.server.MinecraftServer.getServer().hasStopped();
      }

--- a/patches/server/0647-Add-basic-Datapack-API.patch
+++ b/patches/server/0647-Add-basic-Datapack-API.patch
@@ -111,7 +111,7 @@ index b651a9d86a5b0e7ec2b10d2e756bbac4624f7f9c..52aaa4837423585e7f66790ca95ad7c0
      }
  
      public boolean getCommandBlockOverride(String command) {
-@@ -2743,5 +2745,11 @@ public final class CraftServer implements Server {
+@@ -2749,5 +2751,11 @@ public final class CraftServer implements Server {
      public com.destroystokyo.paper.entity.ai.MobGoals getMobGoals() {
          return mobGoals;
      }

--- a/patches/server/0863-Custom-Potion-Mixes.patch
+++ b/patches/server/0863-Custom-Potion-Mixes.patch
@@ -184,7 +184,7 @@ index 19973165c7aa918c072db869c979d395895546d5..776b2b0ab9942282d9c8cb5ba8e86e25
          MobEffects.BLINDNESS.getClass();
          PotionEffectType.stopAcceptingRegistrations();
          // Ugly hack :(
-@@ -2871,5 +2872,10 @@ public final class CraftServer implements Server {
+@@ -2877,5 +2878,10 @@ public final class CraftServer implements Server {
          return datapackManager;
      }
  


### PR DESCRIPTION
* Removes a no-longer-needed `@UndefinedNullability` annotation since upstream changed behavior.
* getLootTable now honors its method contract and returns null if there isn't a loot table with that key.