### PR TITLE
Add PlayerInventorySlotChangeEvent

### DIFF
--- a/patches/api/0399-Add-PlayerInventorySlotChangeEvent.patch
+++ b/patches/api/0399-Add-PlayerInventorySlotChangeEvent.patch
@@ -1,0 +1,96 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Sun, 24 Apr 2022 22:56:31 +0200
+Subject: [PATCH] Add PlayerInventorySlotChangeEvent
+
+
+diff --git a/src/main/java/com/destroystokyo/paper/event/player/PlayerInventorySlotChangeEvent.java b/src/main/java/com/destroystokyo/paper/event/player/PlayerInventorySlotChangeEvent.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..f106d2c6fb349c57ed00f1d7f96efacb1ade3959
+--- /dev/null
++++ b/src/main/java/com/destroystokyo/paper/event/player/PlayerInventorySlotChangeEvent.java
+@@ -0,0 +1,84 @@
++package com.destroystokyo.paper.event.player;
++
++import org.bukkit.entity.Player;
++import org.bukkit.event.Cancellable;
++import org.bukkit.event.HandlerList;
++import org.bukkit.event.player.PlayerEvent;
++import org.bukkit.inventory.ItemStack;
++import org.jetbrains.annotations.NotNull;
++
++/**
++ * Called when a slot contents change in a player's inventory.
++ */
++public class PlayerInventorySlotChangeEvent extends PlayerEvent {
++    private static final HandlerList handlers = new HandlerList();
++    private final int slot;
++    private final ItemStack oldItemStack;
++    private final ItemStack newItemStack;
++    private boolean triggerAdvancements = true;
++
++    public PlayerInventorySlotChangeEvent(@NotNull Player player, int slot, @NotNull ItemStack oldItemStack, @NotNull ItemStack newItemStack) {
++        super(player);
++        this.slot = slot;
++        this.oldItemStack = oldItemStack;
++        this.newItemStack = newItemStack;
++    }
++
++    /**
++     * The slot number that was changed.
++     *
++     * @return The slot number.
++     */
++    public int getSlot() {
++        return slot;
++    }
++
++    /**
++     * Clone of ItemStack that was in the slot before the change.
++     *
++     * @return The old ItemStack in the slot.
++     */
++    @NotNull
++    public ItemStack getOldItemStack() {
++        return oldItemStack;
++    }
++
++    /**
++     * Clone of ItemStack that is in the slot after the change.
++     *
++     * @return The new ItemStack in the slot.
++     */
++    @NotNull
++    public ItemStack getNewItemStack() {
++        return newItemStack;
++    }
++
++    /**
++     * Gets whether the slot change advancements will be triggered.
++     *
++     * @return Whether the slot change advancements will be triggered.
++     */
++    public boolean isTriggerAdvancements() {
++        return triggerAdvancements;
++    }
++
++    /**
++     * Sets whether the slot change advancements will be triggered.
++     *
++     * @param triggerAdvancements Whether the slot change advancements will be triggered.
++     */
++    public void setTriggerAdvancements(boolean triggerAdvancements) {
++        this.triggerAdvancements = triggerAdvancements;
++    }
++
++    @NotNull
++    @Override
++    public HandlerList getHandlers() {
++        return handlers;
++    }
++
++    @NotNull
++    public static HandlerList getHandlerList() {
++        return handlers;
++    }
++}

--- a/patches/server/0925-Add-PlayerInventorySlotChangeEvent.patch
+++ b/patches/server/0925-Add-PlayerInventorySlotChangeEvent.patch
@@ -1,0 +1,65 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Jakub Zacek <dawon@dawon.eu>
+Date: Sun, 24 Apr 2022 22:56:59 +0200
+Subject: [PATCH] Add PlayerInventorySlotChangeEvent
+
+
+diff --git a/src/main/java/net/minecraft/server/level/ServerPlayer.java b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+index af7acb628b84539b1ee5ef1934f75f091c4cd91e..e5af7ef4ada68922a70f593ccec555ecb50627a9 100644
+--- a/src/main/java/net/minecraft/server/level/ServerPlayer.java
++++ b/src/main/java/net/minecraft/server/level/ServerPlayer.java
+@@ -318,6 +318,25 @@ public class ServerPlayer extends Player {
+ 
+                 }
+             }
++            // Paper start
++            @Override
++            public void slotChanged(AbstractContainerMenu handler, int slotId, ItemStack oldStack, ItemStack stack) {
++                Slot slot = handler.getSlot(slotId);
++                if (!(slot instanceof ResultSlot)) {
++                    if (slot.container == ServerPlayer.this.getInventory()) {
++                        if (com.destroystokyo.paper.event.player.PlayerInventorySlotChangeEvent.getHandlerList().getRegisteredListeners().length == 0) {
++                            CriteriaTriggers.INVENTORY_CHANGED.trigger(ServerPlayer.this, ServerPlayer.this.getInventory(), stack);
++                            return;
++                        }
++                        com.destroystokyo.paper.event.player.PlayerInventorySlotChangeEvent event = new com.destroystokyo.paper.event.player.PlayerInventorySlotChangeEvent(ServerPlayer.this.getBukkitEntity(), slotId, CraftItemStack.asBukkitCopy(oldStack), CraftItemStack.asBukkitCopy(stack));
++                        event.callEvent();
++                        if (event.isTriggerAdvancements()) {
++                            CriteriaTriggers.INVENTORY_CHANGED.trigger(ServerPlayer.this, ServerPlayer.this.getInventory(), stack);
++                        }
++                    }
++                }
++            }
++            // Paper end
+ 
+             @Override
+             public void dataChanged(AbstractContainerMenu handler, int property, int value) {}
+diff --git a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+index 49b063655dfc09e30d446dbf07503fdda04a7e30..1ad44a49c1da9ede750984306960282f0df5844c 100644
+--- a/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
++++ b/src/main/java/net/minecraft/world/inventory/AbstractContainerMenu.java
+@@ -301,7 +301,7 @@ public abstract class AbstractContainerMenu {
+             while (iterator.hasNext()) {
+                 ContainerListener icrafting = (ContainerListener) iterator.next();
+ 
+-                icrafting.slotChanged(this, slot, itemstack2);
++                icrafting.slotChanged(this, slot, itemstack1, itemstack2); // Paper
+             }
+         }
+ 
+diff --git a/src/main/java/net/minecraft/world/inventory/ContainerListener.java b/src/main/java/net/minecraft/world/inventory/ContainerListener.java
+index 0e19cc55646625bf32a354d3df2dc2d6bcff96f4..8ca9c14310b1e809662dd4ca6d35668992c2fc8d 100644
+--- a/src/main/java/net/minecraft/world/inventory/ContainerListener.java
++++ b/src/main/java/net/minecraft/world/inventory/ContainerListener.java
+@@ -5,5 +5,11 @@ import net.minecraft.world.item.ItemStack;
+ public interface ContainerListener {
+     void slotChanged(AbstractContainerMenu handler, int slotId, ItemStack stack);
+ 
++    // Paper start
++    default void slotChanged(AbstractContainerMenu handler, int slotId, ItemStack oldStack, ItemStack stack) {
++        slotChanged(handler, slotId, stack);
++    }
++    // Paper end
++
+     void dataChanged(AbstractContainerMenu handler, int property, int value);
+ }


### PR DESCRIPTION
Useful event for detecting user acquired/lost an item in any way (e.g. custom advancement). 

Otherwise, it is needed to listen for several events and I am not sure whether it is possible to listen for example for /give.

Originally I wanted it to be InventoryEvent, but since there is no InventoryView and it would have to be null, I thought PlayerEvent would be better.