### PR TITLE
Don't tick markers

### DIFF
--- a/patches/server/0904-Don-t-tick-markers.patch
+++ b/patches/server/0904-Don-t-tick-markers.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Noah van der Aa <ndvdaa@gmail.com>
+Date: Fri, 7 Jan 2022 11:58:26 +0100
+Subject: [PATCH] Don't tick markers
+
+Fixes https://github.com/PaperMC/Paper/issues/7276 by not adding markers to the entity
+tick list at all and ignoring them in Spigot's activation range checks. The entity tick
+list is only used in the tick and tickPassenger methods, so we can safely not add the
+markers to it.
+
+diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+index d0c55497040158d959693ef2ddf3ff03bd6df05f..45d1807b31f5acd5f08f729701cec4b464ad9398 100644
+--- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
++++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
+@@ -614,7 +614,7 @@ public class PaperCommand extends Command {
+                     ChunkPos chunk = e.chunkPosition();
+                     info.left++;
+                     info.right.put(chunk, info.right.getOrDefault(chunk, 0) + 1);
+-                    if (!chunkProviderServer.isPositionTicking(e)) {
++                    if (!chunkProviderServer.isPositionTicking(e) || e instanceof net.minecraft.world.entity.Marker) { // Markers aren't ticked.
+                         nonEntityTicking.merge(key, Integer.valueOf(1), Integer::sum);
+                     }
+                 });
+diff --git a/src/main/java/net/minecraft/server/level/ServerLevel.java b/src/main/java/net/minecraft/server/level/ServerLevel.java
+index 50fd3419deb668dda64b1056f03fb66da55e6960..62ec40de8ed8acb293ef21c8d2c624060d51cfe8 100644
+--- a/src/main/java/net/minecraft/server/level/ServerLevel.java
++++ b/src/main/java/net/minecraft/server/level/ServerLevel.java
+@@ -2418,6 +2418,7 @@ public class ServerLevel extends Level implements WorldGenLevel {
+         }
+ 
+         public void onTickingStart(Entity entity) {
++            if (entity instanceof net.minecraft.world.entity.Marker) return; // Paper - Don't tick markers
+             ServerLevel.this.entityTickList.add(entity);
+             ServerLevel.this.entityManager.addNavigatorsIfPathingToRegion(entity); // Paper - optimise notify
+         }
+diff --git a/src/main/java/org/spigotmc/ActivationRange.java b/src/main/java/org/spigotmc/ActivationRange.java
+index 5bffc9a0f6ef9d54abb359565d07509b177c2b82..1a1a1f4d0ac025daccc2d3f84faf6592819f4d5c 100644
+--- a/src/main/java/org/spigotmc/ActivationRange.java
++++ b/src/main/java/org/spigotmc/ActivationRange.java
+@@ -211,7 +211,7 @@ public class ActivationRange
+             // Paper end
+ 
+             // Paper start
+-            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, null);
++            java.util.List<Entity> entities = world.getEntities((Entity)null, maxBB, (e) -> !(e instanceof net.minecraft.world.entity.Marker)); // Don't tick markers
+             for (int i = 0; i < entities.size(); i++) {
+                 Entity entity = entities.get(i);
+                 ActivationRange.activateEntity(entity);


### PR DESCRIPTION
Fixes #7276 by not adding markers to the entity tick list at all and ignoring them
in Spigot's activation range checks. The entity tick list is only used in the tick
and tickPassenger methods, so we can safely not add the markers to it.

To make testing easier, I've attached a world with roughly 100k marker entities
at spawn (on top of the diamond blocks)

[world.zip](https://github.com/PaperMC/Paper/files/7829098/world.zip)
