### PR TITLE
Unregister the enchantments registered by plugins on reload

### DIFF
--- a/patches/api/0352-Unregister-the-enchantment-registered-by-plugin-when.patch
+++ b/patches/api/0352-Unregister-the-enchantment-registered-by-plugin-when.patch
@@ -1,0 +1,63 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hai_tun <1346653001@qq.com>
+Date: Wed, 5 Jan 2022 04:12:52 +0800
+Subject: [PATCH] Unregister the enchantment registered by plugin when reload.
+ And optimize the tab completion of the reload command.
+
+
+diff --git a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+index 0c7ba0718de2b93d013968ca0fec34ffd423990f..46d6f62589498b43743f1bdcba4e66e013d331dd 100644
+--- a/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
++++ b/src/main/java/org/bukkit/command/defaults/ReloadCommand.java
+@@ -8,6 +8,7 @@ import org.bukkit.ChatColor;
+ import org.bukkit.command.Command;
+ import org.bukkit.command.CommandSender;
+ import org.jetbrains.annotations.NotNull;
++import com.google.common.collect.Lists; // Paper
+ 
+ public class ReloadCommand extends BukkitCommand {
+     public ReloadCommand(@NotNull String name) {
+@@ -60,6 +61,6 @@ public class ReloadCommand extends BukkitCommand {
+     @NotNull
+     @Override
+     public List<String> tabComplete(@NotNull CommandSender sender, @NotNull String alias, @NotNull String[] args) throws IllegalArgumentException {
+-        return com.google.common.collect.Lists.newArrayList("permissions", "commands"); // Paper
++        return args.length == 1 ? Lists.newArrayList("permissions", "commands") : Collections.emptyList(); // Paper
+     }
+ }
+diff --git a/src/main/java/org/bukkit/enchantments/Enchantment.java b/src/main/java/org/bukkit/enchantments/Enchantment.java
+index 1e1c5a9d9a769018c4604e6e44fc5ed2312981e9..6ca77ad15d077a8e2c8a1e7b5d1cb0ea35e29588 100644
+--- a/src/main/java/org/bukkit/enchantments/Enchantment.java
++++ b/src/main/java/org/bukkit/enchantments/Enchantment.java
+@@ -342,6 +342,17 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
+      */
+     @NotNull
+     public abstract java.util.Set<org.bukkit.inventory.EquipmentSlot> getActiveSlots();
++
++    /**
++     * Gets the enchantment is registered by server.
++     * If the enchantment is registered by plugin, it should return false and can be unregistered when reload.
++     *
++     * @return true if the enchantment is registered by server.
++     */
++    public boolean isServerEnchantment()
++    {
++        return false;
++    }
+     // Paper end
+ 
+     @Override
+@@ -387,6 +398,13 @@ public abstract class Enchantment implements Keyed, net.kyori.adventure.translat
+         byName.put(enchantment.getName(), enchantment);
+     }
+ 
++    // Paper start
++    public static void clearPluginEnchantments() {
++        byKey.values().removeIf(enchantment -> !(enchantment.isServerEnchantment()));
++        byName.values().removeIf(enchantment -> !(enchantment.isServerEnchantment()));
++    }
++    // Paper end
++
+     /**
+      * Checks if this is accepting Enchantment registrations.
+      *

--- a/patches/server/0842-Unregister-the-enchantment-registered-by-plugin-when.patch
+++ b/patches/server/0842-Unregister-the-enchantment-registered-by-plugin-when.patch
@@ -1,0 +1,44 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Hai_tun <1346653001@qq.com>
+Date: Wed, 5 Jan 2022 04:12:52 +0800
+Subject: [PATCH] Unregister the enchantment registered by plugin when reload.
+ And optimize the tab completion of the reload command.
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index ba7023e7ca5d29375ff53c2951892138d155f69f..99657222fe9ffff1bc36dee3afe8b5dee8b1fe5a 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -197,6 +197,7 @@ import org.bukkit.craftbukkit.util.CraftNamespacedKey;
+ import org.bukkit.craftbukkit.util.DatFileFilter;
+ import org.bukkit.craftbukkit.util.Versioning;
+ import org.bukkit.craftbukkit.util.permissions.CraftDefaultPermissions;
++import org.bukkit.enchantments.Enchantment; // Paper
+ import org.bukkit.entity.Entity;
+ import org.bukkit.entity.Player;
+ import org.bukkit.event.inventory.InventoryType;
+@@ -1005,6 +1006,7 @@ public final class CraftServer implements Server {
+         }
+         // Paper end
+         this.reloadData();
++        Enchantment.clearPluginEnchantments(); // Paper
+         org.spigotmc.SpigotConfig.registerCommands(); // Spigot
+         com.destroystokyo.paper.PaperConfig.registerCommands(); // Paper
+         this.overrideAllCommandBlockCommands = this.commandsConfiguration.getStringList("command-block-overrides").contains("*");
+diff --git a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
+index 11c1eb0e0bc326b28dc0cab16f67c413cc52e98c..7687f86b1c4f9dd8ff441aefccb57ae40c4350a9 100644
+--- a/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
++++ b/src/main/java/org/bukkit/craftbukkit/enchantments/CraftEnchantment.java
+@@ -223,6 +223,12 @@ public class CraftEnchantment extends Enchantment {
+         return java.util.stream.Stream.of(target.slots).map(org.bukkit.craftbukkit.CraftEquipmentSlot::getSlot).collect(java.util.stream.Collectors.toSet());
+     }
+ 
++    @Override
++    public boolean isServerEnchantment()
++    {
++        return true;
++    }
++
+     public static io.papermc.paper.enchantments.EnchantmentRarity fromNMSRarity(net.minecraft.world.item.enchantment.Enchantment.Rarity nmsRarity) {
+         if (nmsRarity == net.minecraft.world.item.enchantment.Enchantment.Rarity.COMMON) {
+             return io.papermc.paper.enchantments.EnchantmentRarity.COMMON;


### PR DESCRIPTION
I've meet bugs on slimefun and LiteXpansion with reload command. The LiteXpansion could not register its new class because there is already one old instance in the enchantment list. So it would use the old classes and cause some suspicious errors and memory leak. This commit would unregister the enchantments which is registered by plugins, so it can fix wrong things and avoid confusing errors.
By the way we have repaired the tab completion of the reload command. 