### PR TITLE
Added fire-tick-delay config option

### DIFF
--- a/patches/server/0842-Added-fire-tick-delay-config-option.patch
+++ b/patches/server/0842-Added-fire-tick-delay-config-option.patch
@@ -19,7 +19,7 @@ index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..3cabdb76060314bbcbe8d95f685a5ea9
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index d8e4fda2d501545e5f891bca317e2aa5f9368f47..f1888fdbc34176ddd4cc26f98d85f16012696b5f 100644
+index d8e4fda2d501545e5f891bca317e2aa5f9368f47..c2f0c9f13a8f407f667751f3f30b8a6500e1224c 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 @@ -164,7 +164,7 @@ public class FireBlock extends BaseFireBlock {
@@ -31,7 +31,7 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..f1888fdbc34176ddd4cc26f98d85f160
          if (world.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK)) {
              if (!state.canSurvive(world, pos)) {
                  fireExtinguished(world, pos); // CraftBukkit - invalid place location
-@@ -362,14 +362,20 @@ public class FireBlock extends BaseFireBlock {
+@@ -362,14 +362,21 @@ public class FireBlock extends BaseFireBlock {
      // Paper start - ItemActionContext param
      public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
          super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
@@ -40,6 +40,7 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..f1888fdbc34176ddd4cc26f98d85f160
 -        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
      }
  
++    @Deprecated
      private static int getFireTickDelay(Random random) {
          return 30 + random.nextInt(10);
      }

--- a/patches/server/0842-Added-fire-tick-delay-config-option.patch
+++ b/patches/server/0842-Added-fire-tick-delay-config-option.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jan Trummer <jan.trummer@hotmail.com>
+Date: Tue, 4 Jan 2022 10:09:09 +0100
+Subject: [PATCH] Added fire-tick-delay config option
+
+Added a config option to set the fire tick delay. The default value is 30, the game adds a random integer with a max value of 10 to that base value.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..66393244a5e63575454dc8a530aec7569b170313 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
++++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
+@@ -1019,4 +1019,10 @@ public class PaperWorldConfig {
+     private void minBlockLightForMobSpawning() {
+         this.maxBlockLightForMonsterSpawning = getInt("monster-spawn-max-light-level", maxBlockLightForMonsterSpawning);
+     }
++
++
++    public int fireTickDelay = 30;
++    private void fireTickDelay() {
++        fireTickDelay = getInt("fire-tick-delay", 30);
++    }
+ }
+diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
+index d8e4fda2d501545e5f891bca317e2aa5f9368f47..d1eadf4d700a22fa100746920226d1bd7abefe7d 100644
+--- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
++++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
+@@ -164,7 +164,7 @@ public class FireBlock extends BaseFireBlock {
+ 
+     @Override
+     public void tick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
+-        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
++        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random, world.paperConfig.fireTickDelay)); //Paper
+         if (world.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK)) {
+             if (!state.canSurvive(world, pos)) {
+                 fireExtinguished(world, pos); // CraftBukkit - invalid place location
+@@ -362,13 +362,15 @@ public class FireBlock extends BaseFireBlock {
+     // Paper start - ItemActionContext param
+     public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
+         super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
++        world.scheduleTick(blockposition, this, getFireTickDelay(world.random, world.paperConfig.fireTickDelay));
+         // Paper end
+-        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
+     }
+ 
+-    private static int getFireTickDelay(Random random) {
+-        return 30 + random.nextInt(10);
++    //Paper start
++    private static int getFireTickDelay(Random random, int tickDelayBase) {
++        return tickDelayBase + random.nextInt(10);
+     }
++    //Paper end
+ 
+     @Override
+     protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {

--- a/patches/server/0842-Added-fire-tick-delay-config-option.patch
+++ b/patches/server/0842-Added-fire-tick-delay-config-option.patch
@@ -27,7 +27,7 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..c2f0c9f13a8f407f667751f3f30b8a65
      @Override
      public void tick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
 -        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
-+        world.scheduleTick(pos, (Block) this, FireBlock.getFireUpdateDelay(world));
++        world.scheduleTick(pos, (Block) this, FireBlock.getFireUpdateDelay(world)); // Paper
          if (world.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK)) {
              if (!state.canSurvive(world, pos)) {
                  fireExtinguished(world, pos); // CraftBukkit - invalid place location
@@ -40,7 +40,7 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..c2f0c9f13a8f407f667751f3f30b8a65
 -        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
      }
  
-+    @Deprecated
++    @Deprecated // Paper
      private static int getFireTickDelay(Random random) {
          return 30 + random.nextInt(10);
      }
@@ -49,7 +49,7 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..c2f0c9f13a8f407f667751f3f30b8a65
 +    private static int getFireUpdateDelay(Level world){
 +        return world.paperConfig.fireTickDelay + world.random.nextInt(10);
 +    }
-+    //Paper end
++    // Paper end
 +
      @Override
      protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {

--- a/patches/server/0842-Added-fire-tick-delay-config-option.patch
+++ b/patches/server/0842-Added-fire-tick-delay-config-option.patch
@@ -1,27 +1,25 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Jan Trummer <jan.trummer@hotmail.com>
-Date: Tue, 4 Jan 2022 10:09:09 +0100
+Date: Tue, 4 Jan 2022 19:16:24 +0100
 Subject: [PATCH] Added fire-tick-delay config option
 
-Added a config option to set the fire tick delay. The default value is 30, the game adds a random integer with a max value of 10 to that base value.
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..66393244a5e63575454dc8a530aec7569b170313 100644
+index 5a5db15493cd9b83815c36487c2f38cb8ac76f3a..3cabdb76060314bbcbe8d95f685a5ea93bb1d2ac 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperWorldConfig.java
-@@ -1019,4 +1019,10 @@ public class PaperWorldConfig {
+@@ -1019,4 +1019,9 @@ public class PaperWorldConfig {
      private void minBlockLightForMobSpawning() {
          this.maxBlockLightForMonsterSpawning = getInt("monster-spawn-max-light-level", maxBlockLightForMonsterSpawning);
      }
 +
-+
 +    public int fireTickDelay = 30;
 +    private void fireTickDelay() {
-+        fireTickDelay = getInt("fire-tick-delay", 30);
++        fireTickDelay = getInt("fire-tick-delay", this.fireTickDelay);
 +    }
  }
 diff --git a/src/main/java/net/minecraft/world/level/block/FireBlock.java b/src/main/java/net/minecraft/world/level/block/FireBlock.java
-index d8e4fda2d501545e5f891bca317e2aa5f9368f47..d1eadf4d700a22fa100746920226d1bd7abefe7d 100644
+index d8e4fda2d501545e5f891bca317e2aa5f9368f47..f1888fdbc34176ddd4cc26f98d85f16012696b5f 100644
 --- a/src/main/java/net/minecraft/world/level/block/FireBlock.java
 +++ b/src/main/java/net/minecraft/world/level/block/FireBlock.java
 @@ -164,7 +164,7 @@ public class FireBlock extends BaseFireBlock {
@@ -29,26 +27,29 @@ index d8e4fda2d501545e5f891bca317e2aa5f9368f47..d1eadf4d700a22fa100746920226d1bd
      @Override
      public void tick(BlockState state, ServerLevel world, BlockPos pos, Random random) {
 -        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random));
-+        world.scheduleTick(pos, (Block) this, FireBlock.getFireTickDelay(world.random, world.paperConfig.fireTickDelay)); //Paper
++        world.scheduleTick(pos, (Block) this, FireBlock.getFireUpdateDelay(world));
          if (world.getGameRules().getBoolean(GameRules.RULE_DOFIRETICK)) {
              if (!state.canSurvive(world, pos)) {
                  fireExtinguished(world, pos); // CraftBukkit - invalid place location
-@@ -362,13 +362,15 @@ public class FireBlock extends BaseFireBlock {
+@@ -362,14 +362,20 @@ public class FireBlock extends BaseFireBlock {
      // Paper start - ItemActionContext param
      public void onPlace(BlockState iblockdata, Level world, BlockPos blockposition, BlockState iblockdata1, boolean flag, UseOnContext itemActionContext) {
          super.onPlace(iblockdata, world, blockposition, iblockdata1, flag, itemActionContext);
-+        world.scheduleTick(blockposition, this, getFireTickDelay(world.random, world.paperConfig.fireTickDelay));
++        world.scheduleTick(blockposition, this, getFireUpdateDelay(world));
          // Paper end
 -        world.scheduleTick(blockposition, this, getFireTickDelay(world.random));
      }
  
--    private static int getFireTickDelay(Random random) {
--        return 30 + random.nextInt(10);
-+    //Paper start
-+    private static int getFireTickDelay(Random random, int tickDelayBase) {
-+        return tickDelayBase + random.nextInt(10);
+     private static int getFireTickDelay(Random random) {
+         return 30 + random.nextInt(10);
      }
-+    //Paper end
  
++    // Paper start
++    private static int getFireUpdateDelay(Level world){
++        return world.paperConfig.fireTickDelay + world.random.nextInt(10);
++    }
++    //Paper end
++
      @Override
      protected void createBlockStateDefinition(StateDefinition.Builder<Block, BlockState> builder) {
+         builder.add(FireBlock.AGE, FireBlock.NORTH, FireBlock.EAST, FireBlock.SOUTH, FireBlock.WEST, FireBlock.UP);


### PR DESCRIPTION
As requested in [this](https://github.com/PaperMC/Paper/issues/7277) issue

This makes the speed at which fire should spread configurable, the default value is 30. Increasing the value makes the fire spread slower, decreasing it speeds it up.